### PR TITLE
DEVPROD-13982 Upgrade TemporaryRoleARN to RoleARN

### DIFF
--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -12,7 +12,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
-	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/pail"
 	"github.com/evergreen-ci/utility"
@@ -33,6 +32,7 @@ var (
 	s3GetRemoteFileAttribute           = fmt.Sprintf("%s.remote_file", s3GetAttribute)
 	s3GetExpandedRemoteFileAttribute   = fmt.Sprintf("%s.expanded_remote_file", s3GetAttribute)
 	s3GetRoleARN                       = fmt.Sprintf("%s.role_arn", s3GetAttribute)
+	s3GetAssumeRoleARN                 = fmt.Sprintf("%s.assume_role_arn", s3GetAttribute) // This tracks the role ARN used when this command is passed temporary credentials.
 	s3GetInternalBucketAttribute       = fmt.Sprintf("%s.internal_bucket", s3GetAttribute)
 )
 
@@ -74,11 +74,10 @@ type s3get struct {
 	// for missing files.
 	Optional string `mapstructure:"optional" plugin:"expand"`
 
-	// TemporaryRoleARN is not meant to be used in production. It is used for testing purposes
-	// relating to the DEVPROD-5553 project.
-	// This is an ARN that should be assumed to make the S3 request.
-	// TODO (DEVPROD-13982): Upgrade this flag to RoleARN.
-	TemporaryRoleARN string `mapstructure:"temporary_role_arn" plugin:"expand"`
+	// RoleARN is an ARN that should be assumed to make the S3 request.
+	// If one is not provided and a user provided credentials coming from an ec2.assume_role command,
+	// this wil be set to the ARN associated with the session token.
+	RoleARN string `mapstructure:"role_arn" plugin:"expand"`
 
 	// TemporaryUseInternalBucket is not meant to be used in production. It is used for testing purposes
 	// relating to the DEVPROD-5553 project.
@@ -94,6 +93,7 @@ type s3get struct {
 
 	temporaryUseInternalBucket bool
 
+	taskData client.TaskData
 	base
 }
 
@@ -126,12 +126,13 @@ func (c *s3get) ParseParams(params map[string]any) error {
 func (c *s3get) validate() error {
 	catcher := grip.NewSimpleCatcher()
 
-	if c.TemporaryRoleARN != "" {
+	if c.RoleARN != "" {
 		// When using the role ARN, there should be no provided AWS credentials.
 		catcher.NewWhen(c.AwsKey != "", "AWS key must be empty when using role ARN")
 		catcher.NewWhen(c.AwsSecret != "", "AWS secret must be empty when using role ARN")
 		catcher.NewWhen(c.AwsSessionToken != "", "AWS session token must be empty when using role ARN")
 	} else {
+		// Otherwise, the AWS credentials must be provided.
 		catcher.NewWhen(c.AwsKey == "", "AWS key cannot be blank")
 		catcher.NewWhen(c.AwsSecret == "", "AWS secret cannot be blank")
 	}
@@ -180,6 +181,7 @@ func (c *s3get) expandParams(conf *internal.TaskConfig) error {
 // Execute expands the parameters, and then fetches the
 // resource from s3.
 func (c *s3get) Execute(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig) error {
+	c.taskData = client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}
 	c.internalBuckets = conf.InternalBuckets
 
 	// expand necessary params
@@ -197,44 +199,27 @@ func (c *s3get) Execute(ctx context.Context, comm client.Communicator, logger cl
 		attribute.Bool(s3GetTemporaryCredentialsAttribute, c.AwsSessionToken != ""),
 		attribute.String(s3GetRemoteFileAttribute, c.remoteFile),
 		attribute.String(s3GetExpandedRemoteFileAttribute, c.RemoteFile),
-		attribute.String(s3GetRoleARN, c.TemporaryRoleARN),
+		attribute.String(s3GetRoleARN, c.RoleARN),
 		attribute.Bool(s3GetInternalBucketAttribute, utility.StringSliceContains(conf.InternalBuckets, c.Bucket)),
 	)
 
-	taskData := client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}
-	if c.TemporaryRoleARN != "" {
-		creds, err := comm.AssumeRole(ctx, taskData, apimodels.AssumeRoleRequest{
-			RoleARN: c.TemporaryRoleARN,
-		})
-		if err != nil {
-			return errors.Wrapf(err, "getting credentials for '%s' role arn", c.TemporaryRoleARN)
+	if c.AwsSessionToken != "" && c.RoleARN == "" {
+		// If no role was provided but a session token is being used (which means an AssumeRole credentials is being
+		// used), check if the session token matches any saved from ec2.assume_role commands in the task config.
+		// If it does, associate this command with the corresponding role ARN.
+		if roleARN, ok := conf.AssumeRoleRoles[c.AwsSessionToken]; ok {
+			c.RoleARN = roleARN
+			trace.SpanFromContext(ctx).SetAttributes(
+				attribute.String(s3GetAssumeRoleARN, roleARN),
+			)
 		}
-		if creds == nil {
-			return errors.Errorf("nil credentials returned for '%s' role arn", c.TemporaryRoleARN)
-		}
-		c.AwsKey = creds.AccessKeyID
-		c.AwsSecret = creds.SecretAccessKey
-		c.AwsSessionToken = creds.SessionToken
-	}
-
-	if c.temporaryUseInternalBucket {
-		creds, err := comm.S3Credentials(ctx, taskData, c.Bucket)
-		if err != nil {
-			return errors.Wrap(err, "getting S3 credentials")
-		}
-		if creds == nil {
-			return errors.New("nil credentials returned for provided role arn")
-		}
-		c.AwsKey = creds.AccessKeyID
-		c.AwsSecret = creds.SecretAccessKey
-		c.AwsSessionToken = creds.SessionToken
 	}
 
 	// create pail bucket
 	httpClient := utility.GetHTTPClient()
 	httpClient.Timeout = s3HTTPClientTimeout
 	defer utility.PutHTTPClient(httpClient)
-	err := c.createPailBucket(ctx, httpClient)
+	err := c.createPailBucket(ctx, comm, httpClient)
 	if err != nil {
 		return errors.Wrap(err, "creating S3 bucket")
 	}
@@ -353,12 +338,18 @@ func (c *s3get) get(ctx context.Context) error {
 	return nil
 }
 
-func (c *s3get) createPailBucket(ctx context.Context, httpClient *http.Client) error {
+func (c *s3get) createPailBucket(ctx context.Context, comm client.Communicator, httpClient *http.Client) error {
 	opts := pail.S3Options{
-		Credentials: pail.CreateAWSStaticCredentials(c.AwsKey, c.AwsSecret, c.AwsSessionToken),
-		Region:      c.Region,
-		Name:        c.Bucket,
+		Region: c.Region,
+		Name:   c.Bucket,
 	}
+
+	if c.AwsKey != "" {
+		opts.Credentials = pail.CreateAWSStaticCredentials(c.AwsKey, c.AwsSecret, c.AwsSessionToken)
+	} else if c.RoleARN != "" || c.temporaryUseInternalBucket {
+		opts.Credentials = createEvergreenCredentials(comm, c.taskData, c.RoleARN, c.Bucket)
+	}
+
 	bucket, err := pail.NewS3BucketWithHTTPClient(ctx, httpClient, opts)
 	c.bucket = bucket
 	return err

--- a/agent/command/s3_get_test.go
+++ b/agent/command/s3_get_test.go
@@ -136,8 +136,8 @@ func TestExpandS3GetParams(t *testing.T) {
 			Convey("all appropriate values should be expanded, if they"+
 				" contain expansions", func() {
 
-				cmd.AwsKey = "${aws_key}"
-				cmd.AwsSecret = "${aws_secret}"
+				cmd.AWSKey = "${aws_key}"
+				cmd.AWSSecret = "${aws_secret}"
 				cmd.Bucket = "${bucket}"
 
 				conf.Expansions.Update(
@@ -148,8 +148,8 @@ func TestExpandS3GetParams(t *testing.T) {
 				)
 
 				So(cmd.expandParams(conf), ShouldBeNil)
-				So(cmd.AwsKey, ShouldEqual, "key")
-				So(cmd.AwsSecret, ShouldEqual, "secret")
+				So(cmd.AWSKey, ShouldEqual, "key")
+				So(cmd.AWSSecret, ShouldEqual, "secret")
 			})
 
 		})

--- a/agent/command/s3_operation.go
+++ b/agent/command/s3_operation.go
@@ -1,0 +1,186 @@
+package command
+
+import (
+	"strconv"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/evergreen/agent/internal/client"
+	"github.com/evergreen-ci/pail"
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
+	"github.com/pkg/errors"
+)
+
+// s3Operation isn't a command itself, but it contains the common parameters
+// and logic for S3 commands.
+type s3Operation struct {
+	awsCredentials `plugin:"expand"`
+	bucketOptions  `plugin:"expand"`
+
+	// BuildVariants stores a list of build variants to run the command for.
+	// If the list is empty, it runs for all build variants.
+	BuildVariants []string `mapstructure:"build_variants"`
+
+	// Optional, when set to true, causes this command to be skipped over without an error when
+	// the path specified in remote_file does not exist. Defaults to false, which triggers errors
+	// for missing files.
+	Optional string `mapstructure:"optional" plugin:"expand"`
+	// optional is the parsed boolean value of Optional.
+	optional bool
+
+	// TemporaryUseInternalBucket is not meant to be used in production. It is used for testing purposes
+	// relating to the DEVPROD-5553 project.
+	// This flag is used to determine if the s3_credentials route should be called before the command is executed.
+	// TODO (DEVPROD-13982): Remove this flag and use the internal bucket list to determine if the s3_credentials
+	// route should be called.
+	TemporaryUseInternalBucket string `mapstructure:"temporary_use_internal_bucket" plugin:"expand"`
+	// temporaryUseInternalBucket is the parsed boolean value of TemporaryUseInternalBucket.
+	temporaryUseInternalBucket bool
+
+	internalBuckets []string
+
+	taskData client.TaskData
+	base
+}
+
+func (s *s3Operation) validate() []error {
+	catcher := grip.NewBasicCatcher()
+
+	catcher.Extend(s.awsCredentials.validate())
+	catcher.Extend(s.bucketOptions.validate())
+
+	return catcher.Errors()
+}
+
+func (s *s3Operation) expandParams(conf *internal.TaskConfig) error {
+	var err error
+
+	s.bucketOptions.expandParams()
+
+	if s.Optional != "" {
+		s.optional, err = strconv.ParseBool(s.Optional)
+		if err != nil {
+			return errors.Wrap(err, "parsing optional parameter as a boolean")
+		}
+	}
+
+	if s.TemporaryUseInternalBucket != "" {
+		s.temporaryUseInternalBucket, err = strconv.ParseBool(s.TemporaryUseInternalBucket)
+		if err != nil {
+			return errors.Wrap(err, "parsing temporary use internal bucket parameter as a boolean")
+		}
+	}
+
+	s.taskData = client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}
+	s.internalBuckets = conf.InternalBuckets
+
+	if s.AWSSessionToken != "" && s.RoleARN == "" {
+		// If no role was provided but a session token is being used (which means an AssumeRole credentials is being
+		// used), check if the session token matches any saved from ec2.assume_role commands in the task config.
+		// If it does, associate this command with the corresponding role ARN.
+		if roleARN, ok := conf.AssumeRoleRoles[s.AWSSessionToken]; ok {
+			s.assumeRoleARN = roleARN
+		}
+	}
+
+	return nil
+}
+
+// createPailBucket completes the given options and creates the pail.Bucket using the
+// given bucketFunc.
+func (s *s3Operation) createPailBucket(opts pail.S3Options, comm client.Communicator, bucketFunc func(pail.S3Options) (pail.Bucket, error)) error {
+	// No-op if the bucket is already created.
+	if s.bucket != nil {
+		return nil
+	}
+
+	opts.Region = s.Region
+	opts.Name = s.Bucket
+
+	if s.AWSKey != "" {
+		opts.Credentials = pail.CreateAWSStaticCredentials(s.AWSKey, s.AWSSecret, s.AWSSessionToken)
+	} else if s.getRoleARN() != "" || s.temporaryUseInternalBucket {
+		opts.Credentials = createEvergreenCredentials(comm, s.taskData, s.getRoleARN(), s.Bucket)
+	}
+
+	var err error
+	s.bucket, err = bucketFunc(opts)
+	return err
+}
+
+// getRoleARN gets the role arn that's associated with this command,
+// either from the passed in parameter or a previous ec2.assume_role command.
+func (s *s3Operation) getRoleARN() string {
+	if s.RoleARN != "" {
+		return s.RoleARN
+	}
+	return s.assumeRoleARN
+}
+
+func (s *s3Operation) shouldRunForVariant(bv string) bool {
+	return len(s.BuildVariants) == 0 || utility.StringSliceContains(s.BuildVariants, bv)
+}
+
+type awsCredentials struct {
+	// AWSKey, AwsSecret, and AwsSessionToken are the user's static credentials for
+	// authenticating interactions with S3.
+	AWSKey          string `mapstructure:"aws_key" plugin:"expand"`
+	AWSSecret       string `mapstructure:"aws_secret" plugin:"expand"`
+	AWSSessionToken string `mapstructure:"aws_session_token" plugin:"expand"`
+
+	// RoleARN is an ARN that should be assumed to make the S3 request.
+	RoleARN string `mapstructure:"role_arn" plugin:"expand"`
+
+	//assumeRoleARN is the ARN assoaciated with this command if the user provided
+	// credentials came from an ec2.assume_role command.
+	assumeRoleARN string
+}
+
+func (a *awsCredentials) validate() []error {
+	catcher := grip.NewBasicCatcher()
+
+	if a.RoleARN != "" {
+		// When using the role ARN, there should be no provided AWS credentials.
+		catcher.NewWhen(a.AWSKey != "", "AWS key must be empty when using role ARN")
+		catcher.NewWhen(a.AWSSecret != "", "AWS secret must be empty when using role ARN")
+		catcher.NewWhen(a.AWSSessionToken != "", "AWS session token must be empty when using role ARN")
+	} else {
+		catcher.NewWhen(a.AWSKey == "", "AWS key cannot be blank")
+		catcher.NewWhen(a.AWSSecret == "", "AWS secret cannot be blank")
+	}
+
+	return catcher.Errors()
+}
+
+type bucketOptions struct {
+	// Region is the S3 region where the bucket is located. It defaults to
+	// "us-east-1".
+	Region string `mapstructure:"region" plugin:"region"`
+
+	// Bucket is the s3 bucket to use when storing the desired file.
+	Bucket string `mapstructure:"bucket" plugin:"expand"`
+	// bucket is the parsed pail bucket.
+	bucket pail.Bucket
+
+	// RemoteFile is the filepath to store the file to,
+	// within an S3 bucket. Is a prefix when multiple files are uploaded via LocalFilesIncludeFilter.
+	RemoteFile string `mapstructure:"remote_file" plugin:"expand"`
+	// remoteFile is the file path without any expansions applied.
+	remoteFile string
+}
+
+func (b *bucketOptions) validate() []error {
+	catcher := grip.NewBasicCatcher()
+
+	catcher.Wrapf(validateS3BucketName(b.Bucket), "invalid bucket name '%s'", b.Bucket)
+	catcher.NewWhen(b.RemoteFile == "", "remote file cannot be blank")
+
+	return catcher.Errors()
+}
+
+func (b *bucketOptions) expandParams() {
+	if b.Region == "" {
+		b.Region = evergreen.DefaultEC2Region
+	}
+}

--- a/agent/command/s3_operation_test.go
+++ b/agent/command/s3_operation_test.go
@@ -248,7 +248,7 @@ func TestBucketOptionsValidate(t *testing.T) {
 		}
 		err := errors.Join(opts.validate()...)
 		require.Error(t, err)
-		assert.ErrorContains(t, err, "must be at leaset 3 characters")
+		assert.ErrorContains(t, err, "must be at least 3 characters")
 	})
 
 	t.Run("InvalidRemoteFile", func(t *testing.T) {

--- a/agent/command/s3_operation_test.go
+++ b/agent/command/s3_operation_test.go
@@ -17,12 +17,16 @@ import (
 func TestS3OperationExpandParams(t *testing.T) {
 	for tName, tCase := range map[string]func(*testing.T, s3Operation, *internal.TaskConfig){
 		"OptionalFails": func(t *testing.T, op s3Operation, conf *internal.TaskConfig) {
-			op.Optional = "invalid"
-			require.ErrorContains(t, op.expandParams(conf), "expanding optional")
+			for _, v := range []string{"NOPE", "NONE", "EMPTY", "01", "100", "${foo|wat}"} {
+				op.Optional = v
+				require.ErrorContains(t, op.expandParams(conf), "expanding optional")
+			}
 		},
 		"OptionalSucceeds": func(t *testing.T, op s3Operation, conf *internal.TaskConfig) {
-			op.Optional = "true"
-			require.NoError(t, op.expandParams(conf))
+			for _, v := range []string{"true", "True", "1", "T", "t"} {
+				op.Optional = v
+				require.NoError(t, op.expandParams(conf))
+			}
 		},
 		"TaskData": func(t *testing.T, op s3Operation, conf *internal.TaskConfig) {
 			assert.Empty(t, op.taskData.ID)

--- a/agent/command/s3_operation_test.go
+++ b/agent/command/s3_operation_test.go
@@ -193,7 +193,7 @@ func TestS3CredentialsShouldRunForVariant(t *testing.T) {
 	t.Run("IncludesBV", func(t *testing.T) {
 		op := s3Operation{}
 		op.BuildVariants = []string{"bv1", "bv2"}
-		assert.False(t, op.shouldRunForVariant("bv2"))
+		assert.True(t, op.shouldRunForVariant("bv2"))
 	})
 }
 

--- a/agent/command/s3_operation_test.go
+++ b/agent/command/s3_operation_test.go
@@ -1,0 +1,266 @@
+package command
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/evergreen/agent/internal/client"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/pail"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestS3OperationExpandParams(t *testing.T) {
+	for tName, tCase := range map[string]func(*testing.T, s3Operation, *internal.TaskConfig){
+		"OptionalFails": func(t *testing.T, op s3Operation, conf *internal.TaskConfig) {
+			op.Optional = "invalid"
+			require.ErrorContains(t, op.expandParams(conf), "expanding optional")
+		},
+		"OptionalSucceeds": func(t *testing.T, op s3Operation, conf *internal.TaskConfig) {
+			op.Optional = "true"
+			require.NoError(t, op.expandParams(conf))
+		},
+		"TaskData": func(t *testing.T, op s3Operation, conf *internal.TaskConfig) {
+			assert.Empty(t, op.taskData.ID)
+			assert.Empty(t, op.taskData.Secret)
+			require.NoError(t, op.expandParams(conf))
+			assert.Equal(t, conf.Task.Id, op.taskData.ID)
+			assert.Equal(t, conf.Task.Secret, op.taskData.Secret)
+		},
+		"AssumeRoleARNIsNotFound": func(t *testing.T, op s3Operation, conf *internal.TaskConfig) {
+			sessionToken := "sessionToken"
+			roleARN := "roleARN"
+			conf.AssumeRoleRoles[sessionToken] = roleARN
+			require.NoError(t, op.expandParams(conf))
+			assert.Empty(t, op.assumeRoleARN)
+		},
+		"AssumeRoleARNIsFound": func(t *testing.T, op s3Operation, conf *internal.TaskConfig) {
+			sessionToken := "sessionToken"
+			roleARN := "roleARN"
+			conf.AssumeRoleRoles[sessionToken] = roleARN
+			op.AWSSessionToken = sessionToken
+			require.NoError(t, op.expandParams(conf))
+			assert.Equal(t, op.assumeRoleARN, roleARN)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			op := s3Operation{}
+
+			conf := &internal.TaskConfig{
+				Task: task.Task{
+					Id:     "taskid",
+					Secret: "tasksecret",
+				},
+				AssumeRoleRoles: map[string]string{},
+			}
+
+			tCase(t, op, conf)
+		})
+	}
+}
+
+func TestS3OperationCreatePailBucket(t *testing.T) {
+	bucket, err := pail.NewLocalTemporaryBucket(pail.LocalOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, bucket)
+
+	mock := client.NewMock("url")
+
+	t.Run("CopiesOverRegionAndBucket", func(t *testing.T) {
+		op := s3Operation{}
+		op.Region = "region"
+		op.Bucket = "bucket"
+
+		foundRegion := false
+		foundBucket := false
+		require.NoError(t, op.createPailBucket(pail.S3Options{}, mock,
+			func(opts pail.S3Options) (pail.Bucket, error) {
+				foundRegion = opts.Region == op.Region
+				foundBucket = opts.Name == op.Bucket
+				return nil, nil
+			},
+		))
+		assert.True(t, foundRegion)
+		assert.True(t, foundBucket)
+	})
+
+	t.Run("EvergreenCredentialsWithRoleARN", func(t *testing.T) {
+		op := s3Operation{}
+		op.RoleARN = "roleARN"
+
+		var creds aws.CredentialsProvider
+		require.NoError(t, op.createPailBucket(pail.S3Options{}, mock,
+			func(opts pail.S3Options) (pail.Bucket, error) {
+				creds = opts.Credentials
+				return nil, nil
+			},
+		))
+		assert.IsType(t, &evergreenCredentialProvider{}, creds)
+	})
+
+	t.Run("EvergreenCredentialsWithAssumeRoleARN", func(t *testing.T) {
+		op := s3Operation{}
+		op.assumeRoleARN = "roleARN"
+
+		var creds aws.CredentialsProvider
+		require.NoError(t, op.createPailBucket(pail.S3Options{}, mock,
+			func(opts pail.S3Options) (pail.Bucket, error) {
+				creds = opts.Credentials
+				return nil, nil
+			},
+		))
+		assert.IsType(t, &evergreenCredentialProvider{}, creds)
+	})
+
+	t.Run("EvergreenCredentialsWithInternalBucket", func(t *testing.T) {
+		op := s3Operation{}
+		op.temporaryUseInternalBucket = true
+
+		var creds aws.CredentialsProvider
+		require.NoError(t, op.createPailBucket(pail.S3Options{}, mock,
+			func(opts pail.S3Options) (pail.Bucket, error) {
+				creds = opts.Credentials
+				return nil, nil
+			},
+		))
+		assert.IsType(t, &evergreenCredentialProvider{}, creds)
+	})
+
+	t.Run("StaticCredentials", func(t *testing.T) {
+		op := s3Operation{}
+		op.AWSKey = "test"
+
+		var creds aws.CredentialsProvider
+		require.NoError(t, op.createPailBucket(pail.S3Options{}, mock,
+			func(opts pail.S3Options) (pail.Bucket, error) {
+				creds = opts.Credentials
+				return nil, nil
+			},
+		))
+		assert.IsType(t, credentials.StaticCredentialsProvider{}, creds)
+	})
+
+	t.Run("EvergreenCredentialsTakesPrecedenceOverStatic", func(t *testing.T) {
+		op := s3Operation{}
+		op.AWSKey = "test"
+		op.RoleARN = "roleARN"
+
+		var creds aws.CredentialsProvider
+		require.NoError(t, op.createPailBucket(pail.S3Options{}, mock,
+			func(opts pail.S3Options) (pail.Bucket, error) {
+				creds = opts.Credentials
+				return nil, nil
+			},
+		))
+		assert.IsType(t, &evergreenCredentialProvider{}, creds)
+	})
+}
+
+func TestS3OperationGetRoleARN(t *testing.T) {
+	t.Run("Parameter", func(t *testing.T) {
+		op := s3Operation{}
+		op.RoleARN = "roleARN"
+		assert.Equal(t, op.getRoleARN(), "roleARN")
+	})
+
+	t.Run("AssumeRole", func(t *testing.T) {
+		op := s3Operation{}
+		op.assumeRoleARN = "assumeRoleARN"
+		assert.Equal(t, op.getRoleARN(), "assumeRoleARN")
+	})
+}
+
+func TestS3CredentialsShouldRunForVariant(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		op := s3Operation{}
+		assert.True(t, op.shouldRunForVariant("bv"))
+	})
+
+	t.Run("ExcludesBV", func(t *testing.T) {
+		op := s3Operation{}
+		op.BuildVariants = []string{"bv1"}
+		assert.False(t, op.shouldRunForVariant("bv2"))
+	})
+
+	t.Run("IncludesBV", func(t *testing.T) {
+		op := s3Operation{}
+		op.BuildVariants = []string{"bv1", "bv2"}
+		assert.False(t, op.shouldRunForVariant("bv2"))
+	})
+}
+
+func TestAWSCredentialsValidate(t *testing.T) {
+	t.Run("StaticCredentials", func(t *testing.T) {
+		t.Run("Fails", func(t *testing.T) {
+			creds := awsCredentials{}
+			err := errors.Join(creds.validate()...)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "AWS key cannot be blank")
+			assert.ErrorContains(t, err, "AWS secret cannot be blank")
+		})
+
+		t.Run("Succeeds", func(t *testing.T) {
+			creds := awsCredentials{
+				AWSKey:    "key",
+				AWSSecret: "secret",
+			}
+			assert.Empty(t, creds.validate())
+		})
+	})
+
+	t.Run("RoleARN", func(t *testing.T) {
+		t.Run("Fails", func(t *testing.T) {
+			creds := awsCredentials{
+				RoleARN:         "roleARN",
+				AWSKey:          "key",
+				AWSSecret:       "secret",
+				AWSSessionToken: "session",
+			}
+			err := errors.Join(creds.validate()...)
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "AWS key must be empty when using role ARN")
+			assert.ErrorContains(t, err, "AWS secret must be empty when using role ARN")
+			assert.ErrorContains(t, err, "AWS session token must be empty when using role ARN")
+		})
+
+		t.Run("Succeeds", func(t *testing.T) {
+			creds := awsCredentials{
+				RoleARN: "roleARN",
+			}
+			assert.Empty(t, creds.validate())
+		})
+	})
+}
+
+func TestBucketOptionsValidate(t *testing.T) {
+	t.Run("InvalidBucket", func(t *testing.T) {
+		opts := bucketOptions{
+			Bucket:     "1",
+			RemoteFile: "file",
+		}
+		err := errors.Join(opts.validate()...)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "must be at leaset 3 characters")
+	})
+
+	t.Run("InvalidRemoteFile", func(t *testing.T) {
+		opts := bucketOptions{
+			Bucket: "bucket",
+		}
+		err := errors.Join(opts.validate()...)
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "remote file cannot be blank")
+	})
+
+	t.Run("Valid", func(t *testing.T) {
+		opts := bucketOptions{
+			Bucket:     "bucket",
+			RemoteFile: "file",
+		}
+		assert.Empty(t, opts.validate())
+	})
+}

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -101,11 +101,11 @@ type s3put struct {
 
 	// workDir sets the working directory relative to which s3put should look for files to upload.
 	// workDir will be empty if an absolute path is provided to the file.
-	workDir          string
-	preservePath     bool
-	skipExistingBool bool
-	isPatchable      bool
-	isPatchOnly      bool
+	workDir      string
+	preservePath bool
+	skipExisting bool
+	isPatchable  bool
+	isPatchOnly  bool
 
 	s3Operation `plugin:"expand"`
 	base
@@ -192,7 +192,7 @@ func (s3pc *s3put) expandParams(conf *internal.TaskConfig) error {
 		return errors.Wrap(err, "expanding preserve path")
 	}
 
-	if err := expandBool(s3pc.SkipExisting, &s3pc.skipExistingBool); err != nil {
+	if err := expandBool(s3pc.SkipExisting, &s3pc.skipExisting); err != nil {
 		return errors.Wrap(err, "expanding skip existing")
 	}
 
@@ -400,7 +400,7 @@ retryLoop:
 						}
 					}
 
-					if s3pc.skipExistingBool {
+					if s3pc.skipExisting {
 						var ae smithy.APIError
 
 						if errors.As(err, &ae) {
@@ -518,7 +518,7 @@ func (s3pc *s3put) createPailBucket(ctx context.Context, comm client.Communicato
 	opts := pail.S3Options{
 		Permissions: pail.S3Permissions(s3pc.Permissions),
 		ContentType: s3pc.ContentType,
-		IfNotExists: s3pc.skipExistingBool,
+		IfNotExists: s3pc.skipExisting,
 	}
 	return s3pc.s3Operation.createPailBucket(opts, comm, func(so pail.S3Options) (pail.Bucket, error) {
 		return pail.NewS3MultiPartBucketWithHTTPClient(ctx, httpClient, opts)

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -634,19 +634,16 @@ func TestS3PutSkipExisting(t *testing.T) {
 		WorkDir: temproot,
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	sender := send.MakeInternalLogger()
 	logger := client.NewSingleChannelLogHarness("test", sender)
 	comm := client.NewMock("")
 
-	require.NoError(t, cmd.Execute(ctx, comm, logger, tconf))
+	require.NoError(t, cmd.Execute(t.Context(), comm, logger, tconf))
 
 	params["local_file"] = secondFilePath
 	require.NoError(t, cmd.ParseParams(params))
 
-	require.NoError(t, cmd.Execute(ctx, comm, logger, tconf))
+	require.NoError(t, cmd.Execute(t.Context(), comm, logger, tconf))
 
 	creds := credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, token)
 
@@ -656,10 +653,10 @@ func TestS3PutSkipExisting(t *testing.T) {
 		Credentials: creds,
 	}
 
-	bucket, err := pail.NewS3Bucket(ctx, opts)
+	bucket, err := pail.NewS3Bucket(t.Context(), opts)
 	require.NoError(t, err)
 
-	got, err := bucket.Get(ctx, remoteFile)
+	got, err := bucket.Get(t.Context(), remoteFile)
 	require.NoError(t, err)
 
 	content, err := io.ReadAll(got)

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -36,21 +36,6 @@ func TestS3PutValidateParams(t *testing.T) {
 
 			cmd = &s3put{}
 
-			Convey("a missing aws key should cause an error", func() {
-
-				params := map[string]any{
-					"aws_secret":   "secret",
-					"local_file":   "local",
-					"remote_file":  "remote",
-					"bucket":       "bck",
-					"permissions":  "public-read",
-					"content_type": "application/x-tar",
-					"display_name": "test_file",
-				}
-				err := cmd.ParseParams(params)
-				require.Error(t, err)
-				So(err.Error(), ShouldContainSubstring, "AWS key cannot be blank")
-			})
 			Convey("a defined local file and inclusion filter should cause an error", func() {
 
 				params := map[string]any{
@@ -99,22 +84,6 @@ func TestS3PutValidateParams(t *testing.T) {
 				So(err.Error(), ShouldContainSubstring, "cannot use optional with local files include filter as by default it is optional")
 			})
 
-			Convey("a missing aws secret should cause an error", func() {
-
-				params := map[string]any{
-					"aws_key":      "key",
-					"local_file":   "local",
-					"remote_file":  "remote",
-					"bucket":       "bck",
-					"permissions":  "public-read",
-					"content_type": "application/x-tar",
-					"display_name": "test_file",
-				}
-				err := cmd.ParseParams(params)
-				require.Error(t, err)
-				So(err.Error(), ShouldContainSubstring, "AWS secret cannot be blank")
-			})
-
 			Convey("a missing local file should cause an error", func() {
 
 				params := map[string]any{
@@ -129,38 +98,6 @@ func TestS3PutValidateParams(t *testing.T) {
 				err := cmd.ParseParams(params)
 				require.Error(t, err)
 				So(err.Error(), ShouldContainSubstring, "local file and local files include filter cannot both be blank")
-			})
-
-			Convey("a missing remote file should cause an error", func() {
-
-				params := map[string]any{
-					"aws_key":      "key",
-					"aws_secret":   "secret",
-					"local_file":   "local",
-					"bucket":       "bck",
-					"permissions":  "public-read",
-					"content_type": "application/x-tar",
-					"display_name": "test_file",
-				}
-				err := cmd.ParseParams(params)
-				require.Error(t, err)
-				So(err.Error(), ShouldContainSubstring, "remote file cannot be blank")
-			})
-
-			Convey("a missing bucket should cause an error", func() {
-
-				params := map[string]any{
-					"aws_key":      "key",
-					"aws_secret":   "secret",
-					"local_file":   "local",
-					"remote_file":  "remote",
-					"permissions":  "public-read",
-					"content_type": "application/x-tar",
-					"display_name": "test_file",
-				}
-				err := cmd.ParseParams(params)
-				require.Error(t, err)
-				So(err.Error(), ShouldContainSubstring, "invalid bucket name")
 			})
 
 			Convey("a missing s3 permission should cause an error", func() {
@@ -324,32 +261,6 @@ func TestExpandS3PutParams(t *testing.T) {
 			// EVG-7226 Since LocalFile is an absolute path, workDir should be empty
 			So(cmd.workDir, ShouldEqual, "")
 		})
-
-		Convey("the expandParams function should error for invalid optional values", func() {
-			cmd = &s3put{}
-
-			for _, v := range []string{"", "false", "False", "0", "F", "f", "${foo|false}", "${foo|}", "${foo}"} {
-				cmd.SkipExisting = "true"
-				cmd.Optional = v
-				So(cmd.expandParams(conf), ShouldBeNil)
-				So(cmd.optional, ShouldBeFalse)
-			}
-
-			for _, v := range []string{"true", "True", "1", "T", "t", "${foo|true}"} {
-				cmd.optional = false
-				cmd.Optional = v
-				So(cmd.expandParams(conf), ShouldBeNil)
-				So(cmd.optional, ShouldBeTrue)
-			}
-
-			for _, v := range []string{"NOPE", "NONE", "EMPTY", "01", "100", "${foo|wat}"} {
-				cmd.Optional = v
-				So(cmd.expandParams(conf), ShouldNotBeNil)
-				So(cmd.optional, ShouldBeFalse)
-			}
-
-		})
-
 	})
 }
 

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -613,7 +613,7 @@ func TestS3PutSkipExisting(t *testing.T) {
 
 	remoteFile := fmt.Sprintf("tests/%s/%s", t.Name(), id)
 
-	cmd := s3PutFactory()
+	cmd := s3PutFactory().(*s3put)
 	params := map[string]any{
 		"aws_key":           accessKeyID,
 		"aws_secret":        secretAccessKey,
@@ -628,6 +628,7 @@ func TestS3PutSkipExisting(t *testing.T) {
 	}
 
 	require.NoError(t, cmd.ParseParams(params))
+	require.True(t, cmd.skipExisting)
 
 	tconf := &internal.TaskConfig{
 		Task:    task.Task{},

--- a/agent/command/s3_util.go
+++ b/agent/command/s3_util.go
@@ -74,7 +74,3 @@ func getS3OpBackoff() *backoff.Backoff {
 		Jitter: true,
 	}
 }
-
-func shouldRunForVariant(bvs []string, bv string) bool {
-	return len(bvs) == 0 || utility.StringSliceContains(bvs, bv)
-}

--- a/agent/command/util.go
+++ b/agent/command/util.go
@@ -3,6 +3,7 @@ package command
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/evergreen-ci/evergreen/agent/internal"
@@ -108,4 +109,13 @@ func getTracer() trace.Tracer {
 	}
 
 	return tracer
+}
+
+func expandBool(fromString string, toBool *bool) error {
+	if fromString == "" {
+		return nil
+	}
+	var err error
+	*toBool, err = strconv.ParseBool(fromString)
+	return errors.Wrapf(err, "parsing '%s' as a boolean", fromString)
 }

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-03-19"
+	AgentVersion = "2025-03-26"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-13982

### Description
This upgrades `TemporaryRoleARN` to `RoleARN`. Along the way, I noticed how much duplicate code is in s3.get and s3.put, so I made a new struct `s3Operation` that holds the shared logic. Inside that struct, I broke it down in to the credentials and the bucket options.

### Testing
Unit tests
