### PR TITLE
DEVPROD-15996 Use WithFields for slow version queries

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1234,7 +1234,7 @@ func (p *Project) FindTaskGroupForTask(bvName, taskName string) *TaskGroup {
 }
 
 func FindProjectFromVersionID(ctx context.Context, versionStr string) (*Project, error) {
-	ver, err := VersionFindOne(ctx, VersionById(versionStr))
+	ver, err := VersionFindOne(ctx, VersionById(versionStr).WithFields(VersionIdKey))
 	if err != nil {
 		return nil, err
 	}

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -530,7 +530,7 @@ func checkMaxConcurrentLargeParserProjectTasks(ctx context.Context, settings *ev
 	if maxConcurrentLargeParserProjTasks <= 0 {
 		return false, false
 	}
-	taskVersion, err := VersionFindOneId(ctx, nextTaskFromDB.Version)
+	taskVersion, err := VersionFindOne(ctx, VersionById(nextTaskFromDB.Version).WithFields(VersionProjectStorageMethodKey))
 	if err != nil {
 		grip.Warning(message.WrapError(err, message.Fields{
 			"dispatcher": DAGDispatcher,

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -411,7 +411,7 @@ func (h *getExpansionsAndVarsHandler) Run(ctx context.Context) gimlet.Responder 
 		}
 	}
 
-	v, err := model.VersionFindOneId(ctx, t.Version)
+	v, err := model.VersionFindOne(ctx, model.VersionById(t.Version).WithFields(model.VersionParametersKey))
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding version '%s'", t.Version))
 	}
@@ -508,7 +508,7 @@ func (h *getParserProjectHandler) Run(ctx context.Context) gimlet.Responder {
 			Message:    fmt.Sprintf("task '%s' not found", h.taskID),
 		})
 	}
-	v, err := model.VersionFindOne(ctx, model.VersionById(t.Version))
+	v, err := model.VersionFindOne(ctx, model.VersionById(t.Version).WithFields(model.VersionIdKey, model.VersionProjectStorageMethodKey))
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}

--- a/rest/route/build.go
+++ b/rest/route/build.go
@@ -61,7 +61,7 @@ func (b *buildGetHandler) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 
-	v, err := serviceModel.VersionFindOneId(ctx, foundBuild.Version)
+	v, err := serviceModel.VersionFindOne(ctx, serviceModel.VersionById(foundBuild.Version).WithFields(serviceModel.VersionIdKey, serviceModel.VersionProjectStorageMethodKey))
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding version '%s'", foundBuild.Version))
 	}


### PR DESCRIPTION
DEVPROD-15996

### Description
All of these following locations were showing up as contributing to the large number of bytes the DB is sending over the wire during periods of slowness / network saturation:
- `/task/{task_id}/expansions_and_vars` route
- `/task/{task_id}/parser_project` route
- `/builds/{build_id}` route
- `MarkEnd`
- concurrent large parser project task limit check

.WithFields are added to queries that use these frequently used queries to reduce data sent.
### Testing
Existing tests