### PR TITLE
DEVPROD-7795 Consider task group timeout in idle host check

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2185,7 +2185,7 @@ func (h *Host) GetElapsedCommunicationTime() time.Duration {
 // TeardownTimeExceededMax checks if the time since the host's task group teardown start time
 // has exceeded the maximum teardown threshold.
 func (h *Host) TeardownTimeExceededMax() bool {
-	return time.Since(h.TaskGroupTeardownStartTime) < evergreen.MaxTeardownGroupThreshold
+	return time.Since(h.TaskGroupTeardownStartTime) > evergreen.MaxTeardownGroupThreshold
 }
 
 // DecommissionHostsWithDistroId marks all up hosts intended for running tasks

--- a/units/host_drawdown.go
+++ b/units/host_drawdown.go
@@ -117,7 +117,7 @@ func (j *hostDrawdownJob) checkAndDecommission(ctx context.Context, h *host.Host
 	}
 
 	// Don't drawdown hosts that are currently in the middle of tearing down a task group.
-	if h.IsTearingDown() && h.TeardownTimeExceededMax() {
+	if h.IsTearingDown() && !h.TeardownTimeExceededMax() {
 		return nil
 	}
 

--- a/units/host_drawdown.go
+++ b/units/host_drawdown.go
@@ -117,7 +117,7 @@ func (j *hostDrawdownJob) checkAndDecommission(ctx context.Context, h *host.Host
 	}
 
 	// Don't drawdown hosts that are currently in the middle of tearing down a task group.
-	if h.IsTearingDown() && !h.TeardownTimeExceededMax() {
+	if h.IsTearingDown() && h.TeardownTimeExceededMax() {
 		return nil
 	}
 

--- a/units/host_monitoring_idle_termination.go
+++ b/units/host_monitoring_idle_termination.go
@@ -272,7 +272,7 @@ func (i hostIdleInfo) getTerminationReason() string {
 	if i.timeSinceLastCommunication >= i.idleThreshold && !i.isRunningTearDownTaskGroup {
 		return fmt.Sprintf("host is idle or unreachable, communication time %s is over threshold time %s", i.timeSinceLastCommunication, i.idleThreshold)
 	}
-	if i.idleTime >= i.idleThreshold {
+	if i.idleTime > 0 && i.idleTime >= i.idleThreshold {
 		return fmt.Sprintf("host is idle or unreachable, idle time %s is over threshold time %s", i.idleTime, i.idleThreshold)
 	}
 	if i.teardownTimeExceededMax {

--- a/units/host_monitoring_idle_termination_test.go
+++ b/units/host_monitoring_idle_termination_test.go
@@ -850,17 +850,8 @@ func TestTearingDownIsNotConsideredIdle(t *testing.T) {
 	// The host tearing down should not be flagged as idle.
 	num, hosts := numIdleHostsFound(tctx, env, t)
 	require.Equal(t, 2, num)
-	var host1Found, host3Found bool
-	for _, h := range hosts {
-		if h == host1.Id {
-			host1Found = true
-		}
-		if h == host3.Id {
-			host3Found = true
-		}
-	}
-	assert.True(t, host1Found)
-	assert.True(t, host3Found)
+	assert.Contains(t, hosts, host1.Id)
+	assert.Contains(t, hosts, host3.Id)
 }
 func TestPopulateIdleHostJobsCalculations(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/units/host_monitoring_idle_termination_test.go
+++ b/units/host_monitoring_idle_termination_test.go
@@ -821,15 +821,46 @@ func TestTearingDownIsNotConsideredIdle(t *testing.T) {
 		StartedBy:                  evergreen.User,
 		TaskGroupTeardownStartTime: time.Now(),
 	}
+	host3 := host.Host{
+		Id:                         utility.RandomString(),
+		Distro:                     distro1,
+		Provider:                   evergreen.ProviderNameMock,
+		CreationTime:               time.Now().Add(-30 * time.Minute),
+		LastCommunicationTime:      time.Now(),
+		Status:                     evergreen.HostRunning,
+		StartedBy:                  evergreen.User,
+		TaskGroupTeardownStartTime: time.Now().Add(-20 * time.Minute),
+	}
+	host4 := host.Host{
+		Id:                         utility.RandomString(),
+		Distro:                     distro1,
+		Provider:                   evergreen.ProviderNameMock,
+		CreationTime:               time.Now().Add(-30 * time.Minute),
+		LastCommunicationTime:      time.Now().Add(-20 * time.Minute),
+		Status:                     evergreen.HostRunning,
+		StartedBy:                  evergreen.User,
+		TaskGroupTeardownStartTime: time.Now(),
+	}
 
 	require.NoError(t, host1.Insert(tctx))
 	require.NoError(t, host2.Insert(tctx))
+	require.NoError(t, host3.Insert(tctx))
+	require.NoError(t, host4.Insert(tctx))
 
 	// The host tearing down should not be flagged as idle.
 	num, hosts := numIdleHostsFound(tctx, env, t)
-	require.Equal(t, 1, num)
-	assert.Equal(t, host1.Id, hosts[0])
-
+	require.Equal(t, 2, num)
+	var host1Found, host3Found bool
+	for _, h := range hosts {
+		if h == host1.Id {
+			host1Found = true
+		}
+		if h == host3.Id {
+			host3Found = true
+		}
+	}
+	assert.True(t, host1Found)
+	assert.True(t, host3Found)
 }
 func TestPopulateIdleHostJobsCalculations(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/units/host_monitoring_idle_termination_test.go
+++ b/units/host_monitoring_idle_termination_test.go
@@ -799,15 +799,6 @@ func TestTearingDownIsNotConsideredIdle(t *testing.T) {
 	distro1 := distro.Distro{
 		Id:       "distro1",
 		Provider: evergreen.ProviderNameMock,
-		HostAllocatorSettings: distro.HostAllocatorSettings{
-			// TODO (DEVPROD-7795): this test doesn't pass currently unless you
-			// set the acceptable host idle time to be non-zero. However, it
-			// should pass even if it's acceptable idle time is 0 since the host
-			// should be busy running the teardown group. Once DEVPROD-7795 is
-			// fixed, this distro setting can/should be modified/removed and the
-			// test should still pass.
-			AcceptableHostIdleTime: time.Minute,
-		},
 	}
 	require.NoError(t, distro1.Insert(tctx))
 


### PR DESCRIPTION
DEVPROD-7795

### Description
This fixes a few bugs:
- Enable host drawdown job to decommission hosts that have been running their teardown group for longer than the allowed timeout duration
- Do not consider hosts idle if they have not provided a heartbeat and they are running teardown, since we do not send heartbeats during teardown
- Include tasks that have surpassed the teardown timeout in the idle host termination job
### Testing
Existing tests