### PR TITLE
DEVPROD-15371: clean up git config before setting auth token

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -202,6 +202,11 @@ functions:
         include_expansions_in_env: ["GOROOT", "github_token"]
         shell: bash
         script: |
+          # TODO (DEVPROD-15806): removing these files is a temporary workaround to ensure the git
+          # configuration/credentials files are clean on Windows. Once DEVPROD-15806 is addressed, this can be removed.
+          rm -f ~/.gitconfig
+          rm -f ~/.git-credentials
+
           # Set GitHub app dynamic token to ensure it can clone non-public repos for Go modules.
           git config --global url."https://x-access-token:${github_token}@github.com/evergreen-ci/".insteadOf https://github.com/evergreen-ci/
 


### PR DESCRIPTION
DEVPROD-15371

### Description
Downloading the internal repo for Go modules occasionally fails cloning internal modules on Windows. Turns out it's because specifically on Windows, the agent doesn't clean up the global `.gitconfig` file between tasks due to DEVPROD-15806.

`git config --global url."https://x-access-token:${github_token}@github.com/evergreen-ci/".insteadOf https://github.com/evergreen-ci/` appends a new configuration line to `.gitconfig` to set the URL to use when cloning Go modules. If the global `.gitconfig` already contained some pre-existing clone URL from a previous task, the new clone URL that was appended would be ignored in favor of the earlier clone URL. The Windows self-test task would flake because it would occasionally be assigned to a host that had already run a previous Windows self-test task that had set the global `.gitconfig` clone URL.

### Testing
Ran patches with this change and verified that Go module downloads worked, even when Windows tasks in my patch were assigned to the same host by chance.
