### PR TITLE
DEVPROD-15759: reduce log level for host already terminated

### DIFF
--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -400,10 +400,12 @@ func (j *hostTerminationJob) checkAndTerminateCloudHost(ctx context.Context) err
 	}
 
 	if cloudInfo.Status == cloud.StatusTerminated {
-		catcher := grip.NewBasicCatcher()
-		catcher.Errorf("host is already terminated in the cloud: '%s'", cloudInfo.StateReason)
-		catcher.Wrap(j.host.Terminate(ctx, evergreen.User, "cloud provider indicated that host was already terminated"), "marking host as terminated")
-		return catcher.Resolve()
+		grip.Info(message.Fields{
+			"message":             "host is already terminated in the cloud, setting the host status to terminated",
+			"cloud_status":        cloudInfo.Status,
+			"cloud_status_reason": cloudInfo.StateReason,
+		})
+		return j.host.Terminate(ctx, evergreen.User, "cloud provider indicated that the host was already terminated")
 	}
 
 	if err := cloudHost.TerminateInstance(ctx, evergreen.User, j.TerminationReason); err != nil {


### PR DESCRIPTION
DEVPROD-15759

### Description
If a host has already been terminated, the host termination job just marks it as terminated in the DB, so there's no need to log an error for that. I reduced the log level to info so we can still trace when it happens (since it is a little weird to terminate a host that we should already know is terminated). BUt it won't appear in the error rate, so it reduces alerting noise.

### Testing
N/A