### PR TITLE
DEVPROD-5407: consider rulesets for status checks

### DIFF
--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -533,14 +533,8 @@ func (j *patchIntentProcessor) createGitHubMergeSubscription(ctx context.Context
 		Caller:    j.Name,
 	}
 
-	// kim: TODO: determine if rulesets need to be obeyed for merge queue as
-	// well. Since they're interchangeable, I believe they should be checked as
-	// well.
 	rules := j.getEvergreenRulesForStatuses(ctx, p.GithubMergeData.Org, p.GithubMergeData.Repo, p.GithubMergeData.BaseBranch)
 	for i, rule := range rules {
-		// kim: TODO: ask BrianS why we would limit the merge queue pending
-		// checks to the first 10 branch protection rules.
-		// Limit statuses to 10
 		if i >= 10 {
 			break
 		}
@@ -1270,8 +1264,6 @@ func (j *patchIntentProcessor) sendGitHubErrorStatus(ctx context.Context, patchD
 // sendGitHubSuccessMessages sends a successful status to GitHub with the given message for all
 // Evergreen rules configured for the given project.
 func (j *patchIntentProcessor) sendGitHubSuccessMessages(ctx context.Context, patchDoc *patch.Patch, projectRef *model.ProjectRef, msg string) {
-	// kim: TODO: test that this works in staging with rulesets and with a
-	// combination of branch protection rules + rulesets.
 	rules := j.getEvergreenRulesForStatuses(ctx, patchDoc.GithubPatchData.BaseOwner, projectRef.Repo, projectRef.Branch)
 	for _, rule := range rules {
 		update := NewGithubStatusUpdateJobWithSuccessMessage(

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1304,8 +1304,8 @@ func (j *patchIntentProcessor) getEvergreenRulesForStatuses(ctx context.Context,
 		"patch":    j.PatchID.Hex(),
 	}))
 
-	allRules := append(branchProtectionRules, rulesetRules...)
-	allRules = append(allRules, thirdparty.GithubStatusDefaultContext)
+	allRules := append([]string{thirdparty.GithubStatusDefaultContext}, branchProtectionRules...)
+	allRules = append(allRules, rulesetRules...)
 
 	return utility.UniqueStrings(allRules)
 }


### PR DESCRIPTION
DEVPROD-5407

### Description
When all files are ignored, Evergreen sends dummy success status checks based on the status checks that are required by branch protection rules (e.g. `evergreen` and `evergreen/ubuntu2204` for self-tests). This is needed so that the user can press the merge button. GitHub also has something called rulesets, which provides effectively the same functionality as branch protection rules, but in a different feature. To accommodate projects that want to use rulesets instead of branch protection rules, send the same success status checks for rulesets as are currently sent for branch protection rules when all files are ignored.

Worth calling out that this logic is also relied on by the merge queue when determining what pending statuses to show for a merging PR. I thought it was reasonable to consider both branch protection rules and rulesets when deciding what pending statuses to send to the merge queue since they're functionally the same.

### Testing
Tested in merge queue sandbox that when all files were ignored and a ruleset was defined, Evergreen sent a success status for every `evergreen` status check required by the ruleset.