### PR TITLE
DEVPROD-13981 Add repo ref id otel attribute to task traces

### DIFF
--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -259,6 +259,7 @@ func (tc *TaskConfig) TaskAttributeMap() map[string]string {
 		evergreen.ProjectOrgOtelAttribute:         tc.ProjectRef.Owner,
 		evergreen.ProjectRepoOtelAttribute:        tc.ProjectRef.Repo,
 		evergreen.ProjectIDOtelAttribute:          tc.ProjectRef.Id,
+		evergreen.RepoRefIDOtelAttribute:          tc.ProjectRef.RepoRefId,
 		evergreen.DistroIDOtelAttribute:           tc.Task.DistroId,
 		evergreen.VersionDescriptionOtelAttribute: tc.PatchOrVersionDescription,
 	}

--- a/globals.go
+++ b/globals.go
@@ -514,6 +514,7 @@ const (
 	ProjectOrgOtelAttribute        = "evergreen.project.org"
 	ProjectRepoOtelAttribute       = "evergreen.project.repo"
 	ProjectIDOtelAttribute         = "evergreen.project.id"
+	RepoRefIDOtelAttribute         = "evergreen.project.repo_ref_id"
 	DistroIDOtelAttribute          = "evergreen.distro.id"
 	HostIDOtelAttribute            = "evergreen.host.id"
 	HostnameOtelAttribute          = "evergreen.host.hostname"


### PR DESCRIPTION
DEVPROD-13981

### Description
Adds a repo_ref_id otel attribute to task traces. This would've helped with the linked ticket (and might still), but I'm adding this since it's better to have it than not
