### PR TITLE
DEVPROD-11126: shorten Windows task directory hash

### DIFF
--- a/agent/directory.go
+++ b/agent/directory.go
@@ -62,7 +62,6 @@ func (a *Agent) createTaskDirectory(tc *taskContext, taskDir string) (string, er
 // issues for some tasks that have deep paths that hit the Windows path length
 // limit. Shortening the typical 32-character directory name reduces the
 // problem.
-// kim: TODO: test in staging, Linux/Windows
 func (a *Agent) generateTaskDirectoryName(tc *taskContext) (string, error) {
 	dirName, err := a.generateTaskDirectoryHash(fmt.Sprintf("%s_%d_%d", tc.taskConfig.Task.Id, tc.taskConfig.Task.Execution, os.Getpid()))
 	if err != nil {

--- a/agent/directory.go
+++ b/agent/directory.go
@@ -118,7 +118,7 @@ func (a *Agent) generateTaskDirectoryHash(toHash string) (string, error) {
 	// On Windows, the agent has to use a shorter task working directory due to
 	// max file path length limitations. To accommodate this, try shortening the
 	// long hash.
-	const maxWindowsHashLength = 3
+	const maxWindowsHashLength = 4
 	return dirName[:maxWindowsHashLength], nil
 }
 

--- a/agent/directory.go
+++ b/agent/directory.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -36,7 +37,16 @@ func (a *Agent) createTaskDirectory(tc *taskContext, taskDir string) (string, er
 			return "", err
 		}
 
-		dirName := hex.EncodeToString(h.Sum(nil))
+		md5Sum := h.Sum(nil)
+
+		dirName := hex.EncodeToString(md5Sum)
+		if runtime.GOOS == "windows" {
+			// Windows has a max filepath length which can cause issues for some
+			// tasks that hit the length limit. Shortening the typical
+			// 32-character directory name reduces the problem.
+			dirName = dirName[:3]
+		}
+
 		taskDir = filepath.Join(a.opts.WorkingDirectory, dirName)
 	}
 

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-03-18"
+	AgentVersion = "2025-03-18a"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-11126

### Description
Windows has a restrictive maximum string length on file paths, which is difficult to work around for users. To make it slightly less difficult, I reduced the usual 32-character hash in the task working directory to be 4 characters for Windows.

Because reducing the hash also makes it less unique (16^4 instead of 16^32 possible combinations) and the fact that cleaning up previous task working directories is best-effort and not a guarantee, I added some logic to attempt to re-hash the directory in case of collisions with leftover task directories on the host.

As far as backward compatibility, there's a very slight chance that some task out there that depends on the hash being exactly 32 characters long in Windows (e.g. if they're for some reason trying to parse the task working directory's absolute path format and assume it's exactly 32 characters long), but it seems unlikely. I'll send out a small pinned notice in #ask-devprod-evergreen saying that it happened in case anyone does have issues.

### Testing
* Tested in staging and verified that it produced a working directory with 4 characters in the hash rather than 32.

### Documentation
N/A - we don't document the exact format of the task working directory because it depends partly on distro settings and I'd rather not encourage users to depend on the task working directory following an exact, rigid format.