### PR TITLE
DEVPROD-13979 Sign artifacts with stored role ARN

### DIFF
--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -189,7 +189,6 @@ func (s3pc *s3put) validate() error {
 		catcher.NewWhen(s3pc.AwsSecret == "", "AWS secret cannot be blank")
 	}
 
-	catcher.NewWhen(s3pc.AwsSessionToken != "" && s3pc.Visibility == artifact.Signed, "cannot use temporary AWS credentials with signed link visibility")
 	if s3pc.LocalFile == "" && !s3pc.isMulti() {
 		catcher.New("local file and local files include filter cannot both be blank")
 	}
@@ -237,10 +236,6 @@ func (s3pc *s3put) expandParams(conf *internal.TaskConfig) error {
 	var err error
 	if err = util.ExpandValues(s3pc, &conf.Expansions); err != nil {
 		return errors.Wrap(err, "applying expansions")
-	}
-
-	if s3pc.AwsSessionToken != "" && s3pc.Visibility == artifact.Signed {
-		return errors.New("cannot use temporary AWS credentials with a signed link visibility")
 	}
 
 	s3pc.workDir = conf.WorkDir

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -252,7 +252,7 @@ func TestS3PutValidateParams(t *testing.T) {
 				So(cmd.ResourceDisplayName, ShouldEqual, params["display_name"])
 			})
 
-			Convey("combining temporary credentials with signed visibility should cause an error", func() {
+			Convey("combining temporary credentials with signed visibility should not cause an error", func() {
 				params := map[string]any{
 					"aws_key":           "key",
 					"aws_secret":        "secret",
@@ -260,14 +260,12 @@ func TestS3PutValidateParams(t *testing.T) {
 					"local_file":        "local",
 					"remote_file":       "remote",
 					"bucket":            "bck",
-					"permissions":       "public-read",
+					"permissions":       "private",
 					"content_type":      "application/x-tar",
 					"display_name":      "test_file",
 					"visibility":        "signed",
 				}
-				err := cmd.ParseParams(params)
-				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldContainSubstring, "cannot use temporary AWS credentials with signed link visibility")
+				So(cmd.ParseParams(params), ShouldBeNil)
 			})
 		})
 

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-03-18"
+	AgentVersion = "2025-03-18-a"
 )
 
 const (

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -121,14 +121,17 @@ func presignFile(ctx context.Context, file File) (string, error) {
 		file.AWSSecret = ""
 	}
 
-	// TODO (DEVPROD-13979): Use the role ARN to sign the URL.
-	// A pail update is required to support this and will be done in
-	// the above ticket.
+	if file.AWSRoleARN != "" {
+		file.AWSKey = ""
+		file.AWSSecret = ""
+	}
+
 	requestParams := pail.PreSignRequestParams{
 		Bucket:                file.Bucket,
 		FileKey:               file.FileKey,
 		AWSKey:                file.AWSKey,
 		AWSSecret:             file.AWSSecret,
+		AWSRoleARN:            file.AWSRoleARN,
 		SignatureExpiryWindow: evergreen.PresignMinimumValidTime,
 	}
 	return pail.PreSign(ctx, requestParams)

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -76,9 +76,8 @@ func (f *File) validate() error {
 	catcher.ErrorfWhen(f.FileKey == "", "file key is required")
 
 	// Buckets that are not devprod owned require AWS credentials.
-	if !isInternalBucket(f.Bucket) {
-		catcher.ErrorfWhen(f.AWSKey == "", "AWS key is required")
-		catcher.ErrorfWhen(f.AWSSecret == "", "AWS secret is required")
+	if !isInternalBucket(f.Bucket) && f.AWSRoleARN == "" {
+		catcher.ErrorfWhen(f.AWSKey == "" || f.AWSSecret == "", "AWS key/secret or AWS role ARN is required")
 	}
 
 	return catcher.Resolve()


### PR DESCRIPTION
DEVPROD-13979

### Description
Since the project is moving static -> temp credentials, this means signing artifacts is a bit different. The s3.put calls stored the role arn that was used to perform the operation, then this will cause our presign to use that role arn to generate a temporary credential.

We already use temporary credentials with all presigning of internal buckets (e.g. `mciuploads`).

### Testing
I deployed to my staging, I have these two tasks:
```
    - name: role-arn-ec2-assume-role
      commands:
          - func: clone-project
          - command: ec2.assume_role
            params:
              role_arn: ${assume_role_arn}
          - command: s3.put
            params:
              aws_key: ${AWS_ACCESS_KEY_ID}
              aws_secret: ${AWS_SECRET_ACCESS_KEY}
              aws_session_token: ${AWS_SESSION_TOKEN}
              local_file: src/old-evergreen.yaml
              remote_file: ${project}/${task_id}.txt
              bucket: ${artifacts_bucket}
              permissions: private
              visibility: signed
              content_type: text/plain
    - name: role-arn-parameter
      commands:
          - func: clone-project
          - command: s3.put
            params:
              temporary_role_arn: ${assume_role_arn}
              local_file: src/old-evergreen.yaml
              remote_file: ${project}/${task_id}.txt
              bucket: ${artifacts_bucket}
              permissions: private
              visibility: signed
              content_type: text/plain
```

On the UI, I can view them. If I try viewing it via the link in the database, it gives AccessDenied because it isn't presigned.