### PR TITLE
DEVPROD-15018 Add route to copy distros

### DIFF
--- a/rest/data/distro.go
+++ b/rest/data/distro.go
@@ -112,7 +112,7 @@ func CopyDistro(ctx context.Context, u *user.DBUser, opts restModel.CopyDistroOp
 	}
 
 	distroToCopy.Id = opts.NewDistroId
-	return newDistro(ctx, distroToCopy, u)
+	return NewDistro(ctx, distroToCopy, u)
 }
 
 // CreateDistro creates a new distro with the provided ID using the default settings specified here.
@@ -143,10 +143,11 @@ func CreateDistro(ctx context.Context, u *user.DBUser, newDistroId string, singl
 		WorkDir:          "/data/mci",
 	}
 
-	return newDistro(ctx, defaultDistro, u)
+	return NewDistro(ctx, defaultDistro, u)
 }
 
-func newDistro(ctx context.Context, d *distro.Distro, u *user.DBUser) error {
+// NewDistro creates a new distro in the database with the given user as the creator and creates an event log.
+func NewDistro(ctx context.Context, d *distro.Distro, u *user.DBUser) error {
 	settings, err := evergreen.GetConfig(ctx)
 	if err != nil {
 		return errors.Wrap(err, "getting admin settings")

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -268,9 +268,9 @@ func makeCopyDistro() gimlet.RouteHandler {
 //	@Tags			distros
 //	@Router			/distros/{distro_id}/copy/{new_distro_id} [put]
 //	@Security		Api-User || Api-Key
-//	@Param			distro_id	            path	string	true	"distro ID to copy"
-//	@Param			new_distro_id	        path	string	true	"ID of new distro to be created"
-//	@Param			single_task_distro	 	query	bool	false	"if should the copied distro should be single task"
+//	@Param			distro_id			path	string	true	"distro ID to copy"
+//	@Param			new_distro_id		path	string	true	"ID of new distro to be created"
+//	@Param			single_task_distro	query	bool	false	"if should the copied distro should be single task"
 //	@Success		201
 //	@Success		200
 func (h *distroCopyHandler) Factory() gimlet.RouteHandler {

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -249,6 +249,83 @@ func (h *distroIDPutHandler) Run(ctx context.Context) gimlet.Responder {
 
 ///////////////////////////////////////////////////////////////////////
 //
+// PUT /rest/v2/distros/{distro_id}/copy/{new_distro_id}
+
+type distroCopyHandler struct {
+	distroToCopy       string
+	newDistroID        string
+	single_task_distro bool
+}
+
+func makeCopyDistro() gimlet.RouteHandler {
+	return &distroCopyHandler{}
+}
+
+// Factory creates an instance of the handler.
+//
+//	@Summary		Copy an existing distro
+//	@Description	Create a new distro by copying an existing distro. Specifying "single task distro" will mark the copied distro as a single task distro.
+//	@Tags			distros
+//	@Router			/distros/{distro_id}/copy/{new_distro_id} [put]
+//	@Security		Api-User || Api-Key
+//	@Param			distro_id	            path	string	true	"distro ID to copy"
+//	@Param			new_distro_id	        path	string	true	"ID of new distro to be created"
+//	@Param			single_task_distro	 	query	bool	false	"if should the copied distro should be single task"
+//	@Success		201
+//	@Success		200
+func (h *distroCopyHandler) Factory() gimlet.RouteHandler {
+	return &distroCopyHandler{}
+}
+
+// Parse fetches the distroId and JSON payload from the http request.
+func (h *distroCopyHandler) Parse(ctx context.Context, r *http.Request) error {
+	h.distroToCopy = gimlet.GetVars(r)["distro_id"]
+	h.newDistroID = gimlet.GetVars(r)["new_distro_id"]
+	h.single_task_distro = r.URL.Query().Get("single_task_distro") == "true"
+
+	return nil
+}
+
+// Run creates a new distro by copying an existing distro.
+func (h *distroCopyHandler) Run(ctx context.Context) gimlet.Responder {
+	if h.distroToCopy == h.newDistroID {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    "new and existing distro IDs cannot be identical",
+		})
+	}
+
+	user := MustHaveUser(ctx)
+	toCopy, err := distro.FindOneId(ctx, h.distroToCopy)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding distro '%s'", h.distroToCopy))
+	}
+	if toCopy == nil {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("distro '%s' not found", h.distroToCopy),
+		})
+	}
+
+	toCopy.Id = h.newDistroID
+	if h.single_task_distro {
+		toCopy.SingleTaskDistro = true
+	}
+
+	err = data.NewDistro(ctx, toCopy, user)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating and inserting new distro '%s'", h.newDistroID))
+	}
+
+	responder := gimlet.NewJSONResponse(struct{}{})
+	if err = responder.SetStatus(http.StatusCreated); err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "setting HTTP status code to %d", http.StatusCreated))
+	}
+	return responder
+}
+
+///////////////////////////////////////////////////////////////////////
+//
 // DELETE /rest/v2/distros/{distro_id}
 
 type distroIDDeleteHandler struct {

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -1484,13 +1484,6 @@ func (s *distroCopySuite) SetupTest() {
 	s.rm = makeCopyDistro()
 }
 
-func (s *distroCopySuite) TestParse() {
-	ctx := context.Background()
-	req, _ := http.NewRequest(http.MethodPut, "http://example.com/api/rest/v2/distros/distro1/copy/distro3?single_task_distro=true", nil)
-	err := s.rm.Parse(ctx, req)
-	s.NoError(err)
-}
-
 func (s *distroCopySuite) TestParseInvalidIDs() {
 	ctx := context.Background()
 	req, _ := http.NewRequest(http.MethodPut, "http://example.com/api/rest/v2/distros/distro1/copy/distro1?single_task_distro=true", nil)

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -148,6 +148,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/distros/{distro_id}").Version(2).Put().Wrap(requireUser, createDistro).RouteHandler(makePutDistro())
 	app.AddRoute("/distros/{distro_id}/setup").Version(2).Get().Wrap(requireUser, editDistroSettings).RouteHandler(makeGetDistroSetup())
 	app.AddRoute("/distros/{distro_id}/setup").Version(2).Patch().Wrap(requireUser, editDistroSettings).RouteHandler(makeChangeDistroSetup())
+	app.AddRoute("/distros/{distro_id}/copy/{new_distro_id}").Version(2).Put().Wrap(requireUser, editDistroSettings).RouteHandler(makeCopyDistro())
 
 	app.AddRoute("/hooks/github").Version(2).Post().Wrap(requireValidGithubPayload).RouteHandler(makeGithubHooksRoute(sc, opts.APIQueue, opts.GithubSecret, settings))
 	app.AddRoute("/hooks/aws").Version(2).Post().Wrap(requireValidSNSPayload).RouteHandler(makeEC2SNS(env, opts.APIQueue))


### PR DESCRIPTION
DEVPROD-15018 

### Description
route for copying distros 
takes in single_task_distro field to make the creation of these distros easier for the buildenv team

### Testing
unit tests 

tested on staging route works and created these distros 
https://spruce-staging.corp.mongodb.com/distro/routecopy1/settings/general
https://spruce-staging.corp.mongodb.com/distro/routecopy2/settings/general