### PR TITLE
DEVPROD-15687 respect disable auto defaulting when setting project

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-03-17"
+	ClientVersion = "2025-03-24"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/model.go
+++ b/operations/model.go
@@ -260,32 +260,17 @@ func (s *ClientSettings) FindDefaultProject(cwd string, useRoot bool) string {
 	return ""
 }
 
-func (s *ClientSettings) getModulePath(project, moduleName string) string {
-	var modulePath string
-	for _, p := range s.Projects {
-		if p.Name == project && p.ModulePaths[moduleName] != "" {
-			modulePath = p.ModulePaths[moduleName]
-			break
-		}
-	}
-	return modulePath
-}
-
-// setModulePath updates the given client settings to include the new module path. It does this
-// regardless of whether auto updating is disabled, so that the path is cached locally in case of include files.
-func (s *ClientSettings) setModulePath(project, moduleName, modulePath string) {
+// setModulePath updates the given client settings to match the given module patch cache.
+func (s *ClientSettings) setModulePath(project string, modulePathCache map[string]string) {
 	for i, p := range s.Projects {
 		if p.Name == project {
-			if s.Projects[i].ModulePaths == nil {
-				s.Projects[i].ModulePaths = map[string]string{}
-			}
-			s.Projects[i].ModulePaths[moduleName] = modulePath
+			s.Projects[i].ModulePaths = modulePathCache
 			return
 		}
 	}
 	s.Projects = append(s.Projects, ClientProjectConf{
 		Name:        project,
-		ModulePaths: map[string]string{moduleName: modulePath},
+		ModulePaths: modulePathCache,
 	})
 }
 

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -220,8 +220,9 @@ func Patch() cli.Command {
 				return err
 			}
 
+			modulePathCache := map[string]string{}
 			if params.IncludeModules {
-				localModuleIncludes, err := getLocalModuleIncludes(params, conf, params.Path, ref.RemotePath)
+				localModuleIncludes, err := getLocalModuleIncludes(params, conf, params.Path, ref.RemotePath, modulePathCache)
 				if err != nil {
 					return err
 				}
@@ -243,7 +244,7 @@ func Patch() cli.Command {
 				}
 
 				for _, module := range proj.Modules {
-					modulePath, err := params.getModulePath(conf, module.Name)
+					modulePath, err := params.getModulePath(conf, module.Name, modulePathCache)
 					if err != nil {
 						grip.Error(err)
 						continue
@@ -518,7 +519,7 @@ func PatchFile() cli.Command {
 }
 
 // getLocalModuleIncludes reads and saves files module includes from the local project config.
-func getLocalModuleIncludes(params *patchParams, conf *ClientSettings, path, remotePath string) ([]patch.LocalModuleInclude, error) {
+func getLocalModuleIncludes(params *patchParams, conf *ClientSettings, path, remotePath string, modulePathCache map[string]string) ([]patch.LocalModuleInclude, error) {
 	var yml []byte
 	var err error
 	if path != "" {
@@ -540,7 +541,7 @@ func getLocalModuleIncludes(params *patchParams, conf *ClientSettings, path, rem
 		if include.Module == "" {
 			continue
 		}
-		modulePath, err := params.getModulePath(conf, include.Module)
+		modulePath, err := params.getModulePath(conf, include.Module, modulePathCache)
 		if err != nil {
 			grip.Error(errors.Wrapf(err, "getting module path for '%s'", include.Module))
 			continue

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -366,9 +366,6 @@ func (p *patchParams) addAliasToPatchParams(alias model.ProjectAlias) {
 }
 
 func (p *patchParams) setDefaultProject(conf *ClientSettings) {
-	if conf.DisableAutoDefaulting {
-		return
-	}
 	cwd, err := os.Getwd()
 	grip.Error(errors.Wrap(err, "getting current working directory"))
 	cwd, err = filepath.EvalSymlinks(cwd)
@@ -499,8 +496,10 @@ func (p *patchParams) getDescription() string {
 	return description
 }
 
-func (p *patchParams) getModulePath(conf *ClientSettings, module string) (string, error) {
-	modulePath := conf.getModulePath(p.Project, module)
+// getModulePath takes in a cache in addition to the conf, so that if we've disabled auto-defaulting, we can use the cache
+// without making any updates to conf, since this may be written to for future operations as well.
+func (p *patchParams) getModulePath(conf *ClientSettings, module string, modulePathCache map[string]string) (string, error) {
+	modulePath := modulePathCache[module]
 	if modulePath != "" || p.SkipConfirm {
 		return modulePath, nil
 	}
@@ -509,15 +508,14 @@ func (p *patchParams) getModulePath(conf *ClientSettings, module string) (string
 	if modulePath == "" {
 		return "", errors.Errorf("no module path given")
 	}
-	// Set path locally regardless of auto defaulting, so that its cached for the rest of the command.
-	conf.setModulePath(p.Project, module, modulePath)
+	modulePathCache[module] = modulePath
 
 	if !conf.DisableAutoDefaulting {
 		// Verify that the path is correct before auto defaulting
 		if _, err := gitUncommittedChanges(modulePath); err != nil {
 			return "", errors.Wrapf(err, "verifying module '%s''", module)
 		}
-
+		conf.setModulePath(p.Project, modulePathCache)
 		grip.Infof("Project module '%s' will be set to use path '%s'. "+
 			"To disable automatic defaulting, set 'disable_auto_defaulting' to true.", module, modulePath)
 
@@ -525,7 +523,6 @@ func (p *patchParams) getModulePath(conf *ClientSettings, module string) (string
 			grip.Errorf("problem setting module '%s' path in config: %s", module, err.Error())
 		}
 	}
-
 	return modulePath, nil
 }
 

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -366,6 +366,9 @@ func (p *patchParams) addAliasToPatchParams(alias model.ProjectAlias) {
 }
 
 func (p *patchParams) setDefaultProject(conf *ClientSettings) {
+	if conf.DisableAutoDefaulting {
+		return
+	}
 	cwd, err := os.Getwd()
 	grip.Error(errors.Wrap(err, "getting current working directory"))
 	cwd, err = filepath.EvalSymlinks(cwd)


### PR DESCRIPTION
DEVPROD-15687 

### Description
Previously I updated this to update conf with the module paths and just not write it; however, we do actually write elsewhere; generally in the UI we assume that the conf is always in a writeable state. Modified this logic to use a cache to respect that.

### Testing
Confirmed end-to-end that, with multiple calls of the same Evergreen yaml in includes, this uses the cache and does not set it in conf if disable_auto_defaulting is set to true. 

