### PR TITLE
DEVPROD-16047: add distro option for assigning public IPv4 address

### DIFF
--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -439,9 +439,13 @@ func (m *ec2FleetManager) uploadLaunchTemplate(ctx context.Context, h *host.Host
 	}
 
 	if ec2Settings.IsVpc {
+		assignPublicIPv4 := !ec2Settings.DoNotAssignPublicIPv4Address
+		if h.UserHost {
+			assignPublicIPv4 = true
+		}
 		launchTemplate.NetworkInterfaces = []types.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{
 			{
-				AssociatePublicIpAddress: aws.Bool(true),
+				AssociatePublicIpAddress: aws.Bool(assignPublicIPv4),
 				DeviceIndex:              aws.Int32(0),
 				Groups:                   ec2Settings.SecurityGroupIDs,
 				SubnetId:                 aws.String(ec2Settings.SubnetId),

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -370,7 +370,6 @@ func validateCloudProviderData(instance *types.Instance) error {
 	catcher.ErrorfWhen(instance.Placement == nil || instance.Placement.AvailabilityZone == nil, "instance missing availability zone")
 	catcher.ErrorfWhen(instance.LaunchTime == nil, "instance missing launch time")
 	catcher.ErrorfWhen(instance.PublicDnsName == nil, "instance missing public DNS name")
-	catcher.ErrorfWhen(instance.PublicIpAddress == nil, "instance missing public IP address")
 	catcher.ErrorfWhen(instance.PrivateIpAddress == nil, "instance missing private IP address")
 	return catcher.Resolve()
 }

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2101,16 +2101,23 @@ func CacheAllCloudProviderData(ctx context.Context, env evergreen.Environment, h
 // cacheCloudProviderDataUpdate returns an update for caching cloud provider
 // data.
 func cacheCloudProviderDataUpdate(data CloudProviderData) bson.M {
+	setFields := bson.M{
+		ZoneKey:      data.Zone,
+		StartTimeKey: data.StartedAt,
+		IPv4Key:      data.PrivateIPv4,
+		IPKey:        data.IPv6,
+		VolumesKey:   data.Volumes,
+	}
+	// kim: TODO: verify that PublicIPv4 and PublicDNS are only set if
+	// AssociatePublicIpAddress is true.
+	if data.PublicIPv4 != "" {
+		setFields[PublicIPv4Key] = data.PublicIPv4
+	}
+	if data.PublicDNS != "" {
+		setFields[DNSKey] = data.PublicDNS
+	}
 	return bson.M{
-		"$set": bson.M{
-			ZoneKey:       data.Zone,
-			StartTimeKey:  data.StartedAt,
-			DNSKey:        data.PublicDNS,
-			PublicIPv4Key: data.PublicIPv4,
-			IPv4Key:       data.PrivateIPv4,
-			IPKey:         data.IPv6,
-			VolumesKey:    data.Volumes,
-		},
+		"$set": setFields,
 	}
 }
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2108,8 +2108,6 @@ func cacheCloudProviderDataUpdate(data CloudProviderData) bson.M {
 		IPKey:        data.IPv6,
 		VolumesKey:   data.Volumes,
 	}
-	// kim: TODO: verify that PublicIPv4 and PublicDNS are only set if
-	// AssociatePublicIpAddress is true.
 	if data.PublicIPv4 != "" {
 		setFields[PublicIPv4Key] = data.PublicIPv4
 	}

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -39,7 +39,7 @@ import (
 
 type Host struct {
 	Id string `bson:"_id" json:"id"`
-	// Host is the ephemeral DNS name of the host.
+	// Host is the ephemeral DNS name of the host when available.
 	Host            string        `bson:"host_id" json:"host"`
 	User            string        `bson:"user" json:"user"`
 	Secret          string        `bson:"secret" json:"secret"`
@@ -54,7 +54,7 @@ type Host struct {
 	// PersistentDNSName is the long-lived DNS name of the host, which should
 	// never change once set.
 	PersistentDNSName string `bson:"persistent_dns_name,omitempty" json:"persistent_dns_name,omitempty"`
-	// PublicIPv4 is the host's IPv4 address.
+	// PublicIPv4 is the host's IPv4 address when available.
 	PublicIPv4 string `bson:"public_ipv4_address,omitempty" json:"public_ipv4_address,omitempty"`
 
 	// secondary (external) identifier for the host

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -47,6 +47,8 @@ func NewCloudHostReadyJob(env evergreen.Environment, id string) amboy.Job {
 	return j
 }
 
+// kim: TODO: verify that host still becomes running without
+// AssociatePublicIpAddress.
 func makeCloudHostReadyJob() *cloudHostReadyJob {
 	j := &cloudHostReadyJob{
 		Base: job.Base{

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -47,8 +47,6 @@ func NewCloudHostReadyJob(env evergreen.Environment, id string) amboy.Job {
 	return j
 }
 
-// kim: TODO: verify that host still becomes running without
-// AssociatePublicIpAddress.
 func makeCloudHostReadyJob() *cloudHostReadyJob {
 	j := &cloudHostReadyJob{
 		Base: job.Base{


### PR DESCRIPTION
DEVPROD-16047

### Description
Currently, all Evergreen hosts are assigned a public IPv4 address. CISA requires network isolation for release task distros and on top of CISA, the runtime environments team would like to eventually slowly remove public IPv4 addresses from task hosts in general because they pose a security risk and cost money. To accommodate both the immediate CISA need and assist the future path to get rid of IPv4 addresses entirely, I added a distro setting that lets you disable public IPv4 address assignment. The implication of not assigning an IPv4 address is the host will also no longer have a public hostname, meaning we cannot SSH into them (we could use SSM to connect to the host in a more secure way if needed).

Note that spawn hosts have to always get a public IPv4 address because they don't run Evergreen tasks and because Evergreen users can currently only access their hosts via SSH.

* Add distro option to disable public IPv4 address assignment for non-spawn hosts.
* Update host data caching logic to not assume that IPv4 address and public hostname will be available.

### Testing
Tested in Jason's staging that setting the distro setting created hosts without a public IPv4 address. Those hosts could still run tasks and get to the running state normally (he has a particular setup that makes it possible to test Evergreen tasks without public IPv4 addresses).

### Documentation
N/A