### PR TITLE
DEVPROD-53 Don't alert on context cancelled error when getting parser project

### DIFF
--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -418,7 +418,9 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 			"task_version":       nextTask.Version,
 		}
 		if err != nil {
-			grip.Alert(message.WrapError(err, errMsg))
+			if !errors.Is(err, context.Canceled) && ctx.Err() == nil {
+				grip.Alert(message.WrapError(err, errMsg))
+			}
 			return nil, false, errors.Wrapf(err, "could not find project ref for next task '%s'", nextTask.Id)
 		}
 		if projectRef == nil {


### PR DESCRIPTION
DEVPROD-53

### Description
Causing some alerts in splunk, it looks like we're properly timing out- but we probably don't want to alert on the context being cancelled.

### Testing
Unit tests
