### PR TITLE
DEVPROD-13973 Stop storing keys for internal buckets

### DIFF
--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -602,10 +602,10 @@ func (s3pc *s3put) attachFiles(ctx context.Context, comm client.Communicator, lo
 			// If the bucket is an internal one, Evergreen does not need the credentials
 			// to sign the URL. If the bucket is not an internal one, Evergreen needs the
 			// credentials to sign the URL.
-			// if !utility.StringSliceContains(s3pc.internalBuckets, s3pc.Bucket) {
-			key = s3pc.AwsKey
-			secret = s3pc.AwsSecret
-			// }
+			if !utility.StringSliceContains(s3pc.internalBuckets, s3pc.Bucket) {
+				key = s3pc.AwsKey
+				secret = s3pc.AwsSecret
+			}
 		}
 
 		files = append(files, &artifact.File{

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-03-14"
+	AgentVersion = "2025-03-17"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-13973

### Description
I readded storing keys while I added a lot of internal buckets- to make sure all artifacts have some type of coverage/retrieval method. This reverts it back.

### Testing
Info in ticket thread.
