### PR TITLE
DEVPROD-14799 Use same context as amboy job for generate-tasks jobs

### DIFF
--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -166,13 +166,12 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 		return errors.Wrap(err, "checking new dependency graph for cycles")
 	}
 
-	// Don't use the job's context, because it's better to try finishing than to
-	// exit early after a SIGTERM from app server shutdown.
-	saveCtx, saveCancel := context.WithTimeout(context.Background(), 30*time.Minute)
-	defer saveCancel()
-	// Inject the span context into the saveCtx.
-	saveCtx = trace.ContextWithSpanContext(saveCtx, span.SpanContext())
-	err = g.Save(saveCtx, j.env.Settings(), p, pp, v)
+	// Ignore the cancel signal from the job's context, because it's better
+	// to try finishing than to exit early after a SIGTERM from app server shutdown.
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Minute)
+	defer cancel()
+
+	err = g.Save(ctx, j.env.Settings(), p, pp, v)
 
 	// If the version or parser project has changed there was a race. Another generator will try again.
 	if adb.ResultsNotFound(err) || db.IsDuplicateKey(err) {


### PR DESCRIPTION
DEVPROD-14799

### Description
This replaces the usage of `trace.ContextWithSpanContext` with some modern std context commands. Looking at honeycomb:
<img width="774" alt="Screenshot 2025-03-25 at 10 45 53 AM" src="https://github.com/user-attachments/assets/e25abbe4-fabc-423e-bcc6-1b479d639197" />
We haven't been collecting spans for generate.tasks because  the `trace.ContextWithSpanContext` does not work as expected, it makes a non-recording span:
<img width="668" alt="image" src="https://github.com/user-attachments/assets/45e49485-0412-4ade-8931-3d964272cfa8" />

This doesn't fix the ticket, but is a step towards collecting data

### Testing
Unit tests

