### PR TITLE
DEVPROD-12752: add distro setting for consecutive system failures

### DIFF
--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -61,6 +61,12 @@ type Distro struct {
 
 	// ExecUser is the user to run shell.exec and subprocess.exec processes as. If unset, processes are run as the regular distro User.
 	ExecUser string `bson:"exec_user,omitempty" json:"exec_user,omitempty" mapstructure:"exec_user,omitempty"`
+
+	// ConsecutiveSystemFailureLimit is the number of consecutive system
+	// failures allowed before a host is marked as disabled. If this is not a
+	// positive number, a default number of system failures will be used
+	// instead.
+	ConsecutiveSystemFailureLimit int `bson:"consecutive_system_failure_limit,omitempty" json:"consecutive_system_failure_limit,omitempty" mapstructure:"consecutive_system_failure_limit,omitempty"`
 }
 
 // DistroData is the same as a distro, with the only difference being that all

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -336,39 +336,40 @@ func (s *APIIceCreamSettings) ToService() distro.IceCreamSettings {
 // APIDistro is the model to be returned by the API whenever distros are fetched
 
 type APIDistro struct {
-	Name                  *string                  `json:"name"`
-	AdminOnly             bool                     `json:"admin_only"`
-	Aliases               []string                 `json:"aliases"`
-	UserSpawnAllowed      bool                     `json:"user_spawn_allowed"`
-	Provider              *string                  `json:"provider"`
-	ProviderSettingsList  []*birch.Document        `json:"provider_settings" swaggertype:"object"`
-	Arch                  *string                  `json:"arch"`
-	WorkDir               *string                  `json:"work_dir"`
-	SetupAsSudo           bool                     `json:"setup_as_sudo"`
-	Setup                 *string                  `json:"setup"`
-	User                  *string                  `json:"user"`
-	BootstrapSettings     APIBootstrapSettings     `json:"bootstrap_settings"`
-	SSHOptions            []string                 `json:"ssh_options"`
-	AuthorizedKeysFile    *string                  `json:"authorized_keys_file"`
-	Expansions            []APIExpansion           `json:"expansions"`
-	Disabled              bool                     `json:"disabled"`
-	ContainerPool         *string                  `json:"container_pool"`
-	FinderSettings        APIFinderSettings        `json:"finder_settings"`
-	PlannerSettings       APIPlannerSettings       `json:"planner_settings"`
-	DispatcherSettings    APIDispatcherSettings    `json:"dispatcher_settings"`
-	HostAllocatorSettings APIHostAllocatorSettings `json:"host_allocator_settings"`
-	DisableShallowClone   bool                     `json:"disable_shallow_clone"`
-	HomeVolumeSettings    APIHomeVolumeSettings    `json:"home_volume_settings"`
-	IcecreamSettings      APIIceCreamSettings      `json:"icecream_settings"`
-	IsVirtualWorkstation  bool                     `json:"is_virtual_workstation"`
-	IsCluster             bool                     `json:"is_cluster"`
-	Note                  *string                  `json:"note"`
-	WarningNote           *string                  `json:"warning_note"`
-	ValidProjects         []*string                `json:"valid_projects"`
-	Mountpoints           []string                 `json:"mountpoints"`
-	SingleTaskDistro      bool                     `json:"single_task_distro"`
-	ImageID               *string                  `json:"image_id"`
-	ExecUser              *string                  `json:"exec_user"`
+	Name                          *string                  `json:"name"`
+	AdminOnly                     bool                     `json:"admin_only"`
+	Aliases                       []string                 `json:"aliases"`
+	UserSpawnAllowed              bool                     `json:"user_spawn_allowed"`
+	Provider                      *string                  `json:"provider"`
+	ProviderSettingsList          []*birch.Document        `json:"provider_settings" swaggertype:"object"`
+	Arch                          *string                  `json:"arch"`
+	WorkDir                       *string                  `json:"work_dir"`
+	SetupAsSudo                   bool                     `json:"setup_as_sudo"`
+	Setup                         *string                  `json:"setup"`
+	User                          *string                  `json:"user"`
+	BootstrapSettings             APIBootstrapSettings     `json:"bootstrap_settings"`
+	SSHOptions                    []string                 `json:"ssh_options"`
+	AuthorizedKeysFile            *string                  `json:"authorized_keys_file"`
+	Expansions                    []APIExpansion           `json:"expansions"`
+	Disabled                      bool                     `json:"disabled"`
+	ContainerPool                 *string                  `json:"container_pool"`
+	FinderSettings                APIFinderSettings        `json:"finder_settings"`
+	PlannerSettings               APIPlannerSettings       `json:"planner_settings"`
+	DispatcherSettings            APIDispatcherSettings    `json:"dispatcher_settings"`
+	HostAllocatorSettings         APIHostAllocatorSettings `json:"host_allocator_settings"`
+	DisableShallowClone           bool                     `json:"disable_shallow_clone"`
+	HomeVolumeSettings            APIHomeVolumeSettings    `json:"home_volume_settings"`
+	IcecreamSettings              APIIceCreamSettings      `json:"icecream_settings"`
+	IsVirtualWorkstation          bool                     `json:"is_virtual_workstation"`
+	IsCluster                     bool                     `json:"is_cluster"`
+	Note                          *string                  `json:"note"`
+	WarningNote                   *string                  `json:"warning_note"`
+	ValidProjects                 []*string                `json:"valid_projects"`
+	Mountpoints                   []string                 `json:"mountpoints"`
+	SingleTaskDistro              bool                     `json:"single_task_distro"`
+	ImageID                       *string                  `json:"image_id"`
+	ExecUser                      *string                  `json:"exec_user"`
+	ConsecutiveSystemFailureLimit int                      `json:"consecutive_system_failure_limit"`
 }
 
 // BuildFromService converts from service level distro.Distro to an APIDistro
@@ -396,6 +397,7 @@ func (apiDistro *APIDistro) BuildFromService(d distro.Distro) {
 	apiDistro.SingleTaskDistro = d.SingleTaskDistro
 	apiDistro.ImageID = utility.ToStringPtr(d.ImageID)
 	apiDistro.ExecUser = utility.ToStringPtr(d.ExecUser)
+	apiDistro.ConsecutiveSystemFailureLimit = d.ConsecutiveSystemFailureLimit
 
 	if d.Expansions != nil {
 		apiDistro.Expansions = []APIExpansion{}
@@ -463,6 +465,7 @@ func (apiDistro *APIDistro) ToService() *distro.Distro {
 	d.ContainerPool = utility.FromStringPtr(apiDistro.ContainerPool)
 	d.ImageID = utility.FromStringPtr(apiDistro.ImageID)
 	d.ExecUser = utility.FromStringPtr(apiDistro.ExecUser)
+	d.ConsecutiveSystemFailureLimit = apiDistro.ConsecutiveSystemFailureLimit
 
 	d.FinderSettings = apiDistro.FinderSettings.ToService()
 	d.PlannerSettings = apiDistro.PlannerSettings.ToService()

--- a/rest/route/host_agent_test.go
+++ b/rest/route/host_agent_test.go
@@ -989,7 +989,7 @@ func TestHostEndTask(t *testing.T) {
 			}))
 
 			for i := 0; i < defaultConsecutiveSystemFailureThreshold+5; i++ {
-				event.LogHostTaskFinished(fmt.Sprintf("some-system-failed-task-%d", i), 0, hostId, evergreen.TaskSystemFailed)
+				event.LogHostTaskFinished(fmt.Sprintf("some-system-failed-task-%d", i), 0, hostId, evergreen.TaskSystemTimedOut)
 			}
 
 			details := &apimodels.TaskEndDetail{


### PR DESCRIPTION
DEVPROD-12752

### Description
Rather than using a hard-coded number of consecutive system failures, add a distro setting that lets distro admins determine how many consecutive system failures to allow before disabling the host.

### Testing
Updated unit test.
