### PR TITLE
DEVPROD-15507 Scope down GitHub token generated in self-tests to contents: read

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -189,6 +189,8 @@ functions:
       type: setup
       params:
         expansion_name: github_token
+        permissions:
+          contents: read
     - command: git.get_project
       type: setup
       params:
@@ -276,9 +278,6 @@ functions:
         EVG_CLIENT_S3_BUCKET: evg-bucket-evergreen
 
   setup-credentials:
-    - command: github.generate_token
-      params:
-        expansion_name: github_token
     - command: subprocess.exec
       type: setup
       params:
@@ -685,6 +684,8 @@ tasks:
       - command: github.generate_token
         params:
           expansion_name: github_token
+          permissions:
+            contents: read
       - command: git.get_project
         type: setup
         params:

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -627,6 +627,8 @@ tasks:
       - command: github.generate_token
         params:
           expansion_name: github_token
+          permissions:
+            contents: read
       - command: git.get_project
         type: setup
         params:


### PR DESCRIPTION
DEVPROD-15507

### Description
This scopes down our tokens generated in self-tests to just contents: read. 

### Testing
[This](https://parsley.mongodb.com/evergreen/evergreen_lint_generate_lint_ceae5aa100d628053b09b71a6ab4f80aabab4e48_25_03_17_18_32_26/0/task?bookmarks=0,301&shareLine=9) is a token generated before by our lint tests.[This](https://parsley.mongodb.com/evergreen/evergreen_lint_generate_lint_patch_ceae5aa100d628053b09b71a6ab4f80aabab4e48_67d871f2bd6d320007602cc5_25_03_17_19_03_15/0/task?bookmarks=0,301&selectedLineRange=L9) is a token generated after by our lint tests.
