### PR TITLE
DEVPROD-53 Add context to db queries (Remove, Find, FindAll, UpdateAll, and UpdateId)

### DIFF
--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -326,19 +326,6 @@ func UpdateAllContext(ctx context.Context, collection string, query any, update 
 	return &db.ChangeInfo{Updated: int(res.ModifiedCount)}, nil
 }
 
-// UpdateId updates one _id-matching document in the collection.
-func UpdateId(collection string, id, update any) error {
-	session, db, err := GetGlobalSessionFactory().GetSession()
-	if err != nil {
-		grip.Errorf("error establishing db connection: %+v", err)
-
-		return err
-	}
-	defer session.Close()
-
-	return db.C(collection).UpdateId(id, update)
-}
-
 // UpdateIdContext updates one _id-matching document in the collection.
 func UpdateIdContext(ctx context.Context, collection string, id, update any) error {
 	res, err := evergreen.GetEnvironment().DB().Collection(collection).UpdateOne(ctx,

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -356,6 +356,7 @@ func UpdateIdContext(ctx context.Context, collection string, id, update any) err
 }
 
 // UpdateAll updates all matching documents in the collection.
+// DEPRECATED: Use UpdateAllContext instead.
 func UpdateAll(collection string, query any, update any) (*db.ChangeInfo, error) {
 	switch query.(type) {
 	case *Q, Q:
@@ -385,6 +386,7 @@ func UpdateAll(collection string, query any, update any) (*db.ChangeInfo, error)
 }
 
 // Upsert run the specified update against the collection as an upsert operation.
+// DEPRECATED: Use UpsertContext instead.
 func Upsert(collection string, query any, update any) (*db.ChangeInfo, error) {
 	session, db, err := GetGlobalSessionFactory().GetSession()
 	if err != nil {

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -222,7 +222,8 @@ func RemoveAll(ctx context.Context, collection string, query any) error {
 }
 
 // Update updates one matching document in the collection.
-// DEPRECATED: Use UpdateContext instead.
+// DEPRECATED (DEVPROD-15398): This is only here to support a cache
+// // with Gimlet, use UpdateContext instead.
 func Update(collection string, query any, update any) error {
 	session, db, err := GetGlobalSessionFactory().GetSession()
 	if err != nil {
@@ -334,7 +335,8 @@ func UpdateIdContext(ctx context.Context, collection string, id, update any) err
 }
 
 // UpdateAll updates all matching documents in the collection.
-// DEPRECATED: Use UpdateAllContext instead.
+// DEPRECATED (DEVPROD-15398): This is only here to support a cache
+// // with Gimlet, use UpdateAllContext instead.
 func UpdateAll(collection string, query any, update any) (*db.ChangeInfo, error) {
 	switch query.(type) {
 	case *Q, Q:

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -374,7 +374,6 @@ func UpdateAll(collection string, query any, update any) (*db.ChangeInfo, error)
 }
 
 // Upsert run the specified update against the collection as an upsert operation.
-// DEPRECATED: Use UpsertContext instead.
 func Upsert(collection string, query any, update any) (*db.ChangeInfo, error) {
 	session, db, err := GetGlobalSessionFactory().GetSession()
 	if err != nil {

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -220,7 +220,7 @@ func RemoveContext(ctx context.Context, collection string, query any) error {
 }
 
 // RemoveAll removes all items matching the query from the specified collection.
-func RemoveAll(collection string, query any) error {
+func RemoveAll(ctx context.Context, collection string, query any) error {
 	session, db, err := GetGlobalSessionFactory().GetSession()
 	if err != nil {
 		return err
@@ -232,6 +232,7 @@ func RemoveAll(collection string, query any) error {
 }
 
 // Update updates one matching document in the collection.
+// DEPRECATED: Use UpdateContext instead.
 func Update(collection string, query any, update any) error {
 	session, db, err := GetGlobalSessionFactory().GetSession()
 	if err != nil {

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -223,7 +223,7 @@ func RemoveAll(ctx context.Context, collection string, query any) error {
 
 // Update updates one matching document in the collection.
 // DEPRECATED (DEVPROD-15398): This is only here to support a cache
-// // with Gimlet, use UpdateContext instead.
+// with Gimlet, use UpdateContext instead.
 func Update(collection string, query any, update any) error {
 	session, db, err := GetGlobalSessionFactory().GetSession()
 	if err != nil {
@@ -336,7 +336,7 @@ func UpdateIdContext(ctx context.Context, collection string, id, update any) err
 
 // UpdateAll updates all matching documents in the collection.
 // DEPRECATED (DEVPROD-15398): This is only here to support a cache
-// // with Gimlet, use UpdateAllContext instead.
+// with Gimlet, use UpdateAllContext instead.
 func UpdateAll(collection string, query any, update any) (*db.ChangeInfo, error) {
 	switch query.(type) {
 	case *Q, Q:

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -199,17 +199,7 @@ func EnsureIndex(collection string, index mongo.IndexModel) error {
 }
 
 // Remove removes one item matching the query from the specified collection.
-func Remove(collection string, query any) error {
-	session, db, err := GetGlobalSessionFactory().GetSession()
-	if err != nil {
-		return err
-	}
-	defer session.Close()
-
-	return db.C(collection).Remove(query)
-}
-
-func RemoveContext(ctx context.Context, collection string, query any) error {
+func Remove(ctx context.Context, collection string, query any) error {
 	session, db, err := GetGlobalSessionFactory().GetContextSession(ctx)
 	if err != nil {
 		return err

--- a/db/db_utils_test.go
+++ b/db/db_utils_test.go
@@ -205,7 +205,7 @@ func TestDBUtils(t *testing.T) {
 			// one and limit to one (meaning only the second struct should be
 			// returned)
 			out := []insertableStruct{}
-			err = FindAllQ(collection, Query(bson.M{"field_two": 1}).
+			err = FindAllQContext(t.Context(), collection, Query(bson.M{"field_two": 1}).
 				Project(bson.M{"field_three": 0}).
 				Sort([]string{"-field_one"}).
 				Limit(1).
@@ -302,7 +302,7 @@ func TestDBUtils(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			out := []insertableStruct{}
-			err = FindAllQ(collection, Query(bson.M{"field_two": 3}), &out)
+			err = FindAllQContext(t.Context(), collection, Query(bson.M{"field_two": 3}), &out)
 			So(err, ShouldBeNil)
 			So(len(out), ShouldEqual, 2)
 

--- a/db/db_utils_test.go
+++ b/db/db_utils_test.go
@@ -151,7 +151,7 @@ func TestDBUtils(t *testing.T) {
 			So(count, ShouldEqual, 3)
 
 			// remove just the first
-			So(RemoveAll(collection, bson.M{"field_one": "1"}),
+			So(RemoveAll(t.Context(), collection, bson.M{"field_one": "1"}),
 				ShouldBeNil)
 			count, err = Count(collection, bson.M{})
 			So(err, ShouldBeNil)

--- a/db/db_utils_test.go
+++ b/db/db_utils_test.go
@@ -288,7 +288,8 @@ func TestDBUtils(t *testing.T) {
 			So(count, ShouldEqual, 3)
 
 			// update the first and third
-			_, err = UpdateAll(
+			_, err = UpdateAllContext(
+				t.Context(),
 				collection,
 				bson.M{
 					"field_one": "1",

--- a/db/db_utils_test.go
+++ b/db/db_utils_test.go
@@ -111,7 +111,7 @@ func TestDBUtils(t *testing.T) {
 			So(count, ShouldEqual, 2)
 
 			// remove just the first
-			So(Remove(collection, bson.M{"field_one": "1"}),
+			So(Remove(t.Context(), collection, bson.M{"field_one": "1"}),
 				ShouldBeNil)
 			count, err = Count(collection, bson.M{})
 			So(err, ShouldBeNil)

--- a/db/query.go
+++ b/db/query.go
@@ -150,8 +150,8 @@ func CountQContext(ctx context.Context, collection string, q Q) (int, error) {
 }
 
 // RemoveAllQ removes all docs that satisfy the query
-func RemoveAllQ(collection string, q Q) error {
-	return Remove(collection, q.filter)
+func RemoveAllQ(ctx context.Context, collection string, q Q) error {
+	return Remove(ctx, collection, q.filter)
 }
 
 // implement custom marshaller interfaces to prevent the bug where we

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -56,14 +56,14 @@ func TestQueryExecution(t *testing.T) {
 
 			Convey("BelowFive should return 4 documents", func() {
 				out := []insertableStruct{}
-				err := FindAllQ(collection, BelowFive, &out)
+				err := FindAllQContext(t.Context(), collection, BelowFive, &out)
 				So(err, ShouldBeNil)
 				So(len(out), ShouldEqual, 4)
 			})
 
 			Convey("BelowFiveSorted should return 4 documents, sorted in reverse", func() {
 				out := []insertableStruct{}
-				err := FindAllQ(collection, BelowFiveSorted, &out)
+				err := FindAllQContext(t.Context(), collection, BelowFiveSorted, &out)
 				So(err, ShouldBeNil)
 				So(len(out), ShouldEqual, 4)
 				So(out[0].FieldTwo, ShouldEqual, 4)
@@ -74,14 +74,14 @@ func TestQueryExecution(t *testing.T) {
 
 			Convey("BelowFiveLimit should return 2 documents", func() {
 				out := []insertableStruct{}
-				err := FindAllQ(collection, BelowFiveLimit, &out)
+				err := FindAllQContext(t.Context(), collection, BelowFiveLimit, &out)
 				So(err, ShouldBeNil)
 				So(len(out), ShouldEqual, 2)
 			})
 
 			Convey("JustOneField should return 1 document", func() {
 				out := []bson.M{}
-				err := FindAllQ(collection, JustOneField, &out)
+				err := FindAllQContext(t.Context(), collection, JustOneField, &out)
 				So(err, ShouldBeNil)
 				So(out[0]["three"], ShouldEqual, "COOL")
 			})

--- a/graphql/annotation_resolver.go
+++ b/graphql/annotation_resolver.go
@@ -20,7 +20,7 @@ func (r *annotationResolver) WebhookConfigured(ctx context.Context, obj *restMod
 	if t == nil {
 		return false, ResourceNotFound.Send(ctx, fmt.Sprintf("task '%s' not found", taskID))
 	}
-	_, ok, _ := model.IsWebhookConfigured(t.Project, t.Version)
+	_, ok, _ := model.IsWebhookConfigured(ctx, t.Project, t.Version)
 	return ok, nil
 }
 

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -597,7 +597,7 @@ func (r *mutationResolver) SetLastRevision(ctx context.Context, opts SetLastRevi
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("updating last revision for '%s': %s", opts.ProjectIdentifier, err.Error()))
 	}
 
-	if err = project.SetRepotrackerError(&model.RepositoryErrorDetails{}); err != nil {
+	if err = project.SetRepotrackerError(ctx, &model.RepositoryErrorDetails{}); err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("clearing repotracker error for '%s': %s", opts.ProjectIdentifier, err.Error()))
 	}
 

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -346,7 +346,7 @@ func (r *mutationResolver) SchedulePatch(ctx context.Context, patchID string, co
 // AttachProjectToNewRepo is the resolver for the attachProjectToNewRepo field.
 func (r *mutationResolver) AttachProjectToNewRepo(ctx context.Context, project MoveProjectInput) (*restModel.APIProjectRef, error) {
 	usr := mustHaveUser(ctx)
-	pRef, err := data.FindProjectById(project.ProjectID, false, false)
+	pRef, err := data.FindProjectById(ctx, project.ProjectID, false, false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching project '%s': %s", project.ProjectID, err.Error()))
 	}
@@ -370,7 +370,7 @@ func (r *mutationResolver) AttachProjectToNewRepo(ctx context.Context, project M
 // AttachProjectToRepo is the resolver for the attachProjectToRepo field.
 func (r *mutationResolver) AttachProjectToRepo(ctx context.Context, projectID string) (*restModel.APIProjectRef, error) {
 	usr := mustHaveUser(ctx)
-	pRef, err := data.FindProjectById(projectID, false, false)
+	pRef, err := data.FindProjectById(ctx, projectID, false, false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching project '%s': %s", projectID, err.Error()))
 	}
@@ -519,7 +519,7 @@ func (r *mutationResolver) DeleteProject(ctx context.Context, projectID string) 
 // DetachProjectFromRepo is the resolver for the detachProjectFromRepo field.
 func (r *mutationResolver) DetachProjectFromRepo(ctx context.Context, projectID string) (*restModel.APIProjectRef, error) {
 	usr := mustHaveUser(ctx)
-	pRef, err := data.FindProjectById(projectID, false, false)
+	pRef, err := data.FindProjectById(ctx, projectID, false, false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching project '%s': %s", projectID, err.Error()))
 	}
@@ -1188,7 +1188,7 @@ func (r *mutationResolver) SaveSubscription(ctx context.Context, subscription re
 			return false, ResourceNotFound.Send(ctx, fmt.Sprintf("version '%s' not found", id))
 		}
 	case "project":
-		p, projectErr := data.FindProjectById(id, false, false)
+		p, projectErr := data.FindProjectById(ctx, id, false, false)
 		if projectErr != nil {
 			return false, InternalServerError.Send(ctx, fmt.Sprintf("fetching project '%s': %s", id, projectErr.Error()))
 		}

--- a/graphql/patch_resolver.go
+++ b/graphql/patch_resolver.go
@@ -129,7 +129,7 @@ func (r *patchResolver) GeneratedTaskCounts(ctx context.Context, obj *restModel.
 // PatchTriggerAliases is the resolver for the patchTriggerAliases field.
 func (r *patchResolver) PatchTriggerAliases(ctx context.Context, obj *restModel.APIPatch) ([]*restModel.APIPatchTriggerDefinition, error) {
 	projectID := utility.FromStringPtr(obj.ProjectId)
-	projectRef, err := data.FindProjectById(projectID, true, true)
+	projectRef, err := data.FindProjectById(ctx, projectID, true, true)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching project '%s': %s", projectID, err.Error()))
 	}
@@ -153,7 +153,7 @@ func (r *patchResolver) PatchTriggerAliases(ctx context.Context, obj *restModel.
 			projectCache[alias.ChildProject] = project
 		}
 
-		matchingTasks, err := project.VariantTasksForSelectors([]patch.PatchTriggerDefinition{alias}, utility.FromStringPtr(obj.Requester))
+		matchingTasks, err := project.VariantTasksForSelectors(ctx, []patch.PatchTriggerDefinition{alias}, utility.FromStringPtr(obj.Requester))
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("matching tasks to definitions for alias '%s': %s", alias.Alias, err.Error()))
 		}

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -405,7 +405,7 @@ func (r *queryResolver) Patch(ctx context.Context, patchID string) (*restModel.A
 
 // GithubProjectConflicts is the resolver for the githubProjectConflicts field.
 func (r *queryResolver) GithubProjectConflicts(ctx context.Context, projectID string) (*model.GithubProjectConflicts, error) {
-	pRef, err := model.FindMergedProjectRef(projectID, "", false)
+	pRef, err := model.FindMergedProjectRef(ctx, projectID, "", false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching project '%s': %s", projectID, err.Error()))
 	}
@@ -422,7 +422,7 @@ func (r *queryResolver) GithubProjectConflicts(ctx context.Context, projectID st
 
 // Project is the resolver for the project field.
 func (r *queryResolver) Project(ctx context.Context, projectIdentifier string) (*restModel.APIProjectRef, error) {
-	project, err := data.FindProjectById(projectIdentifier, true, false)
+	project, err := data.FindProjectById(ctx, projectIdentifier, true, false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching project '%s': %s", projectIdentifier, err.Error()))
 	}

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -453,7 +453,7 @@ func (r *taskResolver) IsPerfPluginEnabled(ctx context.Context, obj *restModel.A
 	if !evergreen.IsFinishedTaskStatus(utility.FromStringPtr(obj.Status)) {
 		return false, nil
 	}
-	if !model.IsPerfEnabledForProject(utility.FromStringPtr(obj.ProjectId)) {
+	if !model.IsPerfEnabledForProject(ctx, utility.FromStringPtr(obj.ProjectId)) {
 		return false, nil
 	}
 	opts := apimodels.GetPerfCountOptions{
@@ -527,7 +527,7 @@ func (r *taskResolver) Pod(ctx context.Context, obj *restModel.APITask) (*restMo
 // Project is the resolver for the project field.
 func (r *taskResolver) Project(ctx context.Context, obj *restModel.APITask) (*restModel.APIProjectRef, error) {
 	projectID := utility.FromStringPtr(obj.ProjectId)
-	pRef, err := data.FindProjectById(projectID, true, false)
+	pRef, err := data.FindProjectById(ctx, projectID, true, false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching project '%s': %s", projectID, err.Error()))
 	}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -882,7 +882,7 @@ func getHostRequestOptions(ctx context.Context, usr *user.DBUser, spawnHostInput
 }
 
 func getProjectMetadata(ctx context.Context, projectId *string, patchId *string) (*restModel.APIProjectRef, error) {
-	projectRef, err := model.FindMergedProjectRef(*projectId, *patchId, false)
+	projectRef, err := model.FindMergedProjectRef(ctx, *projectId, *patchId, false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding merged project ref for project '%s': %s", utility.FromStringPtr(projectId), err.Error()))
 	}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -48,7 +48,7 @@ const (
 
 // getGroupedFiles returns the files of a Task inside a GroupedFile struct
 func getGroupedFiles(ctx context.Context, name string, taskID string, execution int) (*GroupedFiles, error) {
-	taskFiles, err := artifact.GetAllArtifacts([]artifact.TaskIDAndExecution{{TaskID: taskID, Execution: execution}})
+	taskFiles, err := artifact.GetAllArtifacts(ctx, []artifact.TaskIDAndExecution{{TaskID: taskID, Execution: execution}})
 	if err != nil {
 		return nil, ResourceNotFound.Send(ctx, err.Error())
 	}

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -140,7 +140,7 @@ func (r *versionResolver) ChildVersions(ctx context.Context, obj *restModel.APIV
 // ExternalLinksForMetadata is the resolver for the externalLinksForMetadata field.
 func (r *versionResolver) ExternalLinksForMetadata(ctx context.Context, obj *restModel.APIVersion) ([]*ExternalLinkForMetadata, error) {
 	projectID := utility.FromStringPtr(obj.Project)
-	pRef, err := data.FindProjectById(projectID, false, false)
+	pRef, err := data.FindProjectById(ctx, projectID, false, false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching project '%s': %s", projectID, err.Error()))
 	}

--- a/model/alertrecord/alert_bookkeeping_test.go
+++ b/model/alertrecord/alert_bookkeeping_test.go
@@ -175,7 +175,7 @@ func (s *alertRecordSuite) TestFindOneWithUnsetIDQuery() {
 	s.Equal(2, rec.RevisionOrderNumber)
 
 	records := []AlertRecord{}
-	err = db.FindAllQ(Collection, ByLastFailureTransition(legacyAlertsSubscription, "task", "variant", "project").Limit(999), &records)
+	err = db.FindAllQContext(s.T().Context(), Collection, ByLastFailureTransition(legacyAlertsSubscription, "task", "variant", "project").Limit(999), &records)
 	s.NoError(err)
 	s.Len(records, 3)
 }

--- a/model/annotations/db.go
+++ b/model/annotations/db.go
@@ -44,9 +44,9 @@ func FindOne(ctx context.Context, query db.Q) (*TaskAnnotation, error) {
 }
 
 // Find gets every TaskAnnotation matching the given query.
-func Find(query db.Q) ([]TaskAnnotation, error) {
+func Find(ctx context.Context, query db.Q) ([]TaskAnnotation, error) {
 	annotations := []TaskAnnotation{}
-	err := db.FindAllQ(Collection, query, &annotations)
+	err := db.FindAllQContext(ctx, Collection, query, &annotations)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding task annotations")
 	}
@@ -58,12 +58,12 @@ func FindOneByTaskIdAndExecution(ctx context.Context, id string, execution int) 
 	return FindOne(ctx, db.Query(ByTaskIdAndExecution(id, execution)))
 }
 
-func FindByTaskIds(ids []string) ([]TaskAnnotation, error) {
-	return Find(ByTaskIds(ids))
+func FindByTaskIds(ctx context.Context, ids []string) ([]TaskAnnotation, error) {
+	return Find(ctx, ByTaskIds(ids))
 }
 
-func FindByTaskId(id string) ([]TaskAnnotation, error) {
-	return Find(db.Query(ByTaskId(id)))
+func FindByTaskId(ctx context.Context, id string) ([]TaskAnnotation, error) {
+	return Find(ctx, db.Query(ByTaskId(id)))
 }
 
 // Upsert writes the task_annotation to the database.

--- a/model/annotations/task_annotations_test.go
+++ b/model/annotations/task_annotations_test.go
@@ -35,7 +35,7 @@ func TestGetLatestExecutions(t *testing.T) {
 		assert.NoError(t, a.Upsert())
 	}
 
-	taskAnnotations, err := FindByTaskIds([]string{"t1", "t2"})
+	taskAnnotations, err := FindByTaskIds(t.Context(), []string{"t1", "t2"})
 	assert.NoError(t, err)
 	assert.Len(t, taskAnnotations, 3)
 	assert.Len(t, GetLatestExecutions(taskAnnotations), 2)

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -129,8 +129,8 @@ func presignFile(ctx context.Context, file File) (string, error) {
 	return pail.PreSign(ctx, requestParams)
 }
 
-func GetAllArtifacts(tasks []TaskIDAndExecution) ([]File, error) {
-	artifacts, err := FindAll(ByTaskIdsAndExecutions(tasks))
+func GetAllArtifacts(ctx context.Context, tasks []TaskIDAndExecution) ([]File, error) {
+	artifacts, err := FindAll(ctx, ByTaskIdsAndExecutions(tasks))
 	if err != nil {
 		return nil, errors.Wrap(err, "finding artifact files for task")
 	}
@@ -139,7 +139,7 @@ func GetAllArtifacts(tasks []TaskIDAndExecution) ([]File, error) {
 		for _, t := range tasks {
 			taskIds = append(taskIds, t.TaskID)
 		}
-		artifacts, err = FindAll(ByTaskIds(taskIds))
+		artifacts, err = FindAll(ctx, ByTaskIds(taskIds))
 		if err != nil {
 			return nil, errors.Wrap(err, "finding artifact files for task without execution number")
 		}

--- a/model/artifact/artifact_file_test.go
+++ b/model/artifact/artifact_file_test.go
@@ -155,19 +155,19 @@ func (s *TestArtifactFileSuite) TestArtifactFieldsAfterUpdate() {
 }
 
 func (s *TestArtifactFileSuite) TestFindByTaskIdAndExecution() {
-	entries, err := FindAll(ByTaskIdAndExecution("task1", 1))
+	entries, err := FindAll(s.T().Context(), ByTaskIdAndExecution("task1", 1))
 	s.Len(entries, 1)
 	s.NoError(err)
 	s.NotNil(entries[0])
 	s.Equal(1, entries[0].Execution)
 	s.Equal("task1", entries[0].TaskId)
 
-	entries, err = FindAll(ByTaskIdAndExecution("task2", 0))
+	entries, err = FindAll(s.T().Context(), ByTaskIdAndExecution("task2", 0))
 	s.Empty(entries)
 	s.NoError(err)
 	s.Empty(entries)
 
-	entries, err = FindAll(ByTaskIdAndExecution("task2", 5))
+	entries, err = FindAll(s.T().Context(), ByTaskIdAndExecution("task2", 5))
 	s.Len(entries, 1)
 	s.NoError(err)
 	s.NotNil(entries[0])
@@ -176,11 +176,11 @@ func (s *TestArtifactFileSuite) TestFindByTaskIdAndExecution() {
 }
 
 func (s *TestArtifactFileSuite) TestFindByTaskIdWithoutExecution() {
-	entries, err := FindAll(ByTaskIdWithoutExecution("task1"))
+	entries, err := FindAll(s.T().Context(), ByTaskIdWithoutExecution("task1"))
 	s.Empty(entries)
 	s.NoError(err)
 
-	entries, err = FindAll(ByTaskIdWithoutExecution("task2"))
+	entries, err = FindAll(s.T().Context(), ByTaskIdWithoutExecution("task2"))
 	s.Len(entries, 1)
 	s.NoError(err)
 	s.NotNil(entries[0])
@@ -193,13 +193,13 @@ func (s *TestArtifactFileSuite) TestFindByIdsAndExecutions() {
 		{TaskID: "task1", Execution: 1},
 		{TaskID: "task2", Execution: 5},
 	}
-	entries, err := FindAll(ByTaskIdsAndExecutions(tasks))
+	entries, err := FindAll(s.T().Context(), ByTaskIdsAndExecutions(tasks))
 	s.NoError(err)
 	s.Len(entries, 2)
 }
 
 func (s *TestArtifactFileSuite) TestFindByIds() {
-	entries, err := FindAll(ByTaskIds([]string{"task1", "task2"}))
+	entries, err := FindAll(s.T().Context(), ByTaskIds([]string{"task1", "task2"}))
 	s.NoError(err)
 	s.Len(entries, 3)
 }

--- a/model/artifact/db.go
+++ b/model/artifact/db.go
@@ -129,8 +129,8 @@ func FindOne(ctx context.Context, query db.Q) (*Entry, error) {
 }
 
 // FindAll gets every Entry for the given query
-func FindAll(query db.Q) ([]Entry, error) {
+func FindAll(ctx context.Context, query db.Q) ([]Entry, error) {
 	entries := []Entry{}
-	err := db.FindAllQ(Collection, query, &entries)
+	err := db.FindAllQContext(ctx, Collection, query, &entries)
 	return entries, err
 }

--- a/model/build/build.go
+++ b/model/build/build.go
@@ -116,7 +116,7 @@ func getSetBuildActivatedUpdate(active bool, caller string) bson.M {
 
 // UpdateActivation updates builds with the given ids
 // to the given activation setting.
-func UpdateActivation(buildIds []string, active bool, caller string) error {
+func UpdateActivation(ctx context.Context, buildIds []string, active bool, caller string) error {
 	if len(buildIds) == 0 {
 		return nil
 	}
@@ -126,6 +126,7 @@ func UpdateActivation(buildIds []string, active bool, caller string) error {
 	}
 
 	err := UpdateAllBuilds(
+		ctx,
 		query,
 		bson.M{
 			"$set": getSetBuildActivatedUpdate(active, caller),

--- a/model/build/db.go
+++ b/model/build/db.go
@@ -218,8 +218,9 @@ func UpdateOne(ctx context.Context, query any, update any) error {
 	)
 }
 
-func UpdateAllBuilds(query any, update any) error {
-	_, err := db.UpdateAll(
+func UpdateAllBuilds(ctx context.Context, query any, update any) error {
+	_, err := db.UpdateAllContext(
+		ctx,
 		Collection,
 		query,
 		update,
@@ -256,7 +257,7 @@ func FindBuildsForTasks(tasks []task.Task) ([]Build, error) {
 }
 
 // SetBuildStartedForTasks sets tasks' builds status to started and activates them
-func SetBuildStartedForTasks(tasks []task.Task, caller string) error {
+func SetBuildStartedForTasks(ctx context.Context, tasks []task.Task, caller string) error {
 	buildIdSet := map[string]bool{}
 	for _, t := range tasks {
 		buildIdSet[t.BuildId] = true
@@ -270,6 +271,7 @@ func SetBuildStartedForTasks(tasks []task.Task, caller string) error {
 	update[StartTimeKey] = time.Now()
 	// Set the build status/activation for all the builds containing the tasks that we touched.
 	err := UpdateAllBuilds(
+		ctx,
 		bson.M{IdKey: bson.M{"$in": buildIdList}},
 		bson.M{"$set": update},
 	)

--- a/model/build_baron.go
+++ b/model/build_baron.go
@@ -56,20 +56,20 @@ func (mss *MultiSourceSuggest) Suggest(t *task.Task) ([]thirdparty.JiraTicket, s
 // GetBuildBaronSettings retrieves build baron settings from project settings.
 // Project page settings takes precedence, otherwise fallback to project config yaml.
 // Returns build baron settings and ok if found.
-func GetBuildBaronSettings(projectId string, version string) (evergreen.BuildBaronSettings, bool) {
-	projectRef, err := FindMergedProjectRef(projectId, version, true)
+func GetBuildBaronSettings(ctx context.Context, projectId string, version string) (evergreen.BuildBaronSettings, bool) {
+	projectRef, err := FindMergedProjectRef(ctx, projectId, version, true)
 	if err != nil || projectRef == nil {
 		return evergreen.BuildBaronSettings{}, false
 	}
 	return projectRef.BuildBaronSettings, true
 }
 
-func ValidateBbProject(projName string, proj evergreen.BuildBaronSettings, webhook *evergreen.WebHook) error {
+func ValidateBbProject(ctx context.Context, projName string, proj evergreen.BuildBaronSettings, webhook *evergreen.WebHook) error {
 	catcher := grip.NewBasicCatcher()
 	var err error
 	var webhookConfigured bool
 	if webhook == nil {
-		pRefWebHook, _, err := IsWebhookConfigured(projName, "")
+		pRefWebHook, _, err := IsWebhookConfigured(ctx, projName, "")
 		if err != nil {
 			return errors.Wrapf(err, "retrieving webhook config for project '%s'", projName)
 		}
@@ -132,7 +132,7 @@ func GetSearchReturnInfo(ctx context.Context, taskId string, exec string) (*thir
 		return nil, bbConfig, err
 	}
 	settings := evergreen.GetEnvironment().Settings()
-	bbProj, ok := GetBuildBaronSettings(t.Project, t.Version)
+	bbProj, ok := GetBuildBaronSettings(ctx, t.Project, t.Version)
 	if !ok {
 		// build baron project not found, meaning it's not configured for
 		// either regular build baron or for a custom ticket filing webhook

--- a/model/cache/cache.go
+++ b/model/cache/cache.go
@@ -78,7 +78,7 @@ func (c *DBCache) Set(ctx context.Context, key string, valueBytes []byte) error 
 
 // Delete removes the value associated with the key.
 func (c *DBCache) Delete(ctx context.Context, key string) error {
-	err := db.RemoveContext(ctx, collection, bson.M{IDKey: key})
+	err := db.Remove(ctx, collection, bson.M{IDKey: key})
 	grip.Error(message.WrapError(err,
 		message.Fields{
 			"message":   "deleting cached value",

--- a/model/context.go
+++ b/model/context.go
@@ -49,7 +49,7 @@ func LoadContext(ctx context.Context, taskId, buildId, versionId, patchId, proje
 	// Try to load project for the ID we found, and set cookie with it for subsequent requests
 	if len(projectId) > 0 {
 		// Also lookup the ProjectRef itself and add it to context.
-		c.ProjectRef, err = FindMergedProjectRef(projectId, versionId, true)
+		c.ProjectRef, err = FindMergedProjectRef(ctx, projectId, versionId, true)
 		if err != nil {
 			return c, err
 		}

--- a/model/event/event_test.go
+++ b/model/event/event_test.go
@@ -279,7 +279,7 @@ func (s *eventSuite) TestMarkProcessed() {
 	s.EqualError(event.MarkProcessed(s.T().Context()), "updating 'processed at' time: document not found")
 	s.NoError(event.Log())
 
-	s.NoError(db.UpdateId(EventCollection, event.ID, bson.M{
+	s.NoError(db.UpdateIdContext(s.T().Context(), EventCollection, event.ID, bson.M{
 		"$set": bson.M{
 			"processed_at": time.Time{},
 		},

--- a/model/event/subscribers_test.go
+++ b/model/event/subscribers_test.go
@@ -58,7 +58,7 @@ func TestSubscribers(t *testing.T) {
 	}
 
 	fetchedSubs := []Subscriber{}
-	assert.NoError(db.FindAllQ(SubscriptionsCollection, db.Q{}, &fetchedSubs))
+	assert.NoError(db.FindAllQContext(t.Context(), SubscriptionsCollection, db.Q{}, &fetchedSubs))
 
 	assert.Len(fetchedSubs, 5)
 
@@ -73,7 +73,7 @@ func TestSubscribers(t *testing.T) {
 		Target: "*boom*",
 	}))
 	fetchedSubs = []Subscriber{}
-	err := db.FindAllQ(SubscriptionsCollection, db.Q{}, &fetchedSubs)
+	err := db.FindAllQContext(t.Context(), SubscriptionsCollection, db.Q{}, &fetchedSubs)
 
 	require.Error(t, err)
 	assert.Contains(err.Error(), "unknown subscriber type 'something completely different'")

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -531,12 +531,12 @@ func FindSubscriptionByID(ctx context.Context, id string) (*Subscription, error)
 	return &out, nil
 }
 
-func RemoveSubscription(id string) error {
+func RemoveSubscription(ctx context.Context, id string) error {
 	if id == "" {
 		return errors.New("id is not valid, cannot remove")
 	}
 
-	return db.Remove(SubscriptionsCollection, bson.M{
+	return db.Remove(ctx, SubscriptionsCollection, bson.M{
 		subscriptionIDKey: id,
 	})
 }
@@ -753,7 +753,7 @@ func CreateOrUpdateGeneralSubscription(ctx context.Context, resourceType string,
 		}
 	} else {
 		if id != "" {
-			if err := RemoveSubscription(id); err != nil {
+			if err := RemoveSubscription(ctx, id); err != nil {
 				return nil, errors.Wrap(err, "removing subscription")
 			}
 			sub = nil

--- a/model/event/subscriptions_test.go
+++ b/model/event/subscriptions_test.go
@@ -152,7 +152,7 @@ func (s *subscriptionsSuite) SetupTest() {
 
 func (s *subscriptionsSuite) TestUpsert() {
 	out := []Subscription{}
-	s.NoError(db.FindAllQ(SubscriptionsCollection, db.Q{}, &out))
+	s.NoError(db.FindAllQContext(s.T().Context(), SubscriptionsCollection, db.Q{}, &out))
 
 	s.Require().Len(out, 6)
 
@@ -174,7 +174,7 @@ func (s *subscriptionsSuite) TestRemove() {
 		s.NoError(RemoveSubscription(s.subscriptions[i].ID))
 
 		out := []Subscription{}
-		s.NoError(db.FindAllQ(SubscriptionsCollection, db.Q{}, &out))
+		s.NoError(db.FindAllQContext(s.T().Context(), SubscriptionsCollection, db.Q{}, &out))
 		s.Len(out, len(s.subscriptions)-i-1)
 	}
 }

--- a/model/event/subscriptions_test.go
+++ b/model/event/subscriptions_test.go
@@ -171,7 +171,7 @@ func (s *subscriptionsSuite) TestUpsert() {
 
 func (s *subscriptionsSuite) TestRemove() {
 	for i := range s.subscriptions {
-		s.NoError(RemoveSubscription(s.subscriptions[i].ID))
+		s.NoError(RemoveSubscription(s.T().Context(), s.subscriptions[i].ID))
 
 		out := []Subscription{}
 		s.NoError(db.FindAllQContext(s.T().Context(), SubscriptionsCollection, db.Q{}, &out))

--- a/model/event/task_event_test.go
+++ b/model/event/task_event_test.go
@@ -114,6 +114,6 @@ func TestLogManyTestEvents(t *testing.T) {
 	require.NoError(db.ClearCollections(EventCollection))
 	LogManyTaskAbortRequests([]string{"task_1", "task_2"}, "example_user")
 	events := []EventLogEntry{}
-	assert.NoError(db.FindAllQ(EventCollection, db.Query(bson.M{}), &events))
+	assert.NoError(db.FindAllQContext(t.Context(), EventCollection, db.Query(bson.M{}), &events))
 	assert.Len(events, 2)
 }

--- a/model/generate.go
+++ b/model/generate.go
@@ -294,7 +294,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 	}
 
 	// This will only be populated for patches, not mainline commits.
-	projectRef, err := FindMergedProjectRef(p.Identifier, v.Id, true)
+	projectRef, err := FindMergedProjectRef(ctx, p.Identifier, v.Id, true)
 	if err != nil {
 		return errors.Wrapf(err, "finding merged project ref '%s' for version '%s'", p.Identifier, v.Id)
 	}

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -1140,7 +1140,7 @@ func (s *GenerateSuite) TestSaveWithAlreadyGeneratedTasksAndVariants() {
 
 	tasks := []task.Task{}
 	taskQuery := db.Query(bson.M{task.GeneratedByKey: "generator"}).Sort([]string{task.CreateTimeKey})
-	err = db.FindAllQ(task.Collection, taskQuery, &tasks)
+	err = db.FindAllQContext(s.ctx, task.Collection, taskQuery, &tasks)
 	s.NoError(err)
 	s.Require().Len(tasks, 3)
 	// New task is added both to previously generated variant, and new variant.
@@ -1235,7 +1235,7 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 	s.True(taskWithDepsFound, "task '%s' should have been added to build variant", expectedTask)
 
 	tasks := []task.Task{}
-	s.NoError(db.FindAllQ(task.Collection, db.Query(bson.M{task.DisplayNameKey: expectedTask}), &tasks))
+	s.NoError(db.FindAllQContext(s.ctx, task.Collection, db.Query(bson.M{task.DisplayNameKey: expectedTask}), &tasks))
 	s.Require().Len(tasks, 1)
 	s.Require().Len(tasks[0].DependsOn, 3)
 	expected := map[string]bool{"say-hi-task-id": false, "say-bye-task-id": false, "say_something_else": false}
@@ -1289,7 +1289,7 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependenciesInNewBuilds() {
 	s.NoError(g.Save(s.ctx, s.env.Settings(), p, pp, v))
 
 	tasks := []task.Task{}
-	s.NoError(db.FindAllQ(task.Collection, db.Query(bson.M{task.VersionKey: v.Id}), &tasks))
+	s.NoError(db.FindAllQContext(s.ctx, task.Collection, db.Query(bson.M{task.VersionKey: v.Id}), &tasks))
 	s.Require().Len(tasks, 4)
 	for _, t := range tasks {
 		s.True(t.Activated)
@@ -1849,10 +1849,10 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 	s.True(dtFound, "display task '%s' should have been added", expectedDisplayTask)
 
 	tasks := []task.Task{}
-	s.NoError(db.FindAllQ(task.Collection, db.Query(bson.M{}), &tasks))
-	s.NoError(db.FindAllQ(task.Collection, db.Query(bson.M{task.DisplayNameKey: "my_display_task_gen"}), &tasks))
+	s.NoError(db.FindAllQContext(s.ctx, task.Collection, db.Query(bson.M{}), &tasks))
+	s.NoError(db.FindAllQContext(s.ctx, task.Collection, db.Query(bson.M{task.DisplayNameKey: "my_display_task_gen"}), &tasks))
 	s.Len(tasks, 1)
-	s.NoError(db.FindAllQ(task.Collection, db.Query(bson.M{task.DisplayNameKey: "my_display_task"}), &tasks))
+	s.NoError(db.FindAllQContext(s.ctx, task.Collection, db.Query(bson.M{task.DisplayNameKey: "my_display_task"}), &tasks))
 	s.Len(tasks, 1)
 	s.Len(tasks[0].ExecutionTasks, 1)
 }

--- a/model/githubapp/github_app_auth_db.go
+++ b/model/githubapp/github_app_auth_db.go
@@ -174,7 +174,7 @@ func RemoveGitHubAppAuth(ctx context.Context, appAuth *GithubAppAuth) error {
 
 // removeGitHubAppAuthDB removes the GitHub app auth from the database.
 func removeGitHubAppAuthDB(ctx context.Context, id string) error {
-	return db.RemoveContext(
+	return db.Remove(
 		ctx,
 		GitHubAppAuthCollection,
 		bson.M{GhAuthIdKey: id},

--- a/model/host/volume.go
+++ b/model/host/volume.go
@@ -90,7 +90,7 @@ func (v *Volume) SetMigrating(ctx context.Context, migrating bool) error {
 // Note this shouldn't be used when you want to
 // remove from AWS itself.
 func (v *Volume) Remove(ctx context.Context) error {
-	return db.RemoveContext(
+	return db.Remove(
 		ctx,
 		VolumesCollection,
 		bson.M{

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -102,7 +102,7 @@ func SetVersionActivation(ctx context.Context, versionId string, active bool, ca
 	for buildId := range buildIdsMap {
 		buildIds = append(buildIds, buildId)
 	}
-	if err := build.UpdateActivation(buildIds, active, caller); err != nil {
+	if err := build.UpdateActivation(ctx, buildIds, active, caller); err != nil {
 		return errors.Wrapf(err, "setting build activations to %t", active)
 	}
 	if err := UpdateVersionAndPatchStatusForBuilds(ctx, buildIds); err != nil {
@@ -114,7 +114,7 @@ func SetVersionActivation(ctx context.Context, versionId string, active bool, ca
 // ActivateBuildsAndTasks updates the "active" state of this build and all associated tasks.
 // It also updates the task cache for the build document.
 func ActivateBuildsAndTasks(ctx context.Context, buildIds []string, active bool, caller string) error {
-	if err := build.UpdateActivation(buildIds, active, caller); err != nil {
+	if err := build.UpdateActivation(ctx, buildIds, active, caller); err != nil {
 		return errors.Wrapf(err, "setting build activation to %t for builds '%v'", active, buildIds)
 	}
 
@@ -184,7 +184,7 @@ func setTaskActivationForBuilds(ctx context.Context, buildIds []string, active, 
 // AbortBuild marks the build as deactivated and sets the abort flag on all tasks associated
 // with the build which are in an abortable state.
 func AbortBuild(ctx context.Context, buildId string, caller string) error {
-	if err := build.UpdateActivation([]string{buildId}, false, caller); err != nil {
+	if err := build.UpdateActivation(ctx, []string{buildId}, false, caller); err != nil {
 		return errors.Wrapf(err, "deactivating build '%s'", buildId)
 	}
 
@@ -421,7 +421,7 @@ func restartTasks(ctx context.Context, allFinishedTasks []task.Task, caller, ver
 		}
 	}
 
-	if err := build.SetBuildStartedForTasks(allFinishedTasks, caller); err != nil {
+	if err := build.SetBuildStartedForTasks(ctx, allFinishedTasks, caller); err != nil {
 		return errors.Wrap(err, "setting builds started")
 	}
 	builds, err := build.FindBuildsForTasks(allFinishedTasks)
@@ -1747,7 +1747,7 @@ func addNewTasksToExistingBuilds(ctx context.Context, creationInfo TaskCreationI
 		return nil, nil, errors.Wrap(err, "updating patch task limit for user")
 	}
 	if len(buildIdsToActivate) > 0 {
-		if err := build.UpdateActivation(buildIdsToActivate, true, caller); err != nil {
+		if err := build.UpdateActivation(ctx, buildIdsToActivate, true, caller); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -493,7 +493,7 @@ func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build
 
 	var githubCheckAliases ProjectAliases
 	if creationInfo.Version.Requester == evergreen.RepotrackerVersionRequester && creationInfo.ProjectRef.IsGithubChecksEnabled() {
-		githubCheckAliases, err = FindAliasInProjectRepoOrConfig(creationInfo.Version.Identifier, evergreen.GithubChecksAlias)
+		githubCheckAliases, err = FindAliasInProjectRepoOrConfig(ctx, creationInfo.Version.Identifier, evergreen.GithubChecksAlias)
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":            "error getting github check aliases when adding tasks to build",
 			"project":            creationInfo.Version.Identifier,

--- a/model/notification/notification.go
+++ b/model/notification/notification.go
@@ -1,6 +1,7 @@
 package notification
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -216,7 +217,7 @@ func (n *Notification) Composer() (message.Composer, error) {
 	}
 }
 
-func (n *Notification) MarkSent() error {
+func (n *Notification) MarkSent(ctx context.Context) error {
 	if len(n.ID) == 0 {
 		return errors.New("notification has no ID")
 	}
@@ -229,14 +230,14 @@ func (n *Notification) MarkSent() error {
 		},
 	}
 
-	if err := db.UpdateId(Collection, n.ID, update); err != nil {
+	if err := db.UpdateIdContext(ctx, Collection, n.ID, update); err != nil {
 		return errors.Wrap(err, "marking notification as sent")
 	}
 
 	return nil
 }
 
-func (n *Notification) MarkError(sendErr error) error {
+func (n *Notification) MarkError(ctx context.Context, sendErr error) error {
 	if sendErr == nil {
 		return nil
 	}
@@ -244,7 +245,7 @@ func (n *Notification) MarkError(sendErr error) error {
 		return errors.New("notification has no ID")
 	}
 	if n.SentAt.IsZero() {
-		if err := n.MarkSent(); err != nil {
+		if err := n.MarkSent(ctx); err != nil {
 			return err
 		}
 	}
@@ -257,7 +258,7 @@ func (n *Notification) MarkError(sendErr error) error {
 	}
 	n.Error = errMsg
 
-	if err := db.UpdateId(Collection, n.ID, update); err != nil {
+	if err := db.UpdateIdContext(ctx, Collection, n.ID, update); err != nil {
 		n.Error = ""
 		return errors.Wrap(err, "setting error for notification")
 	}

--- a/model/notification/notification_test.go
+++ b/model/notification/notification_test.go
@@ -54,7 +54,7 @@ func (s *notificationSuite) SetupTest() {
 
 func (s *notificationSuite) TestMarkSent() {
 	// MarkSent with notification that hasn't been stored
-	s.EqualError(s.n.MarkSent(), "notification has no ID")
+	s.EqualError(s.n.MarkSent(s.T().Context()), "notification has no ID")
 	s.Empty(s.n.ID)
 	s.Empty(s.n.Error)
 	s.Zero(s.n.SentAt)
@@ -63,7 +63,7 @@ func (s *notificationSuite) TestMarkSent() {
 	s.NoError(InsertMany(s.n))
 
 	// mark that notification as sent
-	s.NoError(s.n.MarkSent())
+	s.NoError(s.n.MarkSent(s.T().Context()))
 	s.Empty(s.n.Error)
 	s.NotZero(s.n.SentAt)
 
@@ -76,12 +76,12 @@ func (s *notificationSuite) TestMarkSent() {
 
 func (s *notificationSuite) TestMarkError() {
 	// MarkError, uninserted notification
-	s.EqualError(s.n.MarkError(errors.New("")), "notification has no ID")
+	s.EqualError(s.n.MarkError(s.T().Context(), errors.New("")), "notification has no ID")
 	s.Empty(s.n.ID)
 	s.Empty(s.n.Error)
 	s.Zero(s.n.SentAt)
 
-	s.NoError(s.n.MarkError(nil))
+	s.NoError(s.n.MarkError(s.T().Context(), nil))
 	s.Empty(s.n.ID)
 	s.Empty(s.n.Error)
 	s.Zero(s.n.SentAt)
@@ -90,7 +90,7 @@ func (s *notificationSuite) TestMarkError() {
 	s.n.ID = "1"
 	s.NoError(InsertMany(s.n))
 
-	s.NoError(s.n.MarkError(errors.New("test")))
+	s.NoError(s.n.MarkError(s.T().Context(), errors.New("test")))
 	s.NotEmpty(s.n.ID)
 	s.Equal("test", s.n.Error)
 	s.NotZero(s.n.SentAt)
@@ -106,7 +106,7 @@ func (s *notificationSuite) TestMarkErrorWithNilErrorHasNoSideEffect() {
 	s.NoError(InsertMany(s.n))
 
 	// nil error should have no side effect
-	s.NoError(s.n.MarkError(nil))
+	s.NoError(s.n.MarkError(s.T().Context(), nil))
 	n, err := Find(s.T().Context(), s.n.ID)
 	s.NoError(err)
 	s.Empty(n.Error)

--- a/model/notification/notification_test.go
+++ b/model/notification/notification_test.go
@@ -146,7 +146,7 @@ func (s *notificationSuite) TestInsertMany() {
 	}
 
 	out := []Notification{}
-	s.NoError(db.FindAllQ(Collection, db.Q{}, &out))
+	s.NoError(db.FindAllQContext(s.T().Context(), Collection, db.Q{}, &out))
 	s.Len(out, 3)
 
 	for _, n := range out {
@@ -211,7 +211,7 @@ func (s *notificationSuite) TestInsertManyUnordered() {
 
 	s.Error(InsertMany(slice...))
 	out := []Notification{}
-	s.NoError(db.FindAllQ(Collection, db.Q{}, &out))
+	s.NoError(db.FindAllQContext(s.T().Context(), Collection, db.Q{}, &out))
 	s.Len(out, 2)
 }
 

--- a/model/patch/cli_intent_test.go
+++ b/model/patch/cli_intent_test.go
@@ -1,6 +1,7 @@
 package patch
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -230,7 +231,7 @@ func (s *CliIntentSuite) TestInsert() {
 	s.Require().NoError(intent.Insert())
 
 	var intents []*cliIntent
-	intents, err = findCliIntents(false)
+	intents, err = findCliIntents(s.T().Context(), false)
 	s.NoError(err)
 	s.Len(intents, 1)
 	s.Equal(intent.ID(), intents[0].DocumentID)
@@ -257,16 +258,16 @@ func (s *CliIntentSuite) TestSetProcessed() {
 	s.True(intent.IsProcessed())
 
 	var intents []*cliIntent
-	intents, err = findCliIntents(true)
+	intents, err = findCliIntents(s.T().Context(), true)
 	s.NoError(err)
 	s.Len(intents, 1)
 
 	s.True(intents[0].Processed)
 }
 
-func findCliIntents(processed bool) ([]*cliIntent, error) {
+func findCliIntents(ctx context.Context, processed bool) ([]*cliIntent, error) {
 	var intents []*cliIntent
-	err := db.FindAllQ(IntentCollection, db.Query(bson.M{cliProcessedKey: processed, cliIntentTypeKey: CliIntentType}), &intents)
+	err := db.FindAllQContext(ctx, IntentCollection, db.Query(bson.M{cliProcessedKey: processed, cliIntentTypeKey: CliIntentType}), &intents)
 	if err != nil {
 		return []*cliIntent{}, err
 	}

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -336,8 +336,8 @@ func Remove(query db.Q) error {
 }
 
 // UpdateAll runs an update on all patch documents.
-func UpdateAll(query any, update any) (info *adb.ChangeInfo, err error) {
-	return db.UpdateAll(Collection, query, update)
+func UpdateAll(ctx context.Context, query any, update any) (info *adb.ChangeInfo, err error) {
+	return db.UpdateAllContext(ctx, Collection, query, update)
 }
 
 // UpdateOne runs an update on a single patch document.
@@ -394,7 +394,7 @@ func ConsolidatePatchesForUser(ctx context.Context, oldAuthor string, newUsr *us
 	update := bson.M{
 		"$set": bson.M{AuthorKey: newUsr.Id},
 	}
-	_, err = UpdateAll(byUser(oldAuthor), update)
+	_, err = UpdateAll(ctx, byUser(oldAuthor), update)
 	return err
 }
 

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -331,8 +331,8 @@ func Find(query db.Q) ([]Patch, error) {
 }
 
 // Remove removes all patch documents that satisfy the query.
-func Remove(query db.Q) error {
-	return db.RemoveAllQ(Collection, query)
+func Remove(ctx context.Context, query db.Q) error {
+	return db.RemoveAllQ(ctx, Collection, query)
 }
 
 // UpdateAll runs an update on all patch documents.

--- a/model/patch/github_merge_test.go
+++ b/model/patch/github_merge_test.go
@@ -61,7 +61,7 @@ func TestGithubMergeIntent(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NoError(t, intent.Insert())
 			intents := []githubMergeIntent{}
-			err = db.FindAllQ(IntentCollection, db.Query(bson.M{}), &intents)
+			err = db.FindAllQContext(t.Context(), IntentCollection, db.Query(bson.M{}), &intents)
 			assert.NoError(t, err)
 			assert.Len(t, intents, 1)
 			assert.Equal(t, intent, &intents[0])
@@ -74,7 +74,7 @@ func TestGithubMergeIntent(t *testing.T) {
 			assert.NoError(t, intent.Insert())
 			assert.NoError(t, intent.SetProcessed(t.Context()))
 			intents := []githubMergeIntent{}
-			err = db.FindAllQ(IntentCollection, db.Query(bson.M{}), &intents)
+			err = db.FindAllQContext(t.Context(), IntentCollection, db.Query(bson.M{}), &intents)
 			assert.NoError(t, err)
 			assert.Len(t, intents, 1)
 			assert.True(t, intents[0].IsProcessed())

--- a/model/patch/github_test.go
+++ b/model/patch/github_test.go
@@ -190,7 +190,7 @@ func (s *GithubSuite) TestSetProcessed() {
 	s.Empty(found)
 
 	var intents []githubIntent
-	s.NoError(db.FindAllQ(IntentCollection, db.Query(bson.M{processedKey: true}), &intents))
+	s.NoError(db.FindAllQContext(s.T().Context(), IntentCollection, db.Query(bson.M{processedKey: true}), &intents))
 	s.Len(intents, 1)
 	s.Equal(s.pr, intents[0].PRNumber)
 	s.Equal(s.hash, intents[0].HeadHash)

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -612,7 +612,7 @@ func (p *Patch) UpdateModulePatch(ctx context.Context, modulePatch ModulePatch) 
 		PatchesKey + "." + ModulePatchNameKey: modulePatch.ModuleName,
 	}
 	update := bson.M{PatchesKey + ".$": modulePatch}
-	result, err := UpdateAll(query, bson.M{"$set": update})
+	result, err := UpdateAll(ctx, query, bson.M{"$set": update})
 	if err != nil {
 		return err
 	}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -950,7 +950,7 @@ func CancelPatch(ctx context.Context, p *patch.Patch, reason task.AbortInfo) err
 		return errors.WithStack(task.AbortVersionTasks(ctx, p.Version, reason))
 	}
 
-	return errors.WithStack(patch.Remove(patch.ById(p.Id)))
+	return errors.WithStack(patch.Remove(ctx, patch.ById(p.Id)))
 }
 
 // AbortPatchesWithGithubPatchData aborts patches created

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -478,7 +478,7 @@ func TestGetFullPatchParams(t *testing.T) {
 	require.NoError(t, p.Insert())
 	require.NoError(t, alias.Upsert())
 
-	params, err := getFullPatchParams(&p)
+	params, err := getFullPatchParams(t.Context(), &p)
 	require.NoError(t, err)
 	require.Len(t, params, 3)
 	for _, param := range params {

--- a/model/pod/definition/definition.go
+++ b/model/pod/definition/definition.go
@@ -39,8 +39,8 @@ func (pd *PodDefinition) Upsert() error {
 }
 
 // Remove removes the pod definition from the collection.
-func (pd *PodDefinition) Remove() error {
-	return db.Remove(Collection, ByID(pd.ID))
+func (pd *PodDefinition) Remove(ctx context.Context) error {
+	return db.Remove(ctx, Collection, ByID(pd.ID))
 }
 
 // UpdateLastAccessed updates the time this pod definition was last accessed to
@@ -83,8 +83,8 @@ func (pdc PodDefinitionCache) Put(ctx context.Context, item cocoa.ECSPodDefiniti
 
 // Delete deletes a new pod definition by its external ID. If the pod definition
 // does not exist, this is a no-op.
-func (pdc PodDefinitionCache) Delete(_ context.Context, externalID string) error {
-	if err := db.Remove(Collection, bson.M{
+func (pdc PodDefinitionCache) Delete(ctx context.Context, externalID string) error {
+	if err := db.Remove(ctx, Collection, bson.M{
 		ExternalIDKey: externalID,
 	}); err != nil {
 		return errors.Wrapf(err, "deleting pod definition with external ID '%s'", externalID)

--- a/model/pod/pod.go
+++ b/model/pod/pod.go
@@ -581,8 +581,9 @@ func (p *Pod) InsertWithContext(ctx context.Context, env evergreen.Environment) 
 }
 
 // Remove removes the pod from the collection.
-func (p *Pod) Remove() error {
+func (p *Pod) Remove(ctx context.Context) error {
 	return db.Remove(
+		ctx,
 		Collection,
 		bson.M{
 			IDKey: p.ID,

--- a/model/pod/pod_test.go
+++ b/model/pod/pod_test.go
@@ -192,7 +192,7 @@ func TestRemove(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Zero(t, dbPod)
 
-			assert.NoError(t, p.Remove())
+			assert.NoError(t, p.Remove(t.Context()))
 		},
 		"SucceedsWithExistingPod": func(t *testing.T) {
 			p := Pod{
@@ -204,7 +204,7 @@ func TestRemove(t *testing.T) {
 			require.NoError(t, err)
 			require.NotNil(t, dbPod)
 
-			require.NoError(t, p.Remove())
+			require.NoError(t, p.Remove(t.Context()))
 
 			dbPod, err = FindOneByID(t.Context(), p.ID)
 			assert.NoError(t, err)

--- a/model/project.go
+++ b/model/project.go
@@ -1668,8 +1668,8 @@ func (p *Project) IgnoresAllFiles(files []string) bool {
 // variants will run and which tasks will run on each build variant. This
 // filters out tasks that cannot run due to being disabled or having an
 // unmatched requester (e.g. a patch-only task for a mainline commit).
-func (p *Project) BuildProjectTVPairs(patchDoc *patch.Patch, alias string) {
-	patchDoc.BuildVariants, patchDoc.Tasks, patchDoc.VariantsTasks = p.ResolvePatchVTs(patchDoc, patchDoc.GetRequester(), alias, true)
+func (p *Project) BuildProjectTVPairs(ctx context.Context, patchDoc *patch.Patch, alias string) {
+	patchDoc.BuildVariants, patchDoc.Tasks, patchDoc.VariantsTasks = p.ResolvePatchVTs(ctx, patchDoc, patchDoc.GetRequester(), alias, true)
 
 	// Connect the execution tasks to the display tasks.
 	displayTasksToExecTasks := map[string][]string{}
@@ -1700,7 +1700,7 @@ func (p *Project) BuildProjectTVPairs(patchDoc *patch.Patch, alias string) {
 // variant. If includeDeps is set, it will also resolve task dependencies. This
 // filters out tasks that cannot run due to being disabled or having an
 // unmatched requester (e.g. a patch-only task for a mainline commit).
-func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string, includeDeps bool) (resolvedBVs []string, resolvedTasks []string, vts []patch.VariantTasks) {
+func (p *Project) ResolvePatchVTs(ctx context.Context, patchDoc *patch.Patch, requester, alias string, includeDeps bool) (resolvedBVs []string, resolvedTasks []string, vts []patch.VariantTasks) {
 	var bvs, bvTags, tasks, taskTags []string
 	for _, bv := range patchDoc.BuildVariants {
 		// Tags should start with "."
@@ -1781,7 +1781,7 @@ func (p *Project) ResolvePatchVTs(patchDoc *patch.Patch, requester, alias string
 
 	if alias != "" {
 		catcher := grip.NewBasicCatcher()
-		aliases, err := findAliasesForPatch(p.Identifier, alias, patchDoc)
+		aliases, err := findAliasesForPatch(ctx, p.Identifier, alias, patchDoc)
 		catcher.Wrapf(err, "retrieving alias '%s' for patched project config '%s'", alias, patchDoc.Id.Hex())
 
 		aliasPairs := TaskVariantPairs{}
@@ -1876,7 +1876,7 @@ func (p *Project) IsGenerateTask(taskName string) bool {
 	return ok
 }
 
-func findAliasesForPatch(projectId, alias string, patchDoc *patch.Patch) ([]ProjectAlias, error) {
+func findAliasesForPatch(ctx context.Context, projectId, alias string, patchDoc *patch.Patch) ([]ProjectAlias, error) {
 	aliases, err := findAliasInProjectOrRepoFromDb(projectId, alias)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting alias from project")
@@ -1884,7 +1884,7 @@ func findAliasesForPatch(projectId, alias string, patchDoc *patch.Patch) ([]Proj
 	if len(aliases) > 0 {
 		return aliases, nil
 	}
-	pRef, err := FindMergedProjectRef(projectId, "", false)
+	pRef, err := FindMergedProjectRef(ctx, projectId, "", false)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting project ref")
 	}
@@ -1901,7 +1901,7 @@ func findAliasesForPatch(projectId, alias string, patchDoc *patch.Patch) ([]Proj
 			return nil, errors.Wrapf(err, "retrieving alias '%s' from project config", alias)
 		}
 	} else if patchDoc.Version != "" {
-		aliases, err = getMatchingAliasesForProjectConfig(projectId, patchDoc.Version, alias)
+		aliases, err = getMatchingAliasesForProjectConfig(ctx, projectId, patchDoc.Version, alias)
 		if err != nil {
 			return nil, errors.Wrapf(err, "retrieving alias '%s' from project config", alias)
 		}
@@ -2020,12 +2020,12 @@ func (p *Project) BuildProjectTVPairsWithAlias(aliases []ProjectAlias, requester
 	return res, nil
 }
 
-func (p *Project) VariantTasksForSelectors(definitions []patch.PatchTriggerDefinition, requester string) ([]patch.VariantTasks, error) {
+func (p *Project) VariantTasksForSelectors(ctx context.Context, definitions []patch.PatchTriggerDefinition, requester string) ([]patch.VariantTasks, error) {
 	projectAliases := []ProjectAlias{}
 	for _, definition := range definitions {
 		for _, specifier := range definition.TaskSpecifiers {
 			if specifier.PatchAlias != "" {
-				aliases, err := FindAliasInProjectRepoOrConfig(p.Identifier, specifier.PatchAlias)
+				aliases, err := FindAliasInProjectRepoOrConfig(ctx, p.Identifier, specifier.PatchAlias)
 				if err != nil {
 					return nil, errors.Wrap(err, "getting alias from project")
 				}

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -187,8 +188,8 @@ func findMatchingAliasForProjectRef(projectID, alias string) ([]ProjectAlias, er
 }
 
 // getMatchingAliasesForProjectConfig finds any aliases matching the alias input in the project config.
-func getMatchingAliasesForProjectConfig(projectID, versionID, alias string) ([]ProjectAlias, error) {
-	projectConfig, err := FindProjectConfigForProjectOrVersion(projectID, versionID)
+func getMatchingAliasesForProjectConfig(ctx context.Context, projectID, versionID, alias string) ([]ProjectAlias, error) {
+	projectConfig, err := FindProjectConfigForProjectOrVersion(ctx, projectID, versionID)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding project config")
 	}
@@ -223,7 +224,7 @@ func aliasesFromMap(input map[string]ProjectAliases) []ProjectAlias {
 
 // FindAliasInProjectRepoOrConfig finds all aliases with a given name for a project.
 // If the project has no aliases, the repo is checked for aliases.
-func FindAliasInProjectRepoOrConfig(projectID, alias string) ([]ProjectAlias, error) {
+func FindAliasInProjectRepoOrConfig(ctx context.Context, projectID, alias string) ([]ProjectAlias, error) {
 	aliases, err := findAliasInProjectOrRepoFromDb(projectID, alias)
 	if err != nil {
 		return nil, errors.Wrap(err, "checking for existing aliases")
@@ -232,7 +233,7 @@ func FindAliasInProjectRepoOrConfig(projectID, alias string) ([]ProjectAlias, er
 	if len(aliases) > 0 {
 		return aliases, nil
 	}
-	return getMatchingAliasesForProjectConfig(projectID, "", alias)
+	return getMatchingAliasesForProjectConfig(ctx, projectID, "", alias)
 }
 
 // patchAliasKey is used internally to group patch aliases together.
@@ -367,8 +368,8 @@ func tryGetRepoAliases(projectID string, alias string, aliases []ProjectAlias) (
 }
 
 // HasMatchingGitTagAliasAndRemotePath returns matching git tag aliases that match the given git tag
-func HasMatchingGitTagAliasAndRemotePath(projectId, tag string) (bool, string, error) {
-	aliases, err := FindMatchingGitTagAliasesInProject(projectId, tag)
+func HasMatchingGitTagAliasAndRemotePath(ctx context.Context, projectId, tag string) (bool, string, error) {
+	aliases, err := FindMatchingGitTagAliasesInProject(ctx, projectId, tag)
 	if err != nil {
 		return false, "", err
 	}
@@ -393,8 +394,8 @@ func CopyProjectAliases(oldProjectId, newProjectId string) error {
 	return nil
 }
 
-func FindMatchingGitTagAliasesInProject(projectID, tag string) ([]ProjectAlias, error) {
-	aliases, err := FindAliasInProjectRepoOrConfig(projectID, evergreen.GitTagAlias)
+func FindMatchingGitTagAliasesInProject(ctx context.Context, projectID, tag string) ([]ProjectAlias, error) {
+	aliases, err := FindAliasInProjectRepoOrConfig(ctx, projectID, evergreen.GitTagAlias)
 	if err != nil {
 		return nil, err
 	}

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -466,11 +466,11 @@ func UpsertAliasesForProject(aliases []ProjectAlias, projectId string) error {
 
 // RemoveProjectAlias removes a project alias with the given document ID from the
 // database.
-func RemoveProjectAlias(id string) error {
+func RemoveProjectAlias(ctx context.Context, id string) error {
 	if id == "" {
 		return errors.New("can't remove project alias with empty id")
 	}
-	err := db.Remove(ProjectAliasCollection, bson.M{idKey: mgobson.ObjectIdHex(id)})
+	err := db.Remove(ctx, ProjectAliasCollection, bson.M{idKey: mgobson.ObjectIdHex(id)})
 	if err != nil {
 		return errors.Wrapf(err, "removing project alias '%s'", id)
 	}

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -94,19 +94,19 @@ func (s *ProjectAliasSuite) TestHasMatchingGitTagAliasAndRemotePath() {
 		RemotePath: "file.yml",
 	}
 	s.NoError(newAlias2.Upsert())
-	hasAliases, path, err := HasMatchingGitTagAliasAndRemotePath("project_id", "release")
+	hasAliases, path, err := HasMatchingGitTagAliasAndRemotePath(s.T().Context(), "project_id", "release")
 	s.Error(err)
 	s.False(hasAliases)
 	s.Empty(path)
 
 	newAlias2.RemotePath = ""
 	s.NoError(newAlias2.Upsert())
-	hasAliases, path, err = HasMatchingGitTagAliasAndRemotePath("project_id", "release")
+	hasAliases, path, err = HasMatchingGitTagAliasAndRemotePath(s.T().Context(), "project_id", "release")
 	s.NoError(err)
 	s.True(hasAliases)
 	s.Empty(path)
 
-	hasAliases, path, err = HasMatchingGitTagAliasAndRemotePath("project_id2", "release")
+	hasAliases, path, err = HasMatchingGitTagAliasAndRemotePath(s.T().Context(), "project_id2", "release")
 	s.Error(err)
 	s.False(hasAliases)
 	s.Empty(path)
@@ -118,7 +118,7 @@ func (s *ProjectAliasSuite) TestHasMatchingGitTagAliasAndRemotePath() {
 		RemotePath: "file.yml",
 	}
 	s.NoError(newAlias3.Upsert())
-	hasAliases, path, err = HasMatchingGitTagAliasAndRemotePath("project_id2", "release")
+	hasAliases, path, err = HasMatchingGitTagAliasAndRemotePath(s.T().Context(), "project_id2", "release")
 	s.NoError(err)
 	s.True(hasAliases)
 	s.Equal("file.yml", path)
@@ -281,31 +281,31 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectOrConfig() {
 		}}
 	s.NoError(projectConfig.Insert())
 
-	projectAliases, err := FindAliasInProjectRepoOrConfig("project-1", evergreen.CommitQueueAlias)
+	projectAliases, err := FindAliasInProjectRepoOrConfig(s.T().Context(), "project-1", evergreen.CommitQueueAlias)
 	s.NoError(err)
 	s.Len(projectAliases, 2)
 
-	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", evergreen.GithubPRAlias)
+	projectAliases, err = FindAliasInProjectRepoOrConfig(s.T().Context(), "project-1", evergreen.GithubPRAlias)
 	s.NoError(err)
 	s.Len(projectAliases, 1)
 
-	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", evergreen.GithubChecksAlias)
+	projectAliases, err = FindAliasInProjectRepoOrConfig(s.T().Context(), "project-1", evergreen.GithubChecksAlias)
 	s.NoError(err)
 	s.Len(projectAliases, 1)
 
-	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", "alias-0")
+	projectAliases, err = FindAliasInProjectRepoOrConfig(s.T().Context(), "project-1", "alias-0")
 	s.NoError(err)
 	s.Len(projectAliases, 1)
-	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", "alias-1")
+	projectAliases, err = FindAliasInProjectRepoOrConfig(s.T().Context(), "project-1", "alias-1")
 	s.NoError(err)
 	s.Len(projectAliases, 1)
-	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", "alias-2")
+	projectAliases, err = FindAliasInProjectRepoOrConfig(s.T().Context(), "project-1", "alias-2")
 	s.NoError(err)
 	s.Len(projectAliases, 1)
 
 	// If the same alias is defined in both UI and project config,
 	// UI takes precedence.
-	projectAliases, err = FindAliasInProjectRepoOrConfig("project-1", "duplicate")
+	projectAliases, err = FindAliasInProjectRepoOrConfig(s.T().Context(), "project-1", "duplicate")
 	s.NoError(err)
 	s.Len(projectAliases, 1)
 	s.Equal("from UI", projectAliases[0].Description)
@@ -510,27 +510,27 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectRepoOrConfig() {
 	}
 
 	// Test project with aliases
-	found, err := FindAliasInProjectRepoOrConfig(pRef1.Id, "alias-3")
+	found, err := FindAliasInProjectRepoOrConfig(s.T().Context(), pRef1.Id, "alias-3")
 	s.NoError(err)
 	s.Len(found, 3)
 
 	// Test project without aliases; parent repo has aliases
-	found, err = FindAliasInProjectRepoOrConfig(pRef2.Id, "alias-1")
+	found, err = FindAliasInProjectRepoOrConfig(s.T().Context(), pRef2.Id, "alias-1")
 	s.NoError(err)
 	s.Len(found, 2)
 
 	// Test non-existent project
-	found, err = FindAliasInProjectRepoOrConfig("bad-project", "alias-1")
+	found, err = FindAliasInProjectRepoOrConfig(s.T().Context(), "bad-project", "alias-1")
 	s.Error(err)
 	s.Empty(found)
 
 	// Test no aliases found
-	found, err = FindAliasInProjectRepoOrConfig(pRef1.Id, "alias-5")
+	found, err = FindAliasInProjectRepoOrConfig(s.T().Context(), pRef1.Id, "alias-5")
 	s.NoError(err)
 	s.Empty(found)
 
 	// Test project config
-	found, err = FindAliasInProjectRepoOrConfig(pRef1.Id, "alias-6")
+	found, err = FindAliasInProjectRepoOrConfig(s.T().Context(), pRef1.Id, "alias-6")
 	s.NoError(err)
 	s.Require().Len(found, 1)
 	s.Equal("alias-6", found[0].Alias)
@@ -538,7 +538,7 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectRepoOrConfig() {
 	s.Equal("*", found[0].Variant)
 
 	// Test non-patch aliases defined in config
-	found, err = FindAliasInProjectRepoOrConfig(pRef1.Id, evergreen.CommitQueueAlias)
+	found, err = FindAliasInProjectRepoOrConfig(s.T().Context(), pRef1.Id, evergreen.CommitQueueAlias)
 	s.NoError(err)
 	s.Require().Len(found, 1)
 	s.Equal(evergreen.CommitQueueAlias, found[0].Alias)

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -154,12 +154,12 @@ func (s *ProjectAliasSuite) TestRemove() {
 	}
 	var out []ProjectAlias
 	q := db.Query(bson.M{})
-	s.NoError(db.FindAllQ(ProjectAliasCollection, q, &out))
+	s.NoError(db.FindAllQContext(s.T().Context(), ProjectAliasCollection, q, &out))
 	s.Len(out, 10)
 
 	for i, a := range s.aliases {
 		s.NoError(RemoveProjectAlias(a.ID.Hex()))
-		s.NoError(db.FindAllQ(ProjectAliasCollection, q, &out))
+		s.NoError(db.FindAllQContext(s.T().Context(), ProjectAliasCollection, q, &out))
 		s.Len(out, 10-i-1)
 	}
 }

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -158,7 +158,7 @@ func (s *ProjectAliasSuite) TestRemove() {
 	s.Len(out, 10)
 
 	for i, a := range s.aliases {
-		s.NoError(RemoveProjectAlias(a.ID.Hex()))
+		s.NoError(RemoveProjectAlias(s.T().Context(), a.ID.Hex()))
 		s.NoError(db.FindAllQContext(s.T().Context(), ProjectAliasCollection, q, &out))
 		s.Len(out, 10-i-1)
 	}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -599,7 +599,7 @@ func FindAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.
 func LoadProjectInfoForVersion(ctx context.Context, settings *evergreen.Settings, v *Version, id string) (ProjectInfo, error) {
 	var err error
 
-	pRef, err := FindMergedProjectRef(id, "", false)
+	pRef, err := FindMergedProjectRef(ctx, id, "", false)
 	if err != nil {
 		return ProjectInfo{}, errors.Wrap(err, "finding project ref")
 	}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -717,8 +717,8 @@ func (p *ProjectRef) GetPatchTriggerAlias(aliasName string) (patch.PatchTriggerD
 // the project ref scanning for any properties that can be set on both project ref and project parser.
 // Any values that are set at the project config level will be set on the project ref IF they are not set on
 // the project ref. If the version isn't specified, we get the latest config.
-func (p *ProjectRef) MergeWithProjectConfig(version string) (err error) {
-	projectConfig, err := FindProjectConfigForProjectOrVersion(p.Id, version)
+func (p *ProjectRef) MergeWithProjectConfig(ctx context.Context, version string) (err error) {
+	projectConfig, err := FindProjectConfigForProjectOrVersion(ctx, p.Id, version)
 	if err != nil {
 		return err
 	}
@@ -834,7 +834,7 @@ func (p *ProjectRef) DetachFromRepo(ctx context.Context, u *user.DBUser) error {
 		return err
 	}
 
-	mergedProject, err := FindMergedProjectRef(p.Id, "", false)
+	mergedProject, err := FindMergedProjectRef(ctx, p.Id, "", false)
 	if err != nil {
 		return errors.Wrap(err, "finding merged project ref")
 	}
@@ -1108,7 +1108,7 @@ func FindBranchProjectRef(identifier string) (*ProjectRef, error) {
 // FindMergedProjectRef also finds the repo ref settings and merges relevant fields.
 // Relevant fields will also be merged from the parser project with a specified version.
 // If no version is specified, the most recent valid parser project version will be used for merge.
-func FindMergedProjectRef(identifier string, version string, includeProjectConfig bool) (*ProjectRef, error) {
+func FindMergedProjectRef(ctx context.Context, identifier string, version string, includeProjectConfig bool) (*ProjectRef, error) {
 	pRef, err := FindBranchProjectRef(identifier)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding project ref '%s'", identifier)
@@ -1130,7 +1130,7 @@ func FindMergedProjectRef(identifier string, version string, includeProjectConfi
 		}
 	}
 	if includeProjectConfig && pRef.IsVersionControlEnabled() {
-		err = pRef.MergeWithProjectConfig(version)
+		err = pRef.MergeWithProjectConfig(ctx, version)
 		if err != nil {
 			return nil, errors.Wrapf(err, "merging project config with project ref '%s'", pRef.Identifier)
 		}
@@ -2087,8 +2087,8 @@ func GetProjectSettings(ctx context.Context, p *ProjectRef) (*ProjectSettings, e
 	return &projectSettingsEvent, nil
 }
 
-func IsPerfEnabledForProject(projectId string) bool {
-	projectRef, err := FindMergedProjectRef(projectId, "", true)
+func IsPerfEnabledForProject(ctx context.Context, projectId string) bool {
+	projectRef, err := FindMergedProjectRef(ctx, projectId, "", true)
 	if err != nil || projectRef == nil {
 		return false
 	}
@@ -3098,7 +3098,7 @@ func GetProjectRefForTask(ctx context.Context, taskId string) (*ProjectRef, erro
 	if t == nil {
 		return nil, errors.Errorf("task '%s' not found", taskId)
 	}
-	pRef, err := FindMergedProjectRef(t.Project, t.Version, true)
+	pRef, err := FindMergedProjectRef(ctx, t.Project, t.Version, true)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting project '%s'", t.Project)
 	}
@@ -3266,7 +3266,7 @@ func (c ContainerSecret) Validate() error {
 
 var validTriggerStatuses = []string{"", AllStatuses, evergreen.VersionSucceeded, evergreen.VersionFailed}
 
-func ValidateTriggerDefinition(definition patch.PatchTriggerDefinition, parentProject string) (patch.PatchTriggerDefinition, error) {
+func ValidateTriggerDefinition(ctx context.Context, definition patch.PatchTriggerDefinition, parentProject string) (patch.PatchTriggerDefinition, error) {
 	if definition.ChildProject == parentProject {
 		return definition, errors.New("a project cannot trigger itself")
 	}
@@ -3308,7 +3308,7 @@ func ValidateTriggerDefinition(definition patch.PatchTriggerDefinition, parentPr
 
 		if specifier.PatchAlias != "" {
 			var aliases []ProjectAlias
-			aliases, err = FindAliasInProjectRepoOrConfig(definition.ChildProject, specifier.PatchAlias)
+			aliases, err = FindAliasInProjectRepoOrConfig(ctx, definition.ChildProject, specifier.PatchAlias)
 			if err != nil {
 				return definition, errors.Wrap(err, "fetching aliases for project")
 			}
@@ -3338,8 +3338,8 @@ func (d *PeriodicBuildDefinition) Validate() error {
 }
 
 // IsWebhookConfigured retrieves webhook configuration from the project settings.
-func IsWebhookConfigured(project string, version string) (evergreen.WebHook, bool, error) {
-	projectRef, err := FindMergedProjectRef(project, version, true)
+func IsWebhookConfigured(ctx context.Context, project string, version string) (evergreen.WebHook, bool, error) {
+	projectRef, err := FindMergedProjectRef(ctx, project, version, true)
 	if err != nil || projectRef == nil {
 		return evergreen.WebHook{}, false, errors.Errorf("finding merged project ref for project '%s'", project)
 	}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -975,7 +975,7 @@ func (p *ProjectRef) AttachToNewRepo(ctx context.Context, u *user.DBUser) error 
 	}
 	update = p.addGithubConflictsToUpdate(update)
 
-	err = db.UpdateId(ProjectRefCollection, p.Id, bson.M{
+	err = db.UpdateIdContext(ctx, ProjectRefCollection, p.Id, bson.M{
 		"$set":   update,
 		"$unset": bson.M{ProjectRefTracksPushEventsKey: 1},
 	})
@@ -2153,8 +2153,8 @@ func (p *ProjectRef) SetRepotrackerError(ctx context.Context, d *RepositoryError
 }
 
 // SetContainerSecrets updates the container secrets for the project ref.
-func (p *ProjectRef) SetContainerSecrets(secrets []ContainerSecret) error {
-	if err := db.UpdateId(ProjectRefCollection, p.Id, bson.M{
+func (p *ProjectRef) SetContainerSecrets(ctx context.Context, secrets []ContainerSecret) error {
+	if err := db.UpdateIdContext(ctx, ProjectRefCollection, p.Id, bson.M{
 		"$set": bson.M{
 			projectRefContainerSecretsKey: secrets,
 		},

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2796,7 +2796,7 @@ func (p *ProjectRef) ValidateIdentifier() error {
 }
 
 // RemoveAdminFromProjects removes a user from all Admin slices of every project and repo
-func RemoveAdminFromProjects(toDelete string) error {
+func RemoveAdminFromProjects(ctx context.Context, toDelete string) error {
 	projectUpdate := bson.M{
 		"$pull": bson.M{
 			ProjectRefAdminsKey: toDelete,
@@ -2809,9 +2809,9 @@ func RemoveAdminFromProjects(toDelete string) error {
 	}
 
 	catcher := grip.NewBasicCatcher()
-	_, err := db.UpdateAll(ProjectRefCollection, bson.M{ProjectRefAdminsKey: bson.M{"$ne": nil}}, projectUpdate)
+	_, err := db.UpdateAllContext(ctx, ProjectRefCollection, bson.M{ProjectRefAdminsKey: bson.M{"$ne": nil}}, projectUpdate)
 	catcher.Wrap(err, "updating projects")
-	_, err = db.UpdateAll(RepoRefCollection, bson.M{RepoRefAdminsKey: bson.M{"$ne": nil}}, repoUpdate)
+	_, err = db.UpdateAllContext(ctx, RepoRefCollection, bson.M{RepoRefAdminsKey: bson.M{"$ne": nil}}, repoUpdate)
 	catcher.Wrap(err, "updating repos")
 	return catcher.Resolve()
 }

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -934,7 +934,7 @@ func (p *ProjectRef) AttachToRepo(ctx context.Context, u *user.DBUser) error {
 		ProjectRefRepoRefIdKey: p.RepoRefId, // This is set locally in AddToRepoScope
 	}
 	update = p.addGithubConflictsToUpdate(update)
-	err = db.UpdateId(ProjectRefCollection, p.Id, bson.M{
+	err = db.UpdateIdContext(ctx, ProjectRefCollection, p.Id, bson.M{
 		"$set":   update,
 		"$unset": bson.M{ProjectRefTracksPushEventsKey: 1},
 	})
@@ -2140,8 +2140,8 @@ func (p *ProjectRef) Upsert() error {
 }
 
 // SetRepotrackerError updates the repotracker error for the project ref.
-func (p *ProjectRef) SetRepotrackerError(d *RepositoryErrorDetails) error {
-	if err := db.UpdateId(ProjectRefCollection, p.Id, bson.M{
+func (p *ProjectRef) SetRepotrackerError(ctx context.Context, d *RepositoryErrorDetails) error {
+	if err := db.UpdateIdContext(ctx, ProjectRefCollection, p.Id, bson.M{
 		"$set": bson.M{
 			ProjectRefRepotrackerErrorKey: d,
 		},

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2371,7 +2371,7 @@ func DefaultSectionToRepo(ctx context.Context, projectId string, section Project
 		for _, a := range before.Aliases {
 			// remove only internal aliases; any alias without these labels is a patch alias
 			if utility.StringSliceContains(evergreen.InternalAliases, a.Alias) {
-				err = RemoveProjectAlias(a.ID.Hex())
+				err = RemoveProjectAlias(ctx, a.ID.Hex())
 				if err == nil {
 					modified = true // track if any aliases here were correctly modified so we can log the changes
 				}
@@ -2381,7 +2381,7 @@ func DefaultSectionToRepo(ctx context.Context, projectId string, section Project
 	case ProjectPageNotificationsSection:
 		// handle subscriptions
 		for _, sub := range before.Subscriptions {
-			err = event.RemoveSubscription(sub.ID)
+			err = event.RemoveSubscription(ctx, sub.ID)
 			if err == nil {
 				modified = true // track if any subscriptions were correctly modified so we can log the changes
 			}
@@ -2392,7 +2392,7 @@ func DefaultSectionToRepo(ctx context.Context, projectId string, section Project
 		// remove only patch aliases, i.e. aliases without an Evergreen-internal label
 		for _, a := range before.Aliases {
 			if !utility.StringSliceContains(evergreen.InternalAliases, a.Alias) {
-				err = RemoveProjectAlias(a.ID.Hex())
+				err = RemoveProjectAlias(ctx, a.ID.Hex())
 				if err == nil {
 					modified = true // track if any aliases were correctly modified so we can log the changes
 				}

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -4053,7 +4053,7 @@ func TestSetContainerSecrets(t *testing.T) {
 			ExternalName: "external_name",
 			ExternalID:   "external_id",
 		}}
-		require.NoError(t, pRef.SetContainerSecrets(secrets))
+		require.NoError(t, pRef.SetContainerSecrets(t.Context(), secrets))
 		dbProjRef, err := FindBranchProjectRef(pRef.Identifier)
 		require.NoError(t, err)
 		require.NotZero(t, dbProjRef)
@@ -4061,7 +4061,7 @@ func TestSetContainerSecrets(t *testing.T) {
 		assert.Equal(t, secrets, dbProjRef.ContainerSecrets)
 	})
 	t.Run("ClearsContainerSecrets", func(t *testing.T) {
-		require.NoError(t, pRef.SetContainerSecrets(nil))
+		require.NoError(t, pRef.SetContainerSecrets(t.Context(), nil))
 		dbProjRef, err := FindBranchProjectRef(pRef.Identifier)
 		require.NoError(t, err)
 		require.NotZero(t, dbProjRef)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -4019,7 +4019,7 @@ func TestSetRepotrackerError(t *testing.T) {
 			InvalidRevision:   "invalid_revision",
 			MergeBaseRevision: "merge_base_revision",
 		}
-		require.NoError(t, pRef.SetRepotrackerError(repotrackerErr))
+		require.NoError(t, pRef.SetRepotrackerError(t.Context(), repotrackerErr))
 		dbProjRef, err := FindBranchProjectRef(pRef.Identifier)
 		require.NoError(t, err)
 		require.NotZero(t, dbProjRef)
@@ -4027,7 +4027,7 @@ func TestSetRepotrackerError(t *testing.T) {
 		assert.Equal(t, *repotrackerErr, *dbProjRef.RepotrackerError)
 	})
 	t.Run("ClearsError", func(t *testing.T) {
-		require.NoError(t, pRef.SetRepotrackerError(&RepositoryErrorDetails{}))
+		require.NoError(t, pRef.SetRepotrackerError(t.Context(), &RepositoryErrorDetails{}))
 		dbProjRef, err := FindBranchProjectRef(pRef.Identifier)
 		require.NoError(t, err)
 		require.NotZero(t, dbProjRef)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1119,7 +1119,7 @@ func TestDetachFromRepo(t *testing.T) {
 			assert.NoError(t, pRef.AttachToRepo(ctx, dbUser))
 			assert.NotEmpty(t, pRef.RepoRefId)
 			assert.True(t, pRef.UseRepoSettings())
-			assert.NoError(t, RemoveProjectAlias(projectAlias.ID.Hex()))
+			assert.NoError(t, RemoveProjectAlias(ctx, projectAlias.ID.Hex()))
 
 			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 			aliases, err = FindAliasesForProjectFromDb(pRef.Id)
@@ -1203,7 +1203,7 @@ func TestDetachFromRepo(t *testing.T) {
 
 			// reattach to repo to test without subscription
 			assert.NoError(t, pRef.AttachToRepo(ctx, dbUser))
-			assert.NoError(t, event.RemoveSubscription(projectSubscription.ID))
+			assert.NoError(t, event.RemoveSubscription(ctx, projectSubscription.ID))
 			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 
 			subs, err = event.FindSubscriptionsByOwner(pRef.Id, event.OwnerTypeProject)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -124,7 +124,7 @@ func TestFindMergedProjectRef(t *testing.T) {
 	}}
 	assert.NoError(t, repoRef.Upsert())
 
-	mergedProject, err := FindMergedProjectRef("ident", "ident", true)
+	mergedProject, err := FindMergedProjectRef(t.Context(), "ident", "ident", true)
 	assert.NoError(t, err)
 	require.NotNil(t, mergedProject)
 	assert.Equal(t, "ident", mergedProject.Id)
@@ -158,13 +158,13 @@ func TestFindMergedProjectRef(t *testing.T) {
 	projectRef.ParsleyFilters = []parsley.Filter{}
 
 	assert.NoError(t, projectRef.Upsert())
-	mergedProject, err = FindMergedProjectRef("ident", "ident", true)
+	mergedProject, err = FindMergedProjectRef(t.Context(), "ident", "ident", true)
 	assert.NoError(t, err)
 	assert.Len(t, mergedProject.ParsleyFilters, 1)
 
 	projectRef.ParsleyFilters = nil
 	assert.NoError(t, projectRef.Upsert())
-	mergedProject, err = FindMergedProjectRef("ident", "ident", true)
+	mergedProject, err = FindMergedProjectRef(t.Context(), "ident", "ident", true)
 	assert.NoError(t, err)
 	assert.Len(t, mergedProject.ParsleyFilters, 1)
 }
@@ -389,7 +389,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 
 	// Should error when trying to enable an existing project past limits.
 	disabled1.Enabled = true
-	original, err := FindMergedProjectRef(disabled1.Id, "", false)
+	original, err := FindMergedProjectRef(t.Context(), disabled1.Id, "", false)
 	assert.NoError(t, err)
 	statusCode, err := ValidateEnabledProjectsLimit(disabled1.Id, &settings, original, disabled1)
 	assert.Error(t, err)
@@ -402,7 +402,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 		Repo:    "repo_exception",
 		Enabled: true,
 	}
-	original, err = FindMergedProjectRef(exception.Id, "", false)
+	original, err = FindMergedProjectRef(t.Context(), exception.Id, "", false)
 	assert.NoError(t, err)
 	_, err = ValidateEnabledProjectsLimit(enabled1.Id, &settings, original, exception)
 	assert.NoError(t, err)
@@ -414,7 +414,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 		Repo:    "mci",
 		Enabled: true,
 	}
-	original, err = FindMergedProjectRef(notException.Id, "", false)
+	original, err = FindMergedProjectRef(t.Context(), notException.Id, "", false)
 	assert.NoError(t, err)
 	statusCode, err = ValidateEnabledProjectsLimit(notException.Id, &settings, original, notException)
 	assert.Error(t, err)
@@ -425,7 +425,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 	assert.NoError(t, disableRepo.Upsert())
 	mergedRef, err := GetProjectRefMergedWithRepo(*disabledByRepo)
 	assert.NoError(t, err)
-	original, err = FindMergedProjectRef(disabledByRepo.Id, "", false)
+	original, err = FindMergedProjectRef(t.Context(), disabledByRepo.Id, "", false)
 	assert.NoError(t, err)
 	_, err = ValidateEnabledProjectsLimit(disabledByRepo.Id, &settings, original, mergedRef)
 	assert.NoError(t, err)
@@ -433,7 +433,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 	// Should error on enabled if you try to change owner/repo past limit.
 	enabled2.Owner = "mongodb"
 	enabled2.Repo = "mci"
-	original, err = FindMergedProjectRef(enabled2.Id, "", false)
+	original, err = FindMergedProjectRef(t.Context(), enabled2.Id, "", false)
 	assert.NoError(t, err)
 	statusCode, err = ValidateEnabledProjectsLimit(enabled2.Id, &settings, original, enabled2)
 	assert.Error(t, err)
@@ -441,7 +441,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 
 	// Total project limit cannot be exceeded. Even with the exception.
 	settings.ProjectCreation.TotalProjectLimit = 2
-	original, err = FindMergedProjectRef(exception.Id, "", false)
+	original, err = FindMergedProjectRef(t.Context(), exception.Id, "", false)
 	assert.NoError(t, err)
 	statusCode, err = ValidateEnabledProjectsLimit(exception.Id, &settings, original, exception)
 	assert.Error(t, err)
@@ -863,7 +863,7 @@ func TestAttachToNewRepo(t *testing.T) {
 
 	assert.True(t, newRepoRef.DoesTrackPushEvents())
 
-	mergedRef, err := FindMergedProjectRef(pRef.Id, "", false)
+	mergedRef, err := FindMergedProjectRef(t.Context(), pRef.Id, "", false)
 	assert.NoError(t, err)
 	assert.True(t, mergedRef.DoesTrackPushEvents())
 
@@ -2949,7 +2949,7 @@ func TestContainerSecretCache(t *testing.T) {
 				Name: pRef.ContainerSecrets[0].ExternalName,
 			}))
 
-			dbProjRef, err := FindMergedProjectRef(pRef.Id, "", false)
+			dbProjRef, err := FindMergedProjectRef(t.Context(), pRef.Id, "", false)
 			require.NoError(t, err)
 			require.NotZero(t, dbProjRef)
 			require.Len(t, dbProjRef.ContainerSecrets, len(pRef.ContainerSecrets))
@@ -2973,7 +2973,7 @@ func TestContainerSecretCache(t *testing.T) {
 				Name: "nonexistent",
 			}))
 
-			dbProjRef, err := FindMergedProjectRef(pRef.Id, "", false)
+			dbProjRef, err := FindMergedProjectRef(t.Context(), pRef.Id, "", false)
 			require.NoError(t, err)
 			require.NotZero(t, dbProjRef)
 			require.Len(t, dbProjRef.ContainerSecrets, len(pRef.ContainerSecrets))
@@ -2989,7 +2989,7 @@ func TestContainerSecretCache(t *testing.T) {
 				Name: pRef.ContainerSecrets[0].ExternalName,
 			}))
 
-			dbProjRef, err := FindMergedProjectRef(pRef.Id, "", false)
+			dbProjRef, err := FindMergedProjectRef(t.Context(), pRef.Id, "", false)
 			require.NoError(t, err)
 			require.NotZero(t, dbProjRef)
 			require.Len(t, dbProjRef.ContainerSecrets, len(pRef.ContainerSecrets))
@@ -3006,7 +3006,7 @@ func TestContainerSecretCache(t *testing.T) {
 				Name: pRef.ContainerSecrets[0].ExternalName,
 			}))
 
-			dbProjRef, err := FindMergedProjectRef(pRef.Id, "", false)
+			dbProjRef, err := FindMergedProjectRef(t.Context(), pRef.Id, "", false)
 			require.NoError(t, err)
 			require.NotZero(t, dbProjRef)
 			require.Len(t, dbProjRef.ContainerSecrets, len(pRef.ContainerSecrets))
@@ -3018,7 +3018,7 @@ func TestContainerSecretCache(t *testing.T) {
 			require.NoError(t, pRef.Insert())
 			require.NoError(t, c.Delete(ctx, pRef.ContainerSecrets[1].ExternalID))
 
-			dbProjRef, err := FindMergedProjectRef(pRef.Id, "", false)
+			dbProjRef, err := FindMergedProjectRef(t.Context(), pRef.Id, "", false)
 			require.NoError(t, err)
 			require.NotZero(t, dbProjRef)
 			require.Len(t, dbProjRef.ContainerSecrets, len(pRef.ContainerSecrets)-1)
@@ -3032,7 +3032,7 @@ func TestContainerSecretCache(t *testing.T) {
 			require.NoError(t, pRef.Insert())
 			assert.NoError(t, c.Delete(ctx, "nonexistent"), "should not error for nonexistent container secret")
 
-			dbProjRef, err := FindMergedProjectRef(pRef.Id, "", false)
+			dbProjRef, err := FindMergedProjectRef(t.Context(), pRef.Id, "", false)
 			require.NoError(t, err)
 			require.NotZero(t, dbProjRef)
 			assert.Len(t, dbProjRef.ContainerSecrets, len(pRef.ContainerSecrets))
@@ -3735,7 +3735,7 @@ func TestMergeWithProjectConfig(t *testing.T) {
 	assert.NoError(t, projectRef.Insert())
 	assert.NoError(t, projectConfig.Insert())
 
-	err := projectRef.MergeWithProjectConfig("version1")
+	err := projectRef.MergeWithProjectConfig(t.Context(), "version1")
 	assert.NoError(t, err)
 	require.NotNil(t, projectRef)
 	assert.Equal(t, "ident", projectRef.Id)
@@ -3761,7 +3761,7 @@ func TestMergeWithProjectConfig(t *testing.T) {
 			MemoryMB: 800,
 		},
 	}
-	err = projectRef.MergeWithProjectConfig("version1")
+	err = projectRef.MergeWithProjectConfig(t.Context(), "version1")
 	assert.NoError(t, err)
 	require.NotNil(t, projectRef)
 	assert.Equal(t, 4, projectRef.ContainerSizeDefinitions[0].CPU)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -3616,7 +3616,7 @@ func TestRemoveAdminFromProjects(t *testing.T) {
 	assert.NoError(t, repoRef2.Upsert())
 	assert.NoError(t, repoRef3.Upsert())
 
-	assert.NoError(t, RemoveAdminFromProjects("villain"))
+	assert.NoError(t, RemoveAdminFromProjects(t.Context(), "villain"))
 
 	// verify that we carry out multiple updates
 	pRefFromDB, err := FindBranchProjectRef(pRef.Id)

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -924,7 +924,7 @@ func (s *projectSuite) TestBuildProjectTVPairs() {
 		Tasks:         []string{"all"},
 	}
 
-	s.project.BuildProjectTVPairs(&patchDoc, evergreen.PatchVersionRequester)
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, evergreen.PatchVersionRequester)
 
 	s.Len(patchDoc.BuildVariants, 2)
 	s.ElementsMatch([]string{"bv_1", "bv_2"}, patchDoc.BuildVariants)
@@ -968,7 +968,7 @@ func (s *projectSuite) TestBuildProjectTVPairs() {
 	patchDoc.Tasks = []string{"all"}
 	patchDoc.VariantsTasks = []patch.VariantTasks{}
 
-	s.project.BuildProjectTVPairs(&patchDoc, evergreen.PatchVersionRequester)
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, evergreen.PatchVersionRequester)
 
 	s.Len(patchDoc.BuildVariants, 2)
 	s.Len(patchDoc.Tasks, 6)
@@ -977,7 +977,7 @@ func (s *projectSuite) TestBuildProjectTVPairs() {
 	patchDoc.BuildVariants = []string{"all"}
 	patchDoc.VariantsTasks = []patch.VariantTasks{}
 
-	s.project.BuildProjectTVPairs(&patchDoc, evergreen.PatchVersionRequester)
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, evergreen.PatchVersionRequester)
 
 	s.Len(patchDoc.BuildVariants, 2)
 	s.Len(patchDoc.Tasks, 6)
@@ -990,7 +990,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		Tasks:         []string{"all"},
 	}
 
-	bvs, tasks, variantTasks := s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
+	bvs, tasks, variantTasks := s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "", true)
 	s.Len(bvs, 2)
 	s.ElementsMatch([]string{"bv_1", "bv_2"}, bvs)
 	s.Len(tasks, 7)
@@ -1037,7 +1037,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		RegexTasks:         []string{"_1$"},
 	}
 
-	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "", true)
 	s.Len(bvs, 2)
 	s.Len(tasks, 7)
 	s.Len(variantTasks, 2)
@@ -1048,7 +1048,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		RegexTasks:         []string{"_1$"},
 	}
 
-	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "", true)
 	s.Len(bvs, 2)
 	s.Contains(bvs, "bv_1")
 	s.Contains(bvs, "bv_2")
@@ -1070,7 +1070,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		RegexTasks:    []string{"_1$"},
 	}
 
-	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "", true)
 	s.Len(bvs, 2)
 	s.Contains(bvs, "bv_1")
 	s.Contains(bvs, "bv_2")
@@ -1092,7 +1092,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		RegexTasks:    []string{"_1$"},
 	}
 
-	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "", true)
 	s.Len(bvs, 2)
 	s.Contains(bvs, "bv_1")
 	s.Contains(bvs, "bv_2")
@@ -1114,7 +1114,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		RegexTasks:         []string{"_1$"},
 	}
 
-	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "aTags", true)
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "aTags", true)
 	s.Len(bvs, 2)
 	s.Contains(bvs, "bv_1")
 	s.Contains(bvs, "bv_2")
@@ -1138,7 +1138,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		Tasks:         []string{".a", ".1"},
 	}
 
-	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "", true)
 	s.Len(bvs, 1)
 	s.Contains(bvs, "bv_2")
 	s.Len(tasks, 3)
@@ -1161,7 +1161,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		Tasks:         []string{".a", ".1", "b_task_2"},
 	}
 
-	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "", true)
 	s.Len(bvs, 2)
 	s.Contains(bvs, "bv_1")
 	s.Contains(bvs, "bv_2")
@@ -1188,7 +1188,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		RegexTasks:    []string{"_1$"},
 	}
 
-	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(&patchDoc, patchDoc.GetRequester(), "", true)
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "", true)
 	s.Len(bvs, 2)
 	s.Contains(bvs, "bv_1")
 	s.Contains(bvs, "bv_2")
@@ -1211,7 +1211,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 func (s *projectSuite) TestBuildProjectTVPairsWithAlias() {
 	patchDoc := patch.Patch{}
 
-	s.project.BuildProjectTVPairs(&patchDoc, "2tasks(obsolete)")
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "2tasks(obsolete)")
 
 	s.Len(patchDoc.BuildVariants, 2)
 	s.Contains(patchDoc.BuildVariants, "bv_1")
@@ -1237,7 +1237,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithBadBuildVariant() {
 		Tasks:         []string{"a_task_1", "b_task_1"},
 	}
 
-	s.project.BuildProjectTVPairs(&patchDoc, "")
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "")
 
 	s.Require().Len(patchDoc.Tasks, 2)
 	s.Contains(patchDoc.Tasks, "a_task_1")
@@ -1260,7 +1260,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithBadBuildVariant() {
 func (s *projectSuite) TestBuildProjectTVPairsWithAliasWithTags() {
 	patchDoc := patch.Patch{}
 
-	s.project.BuildProjectTVPairs(&patchDoc, "aTags")
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "aTags")
 
 	s.Len(patchDoc.BuildVariants, 2)
 	s.Contains(patchDoc.BuildVariants, "bv_1")
@@ -1283,7 +1283,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithAliasWithTags() {
 func (s *projectSuite) TestBuildProjectTVPairsWithAliasWithDisplayTask() {
 	patchDoc := patch.Patch{}
 
-	s.project.BuildProjectTVPairs(&patchDoc, "memes")
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "memes")
 	s.Len(patchDoc.BuildVariants, 2)
 	s.Contains(patchDoc.BuildVariants, "bv_1")
 	s.Contains(patchDoc.BuildVariants, "bv_2")
@@ -1310,7 +1310,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithAliasWithDisplayTask() {
 func (s *projectSuite) TestBuildProjectTVPairsWithDisabledBuildVariant() {
 	patchDoc := patch.Patch{}
 
-	s.project.BuildProjectTVPairs(&patchDoc, "disabled_stuff")
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "disabled_stuff")
 	s.Empty(patchDoc.BuildVariants)
 	s.Empty(patchDoc.Tasks)
 	s.Empty(patchDoc.VariantsTasks)
@@ -1320,7 +1320,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithDisabledBuildVariant() {
 		Tasks:         []string{"disabled_task"},
 	}
 
-	s.project.BuildProjectTVPairs(&patchDoc, "")
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "")
 	s.Empty(patchDoc.BuildVariants)
 	s.Empty(patchDoc.Tasks)
 	s.Empty(patchDoc.VariantsTasks)
@@ -1332,7 +1332,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithDisplayTaskWithDependencies() 
 		Tasks:         []string{"memes"},
 	}
 
-	s.project.BuildProjectTVPairs(&patchDoc, "")
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "")
 	s.Len(patchDoc.BuildVariants, 2)
 	s.Contains(patchDoc.BuildVariants, "bv_1")
 	s.Contains(patchDoc.BuildVariants, "bv_2")
@@ -1364,7 +1364,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithDisplayTaskWithDependencies() 
 
 func (s *projectSuite) TestBuildProjectTVPairsWithExecutionTaskFromTags() {
 	patchDoc := patch.Patch{}
-	s.project.BuildProjectTVPairs(&patchDoc, "part_of_memes")
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "part_of_memes")
 	s.Len(patchDoc.BuildVariants, 2)
 	s.Contains(patchDoc.BuildVariants, "bv_1")
 	s.Len(patchDoc.Tasks, 3)
@@ -1391,7 +1391,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithExecutionTask() {
 		BuildVariants: []string{"bv_1"},
 		Tasks:         []string{"9001_task"},
 	}
-	s.project.BuildProjectTVPairs(&patchDoc, "")
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "")
 	s.Len(patchDoc.BuildVariants, 2)
 	s.Contains(patchDoc.BuildVariants, "bv_1")
 	s.Contains(patchDoc.BuildVariants, "bv_2")
@@ -2088,7 +2088,7 @@ func TestVariantTasksForSelectors(t *testing.T) {
 	for testName, test := range map[string]func(*testing.T){
 		"patch alias selector": func(t *testing.T) {
 			definitions := []patch.PatchTriggerDefinition{{TaskSpecifiers: []patch.TaskSpecifier{{PatchAlias: alias}}}}
-			vts, err := project.VariantTasksForSelectors(definitions, "")
+			vts, err := project.VariantTasksForSelectors(t.Context(), definitions, "")
 			assert.NoError(t, err)
 			require.Len(t, vts, 1)
 			require.Len(t, vts[0].Tasks, 1)
@@ -2096,7 +2096,7 @@ func TestVariantTasksForSelectors(t *testing.T) {
 		},
 		"selector with dependency": func(t *testing.T) {
 			definitions := []patch.PatchTriggerDefinition{{TaskSpecifiers: []patch.TaskSpecifier{{VariantRegex: "bv0", TaskRegex: "t1"}}}}
-			vts, err := project.VariantTasksForSelectors(definitions, "")
+			vts, err := project.VariantTasksForSelectors(t.Context(), definitions, "")
 			assert.NoError(t, err)
 			require.Len(t, vts, 1)
 			require.Len(t, vts[0].Tasks, 2)
@@ -2105,7 +2105,7 @@ func TestVariantTasksForSelectors(t *testing.T) {
 		},
 		"selector with display task": func(t *testing.T) {
 			definitions := []patch.PatchTriggerDefinition{{TaskSpecifiers: []patch.TaskSpecifier{{VariantRegex: "bv0", TaskRegex: "dt0"}}}}
-			vts, err := project.VariantTasksForSelectors(definitions, "")
+			vts, err := project.VariantTasksForSelectors(t.Context(), definitions, "")
 			assert.NoError(t, err)
 			require.Len(t, vts, 1)
 			require.Len(t, vts[0].Tasks, 1)

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1676,7 +1676,7 @@ func UpdateAllWithHint(ctx context.Context, query any, update any, hint any) (*a
 
 // Remove deletes the task of the given id from the database
 func Remove(ctx context.Context, id string) error {
-	return db.RemoveContext(
+	return db.Remove(
 		ctx,
 		Collection,
 		bson.M{IdKey: id},

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -91,14 +91,14 @@ func SetActiveState(ctx context.Context, caller string, active bool, tasks ...ta
 		for v := range versionIdsSet {
 			versionIdsToActivate = append(versionIdsToActivate, v)
 		}
-		if err := ActivateVersions(versionIdsToActivate); err != nil {
+		if err := ActivateVersions(ctx, versionIdsToActivate); err != nil {
 			return errors.Wrap(err, "marking version as activated")
 		}
 		buildIdsToActivate := []string{}
 		for b := range buildToTaskMap {
 			buildIdsToActivate = append(buildIdsToActivate, b)
 		}
-		if err := build.UpdateActivation(buildIdsToActivate, true, caller); err != nil {
+		if err := build.UpdateActivation(ctx, buildIdsToActivate, true, caller); err != nil {
 			return errors.Wrap(err, "marking builds as activated")
 		}
 	} else {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -892,7 +892,7 @@ func getDeactivatePrevious(t *task.Task, pRef *ProjectRef, project *Project) boo
 
 func attemptStepbackAndDeactivatePrevious(ctx context.Context, t *task.Task, status, caller string) {
 	catcher := grip.NewBasicCatcher()
-	pRef, err := FindMergedProjectRef(t.Project, t.Version, false)
+	pRef, err := FindMergedProjectRef(ctx, t.Project, t.Version, false)
 	if err != nil {
 		catcher.Wrapf(err, "finding merged project ref for task '%s'", t.Id)
 	}

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -92,12 +92,12 @@ func getDistroQueueInfoCollection(distroID, collection string) (DistroQueueInfo,
 	return taskQueue.DistroQueueInfo, nil
 }
 
-func RemoveTaskQueues(distroID string) error {
+func RemoveTaskQueues(ctx context.Context, distroID string) error {
 	query := db.Query(bson.M{taskQueueDistroKey: distroID})
 	catcher := grip.NewBasicCatcher()
-	err := db.RemoveAllQ(TaskQueuesCollection, query)
+	err := db.RemoveAllQ(ctx, TaskQueuesCollection, query)
 	catcher.AddWhen(!adb.ResultsNotFound(err), errors.Wrapf(err, "removing task queue for distro '%s'", distroID))
-	err = db.RemoveAllQ(TaskSecondaryQueuesCollection, query)
+	err = db.RemoveAllQ(ctx, TaskSecondaryQueuesCollection, query)
 	catcher.AddWhen(!adb.ResultsNotFound(err), errors.Wrapf(err, "removing task alias queue for distro '%s'", distroID))
 	return catcher.Resolve()
 }

--- a/model/user/db.go
+++ b/model/user/db.go
@@ -95,9 +95,9 @@ func FindOneById(id string) (*DBUser, error) {
 }
 
 // Find gets all DBUser for the given query.
-func Find(query db.Q) ([]DBUser, error) {
+func Find(ctx context.Context, query db.Q) ([]DBUser, error) {
 	us := []DBUser{}
-	err := db.FindAllQ(Collection, query, &us)
+	err := db.FindAllQContext(ctx, Collection, query, &us)
 	return us, err
 }
 
@@ -414,9 +414,9 @@ func setSlackInformation(ctx context.Context, env evergreen.Environment, u *DBUs
 // FindNeedsReauthorization finds all users that need to be reauthorized after
 // the given period has passed and who have not exceeded the max reauthorization
 // attempts.
-func FindNeedsReauthorization(reauthorizeAfter time.Duration) ([]DBUser, error) {
+func FindNeedsReauthorization(ctx context.Context, reauthorizeAfter time.Duration) ([]DBUser, error) {
 	cutoff := time.Now().Add(-reauthorizeAfter)
-	users, err := Find(db.Query(bson.M{
+	users, err := Find(ctx, db.Query(bson.M{
 		bsonutil.GetDottedKeyName(LoginCacheKey, LoginCacheTokenKey): bson.M{"$exists": true},
 		bsonutil.GetDottedKeyName(LoginCacheKey, LoginCacheTTLKey):   bson.M{"$lte": cutoff},
 	}))
@@ -424,11 +424,11 @@ func FindNeedsReauthorization(reauthorizeAfter time.Duration) ([]DBUser, error) 
 }
 
 // FindServiceUsers returns all API-only users.
-func FindServiceUsers() ([]DBUser, error) {
+func FindServiceUsers(ctx context.Context) ([]DBUser, error) {
 	query := bson.M{
 		OnlyAPIKey: true,
 	}
-	return Find(db.Query(query))
+	return Find(ctx, db.Query(query))
 }
 
 // PutLoginCache generates a token if one does not exist, and sets the TTL to

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -659,24 +659,24 @@ func (s *UserTestSuite) TestFindNeedsReauthorization() {
 		return len(left) == 0 && len(right) == 0
 	}
 
-	users, err := FindNeedsReauthorization(0)
+	users, err := FindNeedsReauthorization(s.T().Context(), 0)
 	s.NoError(err)
 	s.Require().Len(users, 4)
 	s.True(containsUsers(users, "Test1", "Test2", "Test4", "Test5"), "should find all logged in users")
 	s.False(containsUsers(users, "Test3"), "should not find logged out users")
 
-	users, err = FindNeedsReauthorization(0)
+	users, err = FindNeedsReauthorization(s.T().Context(), 0)
 	s.NoError(err)
 	s.Require().Len(users, 4)
 	s.True(containsUsers(users, "Test1", "Test2", "Test4", "Test5"), "should find logged in users who have not exceeded max reauth attempts")
 	s.False(containsUsers(users, "Test3", "Test6"), "should not find logged out users or users who have exceeded max reauth attempts")
 
-	users, err = FindNeedsReauthorization(30 * time.Minute)
+	users, err = FindNeedsReauthorization(s.T().Context(), 30*time.Minute)
 	s.NoError(err)
 	s.Require().Len(users, 1)
 	s.True(containsUsers(users, "Test2"), "should find logged in users who have exceeded the reauth limit")
 
-	users, err = FindNeedsReauthorization(24 * time.Hour)
+	users, err = FindNeedsReauthorization(s.T().Context(), 24*time.Hour)
 	s.NoError(err)
 	s.Empty(users, "should not find users who have not exceeded the reauth limit")
 }
@@ -714,7 +714,7 @@ func TestServiceUserOperations(t *testing.T) {
 	assert.Equal(t, u.APIKey, dbUser.APIKey)
 	assert.Equal(t, u.EmailAddress, dbUser.EmailAddress)
 
-	users, err := FindServiceUsers()
+	users, err := FindServiceUsers(t.Context())
 	assert.NoError(t, err)
 	assert.Len(t, users, 1)
 

--- a/model/version_activation.go
+++ b/model/version_activation.go
@@ -121,7 +121,7 @@ func ActivateElapsedBuildsAndTasks(ctx context.Context, v *Version) (bool, error
 	}
 	if len(buildIdsToActivate) > 0 {
 		// Don't need to set the version in here since we do it ourselves in a single update
-		if err := build.UpdateActivation(buildIdsToActivate, true, evergreen.BuildActivator); err != nil {
+		if err := build.UpdateActivation(ctx, buildIdsToActivate, true, evergreen.BuildActivator); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"operation": "project-activation",
 				"message":   "problem activating builds",

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -338,8 +338,9 @@ func VersionUpdateOne(ctx context.Context, query any, update any) error {
 	)
 }
 
-func ActivateVersions(versionIds []string) error {
-	_, err := db.UpdateAll(
+func ActivateVersions(ctx context.Context, versionIds []string) error {
+	_, err := db.UpdateAllContext(
+		ctx,
 		VersionCollection,
 		bson.M{
 			VersionIdKey: bson.M{"$in": versionIds},

--- a/plugin/attach_plugin.go
+++ b/plugin/attach_plugin.go
@@ -56,7 +56,7 @@ func (ap *AttachPlugin) GetPanelConfig() (*PanelConfig, error) {
 						files := []displayTaskFiles{}
 						for _, execTaskID := range t.ExecutionTasks {
 							var execTaskFiles []artifact.File
-							execTaskFiles, err = artifact.GetAllArtifacts([]artifact.TaskIDAndExecution{{TaskID: execTaskID, Execution: uiCtx.Task.Execution}})
+							execTaskFiles, err = artifact.GetAllArtifacts(uiCtx.Request.Context(), []artifact.TaskIDAndExecution{{TaskID: execTaskID, Execution: uiCtx.Task.Execution}})
 							if err != nil {
 								return nil, err
 							}
@@ -86,7 +86,7 @@ func (ap *AttachPlugin) GetPanelConfig() (*PanelConfig, error) {
 						return files, nil
 					}
 
-					files, err := artifact.GetAllArtifacts([]artifact.TaskIDAndExecution{{TaskID: taskId, Execution: uiCtx.Task.Execution}})
+					files, err := artifact.GetAllArtifacts(uiCtx.Request.Context(), []artifact.TaskIDAndExecution{{TaskID: taskId, Execution: uiCtx.Task.Execution}})
 					if err != nil {
 						return nil, err
 					}
@@ -108,7 +108,7 @@ func (ap *AttachPlugin) GetPanelConfig() (*PanelConfig, error) {
 					if uiCtx.Build == nil {
 						return nil, nil
 					}
-					taskArtifactFiles, err := artifact.FindAll(artifact.ByBuildId(uiCtx.Build.Id))
+					taskArtifactFiles, err := artifact.FindAll(uiCtx.Request.Context(), artifact.ByBuildId(uiCtx.Build.Id))
 					if err != nil {
 						return nil, errors.Wrap(err, "error finding artifact files for build")
 					}

--- a/plugin/build_baron.go
+++ b/plugin/build_baron.go
@@ -28,7 +28,7 @@ func (bbp *BuildBaronPlugin) GetPanelConfig() (*PanelConfig, error) {
 					template.HTML(`<script type="text/javascript" src="/static/plugins/buildbaron/js/task_build_baron.js"></script>`),
 				},
 				DataFunc: func(context UIContext) (any, error) {
-					bbSettings, ok := model.GetBuildBaronSettings(context.ProjectRef.Id, "")
+					bbSettings, ok := model.GetBuildBaronSettings(context.Request.Context(), context.ProjectRef.Id, "")
 					enabled := ok && len(bbSettings.TicketSearchProjects) > 0
 					return struct {
 						Enabled bool `json:"enabled"`

--- a/plugin/build_baron_test.go
+++ b/plugin/build_baron_test.go
@@ -56,8 +56,8 @@ func TestBbGetProject(t *testing.T) {
 	assert.NoError(t, myProject2.Insert())
 	assert.NoError(t, myProjectConfig.Insert())
 
-	bbProj, ok1 := model.GetBuildBaronSettings(testTask.Project, testTask.Version)
-	bbProj2, ok2 := model.GetBuildBaronSettings(testTask2.Project, testTask2.Version)
+	bbProj, ok1 := model.GetBuildBaronSettings(t.Context(), testTask.Project, testTask.Version)
+	bbProj2, ok2 := model.GetBuildBaronSettings(t.Context(), testTask2.Project, testTask2.Version)
 	assert.True(t, ok1)
 	assert.True(t, ok2)
 	assert.Equal(t, "BFG", bbProj.TicketCreateProject)

--- a/plugin/perf.go
+++ b/plugin/perf.go
@@ -40,7 +40,7 @@ func (pp *PerfPlugin) GetPanelConfig() (*PanelConfig, error) {
 				Position:  PageCenter,
 				PanelHTML: template.HTML(panelHTML),
 				DataFunc: func(context UIContext) (any, error) {
-					enabled := model.IsPerfEnabledForProject(context.ProjectRef.Id)
+					enabled := model.IsPerfEnabledForProject(context.Request.Context(), context.ProjectRef.Id)
 					return struct {
 						Enabled bool `json:"enabled"`
 					}{Enabled: enabled}, nil

--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -98,7 +98,7 @@ func (gRepoPoller *GithubRepositoryPoller) GetChangedFiles(ctx context.Context, 
 // commits more recent than that revision, in order of most recent to least recent. Otherwise, if it
 // cannot find the revision, it will attempt to add the base revision between the most recent commit
 // and the given revision.
-func (gRepoPoller *GithubRepositoryPoller) GetRevisionsSince(revision string, maxRevisionsToSearch int) ([]model.Revision, error) {
+func (gRepoPoller *GithubRepositoryPoller) GetRevisionsSince(ctx context.Context, revision string, maxRevisionsToSearch int) ([]model.Revision, error) {
 	ctx, cancel := context.WithTimeout(context.TODO(), 30*time.Second)
 	defer cancel()
 
@@ -188,7 +188,7 @@ func (gRepoPoller *GithubRepositoryPoller) GetRevisionsSince(revision string, ma
 			revisionError := errors.Wrapf(err,
 				"unable to find a suggested merge base commit for revision '%s', must fix on projects settings page",
 				revision)
-			if err := gRepoPoller.ProjectRef.SetRepotrackerError(revisionDetails); err != nil {
+			if err := gRepoPoller.ProjectRef.SetRepotrackerError(ctx, revisionDetails); err != nil {
 				return []model.Revision{}, errors.Wrap(err, "setting repotracker error")
 			}
 			return []model.Revision{}, revisionError

--- a/repotracker/github_poller_test.go
+++ b/repotracker/github_poller_test.go
@@ -112,7 +112,7 @@ func TestGetRevisionsSinceWithPaging(t *testing.T) {
 			distantEvgRevision, err := getDistantEVGRevision()
 			So(err, ShouldBeNil)
 			So(distantEvgRevision, ShouldNotEqual, "")
-			revisions, err := grp.GetRevisionsSince(distantEvgRevision, 5000)
+			revisions, err := grp.GetRevisionsSince(t.Context(), distantEvgRevision, 5000)
 			So(err, ShouldBeNil)
 			Convey("and the revision should be found", func() {
 				So(len(revisions), ShouldNotEqual, 0)
@@ -138,7 +138,7 @@ func TestGetRevisionsSince(t *testing.T) {
 
 		Convey("There should be only two revisions since the first revision",
 			func() {
-				revisions, err := ghp.GetRevisionsSince(firstRevision, 10)
+				revisions, err := ghp.GetRevisionsSince(t.Context(), firstRevision, 10)
 				require.NoError(t, err)
 				So(len(revisions), ShouldEqual, 2)
 
@@ -154,19 +154,19 @@ func TestGetRevisionsSince(t *testing.T) {
 			})
 
 		Convey("There should be no revisions since the last revision", func() {
-			revisions, err := ghp.GetRevisionsSince(lastRevision, 10)
+			revisions, err := ghp.GetRevisionsSince(t.Context(), lastRevision, 10)
 			require.NoError(t, err)
 			So(len(revisions), ShouldEqual, 0)
 		})
 
 		Convey("There should be an error returned if the requested revision "+
 			"isn't found", func() {
-			revisions, err := ghp.GetRevisionsSince(badRevision, 10)
+			revisions, err := ghp.GetRevisionsSince(t.Context(), badRevision, 10)
 			So(len(revisions), ShouldEqual, 0)
 			So(err, ShouldNotBeNil)
 		})
 		Convey("If the revision is not valid because it has less than 10 characters, should return an error", func() {
-			_, err := ghp.GetRevisionsSince("master", 10)
+			_, err := ghp.GetRevisionsSince(t.Context(), "master", 10)
 			So(err, ShouldNotBeNil)
 		})
 		Convey("should limit number of revisions returned and set last repo revision", func() {
@@ -175,7 +175,7 @@ func TestGetRevisionsSince(t *testing.T) {
 			// (i.e. earliest) revisions should not be found. The expected behavior here is that if it cannot find the
 			// given revision, it will search for maxRevisions, then add one revision as the new base revision if
 			// necessary.
-			revisions, err := ghp.GetRevisionsSince(firstRevision, maxRevisions)
+			revisions, err := ghp.GetRevisionsSince(t.Context(), firstRevision, maxRevisions)
 			require.NoError(t, err)
 			require.Len(t, revisions, maxRevisions+1, "should find revisions up to limit, plus one for the base revision when the starting revision is not found in the listed revisions")
 			assert.Equal(t, lastRevision, revisions[0].Revision, "revisions should be reverse time ordered")

--- a/repotracker/mock_poller.go
+++ b/repotracker/mock_poller.go
@@ -65,7 +65,7 @@ func (d *mockRepoPoller) GetRemoteConfig(_ context.Context, revision string) (mo
 	}, nil
 }
 
-func (d *mockRepoPoller) GetRevisionsSince(revision string, maxRevisionsToSearch int) ([]model.Revision, error) {
+func (d *mockRepoPoller) GetRevisionsSince(ctx context.Context, revision string, maxRevisionsToSearch int) ([]model.Revision, error) {
 	if d.nextError != nil {
 		return nil, d.clearError()
 	}

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -64,7 +64,7 @@ type RepoPoller interface {
 	// allow to search through - in order to find 'revision' - before we give
 	// up. A value <= 0 implies we allow to search through till we hit the first
 	// revision for the project.
-	GetRevisionsSince(sinceRevision string, maxRevisions int) ([]model.Revision, error)
+	GetRevisionsSince(ctx context.Context, sinceRevision string, maxRevisions int) ([]model.Revision, error)
 	// Fetches the most recent 'numNewRepoRevisionsToFetch' revisions for a
 	// project - with the most recent revision appearing as the first element in
 	// the slice.
@@ -152,7 +152,7 @@ func (repoTracker *RepoTracker) FetchRevisions(ctx context.Context) error {
 		if max <= 0 {
 			max = DefaultMaxRepoRevisionsToSearch
 		}
-		revisions, err = repoTracker.GetRevisionsSince(lastRevision, max)
+		revisions, err = repoTracker.GetRevisionsSince(ctx, lastRevision, max)
 	}
 
 	if err != nil {

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -622,12 +622,12 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 	// Compute aliases first to include undefined requested alias in the stub version errors list.
 	var aliases model.ProjectAliases
 	if metadata.Alias == evergreen.GitTagAlias {
-		aliases, err = model.FindMatchingGitTagAliasesInProject(projectInfo.Ref.Id, metadata.GitTag.Tag)
+		aliases, err = model.FindMatchingGitTagAliasesInProject(ctx, projectInfo.Ref.Id, metadata.GitTag.Tag)
 		if err != nil {
 			return v, errors.Wrapf(err, "error finding project alias for tag '%s'", metadata.GitTag.Tag)
 		}
 	} else if metadata.Alias != "" {
-		aliases, err = model.FindAliasInProjectRepoOrConfig(projectInfo.Ref.Id, metadata.Alias)
+		aliases, err = model.FindAliasInProjectRepoOrConfig(ctx, projectInfo.Ref.Id, metadata.Alias)
 		if err != nil {
 			return v, errors.Wrap(err, "error finding project alias")
 		}
@@ -873,7 +873,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 
 	var githubCheckAliases model.ProjectAliases
 	if v.Requester == evergreen.RepotrackerVersionRequester && projectInfo.Ref.IsGithubChecksEnabled() {
-		githubCheckAliases, err = model.FindAliasInProjectRepoOrConfig(v.Identifier, evergreen.GithubChecksAlias)
+		githubCheckAliases, err = model.FindAliasInProjectRepoOrConfig(ctx, v.Identifier, evergreen.GithubChecksAlias)
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "error getting github check aliases",
 			"project": projectInfo.Project.Identifier,

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -865,7 +865,7 @@ func TestBuildBreakSubscriptions(t *testing.T) {
 		Branch:     "branch",
 	}
 	assert.NoError(AddBuildBreakSubscriptions(&v1, &proj1))
-	assert.NoError(db.FindAllQ(event.SubscriptionsCollection, db.Q{}, &subs))
+	assert.NoError(db.FindAllQContext(t.Context(), event.SubscriptionsCollection, db.Q{}, &subs))
 	assert.Empty(subs)
 
 	// just a project
@@ -906,7 +906,7 @@ func TestBuildBreakSubscriptions(t *testing.T) {
 	}
 	assert.NoError(u4.Insert())
 	assert.NoError(AddBuildBreakSubscriptions(&v1, &proj2))
-	assert.NoError(db.FindAllQ(event.SubscriptionsCollection, db.Q{}, &subs))
+	assert.NoError(db.FindAllQContext(t.Context(), event.SubscriptionsCollection, db.Q{}, &subs))
 	assert.Len(subs, 2)
 
 	// project has it enabled, but user doesn't want notifications
@@ -920,7 +920,7 @@ func TestBuildBreakSubscriptions(t *testing.T) {
 		AuthorID:   u4.Id,
 	}
 	assert.NoError(AddBuildBreakSubscriptions(&v3, &proj2))
-	assert.NoError(db.FindAllQ(event.SubscriptionsCollection, db.Q{}, &subs))
+	assert.NoError(db.FindAllQContext(t.Context(), event.SubscriptionsCollection, db.Q{}, &subs))
 	targetString, ok := subs[0].Subscriber.Target.(*string)
 	assert.True(ok)
 	assert.EqualValues("@hello.itsme", utility.FromStringPtr(targetString))

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -1,6 +1,8 @@
 package data
 
 import (
+	"context"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
@@ -15,14 +17,14 @@ import (
 // 3. aliases defined in the project config YAML
 // The includeProjectConfig flag determines whether to include aliases defined in the project config YAML.
 // If the aliasesToAdd parameter is defined, we fold those aliases in and remove any that are marked as deleted.
-func FindMergedProjectAliases(projectId, repoId string, aliasesToAdd []restModel.APIProjectAlias, includeProjectConfig bool) ([]restModel.APIProjectAlias, error) {
-	projectRef, err := model.FindMergedProjectRef(projectId, "", false)
+func FindMergedProjectAliases(ctx context.Context, projectId, repoId string, aliasesToAdd []restModel.APIProjectAlias, includeProjectConfig bool) ([]restModel.APIProjectAlias, error) {
+	projectRef, err := model.FindMergedProjectRef(ctx, projectId, "", false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding project ref for project '%s'", projectId)
 	}
 	var projectConfig *model.ProjectConfig
 	if includeProjectConfig {
-		projectConfig, err = model.FindLastKnownGoodProjectConfig(projectId)
+		projectConfig, err = model.FindLastKnownGoodProjectConfig(ctx, projectId)
 		if err != nil {
 			return nil, errors.Wrapf(err, "finding project config for project '%s'", projectId)
 		}

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -241,7 +241,7 @@ func (a *AliasSuite) TestUpdateProjectAliases() {
 			Variant: utility.ToStringPtr("new_variant"),
 		},
 	}
-	a.NoError(UpdateProjectAliases("other_project_id", aliasUpdates))
+	a.NoError(UpdateProjectAliases(a.T().Context(), "other_project_id", aliasUpdates))
 	found, err = FindMergedProjectAliases(a.T().Context(), "other_project_id", "", nil, false)
 	a.NoError(err)
 	a.Require().Len(found, 2) // added one alias, deleted another
@@ -283,7 +283,7 @@ func (a *AliasSuite) TestUpdateAliasesForSection() {
 	}
 
 	updatedAliases := []restModel.APIProjectAlias{aliasToKeep, aliasToModify, newAlias, newInternalAlias}
-	modified, err := updateAliasesForSection("project_id", updatedAliases, originalAliases, model.ProjectPagePatchAliasSection)
+	modified, err := updateAliasesForSection(a.T().Context(), "project_id", updatedAliases, originalAliases, model.ProjectPagePatchAliasSection)
 	a.NoError(err)
 	a.True(modified)
 
@@ -298,7 +298,7 @@ func (a *AliasSuite) TestUpdateAliasesForSection() {
 		}
 	}
 
-	modified, err = updateAliasesForSection("project_id", updatedAliases, originalAliases, model.ProjectPageGithubAndCQSection)
+	modified, err = updateAliasesForSection(a.T().Context(), "project_id", updatedAliases, originalAliases, model.ProjectPageGithubAndCQSection)
 	a.NoError(err)
 	a.True(modified)
 	aliasesFromDb, err = model.FindAliasesForProjectFromDb("project_id")

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -149,7 +149,7 @@ func (a *AliasSuite) SetupTest() {
 }
 
 func (a *AliasSuite) TestFindProjectAliasesMergedWithProjectConfig() {
-	found, err := FindMergedProjectAliases("project_id", "", nil, true)
+	found, err := FindMergedProjectAliases(a.T().Context(), "project_id", "", nil, true)
 	a.Require().NoError(err)
 	a.Require().Len(found, 6)
 	sort.Slice(found, func(i, j int) bool {
@@ -165,22 +165,22 @@ func (a *AliasSuite) TestFindProjectAliasesMergedWithProjectConfig() {
 
 func (a *AliasSuite) TestFindMergedProjectAliases() {
 	// project ref only
-	found, err := FindMergedProjectAliases("project_id", "", nil, false)
+	found, err := FindMergedProjectAliases(a.T().Context(), "project_id", "", nil, false)
 	a.NoError(err)
 	a.Len(found, 4)
 
 	// project ref merged with repo
-	found, err = FindMergedProjectAliases("project_id", "repo_id", nil, false)
+	found, err = FindMergedProjectAliases(a.T().Context(), "project_id", "repo_id", nil, false)
 	a.NoError(err)
 	a.Len(found, 5)
 
 	// all non-existent
-	found, err = FindMergedProjectAliases("non-existent", "non-existent", nil, false)
+	found, err = FindMergedProjectAliases(a.T().Context(), "non-existent", "non-existent", nil, false)
 	a.NoError(err)
 	a.Empty(found)
 
 	// repo only
-	found, err = FindMergedProjectAliases("non-existent", "repo_id", nil, false)
+	found, err = FindMergedProjectAliases(a.T().Context(), "non-existent", "repo_id", nil, false)
 	a.NoError(err)
 	a.Len(found, 3)
 
@@ -188,7 +188,7 @@ func (a *AliasSuite) TestFindMergedProjectAliases() {
 	aliasesToAdd := []restModel.APIProjectAlias{
 		{Alias: utility.ToStringPtr(evergreen.GitTagAlias), Task: utility.ToStringPtr("added_task")},
 	}
-	found, err = FindMergedProjectAliases("project_id", "repo_id", aliasesToAdd, true)
+	found, err = FindMergedProjectAliases(a.T().Context(), "project_id", "repo_id", aliasesToAdd, true)
 	a.NoError(err)
 	a.Len(found, 7)
 	for _, alias := range found {
@@ -208,24 +208,24 @@ func (a *AliasSuite) TestFindMergedProjectAliases() {
 }
 
 func (a *AliasSuite) TestCopyProjectAliases() {
-	res, err := FindMergedProjectAliases("new_project_id", "", nil, false)
+	res, err := FindMergedProjectAliases(a.T().Context(), "new_project_id", "", nil, false)
 	a.NoError(err)
 	a.Empty(res)
 
 	a.NoError(model.CopyProjectAliases("project_id", "new_project_id"))
 
-	res, err = FindMergedProjectAliases("project_id", "", nil, false)
+	res, err = FindMergedProjectAliases(a.T().Context(), "project_id", "", nil, false)
 	a.NoError(err)
 	a.Len(res, 4)
 
-	res, err = FindMergedProjectAliases("new_project_id", "", nil, false)
+	res, err = FindMergedProjectAliases(a.T().Context(), "new_project_id", "", nil, false)
 	a.NoError(err)
 	a.Len(res, 4)
 
 }
 
 func (a *AliasSuite) TestUpdateProjectAliases() {
-	found, err := FindMergedProjectAliases("other_project_id", "", nil, false)
+	found, err := FindMergedProjectAliases(a.T().Context(), "other_project_id", "", nil, false)
 	a.NoError(err)
 	a.Require().Len(found, 2)
 	toUpdate := found[0]
@@ -242,7 +242,7 @@ func (a *AliasSuite) TestUpdateProjectAliases() {
 		},
 	}
 	a.NoError(UpdateProjectAliases("other_project_id", aliasUpdates))
-	found, err = FindMergedProjectAliases("other_project_id", "", nil, false)
+	found, err = FindMergedProjectAliases(a.T().Context(), "other_project_id", "", nil, false)
 	a.NoError(err)
 	a.Require().Len(found, 2) // added one alias, deleted another
 

--- a/rest/data/build_baron.go
+++ b/rest/data/build_baron.go
@@ -36,7 +36,7 @@ func BbFileTicket(ctx context.Context, taskId string, execution int) (int, error
 		return http.StatusNotFound, errors.Wrapf(err, "task '%s' not found with execution '%d'", taskId, execution)
 	}
 
-	webHook, ok, err := model.IsWebhookConfigured(t.Project, t.Version)
+	webHook, ok, err := model.IsWebhookConfigured(ctx, t.Project, t.Version)
 	if err != nil {
 		return http.StatusInternalServerError, errors.Wrapf(err, "retrieving webhook config for project '%s'", t.Project)
 	}
@@ -53,7 +53,7 @@ func BbFileTicket(ctx context.Context, taskId string, execution int) (int, error
 	env := evergreen.GetEnvironment()
 	settings := env.Settings()
 	queue := env.RemoteQueue()
-	bbProject, ok := model.GetBuildBaronSettings(t.Project, t.Version)
+	bbProject, ok := model.GetBuildBaronSettings(ctx, t.Project, t.Version)
 	if !ok {
 		return http.StatusInternalServerError, errors.Errorf("could not find build baron plugin for task '%s' with execution '%d'", taskId, execution)
 	}

--- a/rest/data/distro.go
+++ b/rest/data/distro.go
@@ -27,7 +27,7 @@ func UpdateDistro(ctx context.Context, old, new *distro.Distro) error {
 	}
 
 	if old.DispatcherSettings.Version == evergreen.DispatcherVersionRevisedWithDependencies && new.DispatcherSettings.Version != evergreen.DispatcherVersionRevisedWithDependencies {
-		if err := model.RemoveTaskQueues(new.Id); err != nil {
+		if err := model.RemoveTaskQueues(ctx, new.Id); err != nil {
 			return gimlet.ErrorResponse{
 				StatusCode: http.StatusInternalServerError,
 				Message:    errors.Wrapf(err, "removing task queues for distro '%s'", new.Id).Error(),

--- a/rest/data/middleware.go
+++ b/rest/data/middleware.go
@@ -105,7 +105,7 @@ func GetProjectIdFromParams(ctx context.Context, paramsMap map[string]string) (s
 		return "", http.StatusNotFound, errors.New("no project found")
 	}
 
-	projectRef, err := model.FindMergedProjectRef(projectID, versionID, true)
+	projectRef, err := model.FindMergedProjectRef(ctx, projectID, versionID, true)
 	if err != nil {
 		return "", http.StatusInternalServerError, errors.Wrap(err, "finding project")
 	}

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -183,7 +183,7 @@ func tryCopyingContainerSecrets(ctx context.Context, settings *evergreen.Setting
 	if err != nil {
 		return errors.Wrapf(err, "copying existing container secrets")
 	}
-	if err := pRef.SetContainerSecrets(secrets); err != nil {
+	if err := pRef.SetContainerSecrets(ctx, secrets); err != nil {
 		return errors.Wrap(err, "setting container secrets")
 	}
 

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -458,7 +458,7 @@ func HideBranch(ctx context.Context, projectID string) error {
 		return errors.Wrapf(err, "finding aliases for project '%s'", pRef.Id)
 	}
 	for _, alias := range projectAliases {
-		if err := model.RemoveProjectAlias(alias.ID.Hex()); err != nil {
+		if err := model.RemoveProjectAlias(ctx, alias.ID.Hex()); err != nil {
 			return errors.Wrapf(err, "removing project alias '%s' for project '%s'", alias.ID.Hex(), pRef.Id)
 		}
 	}

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -29,7 +29,7 @@ import (
 
 // CopyProject copies the passed in project with the given project identifier, and returns the new project.
 func CopyProject(ctx context.Context, env evergreen.Environment, opts restModel.CopyProjectOpts) (*restModel.APIProjectRef, error) {
-	projectToCopy, err := FindProjectById(opts.ProjectIdToCopy, false, false)
+	projectToCopy, err := FindProjectById(ctx, opts.ProjectIdToCopy, false, false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding project '%s'", opts.ProjectIdToCopy)
 	}
@@ -388,7 +388,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 		catcher.Add(err)
 	case model.ProjectPagePatchAliasSection:
 		for i := range mergedSection.PatchTriggerAliases {
-			mergedSection.PatchTriggerAliases[i], err = model.ValidateTriggerDefinition(mergedSection.PatchTriggerAliases[i], projectId)
+			mergedSection.PatchTriggerAliases[i], err = model.ValidateTriggerDefinition(ctx, mergedSection.PatchTriggerAliases[i], projectId)
 			catcher.Add(err)
 		}
 		if catcher.HasErrors() {

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -384,7 +384,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 		if err = mergedSection.ValidateGitHubPermissionGroupsByRequester(); err != nil {
 			return nil, err
 		}
-		modified, err = updateAliasesForSection(projectId, changes.Aliases, before.Aliases, section)
+		modified, err = updateAliasesForSection(ctx, projectId, changes.Aliases, before.Aliases, section)
 		catcher.Add(err)
 	case model.ProjectPagePatchAliasSection:
 		for i := range mergedSection.PatchTriggerAliases {
@@ -394,7 +394,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 		if catcher.HasErrors() {
 			return nil, errors.Wrap(catcher.Resolve(), "invalid patch trigger aliases")
 		}
-		modified, err = updateAliasesForSection(projectId, changes.Aliases, before.Aliases, section)
+		modified, err = updateAliasesForSection(ctx, projectId, changes.Aliases, before.Aliases, section)
 		catcher.Add(err)
 	case model.ProjectPageNotificationsSection:
 		// Some subscription values are redacted like webhook secret and 'Authorization' header.

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -92,13 +92,13 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 			assert.Equal(t, repoRefFromDb.Admins, ref.Admins)
 
 			// should be restricted
-			projectThatDefaults, err := model.FindMergedProjectRef("myId", "", true)
+			projectThatDefaults, err := model.FindMergedProjectRef(t.Context(), "myId", "", true)
 			assert.NoError(t, err)
 			assert.NotNil(t, projectThatDefaults)
 			assert.True(t, projectThatDefaults.IsRestricted())
 
 			// should not be restricted
-			projectThatDoesNotDefault, err := model.FindMergedProjectRef("myId2", "", true)
+			projectThatDoesNotDefault, err := model.FindMergedProjectRef(t.Context(), "myId2", "", true)
 			assert.NoError(t, err)
 			assert.NotNil(t, projectThatDoesNotDefault)
 			assert.False(t, projectThatDoesNotDefault.IsRestricted())
@@ -616,7 +616,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.Nil(t, pRefFromDB.Restricted)
 			assert.Equal(t, pRefFromDB.Admins, ref.Admins)
 
-			mergedProject, err := model.FindMergedProjectRef(ref.Id, "", true)
+			mergedProject, err := model.FindMergedProjectRef(t.Context(), ref.Id, "", true)
 			assert.NoError(t, err)
 			assert.NotNil(t, mergedProject)
 			assert.True(t, mergedProject.IsRestricted())

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -395,12 +395,12 @@ func TestGetProjectAliasResults(t *testing.T) {
 	}
 	require.NoError(t, alias2.Upsert())
 
-	variantTasks, err := GetProjectAliasResults(&p, alias1.Alias, false)
+	variantTasks, err := GetProjectAliasResults(t.Context(), &p, alias1.Alias, false)
 	assert.NoError(t, err)
 	assert.Len(t, variantTasks, 1)
 	assert.Len(t, variantTasks[0].Tasks, 1)
 	assert.Equal(t, "task1", variantTasks[0].Tasks[0])
-	variantTasks, err = GetProjectAliasResults(&p, alias2.Alias, false)
+	variantTasks, err = GetProjectAliasResults(t.Context(), &p, alias2.Alias, false)
 	assert.NoError(t, err)
 	assert.Len(t, variantTasks, 1)
 	assert.Len(t, variantTasks[0].Tasks, 2)
@@ -640,7 +640,7 @@ func TestHideBranch(t *testing.T) {
 	err := HideBranch(t.Context(), project.Id)
 	assert.NoError(t, err)
 
-	hiddenProj, err := model.FindMergedProjectRef(project.Id, "", true)
+	hiddenProj, err := model.FindMergedProjectRef(t.Context(), project.Id, "", true)
 	assert.NoError(t, err)
 	skeletonProj := model.ProjectRef{
 		Id:        project.Id,

--- a/rest/data/subscription.go
+++ b/rest/data/subscription.go
@@ -163,7 +163,7 @@ func DeleteSubscriptions(ctx context.Context, owner string, ids []string) error 
 
 	catcher := grip.NewBasicCatcher()
 	for _, id := range ids {
-		catcher.Wrapf(event.RemoveSubscription(id), "removing subscription '%s'", id)
+		catcher.Wrapf(event.RemoveSubscription(ctx, id), "removing subscription '%s'", id)
 	}
 	return catcher.Resolve()
 }

--- a/rest/data/user.go
+++ b/rest/data/user.go
@@ -131,8 +131,8 @@ func SubmitFeedback(in restModel.APIFeedbackSubmission) error {
 	return errors.Wrap(f.Insert(), "error saving feedback")
 }
 
-func GetServiceUsers() ([]restModel.APIDBUser, error) {
-	users, err := user.FindServiceUsers()
+func GetServiceUsers(ctx context.Context) ([]restModel.APIDBUser, error) {
+	users, err := user.FindServiceUsers(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding service users")
 	}

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -615,10 +615,10 @@ func (at *APITask) getArtifacts(ctx context.Context) error {
 			ets = append(ets, artifact.TaskIDAndExecution{TaskID: *t, Execution: at.Execution})
 		}
 		if len(ets) > 0 {
-			entries, err = artifact.FindAll(artifact.ByTaskIdsAndExecutions(ets))
+			entries, err = artifact.FindAll(ctx, artifact.ByTaskIdsAndExecutions(ets))
 		}
 	} else {
-		entries, err = artifact.FindAll(artifact.ByTaskIdAndExecution(utility.FromStringPtr(at.Id), at.Execution))
+		entries, err = artifact.FindAll(ctx, artifact.ByTaskIdAndExecution(utility.FromStringPtr(at.Id), at.Execution))
 	}
 	if err != nil {
 		return errors.Wrap(err, "retrieving artifacts")

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -279,7 +279,7 @@ func (h *markTaskForRestartHandler) Run(ctx context.Context) gimlet.Responder {
 			Message:    fmt.Sprintf("task has already reached the maximum (%d) number of automatic restarts", evergreen.MaxAutomaticRestarts),
 		})
 	}
-	projectRef, err := model.FindMergedProjectRef(t.Project, t.Version, false)
+	projectRef, err := model.FindMergedProjectRef(ctx, t.Project, t.Version, false)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding project '%s' for version '%s'", t.Project, t.Version))
 	}
@@ -461,7 +461,7 @@ func (h *getProjectRefHandler) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 
-	p, err := model.FindMergedProjectRef(t.Project, t.Version, true)
+	p, err := model.FindMergedProjectRef(ctx, t.Project, t.Version, true)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}
@@ -1254,7 +1254,7 @@ func (h *manifestLoadHandler) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 
-	projectRef, err := model.FindMergedProjectRef(task.Project, task.Version, true)
+	projectRef, err := model.FindMergedProjectRef(ctx, task.Project, task.Version, true)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding project '%s'", task.Project))
 	}
@@ -1646,7 +1646,7 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 	// When creating a token for a task, we want to consider the project's
 	// permission groups. These permission groups can restrict the permissions
 	// so that each requester only gets the permissions they have been set.
-	p, err := model.FindMergedProjectRef(t.Project, t.Version, true)
+	p, err := model.FindMergedProjectRef(ctx, t.Project, t.Version, true)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}

--- a/rest/route/alias.go
+++ b/rest/route/alias.go
@@ -47,7 +47,7 @@ func (a *aliasGetHandler) Run(ctx context.Context) gimlet.Responder {
 	if pRef == nil {
 		return gimlet.MakeJSONErrorResponder(errors.Errorf("project '%s' not found", a.projectID))
 	}
-	aliasModels, err := data.FindMergedProjectAliases(pRef.Id, pRef.RepoRefId, nil, a.includeProjectConfig)
+	aliasModels, err := data.FindMergedProjectAliases(ctx, pRef.Id, pRef.RepoRefId, nil, a.includeProjectConfig)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding project aliases for project '%s'", pRef.Id))
 	}

--- a/rest/route/alias_test.go
+++ b/rest/route/alias_test.go
@@ -32,7 +32,7 @@ func TestGetAliasesHandler(t *testing.T) {
 			projectAliases, err := dbModel.FindAliasesForProjectFromDb("project_ref")
 			require.NoError(t, err)
 			require.Len(t, projectAliases, 1)
-			require.NoError(t, dbModel.RemoveProjectAlias(projectAliases[0].ID.Hex()))
+			require.NoError(t, dbModel.RemoveProjectAlias(ctx, projectAliases[0].ID.Hex()))
 
 			r, err := http.NewRequest(http.MethodGet, "/alias/project_ref", nil)
 			assert.NoError(t, err)

--- a/rest/route/annotations.go
+++ b/rest/route/annotations.go
@@ -63,7 +63,7 @@ func (h *annotationsByBuildHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(err, "finding task IDs for build '%s'", h.buildId))
 	}
 
-	return getAPIAnnotationsForTaskIds(taskIds, h.fetchAllExecutions)
+	return getAPIAnnotationsForTaskIds(ctx, taskIds, h.fetchAllExecutions)
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -111,11 +111,11 @@ func (h *annotationsByVersionHandler) Run(ctx context.Context) gimlet.Responder 
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(err, "finding task IDs for version '%s'", h.versionId))
 	}
-	return getAPIAnnotationsForTaskIds(taskIds, h.fetchAllExecutions)
+	return getAPIAnnotationsForTaskIds(ctx, taskIds, h.fetchAllExecutions)
 }
 
-func getAPIAnnotationsForTaskIds(taskIds []string, allExecutions bool) gimlet.Responder {
-	allAnnotations, err := annotations.FindByTaskIds(taskIds)
+func getAPIAnnotationsForTaskIds(ctx context.Context, taskIds []string, allExecutions bool) gimlet.Responder {
+	allAnnotations, err := annotations.FindByTaskIds(ctx, taskIds)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "finding task annotations"))
 	}
@@ -205,7 +205,7 @@ func (h *annotationByTaskGetHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.NewJSONResponse([]restModel.APITaskAnnotation{*taskAnnotation})
 	}
 
-	allAnnotations, err := annotations.FindByTaskId(h.taskId)
+	allAnnotations, err := annotations.FindByTaskId(ctx, h.taskId)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(err, "finding task annotation for task '%s'", h.taskId))
 	}

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -1062,7 +1062,7 @@ func (gh *githubHookApi) createVersionForTag(ctx context.Context, pRef model.Pro
 		}
 		return nil, nil
 	}
-	hasAliases, remotePath, err := model.HasMatchingGitTagAliasAndRemotePath(pRef.Id, tag.Tag)
+	hasAliases, remotePath, err := model.HasMatchingGitTagAliasAndRemotePath(ctx, pRef.Id, tag.Tag)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -405,7 +405,7 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 			continue
 		}
 
-		projectRef, err := model.FindMergedProjectRef(nextTask.Project, nextTask.Version, true)
+		projectRef, err := model.FindMergedProjectRef(ctx, nextTask.Project, nextTask.Version, true)
 		errMsg := message.Fields{
 			"task_id":            nextTask.Id,
 			"message":            "could not find project ref for next task, skipping",

--- a/rest/route/pod_agent.go
+++ b/rest/route/pod_agent.go
@@ -472,7 +472,7 @@ func (h *podAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.NewJSONResponse(endTaskResp)
 	}
 
-	projectRef, err := model.FindMergedProjectRef(t.Project, t.Version, true)
+	projectRef, err := model.FindMergedProjectRef(ctx, t.Project, t.Version, true)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding project '%s' for version '%s'", t.Project, t.Version))
 	}

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -571,7 +571,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	if err = data.UpdateProjectVars(h.newProjectRef.Id, &h.apiNewProjectRef.Variables, false); err != nil { // destructively modifies h.apiNewProjectRef.Variables
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "updating variables for project '%s'", h.project))
 	}
-	if err = data.UpdateProjectAliases(h.newProjectRef.Id, h.apiNewProjectRef.Aliases); err != nil {
+	if err = data.UpdateProjectAliases(ctx, h.newProjectRef.Id, h.apiNewProjectRef.Aliases); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "updating aliases for project '%s'", h.project))
 	}
 

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -200,7 +200,7 @@ func (h *attachProjectToRepoHandler) Parse(ctx context.Context, r *http.Request)
 	h.user = MustHaveUser(ctx)
 
 	var err error
-	h.project, err = data.FindProjectById(projectIdentifier, false, false)
+	h.project, err = data.FindProjectById(ctx, projectIdentifier, false, false)
 	if err != nil {
 		return errors.Wrapf(err, "finding project '%s'", projectIdentifier)
 	}
@@ -241,7 +241,7 @@ func (h *detachProjectFromRepoHandler) Parse(ctx context.Context, r *http.Reques
 	h.user = MustHaveUser(ctx)
 
 	var err error
-	h.project, err = data.FindProjectById(projectIdentifier, false, false)
+	h.project, err = data.FindProjectById(ctx, projectIdentifier, false, false)
 	if err != nil {
 		return errors.Wrapf(err, "finding project '%s'", projectIdentifier)
 	}
@@ -306,7 +306,7 @@ func (h *projectIDPatchHandler) Parse(ctx context.Context, r *http.Request) erro
 		return errors.Wrap(err, "reading JSON request body")
 	}
 
-	oldProject, err := data.FindProjectById(h.project, false, false)
+	oldProject, err := data.FindProjectById(ctx, h.project, false, false)
 	if err != nil {
 		return errors.Wrapf(err, "finding original project '%s'", h.project)
 	}
@@ -406,7 +406,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 
 		var allAliases []model.APIProjectAlias
 		if mergedProjectRef.AliasesNeeded() {
-			allAliases, err = data.FindMergedProjectAliases(utility.FromStringPtr(h.apiNewProjectRef.Id), mergedProjectRef.RepoRefId, h.apiNewProjectRef.Aliases, false)
+			allAliases, err = data.FindMergedProjectAliases(ctx, utility.FromStringPtr(h.apiNewProjectRef.Id), mergedProjectRef.RepoRefId, h.apiNewProjectRef.Aliases, false)
 			if err != nil {
 				return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(err, "checking existing patch definitions for project '%s'", h.project))
 			}
@@ -462,7 +462,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		catcher.Add(h.newProjectRef.Triggers[i].Validate(h.newProjectRef.Id))
 	}
 	for i := range h.newProjectRef.PatchTriggerAliases {
-		h.newProjectRef.PatchTriggerAliases[i], err = dbModel.ValidateTriggerDefinition(h.newProjectRef.PatchTriggerAliases[i], h.newProjectRef.Id)
+		h.newProjectRef.PatchTriggerAliases[i], err = dbModel.ValidateTriggerDefinition(ctx, h.newProjectRef.PatchTriggerAliases[i], h.newProjectRef.Id)
 		catcher.Add(err)
 	}
 	for _, buildDef := range h.newProjectRef.PeriodicBuilds {
@@ -478,7 +478,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "invalid Parsley filters"))
 	}
 
-	err = dbModel.ValidateBbProject(h.newProjectRef.Id, h.newProjectRef.BuildBaronSettings, &h.newProjectRef.TaskAnnotationSettings.FileTicketWebhook)
+	err = dbModel.ValidateBbProject(ctx, h.newProjectRef.Id, h.newProjectRef.BuildBaronSettings, &h.newProjectRef.TaskAnnotationSettings.FileTicketWebhook)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "validating build baron config"))
 	}
@@ -709,7 +709,7 @@ func (h *projectIDPutHandler) Parse(ctx context.Context, r *http.Request) error 
 
 // Run creates a new resource based on the Request-URI and JSON payload and returns a http.StatusCreated (201)
 func (h *projectIDPutHandler) Run(ctx context.Context) gimlet.Responder {
-	p, err := data.FindProjectById(h.projectName, false, false)
+	p, err := data.FindProjectById(ctx, h.projectName, false, false)
 	if err != nil && err.(gimlet.ErrorResponse).StatusCode != http.StatusNotFound {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding project '%s'", h.projectName))
 	}
@@ -839,7 +839,7 @@ func (h *projectIDGetHandler) Parse(ctx context.Context, r *http.Request) error 
 }
 
 func (h *projectIDGetHandler) Run(ctx context.Context) gimlet.Responder {
-	project, err := data.FindProjectById(h.projectName, h.includeRepo, h.includeProjectConfig)
+	project, err := data.FindProjectById(ctx, h.projectName, h.includeRepo, h.includeProjectConfig)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding project '%s'", h.projectName))
 	}
@@ -862,7 +862,7 @@ func (h *projectIDGetHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding vars for project '%s'", project.Id))
 	}
 	projectModel.Variables = *variables
-	if projectModel.Aliases, err = data.FindMergedProjectAliases(project.Id, repoId, nil, h.includeProjectConfig); err != nil {
+	if projectModel.Aliases, err = data.FindMergedProjectAliases(ctx, project.Id, repoId, nil, h.includeProjectConfig); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding aliases for project '%s'", project.Id))
 	}
 	if projectModel.Subscriptions, err = data.GetSubscriptions(project.Id, event.OwnerTypeProject); err != nil {
@@ -1321,7 +1321,7 @@ func (p *GetProjectAliasResultsHandler) Run(ctx context.Context) gimlet.Responde
 		}))
 		return gimlet.MakeJSONInternalErrorResponder(errors.Errorf("getting project for version '%s'", p.version))
 	}
-	variantTasks, err := data.GetProjectAliasResults(proj, p.alias, p.includeDependencies)
+	variantTasks, err := data.GetProjectAliasResults(ctx, proj, p.alias, p.includeDependencies)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting variants/tasks from for project '%s' and alias '%s'", proj.Identifier, p.alias))
 	}
@@ -1352,7 +1352,7 @@ func (p *GetPatchTriggerAliasHandler) Parse(ctx context.Context, r *http.Request
 }
 
 func (p *GetPatchTriggerAliasHandler) Run(ctx context.Context) gimlet.Responder {
-	proj, err := dbModel.FindMergedProjectRef(p.projectID, "", true)
+	proj, err := dbModel.FindMergedProjectRef(ctx, p.projectID, "", true)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message": "error getting project",

--- a/rest/route/project_copy_test.go
+++ b/rest/route/project_copy_test.go
@@ -125,10 +125,10 @@ func (s *ProjectCopySuite) TestCopyToNewProject() {
 	s.NoError(err)
 	s.Len(usrs, 2)
 
-	res, err := data.FindProjectById("projectC", false, false)
+	res, err := data.FindProjectById(s.T().Context(), "projectC", false, false)
 	s.NoError(err)
 	s.NotNil(res)
-	res, err = data.FindProjectById("projectA", false, false)
+	res, err = data.FindProjectById(s.T().Context(), "projectA", false, false)
 	s.NoError(err)
 	s.NotNil(res)
 	vars, err := data.FindProjectVarsById(utility.FromStringPtr(newProject.Id), "", false)

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -230,7 +230,7 @@ func (s *ProjectPatchByIDSuite) TestRunWithValidBbConfig() {
 	s.NotNil(resp)
 	s.NotNil(resp.Data())
 	s.Require().Equal(http.StatusOK, resp.Status(), resp.Data())
-	pRef, err := data.FindProjectById("dimoxinil", false, false)
+	pRef, err := data.FindProjectById(s.T().Context(), "dimoxinil", false, false)
 	s.NoError(err)
 	s.Require().Equal("EVG", pRef.BuildBaronSettings.TicketCreateProject)
 }
@@ -287,7 +287,7 @@ func (s *ProjectPatchByIDSuite) TestGitTagVersionsEnabled() {
 	s.Require().Equal(http.StatusOK, resp.Status())
 
 	// verify that the repo fields weren't saved with the branch
-	p, err := data.FindProjectById("dimoxinil", false, false)
+	p, err := data.FindProjectById(s.T().Context(), "dimoxinil", false, false)
 	s.NoError(err)
 	s.Require().NotNil(p)
 	s.Empty(p.GitTagAuthorizedUsers)
@@ -363,7 +363,7 @@ func (s *ProjectPatchByIDSuite) TestUpdateParsleyFilters() {
 	s.NotNil(resp.Data())
 	s.Equal(http.StatusOK, resp.Status(), resp.Data())
 
-	p, err := data.FindProjectById("dimoxinil", true, false)
+	p, err := data.FindProjectById(s.T().Context(), "dimoxinil", true, false)
 	s.NoError(err)
 	s.NotNil(p)
 	s.Len(p.ParsleyFilters, 2)
@@ -397,7 +397,7 @@ func (s *ProjectPatchByIDSuite) TestPatchTriggerAliases() {
 	s.NotNil(resp.Data())
 	s.Equal(http.StatusOK, resp.Status())
 
-	p, err := data.FindProjectById("dimoxinil", true, false)
+	p, err := data.FindProjectById(s.T().Context(), "dimoxinil", true, false)
 	s.NoError(err)
 	s.NotEqual(p.PatchTriggerAliases, nil)
 	s.Len(p.PatchTriggerAliases, 1)
@@ -414,7 +414,7 @@ func (s *ProjectPatchByIDSuite) TestPatchTriggerAliases() {
 	s.NotNil(resp.Data())
 	s.Equal(http.StatusOK, resp.Status())
 
-	p, err = data.FindProjectById("dimoxinil", true, false)
+	p, err = data.FindProjectById(s.T().Context(), "dimoxinil", true, false)
 	s.NoError(err)
 	s.NotNil(p.PatchTriggerAliases)
 	s.Empty(p.PatchTriggerAliases)
@@ -429,7 +429,7 @@ func (s *ProjectPatchByIDSuite) TestPatchTriggerAliases() {
 	s.NotNil(resp.Data())
 	s.Equal(http.StatusOK, resp.Status())
 
-	p, err = data.FindProjectById("dimoxinil", true, false)
+	p, err = data.FindProjectById(s.T().Context(), "dimoxinil", true, false)
 	s.NoError(err)
 	s.Nil(p.PatchTriggerAliases)
 }
@@ -640,7 +640,7 @@ func (s *ProjectPutSuite) TestRunNewWithValidEntity() {
 	s.NotNil(resp.Data())
 	s.Equal(http.StatusCreated, resp.Status())
 
-	p, err := data.FindProjectById("nutsandgum", false, false)
+	p, err := data.FindProjectById(s.T().Context(), "nutsandgum", false, false)
 	s.NoError(err)
 	s.Require().NotNil(p)
 	s.NotEqual("nutsandgum", p.Id)
@@ -713,7 +713,7 @@ func (s *ProjectGetByIDSuite) TestRunExistingId() {
 	projectRef, ok := resp.Data().(*model.APIProjectRef)
 	s.Require().True(ok)
 	s.Equal(evergreen.CommitQueueAlias, utility.FromStringPtr(projectRef.Aliases[0].Alias))
-	cachedProject, err := data.FindProjectById(h.projectName, false, false)
+	cachedProject, err := data.FindProjectById(s.T().Context(), h.projectName, false, false)
 	s.NoError(err)
 	s.Equal(cachedProject.Repo, utility.FromStringPtr(projectRef.Repo))
 	s.Equal(cachedProject.Owner, utility.FromStringPtr(projectRef.Owner))
@@ -1100,7 +1100,7 @@ func TestDeleteProject(t *testing.T) {
 		resp := pdh.Run(ctx)
 		assert.Equal(t, http.StatusOK, resp.Status())
 
-		hiddenProj, err := serviceModel.FindMergedProjectRef(projects[i].Id, "", true)
+		hiddenProj, err := serviceModel.FindMergedProjectRef(t.Context(), projects[i].Id, "", true)
 		assert.NoError(t, err)
 		skeletonProj := serviceModel.ProjectRef{
 			Id:        projects[i].Id,
@@ -1195,7 +1195,7 @@ func TestAttachProjectToRepo(t *testing.T) {
 	assert.NotNil(t, resp.Data())
 	assert.Equal(t, http.StatusOK, resp.Status())
 
-	p, err := serviceModel.FindMergedProjectRef("projectIdent", "", false)
+	p, err := serviceModel.FindMergedProjectRef(t.Context(), "projectIdent", "", false)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
 	assert.True(t, p.UseRepoSettings())
@@ -1268,7 +1268,7 @@ func TestDetachProjectFromRepo(t *testing.T) {
 	assert.NotNil(t, resp.Data())
 	assert.Equal(t, http.StatusOK, resp.Status())
 
-	p, err := serviceModel.FindMergedProjectRef("projectIdent", "", false)
+	p, err := serviceModel.FindMergedProjectRef(t.Context(), "projectIdent", "", false)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
 	assert.False(t, p.UseRepoSettings())

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -848,7 +848,7 @@ func (h *serviceUsersGetHandler) Parse(ctx context.Context, r *http.Request) err
 }
 
 func (h *serviceUsersGetHandler) Run(ctx context.Context) gimlet.Responder {
-	users, err := data.GetServiceUsers()
+	users, err := data.GetServiceUsers(ctx)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting all service users"))
 	}

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -1082,7 +1082,7 @@ func (ch *offboardUserHandler) Run(ctx context.Context) gimlet.Responder {
 			"terminated_volumes": toTerminate.TerminatedVolumes,
 		})
 
-		grip.Error(message.WrapError(serviceModel.RemoveAdminFromProjects(ch.user), message.Fields{
+		grip.Error(message.WrapError(serviceModel.RemoveAdminFromProjects(ctx, ch.user), message.Fields{
 			"message": "could not remove user as an admin",
 			"context": "user offboarding",
 			"user":    ch.user,

--- a/service/api.go
+++ b/service/api.go
@@ -124,7 +124,7 @@ func (as *APIServer) FetchTask(w http.ResponseWriter, r *http.Request) {
 // No new information should be added to this route, instead a REST v2 route should be added.
 func (as *APIServer) fetchLimitedProjectRef(w http.ResponseWriter, r *http.Request) {
 	id := gimlet.GetVars(r)["projectId"]
-	p, err := model.FindMergedProjectRef(id, "", true)
+	p, err := model.FindMergedProjectRef(r.Context(), id, "", true)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
@@ -218,7 +218,7 @@ func (as *APIServer) validateProjectConfig(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	projectRef, err := model.FindMergedProjectRef(input.ProjectID, "", false)
+	projectRef, err := model.FindMergedProjectRef(r.Context(), input.ProjectID, "", false)
 	errs := validator.CheckProject(ctx, project, projectConfig, projectRef, input.ProjectID, err)
 
 	if input.Quiet {

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -129,7 +129,7 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	pref, err := model.FindMergedProjectRef(data.Project, "", true)
+	pref, err := model.FindMergedProjectRef(r.Context(), data.Project, "", true)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.Wrapf(err, "project '%s' is not specified", data.Project))
 		return

--- a/service/project.go
+++ b/service/project.go
@@ -54,7 +54,7 @@ func (uis *UIServer) setRevision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := projectRef.SetRepotrackerError(&model.RepositoryErrorDetails{}); err != nil {
+	if err := projectRef.SetRepotrackerError(r.Context(), &model.RepositoryErrorDetails{}); err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}

--- a/service/project_test.go
+++ b/service/project_test.go
@@ -16,26 +16,26 @@ func TestValidateBbProject(t *testing.T) {
 		Identifier: "proj1",
 	}
 	assert.NoError(p.Insert())
-	assert.NoError(model.ValidateBbProject("proj1", evergreen.BuildBaronSettings{
+	assert.NoError(model.ValidateBbProject(t.Context(), "proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:  "BFG",
 		TicketSearchProjects: []string{"BF", "BFG"},
 	}, nil))
 
-	assert.NoError(model.ValidateBbProject("proj1", evergreen.BuildBaronSettings{
+	assert.NoError(model.ValidateBbProject(t.Context(), "proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:  "BFG",
 		TicketSearchProjects: []string{"BF", "BFG"},
 	}, nil))
 
-	assert.NoError(model.ValidateBbProject("proj1", evergreen.BuildBaronSettings{
+	assert.NoError(model.ValidateBbProject(t.Context(), "proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:  "BFG",
 		TicketSearchProjects: []string{"BF", "BFG"},
 	}, nil))
 
-	assert.Error(model.ValidateBbProject("proj1", evergreen.BuildBaronSettings{
+	assert.Error(model.ValidateBbProject(t.Context(), "proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject: "BFG",
 	}, nil))
 
-	assert.Error(model.ValidateBbProject("proj1", evergreen.BuildBaronSettings{
+	assert.Error(model.ValidateBbProject(t.Context(), "proj1", evergreen.BuildBaronSettings{
 		TicketSearchProjects: []string{"BF", "BFG"},
 	}, nil))
 }
@@ -47,7 +47,7 @@ func TestBuildBaronPluginConfigureBFSuggestion(t *testing.T) {
 		Identifier: "proj1",
 	}
 	assert.NoError(p.Insert())
-	assert.NoError(model.ValidateBbProject("proj1", evergreen.BuildBaronSettings{
+	assert.NoError(model.ValidateBbProject(t.Context(), "proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:     "BFG",
 		TicketSearchProjects:    []string{"BF", "BFG"},
 		BFSuggestionServer:      "https://evergreen.mongodb.com",
@@ -56,34 +56,34 @@ func TestBuildBaronPluginConfigureBFSuggestion(t *testing.T) {
 		BFSuggestionTimeoutSecs: 10,
 	}, nil))
 
-	assert.NoError(model.ValidateBbProject("proj1", evergreen.BuildBaronSettings{
+	assert.NoError(model.ValidateBbProject(t.Context(), "proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:     "BFG",
 		TicketSearchProjects:    []string{"BF", "BFG"},
 		BFSuggestionServer:      "https://evergreen.mongodb.com",
 		BFSuggestionTimeoutSecs: 10,
 	}, nil))
 
-	assert.Error(model.ValidateBbProject("proj1", evergreen.BuildBaronSettings{
+	assert.Error(model.ValidateBbProject(t.Context(), "proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:  "BFG",
 		TicketSearchProjects: []string{"BF", "BFG"},
 		BFSuggestionUsername: "user",
 		BFSuggestionPassword: "pass",
 	}, nil))
 
-	assert.Error(model.ValidateBbProject("proj1", evergreen.BuildBaronSettings{
+	assert.Error(model.ValidateBbProject(t.Context(), "proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:     "BFG",
 		TicketSearchProjects:    []string{"BF", "BFG"},
 		BFSuggestionTimeoutSecs: 10,
 	}, nil))
 
-	assert.Error(model.ValidateBbProject("proj1", evergreen.BuildBaronSettings{
+	assert.Error(model.ValidateBbProject(t.Context(), "proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:     "BFG",
 		TicketSearchProjects:    []string{"BF", "BFG"},
 		BFSuggestionServer:      "://evergreen.mongodb.com",
 		BFSuggestionTimeoutSecs: 10,
 	}, nil))
 
-	assert.Error(model.ValidateBbProject("proj1", evergreen.BuildBaronSettings{
+	assert.Error(model.ValidateBbProject(t.Context(), "proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:     "BFG",
 		TicketSearchProjects:    []string{"BF", "BFG"},
 		BFSuggestionServer:      "https://evergreen.mongodb.com",
@@ -91,14 +91,14 @@ func TestBuildBaronPluginConfigureBFSuggestion(t *testing.T) {
 		BFSuggestionTimeoutSecs: 10,
 	}, nil))
 
-	assert.Error(model.ValidateBbProject("proj1", evergreen.BuildBaronSettings{
+	assert.Error(model.ValidateBbProject(t.Context(), "proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:     "BFG",
 		TicketSearchProjects:    []string{"BF", "BFG"},
 		BFSuggestionServer:      "https://evergreen.mongodb.com",
 		BFSuggestionTimeoutSecs: 0,
 	}, nil))
 
-	assert.Error(model.ValidateBbProject("proj1", evergreen.BuildBaronSettings{
+	assert.Error(model.ValidateBbProject(t.Context(), "proj1", evergreen.BuildBaronSettings{
 		TicketCreateProject:     "BFG",
 		TicketSearchProjects:    []string{"BF", "BFG"},
 		BFSuggestionServer:      "https://evergreen.mongodb.com",

--- a/service/rest_task.go
+++ b/service/rest_task.go
@@ -161,7 +161,7 @@ func (restapi restAPI) getTaskInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Copy over artifacts and binaries.
-	entries, err := artifact.FindAll(artifact.ByTaskId(srcTask.Id))
+	entries, err := artifact.FindAll(r.Context(), artifact.ByTaskId(srcTask.Id))
 	if err != nil {
 		msg := fmt.Sprintf("Error finding task '%s'", srcTask.Id)
 		grip.Errorf("%v: %+v", msg, err)

--- a/service/task.go
+++ b/service/task.go
@@ -649,7 +649,7 @@ func (uis *UIServer) taskFileRaw(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	taskFiles, err := artifact.GetAllArtifacts([]artifact.TaskIDAndExecution{{TaskID: projCtx.Task.Id, Execution: executionNum}})
+	taskFiles, err := artifact.GetAllArtifacts(r.Context(), []artifact.TaskIDAndExecution{{TaskID: projCtx.Task.Id, Execution: executionNum}})
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrapf(err, "unable to find artifacts for task '%s'", projCtx.Task.Id))
 		return

--- a/service/ui_plugin_build_baron.go
+++ b/service/ui_plugin_build_baron.go
@@ -114,7 +114,7 @@ func (uis *UIServer) bbGetCustomCreatedTickets(w http.ResponseWriter, r *http.Re
 	taskId := gimlet.GetVars(r)["task_id"]
 	var results []annotations.IssueLink
 
-	annotations, err := annotations.FindByTaskId(taskId)
+	annotations, err := annotations.FindByTaskId(r.Context(), taskId)
 	if err != nil {
 		gimlet.WriteJSONInternalError(w, err.Error())
 		return

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -55,7 +55,7 @@ func TriggerDownstreamVersion(ctx context.Context, args ProcessorArgs) (*model.V
 		projectID = args.SourceVersion.Identifier
 		versionID = args.SourceVersion.Id
 	}
-	upstreamProject, err := model.FindMergedProjectRef(projectID, versionID, true)
+	upstreamProject, err := model.FindMergedProjectRef(ctx, projectID, versionID, true)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding project ref '%s' for source version '%s'", projectID, versionID)
 	}

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -241,7 +241,7 @@ func (t *taskTriggers) makeData(ctx context.Context, sub *event.Subscription, pa
 		return nil, errors.Errorf("build '%s' not found while building email payload", t.task.BuildId)
 	}
 
-	projectRef, err := model.FindMergedProjectRef(t.task.Project, t.task.Version, true)
+	projectRef, err := model.FindMergedProjectRef(ctx, t.task.Project, t.task.Version, true)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding project ref '%s' for version '%s' while building email payload", t.task.Project, t.task.Version)
 	}
@@ -963,7 +963,7 @@ func JIRATaskPayload(ctx context.Context, params JiraIssueParameters) (*message.
 		return nil, errors.Errorf("version '%s' not found while building Jira task payload", params.Task.Version)
 	}
 
-	projectRef, err := model.FindMergedProjectRef(params.Task.Project, params.Task.Version, true)
+	projectRef, err := model.FindMergedProjectRef(ctx, params.Task.Project, params.Task.Version, true)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding project ref '%s' for version '%s' while building Jira task payload", params.Task.Version, params.Task.Version)
 	}

--- a/units/crons.go
+++ b/units/crons.go
@@ -1067,7 +1067,7 @@ func PopulateReauthorizeUserJobs(env evergreen.Environment) amboy.QueueOperation
 		if reauthAfter == 0 {
 			reauthAfter = defaultBackgroundReauth
 		}
-		users, err := user.FindNeedsReauthorization(reauthAfter)
+		users, err := user.FindNeedsReauthorization(ctx, reauthAfter)
 		if err != nil {
 			return errors.Wrap(err, "finding users that need to reauthorize")
 		}

--- a/units/crons_event_test.go
+++ b/units/crons_event_test.go
@@ -161,7 +161,7 @@ func (s *cronsEventSuite) TestSenderDegradedModeDoesntDispatchJobs() {
 	s.Empty(jobs)
 
 	out := []notification.Notification{}
-	s.NoError(db.FindAllQ(notification.Collection, db.Q{}, &out))
+	s.NoError(db.FindAllQContext(s.ctx, notification.Collection, db.Q{}, &out))
 	s.Len(out, 6)
 	for i := range out {
 		s.Equal("notification is disabled", out[i].Error)
@@ -298,7 +298,7 @@ func (s *cronsEventSuite) TestEndToEnd() {
 	s.Require().True(amboy.WaitInterval(s.ctx, q, 10*time.Millisecond))
 
 	out := []notification.Notification{}
-	s.NoError(db.FindAllQ(notification.Collection, db.Q{}, &out))
+	s.NoError(db.FindAllQContext(s.ctx, notification.Collection, db.Q{}, &out))
 	s.Require().Len(out, 1)
 
 	s.NotZero(out[0].SentAt, "%+v", out[0])

--- a/units/event_notifier.go
+++ b/units/event_notifier.go
@@ -231,7 +231,7 @@ func notificationJobs(ctx context.Context, notifications []notification.Notifica
 		if notificationIsEnabled(flags, &notifications[i]) {
 			jobs = append(jobs, NewEventSendJob(notifications[i].ID, ts.Format(TSFormat)))
 		} else {
-			catcher.Wrapf(notifications[i].MarkError(errors.New("notification is disabled")), "setting error for notification '%s'", notifications[i].ID)
+			catcher.Wrapf(notifications[i].MarkError(ctx, errors.New("notification is disabled")), "setting error for notification '%s'", notifications[i].ID)
 		}
 	}
 	return jobs, catcher.Resolve()

--- a/units/event_send.go
+++ b/units/event_send.go
@@ -93,7 +93,7 @@ func (j *eventSendJob) Run(ctx context.Context) {
 	}
 
 	if err = j.checkDegradedMode(n); err != nil {
-		j.AddError(errors.Wrapf(n.MarkError(errors.Wrap(err, "checking degraded mode")), "setting error for notification '%s'", n.ID))
+		j.AddError(errors.Wrapf(n.MarkError(ctx, errors.Wrap(err, "checking degraded mode")), "setting error for notification '%s'", n.ID))
 		return
 	}
 
@@ -110,8 +110,8 @@ func (j *eventSendJob) Run(ctx context.Context) {
 		"message":           "send failed",
 	}))
 	j.AddError(err)
-	j.AddError(errors.Wrapf(n.MarkSent(), "marking notification '%s' as sent", n.ID))
-	j.AddError(errors.Wrapf(n.MarkError(err), "setting error for notification '%s'", n.ID))
+	j.AddError(errors.Wrapf(n.MarkSent(ctx), "marking notification '%s' as sent", n.ID))
+	j.AddError(errors.Wrapf(n.MarkError(ctx, err), "setting error for notification '%s'", n.ID))
 }
 
 func (j *eventSendJob) send(n *notification.Notification) error {

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -150,7 +150,7 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 		return j.handleError(ctx, errors.WithStack(err))
 	}
 
-	pref, err := model.FindMergedProjectRef(t.Project, t.Version, true)
+	pref, err := model.FindMergedProjectRef(ctx, t.Project, t.Version, true)
 	if err != nil {
 		return j.handleError(ctx, errors.WithStack(err))
 	}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -254,7 +254,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		patchDoc.DisplayNewUI = true
 	}
 
-	pref, err := model.FindMergedProjectRef(patchDoc.Project, patchDoc.Version, true)
+	pref, err := model.FindMergedProjectRef(ctx, patchDoc.Project, patchDoc.Version, true)
 	if err != nil {
 		return errors.Wrap(err, "finding project for patch")
 	}
@@ -314,7 +314,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		validationCatcher.Errorf("invalid patched config for current project settings: %s", validator.ValidationErrorsToString(errs))
 	}
 
-	if errs := validator.CheckPatchedProjectConfigErrors(patchedProjectConfig).AtLevel(validator.Error); len(errs) != 0 {
+	if errs := validator.CheckPatchedProjectConfigErrors(ctx, patchedProjectConfig).AtLevel(validator.Error); len(errs) != 0 {
 		validationCatcher.Errorf("invalid patched project config syntax: %s", validator.ValidationErrorsToString(errs))
 	}
 	if validationCatcher.HasErrors() {
@@ -590,7 +590,7 @@ func (j *patchIntentProcessor) buildTasksAndVariants(ctx context.Context, patchD
 	}
 
 	if len(patchDoc.VariantsTasks) == 0 {
-		project.BuildProjectTVPairs(patchDoc, j.intent.GetAlias())
+		project.BuildProjectTVPairs(ctx, patchDoc, j.intent.GetAlias())
 	}
 	return nil
 }
@@ -807,7 +807,7 @@ func (j *patchIntentProcessor) buildCliPatchDoc(ctx context.Context, patchDoc *p
 		}))
 	}()
 
-	projectRef, err := model.FindMergedProjectRef(patchDoc.Project, patchDoc.Version, true)
+	projectRef, err := model.FindMergedProjectRef(ctx, patchDoc.Project, patchDoc.Version, true)
 	if err != nil {
 		return errors.Wrapf(err, "finding project ref '%s'", patchDoc.Project)
 	}
@@ -1028,7 +1028,7 @@ func (j *patchIntentProcessor) buildTriggerPatchDoc(ctx context.Context, patchDo
 	}
 
 	patchDoc.Githash = v.Revision
-	matchingTasks, err := project.VariantTasksForSelectors(intent.Definitions, patchDoc.GetRequester())
+	matchingTasks, err := project.VariantTasksForSelectors(ctx, intent.Definitions, patchDoc.GetRequester())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "matching tasks to alias definitions")
 	}

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1174,7 +1174,7 @@ func (s *PatchIntentUnitsSuite) TestProcessMergeGroupIntent() {
 	s.verifyVersionDoc(dbPatch, evergreen.GithubMergeRequester, evergreen.GithubMergeUser, baseSHA, 1)
 
 	out := []event.Subscription{}
-	s.NoError(db.FindAllQ(event.SubscriptionsCollection, db.Query(bson.M{}), &out))
+	s.NoError(db.FindAllQContext(s.ctx, event.SubscriptionsCollection, db.Query(bson.M{}), &out))
 	s.Len(out, 2)
 	for _, subscription := range out {
 		s.Equal("github_merge", subscription.Subscriber.Type)
@@ -1302,7 +1302,7 @@ func (s *PatchIntentUnitsSuite) TestProcessCliPatchIntent() {
 	s.gridFSFileExists(dbPatch.Patches[0].PatchSet.PatchFileId)
 
 	out := []event.Subscription{}
-	s.NoError(db.FindAllQ(event.SubscriptionsCollection, db.Query(bson.M{}), &out))
+	s.NoError(db.FindAllQContext(s.ctx, event.SubscriptionsCollection, db.Query(bson.M{}), &out))
 	s.Require().Empty(out)
 }
 
@@ -1370,7 +1370,7 @@ func (s *PatchIntentUnitsSuite) TestProcessCliPatchIntentWithoutFinalizing() {
 	s.gridFSFileExists(dbPatch.Patches[0].PatchSet.PatchFileId)
 
 	out := []event.Subscription{}
-	s.NoError(db.FindAllQ(event.SubscriptionsCollection, db.Query(bson.M{}), &out))
+	s.NoError(db.FindAllQContext(s.ctx, event.SubscriptionsCollection, db.Query(bson.M{}), &out))
 	s.Require().Empty(out)
 }
 

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -69,7 +69,7 @@ func (j *periodicBuildJob) Run(ctx context.Context) {
 	}
 	var err error
 	// Use a fully merged project for the rest of the job, since we need it for creating the version
-	j.project, err = model.FindMergedProjectRef(j.ProjectID, "", true)
+	j.project, err = model.FindMergedProjectRef(ctx, j.ProjectID, "", true)
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "finding project '%s'", j.ProjectID))
 		return

--- a/units/pod_definition_cleanup.go
+++ b/units/pod_definition_cleanup.go
@@ -147,7 +147,7 @@ func (j *podDefinitionCleanupJob) cleanupStalePodDefinitions(ctx context.Context
 	catcher := grip.NewBasicCatcher()
 	for _, podDef := range podDefs {
 		if podDef.ExternalID == "" {
-			if err := podDef.Remove(); err != nil {
+			if err := podDef.Remove(ctx); err != nil {
 				catcher.Wrapf(err, "deleting pod definition '%s' which is missing an external ID", podDef.ID)
 				continue
 			}

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -856,7 +856,7 @@ func GetGithubTokensForTask(ctx context.Context, taskId string) (string, []strin
 		if mfest != nil {
 			modules = mfest.Modules
 		}
-		p, err := model.FindMergedProjectRef(t.Project, t.Version, false)
+		p, err := model.FindMergedProjectRef(ctx, t.Project, t.Version, false)
 		catcher.Add(err)
 		if p != nil {
 			projectOwner = p.Owner

--- a/units/repotracker.go
+++ b/units/repotracker.go
@@ -83,7 +83,7 @@ func (j *repotrackerJob) Run(ctx context.Context) {
 		return
 	}
 
-	ref, err := model.FindMergedProjectRef(j.ProjectID, "", true)
+	ref, err := model.FindMergedProjectRef(ctx, j.ProjectID, "", true)
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "finding project '%s'", j.ProjectID))
 		return

--- a/units/schedule_patch.go
+++ b/units/schedule_patch.go
@@ -24,7 +24,7 @@ func SchedulePatch(ctx context.Context, env evergreen.Environment, patchId strin
 	if p.IsMergeQueuePatch() {
 		return http.StatusBadRequest, errors.New("can't schedule commit queue patch")
 	}
-	projectRef, err := model.FindMergedProjectRef(p.Project, p.Version, true)
+	projectRef, err := model.FindMergedProjectRef(ctx, p.Project, p.Version, true)
 	if err != nil {
 		return http.StatusInternalServerError, errors.Wrapf(err, "finding project ref '%s' for version '%s'", p.Project, p.Version)
 	}

--- a/units/spawnhost_expiration_check_test.go
+++ b/units/spawnhost_expiration_check_test.go
@@ -86,7 +86,7 @@ func TestTryIdleSpawnHostNotification(t *testing.T) {
 	assert.NoError(t, tryIdleSpawnHostNotification(h))
 
 	fetchedSubs := []event.Subscription{}
-	assert.NoError(t, db.FindAllQ(event.SubscriptionsCollection, db.Q{}, &fetchedSubs))
+	assert.NoError(t, db.FindAllQContext(t.Context(), event.SubscriptionsCollection, db.Q{}, &fetchedSubs))
 	require.Len(t, fetchedSubs, 1)
 	assert.Equal(t, u.EmailAddress, utility.FromStringPtr(fetchedSubs[0].Subscriber.Target.(*string)))
 	assert.Equal(t, event.EmailSubscriberType, fetchedSubs[0].Subscriber.Type)
@@ -95,7 +95,7 @@ func TestTryIdleSpawnHostNotification(t *testing.T) {
 	// Trying to re-insert the subscription doesn't create a new subscription.
 	assert.NoError(t, tryIdleSpawnHostNotification(h))
 	fetchedSubs = []event.Subscription{}
-	assert.NoError(t, db.FindAllQ(event.SubscriptionsCollection, db.Q{}, &fetchedSubs))
+	assert.NoError(t, db.FindAllQContext(t.Context(), event.SubscriptionsCollection, db.Q{}, &fetchedSubs))
 	require.Len(t, fetchedSubs, 1)
 
 	events, err := event.FindAllByResourceID(h.Id)

--- a/units/spawnhost_expiration_warning_test.go
+++ b/units/spawnhost_expiration_warning_test.go
@@ -164,7 +164,7 @@ func (s *spawnHostExpirationSuite) TestDuplicateEventsAreLoggedAfterRenotificati
 			numHostsToRenotify++
 		}
 	}
-	res, err := db.UpdateAll(alertrecord.Collection, bson.M{
+	res, err := db.UpdateAllContext(s.ctx, alertrecord.Collection, bson.M{
 		alertrecord.HostIdKey: bson.M{"$in": []string{"h1", "h2", "h3", "h4", "h5"}}}, bson.M{
 		"$set": bson.M{
 			alertrecord.AlertTimeKey: time.Now().Add(-7 * utility.Day),

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2525,31 +2525,31 @@ func TestValidatePlugins(t *testing.T) {
 	assert.NoError(projectRef.Insert())
 	Convey("When validating a project", t, func() {
 		Convey("ensure bad plugin configs throw an error", func() {
-			So(validateProjectConfigPlugins(&model.ProjectConfig{}), ShouldResemble, ValidationErrors{})
-			So(validateProjectConfigPlugins(&model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
+			So(validateProjectConfigPlugins(t.Context(), &model.ProjectConfig{}), ShouldResemble, ValidationErrors{})
+			So(validateProjectConfigPlugins(t.Context(), &model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
 				TicketCreateProject:  "BFG",
 				TicketSearchProjects: []string{"BF", "BFG"},
 			}}}), ShouldResemble, ValidationErrors{})
 
-			So(validateProjectConfigPlugins(&model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
+			So(validateProjectConfigPlugins(t.Context(), &model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
 				TicketCreateProject:  "BFG",
 				TicketSearchProjects: []string{"BF", "BFG"},
 			}}}), ShouldResemble, ValidationErrors{})
 
-			So(validateProjectConfigPlugins(&model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
+			So(validateProjectConfigPlugins(t.Context(), &model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
 				TicketCreateProject:  "BFG",
 				TicketSearchProjects: []string{"BF", "BFG"},
 			}}}), ShouldResemble, ValidationErrors{})
 
-			So(validateProjectConfigPlugins(&model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
+			So(validateProjectConfigPlugins(t.Context(), &model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
 				TicketCreateProject: "BFG",
 			}}}), ShouldNotBeNil)
 
-			So(validateProjectConfigPlugins(&model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
+			So(validateProjectConfigPlugins(t.Context(), &model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
 				TicketSearchProjects: []string{"BF", "BFG"},
 			}}}), ShouldNotBeNil)
 
-			So(validateProjectConfigPlugins(&model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
+			So(validateProjectConfigPlugins(t.Context(), &model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
 				TicketCreateProject:     "BFG",
 				TicketSearchProjects:    []string{"BF", "BFG"},
 				BFSuggestionServer:      "https://evergreen.mongodb.com",
@@ -2558,48 +2558,48 @@ func TestValidatePlugins(t *testing.T) {
 				BFSuggestionTimeoutSecs: 10,
 			}}}), ShouldResemble, ValidationErrors{})
 
-			So(validateProjectConfigPlugins(&model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
+			So(validateProjectConfigPlugins(t.Context(), &model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
 				TicketCreateProject:     "BFG",
 				TicketSearchProjects:    []string{"BF", "BFG"},
 				BFSuggestionServer:      "https://evergreen.mongodb.com",
 				BFSuggestionTimeoutSecs: 10,
 			}}}), ShouldResemble, ValidationErrors{})
 
-			So(validateProjectConfigPlugins(&model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
+			So(validateProjectConfigPlugins(t.Context(), &model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
 				TicketCreateProject:  "BFG",
 				TicketSearchProjects: []string{"BF", "BFG"},
 				BFSuggestionUsername: "user",
 				BFSuggestionPassword: "pass",
 			}}}), ShouldNotBeNil)
 
-			So(validateProjectConfigPlugins(&model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
+			So(validateProjectConfigPlugins(t.Context(), &model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
 				TicketCreateProject:     "BFG",
 				TicketSearchProjects:    []string{"BF", "BFG"},
 				BFSuggestionTimeoutSecs: 10,
 			}}}), ShouldNotBeNil)
 
-			So(validateProjectConfigPlugins(&model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
+			So(validateProjectConfigPlugins(t.Context(), &model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
 				TicketCreateProject:     "BFG",
 				TicketSearchProjects:    []string{"BF", "BFG"},
 				BFSuggestionServer:      "://evergreen.mongodb.com",
 				BFSuggestionTimeoutSecs: 10,
 			}}}), ShouldNotBeNil)
 
-			So(validateProjectConfigPlugins(&model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
+			So(validateProjectConfigPlugins(t.Context(), &model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
 				TicketCreateProject:     "BFG",
 				TicketSearchProjects:    []string{"BF", "BFG"},
 				BFSuggestionServer:      "https://evergreen.mongodb.com",
 				BFSuggestionPassword:    "pass",
 				BFSuggestionTimeoutSecs: 10,
 			}}}), ShouldNotBeNil)
-			So(validateProjectConfigPlugins(&model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
+			So(validateProjectConfigPlugins(t.Context(), &model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
 				TicketCreateProject:     "BFG",
 				TicketSearchProjects:    []string{"BF", "BFG"},
 				BFSuggestionServer:      "https://evergreen.mongodb.com",
 				BFSuggestionTimeoutSecs: 0,
 			}}}), ShouldNotBeNil)
 
-			So(validateProjectConfigPlugins(&model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
+			So(validateProjectConfigPlugins(t.Context(), &model.ProjectConfig{Id: "", ProjectConfigFields: model.ProjectConfigFields{BuildBaronSettings: &evergreen.BuildBaronSettings{
 				TicketCreateProject:     "BFG",
 				TicketSearchProjects:    []string{"BF", "BFG"},
 				BFSuggestionServer:      "https://evergreen.mongodb.com",
@@ -3073,7 +3073,7 @@ func TestValidateProjectAliases(t *testing.T) {
 					},
 				},
 			}
-			validationErrs := validateProjectConfigAliases(projectConfig)
+			validationErrs := validateProjectConfigAliases(t.Context(), projectConfig)
 			So(validationErrs, ShouldNotResemble, ValidationErrors{})
 			So(len(validationErrs), ShouldEqual, 8)
 			So(validationErrs[0].Message, ShouldContainSubstring, "can't be empty string")
@@ -3375,7 +3375,7 @@ func TestValidateProjectConfigContainers(t *testing.T) {
 				},
 			},
 		}
-		errs := validateProjectConfigContainers(&pc)
+		errs := validateProjectConfigContainers(t.Context(), &pc)
 		assert.Empty(t, errs)
 	})
 	t.Run("FailsWithInvalidContainerResources", func(t *testing.T) {
@@ -3390,7 +3390,7 @@ func TestValidateProjectConfigContainers(t *testing.T) {
 				},
 			},
 		}
-		errs := validateProjectConfigContainers(&pc)
+		errs := validateProjectConfigContainers(t.Context(), &pc)
 		assert.NotEmpty(t, errs)
 	})
 	t.Run("FailsWithUnnamedContainerSize", func(t *testing.T) {
@@ -3405,7 +3405,7 @@ func TestValidateProjectConfigContainers(t *testing.T) {
 				},
 			},
 		}
-		errs := validateProjectConfigContainers(&pc)
+		errs := validateProjectConfigContainers(t.Context(), &pc)
 		assert.NotEmpty(t, errs)
 	})
 	t.Run("FailsWithContainerSizeExceedingGlobalLimits", func(t *testing.T) {
@@ -3431,7 +3431,7 @@ func TestValidateProjectConfigContainers(t *testing.T) {
 					},
 				},
 			}
-			errs := validateProjectConfigContainers(&pc)
+			errs := validateProjectConfigContainers(t.Context(), &pc)
 			assert.NotEmpty(t, errs)
 		})
 		t.Run("Memory", func(t *testing.T) {
@@ -3446,7 +3446,7 @@ func TestValidateProjectConfigContainers(t *testing.T) {
 					},
 				},
 			}
-			errs := validateProjectConfigContainers(&pc)
+			errs := validateProjectConfigContainers(t.Context(), &pc)
 			assert.NotEmpty(t, errs)
 		})
 	})


### PR DESCRIPTION
DEVPROD-53

### Description
This adds more context to our db queries. It completely removes non-context db queries for a couple of different functions (like Remove, UpdateId). The files changed was creeping again so I broke it off to another PR.

This PR doesn't have any changes other than passing context everywhere, some updates to interfaces/implementations to accept contexts as well.

### Testing
Unit tests
