### PR TITLE
DEVPROD-13983 Add project to bucket mappings to buckets config

### DIFF
--- a/config_bucket.go
+++ b/config_bucket.go
@@ -34,6 +34,16 @@ type ProjectToPrefixMapping struct {
 	Prefix string `yaml:"prefix" bson:"prefix" json:"prefix"`
 }
 
+// ProjectToBucketMapping relates a project to a bucket.
+type ProjectToBucketMapping struct {
+	// ProjectID is the project's ID.
+	ProjectID string `yaml:"project_id" bson:"project_id" json:"project_id"`
+	// Bucket is the bucket that the project should have access to.
+	Bucket string `yaml:"bucket" bson:"bucket" json:"bucket"`
+	// Prefix is an optional bucket path prefix that the project should have access to.
+	Prefix string `yaml:"prefix" bson:"prefix" json:"prefix"`
+}
+
 // BucketsConfig represents the admin config section for interally-owned
 // Evergreen data bucket storage.
 type BucketsConfig struct {
@@ -51,6 +61,10 @@ type BucketsConfig struct {
 	// E.g. if project A should have access to project B's prefix, then
 	// project A's ID and project B's prefix should be in this list.
 	ProjectToPrefixMappings []ProjectToPrefixMapping `yaml:"project_to_prefix_mappings" bson:"project_to_prefix_mappings" json:"project_to_prefix_mappings"`
+
+	// ProjectToBucketMappings is a list of project to bucket mappings.
+	// This is used to connect projects to buckets Evergreen has access to.
+	ProjectToBucketMappings []ProjectToBucketMapping `yaml:"project_to_bucket_mappings" bson:"project_to_bucket_mappings" json:"project_to_bucket_mappings"`
 }
 
 var (
@@ -58,6 +72,7 @@ var (
 	bucketsConfigCredentialsKey     = bsonutil.MustHaveTag(BucketsConfig{}, "Credentials")
 	bucketsConfigInternalBucketsKey = bsonutil.MustHaveTag(BucketsConfig{}, "InternalBuckets")
 	projectToPrefixMappingsKey      = bsonutil.MustHaveTag(BucketsConfig{}, "ProjectToPrefixMappings")
+	projectToBucketMappingsKey      = bsonutil.MustHaveTag(BucketsConfig{}, "ProjectToBucketMappings")
 )
 
 // BucketConfig represents the admin config for an individual bucket.
@@ -92,6 +107,7 @@ func (c *BucketsConfig) Set(ctx context.Context) error {
 			bucketsConfigCredentialsKey:     c.Credentials,
 			bucketsConfigInternalBucketsKey: c.InternalBuckets,
 			projectToPrefixMappingsKey:      c.ProjectToPrefixMappings,
+			projectToBucketMappingsKey:      c.ProjectToBucketMappings,
 		}}), "updating config section '%s'", c.SectionId(),
 	)
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1002,6 +1002,13 @@ func (s *AdminSuite) TestBucketsConfig() {
 				Prefix:    "project-B",
 			},
 		},
+		ProjectToBucketMappings: []ProjectToBucketMapping{
+			{
+				ProjectID: "project-C",
+				Bucket:    "bucket-C",
+				Prefix:    "prefix-1",
+			},
+		},
 	}
 
 	err := config.Set(ctx)
@@ -1016,6 +1023,11 @@ func (s *AdminSuite) TestBucketsConfig() {
 	config.ProjectToPrefixMappings = []ProjectToPrefixMapping{{
 		ProjectID: "project-C",
 		Prefix:    "project-D",
+	}}
+	config.ProjectToBucketMappings = []ProjectToBucketMapping{{
+		ProjectID: "project-A",
+		Bucket:    "bucket-A",
+		Prefix:    "prefix-2",
 	}}
 	s.NoError(config.Set(ctx))
 

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -261,6 +261,26 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
     $scope.invalidProjectToPrefixMapping = "";
   }
 
+  $scope.addProjectToBucketMapping = function () {
+    if ($scope.Settings.buckets == null) {
+      $scope.Settings.buckets = {
+        "project_to_bucket_mappings": []
+      };
+    }
+    if ($scope.Settings.buckets.project_to_bucket_mappings == null) {
+      $scope.Settings.buckets.project_to_bucket_mappings = [];
+    }
+
+    if (!$scope.validProjectToBucketMapping($scope.new_project_to_bucket_mapping)) {
+      $scope.invalidProjectToBucketMapping = "Project and bucket are required.";
+      return
+    }
+
+    $scope.Settings.buckets.project_to_bucket_mappings.push($scope.new_project_to_bucket_mapping);
+    $scope.new_project_to_bucket_mapping = {};
+    $scope.invalidProjectToBucketMapping = "";
+  }
+
   $scope.addInternalBucket = function () {
     if ($scope.Settings.buckets == null) {
       $scope.Settings.buckets = {
@@ -295,6 +315,15 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
 
   $scope.validProjectToPrefixMapping = function (mapping) {
     return mapping && mapping.project_id && mapping.prefix;
+  }
+
+  $scope.deleteProjectToBucketMapping = function (index) {
+    $scope.Settings.buckets.project_to_bucket_mappings.splice(index, 1);
+  }
+
+  $scope.validProjectToBucketMapping = function (mapping) {
+    // We do not check mapping.prefix since it is optional.
+    return mapping && mapping.project_id && mapping.bucket;
   }
 
   $scope.deleteInternalBucket = function (index) {

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -2280,7 +2280,6 @@ Admin Settings
 													<input class="control" type="text" ng-model="new_project_to_prefix_mapping.project_id"
 														placeholder="Project ID">
 												</md-input-container>
-
 												<md-input-container class="control" flex=30>
 													<input class="control" type="text" ng-model="new_project_to_prefix_mapping.prefix"
 														placeholder="Bucket Prefix">
@@ -2292,6 +2291,60 @@ Admin Settings
 														<i class="fa fa-plus"></i>
 													</button>
 													<label class="control">[[ invalidProjectToPrefixMapping ]]</label>
+												</div>
+											</section>
+										</md-card-content>
+									</md-card>
+									<md-card style="margin-bottom:20px;">
+										<md-card-title>
+											<md-card-title-text>
+												<span>Project to bucket mappings</span>
+											</md-card-title-text>
+										</md-card-title>
+										<md-card-content>
+											<div id="project-to-bucket-mappings" class="form-group"
+												ng-repeat="(index, mapping) in Settings.buckets.project_to_bucket_mappings">
+												<section layout="row" flex>
+													<md-input-container class="control" flex=30>
+														<input class="control" type="text" ng-model="mapping.project_id"
+															placeholder="Project ID">
+													</md-input-container>
+													<md-input-container class="control" flex=30>
+														<input class="control" type="text" ng-model="mapping.bucket"
+															placeholder="Bucket name">
+													</md-input-container>
+													<md-input-container class="control" flex=30>
+														<input class="control" type="text" ng-model="mapping.prefix"
+															placeholder="Prefix (Optional)">
+													</md-input-container>
+													<div style="margin-top: 1%;">
+														<button class="btn btn-default btn-danger" type="button"
+															style="float: left" ng-click="deleteProjectToBucketMapping(index)">
+															<i class="fa fa-trash"></i>
+														</button>
+													</div>
+												</section>
+											</div>
+											<section layout="row" flex>
+												<md-input-container class="control" flex=30>
+													<input class="control" type="text" ng-model="new_project_to_bucket_mapping.project_id"
+														placeholder="Project ID">
+												</md-input-container>
+												<md-input-container class="control" flex=30>
+													<input class="control" type="text" ng-model="new_project_to_bucket_mapping.bucket"
+														placeholder="Bucket name">
+												</md-input-container>
+												<md-input-container class="control" flex=30>
+													<input class="control" type="text" ng-model="new_project_to_bucket_mapping.prefix"
+														placeholder="Prefix (Optional)">
+												</md-input-container>
+												<div style="margin-top: 1%;">
+													<button class="plus-button btn btn-primary"
+														ng-disabled="!validProjectToBucketMapping(new_project_to_bucket_mapping)" type="button"
+														style="float: left" ng-click="addProjectToBucketMapping()">
+														<i class="fa fa-plus"></i>
+													</button>
+													<label class="control">[[ invalidProjectToBucketMapping ]]</label>
 												</div>
 											</section>
 										</md-card-content>


### PR DESCRIPTION
DEVPROD-13983

### Description
This adds project to bucket mappings to the buckets config.

For context, this is specifically for the other buckets owned by devprod (internal buckets) but not `mciuploads`. This config gives access to a project to a devprod owned bucket. The prefix value is optional and to support buckets that section off based on prefix (very very few do this)

### Testing
Deployed to staging, set the fields, refreshed, removed some, refreshed. This is how it looks:

This is with some that I added, clicked saved, then refreshed:
<img width="546" alt="Screenshot 2025-03-18 at 8 55 52 AM" src="https://github.com/user-attachments/assets/82d61b28-1f2f-44fe-9cde-5a12e069438f" />

This is after I deleted two (first and third, left the 2nd), clicked saved, then refreshed:
<img width="551" alt="Screenshot 2025-03-18 at 8 56 18 AM" src="https://github.com/user-attachments/assets/e76625f3-b76a-4060-92be-ff9014948932" />

