### PR TITLE
DEVPROD-53 Thread context through Aggregate, Count, and Upsert queries

### DIFF
--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -262,9 +262,6 @@ func ReplaceContext(ctx context.Context, collection string, query any, replaceme
 	if err != nil {
 		return nil, errors.Wrapf(err, "replacing document")
 	}
-	if res.MatchedCount == 0 {
-		return nil, db.ErrNotFound
-	}
 
 	return &db.ChangeInfo{Updated: int(res.UpsertedCount) + int(res.ModifiedCount), UpsertedId: res.UpsertedID}, nil
 }

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -252,7 +252,9 @@ func UpdateContext(ctx context.Context, collection string, query any, update any
 	return nil
 }
 
-// ReplaceContext replaces one matching document in the collection.
+// ReplaceContext replaces one matching document in the collection. If a matching
+// document is not found, it will be upserted. It returns the upserted ID if
+// one was created.
 func ReplaceContext(ctx context.Context, collection string, query any, replacement any) (*db.ChangeInfo, error) {
 	res, err := evergreen.GetEnvironment().DB().Collection(collection).ReplaceOne(ctx,
 		query,

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -359,20 +359,7 @@ func Upsert(ctx context.Context, collection string, query any, update any) (*db.
 }
 
 // Count run a count command with the specified query against the collection.
-func Count(collection string, query any) (int, error) {
-	session, db, err := GetGlobalSessionFactory().GetSession()
-	if err != nil {
-		grip.Errorf("error establishing db connection: %+v", err)
-
-		return 0, err
-	}
-	defer session.Close()
-
-	return db.C(collection).Find(query).Count()
-}
-
-// Count run a count command with the specified query against the collection.
-func CountContext(ctx context.Context, collection string, query any) (int, error) {
+func Count(ctx context.Context, collection string, query any) (int, error) {
 	session, db, err := GetGlobalSessionFactory().GetContextSession(ctx)
 	if err != nil {
 		grip.Errorf("error establishing db connection: %+v", err)
@@ -447,8 +434,8 @@ func FindAllQContext(ctx context.Context, collection string, q Q, out any) error
 }
 
 // CountQ runs a Q count query against the given collection.
-func CountQContext(ctx context.Context, collection string, q Q) (int, error) {
-	return CountContext(ctx, collection, q.filter)
+func CountQ(ctx context.Context, collection string, q Q) (int, error) {
+	return Count(ctx, collection, q.filter)
 }
 
 // RemoveAllQ removes all docs that satisfy the query

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -526,24 +526,7 @@ func ClearGridCollections(fsPrefix string) error {
 // Aggregate runs an aggregation pipeline on a collection and unmarshals
 // the results to the given "out" interface (usually a pointer
 // to an array of structs/bson.M)
-func Aggregate(collection string, pipeline any, out any) error {
-	session, db, err := GetGlobalSessionFactory().GetSession()
-	if err != nil {
-		err = errors.Wrap(err, "establishing db connection")
-		grip.Error(err)
-		return err
-	}
-	defer session.Close()
-
-	pipe := db.C(collection).Pipe(pipeline)
-
-	return errors.WithStack(pipe.All(out))
-}
-
-// AggregateContext runs an aggregation pipeline on a collection and unmarshals
-// the results to the given "out" interface (usually a pointer
-// to an array of structs/bson.M)
-func AggregateContext(ctx context.Context, collection string, pipeline any, out any) error {
+func Aggregate(ctx context.Context, collection string, pipeline any, out any) error {
 	session, db, err := GetGlobalSessionFactory().GetContextSession(ctx)
 	if err != nil {
 		err = errors.Wrap(err, "establishing db connection")

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -342,6 +342,7 @@ func UpdateAll(collection string, query any, update any) (*db.ChangeInfo, error)
 	return db.C(collection).UpdateAll(query, update)
 }
 
+// Upsert run the specified update against the collection as an upsert operation.
 func Upsert(ctx context.Context, collection string, query any, update any) (*db.ChangeInfo, error) {
 	// Temporarily, we check if the document has a key beginning with '$', this would
 	// indicate a proper upsert operation. If not, it's a document intended for replacement.

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -344,21 +344,9 @@ func UpdateAll(collection string, query any, update any) (*db.ChangeInfo, error)
 }
 
 // Upsert run the specified update against the collection as an upsert operation.
-func Upsert(collection string, query any, update any) (*db.ChangeInfo, error) {
-	session, db, err := GetGlobalSessionFactory().GetSession()
-	if err != nil {
-		grip.Errorf("error establishing db connection: %+v", err)
-
-		return nil, err
-	}
-	defer session.Close()
-
-	return db.C(collection).Upsert(query, update)
-}
-
-// UpsertContext run the specified update against the collection as an upsert operation.
-func UpsertContext(ctx context.Context, collection string, query any, update any) (*db.ChangeInfo, error) {
-	res, err := evergreen.GetEnvironment().DB().Collection(collection).UpdateOne(ctx,
+func Upsert(ctx context.Context, collection string, query any, update any) (*db.ChangeInfo, error) {
+	res, err := evergreen.GetEnvironment().DB().Collection(collection).UpdateOne(
+		ctx,
 		query,
 		update,
 		options.Update().SetUpsert(true),

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -422,6 +422,7 @@ func FindAllQ(collection string, q Q, out any) error {
 	return FindAllQContext(context.Background(), collection, q, out)
 }
 
+// FindAllQContext runs a Q query against the given collection, applying the results to "out."
 func FindAllQContext(ctx context.Context, collection string, q Q, out any) error {
 	if q.maxTime > 0 {
 		var cancel context.CancelFunc

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -347,22 +347,26 @@ func Upsert(ctx context.Context, collection string, query any, update any) (*db.
 	// indicate a proper upsert operation. If not, it's a document intended for replacement.
 	// If the document is unable to be transformed (aka err != nil, e.g. a pipeline), we
 	// also default to an update operation.
-	// This will be removed in DEVPROD-<TODO>.
+	// This will be removed in DEVPROD-16579.
 
 	doc, err := transformDocument(update)
 	if err != nil || hasDollarKey(doc) {
 		return upsert(ctx, collection, query, update)
 	}
 
-	msg := "update document must contain a key beginning with '$'"
+	msg := "upsert document must contain a key beginning with '$'"
 	grip.Debug(message.Fields{
 		"message": msg,
 		"error":   errors.New(msg),
-		"ticket":  "DEVPROD-15419",
+		"ticket":  "DEVPROD-16579",
 	})
+
+	// This is to prevent new tests from using the upsert operation as a replacement operation.
+	// This will be removed (as will the fallback completely) in DEVPROD-16579.
 	if testing.Testing() {
 		return nil, errors.New("CHANGE TO REPLACE")
 	}
+
 	return ReplaceContext(ctx, collection, query, update)
 }
 

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -447,11 +447,6 @@ func FindAllQContext(ctx context.Context, collection string, q Q, out any) error
 }
 
 // CountQ runs a Q count query against the given collection.
-func CountQ(collection string, q Q) (int, error) {
-	return Count(collection, q.filter)
-}
-
-// CountQ runs a Q count query against the given collection.
 func CountQContext(ctx context.Context, collection string, q Q) (int, error) {
 	return CountContext(ctx, collection, q.filter)
 }

--- a/db/db_utils_test.go
+++ b/db/db_utils_test.go
@@ -430,7 +430,7 @@ func TestDBUtils(t *testing.T) {
 			}
 
 			output := []bson.M{}
-			err := AggregateContext(t.Context(), collection, testPipeline, &output)
+			err := Aggregate(t.Context(), collection, testPipeline, &output)
 			So(err, ShouldBeNil)
 			So(len(output), ShouldEqual, 2)
 			So(output[0]["total"], ShouldEqual, 5)
@@ -444,7 +444,7 @@ func TestDBUtils(t *testing.T) {
 					TotalSum int    `bson:"total"`
 				}
 				output := []ResultStruct{}
-				err := AggregateContext(t.Context(), collection, testPipeline, &output)
+				err := Aggregate(t.Context(), collection, testPipeline, &output)
 				So(err, ShouldBeNil)
 				So(len(output), ShouldEqual, 2)
 				So(output[0], ShouldResemble, ResultStruct{"2", 5})

--- a/db/db_utils_test.go
+++ b/db/db_utils_test.go
@@ -318,7 +318,7 @@ func TestDBUtils(t *testing.T) {
 					FieldTwo: 1,
 				}
 
-				_, err := Upsert(
+				_, err := UpsertContext(t.Context(),
 					collection,
 					bson.M{
 						"field_one": in.FieldOne,
@@ -348,7 +348,7 @@ func TestDBUtils(t *testing.T) {
 				So(Insert(collection, in), ShouldBeNil)
 				in.FieldTwo = 2
 
-				_, err := Upsert(
+				_, err := UpsertContext(t.Context(),
 					collection,
 					bson.M{
 						"field_one": in.FieldOne,

--- a/db/db_utils_test.go
+++ b/db/db_utils_test.go
@@ -430,7 +430,7 @@ func TestDBUtils(t *testing.T) {
 			}
 
 			output := []bson.M{}
-			err := Aggregate(collection, testPipeline, &output)
+			err := AggregateContext(t.Context(), collection, testPipeline, &output)
 			So(err, ShouldBeNil)
 			So(len(output), ShouldEqual, 2)
 			So(output[0]["total"], ShouldEqual, 5)
@@ -444,7 +444,7 @@ func TestDBUtils(t *testing.T) {
 					TotalSum int    `bson:"total"`
 				}
 				output := []ResultStruct{}
-				err := Aggregate(collection, testPipeline, &output)
+				err := AggregateContext(t.Context(), collection, testPipeline, &output)
 				So(err, ShouldBeNil)
 				So(len(output), ShouldEqual, 2)
 				So(output[0], ShouldResemble, ResultStruct{"2", 5})

--- a/db/db_utils_test.go
+++ b/db/db_utils_test.go
@@ -65,13 +65,13 @@ func TestDBUtils(t *testing.T) {
 			// insert, make sure both were inserted
 			So(Insert(collection, in), ShouldBeNil)
 			So(Insert(collection, inTwo), ShouldBeNil)
-			count, err := Count(collection, bson.M{})
+			count, err := CountContext(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 2)
 
 			// clear and validate the collection is empty
 			So(Clear(collection), ShouldBeNil)
-			count, err = Count(collection, bson.M{})
+			count, err = CountContext(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 0)
 
@@ -106,14 +106,14 @@ func TestDBUtils(t *testing.T) {
 			// insert, make sure both were inserted
 			So(Insert(collection, in), ShouldBeNil)
 			So(Insert(collection, inTwo), ShouldBeNil)
-			count, err := Count(collection, bson.M{})
+			count, err := CountContext(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 2)
 
 			// remove just the first
 			So(Remove(t.Context(), collection, bson.M{"field_one": "1"}),
 				ShouldBeNil)
-			count, err = Count(collection, bson.M{})
+			count, err = CountContext(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 1)
 
@@ -146,14 +146,14 @@ func TestDBUtils(t *testing.T) {
 			So(Insert(collection, in), ShouldBeNil)
 			So(Insert(collection, inTwo), ShouldBeNil)
 			So(Insert(collection, inThree), ShouldBeNil)
-			count, err := Count(collection, bson.M{})
+			count, err := CountContext(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 3)
 
 			// remove just the first
 			So(RemoveAll(t.Context(), collection, bson.M{"field_one": "1"}),
 				ShouldBeNil)
-			count, err = Count(collection, bson.M{})
+			count, err = CountContext(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 1)
 
@@ -196,7 +196,7 @@ func TestDBUtils(t *testing.T) {
 			So(Insert(collection, inTwo), ShouldBeNil)
 			So(Insert(collection, inThree), ShouldBeNil)
 			So(Insert(collection, inFour), ShouldBeNil)
-			count, err := Count(collection, bson.M{})
+			count, err := CountContext(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 4)
 
@@ -235,7 +235,7 @@ func TestDBUtils(t *testing.T) {
 			// insert, make sure both were inserted
 			So(Insert(collection, in), ShouldBeNil)
 			So(Insert(collection, inTwo), ShouldBeNil)
-			count, err := Count(collection, bson.M{})
+			count, err := CountContext(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 2)
 
@@ -283,7 +283,7 @@ func TestDBUtils(t *testing.T) {
 			So(Insert(collection, in), ShouldBeNil)
 			So(Insert(collection, inTwo), ShouldBeNil)
 			So(Insert(collection, inThree), ShouldBeNil)
-			count, err := Count(collection, bson.M{})
+			count, err := CountContext(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 3)
 

--- a/db/db_utils_test.go
+++ b/db/db_utils_test.go
@@ -318,7 +318,7 @@ func TestDBUtils(t *testing.T) {
 					FieldTwo: 1,
 				}
 
-				_, err := UpsertContext(t.Context(),
+				_, err := Upsert(t.Context(),
 					collection,
 					bson.M{
 						"field_one": in.FieldOne,
@@ -348,7 +348,7 @@ func TestDBUtils(t *testing.T) {
 				So(Insert(collection, in), ShouldBeNil)
 				in.FieldTwo = 2
 
-				_, err := UpsertContext(t.Context(),
+				_, err := Upsert(t.Context(),
 					collection,
 					bson.M{
 						"field_one": in.FieldOne,

--- a/db/db_utils_test.go
+++ b/db/db_utils_test.go
@@ -65,13 +65,13 @@ func TestDBUtils(t *testing.T) {
 			// insert, make sure both were inserted
 			So(Insert(collection, in), ShouldBeNil)
 			So(Insert(collection, inTwo), ShouldBeNil)
-			count, err := CountContext(t.Context(), collection, bson.M{})
+			count, err := Count(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 2)
 
 			// clear and validate the collection is empty
 			So(Clear(collection), ShouldBeNil)
-			count, err = CountContext(t.Context(), collection, bson.M{})
+			count, err = Count(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 0)
 
@@ -106,14 +106,14 @@ func TestDBUtils(t *testing.T) {
 			// insert, make sure both were inserted
 			So(Insert(collection, in), ShouldBeNil)
 			So(Insert(collection, inTwo), ShouldBeNil)
-			count, err := CountContext(t.Context(), collection, bson.M{})
+			count, err := Count(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 2)
 
 			// remove just the first
 			So(Remove(t.Context(), collection, bson.M{"field_one": "1"}),
 				ShouldBeNil)
-			count, err = CountContext(t.Context(), collection, bson.M{})
+			count, err = Count(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 1)
 
@@ -146,14 +146,14 @@ func TestDBUtils(t *testing.T) {
 			So(Insert(collection, in), ShouldBeNil)
 			So(Insert(collection, inTwo), ShouldBeNil)
 			So(Insert(collection, inThree), ShouldBeNil)
-			count, err := CountContext(t.Context(), collection, bson.M{})
+			count, err := Count(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 3)
 
 			// remove just the first
 			So(RemoveAll(t.Context(), collection, bson.M{"field_one": "1"}),
 				ShouldBeNil)
-			count, err = CountContext(t.Context(), collection, bson.M{})
+			count, err = Count(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 1)
 
@@ -196,7 +196,7 @@ func TestDBUtils(t *testing.T) {
 			So(Insert(collection, inTwo), ShouldBeNil)
 			So(Insert(collection, inThree), ShouldBeNil)
 			So(Insert(collection, inFour), ShouldBeNil)
-			count, err := CountContext(t.Context(), collection, bson.M{})
+			count, err := Count(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 4)
 
@@ -235,7 +235,7 @@ func TestDBUtils(t *testing.T) {
 			// insert, make sure both were inserted
 			So(Insert(collection, in), ShouldBeNil)
 			So(Insert(collection, inTwo), ShouldBeNil)
-			count, err := CountContext(t.Context(), collection, bson.M{})
+			count, err := Count(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 2)
 
@@ -283,7 +283,7 @@ func TestDBUtils(t *testing.T) {
 			So(Insert(collection, in), ShouldBeNil)
 			So(Insert(collection, inTwo), ShouldBeNil)
 			So(Insert(collection, inThree), ShouldBeNil)
-			count, err := CountContext(t.Context(), collection, bson.M{})
+			count, err := Count(t.Context(), collection, bson.M{})
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 3)
 

--- a/graphql/directive_project_test.go
+++ b/graphql/directive_project_test.go
@@ -106,7 +106,7 @@ func TestRequireProjectAccessForSettings(t *testing.T) {
 	repoRef := model.RepoRef{ProjectRef: model.ProjectRef{
 		Id: "repo_id",
 	}}
-	err = repoRef.Upsert(ctx)
+	err = repoRef.Replace(ctx)
 	require.NoError(t, err)
 
 	obj := any(map[string]any{"projectIdentifier": "invalid_identifier"})

--- a/graphql/directive_project_test.go
+++ b/graphql/directive_project_test.go
@@ -106,7 +106,7 @@ func TestRequireProjectAccessForSettings(t *testing.T) {
 	repoRef := model.RepoRef{ProjectRef: model.ProjectRef{
 		Id: "repo_id",
 	}}
-	err = repoRef.Upsert()
+	err = repoRef.Upsert(ctx)
 	require.NoError(t, err)
 
 	obj := any(map[string]any{"projectIdentifier": "invalid_identifier"})

--- a/graphql/host_resolver.go
+++ b/graphql/host_resolver.go
@@ -71,7 +71,7 @@ func (r *hostResolver) Events(ctx context.Context, obj *restModel.APIHost, opts 
 
 // EventTypes is the resolver for the eventTypes field.
 func (r *hostResolver) EventTypes(ctx context.Context, obj *restModel.APIHost) ([]string, error) {
-	eventTypes, err := event.GetEventTypesForHost(utility.FromStringPtr(obj.Id), utility.FromStringPtr(obj.Tag))
+	eventTypes, err := event.GetEventTypesForHost(ctx, utility.FromStringPtr(obj.Id), utility.FromStringPtr(obj.Tag))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting event types for host '%s': %s", utility.FromStringPtr(obj.Id), err.Error()))
 	}

--- a/graphql/host_resolver.go
+++ b/graphql/host_resolver.go
@@ -50,7 +50,7 @@ func (r *hostResolver) Events(ctx context.Context, obj *restModel.APIHost, opts 
 		SortAsc:    sortAsc,
 		EventTypes: opts.EventTypes,
 	}
-	events, count, err := event.GetPaginatedHostEvents(hostQueryOpts)
+	events, count, err := event.GetPaginatedHostEvents(ctx, hostQueryOpts)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching events for host '%s': %s", utility.FromStringPtr(obj.Id), err.Error()))
 	}

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -68,7 +68,7 @@ func (r *mutationResolver) AddAnnotationIssue(ctx context.Context, taskID string
 		}
 		return true, nil
 	} else {
-		if err := annotations.AddSuspectedIssueToAnnotation(taskID, execution, *issue, usr.Username()); err != nil {
+		if err := annotations.AddSuspectedIssueToAnnotation(ctx, taskID, execution, *issue, usr.Username()); err != nil {
 			return false, InternalServerError.Send(ctx, fmt.Sprintf("adding suspected issue: %s", err.Error()))
 		}
 		return true, nil

--- a/graphql/pod_resolver.go
+++ b/graphql/pod_resolver.go
@@ -12,7 +12,7 @@ import (
 
 // Events is the resolver for the events field.
 func (r *podResolver) Events(ctx context.Context, obj *model.APIPod, limit *int, page *int) (*PodEvents, error) {
-	events, count, err := event.MostRecentPaginatedPodEvents(utility.FromStringPtr(obj.ID), *limit, *page)
+	events, count, err := event.MostRecentPaginatedPodEvents(ctx, utility.FromStringPtr(obj.ID), *limit, *page)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding events for pod '%s': %s", utility.FromStringPtr(obj.ID), err.Error()))
 	}

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -244,7 +244,7 @@ func (r *queryResolver) HostEvents(ctx context.Context, hostID string, hostTag *
 		Page:    utility.FromIntPtr(page),
 		SortAsc: false,
 	}
-	events, count, err := event.GetPaginatedHostEvents(hostQueryOpts)
+	events, count, err := event.GetPaginatedHostEvents(ctx, hostQueryOpts)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching events for host '%s': %s", hostID, err.Error()))
 	}

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -124,7 +124,7 @@ func (r *queryResolver) DistroEvents(ctx context.Context, opts DistroEventsInput
 		limit = utility.FromIntPtr(opts.Limit)
 	}
 
-	events, err := event.FindLatestPrimaryDistroEvents(opts.DistroID, limit, before)
+	events, err := event.FindLatestPrimaryDistroEvents(ctx, opts.DistroID, limit, before)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("retrieving events for distro '%s': %s", opts.DistroID, err.Error()))
 	}
@@ -181,7 +181,7 @@ func (r *queryResolver) Distros(ctx context.Context, onlySpawnable bool) ([]*res
 
 // DistroTaskQueue is the resolver for the distroTaskQueue field.
 func (r *queryResolver) DistroTaskQueue(ctx context.Context, distroID string) ([]*restModel.APITaskQueueItem, error) {
-	distroQueue, err := model.LoadTaskQueue(distroID)
+	distroQueue, err := model.LoadTaskQueue(ctx, distroID)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting task queue for distro '%s': %s", distroID, err.Error()))
 	}

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -483,7 +483,7 @@ func (r *taskResolver) LatestExecution(ctx context.Context, obj *restModel.APITa
 // MinQueuePosition is the resolver for the minQueuePosition field.
 func (r *taskResolver) MinQueuePosition(ctx context.Context, obj *restModel.APITask) (int, error) {
 	taskID := utility.FromStringPtr(obj.Id)
-	position, err := model.FindMinimumQueuePositionForTask(taskID)
+	position, err := model.FindMinimumQueuePositionForTask(ctx, taskID)
 	if err != nil {
 		return 0, InternalServerError.Send(ctx, fmt.Sprintf("finding minimum queue position for task '%s': %s", taskID, err.Error()))
 	}

--- a/graphql/tests/mutation/addFavoriteProject/results.json
+++ b/graphql/tests/mutation/addFavoriteProject/results.json
@@ -18,7 +18,7 @@
       "result": {
         "errors": [
           {
-            "message": "project 'i-dont-exist' not found",
+            "message": "project/repo 'i-dont-exist' not found",
             "path": ["addFavoriteProject"],
             "extensions": {
               "code": "RESOURCE_NOT_FOUND"

--- a/graphql/tests/mutation/addFavoriteProject/results.json
+++ b/graphql/tests/mutation/addFavoriteProject/results.json
@@ -18,7 +18,7 @@
       "result": {
         "errors": [
           {
-            "message": "project/rep 'i-dont-exist' not found",
+            "message": "project 'i-dont-exist' not found",
             "path": ["addFavoriteProject"],
             "extensions": {
               "code": "RESOURCE_NOT_FOUND"

--- a/graphql/tests/mutation/addFavoriteProject/results.json
+++ b/graphql/tests/mutation/addFavoriteProject/results.json
@@ -18,7 +18,7 @@
       "result": {
         "errors": [
           {
-            "message": "project/repo 'i-dont-exist' not found",
+            "message": "project/rep 'i-dont-exist' not found",
             "path": ["addFavoriteProject"],
             "extensions": {
               "code": "RESOURCE_NOT_FOUND"

--- a/graphql/tests/mutation/saveSubscription/results.json
+++ b/graphql/tests/mutation/saveSubscription/results.json
@@ -56,7 +56,7 @@
       "result": {
         "errors": [
           {
-            "message": "fetching project 'not-real': 404 (Not Found): project/repo 'not-real' not found",
+            "message": "fetching project 'not-real': 404 (Not Found): project 'not-real' not found",
             "path": ["saveSubscription"],
             "extensions": { "code": "INTERNAL_SERVER_ERROR" }
           }

--- a/graphql/tests/mutation/saveSubscription/results.json
+++ b/graphql/tests/mutation/saveSubscription/results.json
@@ -56,7 +56,7 @@
       "result": {
         "errors": [
           {
-            "message": "fetching project 'not-real': 404 (Not Found): project 'not-real' not found",
+            "message": "fetching project 'not-real': 404 (Not Found): project/repo 'not-real' not found",
             "path": ["saveSubscription"],
             "extensions": { "code": "INTERNAL_SERVER_ERROR" }
           }

--- a/model/annotations/db.go
+++ b/model/annotations/db.go
@@ -67,7 +67,7 @@ func FindByTaskId(ctx context.Context, id string) ([]TaskAnnotation, error) {
 }
 
 // Upsert writes the task_annotation to the database.
-func (a *TaskAnnotation) Upsert() error {
+func (a *TaskAnnotation) Upsert(ctx context.Context) error {
 	set := bson.M{
 		NoteKey:            a.Note,
 		IssuesKey:          a.Issues,
@@ -78,7 +78,8 @@ func (a *TaskAnnotation) Upsert() error {
 	if a.Metadata != nil {
 		set[MetadataKey] = a.Metadata
 	}
-	_, err := db.Upsert(
+	_, err := db.UpsertContext(
+		ctx,
 		Collection,
 		ByTaskIdAndExecution(a.TaskId, a.TaskExecution),
 		bson.M{

--- a/model/annotations/db.go
+++ b/model/annotations/db.go
@@ -78,7 +78,7 @@ func (a *TaskAnnotation) Upsert(ctx context.Context) error {
 	if a.Metadata != nil {
 		set[MetadataKey] = a.Metadata
 	}
-	_, err := db.UpsertContext(
+	_, err := db.Upsert(
 		ctx,
 		Collection,
 		ByTaskIdAndExecution(a.TaskId, a.TaskExecution),

--- a/model/annotations/task_annotations.go
+++ b/model/annotations/task_annotations.go
@@ -96,7 +96,7 @@ func UpdateAnnotationNote(ctx context.Context, taskId string, execution int, ori
 	if annotation != nil && annotation.Note != nil && annotation.Note.Message != originalMessage {
 		return errors.New("note is out of sync, please try again")
 	}
-	_, err = db.UpsertContext(
+	_, err = db.Upsert(
 		ctx,
 		Collection,
 		ByTaskIdAndExecution(taskId, execution),
@@ -118,7 +118,7 @@ func SetAnnotationMetadataLinks(ctx context.Context, taskId string, execution in
 		}
 	}
 
-	_, err := db.UpsertContext(
+	_, err := db.Upsert(
 		ctx,
 		Collection,
 		ByTaskIdAndExecution(taskId, execution),
@@ -136,7 +136,7 @@ func AddSuspectedIssueToAnnotation(ctx context.Context, taskId string, execution
 		Requester: UIRequester,
 	}
 
-	_, err := db.UpsertContext(
+	_, err := db.Upsert(
 		ctx,
 		Collection,
 		ByTaskIdAndExecution(taskId, execution),
@@ -192,7 +192,7 @@ func AddCreatedTicket(ctx context.Context, taskId string, execution int, ticket 
 		Requester: WebhookRequester,
 	}
 	ticket.Source = source
-	_, err := db.UpsertContext(
+	_, err := db.Upsert(
 		ctx,
 		Collection,
 		ByTaskIdAndExecution(taskId, execution),

--- a/model/annotations/task_annotations.go
+++ b/model/annotations/task_annotations.go
@@ -118,7 +118,8 @@ func SetAnnotationMetadataLinks(ctx context.Context, taskId string, execution in
 		}
 	}
 
-	_, err := db.Upsert(
+	_, err := db.UpsertContext(
+		ctx,
 		Collection,
 		ByTaskIdAndExecution(taskId, execution),
 		bson.M{
@@ -128,14 +129,15 @@ func SetAnnotationMetadataLinks(ctx context.Context, taskId string, execution in
 	return errors.Wrapf(err, "setting task links for task '%s'", taskId)
 }
 
-func AddSuspectedIssueToAnnotation(taskId string, execution int, issue IssueLink, username string) error {
+func AddSuspectedIssueToAnnotation(ctx context.Context, taskId string, execution int, issue IssueLink, username string) error {
 	issue.Source = &Source{
 		Author:    username,
 		Time:      time.Now(),
 		Requester: UIRequester,
 	}
 
-	_, err := db.Upsert(
+	_, err := db.UpsertContext(
+		ctx,
 		Collection,
 		ByTaskIdAndExecution(taskId, execution),
 		bson.M{
@@ -183,14 +185,15 @@ func CreateAnnotationUpdate(annotation *TaskAnnotation, userDisplayName string) 
 	return update
 }
 
-func AddCreatedTicket(taskId string, execution int, ticket IssueLink, userDisplayName string) error {
+func AddCreatedTicket(ctx context.Context, taskId string, execution int, ticket IssueLink, userDisplayName string) error {
 	source := &Source{
 		Author:    userDisplayName,
 		Time:      time.Now(),
 		Requester: WebhookRequester,
 	}
 	ticket.Source = source
-	_, err := db.Upsert(
+	_, err := db.UpsertContext(
+		ctx,
 		Collection,
 		ByTaskIdAndExecution(taskId, execution),
 		bson.M{

--- a/model/annotations/task_annotations_test.go
+++ b/model/annotations/task_annotations_test.go
@@ -32,7 +32,7 @@ func TestGetLatestExecutions(t *testing.T) {
 		},
 	}
 	for _, a := range taskAnnotations {
-		assert.NoError(t, a.Upsert())
+		assert.NoError(t, a.Upsert(t.Context()))
 	}
 
 	taskAnnotations, err := FindByTaskIds(t.Context(), []string{"t1", "t2"})
@@ -72,7 +72,7 @@ func TestSetAnnotationMetadataLinks(t *testing.T) {
 func TestAddSuspectedIssueToAnnotation(t *testing.T) {
 	assert.NoError(t, db.Clear(Collection))
 	issue := IssueLink{URL: "https://issuelink.com", IssueKey: "EVG-1234"}
-	assert.NoError(t, AddSuspectedIssueToAnnotation("t1", 0, issue, "annie.black"))
+	assert.NoError(t, AddSuspectedIssueToAnnotation(t.Context(), "t1", 0, issue, "annie.black"))
 
 	annotation, err := FindOneByTaskIdAndExecution(t.Context(), "t1", 0)
 	assert.NoError(t, err)
@@ -83,7 +83,7 @@ func TestAddSuspectedIssueToAnnotation(t *testing.T) {
 	assert.Equal(t, UIRequester, annotation.SuspectedIssues[0].Source.Requester)
 	assert.Equal(t, "annie.black", annotation.SuspectedIssues[0].Source.Author)
 
-	assert.NoError(t, AddSuspectedIssueToAnnotation("t1", 0, issue, "not.annie.black"))
+	assert.NoError(t, AddSuspectedIssueToAnnotation(t.Context(), "t1", 0, issue, "not.annie.black"))
 	annotation, err = FindOneByTaskIdAndExecution(t.Context(), "t1", 0)
 	assert.NoError(t, err)
 	assert.NotNil(t, annotation)
@@ -97,7 +97,7 @@ func TestRemoveSuspectedIssueFromAnnotation(t *testing.T) {
 	issue2 := IssueLink{URL: "https://issuelink.com", IssueKey: "EVG-1234", Source: &Source{Author: "not.annie.black"}}
 	assert.NoError(t, db.Clear(Collection))
 	a := TaskAnnotation{TaskId: "t1", SuspectedIssues: []IssueLink{issue1, issue2}}
-	assert.NoError(t, a.Upsert())
+	assert.NoError(t, a.Upsert(t.Context()))
 
 	assert.NoError(t, RemoveSuspectedIssueFromAnnotation(t.Context(), "t1", 0, issue1))
 	annotationFromDB, err := FindOneByTaskIdAndExecution(t.Context(), "t1", 0)

--- a/model/artifact/artifact_file_test.go
+++ b/model/artifact/artifact_file_test.go
@@ -90,7 +90,7 @@ func (s *TestArtifactFileSuite) SetupTest() {
 		s.NoError(entry.Upsert(s.T().Context()))
 	}
 
-	count, err := db.Count(Collection, bson.M{})
+	count, err := db.CountContext(s.T().Context(), Collection, bson.M{})
 	s.NoError(err)
 	s.Equal(3, count)
 }
@@ -131,7 +131,7 @@ func (s *TestArtifactFileSuite) TestArtifactFieldsAfterUpdate() {
 	}
 	s.NoError(s.testEntries[0].Upsert(s.T().Context()))
 
-	count, err := db.Count(Collection, bson.M{})
+	count, err := db.CountContext(s.T().Context(), Collection, bson.M{})
 	s.NoError(err)
 	s.Equal(3, count)
 

--- a/model/artifact/artifact_file_test.go
+++ b/model/artifact/artifact_file_test.go
@@ -90,7 +90,7 @@ func (s *TestArtifactFileSuite) SetupTest() {
 		s.NoError(entry.Upsert(s.T().Context()))
 	}
 
-	count, err := db.CountContext(s.T().Context(), Collection, bson.M{})
+	count, err := db.Count(s.T().Context(), Collection, bson.M{})
 	s.NoError(err)
 	s.Equal(3, count)
 }
@@ -131,7 +131,7 @@ func (s *TestArtifactFileSuite) TestArtifactFieldsAfterUpdate() {
 	}
 	s.NoError(s.testEntries[0].Upsert(s.T().Context()))
 
-	count, err := db.CountContext(s.T().Context(), Collection, bson.M{})
+	count, err := db.Count(s.T().Context(), Collection, bson.M{})
 	s.NoError(err)
 	s.Equal(3, count)
 

--- a/model/artifact/artifact_file_test.go
+++ b/model/artifact/artifact_file_test.go
@@ -87,7 +87,7 @@ func (s *TestArtifactFileSuite) SetupTest() {
 	}))
 
 	for _, entry := range s.testEntries {
-		s.NoError(entry.Upsert())
+		s.NoError(entry.Upsert(s.T().Context()))
 	}
 
 	count, err := db.Count(Collection, bson.M{})
@@ -129,7 +129,7 @@ func (s *TestArtifactFileSuite) TestArtifactFieldsAfterUpdate() {
 			AWSSecret:      "secret",
 		},
 	}
-	s.NoError(s.testEntries[0].Upsert())
+	s.NoError(s.testEntries[0].Upsert(s.T().Context()))
 
 	count, err := db.Count(Collection, bson.M{})
 	s.NoError(err)

--- a/model/artifact/db.go
+++ b/model/artifact/db.go
@@ -95,8 +95,9 @@ func BySecret(secret string) db.Q {
 
 // Upsert updates the files entry in the db if an entry already exists,
 // overwriting the existing file data. If no entry exists, one is created
-func (e Entry) Upsert() error {
-	_, err := db.Upsert(
+func (e Entry) Upsert(ctx context.Context) error {
+	_, err := db.UpsertContext(
+		ctx,
 		Collection,
 		bson.M{
 			TaskIdKey:    e.TaskId,

--- a/model/artifact/db.go
+++ b/model/artifact/db.go
@@ -96,7 +96,7 @@ func BySecret(secret string) db.Q {
 // Upsert updates the files entry in the db if an entry already exists,
 // overwriting the existing file data. If no entry exists, one is created
 func (e Entry) Upsert(ctx context.Context) error {
-	_, err := db.UpsertContext(
+	_, err := db.Upsert(
 		ctx,
 		Collection,
 		bson.M{

--- a/model/build_variant_history.go
+++ b/model/build_variant_history.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"context"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -16,7 +18,7 @@ type buildVariantHistoryIterator struct {
 // Interface around getting task and version history for a given build variant
 // in a given project.
 type BuildVariantHistoryIterator interface {
-	GetItems(beforeCommit *Version, numCommits int) ([]bson.M, []Version, error)
+	GetItems(ctx context.Context, beforeCommit *Version, numCommits int) ([]bson.M, []Version, error)
 }
 
 // Since version currently uses build variant display name and task uses build variant
@@ -27,7 +29,7 @@ func NewBuildVariantHistoryIterator(buildVariantInTask string, buildVariantInVer
 }
 
 // Returns versions and tasks grouped by gitspec, newest first (sorted by order number desc)
-func (bvhi *buildVariantHistoryIterator) GetItems(beforeCommit *Version, numRevisions int) ([]bson.M, []Version, error) {
+func (bvhi *buildVariantHistoryIterator) GetItems(ctx context.Context, beforeCommit *Version, numRevisions int) ([]bson.M, []Version, error) {
 	var versionQuery db.Q
 	if beforeCommit != nil {
 		versionQuery = db.Query(bson.M{
@@ -119,7 +121,7 @@ func (bvhi *buildVariantHistoryIterator) GetItems(beforeCommit *Version, numRevi
 	}
 
 	var output []bson.M
-	if err = db.Aggregate(task.Collection, pipeline, &output); err != nil {
+	if err = db.Aggregate(ctx, task.Collection, pipeline, &output); err != nil {
 		return nil, nil, err
 	}
 

--- a/model/build_variant_history_test.go
+++ b/model/build_variant_history_test.go
@@ -72,7 +72,7 @@ func TestBuildVariantHistoryIterator(t *testing.T) {
 		Convey("Should respect project and build variant rules", func() {
 			iter := NewBuildVariantHistoryIterator("bv1", "bv1", "project1")
 
-			tasks, versions, err := iter.GetItems(nil, 5)
+			tasks, versions, err := iter.GetItems(t.Context(), nil, 5)
 			So(err, ShouldBeNil)
 			So(len(versions), ShouldEqual, 2)
 			// Versions on project1 that have `bv1` in their build variants list

--- a/model/cache/cache.go
+++ b/model/cache/cache.go
@@ -54,7 +54,7 @@ func (c *DBCache) Get(ctx context.Context, key string) ([]byte, bool, error) {
 
 // Set stores valueBytes for key.
 func (c *DBCache) Set(ctx context.Context, key string, valueBytes []byte) error {
-	_, err := db.UpsertContext(
+	_, err := db.Upsert(
 		ctx,
 		collection,
 		bson.M{IDKey: key},

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -578,7 +578,7 @@ func TestLogDistroModifiedWithDistroData(t *testing.T) {
 		},
 	}
 	event.LogDistroModified(d.Id, "user1", oldDistro.DistroData(), d.DistroData())
-	eventsForDistro, err := event.FindLatestPrimaryDistroEvents(d.Id, 10, utility.ZeroTime)
+	eventsForDistro, err := event.FindLatestPrimaryDistroEvents(t.Context(), d.Id, 10, utility.ZeroTime)
 	assert.NoError(t, err)
 	require.Len(t, eventsForDistro, 1)
 	eventData, ok := eventsForDistro[0].Data.(*event.DistroEventData)

--- a/model/event/distro_event_test.go
+++ b/model/event/distro_event_test.go
@@ -31,7 +31,7 @@ func TestLoggingDistroEvents(t *testing.T) {
 			// fetch all the events from the database, make sure they are
 			// persisted correctly
 
-			eventsForDistro, err := FindLatestPrimaryDistroEvents(distroId, 10, time.Now())
+			eventsForDistro, err := FindLatestPrimaryDistroEvents(t.Context(), distroId, 10, time.Now())
 			So(err, ShouldBeNil)
 
 			event := eventsForDistro[2]
@@ -86,7 +86,7 @@ func TestLoggingDistroEvents(t *testing.T) {
 
 			LogDistroModified(distroId, userId, oldData, data)
 
-			eventsForDistro, err := FindLatestPrimaryDistroEvents(distroId, 10, utility.ZeroTime)
+			eventsForDistro, err := FindLatestPrimaryDistroEvents(t.Context(), distroId, 10, utility.ZeroTime)
 			So(err, ShouldBeNil)
 			So(len(eventsForDistro), ShouldEqual, 0)
 		})
@@ -103,11 +103,11 @@ func TestLoggingDistroEvents(t *testing.T) {
 			time.Sleep(1 * time.Millisecond)
 			LogDistroModified(distroId, userId, oldData, data)
 
-			eventsForDistro, err := FindLatestPrimaryDistroEvents(distroId, 10, utility.ZeroTime)
+			eventsForDistro, err := FindLatestPrimaryDistroEvents(t.Context(), distroId, 10, utility.ZeroTime)
 			So(err, ShouldBeNil)
 			So(len(eventsForDistro), ShouldEqual, 2)
 
-			eventsForDistro, err = FindLatestPrimaryDistroEvents(distroId, 10, timeBeforeEvents)
+			eventsForDistro, err = FindLatestPrimaryDistroEvents(t.Context(), distroId, 10, timeBeforeEvents)
 			So(err, ShouldBeNil)
 			So(len(eventsForDistro), ShouldEqual, 0)
 		})

--- a/model/event/event_finder.go
+++ b/model/event/event_finder.go
@@ -41,7 +41,7 @@ func Find(query db.Q) ([]EventLogEntry, error) {
 	return events, nil
 }
 
-func FindPaginatedWithTotalCount(query db.Q, limit, page int) ([]EventLogEntry, int, error) {
+func FindPaginatedWithTotalCount(ctx context.Context, query db.Q, limit, page int) ([]EventLogEntry, int, error) {
 	events := []EventLogEntry{}
 	skip := page * limit
 	if skip > 0 {
@@ -54,7 +54,7 @@ func FindPaginatedWithTotalCount(query db.Q, limit, page int) ([]EventLogEntry, 
 	}
 
 	// Count ignores skip and limit by default, so this will return the total number of events.
-	count, err := db.CountQ(EventCollection, query)
+	count, err := db.CountQContext(ctx, EventCollection, query)
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "fetching total count for events")
 	}
@@ -112,10 +112,10 @@ func FindLastProcessedEvent(ctx context.Context) (*EventLogEntry, error) {
 	return &e, nil
 }
 
-func CountUnprocessedEvents() (int, error) {
+func CountUnprocessedEvents(ctx context.Context) (int, error) {
 	q := db.Query(unprocessedEvents())
 
-	n, err := db.CountQ(EventCollection, q)
+	n, err := db.CountQContext(ctx, EventCollection, q)
 	if err != nil {
 		return 0, errors.Wrap(err, "fetching number of unprocessed events")
 	}
@@ -166,7 +166,7 @@ type PaginatedHostEventsOpts struct {
 // GetPaginatedHostEvents returns a limited and paginated list of host events for the given
 // filters sorted in ascending or descending order by timestamp, as well as the total number
 // of host events.
-func GetPaginatedHostEvents(opts PaginatedHostEventsOpts) ([]EventLogEntry, int, error) {
+func GetPaginatedHostEvents(ctx context.Context, opts PaginatedHostEventsOpts) ([]EventLogEntry, int, error) {
 	queryOpts := HostEventsOpts{
 		ID:         opts.ID,
 		Tag:        opts.Tag,
@@ -175,7 +175,7 @@ func GetPaginatedHostEvents(opts PaginatedHostEventsOpts) ([]EventLogEntry, int,
 		EventTypes: opts.EventTypes,
 	}
 	hostEventsQuery := HostEvents(queryOpts)
-	return FindPaginatedWithTotalCount(hostEventsQuery, opts.Limit, opts.Page)
+	return FindPaginatedWithTotalCount(ctx, hostEventsQuery, opts.Limit, opts.Page)
 }
 
 type eventTypeResult struct {
@@ -222,12 +222,12 @@ func GetEventTypesForHost(ctx context.Context, hostID string, tag string) ([]str
 }
 
 // HasNoRecentStoppedHostEvent returns true if no host event exists that is more recent than the passed in time stamp.
-func HasNoRecentStoppedHostEvent(id string, ts time.Time) (bool, error) {
+func HasNoRecentStoppedHostEvent(ctx context.Context, id string, ts time.Time) (bool, error) {
 	filter := ResourceTypeKeyIs(ResourceTypeHost)
 	filter[ResourceIdKey] = id
 	filter[eventTypeKey] = EventHostStopped
 	filter[TimestampKey] = bson.M{"$gte": ts}
-	count, err := db.CountQ(EventCollection, db.Query(filter))
+	count, err := db.CountQContext(ctx, EventCollection, db.Query(filter))
 	if err != nil {
 		return false, errors.Wrap(err, "fetching count of stopped host events")
 	}
@@ -344,7 +344,7 @@ func MostRecentPodEvents(id string, n int) db.Q {
 
 // MostRecentPaginatedPodEvents returns a limited and paginated list of pod events for the
 // given pod ID sorted in descending order by timestamp as well as the total number of events.
-func MostRecentPaginatedPodEvents(id string, limit, page int) ([]EventLogEntry, int, error) {
+func MostRecentPaginatedPodEvents(ctx context.Context, id string, limit, page int) ([]EventLogEntry, int, error) {
 	recentPodsQuery := MostRecentPodEvents(id, limit)
-	return FindPaginatedWithTotalCount(recentPodsQuery, limit, page)
+	return FindPaginatedWithTotalCount(ctx, recentPodsQuery, limit, page)
 }

--- a/model/event/event_finder.go
+++ b/model/event/event_finder.go
@@ -54,7 +54,7 @@ func FindPaginatedWithTotalCount(ctx context.Context, query db.Q, limit, page in
 	}
 
 	// Count ignores skip and limit by default, so this will return the total number of events.
-	count, err := db.CountQContext(ctx, EventCollection, query)
+	count, err := db.CountQ(ctx, EventCollection, query)
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "fetching total count for events")
 	}
@@ -115,7 +115,7 @@ func FindLastProcessedEvent(ctx context.Context) (*EventLogEntry, error) {
 func CountUnprocessedEvents(ctx context.Context) (int, error) {
 	q := db.Query(unprocessedEvents())
 
-	n, err := db.CountQContext(ctx, EventCollection, q)
+	n, err := db.CountQ(ctx, EventCollection, q)
 	if err != nil {
 		return 0, errors.Wrap(err, "fetching number of unprocessed events")
 	}
@@ -227,7 +227,7 @@ func HasNoRecentStoppedHostEvent(ctx context.Context, id string, ts time.Time) (
 	filter[ResourceIdKey] = id
 	filter[eventTypeKey] = EventHostStopped
 	filter[TimestampKey] = bson.M{"$gte": ts}
-	count, err := db.CountQContext(ctx, EventCollection, db.Query(filter))
+	count, err := db.CountQ(ctx, EventCollection, db.Query(filter))
 	if err != nil {
 		return false, errors.Wrap(err, "fetching count of stopped host events")
 	}

--- a/model/event/event_finder.go
+++ b/model/event/event_finder.go
@@ -183,7 +183,7 @@ type eventTypeResult struct {
 }
 
 // GetEventTypesForHost returns the event types that have occurred on the host.
-func GetEventTypesForHost(hostID string, tag string) ([]string, error) {
+func GetEventTypesForHost(ctx context.Context, hostID string, tag string) ([]string, error) {
 	filter := ResourceTypeKeyIs(ResourceTypeHost)
 	if tag != "" {
 		filter[ResourceIdKey] = bson.M{"$in": []string{hostID, tag}}
@@ -212,7 +212,7 @@ func GetEventTypesForHost(hostID string, tag string) ([]string, error) {
 	}
 
 	out := []eventTypeResult{}
-	if err := db.Aggregate(EventCollection, pipeline, &out); err != nil {
+	if err := db.Aggregate(ctx, EventCollection, pipeline, &out); err != nil {
 		return nil, errors.Errorf("finding event types for host '%s': %s", hostID, err)
 	}
 	if len(out) == 0 {
@@ -254,9 +254,9 @@ func TaskEventsInOrder(id string) db.Q {
 
 // FindLatestPrimaryDistroEvents return the most recent non-AMI events for the distro.
 // The before parameter returns only events before the specified time and is used for pagination on the UI.
-func FindLatestPrimaryDistroEvents(id string, n int, before time.Time) ([]EventLogEntry, error) {
+func FindLatestPrimaryDistroEvents(ctx context.Context, id string, n int, before time.Time) ([]EventLogEntry, error) {
 	events := []EventLogEntry{}
-	err := db.Aggregate(EventCollection, latestDistroEventsPipeline(id, n, false, before), &events)
+	err := db.Aggregate(ctx, EventCollection, latestDistroEventsPipeline(id, n, false, before), &events)
 	if err != nil {
 		return nil, err
 	}
@@ -264,10 +264,10 @@ func FindLatestPrimaryDistroEvents(id string, n int, before time.Time) ([]EventL
 }
 
 // FindLatestAMIModifiedDistroEvent returns the most recent AMI event. Returns an empty struct if nothing exists.
-func FindLatestAMIModifiedDistroEvent(id string) (EventLogEntry, error) {
+func FindLatestAMIModifiedDistroEvent(ctx context.Context, id string) (EventLogEntry, error) {
 	events := []EventLogEntry{}
 	res := EventLogEntry{}
-	err := db.Aggregate(EventCollection, latestDistroEventsPipeline(id, 1, true, time.Now()), &events)
+	err := db.Aggregate(ctx, EventCollection, latestDistroEventsPipeline(id, 1, true, time.Now()), &events)
 	if err != nil {
 		return res, err
 	}

--- a/model/event/event_finder_test.go
+++ b/model/event/event_finder_test.go
@@ -148,7 +148,7 @@ func TestGetEventTypesForHost(t *testing.T) {
 	LogHostTaskFinished("task-2", 0, tag, evergreen.TaskSucceeded)       // HOST_TASK_FINISHED
 
 	// Should return non-duplicate host event types.
-	eventTypes, err := GetEventTypesForHost(hostID, tag)
+	eventTypes, err := GetEventTypesForHost(t.Context(), hostID, tag)
 	require.NoError(t, err)
 	require.NotNil(t, eventTypes)
 	require.Len(t, eventTypes, 5)
@@ -158,7 +158,7 @@ func TestGetEventTypesForHost(t *testing.T) {
 	}
 
 	// Should return 0 event types if a host has no events.
-	eventTypes, err = GetEventTypesForHost("host-with-no-events", "")
+	eventTypes, err = GetEventTypesForHost(t.Context(), "host-with-no-events", "")
 	require.NoError(t, err)
 	require.NotNil(t, eventTypes)
 	require.Empty(t, eventTypes)

--- a/model/event/event_finder_test.go
+++ b/model/event/event_finder_test.go
@@ -20,7 +20,7 @@ func TestMostRecentPaginatedPodEvents(t *testing.T) {
 	}
 
 	// Query for pod1 events, limit 10, page 0
-	events, count, err := MostRecentPaginatedPodEvents("pod1", 10, 0)
+	events, count, err := MostRecentPaginatedPodEvents(t.Context(), "pod1", 10, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, 10, count)
 	assert.Len(t, events, 10)
@@ -31,13 +31,13 @@ func TestMostRecentPaginatedPodEvents(t *testing.T) {
 	}
 
 	// Query for pod1 events, limit 10, page 1
-	events, count, err = MostRecentPaginatedPodEvents("pod1", 10, 1)
+	events, count, err = MostRecentPaginatedPodEvents(t.Context(), "pod1", 10, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, 10, count)
 	assert.Empty(t, events)
 
 	// Query for pod1 events, limit 5, page 1
-	events, count, err = MostRecentPaginatedPodEvents("pod1", 5, 1)
+	events, count, err = MostRecentPaginatedPodEvents(t.Context(), "pod1", 5, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, 10, count)
 	assert.Len(t, events, 5)
@@ -47,7 +47,7 @@ func TestMostRecentPaginatedPodEvents(t *testing.T) {
 	}
 
 	// Query for pod1 events, limit 11, page 0
-	events, count, err = MostRecentPaginatedPodEvents("pod1", 11, 0)
+	events, count, err = MostRecentPaginatedPodEvents(t.Context(), "pod1", 11, 0)
 	assert.NoError(t, err)
 	assert.Equal(t, 10, count)
 	assert.Len(t, events, 10)
@@ -80,7 +80,7 @@ func TestGetPaginatedHostEvents(t *testing.T) {
 		SortAsc:    false,
 		EventTypes: []string{},
 	}
-	entries, totalCount, err := GetPaginatedHostEvents(opts)
+	entries, totalCount, err := GetPaginatedHostEvents(t.Context(), opts)
 	require.NoError(t, err)
 	require.Equal(t, 5, totalCount)
 	require.NotNil(t, entries[0])
@@ -94,7 +94,7 @@ func TestGetPaginatedHostEvents(t *testing.T) {
 		SortAsc:    false,
 		EventTypes: []string{},
 	}
-	entries, totalCount, err = GetPaginatedHostEvents(opts)
+	entries, totalCount, err = GetPaginatedHostEvents(t.Context(), opts)
 	require.NoError(t, err)
 	require.Equal(t, 6, totalCount)
 	require.NotNil(t, entries[0])
@@ -109,7 +109,7 @@ func TestGetPaginatedHostEvents(t *testing.T) {
 		SortAsc:    false,
 		EventTypes: []string{EventHostTaskFinished},
 	}
-	entries, totalCount, err = GetPaginatedHostEvents(opts)
+	entries, totalCount, err = GetPaginatedHostEvents(t.Context(), opts)
 	require.NoError(t, err)
 	require.Equal(t, 2, totalCount)
 	require.NotNil(t, entries[0])
@@ -126,7 +126,7 @@ func TestGetPaginatedHostEvents(t *testing.T) {
 		SortAsc:    true,
 		EventTypes: []string{},
 	}
-	entries, totalCount, err = GetPaginatedHostEvents(opts)
+	entries, totalCount, err = GetPaginatedHostEvents(t.Context(), opts)
 	require.NoError(t, err)
 	require.Equal(t, 6, totalCount)
 	require.NotNil(t, entries[0])

--- a/model/event/event_test.go
+++ b/model/event/event_test.go
@@ -435,7 +435,7 @@ func (s *eventSuite) TestCountUnprocessedEvents() {
 		s.NoError(db.Insert(EventCollection, events[i]))
 	}
 
-	n, err := CountUnprocessedEvents()
+	n, err := CountUnprocessedEvents(s.T().Context())
 	s.NoError(err)
 	s.Equal(2, n)
 }

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -487,7 +487,7 @@ func (s *Subscription) Upsert(ctx context.Context) error {
 	}
 
 	// note: this prevents changing the owner of an existing subscription, which is desired
-	c, err := db.Upsert(ctx, SubscriptionsCollection, bson.M{
+	c, err := db.ReplaceContext2(ctx, SubscriptionsCollection, bson.M{
 		subscriptionIDKey:    s.ID,
 		subscriptionOwnerKey: s.Owner,
 	}, update)

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -446,7 +446,7 @@ func regexMatchesValue(regexString string, values []string) bool {
 }
 
 // CopyProjectSubscriptions copies subscriptions from the first project for the second project.
-func CopyProjectSubscriptions(oldProject, newProject string) error {
+func CopyProjectSubscriptions(ctx context.Context, oldProject, newProject string) error {
 	subs, err := FindSubscriptionsByOwner(oldProject, OwnerTypeProject)
 	if err != nil {
 		return errors.Wrapf(err, "finding subscription for project '%s'", oldProject)
@@ -462,12 +462,12 @@ func CopyProjectSubscriptions(oldProject, newProject string) error {
 				sub.Filter.Project = newProject
 			}
 		}
-		catcher.Add(sub.Upsert())
+		catcher.Add(sub.Upsert(ctx))
 	}
 	return catcher.Resolve()
 }
 
-func (s *Subscription) Upsert() error {
+func (s *Subscription) Upsert(ctx context.Context) error {
 	if s.ID == "" {
 		s.ID = mgobson.NewObjectId().Hex()
 	}
@@ -487,7 +487,7 @@ func (s *Subscription) Upsert() error {
 	}
 
 	// note: this prevents changing the owner of an existing subscription, which is desired
-	c, err := db.Upsert(SubscriptionsCollection, bson.M{
+	c, err := db.UpsertContext(ctx, SubscriptionsCollection, bson.M{
 		subscriptionIDKey:    s.ID,
 		subscriptionOwnerKey: s.Owner,
 	}, update)
@@ -748,7 +748,7 @@ func CreateOrUpdateGeneralSubscription(ctx context.Context, resourceType string,
 		sub.OwnerType = OwnerTypePerson
 		sub.Owner = user
 
-		if err := sub.Upsert(); err != nil {
+		if err := sub.Upsert(ctx); err != nil {
 			return nil, errors.Wrap(err, "upserting subscription")
 		}
 	} else {

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -487,7 +487,7 @@ func (s *Subscription) Upsert(ctx context.Context) error {
 	}
 
 	// note: this prevents changing the owner of an existing subscription, which is desired
-	c, err := db.ReplaceContext2(ctx, SubscriptionsCollection, bson.M{
+	c, err := db.ReplaceContext(ctx, SubscriptionsCollection, bson.M{
 		subscriptionIDKey:    s.ID,
 		subscriptionOwnerKey: s.Owner,
 	}, update)

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -487,7 +487,7 @@ func (s *Subscription) Upsert(ctx context.Context) error {
 	}
 
 	// note: this prevents changing the owner of an existing subscription, which is desired
-	c, err := db.UpsertContext(ctx, SubscriptionsCollection, bson.M{
+	c, err := db.Upsert(ctx, SubscriptionsCollection, bson.M{
 		subscriptionIDKey:    s.ID,
 		subscriptionOwnerKey: s.Owner,
 	}, update)

--- a/model/event/subscriptions_test.go
+++ b/model/event/subscriptions_test.go
@@ -146,7 +146,7 @@ func (s *subscriptionsSuite) SetupTest() {
 	}
 
 	for _, sub := range s.subscriptions {
-		s.NoError(sub.Upsert())
+		s.NoError(sub.Upsert(s.T().Context()))
 	}
 }
 
@@ -602,19 +602,19 @@ func TestCopyProjectSubscriptions(t *testing.T) {
 		},
 	}
 	for _, sub := range subs {
-		assert.NoError(t, sub.Upsert())
+		assert.NoError(t, sub.Upsert(t.Context()))
 	}
 
 	for name, test := range map[string]func(t *testing.T){
 		"FromNonExistentProject": func(t *testing.T) {
-			assert.NoError(t, CopyProjectSubscriptions("not-a-project", "my-new-project"))
+			assert.NoError(t, CopyProjectSubscriptions(t.Context(), "not-a-project", "my-new-project"))
 			apiSubs, err := FindSubscriptionsByOwner("my-new-project", OwnerTypeProject)
 			assert.NoError(t, err)
 			require.Empty(t, apiSubs)
 		},
 		"FromExistentProject": func(t *testing.T) {
 			newProjectId := "my-newest-project"
-			assert.NoError(t, CopyProjectSubscriptions(oldProjectId, newProjectId))
+			assert.NoError(t, CopyProjectSubscriptions(t.Context(), oldProjectId, newProjectId))
 			apiSubs, err := FindSubscriptionsByOwner(oldProjectId, OwnerTypeProject)
 			assert.NoError(t, err)
 			require.Len(t, apiSubs, 1)

--- a/model/githubapp/github_app_auth_db.go
+++ b/model/githubapp/github_app_auth_db.go
@@ -119,7 +119,7 @@ func UpsertGitHubAppAuth(ctx context.Context, appAuth *GithubAppAuth) error {
 
 // upsertGitHubAppAuthDB upserts the GitHub app auth into the database.
 func upsertGitHubAppAuthDB(ctx context.Context, appAuth *GithubAppAuth) error {
-	_, err := db.UpsertContext(ctx,
+	_, err := db.Upsert(ctx,
 		GitHubAppAuthCollection,
 		bson.M{
 			GhAuthIdKey: appAuth.Id,

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -703,12 +703,12 @@ func (h *Host) IdleTime() time.Duration {
 }
 
 // ShouldNotifyStoppedSpawnHostIdle returns true if the stopped spawn host has been idle long enough to notify the user.
-func (h *Host) ShouldNotifyStoppedSpawnHostIdle() (bool, error) {
+func (h *Host) ShouldNotifyStoppedSpawnHostIdle(ctx context.Context) (bool, error) {
 	if !h.NoExpiration || h.Status != evergreen.HostStopped {
 		return false, nil
 	}
 	timeToNotifyForStoppedHosts := time.Now().Add(-time.Hour * 24 * evergreen.SpawnHostExpireDays * 3)
-	return event.HasNoRecentStoppedHostEvent(h.Id, timeToNotifyForStoppedHosts)
+	return event.HasNoRecentStoppedHostEvent(ctx, h.Id, timeToNotifyForStoppedHosts)
 }
 
 // WastedComputeTime returns the duration of compute we've paid for that

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -2026,7 +2026,7 @@ func TestInactiveHostCountPipeline(t *testing.T) {
 	assert.NoError(h5.Insert(ctx))
 
 	var out []InactiveHostCounts
-	err := db.Aggregate(Collection, inactiveHostCountPipeline(), &out)
+	err := db.AggregateContext(t.Context(), Collection, inactiveHostCountPipeline(), &out)
 	assert.NoError(err)
 	assert.Len(out, 2)
 	for _, count := range out {
@@ -3004,7 +3004,7 @@ func TestLastContainerFinishTimePipeline(t *testing.T) {
 	var out []FinishTime
 	var results = make(map[string]time.Time)
 
-	err := db.Aggregate(Collection, lastContainerFinishTimePipeline(), &out)
+	err := db.AggregateContext(t.Context(), Collection, lastContainerFinishTimePipeline(), &out)
 	assert.NoError(err)
 
 	for _, doc := range out {

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -1913,7 +1913,7 @@ func TestHostStats(t *testing.T) {
 	assert.NoError(host8.Insert(ctx))
 
 	// test GetStatsByDistro
-	stats, err := GetStatsByDistro()
+	stats, err := GetStatsByDistro(t.Context())
 	assert.NoError(err)
 	for _, entry := range stats {
 		if entry.Distro == d1 {
@@ -2026,7 +2026,7 @@ func TestInactiveHostCountPipeline(t *testing.T) {
 	assert.NoError(h5.Insert(ctx))
 
 	var out []InactiveHostCounts
-	err := db.AggregateContext(t.Context(), Collection, inactiveHostCountPipeline(), &out)
+	err := db.Aggregate(t.Context(), Collection, inactiveHostCountPipeline(), &out)
 	assert.NoError(err)
 	assert.Len(out, 2)
 	for _, count := range out {
@@ -3004,7 +3004,7 @@ func TestLastContainerFinishTimePipeline(t *testing.T) {
 	var out []FinishTime
 	var results = make(map[string]time.Time)
 
-	err := db.AggregateContext(t.Context(), Collection, lastContainerFinishTimePipeline(), &out)
+	err := db.Aggregate(t.Context(), Collection, lastContainerFinishTimePipeline(), &out)
 	assert.NoError(err)
 
 	for _, doc := range out {

--- a/model/host/stats.go
+++ b/model/host/stats.go
@@ -1,6 +1,8 @@
 package host
 
 import (
+	"context"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
@@ -83,18 +85,18 @@ func (d DistroStats) MaxHostsExceeded() map[string]int {
 }
 
 // GetStatsByDistro returns counts of up hosts broken down by distro
-func GetStatsByDistro() (DistroStats, error) {
+func GetStatsByDistro(ctx context.Context) (DistroStats, error) {
 	stats := []StatsByDistro{}
-	if err := db.Aggregate(Collection, statsByDistroPipeline(), &stats); err != nil {
+	if err := db.Aggregate(ctx, Collection, statsByDistroPipeline(), &stats); err != nil {
 		return nil, err
 	}
 	return stats, nil
 }
 
 // GetProviderCounts returns data on the number of hosts by different provider stats.
-func GetProviderCounts() (ProviderStats, error) {
+func GetProviderCounts(ctx context.Context) (ProviderStats, error) {
 	stats := []StatsByProvider{}
-	if err := db.Aggregate(Collection, statsByProviderPipeline(), &stats); err != nil {
+	if err := db.Aggregate(ctx, Collection, statsByProviderPipeline(), &stats); err != nil {
 		return nil, err
 	}
 	return stats, nil

--- a/model/host/stats_test.go
+++ b/model/host/stats_test.go
@@ -84,7 +84,7 @@ func TestHostStatsByProvider(t *testing.T) {
 
 	result := ProviderStats{}
 
-	assert.NoError(db.Aggregate(Collection, statsByProviderPipeline(), &result))
+	assert.NoError(db.AggregateContext(t.Context(), Collection, statsByProviderPipeline(), &result))
 	assert.Len(result, 2, "%+v", result)
 
 	rmap := result.Map()
@@ -107,7 +107,7 @@ func TestHostStatsByDistro(t *testing.T) {
 
 	result := DistroStats{}
 
-	assert.NoError(db.Aggregate(Collection, statsByDistroPipeline(), &result))
+	assert.NoError(db.AggregateContext(t.Context(), Collection, statsByDistroPipeline(), &result))
 	assert.Len(result, 3, "%+v", result)
 
 	rcmap := result.CountMap()

--- a/model/host/stats_test.go
+++ b/model/host/stats_test.go
@@ -84,13 +84,13 @@ func TestHostStatsByProvider(t *testing.T) {
 
 	result := ProviderStats{}
 
-	assert.NoError(db.AggregateContext(t.Context(), Collection, statsByProviderPipeline(), &result))
+	assert.NoError(db.Aggregate(t.Context(), Collection, statsByProviderPipeline(), &result))
 	assert.Len(result, 2, "%+v", result)
 
 	rmap := result.Map()
 	assert.Equal(3, rmap[evergreen.ProviderNameEc2Fleet])
 
-	alt, err := GetProviderCounts()
+	alt, err := GetProviderCounts(t.Context())
 	assert.NoError(err)
 	sort.Slice(alt, func(i, j int) bool { return alt[i].Provider < alt[j].Provider })
 	sort.Slice(result, func(i, j int) bool { return result[i].Provider < result[j].Provider })
@@ -107,7 +107,7 @@ func TestHostStatsByDistro(t *testing.T) {
 
 	result := DistroStats{}
 
-	assert.NoError(db.AggregateContext(t.Context(), Collection, statsByDistroPipeline(), &result))
+	assert.NoError(db.Aggregate(t.Context(), Collection, statsByDistroPipeline(), &result))
 	assert.Len(result, 3, "%+v", result)
 
 	rcmap := result.CountMap()
@@ -122,7 +122,7 @@ func TestHostStatsByDistro(t *testing.T) {
 	assert.Len(exceeded, 2)
 	assert.NotContains(exceeded, "bar")
 
-	alt, err := GetStatsByDistro()
+	alt, err := GetStatsByDistro(t.Context())
 	assert.NoError(err)
 	sort.Slice(alt, func(i, j int) bool { return alt[i].Distro < alt[j].Distro })
 	sort.Slice(result, func(i, j int) bool { return result[i].Distro < result[j].Distro })

--- a/model/host/volume.go
+++ b/model/host/volume.go
@@ -149,7 +149,7 @@ func FindVolumesWithTerminatedHost(ctx context.Context) ([]Volume, error) {
 	project := bson.M{"$project": bson.M{"host_doc": 0}}
 	pipeline := []bson.M{match, lookup, matchTerminatedHosts, project}
 	volumes := []Volume{}
-	if err := db.AggregateContext(ctx, VolumesCollection, pipeline, &volumes); err != nil {
+	if err := db.Aggregate(ctx, VolumesCollection, pipeline, &volumes); err != nil {
 		return nil, err
 	}
 	return volumes, nil
@@ -185,7 +185,7 @@ func FindTotalVolumeSizeByUser(ctx context.Context, user string) (int, error) {
 	}
 
 	out := []volumeSize{}
-	err := db.AggregateContext(ctx, VolumesCollection, pipeline, &out)
+	err := db.Aggregate(ctx, VolumesCollection, pipeline, &out)
 	if err != nil || len(out) == 0 {
 		return 0, err
 	}

--- a/model/host/volume.go
+++ b/model/host/volume.go
@@ -250,7 +250,7 @@ func ValidateVolumeCanBeAttached(ctx context.Context, volumeID string) (*Volume,
 }
 
 func CountNoExpirationVolumesForUser(ctx context.Context, userID string) (int, error) {
-	return db.CountContext(ctx, VolumesCollection, bson.M{
+	return db.Count(ctx, VolumesCollection, bson.M{
 		VolumeNoExpirationKey: true,
 		VolumeCreatedByKey:    userID,
 	})

--- a/model/legacy_task_history.go
+++ b/model/legacy_task_history.go
@@ -204,8 +204,10 @@ func (iter *taskHistoryIterator) GetChunk(ctx context.Context, v *Version, numBe
 		{"$group": groupStage},
 		{"$sort": bson.M{task.RevisionOrderNumberKey: -1}},
 	}
+	aggregateCtx, cancel := context.WithTimeout(ctx, taskHistoryMaxTime)
+	defer cancel()
 	var rawAggregatedTasks []bson.M
-	if err = db.AggregateWithMaxTime(task.Collection, pipeline, &rawAggregatedTasks, taskHistoryMaxTime); err != nil {
+	if err = db.Aggregate(aggregateCtx, task.Collection, pipeline, &rawAggregatedTasks); err != nil {
 		return chunk, errors.Wrap(err, "aggregating task history data")
 	}
 	chunk.Tasks = rawAggregatedTasks

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -949,7 +949,7 @@ func TestCreateBuildFromVersion(t *testing.T) {
 
 		alias := ProjectAlias{ProjectID: pref.Id, TaskTags: []string{"pull-requests"}, Alias: evergreen.GithubPRAlias,
 			Variant: ".*"}
-		So(alias.Upsert(), ShouldBeNil)
+		So(alias.Upsert(t.Context()), ShouldBeNil)
 		mustHaveResults := true
 		container1 := Container{
 			Name:       "container1",

--- a/model/note.go
+++ b/model/note.go
@@ -24,7 +24,7 @@ var NoteTaskIdKey = bsonutil.MustHaveTag(Note{}, "TaskId")
 
 // Upsert overwrites an existing note.
 func (n *Note) Upsert(ctx context.Context) error {
-	_, err := db.UpsertContext(
+	_, err := db.Upsert(
 		ctx,
 		NotesCollection,
 		bson.M{NoteTaskIdKey: n.TaskId},

--- a/model/note.go
+++ b/model/note.go
@@ -22,9 +22,9 @@ type Note struct {
 
 var NoteTaskIdKey = bsonutil.MustHaveTag(Note{}, "TaskId")
 
-// Upsert overwrites an existing note.
-func (n *Note) Upsert(ctx context.Context) error {
-	_, err := db.Upsert(
+// Replace overwrites an existing note if found, or inserts if not found.
+func (n *Note) Replace(ctx context.Context) error {
+	_, err := db.ReplaceContext(
 		ctx,
 		NotesCollection,
 		bson.M{NoteTaskIdKey: n.TaskId},

--- a/model/note.go
+++ b/model/note.go
@@ -23,8 +23,9 @@ type Note struct {
 var NoteTaskIdKey = bsonutil.MustHaveTag(Note{}, "TaskId")
 
 // Upsert overwrites an existing note.
-func (n *Note) Upsert() error {
-	_, err := db.Upsert(
+func (n *Note) Upsert(ctx context.Context) error {
+	_, err := db.UpsertContext(
+		ctx,
 		NotesCollection,
 		bson.M{NoteTaskIdKey: n.TaskId},
 		n,

--- a/model/note_test.go
+++ b/model/note_test.go
@@ -17,7 +17,7 @@ func TestNoteStorage(t *testing.T) {
 			Content:      "test note",
 		}
 		Convey("saving the note should work without error", func() {
-			So(n.Upsert(t.Context()), ShouldBeNil)
+			So(n.Replace(t.Context()), ShouldBeNil)
 
 			Convey("the note should be retrievable", func() {
 				n2, err := NoteForTask(t.Context(), "t1")
@@ -28,7 +28,7 @@ func TestNoteStorage(t *testing.T) {
 			Convey("saving the note again should overwrite the existing note", func() {
 				n3 := n
 				n3.Content = "new content"
-				So(n3.Upsert(t.Context()), ShouldBeNil)
+				So(n3.Replace(t.Context()), ShouldBeNil)
 				n4, err := NoteForTask(t.Context(), "t1")
 				So(err, ShouldBeNil)
 				So(n4, ShouldNotBeNil)

--- a/model/note_test.go
+++ b/model/note_test.go
@@ -17,7 +17,7 @@ func TestNoteStorage(t *testing.T) {
 			Content:      "test note",
 		}
 		Convey("saving the note should work without error", func() {
-			So(n.Upsert(), ShouldBeNil)
+			So(n.Upsert(t.Context()), ShouldBeNil)
 
 			Convey("the note should be retrievable", func() {
 				n2, err := NoteForTask(t.Context(), "t1")
@@ -28,7 +28,7 @@ func TestNoteStorage(t *testing.T) {
 			Convey("saving the note again should overwrite the existing note", func() {
 				n3 := n
 				n3.Content = "new content"
-				So(n3.Upsert(), ShouldBeNil)
+				So(n3.Upsert(t.Context()), ShouldBeNil)
 				n4, err := NoteForTask(t.Context(), "t1")
 				So(err, ShouldBeNil)
 				So(n4, ShouldNotBeNil)

--- a/model/notification/notification.go
+++ b/model/notification/notification.go
@@ -301,7 +301,7 @@ type NotificationStats struct {
 	GithubMerge       int `json:"github_merge" bson:"github_merge" yaml:"github_merge"`
 }
 
-func CollectUnsentNotificationStats() (*NotificationStats, error) {
+func CollectUnsentNotificationStats(ctx context.Context) (*NotificationStats, error) {
 	const subscriberTypeKey = "type"
 	pipeline := []bson.M{
 		{
@@ -326,7 +326,7 @@ func CollectUnsentNotificationStats() (*NotificationStats, error) {
 		Count int    `bson:"n"`
 	}{}
 
-	if err := db.Aggregate(Collection, pipeline, &stats); err != nil {
+	if err := db.Aggregate(ctx, Collection, pipeline, &stats); err != nil {
 		return nil, errors.Wrap(err, "counting unsent notifications")
 	}
 

--- a/model/notification/notification_test.go
+++ b/model/notification/notification_test.go
@@ -400,7 +400,7 @@ func (s *notificationSuite) TestCollectUnsentNotificationStats() {
 	s.n.SentAt = time.Now()
 	s.NoError(db.Insert(Collection, s.n))
 
-	stats, err := CollectUnsentNotificationStats()
+	stats, err := CollectUnsentNotificationStats(s.T().Context())
 	s.NoError(err)
 	s.Require().NotNil(stats)
 

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -922,21 +922,21 @@ func finalizeOrSubscribeChildPatch(ctx context.Context, childPatchId string, par
 		}
 	} else {
 		//subscribe on parent outcome
-		if err = SubscribeOnParentOutcome(triggerIntent.ParentStatus, childPatchId, parentPatch, requester); err != nil {
+		if err = SubscribeOnParentOutcome(ctx, triggerIntent.ParentStatus, childPatchId, parentPatch, requester); err != nil {
 			return errors.Wrap(err, "getting parameters from parent patch")
 		}
 	}
 	return nil
 }
 
-func SubscribeOnParentOutcome(parentStatus string, childPatchId string, parentPatch *patch.Patch, requester string) error {
+func SubscribeOnParentOutcome(ctx context.Context, parentStatus string, childPatchId string, parentPatch *patch.Patch, requester string) error {
 	subscriber := event.NewRunChildPatchSubscriber(event.ChildPatchSubscriber{
 		ParentStatus: parentStatus,
 		ChildPatchId: childPatchId,
 		Requester:    requester,
 	})
 	patchSub := event.NewParentPatchSubscription(parentPatch.Id.Hex(), subscriber)
-	if err := patchSub.Upsert(); err != nil {
+	if err := patchSub.Upsert(ctx); err != nil {
 		return errors.Wrapf(err, "inserting child patch subscription '%s'", childPatchId)
 	}
 	return nil

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -477,7 +477,7 @@ func TestGetFullPatchParams(t *testing.T) {
 	}
 	require.NoError(t, pRef.Insert())
 	require.NoError(t, p.Insert())
-	require.NoError(t, alias.Upsert())
+	require.NoError(t, alias.Upsert(t.Context()))
 
 	params, err := getFullPatchParams(t.Context(), &p)
 	require.NoError(t, err)

--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -213,7 +213,7 @@ type StatusCount struct {
 // for running tasks. For each pod status, it returns the counts for the number
 // of pods and number of running tasks in that particular status. Terminated
 // pods are excluded from these statistics.
-func GetStatsByStatus(statuses ...Status) ([]StatusCount, error) {
+func GetStatsByStatus(ctx context.Context, statuses ...Status) ([]StatusCount, error) {
 	if len(statuses) == 0 {
 		return []StatusCount{}, nil
 	}
@@ -250,7 +250,7 @@ func GetStatsByStatus(statuses ...Status) ([]StatusCount, error) {
 	}
 
 	stats := []StatusCount{}
-	if err := db.Aggregate(Collection, pipeline, &stats); err != nil {
+	if err := db.Aggregate(ctx, Collection, pipeline, &stats); err != nil {
 		return nil, err
 	}
 

--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -69,7 +69,7 @@ func ByExternalID(id string) bson.M {
 
 // Count counts the number of pods matching the given query.
 func Count(ctx context.Context, q db.Q) (int, error) {
-	return db.CountQContext(ctx, Collection, q)
+	return db.CountQ(ctx, Collection, q)
 }
 
 // Find finds all pods matching the given query.

--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -68,8 +68,8 @@ func ByExternalID(id string) bson.M {
 }
 
 // Count counts the number of pods matching the given query.
-func Count(q db.Q) (int, error) {
-	return db.CountQ(Collection, q)
+func Count(ctx context.Context, q db.Q) (int, error) {
+	return db.CountQContext(ctx, Collection, q)
 }
 
 // Find finds all pods matching the given query.
@@ -141,8 +141,8 @@ func FindByInitializing() ([]Pod, error) {
 
 // CountByInitializing counts the number of pods that are initializing but have
 // not started any containers.
-func CountByInitializing() (int, error) {
-	return Count(db.Query(bson.M{
+func CountByInitializing(ctx context.Context) (int, error) {
+	return Count(ctx, db.Query(bson.M{
 		StatusKey: StatusInitializing,
 	}))
 }

--- a/model/pod/db_test.go
+++ b/model/pod/db_test.go
@@ -153,7 +153,7 @@ func TestFindByInitializing(t *testing.T) {
 func TestCountByInitializing(t *testing.T) {
 	for tName, tCase := range map[string]func(t *testing.T){
 		"ReturnsZeroForNoMatches": func(t *testing.T) {
-			count, err := CountByInitializing()
+			count, err := CountByInitializing(t.Context())
 			assert.NoError(t, err)
 			assert.Empty(t, count)
 		},
@@ -176,7 +176,7 @@ func TestCountByInitializing(t *testing.T) {
 			}
 			require.NoError(t, p3.Insert())
 
-			count, err := CountByInitializing()
+			count, err := CountByInitializing(t.Context())
 			require.NoError(t, err)
 			assert.Equal(t, 2, count)
 		},

--- a/model/pod/db_test.go
+++ b/model/pod/db_test.go
@@ -583,7 +583,7 @@ func TestGetStatsByStatus(t *testing.T) {
 	}()
 	for tName, tCase := range map[string]func(t *testing.T){
 		"ReturnsEmptyForNoMatchingPods": func(t *testing.T) {
-			stats, err := GetStatsByStatus()
+			stats, err := GetStatsByStatus(t.Context())
 			assert.NoError(t, err)
 			assert.Empty(t, stats)
 		},
@@ -616,7 +616,7 @@ func TestGetStatsByStatus(t *testing.T) {
 				require.NoError(t, p.Insert())
 			}
 
-			stats, err := GetStatsByStatus(StatusRunning)
+			stats, err := GetStatsByStatus(t.Context(), StatusRunning)
 			require.NoError(t, err)
 			require.Len(t, stats, 1)
 			assert.Equal(t, StatusRunning, stats[0].Status)
@@ -671,7 +671,7 @@ func TestGetStatsByStatus(t *testing.T) {
 				require.NoError(t, p.Insert())
 			}
 
-			stats, err := GetStatsByStatus(StatusInitializing, StatusStarting, StatusRunning)
+			stats, err := GetStatsByStatus(t.Context(), StatusInitializing, StatusStarting, StatusRunning)
 			require.NoError(t, err)
 			require.Len(t, stats, 3)
 			for _, s := range stats {

--- a/model/pod/definition/db.go
+++ b/model/pod/definition/db.go
@@ -39,7 +39,7 @@ func FindOne(ctx context.Context, q db.Q) (*PodDefinition, error) {
 // UpsertOne updates an existing pod definition if it exists based on the
 // query; otherwise, it inserts a new pod definition.
 func UpsertOne(ctx context.Context, query, update any) (*adb.ChangeInfo, error) {
-	return db.UpsertContext(ctx, Collection, query, update)
+	return db.Upsert(ctx, Collection, query, update)
 }
 
 // UpdateOne updates an existing pod definition.

--- a/model/pod/definition/definition.go
+++ b/model/pod/definition/definition.go
@@ -35,7 +35,7 @@ func (pd *PodDefinition) Insert() error {
 
 // Upsert upserts the pod definition into the collection.
 func (pd *PodDefinition) Upsert(ctx context.Context) error {
-	_, err := db.UpsertContext(ctx, Collection, ByID(pd.ID), pd)
+	_, err := db.Upsert(ctx, Collection, ByID(pd.ID), pd)
 	return err
 }
 

--- a/model/pod/definition/definition.go
+++ b/model/pod/definition/definition.go
@@ -34,8 +34,8 @@ func (pd *PodDefinition) Insert() error {
 }
 
 // Upsert upserts the pod definition into the collection.
-func (pd *PodDefinition) Upsert() error {
-	_, err := db.Upsert(Collection, ByID(pd.ID), pd)
+func (pd *PodDefinition) Upsert(ctx context.Context) error {
+	_, err := db.UpsertContext(ctx, Collection, ByID(pd.ID), pd)
 	return err
 }
 

--- a/model/pod/definition/definition.go
+++ b/model/pod/definition/definition.go
@@ -33,9 +33,10 @@ func (pd *PodDefinition) Insert() error {
 	return db.Insert(Collection, pd)
 }
 
-// Upsert upserts the pod definition into the collection.
-func (pd *PodDefinition) Upsert(ctx context.Context) error {
-	_, err := db.Upsert(ctx, Collection, ByID(pd.ID), pd)
+// Replace updates the pod definition in the db if an entry already exists,
+// overwriting the existing definition. If no definition exists, a new one is created.
+func (pd *PodDefinition) Replace(ctx context.Context) error {
+	_, err := db.ReplaceContext(ctx, Collection, ByID(pd.ID), pd)
 	return err
 }
 

--- a/model/pod/dispatcher/db.go
+++ b/model/pod/dispatcher/db.go
@@ -47,8 +47,8 @@ func Find(q db.Q) ([]PodDispatcher, error) {
 
 // UpsertOne updates an existing pod dispatcher if it exists based on the
 // query; otherwise, it inserts a new pod dispatcher.
-func UpsertOne(query, update any) (*adb.ChangeInfo, error) {
-	return db.Upsert(Collection, query, update)
+func UpsertOne(ctx context.Context, query, update any) (*adb.ChangeInfo, error) {
+	return db.UpsertContext(ctx, Collection, query, update)
 }
 
 // FindOneByID finds one pod dispatcher by its ID.

--- a/model/pod/dispatcher/db.go
+++ b/model/pod/dispatcher/db.go
@@ -48,7 +48,7 @@ func Find(q db.Q) ([]PodDispatcher, error) {
 // UpsertOne updates an existing pod dispatcher if it exists based on the
 // query; otherwise, it inserts a new pod dispatcher.
 func UpsertOne(ctx context.Context, query, update any) (*adb.ChangeInfo, error) {
-	return db.UpsertContext(ctx, Collection, query, update)
+	return db.Upsert(ctx, Collection, query, update)
 }
 
 // FindOneByID finds one pod dispatcher by its ID.

--- a/model/pod/dispatcher/dispatcher.go
+++ b/model/pod/dispatcher/dispatcher.go
@@ -82,9 +82,9 @@ func (pd *PodDispatcher) atomicUpsertUpdate(lastModified time.Time) bson.M {
 
 // UpsertAtomically inserts/updates the pod dispatcher depending on whether the
 // document already exists.
-func (pd *PodDispatcher) UpsertAtomically() (*adb.ChangeInfo, error) {
+func (pd *PodDispatcher) UpsertAtomically(ctx context.Context) (*adb.ChangeInfo, error) {
 	lastModified := utility.BSONTime(time.Now())
-	change, err := UpsertOne(pd.atomicUpsertQuery(), pd.atomicUpsertUpdate(lastModified))
+	change, err := UpsertOne(ctx, pd.atomicUpsertQuery(), pd.atomicUpsertUpdate(lastModified))
 	if err != nil {
 		return change, err
 	}

--- a/model/pod/dispatcher/dispatcher_test.go
+++ b/model/pod/dispatcher/dispatcher_test.go
@@ -28,7 +28,7 @@ func TestUpsertAtomically(t *testing.T) {
 
 	for tName, tCase := range map[string]func(t *testing.T, pd PodDispatcher){
 		"InsertsNewPodDispatcher": func(t *testing.T, pd PodDispatcher) {
-			change, err := pd.UpsertAtomically()
+			change, err := pd.UpsertAtomically(t.Context())
 			require.NoError(t, err)
 			require.Equal(t, 1, change.Updated)
 
@@ -40,7 +40,7 @@ func TestUpsertAtomically(t *testing.T) {
 		"UpdatesExistingPodDispatcher": func(t *testing.T, pd PodDispatcher) {
 			require.NoError(t, pd.Insert())
 
-			change, err := pd.UpsertAtomically()
+			change, err := pd.UpsertAtomically(t.Context())
 			require.NoError(t, err)
 			require.Equal(t, 1, change.Updated)
 
@@ -63,7 +63,7 @@ func TestUpsertAtomically(t *testing.T) {
 			modified.PodIDs = []string{"modified-pod0"}
 			modified.TaskIDs = []string{"modified-task0"}
 
-			change, err := modified.UpsertAtomically()
+			change, err := modified.UpsertAtomically(t.Context())
 			assert.Error(t, err)
 			assert.Zero(t, change)
 
@@ -86,7 +86,7 @@ func TestUpsertAtomically(t *testing.T) {
 			modified.PodIDs = []string{"modified-pod0"}
 			modified.TaskIDs = []string{"modified-task0"}
 
-			change, err := modified.UpsertAtomically()
+			change, err := modified.UpsertAtomically(t.Context())
 			assert.Error(t, err)
 			assert.Zero(t, change)
 
@@ -105,7 +105,7 @@ func TestUpsertAtomically(t *testing.T) {
 			modified.PodIDs = []string{"modified-pod0"}
 			modified.TaskIDs = []string{"modified-task0"}
 
-			change, err := modified.UpsertAtomically()
+			change, err := modified.UpsertAtomically(t.Context())
 			assert.Error(t, err)
 			assert.Zero(t, change)
 

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -381,13 +381,13 @@ func HasMatchingGitTagAliasAndRemotePath(ctx context.Context, projectId, tag str
 }
 
 // CopyProjectAliases finds the aliases for a given project and inserts them for the new project.
-func CopyProjectAliases(oldProjectId, newProjectId string) error {
+func CopyProjectAliases(ctx context.Context, oldProjectId, newProjectId string) error {
 	aliases, err := FindAliasesForProjectFromDb(oldProjectId)
 	if err != nil {
 		return errors.Wrapf(err, "finding aliases for project '%s'", oldProjectId)
 	}
 	if aliases != nil {
-		if err = UpsertAliasesForProject(aliases, newProjectId); err != nil {
+		if err = UpsertAliasesForProject(ctx, aliases, newProjectId); err != nil {
 			return errors.Wrapf(err, "inserting aliases for project '%s'", newProjectId)
 		}
 	}
@@ -419,7 +419,7 @@ func IsValidId(id string) bool {
 // NewId constructs a valid patch Id from the given hex string.
 func NewId(id string) mgobson.ObjectId { return mgobson.ObjectIdHex(id) }
 
-func (p *ProjectAlias) Upsert() error {
+func (p *ProjectAlias) Upsert(ctx context.Context) error {
 	if len(p.ProjectID) == 0 {
 		return errors.New("empty project ID")
 	}
@@ -439,7 +439,7 @@ func (p *ProjectAlias) Upsert() error {
 		parametersKey:  p.Parameters,
 	}
 
-	_, err := db.Upsert(ProjectAliasCollection, bson.M{
+	_, err := db.UpsertContext(ctx, ProjectAliasCollection, bson.M{
 		idKey: p.ID,
 	}, bson.M{"$set": update})
 	if err != nil {
@@ -448,14 +448,14 @@ func (p *ProjectAlias) Upsert() error {
 	return nil
 }
 
-func UpsertAliasesForProject(aliases []ProjectAlias, projectId string) error {
+func UpsertAliasesForProject(ctx context.Context, aliases []ProjectAlias, projectId string) error {
 	catcher := grip.NewBasicCatcher()
 	for i := range aliases {
 		if aliases[i].ProjectID != projectId { // new project, so we need a new document (new ID)
 			aliases[i].ProjectID = projectId
 			aliases[i].ID = ""
 		}
-		catcher.Add(aliases[i].Upsert())
+		catcher.Add(aliases[i].Upsert(ctx))
 	}
 	grip.Debug(message.WrapError(catcher.Resolve(), message.Fields{
 		"message":    "problem getting aliases",

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -439,7 +439,7 @@ func (p *ProjectAlias) Upsert(ctx context.Context) error {
 		parametersKey:  p.Parameters,
 	}
 
-	_, err := db.UpsertContext(ctx, ProjectAliasCollection, bson.M{
+	_, err := db.Upsert(ctx, ProjectAliasCollection, bson.M{
 		idKey: p.ID,
 	}, bson.M{"$set": update})
 	if err != nil {

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -219,7 +219,7 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectOrConfig() {
 		RepoRefId:             "r1",
 		VersionControlEnabled: utility.TruePtr(),
 	}
-	s.NoError(pRef.Upsert())
+	s.NoError(pRef.Upsert(s.T().Context()))
 	a1 := ProjectAlias{
 		ProjectID: "project-1",
 		Alias:     evergreen.CommitQueueAlias,
@@ -479,8 +479,8 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectRepoOrConfig() {
 			},
 		}}
 	s.NoError(repoRef.Upsert())
-	s.NoError(pRef1.Upsert())
-	s.NoError(pRef2.Upsert())
+	s.NoError(pRef1.Upsert(s.T().Context()))
+	s.NoError(pRef2.Upsert(s.T().Context()))
 	s.NoError(projectConfig.Insert())
 
 	for i := 0; i < 3; i++ {

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -546,12 +546,13 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectRepoOrConfig() {
 	s.Equal("cq-.*", found[0].Variant)
 }
 
-func (s *ProjectAliasSuite) TestUpsertAliasesForProject(t *testing.T) {
+func (s *ProjectAliasSuite) TestUpsertAliasesForProject() {
 	for _, a := range s.aliases {
 		a.ProjectID = "old-project"
-		s.NoError(a.Upsert(t.Context()))
+
+		s.NoError(a.Upsert(s.T().Context()))
 	}
-	s.NoError(UpsertAliasesForProject(t.Context(), s.aliases, "new-project"))
+	s.NoError(UpsertAliasesForProject(s.T().Context(), s.aliases, "new-project"))
 
 	found, err := FindAliasesForProjectFromDb("new-project")
 	s.NoError(err)

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -478,7 +478,7 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectRepoOrConfig() {
 				},
 			},
 		}}
-	s.NoError(repoRef.Upsert())
+	s.NoError(repoRef.Upsert(s.T().Context()))
 	s.NoError(pRef1.Upsert(s.T().Context()))
 	s.NoError(pRef2.Upsert(s.T().Context()))
 	s.NoError(projectConfig.Insert())

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -40,7 +40,7 @@ func (s *ProjectAliasSuite) SetupTest() {
 
 func (s *ProjectAliasSuite) TestInsertTaskAndVariantWithNoTags() {
 	for _, a := range s.aliases {
-		s.NoError(a.Upsert())
+		s.NoError(a.Upsert(s.T().Context()))
 	}
 
 	var out ProjectAlias
@@ -61,7 +61,7 @@ func (s *ProjectAliasSuite) TestInsertTagsAndNoTask() {
 		aliasCopy := alias
 		aliasCopy.Task = ""
 		aliasCopy.TaskTags = tags
-		s.NoError(aliasCopy.Upsert())
+		s.NoError(aliasCopy.Upsert(s.T().Context()))
 	}
 
 	var out ProjectAlias
@@ -86,21 +86,21 @@ func (s *ProjectAliasSuite) TestHasMatchingGitTagAliasAndRemotePath() {
 		Variant:   "variant",
 		Task:      "task",
 	}
-	s.NoError(newAlias.Upsert())
+	s.NoError(newAlias.Upsert(s.T().Context()))
 	newAlias2 := ProjectAlias{
 		ProjectID:  "project_id",
 		Alias:      evergreen.GitTagAlias,
 		GitTag:     "release",
 		RemotePath: "file.yml",
 	}
-	s.NoError(newAlias2.Upsert())
+	s.NoError(newAlias2.Upsert(s.T().Context()))
 	hasAliases, path, err := HasMatchingGitTagAliasAndRemotePath(s.T().Context(), "project_id", "release")
 	s.Error(err)
 	s.False(hasAliases)
 	s.Empty(path)
 
 	newAlias2.RemotePath = ""
-	s.NoError(newAlias2.Upsert())
+	s.NoError(newAlias2.Upsert(s.T().Context()))
 	hasAliases, path, err = HasMatchingGitTagAliasAndRemotePath(s.T().Context(), "project_id", "release")
 	s.NoError(err)
 	s.True(hasAliases)
@@ -117,7 +117,7 @@ func (s *ProjectAliasSuite) TestHasMatchingGitTagAliasAndRemotePath() {
 		GitTag:     "release",
 		RemotePath: "file.yml",
 	}
-	s.NoError(newAlias3.Upsert())
+	s.NoError(newAlias3.Upsert(s.T().Context()))
 	hasAliases, path, err = HasMatchingGitTagAliasAndRemotePath(s.T().Context(), "project_id2", "release")
 	s.NoError(err)
 	s.True(hasAliases)
@@ -130,7 +130,7 @@ func (s *ProjectAliasSuite) TestInsertTagsAndNoVariant() {
 		aliasCopy := alias
 		aliasCopy.Variant = ""
 		aliasCopy.VariantTags = tags
-		s.NoError(aliasCopy.Upsert())
+		s.NoError(aliasCopy.Upsert(s.T().Context()))
 	}
 
 	var out ProjectAlias
@@ -149,7 +149,7 @@ func (s *ProjectAliasSuite) TestInsertTagsAndNoVariant() {
 
 func (s *ProjectAliasSuite) TestRemove() {
 	for i, a := range s.aliases {
-		s.NoError(a.Upsert())
+		s.NoError(a.Upsert(s.T().Context()))
 		s.aliases[i] = a
 	}
 	var out []ProjectAlias
@@ -166,7 +166,7 @@ func (s *ProjectAliasSuite) TestRemove() {
 
 func (s *ProjectAliasSuite) TestFindAliasesForProject() {
 	for _, a := range s.aliases {
-		s.NoError(a.Upsert())
+		s.NoError(a.Upsert(s.T().Context()))
 	}
 	a1 := ProjectAlias{
 		ProjectID: "project-1",
@@ -174,7 +174,7 @@ func (s *ProjectAliasSuite) TestFindAliasesForProject() {
 		Variant:   "variants-111",
 		Task:      "variants-11",
 	}
-	s.NoError(a1.Upsert())
+	s.NoError(a1.Upsert(s.T().Context()))
 
 	out, err := FindAliasesForProjectFromDb("project-1")
 	s.NoError(err)
@@ -183,7 +183,7 @@ func (s *ProjectAliasSuite) TestFindAliasesForProject() {
 
 func (s *ProjectAliasSuite) TestFindAliasInProject() {
 	for _, a := range s.aliases {
-		s.NoError(a.Upsert())
+		s.NoError(a.Upsert(s.T().Context()))
 	}
 	a1 := ProjectAlias{
 		ProjectID: "project-1",
@@ -203,9 +203,9 @@ func (s *ProjectAliasSuite) TestFindAliasInProject() {
 		Variant:   "variants-11",
 		Task:      "variants-11",
 	}
-	s.NoError(a1.Upsert())
-	s.NoError(a2.Upsert())
-	s.NoError(a3.Upsert())
+	s.NoError(a1.Upsert(s.T().Context()))
+	s.NoError(a2.Upsert(s.T().Context()))
+	s.NoError(a3.Upsert(s.T().Context()))
 
 	found, err := findMatchingAliasForProjectRef("project-1", "alias-1")
 	s.NoError(err)
@@ -241,11 +241,11 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectOrConfig() {
 		Alias:       "duplicate",
 		Description: "from UI",
 	}
-	s.NoError(a1.Upsert())
-	s.NoError(a2.Upsert())
-	s.NoError(a3.Upsert())
-	s.NoError(patchAlias.Upsert())
-	s.NoError(duplicateAlias.Upsert())
+	s.NoError(a1.Upsert(s.T().Context()))
+	s.NoError(a2.Upsert(s.T().Context()))
+	s.NoError(a3.Upsert(s.T().Context()))
+	s.NoError(patchAlias.Upsert(s.T().Context()))
+	s.NoError(duplicateAlias.Upsert(s.T().Context()))
 
 	projectConfig := &ProjectConfig{
 		Id:      "project-1",
@@ -367,9 +367,9 @@ func TestFindMergedAliasesFromProjectRepoOrProjectConfig(t *testing.T) {
 
 	for testName, testCase := range map[string]func(t *testing.T){
 		"nothing enabled": func(t *testing.T) {
-			assert.NoError(t, UpsertAliasesForProject(cqAliases, pRef.Id))
-			assert.NoError(t, UpsertAliasesForProject(githubChecksAlias, pRef.Id))
-			assert.NoError(t, UpsertAliasesForProject(gitTagAliases, pRef.RepoRefId))
+			assert.NoError(t, UpsertAliasesForProject(t.Context(), cqAliases, pRef.Id))
+			assert.NoError(t, UpsertAliasesForProject(t.Context(), githubChecksAlias, pRef.Id))
+			assert.NoError(t, UpsertAliasesForProject(t.Context(), gitTagAliases, pRef.RepoRefId))
 			tempRef := ProjectRef{ // This ref has nothing else enabled so merging should only return project aliases
 				Id: pRef.Id,
 			}
@@ -380,10 +380,10 @@ func TestFindMergedAliasesFromProjectRepoOrProjectConfig(t *testing.T) {
 			assert.Equal(t, res[1].ProjectID, pRef.Id)
 		},
 		"all enabled": func(t *testing.T) {
-			assert.NoError(t, UpsertAliasesForProject(cqAliases, pRef.Id))
-			assert.NoError(t, UpsertAliasesForProject(cqAliases, pRef.RepoRefId))
-			assert.NoError(t, UpsertAliasesForProject(gitTagAliases, pRef.RepoRefId))
-			assert.NoError(t, UpsertAliasesForProject(githubChecksAlias, pRef.RepoRefId))
+			assert.NoError(t, UpsertAliasesForProject(t.Context(), cqAliases, pRef.Id))
+			assert.NoError(t, UpsertAliasesForProject(t.Context(), cqAliases, pRef.RepoRefId))
+			assert.NoError(t, UpsertAliasesForProject(t.Context(), gitTagAliases, pRef.RepoRefId))
+			assert.NoError(t, UpsertAliasesForProject(t.Context(), githubChecksAlias, pRef.RepoRefId))
 			res, err := ConstructMergedAliasesByPrecedence(&pRef, &projectConfig, pRef.RepoRefId)
 			assert.NoError(t, err)
 			// Uses aliases from project, repo, and config
@@ -407,9 +407,9 @@ func TestFindMergedAliasesFromProjectRepoOrProjectConfig(t *testing.T) {
 			assert.Equal(t, 2, cqCount)
 		},
 		"project and repo only used": func(t *testing.T) {
-			assert.NoError(t, UpsertAliasesForProject(cqAliases, pRef.Id))
-			assert.NoError(t, UpsertAliasesForProject(cqAliases, pRef.RepoRefId))
-			assert.NoError(t, UpsertAliasesForProject(patchAliases, pRef.RepoRefId))
+			assert.NoError(t, UpsertAliasesForProject(t.Context(), cqAliases, pRef.Id))
+			assert.NoError(t, UpsertAliasesForProject(t.Context(), cqAliases, pRef.RepoRefId))
+			assert.NoError(t, UpsertAliasesForProject(t.Context(), patchAliases, pRef.RepoRefId))
 			res, err := ConstructMergedAliasesByPrecedence(&pRef, &projectConfig, pRef.RepoRefId)
 			assert.NoError(t, err)
 			// Ignores config aliases because they're already used
@@ -493,7 +493,7 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectRepoOrConfig() {
 		if i%2 != 0 {
 			alias.Alias = "alias-2"
 		}
-		s.NoError(alias.Upsert())
+		s.NoError(alias.Upsert(s.T().Context()))
 	}
 
 	for i := 0; i < 6; i++ {
@@ -506,7 +506,7 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectRepoOrConfig() {
 		if i%2 == 0 {
 			alias.Alias = "alias-4"
 		}
-		s.NoError(alias.Upsert())
+		s.NoError(alias.Upsert(s.T().Context()))
 	}
 
 	// Test project with aliases
@@ -546,12 +546,12 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectRepoOrConfig() {
 	s.Equal("cq-.*", found[0].Variant)
 }
 
-func (s *ProjectAliasSuite) TestUpsertAliasesForProject() {
+func (s *ProjectAliasSuite) TestUpsertAliasesForProject(t *testing.T) {
 	for _, a := range s.aliases {
 		a.ProjectID = "old-project"
-		s.NoError(a.Upsert())
+		s.NoError(a.Upsert(t.Context()))
 	}
-	s.NoError(UpsertAliasesForProject(s.aliases, "new-project"))
+	s.NoError(UpsertAliasesForProject(t.Context(), s.aliases, "new-project"))
 
 	found, err := FindAliasesForProjectFromDb("new-project")
 	s.NoError(err)

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -219,7 +219,7 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectOrConfig() {
 		RepoRefId:             "r1",
 		VersionControlEnabled: utility.TruePtr(),
 	}
-	s.NoError(pRef.Upsert(s.T().Context()))
+	s.NoError(pRef.Replace(s.T().Context()))
 	a1 := ProjectAlias{
 		ProjectID: "project-1",
 		Alias:     evergreen.CommitQueueAlias,
@@ -479,8 +479,8 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectRepoOrConfig() {
 			},
 		}}
 	s.NoError(repoRef.Replace(s.T().Context()))
-	s.NoError(pRef1.Upsert(s.T().Context()))
-	s.NoError(pRef2.Upsert(s.T().Context()))
+	s.NoError(pRef1.Replace(s.T().Context()))
+	s.NoError(pRef2.Replace(s.T().Context()))
 	s.NoError(projectConfig.Insert())
 
 	for i := 0; i < 3; i++ {

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -478,7 +478,7 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectRepoOrConfig() {
 				},
 			},
 		}}
-	s.NoError(repoRef.Upsert(s.T().Context()))
+	s.NoError(repoRef.Replace(s.T().Context()))
 	s.NoError(pRef1.Upsert(s.T().Context()))
 	s.NoError(pRef2.Upsert(s.T().Context()))
 	s.NoError(projectConfig.Insert())

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -65,8 +65,9 @@ func parserProjectById(id string) db.Q {
 }
 
 // parserProjectUpsertOne updates one parser project in the DB.
-func parserProjectUpsertOne(query any, update any) error {
-	_, err := db.Upsert(
+func parserProjectUpsertOne(ctx context.Context, query any, update any) error {
+	_, err := db.UpsertContext(
+		ctx,
 		ParserProjectCollection,
 		query,
 		update,
@@ -95,5 +96,5 @@ func (s ParserProjectDBStorage) FindOneByIDWithFields(ctx context.Context, id st
 // UpsertOne replaces a parser project in the DB if one exists with the same ID.
 // Otherwise, if it does not exist yet, it inserts a new parser project.
 func (s ParserProjectDBStorage) UpsertOne(ctx context.Context, pp *ParserProject) error {
-	return parserProjectUpsertOne(bson.M{ParserProjectIdKey: pp.Id}, pp)
+	return parserProjectUpsertOne(ctx, bson.M{ParserProjectIdKey: pp.Id}, pp)
 }

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -64,13 +64,13 @@ func parserProjectById(id string) db.Q {
 	return db.Query(bson.M{ParserProjectIdKey: id})
 }
 
-// parserProjectUpsertOne updates one parser project in the DB.
-func parserProjectUpsertOne(ctx context.Context, query any, update any) error {
-	_, err := db.Upsert(
+// parserProjectReplaceOne updates one parser project in the DB.
+func parserProjectReplaceOne(ctx context.Context, query any, replacement any) error {
+	_, err := db.ReplaceContext(
 		ctx,
 		ParserProjectCollection,
 		query,
-		update,
+		replacement,
 	)
 
 	return err
@@ -96,5 +96,5 @@ func (s ParserProjectDBStorage) FindOneByIDWithFields(ctx context.Context, id st
 // UpsertOne replaces a parser project in the DB if one exists with the same ID.
 // Otherwise, if it does not exist yet, it inserts a new parser project.
 func (s ParserProjectDBStorage) UpsertOne(ctx context.Context, pp *ParserProject) error {
-	return parserProjectUpsertOne(ctx, bson.M{ParserProjectIdKey: pp.Id}, pp)
+	return parserProjectReplaceOne(ctx, bson.M{ParserProjectIdKey: pp.Id}, pp)
 }

--- a/model/project_parser_db.go
+++ b/model/project_parser_db.go
@@ -66,7 +66,7 @@ func parserProjectById(id string) db.Q {
 
 // parserProjectUpsertOne updates one parser project in the DB.
 func parserProjectUpsertOne(ctx context.Context, query any, update any) error {
-	_, err := db.UpsertContext(
+	_, err := db.Upsert(
 		ctx,
 		ParserProjectCollection,
 		query,

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -857,7 +857,7 @@ func (p *ProjectRef) DetachFromRepo(ctx context.Context, u *user.DBUser) error {
 	// catch any resulting errors so that we log before returning
 	catcher := grip.NewBasicCatcher()
 	if mergedVars != nil {
-		_, err = mergedVars.Upsert()
+		_, err = mergedVars.Upsert(ctx)
 		catcher.Wrap(err, "saving merged vars")
 	}
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1483,8 +1483,10 @@ func GetTasksWithOptions(ctx context.Context, projectName string, taskName strin
 	pipeline := []bson.M{{"$match": match}}
 	pipeline = append(pipeline, bson.M{"$sort": bson.M{task.RevisionOrderNumberKey: -1}})
 
+	aggregateCtx, cancel := context.WithTimeout(ctx, tasksByProjectQueryMaxTime)
+	defer cancel()
 	res := []task.Task{}
-	if err = db.AggregateWithMaxTime(task.Collection, pipeline, &res, tasksByProjectQueryMaxTime); err != nil {
+	if err = db.Aggregate(aggregateCtx, task.Collection, pipeline, &res); err != nil {
 		return nil, errors.Wrapf(err, "aggregating tasks")
 	}
 	return res, nil

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1431,7 +1431,7 @@ func GetIdentifierForProject(ctx context.Context, id string) (string, error) {
 }
 
 func CountProjectRefsWithIdentifier(ctx context.Context, identifier string) (int, error) {
-	return db.CountQContext(ctx, ProjectRefCollection, byId(identifier))
+	return db.CountQ(ctx, ProjectRefCollection, byId(identifier))
 }
 
 type GetProjectTasksOpts struct {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -869,7 +869,7 @@ func (p *ProjectRef) DetachFromRepo(ctx context.Context, u *user.DBUser) error {
 		for _, s := range subs {
 			s.ID = ""
 			s.Owner = p.Id
-			catcher.Add(s.Upsert())
+			catcher.Add(s.Upsert(ctx))
 		}
 	}
 
@@ -905,7 +905,7 @@ func (p *ProjectRef) DetachFromRepo(ctx context.Context, u *user.DBUser) error {
 			}
 		}
 	}
-	catcher.Add(UpsertAliasesForProject(repoAliasesToCopy, p.Id))
+	catcher.Add(UpsertAliasesForProject(ctx, repoAliasesToCopy, p.Id))
 
 	catcher.Add(GetAndLogProjectRepoAttachment(ctx, p.Id, u.Id, event.EventTypeProjectDetachedFromRepo, false, before))
 	return catcher.Resolve()
@@ -1308,7 +1308,7 @@ func (p *ProjectRef) createNewRepoRef(ctx context.Context, u *user.DBUser) (repo
 	}
 	for _, a := range commonAliases {
 		a.ProjectID = repoRef.Id
-		if err = a.Upsert(); err != nil {
+		if err = a.Upsert(ctx); err != nil {
 			return nil, errors.Wrap(err, "upserting alias for repo")
 		}
 	}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -680,7 +680,7 @@ func (p *ProjectRef) Add(ctx context.Context, creator *user.DBUser) error {
 		}
 		if hidden != nil {
 			p.Id = hidden.Id
-			err := p.Upsert()
+			err := p.Upsert(ctx)
 			if err != nil {
 				return errors.Wrapf(err, "upserting project ref '%s'", hidden.Id)
 			}
@@ -850,7 +850,7 @@ func (p *ProjectRef) DetachFromRepo(ctx context.Context, u *user.DBUser) error {
 	}
 
 	mergedProject.RepoRefId = ""
-	if err := mergedProject.Upsert(); err != nil {
+	if err := mergedProject.Upsert(ctx); err != nil {
 		return errors.Wrap(err, "detaching project from repo")
 	}
 
@@ -2142,8 +2142,8 @@ func (p *ProjectRef) CanEnableCommitQueue(ctx context.Context) (bool, error) {
 
 // Upsert updates the project ref in the db if an entry already exists,
 // overwriting the existing ref. If no project ref exists, a new one is created.
-func (p *ProjectRef) Upsert() error {
-	_, err := db.Upsert(ProjectRefCollection, bson.M{ProjectRefIdKey: p.Id}, p)
+func (p *ProjectRef) Upsert(ctx context.Context) error {
+	_, err := db.UpsertContext(ctx, ProjectRefCollection, bson.M{ProjectRefIdKey: p.Id}, p)
 	return err
 }
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2143,7 +2143,7 @@ func (p *ProjectRef) CanEnableCommitQueue(ctx context.Context) (bool, error) {
 // Upsert updates the project ref in the db if an entry already exists,
 // overwriting the existing ref. If no project ref exists, a new one is created.
 func (p *ProjectRef) Upsert(ctx context.Context) error {
-	_, err := db.UpsertContext(ctx, ProjectRefCollection, bson.M{ProjectRefIdKey: p.Id}, p)
+	_, err := db.Upsert(ctx, ProjectRefCollection, bson.M{ProjectRefIdKey: p.Id}, p)
 	return err
 }
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -680,7 +680,7 @@ func (p *ProjectRef) Add(ctx context.Context, creator *user.DBUser) error {
 		}
 		if hidden != nil {
 			p.Id = hidden.Id
-			err := p.Upsert(ctx)
+			err := p.Replace(ctx)
 			if err != nil {
 				return errors.Wrapf(err, "upserting project ref '%s'", hidden.Id)
 			}
@@ -850,7 +850,7 @@ func (p *ProjectRef) DetachFromRepo(ctx context.Context, u *user.DBUser) error {
 	}
 
 	mergedProject.RepoRefId = ""
-	if err := mergedProject.Upsert(ctx); err != nil {
+	if err := mergedProject.Replace(ctx); err != nil {
 		return errors.Wrap(err, "detaching project from repo")
 	}
 
@@ -2140,10 +2140,10 @@ func (p *ProjectRef) CanEnableCommitQueue(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
-// Upsert updates the project ref in the db if an entry already exists,
+// Replace updates the project ref in the db if an entry already exists,
 // overwriting the existing ref. If no project ref exists, a new one is created.
-func (p *ProjectRef) Upsert(ctx context.Context) error {
-	_, err := db.Upsert(ctx, ProjectRefCollection, bson.M{ProjectRefIdKey: p.Id}, p)
+func (p *ProjectRef) Replace(ctx context.Context) error {
+	_, err := db.ReplaceContext(ctx, ProjectRefCollection, bson.M{ProjectRefIdKey: p.Id}, p)
 	return err
 }
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1430,8 +1430,8 @@ func GetIdentifierForProject(ctx context.Context, id string) (string, error) {
 	return pRef.Identifier, nil
 }
 
-func CountProjectRefsWithIdentifier(identifier string) (int, error) {
-	return db.CountQ(ProjectRefCollection, byId(identifier))
+func CountProjectRefsWithIdentifier(ctx context.Context, identifier string) (int, error) {
+	return db.CountQContext(ctx, ProjectRefCollection, byId(identifier))
 }
 
 type GetProjectTasksOpts struct {
@@ -2789,11 +2789,11 @@ func validateOwner(owner string, validOrgs []string) error {
 	return nil
 }
 
-func (p *ProjectRef) ValidateIdentifier() error {
+func (p *ProjectRef) ValidateIdentifier(ctx context.Context) error {
 	if p.Id == p.Identifier { // we already know the id is unique
 		return nil
 	}
-	count, err := CountProjectRefsWithIdentifier(p.Identifier)
+	count, err := CountProjectRefsWithIdentifier(ctx, p.Identifier)
 	if err != nil {
 		return errors.Wrap(err, "counting other project refs")
 	}

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -2461,7 +2461,8 @@ func TestFindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(t *testing.T) {
 	assert.Nil(projectRef)
 
 	doc.CommitQueue.Enabled = utility.TruePtr()
-	require.NoError(db.ReplaceContext(t.Context(), ProjectRefCollection, mgobson.M{ProjectRefIdKey: "mci"}, doc))
+	_, err = db.ReplaceContext(t.Context(), ProjectRefCollection, mgobson.M{ProjectRefIdKey: "mci"}, doc)
+	require.NoError(err)
 
 	projectRef, err = FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(t.Context(), "mongodb", "mci", "main")
 	assert.NoError(err)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -157,13 +157,13 @@ func TestFindMergedProjectRef(t *testing.T) {
 	// Assert that mergeParsleyFilters correctly handles projects with repo filters but not project filters.
 	projectRef.ParsleyFilters = []parsley.Filter{}
 
-	assert.NoError(t, projectRef.Upsert(t.Context()))
+	assert.NoError(t, projectRef.Replace(t.Context()))
 	mergedProject, err = FindMergedProjectRef(t.Context(), "ident", "ident", true)
 	assert.NoError(t, err)
 	assert.Len(t, mergedProject.ParsleyFilters, 1)
 
 	projectRef.ParsleyFilters = nil
-	assert.NoError(t, projectRef.Upsert(t.Context()))
+	assert.NoError(t, projectRef.Replace(t.Context()))
 	mergedProject, err = FindMergedProjectRef(t.Context(), "ident", "ident", true)
 	assert.NoError(t, err)
 	assert.Len(t, mergedProject.ParsleyFilters, 1)
@@ -2365,7 +2365,7 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 	// project PR testing explicitly disabled
 	doc.PRTestingEnabled = utility.FalsePtr()
 	doc.ManualPRTestingEnabled = utility.FalsePtr()
-	assert.NoError(doc.Upsert(t.Context()))
+	assert.NoError(doc.Replace(t.Context()))
 	projectRef, err = FindOneProjectRefByRepoAndBranchWithPRTesting(t.Context(), "mongodb", "mci", "mine", "")
 	assert.NoError(err)
 	assert.Nil(projectRef)
@@ -2379,7 +2379,7 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 	// project auto PR testing enabled, manual disabled
 	doc.PRTestingEnabled = utility.TruePtr()
 	doc.ManualPRTestingEnabled = utility.FalsePtr()
-	assert.NoError(doc.Upsert(t.Context()))
+	assert.NoError(doc.Replace(t.Context()))
 	projectRef, err = FindOneProjectRefByRepoAndBranchWithPRTesting(t.Context(), "mongodb", "mci", "mine", "")
 	assert.NoError(err)
 	assert.NotNil(projectRef)
@@ -2393,7 +2393,7 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 	// project auto PR testing disabled, manual enabled
 	doc.PRTestingEnabled = utility.FalsePtr()
 	doc.ManualPRTestingEnabled = utility.TruePtr()
-	assert.NoError(doc.Upsert(t.Context()))
+	assert.NoError(doc.Replace(t.Context()))
 	projectRef, err = FindOneProjectRefByRepoAndBranchWithPRTesting(t.Context(), "mongodb", "mci", "mine", "")
 	assert.NoError(err)
 	assert.NotNil(projectRef)
@@ -2409,7 +2409,7 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 	assert.NoError(repoDoc.Replace(t.Context()))
 	doc.Enabled = false
 	doc.PRTestingEnabled = utility.TruePtr()
-	assert.NoError(doc.Upsert(t.Context()))
+	assert.NoError(doc.Replace(t.Context()))
 	projectRef, err = FindOneProjectRefByRepoAndBranchWithPRTesting(t.Context(), "mongodb", "mci", "mine", "")
 	assert.NoError(err)
 	assert.Nil(projectRef)
@@ -2471,7 +2471,7 @@ func TestFindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(t *testing.T) {
 
 	// doc doesn't default to repo
 	doc.CommitQueue.Enabled = utility.FalsePtr()
-	assert.NoError(doc.Upsert(t.Context()))
+	assert.NoError(doc.Replace(t.Context()))
 	projectRef, err = FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(t.Context(), "mongodb", "mci", "not_main")
 	assert.NoError(err)
 	assert.Nil(projectRef)
@@ -3626,9 +3626,9 @@ func TestRemoveAdminFromProjects(t *testing.T) {
 		Id: "adminless_repo",
 	}}
 
-	assert.NoError(t, pRef.Upsert(t.Context()))
-	assert.NoError(t, pRef2.Upsert(t.Context()))
-	assert.NoError(t, pRef3.Upsert(t.Context()))
+	assert.NoError(t, pRef.Replace(t.Context()))
+	assert.NoError(t, pRef2.Replace(t.Context()))
+	assert.NoError(t, pRef3.Replace(t.Context()))
 	assert.NoError(t, repoRef.Replace(t.Context()))
 	assert.NoError(t, repoRef2.Replace(t.Context()))
 	assert.NoError(t, repoRef3.Replace(t.Context()))

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -122,7 +122,7 @@ func TestFindMergedProjectRef(t *testing.T) {
 			},
 		},
 	}}
-	assert.NoError(t, repoRef.Upsert(t.Context()))
+	assert.NoError(t, repoRef.Replace(t.Context()))
 
 	mergedProject, err := FindMergedProjectRef(t.Context(), "ident", "ident", true)
 	assert.NoError(t, err)
@@ -277,7 +277,7 @@ func TestFindMergedEnabledProjectRefsByIds(t *testing.T) {
 			},
 		},
 	}}
-	assert.NoError(t, repoRef.Upsert(t.Context()))
+	assert.NoError(t, repoRef.Replace(t.Context()))
 
 	mergedProjects, err := FindMergedEnabledProjectRefsByIds(t.Context(), "ident", "ident_enabled")
 	assert.NoError(t, err)
@@ -361,7 +361,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 		Repo:    "enable_mci",
 		Enabled: true,
 	}}
-	assert.NoError(t, enableRef.Upsert(t.Context()))
+	assert.NoError(t, enableRef.Replace(t.Context()))
 	disabledByRepo := &ProjectRef{
 		Id:        "disabledByRepo",
 		Owner:     "disable_mongodb",
@@ -375,7 +375,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 		Repo:    "disable_mci",
 		Enabled: true,
 	}}
-	assert.NoError(t, disableRepo.Upsert(t.Context()))
+	assert.NoError(t, disableRepo.Replace(t.Context()))
 
 	var settings evergreen.Settings
 	settings.ProjectCreation.TotalProjectLimit = 4
@@ -422,7 +422,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 
 	// Should not error if a repo defaulted project is enabled.
 	disableRepo.Enabled = true
-	assert.NoError(t, disableRepo.Upsert(t.Context()))
+	assert.NoError(t, disableRepo.Replace(t.Context()))
 	mergedRef, err := GetProjectRefMergedWithRepo(t.Context(), *disabledByRepo)
 	assert.NoError(t, err)
 	original, err = FindMergedProjectRef(t.Context(), disabledByRepo.Id, "", false)
@@ -822,7 +822,7 @@ func TestAttachToNewRepo(t *testing.T) {
 	repoRef := RepoRef{ProjectRef{
 		Id: "myRepo",
 	}}
-	assert.NoError(t, repoRef.Upsert(t.Context()))
+	assert.NoError(t, repoRef.Replace(t.Context()))
 	u := &user.DBUser{Id: "me"}
 
 	assert.NoError(t, u.Insert())
@@ -1245,7 +1245,7 @@ func TestDetachFromRepo(t *testing.T) {
 					{ID: "my_build"},
 				},
 			}}
-			assert.NoError(t, repoRef.Upsert(t.Context()))
+			assert.NoError(t, repoRef.Replace(t.Context()))
 
 			pVars := &ProjectVars{
 				Id: pRef.Id,
@@ -1302,7 +1302,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 					Enabled: false,
 				},
 			}
-			assert.NoError(t, repoRef.Upsert(t.Context()))
+			assert.NoError(t, repoRef.Replace(t.Context()))
 			assert.NoError(t, DefaultSectionToRepo(t.Context(), id, ProjectPageGeneralSection, "me"))
 
 			pRefFromDb, err := FindBranchProjectRef(t.Context(), id)
@@ -1497,7 +1497,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 					Id: pRef.RepoRefId,
 				},
 			}
-			assert.NoError(t, repoRef.Upsert(t.Context()))
+			assert.NoError(t, repoRef.Replace(t.Context()))
 
 			pVars := ProjectVars{
 				Id:          pRef.Id,
@@ -1680,7 +1680,7 @@ func TestGetGitHubProjectConflicts(t *testing.T) {
 	r9 := &RepoRef{
 		ProjectRef: *p9,
 	}
-	require.NoError(r9.Upsert(t.Context()))
+	require.NoError(r9.Replace(t.Context()))
 	p10 := &ProjectRef{
 		Owner:     "mongodb",
 		Repo:      "mci4",
@@ -2328,7 +2328,7 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 		Repo:       "mci",
 		RemotePath: "",
 	}}
-	assert.NoError(repoDoc.Upsert(t.Context()))
+	assert.NoError(repoDoc.Replace(t.Context()))
 	doc = &ProjectRef{
 		Id:        "defaulting_project",
 		Owner:     "mongodb",
@@ -2356,7 +2356,7 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 	assert.Nil(projectRef)
 
 	repoDoc.PRTestingEnabled = utility.TruePtr()
-	assert.NoError(repoDoc.Upsert(t.Context()))
+	assert.NoError(repoDoc.Replace(t.Context()))
 	projectRef, err = FindOneProjectRefByRepoAndBranchWithPRTesting(t.Context(), "mongodb", "mci", "mine", "")
 	assert.NoError(err)
 	require.NotNil(projectRef)
@@ -2406,7 +2406,7 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 
 	// project explicitly disabled
 	repoDoc.RemotePath = "my_path"
-	assert.NoError(repoDoc.Upsert(t.Context()))
+	assert.NoError(repoDoc.Replace(t.Context()))
 	doc.Enabled = false
 	doc.PRTestingEnabled = utility.TruePtr()
 	assert.NoError(doc.Upsert(t.Context()))
@@ -2416,13 +2416,13 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 
 	// branch with no project doesn't work and returns an error if repo not configured with a remote path
 	repoDoc.RemotePath = ""
-	assert.NoError(repoDoc.Upsert(t.Context()))
+	assert.NoError(repoDoc.Replace(t.Context()))
 	projectRef, err = FindOneProjectRefByRepoAndBranchWithPRTesting(t.Context(), "mongodb", "mci", "yours", "")
 	assert.Error(err)
 	assert.Nil(projectRef)
 
 	repoDoc.RemotePath = "my_path"
-	assert.NoError(repoDoc.Upsert(t.Context()))
+	assert.NoError(repoDoc.Replace(t.Context()))
 	projectRef, err = FindOneProjectRefByRepoAndBranchWithPRTesting(t.Context(), "mongodb", "mci", "yours", "")
 	assert.NoError(err)
 	require.NotNil(projectRef)
@@ -3399,7 +3399,7 @@ func TestUpdateNextPeriodicBuild(t *testing.T) {
 				},
 			}}
 			assert.NoError(p.Insert())
-			assert.NoError(repoRef.Upsert(t.Context()))
+			assert.NoError(repoRef.Replace(t.Context()))
 
 			assert.NoError(UpdateNextPeriodicBuild(t.Context(), "proj", &p.PeriodicBuilds[1]))
 			dbProject, err := FindBranchProjectRef(t.Context(), p.Id)
@@ -3443,7 +3443,7 @@ func TestUpdateNextPeriodicBuild(t *testing.T) {
 				},
 			}}
 			assert.NoError(p.Insert())
-			assert.NoError(repoRef.Upsert(t.Context()))
+			assert.NoError(repoRef.Replace(t.Context()))
 			assert.NoError(UpdateNextPeriodicBuild(t.Context(), "proj", &repoRef.PeriodicBuilds[0]))
 
 			// Repo is updated because the branch project doesn't have any periodic build override defined.
@@ -3465,7 +3465,7 @@ func TestUpdateNextPeriodicBuild(t *testing.T) {
 				},
 			}}
 			assert.NoError(p.Insert())
-			assert.NoError(repoRef.Upsert(t.Context()))
+			assert.NoError(repoRef.Replace(t.Context()))
 			// Should error because definition isn't relevant for this project, since
 			// we ignore repo definitions when the project has any override defined.
 			assert.Error(UpdateNextPeriodicBuild(t.Context(), "proj", &repoRef.PeriodicBuilds[0]))
@@ -3495,7 +3495,7 @@ func TestUpdateNextPeriodicBuild(t *testing.T) {
 				},
 			}}
 			assert.NoError(p.Insert())
-			assert.NoError(repoRef.Upsert(t.Context()))
+			assert.NoError(repoRef.Replace(t.Context()))
 
 			assert.NoError(UpdateNextPeriodicBuild(t.Context(), "proj", &p.PeriodicBuilds[0]))
 			dbProject, err := FindBranchProjectRef(t.Context(), p.Id)
@@ -3567,7 +3567,7 @@ func TestFindPeriodicProjects(t *testing.T) {
 		Id:             "my_repo",
 		PeriodicBuilds: []PeriodicBuildDefinition{{ID: "repo_def"}},
 	}}
-	assert.NoError(t, repoRef.Upsert(t.Context()))
+	assert.NoError(t, repoRef.Replace(t.Context()))
 
 	pRef := ProjectRef{
 		Id:             "p1",
@@ -3629,9 +3629,9 @@ func TestRemoveAdminFromProjects(t *testing.T) {
 	assert.NoError(t, pRef.Upsert(t.Context()))
 	assert.NoError(t, pRef2.Upsert(t.Context()))
 	assert.NoError(t, pRef3.Upsert(t.Context()))
-	assert.NoError(t, repoRef.Upsert(t.Context()))
-	assert.NoError(t, repoRef2.Upsert(t.Context()))
-	assert.NoError(t, repoRef3.Upsert(t.Context()))
+	assert.NoError(t, repoRef.Replace(t.Context()))
+	assert.NoError(t, repoRef2.Replace(t.Context()))
+	assert.NoError(t, repoRef3.Replace(t.Context()))
 
 	assert.NoError(t, RemoveAdminFromProjects(t.Context(), "villain"))
 

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -122,7 +122,7 @@ func TestFindMergedProjectRef(t *testing.T) {
 			},
 		},
 	}}
-	assert.NoError(t, repoRef.Upsert())
+	assert.NoError(t, repoRef.Upsert(t.Context()))
 
 	mergedProject, err := FindMergedProjectRef(t.Context(), "ident", "ident", true)
 	assert.NoError(t, err)
@@ -277,7 +277,7 @@ func TestFindMergedEnabledProjectRefsByIds(t *testing.T) {
 			},
 		},
 	}}
-	assert.NoError(t, repoRef.Upsert())
+	assert.NoError(t, repoRef.Upsert(t.Context()))
 
 	mergedProjects, err := FindMergedEnabledProjectRefsByIds(t.Context(), "ident", "ident_enabled")
 	assert.NoError(t, err)
@@ -361,7 +361,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 		Repo:    "enable_mci",
 		Enabled: true,
 	}}
-	assert.NoError(t, enableRef.Upsert())
+	assert.NoError(t, enableRef.Upsert(t.Context()))
 	disabledByRepo := &ProjectRef{
 		Id:        "disabledByRepo",
 		Owner:     "disable_mongodb",
@@ -375,7 +375,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 		Repo:    "disable_mci",
 		Enabled: true,
 	}}
-	assert.NoError(t, disableRepo.Upsert())
+	assert.NoError(t, disableRepo.Upsert(t.Context()))
 
 	var settings evergreen.Settings
 	settings.ProjectCreation.TotalProjectLimit = 4
@@ -422,7 +422,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 
 	// Should not error if a repo defaulted project is enabled.
 	disableRepo.Enabled = true
-	assert.NoError(t, disableRepo.Upsert())
+	assert.NoError(t, disableRepo.Upsert(t.Context()))
 	mergedRef, err := GetProjectRefMergedWithRepo(t.Context(), *disabledByRepo)
 	assert.NoError(t, err)
 	original, err = FindMergedProjectRef(t.Context(), disabledByRepo.Id, "", false)
@@ -822,7 +822,7 @@ func TestAttachToNewRepo(t *testing.T) {
 	repoRef := RepoRef{ProjectRef{
 		Id: "myRepo",
 	}}
-	assert.NoError(t, repoRef.Upsert())
+	assert.NoError(t, repoRef.Upsert(t.Context()))
 	u := &user.DBUser{Id: "me"}
 
 	assert.NoError(t, u.Insert())
@@ -1245,7 +1245,7 @@ func TestDetachFromRepo(t *testing.T) {
 					{ID: "my_build"},
 				},
 			}}
-			assert.NoError(t, repoRef.Upsert())
+			assert.NoError(t, repoRef.Upsert(t.Context()))
 
 			pVars := &ProjectVars{
 				Id: pRef.Id,
@@ -1302,7 +1302,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 					Enabled: false,
 				},
 			}
-			assert.NoError(t, repoRef.Upsert())
+			assert.NoError(t, repoRef.Upsert(t.Context()))
 			assert.NoError(t, DefaultSectionToRepo(t.Context(), id, ProjectPageGeneralSection, "me"))
 
 			pRefFromDb, err := FindBranchProjectRef(t.Context(), id)
@@ -1497,7 +1497,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 					Id: pRef.RepoRefId,
 				},
 			}
-			assert.NoError(t, repoRef.Upsert())
+			assert.NoError(t, repoRef.Upsert(t.Context()))
 
 			pVars := ProjectVars{
 				Id:          pRef.Id,
@@ -1680,7 +1680,7 @@ func TestGetGitHubProjectConflicts(t *testing.T) {
 	r9 := &RepoRef{
 		ProjectRef: *p9,
 	}
-	require.NoError(r9.Upsert())
+	require.NoError(r9.Upsert(t.Context()))
 	p10 := &ProjectRef{
 		Owner:     "mongodb",
 		Repo:      "mci4",
@@ -2328,7 +2328,7 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 		Repo:       "mci",
 		RemotePath: "",
 	}}
-	assert.NoError(repoDoc.Upsert())
+	assert.NoError(repoDoc.Upsert(t.Context()))
 	doc = &ProjectRef{
 		Id:        "defaulting_project",
 		Owner:     "mongodb",
@@ -2356,7 +2356,7 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 	assert.Nil(projectRef)
 
 	repoDoc.PRTestingEnabled = utility.TruePtr()
-	assert.NoError(repoDoc.Upsert())
+	assert.NoError(repoDoc.Upsert(t.Context()))
 	projectRef, err = FindOneProjectRefByRepoAndBranchWithPRTesting(t.Context(), "mongodb", "mci", "mine", "")
 	assert.NoError(err)
 	require.NotNil(projectRef)
@@ -2406,7 +2406,7 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 
 	// project explicitly disabled
 	repoDoc.RemotePath = "my_path"
-	assert.NoError(repoDoc.Upsert())
+	assert.NoError(repoDoc.Upsert(t.Context()))
 	doc.Enabled = false
 	doc.PRTestingEnabled = utility.TruePtr()
 	assert.NoError(doc.Upsert(t.Context()))
@@ -2416,13 +2416,13 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 
 	// branch with no project doesn't work and returns an error if repo not configured with a remote path
 	repoDoc.RemotePath = ""
-	assert.NoError(repoDoc.Upsert())
+	assert.NoError(repoDoc.Upsert(t.Context()))
 	projectRef, err = FindOneProjectRefByRepoAndBranchWithPRTesting(t.Context(), "mongodb", "mci", "yours", "")
 	assert.Error(err)
 	assert.Nil(projectRef)
 
 	repoDoc.RemotePath = "my_path"
-	assert.NoError(repoDoc.Upsert())
+	assert.NoError(repoDoc.Upsert(t.Context()))
 	projectRef, err = FindOneProjectRefByRepoAndBranchWithPRTesting(t.Context(), "mongodb", "mci", "yours", "")
 	assert.NoError(err)
 	require.NotNil(projectRef)
@@ -3398,7 +3398,7 @@ func TestUpdateNextPeriodicBuild(t *testing.T) {
 				},
 			}}
 			assert.NoError(p.Insert())
-			assert.NoError(repoRef.Upsert())
+			assert.NoError(repoRef.Upsert(t.Context()))
 
 			assert.NoError(UpdateNextPeriodicBuild(t.Context(), "proj", &p.PeriodicBuilds[1]))
 			dbProject, err := FindBranchProjectRef(t.Context(), p.Id)
@@ -3442,7 +3442,7 @@ func TestUpdateNextPeriodicBuild(t *testing.T) {
 				},
 			}}
 			assert.NoError(p.Insert())
-			assert.NoError(repoRef.Upsert())
+			assert.NoError(repoRef.Upsert(t.Context()))
 			assert.NoError(UpdateNextPeriodicBuild(t.Context(), "proj", &repoRef.PeriodicBuilds[0]))
 
 			// Repo is updated because the branch project doesn't have any periodic build override defined.
@@ -3464,7 +3464,7 @@ func TestUpdateNextPeriodicBuild(t *testing.T) {
 				},
 			}}
 			assert.NoError(p.Insert())
-			assert.NoError(repoRef.Upsert())
+			assert.NoError(repoRef.Upsert(t.Context()))
 			// Should error because definition isn't relevant for this project, since
 			// we ignore repo definitions when the project has any override defined.
 			assert.Error(UpdateNextPeriodicBuild(t.Context(), "proj", &repoRef.PeriodicBuilds[0]))
@@ -3494,7 +3494,7 @@ func TestUpdateNextPeriodicBuild(t *testing.T) {
 				},
 			}}
 			assert.NoError(p.Insert())
-			assert.NoError(repoRef.Upsert())
+			assert.NoError(repoRef.Upsert(t.Context()))
 
 			assert.NoError(UpdateNextPeriodicBuild(t.Context(), "proj", &p.PeriodicBuilds[0]))
 			dbProject, err := FindBranchProjectRef(t.Context(), p.Id)
@@ -3566,7 +3566,7 @@ func TestFindPeriodicProjects(t *testing.T) {
 		Id:             "my_repo",
 		PeriodicBuilds: []PeriodicBuildDefinition{{ID: "repo_def"}},
 	}}
-	assert.NoError(t, repoRef.Upsert())
+	assert.NoError(t, repoRef.Upsert(t.Context()))
 
 	pRef := ProjectRef{
 		Id:             "p1",
@@ -3628,9 +3628,9 @@ func TestRemoveAdminFromProjects(t *testing.T) {
 	assert.NoError(t, pRef.Upsert(t.Context()))
 	assert.NoError(t, pRef2.Upsert(t.Context()))
 	assert.NoError(t, pRef3.Upsert(t.Context()))
-	assert.NoError(t, repoRef.Upsert())
-	assert.NoError(t, repoRef2.Upsert())
-	assert.NoError(t, repoRef3.Upsert())
+	assert.NoError(t, repoRef.Upsert(t.Context()))
+	assert.NoError(t, repoRef2.Upsert(t.Context()))
+	assert.NoError(t, repoRef3.Upsert(t.Context()))
 
 	assert.NoError(t, RemoveAdminFromProjects(t.Context(), "villain"))
 

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1103,10 +1103,10 @@ func TestDetachFromRepo(t *testing.T) {
 		"PatchAliases": func(t *testing.T, pRef *ProjectRef, dbUser *user.DBUser) {
 			// no patch aliases are copied if the project has a patch alias
 			projectAlias := ProjectAlias{Alias: "myProjectAlias", ProjectID: pRef.Id}
-			assert.NoError(t, projectAlias.Upsert())
+			assert.NoError(t, projectAlias.Upsert(t.Context()))
 
 			repoAlias := ProjectAlias{Alias: "myRepoAlias", ProjectID: pRef.RepoRefId}
-			assert.NoError(t, repoAlias.Upsert())
+			assert.NoError(t, repoAlias.Upsert(t.Context()))
 
 			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 			checkRepoAttachmentEventLog(t, *pRef, event.EventTypeProjectDetachedFromRepo)
@@ -1132,12 +1132,12 @@ func TestDetachFromRepo(t *testing.T) {
 				{Alias: evergreen.GitTagAlias, Variant: "projectVariant"},
 				{Alias: evergreen.CommitQueueAlias},
 			}
-			assert.NoError(t, UpsertAliasesForProject(projectAliases, pRef.Id))
+			assert.NoError(t, UpsertAliasesForProject(t.Context(), projectAliases, pRef.Id))
 			repoAliases := []ProjectAlias{
 				{Alias: evergreen.GitTagAlias, Variant: "repoVariant"},
 				{Alias: evergreen.GithubPRAlias},
 			}
-			assert.NoError(t, UpsertAliasesForProject(repoAliases, pRef.RepoRefId))
+			assert.NoError(t, UpsertAliasesForProject(t.Context(), repoAliases, pRef.RepoRefId))
 
 			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 			checkRepoAttachmentEventLog(t, *pRef, event.EventTypeProjectDetachedFromRepo)
@@ -1177,7 +1177,7 @@ func TestDetachFromRepo(t *testing.T) {
 					Target: "a@domain.invalid",
 				},
 			}
-			assert.NoError(t, projectSubscription.Upsert())
+			assert.NoError(t, projectSubscription.Upsert(t.Context()))
 			repoSubscription := event.Subscription{
 				Owner:        pRef.RepoRefId,
 				OwnerType:    event.OwnerTypeProject,
@@ -1191,7 +1191,7 @@ func TestDetachFromRepo(t *testing.T) {
 					Target: "a@domain.invalid",
 				},
 			}
-			assert.NoError(t, repoSubscription.Upsert())
+			assert.NoError(t, repoSubscription.Upsert(t.Context()))
 			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 			checkRepoAttachmentEventLog(t, *pRef, event.EventTypeProjectDetachedFromRepo)
 
@@ -1545,7 +1545,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 				},
 			}
 			for _, a := range aliases {
-				assert.NoError(t, a.Upsert())
+				assert.NoError(t, a.Upsert(t.Context()))
 			}
 			test(t, pRef.Id)
 		})
@@ -1962,7 +1962,7 @@ func TestCreateNewRepoRef(t *testing.T) {
 		},
 	}
 	for _, a := range projectAliases {
-		assert.NoError(t, a.Upsert())
+		assert.NoError(t, a.Upsert(t.Context()))
 	}
 	u := user.DBUser{Id: "me"}
 	assert.NoError(t, u.Insert())

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -157,13 +157,13 @@ func TestFindMergedProjectRef(t *testing.T) {
 	// Assert that mergeParsleyFilters correctly handles projects with repo filters but not project filters.
 	projectRef.ParsleyFilters = []parsley.Filter{}
 
-	assert.NoError(t, projectRef.Upsert())
+	assert.NoError(t, projectRef.Upsert(t.Context()))
 	mergedProject, err = FindMergedProjectRef(t.Context(), "ident", "ident", true)
 	assert.NoError(t, err)
 	assert.Len(t, mergedProject.ParsleyFilters, 1)
 
 	projectRef.ParsleyFilters = nil
-	assert.NoError(t, projectRef.Upsert())
+	assert.NoError(t, projectRef.Upsert(t.Context()))
 	mergedProject, err = FindMergedProjectRef(t.Context(), "ident", "ident", true)
 	assert.NoError(t, err)
 	assert.Len(t, mergedProject.ParsleyFilters, 1)
@@ -2365,7 +2365,7 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 	// project PR testing explicitly disabled
 	doc.PRTestingEnabled = utility.FalsePtr()
 	doc.ManualPRTestingEnabled = utility.FalsePtr()
-	assert.NoError(doc.Upsert())
+	assert.NoError(doc.Upsert(t.Context()))
 	projectRef, err = FindOneProjectRefByRepoAndBranchWithPRTesting(t.Context(), "mongodb", "mci", "mine", "")
 	assert.NoError(err)
 	assert.Nil(projectRef)
@@ -2379,7 +2379,7 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 	// project auto PR testing enabled, manual disabled
 	doc.PRTestingEnabled = utility.TruePtr()
 	doc.ManualPRTestingEnabled = utility.FalsePtr()
-	assert.NoError(doc.Upsert())
+	assert.NoError(doc.Upsert(t.Context()))
 	projectRef, err = FindOneProjectRefByRepoAndBranchWithPRTesting(t.Context(), "mongodb", "mci", "mine", "")
 	assert.NoError(err)
 	assert.NotNil(projectRef)
@@ -2393,7 +2393,7 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 	// project auto PR testing disabled, manual enabled
 	doc.PRTestingEnabled = utility.FalsePtr()
 	doc.ManualPRTestingEnabled = utility.TruePtr()
-	assert.NoError(doc.Upsert())
+	assert.NoError(doc.Upsert(t.Context()))
 	projectRef, err = FindOneProjectRefByRepoAndBranchWithPRTesting(t.Context(), "mongodb", "mci", "mine", "")
 	assert.NoError(err)
 	assert.NotNil(projectRef)
@@ -2409,7 +2409,7 @@ func TestFindOneProjectRefByRepoAndBranchWithPRTesting(t *testing.T) {
 	assert.NoError(repoDoc.Upsert())
 	doc.Enabled = false
 	doc.PRTestingEnabled = utility.TruePtr()
-	assert.NoError(doc.Upsert())
+	assert.NoError(doc.Upsert(t.Context()))
 	projectRef, err = FindOneProjectRefByRepoAndBranchWithPRTesting(t.Context(), "mongodb", "mci", "mine", "")
 	assert.NoError(err)
 	assert.Nil(projectRef)
@@ -2470,7 +2470,7 @@ func TestFindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(t *testing.T) {
 
 	// doc doesn't default to repo
 	doc.CommitQueue.Enabled = utility.FalsePtr()
-	assert.NoError(doc.Upsert())
+	assert.NoError(doc.Upsert(t.Context()))
 	projectRef, err = FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(t.Context(), "mongodb", "mci", "not_main")
 	assert.NoError(err)
 	assert.Nil(projectRef)
@@ -3625,9 +3625,9 @@ func TestRemoveAdminFromProjects(t *testing.T) {
 		Id: "adminless_repo",
 	}}
 
-	assert.NoError(t, pRef.Upsert())
-	assert.NoError(t, pRef2.Upsert())
-	assert.NoError(t, pRef3.Upsert())
+	assert.NoError(t, pRef.Upsert(t.Context()))
+	assert.NoError(t, pRef2.Upsert(t.Context()))
+	assert.NoError(t, pRef3.Upsert(t.Context()))
 	assert.NoError(t, repoRef.Upsert())
 	assert.NoError(t, repoRef2.Upsert())
 	assert.NoError(t, repoRef3.Upsert())

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1257,7 +1257,7 @@ func TestDetachFromRepo(t *testing.T) {
 					"in": true,
 				},
 			}
-			_, err := pVars.Upsert()
+			_, err := pVars.Upsert(t.Context())
 			assert.NoError(t, err)
 
 			dbProjRef, err := FindBranchProjectRef(t.Context(), pRef.Id)
@@ -1274,7 +1274,7 @@ func TestDetachFromRepo(t *testing.T) {
 					"repo": true,
 				},
 			}
-			_, err = repoVars.Upsert()
+			_, err = repoVars.Upsert(t.Context())
 			assert.NoError(t, err)
 
 			dbRepoRef, err := FindOneRepoRef(t.Context(), repoRef.Id)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -317,10 +317,10 @@ func TestGetNumberOfEnabledProjects(t *testing.T) {
 	}
 	assert.NoError(t, disabled2.Insert())
 
-	enabledProjects, err := GetNumberOfEnabledProjects()
+	enabledProjects, err := GetNumberOfEnabledProjects(t.Context())
 	assert.NoError(t, err)
 	assert.Equal(t, 2, enabledProjects)
-	enabledProjectsOwnerRepo, err := GetNumberOfEnabledProjectsForOwnerRepo(enabled2.Owner, enabled2.Repo)
+	enabledProjectsOwnerRepo, err := GetNumberOfEnabledProjectsForOwnerRepo(t.Context(), enabled2.Owner, enabled2.Repo)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, enabledProjectsOwnerRepo)
 }
@@ -391,7 +391,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 	disabled1.Enabled = true
 	original, err := FindMergedProjectRef(t.Context(), disabled1.Id, "", false)
 	assert.NoError(t, err)
-	statusCode, err := ValidateEnabledProjectsLimit(disabled1.Id, &settings, original, disabled1)
+	statusCode, err := ValidateEnabledProjectsLimit(t.Context(), disabled1.Id, &settings, original, disabled1)
 	assert.Error(t, err)
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 
@@ -404,7 +404,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 	}
 	original, err = FindMergedProjectRef(t.Context(), exception.Id, "", false)
 	assert.NoError(t, err)
-	_, err = ValidateEnabledProjectsLimit(enabled1.Id, &settings, original, exception)
+	_, err = ValidateEnabledProjectsLimit(t.Context(), enabled1.Id, &settings, original, exception)
 	assert.NoError(t, err)
 
 	// Should error if owner/repo is not part of exception.
@@ -416,7 +416,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 	}
 	original, err = FindMergedProjectRef(t.Context(), notException.Id, "", false)
 	assert.NoError(t, err)
-	statusCode, err = ValidateEnabledProjectsLimit(notException.Id, &settings, original, notException)
+	statusCode, err = ValidateEnabledProjectsLimit(t.Context(), notException.Id, &settings, original, notException)
 	assert.Error(t, err)
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 
@@ -427,7 +427,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 	assert.NoError(t, err)
 	original, err = FindMergedProjectRef(t.Context(), disabledByRepo.Id, "", false)
 	assert.NoError(t, err)
-	_, err = ValidateEnabledProjectsLimit(disabledByRepo.Id, &settings, original, mergedRef)
+	_, err = ValidateEnabledProjectsLimit(t.Context(), disabledByRepo.Id, &settings, original, mergedRef)
 	assert.NoError(t, err)
 
 	// Should error on enabled if you try to change owner/repo past limit.
@@ -435,7 +435,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 	enabled2.Repo = "mci"
 	original, err = FindMergedProjectRef(t.Context(), enabled2.Id, "", false)
 	assert.NoError(t, err)
-	statusCode, err = ValidateEnabledProjectsLimit(enabled2.Id, &settings, original, enabled2)
+	statusCode, err = ValidateEnabledProjectsLimit(t.Context(), enabled2.Id, &settings, original, enabled2)
 	assert.Error(t, err)
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 
@@ -443,7 +443,7 @@ func TestValidateEnabledProjectsLimit(t *testing.T) {
 	settings.ProjectCreation.TotalProjectLimit = 2
 	original, err = FindMergedProjectRef(t.Context(), exception.Id, "", false)
 	assert.NoError(t, err)
-	statusCode, err = ValidateEnabledProjectsLimit(exception.Id, &settings, original, exception)
+	statusCode, err = ValidateEnabledProjectsLimit(t.Context(), exception.Id, &settings, original, exception)
 	assert.Error(t, err)
 	assert.Equal(t, http.StatusBadRequest, statusCode)
 }
@@ -3105,7 +3105,7 @@ func TestFindDownstreamProjects(t *testing.T) {
 	}
 	require.NoError(t, proj2.Insert())
 
-	projects, err := FindDownstreamProjects("grip")
+	projects, err := FindDownstreamProjects(t.Context(), "grip")
 	assert.NoError(t, err)
 	assert.Len(t, projects, 1)
 	assert.Equal(t, proj1, projects[0])

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -645,7 +645,7 @@ func (s *projectSuite) SetupTest() {
 		},
 	}
 	for _, alias := range s.aliases {
-		s.NoError(alias.Upsert())
+		s.NoError(alias.Upsert(s.T().Context()))
 	}
 	s.project = &Project{
 		Identifier: pRef.Id,
@@ -2066,7 +2066,7 @@ func TestVariantTasksForSelectors(t *testing.T) {
 		Variant:   "bv0",
 		Task:      "t0",
 	}
-	require.NoError(t, patchAlias.Upsert())
+	require.NoError(t, patchAlias.Upsert(t.Context()))
 
 	project := Project{
 		Identifier: projectID,

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1678,7 +1678,7 @@ func TestFindProjectsSuite(t *testing.T) {
 		repoWithVars := &RepoRef{ProjectRef{
 			Id: repoProjectId,
 		}}
-		s.Require().NoError(repoWithVars.Upsert())
+		s.Require().NoError(repoWithVars.Upsert(t.Context()))
 		repoVars := &ProjectVars{
 			Id:          repoProjectId,
 			Vars:        map[string]string{"a": "a_from_repo", "c": "new"},

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1678,7 +1678,7 @@ func TestFindProjectsSuite(t *testing.T) {
 		repoWithVars := &RepoRef{ProjectRef{
 			Id: repoProjectId,
 		}}
-		s.Require().NoError(repoWithVars.Upsert(t.Context()))
+		s.Require().NoError(repoWithVars.Replace(t.Context()))
 		repoVars := &ProjectVars{
 			Id:          repoProjectId,
 			Vars:        map[string]string{"a": "a_from_repo", "c": "new"},

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -315,7 +315,7 @@ func (projectVars *ProjectVars) Upsert(ctx context.Context) (*adb.ChangeInfo, er
 	}
 	update["$set"] = setUpdate
 
-	return db.UpsertContext(
+	return db.Upsert(
 		ctx,
 		ProjectVarsCollection,
 		bson.M{

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -43,7 +43,7 @@ func TestFindOneProjectVar(t *testing.T) {
 		Id:   pRef.Id,
 		Vars: vars,
 	}
-	change, err := projectVars.Upsert()
+	change, err := projectVars.Upsert(t.Context())
 	assert.NotNil(change)
 	assert.NoError(err)
 	assert.Equal(1, change.Updated, "%+v", change)
@@ -312,21 +312,21 @@ func TestProjectVarsUpsert(t *testing.T) {
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, pRef ProjectRef, vars ProjectVars){
 		"InsertsNewVars": func(ctx context.Context, t *testing.T, pRef ProjectRef, vars ProjectVars) {
 			require.NoError(t, pRef.Insert())
-			_, err := vars.Upsert()
+			_, err := vars.Upsert(t.Context())
 			require.NoError(t, err)
 
 			checkProjectVars(t, vars)
 		},
 		"UpdatesExistingVars": func(ctx context.Context, t *testing.T, pRef ProjectRef, vars ProjectVars) {
 			require.NoError(t, pRef.Insert())
-			_, err := vars.Upsert()
+			_, err := vars.Upsert(t.Context())
 			require.NoError(t, err)
 
 			checkProjectVars(t, vars)
 
 			vars.Vars["c"] = "3"
 			delete(vars.Vars, "a")
-			_, err = vars.Upsert()
+			_, err = vars.Upsert(t.Context())
 			require.NoError(t, err)
 
 			dbProjVars, err := FindOneProjectVars(t.Context(), vars.Id)
@@ -350,7 +350,7 @@ func TestProjectVarsUpsert(t *testing.T) {
 		"CreatesNewVarsForSeparateProject": func(ctx context.Context, t *testing.T, pRef ProjectRef, vars ProjectVars) {
 			oldProjectID := vars.Id
 			require.NoError(t, pRef.Insert())
-			_, err := vars.Upsert()
+			_, err := vars.Upsert(t.Context())
 			require.NoError(t, err)
 
 			checkProjectVars(t, vars)
@@ -632,7 +632,7 @@ func TestAWSVars(t *testing.T) {
 		Vars:        vars,
 		PrivateVars: privateVars,
 	}
-	_, err = projectVars.Upsert()
+	_, err = projectVars.Upsert(t.Context()t.Context())
 	assert.NoError(err)
 
 	// canaries

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -68,7 +68,7 @@ func TestFindMergedProjectVars(t *testing.T) {
 		Owner: "mongodb",
 		Repo:  "test_repo",
 	}}
-	require.NoError(t, repo.Upsert(t.Context()))
+	require.NoError(t, repo.Replace(t.Context()))
 
 	project0 := ProjectRef{
 		Id:        "project_0",

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -68,7 +68,7 @@ func TestFindMergedProjectVars(t *testing.T) {
 		Owner: "mongodb",
 		Repo:  "test_repo",
 	}}
-	require.NoError(t, repo.Upsert())
+	require.NoError(t, repo.Upsert(t.Context()))
 
 	project0 := ProjectRef{
 		Id:        "project_0",
@@ -632,7 +632,7 @@ func TestAWSVars(t *testing.T) {
 		Vars:        vars,
 		PrivateVars: privateVars,
 	}
-	_, err = projectVars.Upsert(t.Context()t.Context())
+	_, err = projectVars.Upsert(t.Context())
 	assert.NoError(err)
 
 	// canaries

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -162,7 +162,7 @@ func TestFindMergedProjectVars(t *testing.T) {
 
 	// Testing ProjectRef.RepoRefId == ""
 	project0.RepoRefId = ""
-	require.NoError(t, project0.Upsert())
+	require.NoError(t, project0.Upsert(t.Context()))
 	mergedVars, err = FindMergedProjectVars(t.Context(), project0.Id)
 	assert.NoError(err)
 	require.NotZero(t, mergedVars)

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -162,7 +162,7 @@ func TestFindMergedProjectVars(t *testing.T) {
 
 	// Testing ProjectRef.RepoRefId == ""
 	project0.RepoRefId = ""
-	require.NoError(t, project0.Upsert(t.Context()))
+	require.NoError(t, project0.Replace(t.Context()))
 	mergedVars, err = FindMergedProjectVars(t.Context(), project0.Id)
 	assert.NoError(err)
 	require.NotZero(t, mergedVars)

--- a/model/reliability/db.go
+++ b/model/reliability/db.go
@@ -19,6 +19,7 @@ package reliability
 // See taskstats.db.go for details on the structure of the backing daily_task_stats collection.
 
 import (
+	"context"
 	"time"
 
 	"github.com/evergreen-ci/evergreen/db"
@@ -186,8 +187,8 @@ func (filter TaskReliabilityFilter) taskReliabilityQueryPipeline() []bson.M {
 }
 
 // GetTaskStats create an aggregation to find task stats matching the filter state.
-func (filter TaskReliabilityFilter) GetTaskStats() (taskStats []taskstats.TaskStats, err error) {
+func (filter TaskReliabilityFilter) GetTaskStats(ctx context.Context) (taskStats []taskstats.TaskStats, err error) {
 	pipeline := filter.taskReliabilityQueryPipeline()
-	err = db.Aggregate(taskstats.DailyTaskStatsCollection, pipeline, &taskStats)
+	err = db.Aggregate(ctx, taskstats.DailyTaskStatsCollection, pipeline, &taskStats)
 	return
 }

--- a/model/reliability/query.go
+++ b/model/reliability/query.go
@@ -1,6 +1,7 @@
 package reliability
 
 import (
+	"context"
 	"math"
 	"time"
 
@@ -154,12 +155,12 @@ func significanceToZ(significance float64) float64 {
 // GetTaskReliabilityScores queries the precomputed task statistics using a filter and then calculates
 // the success reliability score from the lower bound wilson confidence interval.
 // https://en.wikipedia.org/wiki/Binomial_proportion_confidence_interval#Wilson_score_interval.
-func GetTaskReliabilityScores(filter TaskReliabilityFilter) ([]TaskReliability, error) {
+func GetTaskReliabilityScores(ctx context.Context, filter TaskReliabilityFilter) ([]TaskReliability, error) {
 	err := filter.ValidateForTaskReliability()
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid stats filter")
 	}
-	taskStats, err := filter.GetTaskStats()
+	taskStats, err := filter.GetTaskStats(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "aggregating task statistics")
 	}

--- a/model/reliability/query_test.go
+++ b/model/reliability/query_test.go
@@ -311,7 +311,7 @@ func TestGetTaskStatsEmptyCollection(t *testing.T) {
 
 	filter := createValidFilter()
 
-	docs, err := GetTaskReliabilityScores(filter)
+	docs, err := GetTaskReliabilityScores(t.Context(), filter)
 	require.NoError(err)
 	require.Empty(docs)
 }
@@ -326,7 +326,7 @@ func TestGetTaskStatsOneDocument(t *testing.T) {
 
 	require.NoError(InsertDailyTaskStats(task1Item1))
 
-	docs, err := GetTaskReliabilityScores(filter)
+	docs, err := GetTaskReliabilityScores(t.Context(), filter)
 	require.NoError(err)
 	require.Len(docs, 1)
 	//nolint:testifylint // We expect it to be exactly 0.42.
@@ -342,7 +342,7 @@ func TestGetTaskStatsTwoDocuments(t *testing.T) {
 	require.NoError(err)
 
 	require.NoError(InsertDailyTaskStats(task1Item1, task1Item2))
-	docs, err := GetTaskReliabilityScores(filter)
+	docs, err := GetTaskReliabilityScores(t.Context(), filter)
 	require.NoError(err)
 	require.Len(docs, 2)
 	//nolint:testifylint // We expect it to be exactly equal.
@@ -378,7 +378,7 @@ func TestGetTaskReliability(t *testing.T) {
 					require := require.New(t)
 					withCancelledContext(ctx, func(ctx context.Context) {
 						filter.StatsFilter.Tasks = []string{"this won't match anything"}
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Empty(docs)
 					})
@@ -389,7 +389,7 @@ func TestGetTaskReliability(t *testing.T) {
 						filter.StatsFilter.Tasks = []string{task1}
 						filter.StatsFilter.BuildVariants = []string{variant2}
 						filter.StatsFilter.Distros = []string{distro2}
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Empty(docs)
 					})
@@ -400,7 +400,7 @@ func TestGetTaskReliability(t *testing.T) {
 						filter.StatsFilter.Tasks = []string{task2}
 						filter.StatsFilter.BuildVariants = []string{variant1}
 						filter.StatsFilter.Distros = []string{distro1}
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Empty(docs)
 					})
@@ -411,7 +411,7 @@ func TestGetTaskReliability(t *testing.T) {
 						filter.StatsFilter.Tasks = []string{task1}
 						filter.StatsFilter.BuildVariants = []string{variant1, variant2}
 						filter.StatsFilter.Distros = []string{distro1, distro2}
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, 2)
 						for _, doc := range docs {
@@ -427,7 +427,7 @@ func TestGetTaskReliability(t *testing.T) {
 						filter.StatsFilter.Tasks = []string{task2}
 						filter.StatsFilter.BuildVariants = []string{variant1, variant2}
 						filter.StatsFilter.Distros = []string{distro1, distro2}
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, 2)
 						for _, doc := range docs {
@@ -441,7 +441,7 @@ func TestGetTaskReliability(t *testing.T) {
 					require := require.New(t)
 					withCancelledContext(ctx, func(ctx context.Context) {
 						filter.StatsFilter.Tasks = []string{task1, task2}
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.NotEmpty(docs)
 					})
@@ -454,7 +454,7 @@ func TestGetTaskReliability(t *testing.T) {
 						filter.StatsFilter.Tasks = []string{task1, task2, task3}
 						filter.StatsFilter.BuildVariants = []string{}
 						filter.StatsFilter.Distros = []string{}
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, MaxQueryLimit)
 					})
@@ -614,7 +614,7 @@ func TestGetTaskReliabilityScores(t *testing.T) {
 				"1": func(ctx context.Context, t *testing.T, filter TaskReliabilityFilter) {
 					require := require.New(t)
 					withCancelledContext(ctx, func(ctx context.Context) {
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, 1)
 
@@ -628,7 +628,7 @@ func TestGetTaskReliabilityScores(t *testing.T) {
 					withCancelledContext(ctx, func(ctx context.Context) {
 						filter.StatsFilter.GroupNumDays = 2
 						filter.StatsFilter.BeforeDate = day2
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, 1)
 
@@ -642,7 +642,7 @@ func TestGetTaskReliabilityScores(t *testing.T) {
 					withCancelledContext(ctx, func(ctx context.Context) {
 						filter.StatsFilter.GroupNumDays = 7
 						filter.StatsFilter.BeforeDate = day1.Add(time.Duration(filter.StatsFilter.GroupNumDays-1) * 24 * time.Hour)
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, 1)
 
@@ -656,7 +656,7 @@ func TestGetTaskReliabilityScores(t *testing.T) {
 					withCancelledContext(ctx, func(ctx context.Context) {
 						filter.StatsFilter.GroupNumDays = 28
 						filter.StatsFilter.BeforeDate = day1.Add(time.Duration(filter.StatsFilter.GroupNumDays-1) * 24 * time.Hour)
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, 1)
 
@@ -683,7 +683,7 @@ func TestGetTaskReliabilityScores(t *testing.T) {
 						filter.StatsFilter.Sort = taskstats.SortLatestFirst
 						filter.StatsFilter.GroupNumDays = 1
 						filter.StatsFilter.BeforeDate = day1.Add(time.Duration(duration-1) * 24 * time.Hour)
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, duration)
 
@@ -705,7 +705,7 @@ func TestGetTaskReliabilityScores(t *testing.T) {
 						filter.StatsFilter.Sort = taskstats.SortEarliestFirst
 						filter.StatsFilter.GroupNumDays = 1
 						filter.StatsFilter.BeforeDate = day1.Add(time.Duration(duration-1) * 24 * time.Hour)
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, duration)
 
@@ -734,7 +734,7 @@ func TestGetTaskReliabilityScores(t *testing.T) {
 				"1 Day": func(ctx context.Context, t *testing.T, filter TaskReliabilityFilter) {
 					require := require.New(t)
 					withCancelledContext(ctx, func(ctx context.Context) {
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, 1)
 
@@ -748,7 +748,7 @@ func TestGetTaskReliabilityScores(t *testing.T) {
 					withCancelledContext(ctx, func(ctx context.Context) {
 						filter.StatsFilter.GroupNumDays = 1
 						filter.StatsFilter.BeforeDate = day2
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, 2)
 
@@ -765,7 +765,7 @@ func TestGetTaskReliabilityScores(t *testing.T) {
 					withCancelledContext(ctx, func(ctx context.Context) {
 						filter.StatsFilter.GroupNumDays = 1
 						filter.StatsFilter.BeforeDate = day1.Add(6 * 24 * time.Hour)
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, 7)
 
@@ -785,7 +785,7 @@ func TestGetTaskReliabilityScores(t *testing.T) {
 					withCancelledContext(ctx, func(ctx context.Context) {
 						filter.StatsFilter.GroupNumDays = 1
 						filter.StatsFilter.BeforeDate = day1.Add(27 * 24 * time.Hour)
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, 28)
 
@@ -805,7 +805,7 @@ func TestGetTaskReliabilityScores(t *testing.T) {
 					withCancelledContext(ctx, func(ctx context.Context) {
 						filter.StatsFilter.GroupNumDays = 56
 						filter.StatsFilter.BeforeDate = day1.Add(time.Duration(filter.StatsFilter.GroupNumDays-1) * 24 * time.Hour)
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, 1)
 
@@ -830,7 +830,7 @@ func TestGetTaskReliabilityScores(t *testing.T) {
 				"1 Day / Group 1": func(ctx context.Context, t *testing.T, filter TaskReliabilityFilter) {
 					require := require.New(t)
 					withCancelledContext(ctx, func(ctx context.Context) {
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, 1)
 
@@ -847,7 +847,7 @@ func TestGetTaskReliabilityScores(t *testing.T) {
 						filter.StatsFilter.Sort = taskstats.SortLatestFirst
 						filter.StatsFilter.GroupNumDays = 1
 						filter.StatsFilter.BeforeDate = day1.Add(time.Duration(duration-1) * 24 * time.Hour)
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, duration)
 
@@ -870,7 +870,7 @@ func TestGetTaskReliabilityScores(t *testing.T) {
 						filter.StatsFilter.Sort = taskstats.SortEarliestFirst
 						filter.StatsFilter.GroupNumDays = 1
 						filter.StatsFilter.BeforeDate = day1.Add(time.Duration(duration-1) * 24 * time.Hour)
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, duration)
 
@@ -892,7 +892,7 @@ func TestGetTaskReliabilityScores(t *testing.T) {
 						duration := 28
 						filter.StatsFilter.GroupNumDays = 1
 						filter.StatsFilter.BeforeDate = day1.Add(time.Duration(duration-1) * 24 * time.Hour)
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, duration)
 
@@ -913,7 +913,7 @@ func TestGetTaskReliabilityScores(t *testing.T) {
 					withCancelledContext(ctx, func(ctx context.Context) {
 						filter.StatsFilter.GroupNumDays = 28
 						filter.StatsFilter.BeforeDate = day1.Add(time.Duration(filter.StatsFilter.GroupNumDays-1) * 24 * time.Hour)
-						docs, err := GetTaskReliabilityScores(filter)
+						docs, err := GetTaskReliabilityScores(t.Context(), filter)
 						require.NoError(err)
 						require.Len(docs, 1)
 

--- a/model/repo_ref.go
+++ b/model/repo_ref.go
@@ -34,7 +34,7 @@ var (
 )
 
 func (r *RepoRef) Add(ctx context.Context, creator *user.DBUser) error {
-	if err := r.Upsert(); err != nil {
+	if err := r.Upsert(ctx); err != nil {
 		return errors.Wrap(err, "upserting repo ref")
 	}
 	return r.addPermissions(ctx, creator)
@@ -48,10 +48,11 @@ func (r *RepoRef) Insert() error {
 // Upsert updates the project ref in the db if an entry already exists,
 // overwriting the existing ref. If no project ref exists, one is created.
 // Ensures that fields that aren't relevant to repos aren't set.
-func (r *RepoRef) Upsert() error {
+func (r *RepoRef) Upsert(ctx context.Context) error {
 	r.RepoRefId = ""
 	r.Branch = ""
-	_, err := db.Upsert(
+	_, err := db.UpsertContext(
+		ctx,
 		RepoRefCollection,
 		bson.M{
 			RepoRefIdKey: r.Id,

--- a/model/repo_ref.go
+++ b/model/repo_ref.go
@@ -51,7 +51,7 @@ func (r *RepoRef) Insert() error {
 func (r *RepoRef) Upsert(ctx context.Context) error {
 	r.RepoRefId = ""
 	r.Branch = ""
-	_, err := db.UpsertContext(
+	_, err := db.Upsert(
 		ctx,
 		RepoRefCollection,
 		bson.M{

--- a/model/repo_ref.go
+++ b/model/repo_ref.go
@@ -34,7 +34,7 @@ var (
 )
 
 func (r *RepoRef) Add(ctx context.Context, creator *user.DBUser) error {
-	if err := r.Upsert(ctx); err != nil {
+	if err := r.Replace(ctx); err != nil {
 		return errors.Wrap(err, "upserting repo ref")
 	}
 	return r.addPermissions(ctx, creator)
@@ -45,13 +45,13 @@ func (r *RepoRef) Insert() error {
 	return errors.New("insert not supported for repoRef")
 }
 
-// Upsert updates the project ref in the db if an entry already exists,
+// Replace updates the project ref in the db if an entry already exists,
 // overwriting the existing ref. If no project ref exists, one is created.
 // Ensures that fields that aren't relevant to repos aren't set.
-func (r *RepoRef) Upsert(ctx context.Context) error {
+func (r *RepoRef) Replace(ctx context.Context) error {
 	r.RepoRefId = ""
 	r.Branch = ""
-	_, err := db.Upsert(
+	_, err := db.ReplaceContext(
 		ctx,
 		RepoRefCollection,
 		bson.M{

--- a/model/repo_ref_test.go
+++ b/model/repo_ref_test.go
@@ -20,7 +20,7 @@ func TestRepoRefUpdateAdminRoles(t *testing.T) {
 	r := RepoRef{ProjectRef{
 		Id: "proj",
 	}}
-	require.NoError(t, r.Upsert(t.Context()))
+	require.NoError(t, r.Replace(t.Context()))
 	adminScope := gimlet.Scope{
 		ID:        "repo_scope",
 		Type:      evergreen.ProjectResourceType,

--- a/model/repo_ref_test.go
+++ b/model/repo_ref_test.go
@@ -20,7 +20,7 @@ func TestRepoRefUpdateAdminRoles(t *testing.T) {
 	r := RepoRef{ProjectRef{
 		Id: "proj",
 	}}
-	require.NoError(t, r.Upsert())
+	require.NoError(t, r.Upsert(t.Context()))
 	adminScope := gimlet.Scope{
 		ID:        "repo_scope",
 		Type:      evergreen.ProjectResourceType,

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1692,7 +1692,7 @@ func Aggregate(ctx context.Context, pipeline []bson.M, results any) error {
 
 // Count returns the number of tasks that satisfy the given query.
 func Count(ctx context.Context, query db.Q) (int, error) {
-	return db.CountQContext(ctx, Collection, query)
+	return db.CountQ(ctx, Collection, query)
 }
 
 func FindProjectForTask(ctx context.Context, taskID string) (string, error) {
@@ -2721,11 +2721,11 @@ func CountNumExecutionsForInterval(ctx context.Context, input NumExecutionsForIn
 	} else {
 		query[FinishTimeKey] = bson.M{"$gt": input.StartTime}
 	}
-	numTasks, err := db.CountContext(ctx, Collection, query)
+	numTasks, err := db.Count(ctx, Collection, query)
 	if err != nil {
 		return 0, errors.Wrap(err, "counting task executions")
 	}
-	numOldTasks, err := db.CountContext(ctx, OldCollection, query)
+	numOldTasks, err := db.Count(ctx, OldCollection, query)
 	if err != nil {
 		return 0, errors.Wrap(err, "counting old task executions")
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -929,7 +929,7 @@ func FindByExecutionTasksAndMaxExecution(ctx context.Context, taskIds []string, 
 		oldTaskPipeline = append(oldTaskPipeline, bson.M{"$replaceRoot": bson.M{"newRoot": "$root"}})
 
 		var oldTasks []Task
-		if err := db.Aggregate(OldCollection, oldTaskPipeline, &oldTasks); err != nil {
+		if err := db.Aggregate(ctx, OldCollection, oldTaskPipeline, &oldTasks); err != nil {
 			return nil, errors.Wrap(err, "finding old tasks")
 		}
 		tasks = append(tasks, oldTasks...)
@@ -1381,7 +1381,7 @@ func findOneOldByIdAndExecutionWithDisplayStatus(ctx context.Context, id string,
 		addDisplayStatus,
 	}
 
-	if err := db.AggregateContext(ctx, OldCollection, pipeline, &tasks); err != nil {
+	if err := db.Aggregate(ctx, OldCollection, pipeline, &tasks); err != nil {
 		return nil, errors.Wrap(err, "finding task")
 	}
 	if len(tasks) != 0 {
@@ -1684,7 +1684,7 @@ func Remove(ctx context.Context, id string) error {
 }
 
 func Aggregate(ctx context.Context, pipeline []bson.M, results any) error {
-	return db.AggregateContext(ctx,
+	return db.Aggregate(ctx,
 		Collection,
 		pipeline,
 		results)

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1692,7 +1692,7 @@ func Aggregate(ctx context.Context, pipeline []bson.M, results any) error {
 
 // Count returns the number of tasks that satisfy the given query.
 func Count(ctx context.Context, query db.Q) (int, error) {
-	return db.CountQ(Collection, query)
+	return db.CountQContext(ctx, Collection, query)
 }
 
 func FindProjectForTask(ctx context.Context, taskID string) (string, error) {

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2701,7 +2701,7 @@ type NumExecutionsForIntervalInput struct {
 	EndTime      time.Time
 }
 
-func CountNumExecutionsForInterval(input NumExecutionsForIntervalInput) (int, error) {
+func CountNumExecutionsForInterval(ctx context.Context, input NumExecutionsForIntervalInput) (int, error) {
 	query := bson.M{
 		ProjectKey:      input.ProjectId,
 		BuildVariantKey: input.BuildVarName,
@@ -2721,11 +2721,11 @@ func CountNumExecutionsForInterval(input NumExecutionsForIntervalInput) (int, er
 	} else {
 		query[FinishTimeKey] = bson.M{"$gt": input.StartTime}
 	}
-	numTasks, err := db.Count(Collection, query)
+	numTasks, err := db.CountContext(ctx, Collection, query)
 	if err != nil {
 		return 0, errors.Wrap(err, "counting task executions")
 	}
-	numOldTasks, err := db.Count(OldCollection, query)
+	numOldTasks, err := db.CountContext(ctx, OldCollection, query)
 	if err != nil {
 		return 0, errors.Wrap(err, "counting old task executions")
 	}

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -28,7 +28,7 @@ func checkStatuses(t *testing.T, expected string, toCheck Task) {
 		}},
 		addDisplayStatus,
 	}
-	err := db.Aggregate(Collection, aggregation, &dbTasks)
+	err := db.Aggregate(t.Context(), Collection, aggregation, &dbTasks)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, dbTasks[0].DisplayStatus)
 	assert.Equal(t, expected, toCheck.GetDisplayStatus())

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -1983,7 +1983,7 @@ func TestCountNumExecutionsForInterval(t *testing.T) {
 				StartTime:    time.Now().Add(-20 * time.Hour),
 				EndTime:      time.Now().Add(-18 * time.Hour),
 			}
-			numExecutions, err := CountNumExecutionsForInterval(input)
+			numExecutions, err := CountNumExecutionsForInterval(t.Context(), input)
 			assert.NoError(t, err)
 			assert.Equal(t, 0, numExecutions)
 		},
@@ -1995,7 +1995,7 @@ func TestCountNumExecutionsForInterval(t *testing.T) {
 				StartTime:    now.Add(-20 * time.Hour),
 			}
 			// Should include the finished tasks in both new and old.
-			numExecutions, err := CountNumExecutionsForInterval(input)
+			numExecutions, err := CountNumExecutionsForInterval(t.Context(), input)
 			assert.NoError(t, err)
 			assert.Equal(t, 6, numExecutions)
 		},
@@ -2007,7 +2007,7 @@ func TestCountNumExecutionsForInterval(t *testing.T) {
 				StartTime:    now.Add(-2 * time.Hour),
 			}
 			// Should include the finished tasks in both new and old except reallyEarly.
-			numExecutions, err := CountNumExecutionsForInterval(input)
+			numExecutions, err := CountNumExecutionsForInterval(t.Context(), input)
 			assert.NoError(t, err)
 			assert.Equal(t, 4, numExecutions)
 		},
@@ -2020,7 +2020,7 @@ func TestCountNumExecutionsForInterval(t *testing.T) {
 				StartTime:    now.Add(-2 * time.Hour),
 			}
 			// Should include the patch requester.
-			numExecutions, err := CountNumExecutionsForInterval(input)
+			numExecutions, err := CountNumExecutionsForInterval(t.Context(), input)
 			assert.NoError(t, err)
 			assert.Equal(t, 2, numExecutions)
 		},

--- a/model/task/task_annotations.go
+++ b/model/task/task_annotations.go
@@ -72,7 +72,8 @@ func AddIssueToAnnotation(ctx context.Context, taskId string, execution int, iss
 		Time:      time.Now(),
 		Requester: annotations.UIRequester,
 	}
-	if _, err := db.Upsert(
+	if _, err := db.UpsertContext(
+		ctx,
 		annotations.Collection,
 		annotations.ByTaskIdAndExecution(taskId, execution),
 		bson.M{
@@ -145,7 +146,8 @@ func UpsertAnnotation(ctx context.Context, a *annotations.TaskAnnotation, userDi
 	if len(update) == 0 {
 		return nil
 	}
-	if _, err := db.Upsert(
+	if _, err := db.UpsertContext(
+		ctx,
 		annotations.Collection,
 		annotations.ByTaskIdAndExecution(a.TaskId, a.TaskExecution),
 		bson.M{

--- a/model/task/task_annotations.go
+++ b/model/task/task_annotations.go
@@ -72,7 +72,7 @@ func AddIssueToAnnotation(ctx context.Context, taskId string, execution int, iss
 		Time:      time.Now(),
 		Requester: annotations.UIRequester,
 	}
-	if _, err := db.UpsertContext(
+	if _, err := db.Upsert(
 		ctx,
 		annotations.Collection,
 		annotations.ByTaskIdAndExecution(taskId, execution),
@@ -146,7 +146,7 @@ func UpsertAnnotation(ctx context.Context, a *annotations.TaskAnnotation, userDi
 	if len(update) == 0 {
 		return nil
 	}
-	if _, err := db.UpsertContext(
+	if _, err := db.Upsert(
 		ctx,
 		annotations.Collection,
 		annotations.ByTaskIdAndExecution(a.TaskId, a.TaskExecution),

--- a/model/task/task_annotations_test.go
+++ b/model/task/task_annotations_test.go
@@ -57,7 +57,7 @@ func TestRemoveIssueFromAnnotation(t *testing.T) {
 	issue2 := annotations.IssueLink{URL: "https://issuelink.com", IssueKey: "EVG-1234", Source: &annotations.Source{Author: "not.annie.black"}}
 	assert.NoError(t, db.ClearCollections(annotations.Collection, Collection))
 	a := annotations.TaskAnnotation{TaskId: "t1", Issues: []annotations.IssueLink{issue1, issue2}}
-	assert.NoError(t, a.Upsert())
+	assert.NoError(t, a.Upsert(t.Context()))
 	task := Task{Id: "t1", HasAnnotations: true, Status: evergreen.TaskFailed, DisplayStatusCache: evergreen.TaskKnownIssue}
 	assert.NoError(t, task.Insert())
 
@@ -96,7 +96,7 @@ func TestMoveIssueToSuspectedIssue(t *testing.T) {
 	issue3 := annotations.IssueLink{URL: "https://issuelink.com", IssueKey: "EVG-3456", Source: &annotations.Source{Author: "different user"}}
 	assert.NoError(t, db.ClearCollections(annotations.Collection, Collection))
 	a := annotations.TaskAnnotation{TaskId: "t1", Issues: []annotations.IssueLink{issue1, issue2}, SuspectedIssues: []annotations.IssueLink{issue3}}
-	assert.NoError(t, a.Upsert())
+	assert.NoError(t, a.Upsert(t.Context()))
 	task := Task{Id: "t1", HasAnnotations: true}
 	assert.NoError(t, task.Insert())
 
@@ -143,7 +143,7 @@ func TestMoveSuspectedIssueToIssue(t *testing.T) {
 	task := Task{Id: "t1"}
 	assert.NoError(t, task.Insert())
 	a := annotations.TaskAnnotation{TaskId: "t1", SuspectedIssues: []annotations.IssueLink{issue1, issue2}, Issues: []annotations.IssueLink{issue3}}
-	assert.NoError(t, a.Upsert())
+	assert.NoError(t, a.Upsert(t.Context()))
 
 	assert.NoError(t, MoveSuspectedIssueToIssue(ctx, a.TaskId, a.TaskExecution, issue1, "someone new"))
 	annotationFromDB, err := annotations.FindOneByTaskIdAndExecution(t.Context(), "t1", 0)

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -4830,11 +4830,11 @@ func TestHasResults(t *testing.T) {
 			defer cancel()
 
 			for _, execTask := range test.executionTasks {
-				_, err := db.UpsertContext(t.Context(), Collection, ById(execTask.Id), &execTask)
+				_, err := db.Upsert(t.Context(), Collection, ById(execTask.Id), &execTask)
 				require.NoError(t, err)
 			}
 			for _, execTask := range test.oldExecutionTasks {
-				_, err := db.UpsertContext(t.Context(), OldCollection, ById(execTask.Id), &execTask)
+				_, err := db.Upsert(t.Context(), OldCollection, ById(execTask.Id), &execTask)
 				require.NoError(t, err)
 			}
 
@@ -5015,12 +5015,12 @@ func TestCreateTestResultsTaskOptions(t *testing.T) {
 			defer cancel()
 
 			for _, execTask := range test.executionTasks {
-				_, err := db.UpsertContext(t.Context(), Collection, ById(execTask.Id), &execTask)
+				_, err := db.Upsert(t.Context(), Collection, ById(execTask.Id), &execTask)
 				require.NoError(t, err)
 			}
 			for _, execTask := range test.oldExecutionTasks {
 				execTask.Archived = true
-				_, err := db.UpsertContext(t.Context(), OldCollection, ById(execTask.Id), &execTask)
+				_, err := db.Upsert(t.Context(), OldCollection, ById(execTask.Id), &execTask)
 				require.NoError(t, err)
 			}
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -4830,11 +4830,11 @@ func TestHasResults(t *testing.T) {
 			defer cancel()
 
 			for _, execTask := range test.executionTasks {
-				_, err := db.Upsert(Collection, ById(execTask.Id), &execTask)
+				_, err := db.UpsertContext(t.Context(), Collection, ById(execTask.Id), &execTask)
 				require.NoError(t, err)
 			}
 			for _, execTask := range test.oldExecutionTasks {
-				_, err := db.Upsert(OldCollection, ById(execTask.Id), &execTask)
+				_, err := db.UpsertContext(t.Context(), OldCollection, ById(execTask.Id), &execTask)
 				require.NoError(t, err)
 			}
 
@@ -5015,12 +5015,12 @@ func TestCreateTestResultsTaskOptions(t *testing.T) {
 			defer cancel()
 
 			for _, execTask := range test.executionTasks {
-				_, err := db.Upsert(Collection, ById(execTask.Id), &execTask)
+				_, err := db.UpsertContext(t.Context(), Collection, ById(execTask.Id), &execTask)
 				require.NoError(t, err)
 			}
 			for _, execTask := range test.oldExecutionTasks {
 				execTask.Archived = true
-				_, err := db.Upsert(OldCollection, ById(execTask.Id), &execTask)
+				_, err := db.UpsertContext(t.Context(), OldCollection, ById(execTask.Id), &execTask)
 				require.NoError(t, err)
 			}
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -4830,11 +4830,11 @@ func TestHasResults(t *testing.T) {
 			defer cancel()
 
 			for _, execTask := range test.executionTasks {
-				_, err := db.Upsert(t.Context(), Collection, ById(execTask.Id), &execTask)
+				_, err := db.ReplaceContext(t.Context(), Collection, ById(execTask.Id), &execTask)
 				require.NoError(t, err)
 			}
 			for _, execTask := range test.oldExecutionTasks {
-				_, err := db.Upsert(t.Context(), OldCollection, ById(execTask.Id), &execTask)
+				_, err := db.ReplaceContext(t.Context(), OldCollection, ById(execTask.Id), &execTask)
 				require.NoError(t, err)
 			}
 
@@ -5015,12 +5015,12 @@ func TestCreateTestResultsTaskOptions(t *testing.T) {
 			defer cancel()
 
 			for _, execTask := range test.executionTasks {
-				_, err := db.Upsert(t.Context(), Collection, ById(execTask.Id), &execTask)
+				_, err := db.ReplaceContext(t.Context(), Collection, ById(execTask.Id), &execTask)
 				require.NoError(t, err)
 			}
 			for _, execTask := range test.oldExecutionTasks {
 				execTask.Archived = true
-				_, err := db.Upsert(t.Context(), OldCollection, ById(execTask.Id), &execTask)
+				_, err := db.ReplaceContext(t.Context(), OldCollection, ById(execTask.Id), &execTask)
 				require.NoError(t, err)
 			}
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -4510,11 +4510,11 @@ func (s *TaskConnectorFetchByIdSuite) TestFindByVersion() {
 	annotationWithSuspectedIssue := annotations.TaskAnnotation{TaskId: "task_not_known", TaskExecution: 0, SuspectedIssues: []annotations.IssueLink{issue}}
 	annotationWithEmptyIssues := annotations.TaskAnnotation{TaskId: "task_not_known", TaskExecution: 0, Issues: []annotations.IssueLink{}, SuspectedIssues: []annotations.IssueLink{issue}}
 
-	s.NoError(annotationExecution0.Upsert())
-	s.NoError(annotationExecution1.Upsert())
-	s.NoError(annotationExecution2.Upsert())
-	s.NoError(annotationWithSuspectedIssue.Upsert())
-	s.NoError(annotationWithEmptyIssues.Upsert())
+	s.NoError(annotationExecution0.Upsert(s.T().Context()))
+	s.NoError(annotationExecution1.Upsert(s.T().Context()))
+	s.NoError(annotationExecution2.Upsert(s.T().Context()))
+	s.NoError(annotationWithSuspectedIssue.Upsert(s.T().Context()))
+	s.NoError(annotationWithEmptyIssues.Upsert(s.T().Context()))
 
 	ctx := context.TODO()
 	opts := GetTasksByVersionOptions{}

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -3243,7 +3243,7 @@ buildvariants:
 			testTask := &task.Task{Id: "t1", DisplayName: "nil", Project: projRef.Id, Version: ver.Id}
 			So(testTask.Insert(), ShouldBeNil)
 			projRef.StepbackDisabled = utility.TruePtr()
-			So(projRef.Upsert(), ShouldBeNil)
+			So(projRef.Upsert(t.Context()), ShouldBeNil)
 			Convey("then the value should be false", func() {
 				val, err := getStepback(ctx, testTask.Id, projRef, project)
 				So(err, ShouldBeNil)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -3243,7 +3243,7 @@ buildvariants:
 			testTask := &task.Task{Id: "t1", DisplayName: "nil", Project: projRef.Id, Version: ver.Id}
 			So(testTask.Insert(), ShouldBeNil)
 			projRef.StepbackDisabled = utility.TruePtr()
-			So(projRef.Upsert(t.Context()), ShouldBeNil)
+			So(projRef.Replace(t.Context()), ShouldBeNil)
 			Convey("then the value should be false", func() {
 				val, err := getStepback(ctx, testTask.Id, projRef, project)
 				So(err, ShouldBeNil)

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -215,7 +215,7 @@ func (tq *TaskQueue) Save(ctx context.Context) error {
 }
 
 func updateTaskQueue(ctx context.Context, distro string, taskQueue []TaskQueueItem, distroQueueInfo DistroQueueInfo) error {
-	_, err := db.UpsertContext(
+	_, err := db.Upsert(
 		ctx,
 		distroQueueInfo.GetQueueCollection(),
 		bson.M{
@@ -293,7 +293,7 @@ func clearQueueInfo(distroQueueInfo DistroQueueInfo) DistroQueueInfo {
 }
 
 func clearTaskQueueCollection(ctx context.Context, distroId string, distroQueueInfo DistroQueueInfo) error {
-	_, err := db.UpsertContext(
+	_, err := db.Upsert(
 		ctx,
 		distroQueueInfo.GetQueueCollection(),
 		bson.M{

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -256,7 +256,7 @@ func ClearTaskQueue(ctx context.Context, distroId string) error {
 	secondaryQueueQuery := bson.M{
 		taskQueueDistroKey: distroId,
 	}
-	aliasCount, err := db.CountContext(ctx, TaskSecondaryQueuesCollection, secondaryQueueQuery)
+	aliasCount, err := db.Count(ctx, TaskSecondaryQueuesCollection, secondaryQueueQuery)
 	if err != nil {
 		catcher.Wrap(err, "counting secondary queues matching distro")
 	}

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -206,16 +206,17 @@ func (tq *TaskQueue) Length() int {
 	return len(tq.Queue)
 }
 
-func (tq *TaskQueue) Save() error {
+func (tq *TaskQueue) Save(ctx context.Context) error {
 	if len(tq.Queue) > 10000 {
 		tq.Queue = tq.Queue[:10000]
 	}
 
-	return updateTaskQueue(tq.Distro, tq.Queue, tq.DistroQueueInfo)
+	return updateTaskQueue(ctx, tq.Distro, tq.Queue, tq.DistroQueueInfo)
 }
 
-func updateTaskQueue(distro string, taskQueue []TaskQueueItem, distroQueueInfo DistroQueueInfo) error {
-	_, err := db.Upsert(
+func updateTaskQueue(ctx context.Context, distro string, taskQueue []TaskQueueItem, distroQueueInfo DistroQueueInfo) error {
+	_, err := db.UpsertContext(
+		ctx,
 		distroQueueInfo.GetQueueCollection(),
 		bson.M{
 			taskQueueDistroKey: distro,

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -256,7 +256,7 @@ func ClearTaskQueue(ctx context.Context, distroId string) error {
 	secondaryQueueQuery := bson.M{
 		taskQueueDistroKey: distroId,
 	}
-	aliasCount, err := db.Count(TaskSecondaryQueuesCollection, secondaryQueueQuery)
+	aliasCount, err := db.CountContext(ctx, TaskSecondaryQueuesCollection, secondaryQueueQuery)
 	if err != nil {
 		catcher.Wrap(err, "counting secondary queues matching distro")
 	}

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -247,7 +247,7 @@ func ClearTaskQueue(ctx context.Context, distroId string) error {
 	distroQueueInfo, err := GetDistroQueueInfo(ctx, distroId)
 	catcher.AddWhen(!adb.ResultsNotFound(err), errors.Wrapf(err, "getting task queue info"))
 	distroQueueInfo = clearQueueInfo(distroQueueInfo)
-	err = clearTaskQueueCollection(distroId, distroQueueInfo)
+	err = clearTaskQueueCollection(ctx, distroId, distroQueueInfo)
 	if err != nil {
 		catcher.Wrap(err, "clearing task queue")
 	}
@@ -272,7 +272,7 @@ func ClearTaskQueue(ctx context.Context, distroId string) error {
 	catcher.Wrap(err, "getting task secondary queue info")
 	distroQueueInfo = clearQueueInfo(distroQueueInfo)
 
-	err = clearTaskQueueCollection(distroId, distroQueueInfo)
+	err = clearTaskQueueCollection(ctx, distroId, distroQueueInfo)
 	catcher.Wrap(err, "clearing task alias queue")
 	return catcher.Resolve()
 }
@@ -292,9 +292,9 @@ func clearQueueInfo(distroQueueInfo DistroQueueInfo) DistroQueueInfo {
 	}
 }
 
-func clearTaskQueueCollection(distroId string, distroQueueInfo DistroQueueInfo) error {
-
-	_, err := db.Upsert(
+func clearTaskQueueCollection(ctx context.Context, distroId string, distroQueueInfo DistroQueueInfo) error {
+	_, err := db.UpsertContext(
+		ctx,
 		distroQueueInfo.GetQueueCollection(),
 		bson.M{
 			taskQueueDistroKey: distroId,

--- a/model/task_queue_service_test.go
+++ b/model/task_queue_service_test.go
@@ -987,7 +987,7 @@ func (s *taskDAGDispatchServiceSuite) TestIsRefreshFindNextTaskThreadSafe() {
 	service, err := newDistroTaskDAGDispatchService(s.taskQueue, time.Nanosecond)
 	s.NoError(err)
 	s.taskQueue.Queue = s.refreshTaskQueue(s.ctx, service)
-	s.Require().NoError(s.taskQueue.Save())
+	s.Require().NoError(s.taskQueue.Save(s.ctx))
 	service.lastUpdated = time.Now().Add(-1 * time.Second)
 	dispatcher := &taskDispatchService{
 		cachedDispatchers: map[string]CachedDispatcher{

--- a/model/task_queue_test.go
+++ b/model/task_queue_test.go
@@ -66,7 +66,7 @@ func TestDequeueTask(t *testing.T) {
 
 			var err error
 			// make sure the db representation was updated
-			taskQueue, err = LoadTaskQueue(distroId)
+			taskQueue, err = LoadTaskQueue(t.Context(), distroId)
 			So(err, ShouldBeNil)
 			So(taskQueue.Length(), ShouldEqual, 2)
 			So(taskQueue.Queue[0].Id, ShouldEqual, taskIds[0])
@@ -130,10 +130,10 @@ func TestClearTaskQueue(t *testing.T) {
 	assert.NoError(otherQueue.Save())
 
 	assert.NoError(ClearTaskQueue(t.Context(), distro))
-	queueFromDb, err := LoadTaskQueue(distro)
+	queueFromDb, err := LoadTaskQueue(t.Context(), distro)
 	assert.NoError(err)
 	assert.Empty(queueFromDb.Queue)
-	otherQueueFromDb, err := LoadTaskQueue(otherDistro)
+	otherQueueFromDb, err := LoadTaskQueue(t.Context(), otherDistro)
 	assert.NoError(err)
 	assert.Len(otherQueueFromDb.Queue, 3)
 }
@@ -235,7 +235,7 @@ func TestFindDuplicateEnqueuedTasks(t *testing.T) {
 			_ = makeTaskQueue(t, "d1", "task1", "task2", "task3")
 			_ = makeTaskQueue(t, "d2", "task1", "task3", "task4", "task5", "task6")
 			_ = makeTaskQueue(t, "d3", "task3")
-			dups, err := FindDuplicateEnqueuedTasks(coll)
+			dups, err := FindDuplicateEnqueuedTasks(t.Context(), coll)
 			require.NoError(t, err)
 			require.Len(t, dups, 2)
 			var task1Found, task3Found bool
@@ -258,20 +258,20 @@ func TestFindDuplicateEnqueuedTasks(t *testing.T) {
 		},
 		"DoesNotMatchDuplicatesWithinSameQueue": func(t *testing.T) {
 			_ = makeTaskQueue(t, "d1", "task1", "task1", "task2")
-			dups, err := FindDuplicateEnqueuedTasks(coll)
+			dups, err := FindDuplicateEnqueuedTasks(t.Context(), coll)
 			assert.NoError(t, err)
 			assert.Empty(t, dups)
 		},
 		"DoesNotMatchEmptyQueues": func(t *testing.T) {
 			_ = makeTaskQueue(t, "d1")
-			dups, err := FindDuplicateEnqueuedTasks(coll)
+			dups, err := FindDuplicateEnqueuedTasks(t.Context(), coll)
 			assert.NoError(t, err)
 			assert.Empty(t, dups)
 		},
 		"DoesNotMatchAllUnique": func(t *testing.T) {
 			_ = makeTaskQueue(t, "d1", "task1", "task2")
 			_ = makeTaskQueue(t, "d2", "task3", "task4")
-			dups, err := FindDuplicateEnqueuedTasks(coll)
+			dups, err := FindDuplicateEnqueuedTasks(t.Context(), coll)
 			assert.NoError(t, err)
 			assert.Empty(t, dups)
 		},

--- a/model/task_queue_test.go
+++ b/model/task_queue_test.go
@@ -27,7 +27,7 @@ func TestDequeueTask(t *testing.T) {
 		So(db.Clear(TaskQueuesCollection), ShouldBeNil)
 
 		Convey("if the task queue is empty, an error should not be thrown", func() {
-			So(taskQueue.Save(), ShouldBeNil)
+			So(taskQueue.Save(t.Context()), ShouldBeNil)
 			So(taskQueue.DequeueTask(t.Context(), taskIds[0]), ShouldBeNil)
 		})
 
@@ -35,7 +35,7 @@ func TestDequeueTask(t *testing.T) {
 			" thrown", func() {
 			taskQueue.Queue = append(taskQueue.Queue,
 				TaskQueueItem{Id: taskIds[1]})
-			So(taskQueue.Save(), ShouldBeNil)
+			So(taskQueue.Save(t.Context()), ShouldBeNil)
 			So(taskQueue.DequeueTask(t.Context(), taskIds[0]), ShouldBeNil)
 		})
 
@@ -43,7 +43,7 @@ func TestDequeueTask(t *testing.T) {
 			", an error should not be thrown", func() {
 			taskQueue.Queue = append(taskQueue.Queue,
 				TaskQueueItem{Id: taskIds[1]})
-			So(taskQueue.Save(), ShouldBeNil)
+			So(taskQueue.Save(t.Context()), ShouldBeNil)
 			taskQueue.Queue = append(taskQueue.Queue,
 				TaskQueueItem{Id: taskIds[0]})
 			So(taskQueue.DequeueTask(t.Context(), taskIds[0]), ShouldBeNil)
@@ -56,7 +56,7 @@ func TestDequeueTask(t *testing.T) {
 				{Id: taskIds[1]},
 				{Id: taskIds[2]},
 			}
-			So(taskQueue.Save(), ShouldBeNil)
+			So(taskQueue.Save(t.Context()), ShouldBeNil)
 			So(taskQueue.DequeueTask(t.Context(), taskIds[1]), ShouldBeNil)
 
 			// make sure the queue was updated in memory
@@ -88,7 +88,7 @@ func TestDequeueTask(t *testing.T) {
 				{Id: taskIds[1]},
 				{Id: taskIds[0]},
 			}
-			So(taskQueue.Save(), ShouldBeNil)
+			So(taskQueue.Save(t.Context()), ShouldBeNil)
 
 			So(taskQueue.DequeueTask(t.Context(), taskIds[0]), ShouldBeNil)
 			So(taskQueue.Length(), ShouldEqual, 1)
@@ -124,10 +124,10 @@ func TestClearTaskQueue(t *testing.T) {
 
 	queue := NewTaskQueue(distro, tasks, info)
 	assert.Len(queue.Queue, 3)
-	assert.NoError(queue.Save())
+	assert.NoError(queue.Save(t.Context()))
 	otherQueue := NewTaskQueue(otherDistro, tasks, info)
 	assert.Len(otherQueue.Queue, 3)
-	assert.NoError(otherQueue.Save())
+	assert.NoError(otherQueue.Save(t.Context()))
 
 	assert.NoError(ClearTaskQueue(t.Context(), distro))
 	queueFromDb, err := LoadTaskQueue(t.Context(), distro)
@@ -169,7 +169,7 @@ func TestFindDistroTaskQueue(t *testing.T) {
 	}
 
 	taskQueueIn := NewTaskQueue(distroID, taskQueueItems, info)
-	assert.NoError(taskQueueIn.Save())
+	assert.NoError(taskQueueIn.Save(t.Context()))
 
 	taskQueueOut, err := FindDistroTaskQueue(t.Context(), distroID)
 	assert.NoError(err)
@@ -209,7 +209,7 @@ func TestGetDistroQueueInfo(t *testing.T) {
 	}
 
 	taskQueueIn := NewTaskQueue(distroID, taskQueueItems, info)
-	assert.NoError(taskQueueIn.Save())
+	assert.NoError(taskQueueIn.Save(t.Context()))
 
 	distroQueueInfoOut, err := GetDistroQueueInfo(t.Context(), distroID)
 	assert.NoError(err)
@@ -227,7 +227,7 @@ func TestFindDuplicateEnqueuedTasks(t *testing.T) {
 		for _, id := range ids {
 			tq.Queue = append(tq.Queue, TaskQueueItem{Id: id})
 		}
-		require.NoError(t, tq.Save())
+		require.NoError(t, tq.Save(t.Context()))
 		return tq
 	}
 	for testName, testCase := range map[string]func(t *testing.T){

--- a/model/task_start_estimation.go
+++ b/model/task_start_estimation.go
@@ -97,7 +97,7 @@ func (s *estimatedTimeSimulator) dispatchNextTask() {
 
 // GetEstimatedStartTime returns the estimated start time for a task
 func GetEstimatedStartTime(ctx context.Context, t task.Task) (time.Duration, error) {
-	queue, err := LoadTaskQueue(t.DistroId)
+	queue, err := LoadTaskQueue(ctx, t.DistroId)
 	if err != nil {
 		return -1, errors.Wrap(err, "retrieving task queue")
 	}

--- a/model/taskstats/query.go
+++ b/model/taskstats/query.go
@@ -1,6 +1,7 @@
 package taskstats
 
 import (
+	"context"
 	"time"
 
 	"github.com/evergreen-ci/evergreen/db"
@@ -180,14 +181,14 @@ func (s *TaskStats) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(s) }
 func (s *TaskStats) UnmarshalBSON(in []byte) error { return mgobson.Unmarshal(in, s) }
 
 // GetTaskStats queries the precomputed task statistics using a filter.
-func GetTaskStats(filter StatsFilter) ([]TaskStats, error) {
+func GetTaskStats(ctx context.Context, filter StatsFilter) ([]TaskStats, error) {
 	err := filter.ValidateForTasks()
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid stats filter")
 	}
 	var stats []TaskStats
 	pipeline := filter.TaskStatsQueryPipeline()
-	err = db.Aggregate(DailyTaskStatsCollection, pipeline, &stats)
+	err = db.Aggregate(ctx, DailyTaskStatsCollection, pipeline, &stats)
 	if err != nil {
 		return nil, errors.Wrap(err, "aggregating task statistics")
 	}

--- a/model/taskstats/query_test.go
+++ b/model/taskstats/query_test.go
@@ -270,7 +270,7 @@ func (s *statsQuerySuite) TestFilterInvalidGroupBy() {
 func (s *statsQuerySuite) TestGetTaskStatsEmptyCollection() {
 	require := s.Require()
 
-	docs, err := GetTaskStats(s.baseTaskFilter)
+	docs, err := GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Empty(docs)
 }
@@ -280,7 +280,7 @@ func (s *statsQuerySuite) TestGetTaskStatsOneDocument() {
 
 	s.insertDailyTaskStats("p1", "r1", "task1", "v1", "d1", day1, 10, 5, 1, 1, 1, 2, 10.5)
 
-	docs, err := GetTaskStats(s.baseTaskFilter)
+	docs, err := GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Len(docs, 1)
 	s.checkTaskStats(docs[0], "task1", "v1", "d1", day1, 10, 5, 1, 1, 2, float64(10.5))
@@ -292,7 +292,7 @@ func (s *statsQuerySuite) TestGetTaskStatsTwoDocuments() {
 	s.insertDailyTaskStats("p1", "r1", "task1", "v1", "d1", day1, 10, 5, 1, 1, 1, 2, 10.5)
 	s.insertDailyTaskStats("p1", "r1", "task1", "v1", "d1", day2, 20, 7, 7, 0, 0, 0, 20.0)
 
-	docs, err := GetTaskStats(s.baseTaskFilter)
+	docs, err := GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Len(docs, 2)
 	s.checkTaskStats(docs[0], "task1", "v1", "d1", day1, 10, 5, 1, 1, 2, float64(10.5))
@@ -312,7 +312,7 @@ func (s *statsQuerySuite) TestGetTaskStatsFilterScope() {
 	s.insertDailyTaskStats("p1", "r1", "task1", "v3", "d1", day1, 1, 1, 1, 0, 0, 0, 1)
 	s.insertDailyTaskStats("p1", "r1", "task1", "v1", "d1", day8, 1, 1, 1, 0, 0, 0, 1)
 
-	docs, err := GetTaskStats(s.baseTaskFilter)
+	docs, err := GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Len(docs, 2)
 	s.checkTaskStats(docs[0], "task1", "v1", "d1", day1, 10, 5, 1, 1, 2, float64(10.5))
@@ -327,7 +327,7 @@ func (s *statsQuerySuite) TestGetTaskStatsSortOrder() {
 
 	s.baseTaskFilter.Sort = SortEarliestFirst
 
-	docs, err := GetTaskStats(s.baseTaskFilter)
+	docs, err := GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Len(docs, 2)
 	s.checkTaskStats(docs[0], "task1", "v1", "d1", day1, 10, 5, 1, 1, 2, float64(10.5))
@@ -335,7 +335,7 @@ func (s *statsQuerySuite) TestGetTaskStatsSortOrder() {
 
 	s.baseTaskFilter.Sort = SortLatestFirst
 
-	docs, err = GetTaskStats(s.baseTaskFilter)
+	docs, err = GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Len(docs, 2)
 	s.checkTaskStats(docs[0], "task1", "v1", "d1", day2, 20, 7, 0, 0, 0, float64(20))
@@ -349,7 +349,7 @@ func (s *statsQuerySuite) TestGetTaskStatsGroupNumDays() {
 	s.insertDailyTaskStats("p1", "r1", "task1", "v1", "d1", day2, 20, 7, 7, 0, 0, 0, 20.0)
 
 	s.baseTaskFilter.GroupNumDays = 2
-	docs, err := GetTaskStats(s.baseTaskFilter)
+	docs, err := GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Len(docs, 1)
 	s.checkTaskStats(docs[0], "task1", "v1", "d1", day1, 30, 12, 1, 1, 2, float64(16.833333333333332))
@@ -367,7 +367,7 @@ func (s *statsQuerySuite) TestGetTaskStatsGroupByDistro() {
 	s.baseTaskFilter.GroupNumDays = 2
 	s.baseTaskFilter.GroupBy = GroupByDistro
 
-	docs, err := GetTaskStats(s.baseTaskFilter)
+	docs, err := GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Len(docs, 2)
 	s.checkTaskStats(docs[0], "task1", "v1", "d1", day1, 30, 12, 1, 1, 2, float64(16.833333333333332))
@@ -388,7 +388,7 @@ func (s *statsQuerySuite) TestGetTaskStatsGroupByVariant() {
 	s.baseTaskFilter.GroupNumDays = 2
 	s.baseTaskFilter.GroupBy = GroupByVariant
 
-	docs, err := GetTaskStats(s.baseTaskFilter)
+	docs, err := GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Len(docs, 2)
 	s.checkTaskStats(docs[0], "task1", "v1", "", day1, 32, 15, 2, 1, 2, float64(16.40625))
@@ -411,7 +411,7 @@ func (s *statsQuerySuite) TestGetTaskStatsGroupByTask() {
 	s.baseTaskFilter.GroupNumDays = 2
 	s.baseTaskFilter.GroupBy = GroupByTask
 
-	docs, err := GetTaskStats(s.baseTaskFilter)
+	docs, err := GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Len(docs, 2)
 	s.checkTaskStats(docs[0], "task1", "", "", day1, 34, 18, 3, 1, 2, float64(16.029411764705884))
@@ -433,7 +433,7 @@ func (s *statsQuerySuite) TestGetTaskStatsPagination() {
 	s.baseTaskFilter.Tasks = []string{"task1", "task2", "task3", "task4", "task5", "task6"}
 	s.baseTaskFilter.Limit = 3
 
-	docs, err := GetTaskStats(s.baseTaskFilter)
+	docs, err := GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Len(docs, 3)
 	// expecting the results ordered by date/variant/task/test/distro
@@ -443,7 +443,7 @@ func (s *statsQuerySuite) TestGetTaskStatsPagination() {
 
 	s.baseTaskFilter.StartAt = &StartAt{Date: day1, Task: "task6", BuildVariant: "v1", Distro: "d1"}
 
-	docs, err = GetTaskStats(s.baseTaskFilter)
+	docs, err = GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Len(docs, 3)
 	s.checkTaskStats(docs[0], "task6", "v1", "d1", day1, 1, 1, 0, 0, 0, float64(10))
@@ -452,7 +452,7 @@ func (s *statsQuerySuite) TestGetTaskStatsPagination() {
 
 	s.baseTaskFilter.StartAt = &StartAt{Date: day1, Task: "task2", BuildVariant: "v2", Distro: "d1"}
 
-	docs, err = GetTaskStats(s.baseTaskFilter)
+	docs, err = GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Len(docs, 3)
 	s.checkTaskStats(docs[0], "task2", "v2", "d1", day1, 1, 1, 0, 0, 0, float64(10))
@@ -475,7 +475,7 @@ func (s *statsQuerySuite) TestGetTaskStatsPaginationGroupByTask() {
 	s.baseTaskFilter.Limit = 3
 	s.baseTaskFilter.GroupBy = GroupByTask
 
-	docs, err := GetTaskStats(s.baseTaskFilter)
+	docs, err := GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Len(docs, 3)
 	s.checkTaskStats(docs[0], "task1", "", "", day1, 1, 1, 0, 0, 0, float64(10))
@@ -484,7 +484,7 @@ func (s *statsQuerySuite) TestGetTaskStatsPaginationGroupByTask() {
 
 	s.baseTaskFilter.StartAt = &StartAt{Date: day1, Task: "task3"}
 
-	docs, err = GetTaskStats(s.baseTaskFilter)
+	docs, err = GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Len(docs, 3)
 	s.checkTaskStats(docs[0], "task3", "", "", day1, 1, 1, 0, 0, 0, float64(10))
@@ -509,7 +509,7 @@ func (s *statsQuerySuite) TestGetTaskStatsPaginationGroupNumDays() {
 	s.baseTaskFilter.BeforeDate = day8.Add(7 * 24 * time.Hour)
 	s.baseTaskFilter.GroupNumDays = 7
 
-	docs, err := GetTaskStats(s.baseTaskFilter)
+	docs, err := GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Len(docs, 3)
 	s.checkTaskStats(docs[0], "task1", "v1", "d1", day1, 2, 2, 0, 0, 0, float64(10))
@@ -517,7 +517,7 @@ func (s *statsQuerySuite) TestGetTaskStatsPaginationGroupNumDays() {
 	s.checkTaskStats(docs[2], "task3", "v1", "d1", day1, 1, 1, 0, 0, 0, float64(10))
 
 	s.baseTaskFilter.StartAt = &StartAt{Date: day1, Task: "task3", BuildVariant: "v1", Distro: "d1"}
-	docs, err = GetTaskStats(s.baseTaskFilter)
+	docs, err = GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Len(docs, 3)
 	s.checkTaskStats(docs[0], "task3", "v1", "d1", day1, 1, 1, 0, 0, 0, float64(10))
@@ -525,7 +525,7 @@ func (s *statsQuerySuite) TestGetTaskStatsPaginationGroupNumDays() {
 	s.checkTaskStats(docs[2], "task1", "v1", "d1", day8, 1, 1, 0, 0, 0, float64(10))
 
 	s.baseTaskFilter.StartAt = &StartAt{Date: day8, Task: "task1", BuildVariant: "v1", Distro: "d1"}
-	docs, err = GetTaskStats(s.baseTaskFilter)
+	docs, err = GetTaskStats(s.T().Context(), s.baseTaskFilter)
 	require.NoError(err)
 	require.Len(docs, 2)
 	s.checkTaskStats(docs[0], "task1", "v1", "d1", day8, 1, 1, 0, 0, 0, float64(10))

--- a/model/taskstats/stats.go
+++ b/model/taskstats/stats.go
@@ -68,14 +68,14 @@ func GetStatsStatus(ctx context.Context, projectID string) (StatsStatus, error) 
 }
 
 // UpdateStatsStatus updates the status of the stats pre-computations for a project.
-func UpdateStatsStatus(projectID string, lastJobRun, processedTasksUntil time.Time, runtime time.Duration) error {
+func UpdateStatsStatus(ctx context.Context, projectID string, lastJobRun, processedTasksUntil time.Time, runtime time.Duration) error {
 	status := StatsStatus{
 		ProjectID:           projectID,
 		LastJobRun:          lastJobRun,
 		ProcessedTasksUntil: processedTasksUntil,
 		Runtime:             runtime,
 	}
-	_, err := db.Upsert(DailyStatsStatusCollection, bson.M{"_id": projectID}, status)
+	_, err := db.UpsertContext(ctx, DailyStatsStatusCollection, bson.M{"_id": projectID}, status)
 	if err != nil {
 		return errors.Wrap(err, "updating test stats status")
 	}

--- a/model/taskstats/stats.go
+++ b/model/taskstats/stats.go
@@ -75,7 +75,7 @@ func UpdateStatsStatus(ctx context.Context, projectID string, lastJobRun, proces
 		ProcessedTasksUntil: processedTasksUntil,
 		Runtime:             runtime,
 	}
-	_, err := db.Upsert(ctx, DailyStatsStatusCollection, bson.M{"_id": projectID}, status)
+	_, err := db.ReplaceContext(ctx, DailyStatsStatusCollection, bson.M{"_id": projectID}, status)
 	if err != nil {
 		return errors.Wrap(err, "updating test stats status")
 	}

--- a/model/taskstats/stats.go
+++ b/model/taskstats/stats.go
@@ -133,7 +133,7 @@ type FindStatsToUpdateOptions struct {
 // FindStatsToUpdate finds the stats that need to be updated as a result of
 // tasks finishing between the given start and end times. The results are
 // ordered are ordered by first by date, then requester.
-func FindStatsToUpdate(opts FindStatsToUpdateOptions) ([]StatsToUpdate, error) {
+func FindStatsToUpdate(ctx context.Context, opts FindStatsToUpdateOptions) ([]StatsToUpdate, error) {
 	grip.Info(message.Fields{
 		"message": "finding tasks that need their stats updated",
 		"project": opts.ProjectID,
@@ -142,7 +142,7 @@ func FindStatsToUpdate(opts FindStatsToUpdateOptions) ([]StatsToUpdate, error) {
 	})
 
 	var toUpdate []StatsToUpdate
-	if err := db.Aggregate(task.Collection, statsToUpdatePipeline(opts.ProjectID, opts.Requesters, opts.Start, opts.End), &toUpdate); err != nil {
+	if err := db.Aggregate(ctx, task.Collection, statsToUpdatePipeline(opts.ProjectID, opts.Requesters, opts.Start, opts.End), &toUpdate); err != nil {
 		return nil, errors.Wrap(err, "finding tasks that need their stats updated")
 	}
 

--- a/model/taskstats/stats.go
+++ b/model/taskstats/stats.go
@@ -75,7 +75,7 @@ func UpdateStatsStatus(ctx context.Context, projectID string, lastJobRun, proces
 		ProcessedTasksUntil: processedTasksUntil,
 		Runtime:             runtime,
 	}
-	_, err := db.UpsertContext(ctx, DailyStatsStatusCollection, bson.M{"_id": projectID}, status)
+	_, err := db.Upsert(ctx, DailyStatsStatusCollection, bson.M{"_id": projectID}, status)
 	if err != nil {
 		return errors.Wrap(err, "updating test stats status")
 	}

--- a/model/taskstats/stats_test.go
+++ b/model/taskstats/stats_test.go
@@ -78,7 +78,7 @@ func (s *statsSuite) TestGenerateStats() {
 		Date:      baseHour,
 		Tasks:     []string{"unknown_task"},
 	}))
-	s.Equal(0, s.countDailyTaskDocs())
+	s.Equal(0, s.countDailyTaskDocs(s.T().Context()))
 
 	// Generate task stats for project p1.
 	s.Require().NoError(GenerateStats(ctx, GenerateStatsOptions{
@@ -87,7 +87,7 @@ func (s *statsSuite) TestGenerateStats() {
 		Date:      baseHour,
 		Tasks:     []string{"task1", "task2"},
 	}))
-	s.Equal(3, s.countDailyTaskDocs())
+	s.Equal(3, s.countDailyTaskDocs(s.T().Context()))
 	doc, err := GetDailyTaskDoc(s.T().Context(), DBTaskStatsID{
 		Project:      "p1",
 		Requester:    "r1",
@@ -121,7 +121,7 @@ func (s *statsSuite) TestGenerateStats() {
 
 	// Generate task stats for project p4 to check status aggregation.
 	s.Require().NoError(GenerateStats(ctx, GenerateStatsOptions{ProjectID: "p4", Requester: "r1", Date: baseHour, Tasks: []string{"task1"}}))
-	s.Equal(4, s.countDailyTaskDocs()) // 1 more task combination was added to the collection.
+	s.Equal(4, s.countDailyTaskDocs(s.T().Context())) // 1 more task combination was added to the collection.
 	doc, err = GetDailyTaskDoc(s.T().Context(), DBTaskStatsID{
 		Project:      "p4",
 		Requester:    "r1",
@@ -144,7 +144,7 @@ func (s *statsSuite) TestGenerateStats() {
 
 	// Generate task for project p2
 	s.Require().NoError(GenerateStats(ctx, GenerateStatsOptions{ProjectID: "p2", Requester: "r1", Date: baseHour, Tasks: []string{"task1"}}))
-	s.Equal(5, s.countDailyTaskDocs()) // 1 more task combination was added to the collection.
+	s.Equal(5, s.countDailyTaskDocs(s.T().Context())) // 1 more task combination was added to the collection.
 	doc, err = GetDailyTaskDoc(s.T().Context(), DBTaskStatsID{
 		Project:      "p2",
 		Requester:    "r1",
@@ -344,12 +344,12 @@ func (s *statsSuite) insertFinishedTask(project string, requester string, taskNa
 // Methods to access database data //
 /////////////////////////////////////
 
-func (s *statsSuite) countDocs(collection string) int {
-	count, err := db.Count(collection, bson.M{})
+func (s *statsSuite) countDocs(ctx context.Context, collection string) int {
+	count, err := db.CountContext(ctx, collection, bson.M{})
 	s.Require().NoError(err)
 	return count
 }
 
-func (s *statsSuite) countDailyTaskDocs() int {
-	return s.countDocs(DailyTaskStatsCollection)
+func (s *statsSuite) countDailyTaskDocs(ctx context.Context) int {
+	return s.countDocs(ctx, DailyTaskStatsCollection)
 }

--- a/model/taskstats/stats_test.go
+++ b/model/taskstats/stats_test.go
@@ -171,23 +171,23 @@ func (s *statsSuite) TestFindStatsToUpdate() {
 	// Find stats for p5 for a period with no finished tasks.
 	start := baseHour
 	end := baseHour.Add(time.Hour)
-	statsList, err := FindStatsToUpdate(FindStatsToUpdateOptions{ProjectID: "p5", Requesters: nil, Start: start, End: end})
+	statsList, err := FindStatsToUpdate(s.T().Context(), FindStatsToUpdateOptions{ProjectID: "p5", Requesters: nil, Start: start, End: end})
 	s.Require().NoError(err)
 	s.Empty(statsList)
 
 	// Find stats for p5 for a period around finish1.
 	start = finish1.Add(-1 * time.Hour)
 	end = finish1.Add(time.Hour)
-	statsList, err = FindStatsToUpdate(FindStatsToUpdateOptions{ProjectID: "p5", Requesters: nil, Start: start, End: end})
+	statsList, err = FindStatsToUpdate(s.T().Context(), FindStatsToUpdateOptions{ProjectID: "p5", Requesters: nil, Start: start, End: end})
 	s.Require().NoError(err)
 	s.Len(statsList, 2)
 
 	// Find stats for p5 for a period around finished1, filtering by
 	// requester.
-	statsList, err = FindStatsToUpdate(FindStatsToUpdateOptions{ProjectID: "p5", Requesters: []string{"r2"}, Start: start, End: end})
+	statsList, err = FindStatsToUpdate(s.T().Context(), FindStatsToUpdateOptions{ProjectID: "p5", Requesters: []string{"r2"}, Start: start, End: end})
 	s.Require().NoError(err)
 	s.Len(statsList, 1)
-	statsList, err = FindStatsToUpdate(FindStatsToUpdateOptions{ProjectID: "p5", Requesters: []string{"r1", "r2"}, Start: start, End: end})
+	statsList, err = FindStatsToUpdate(s.T().Context(), FindStatsToUpdateOptions{ProjectID: "p5", Requesters: []string{"r1", "r2"}, Start: start, End: end})
 	s.Require().NoError(err)
 	s.Require().Len(statsList, 2)
 
@@ -199,7 +199,7 @@ func (s *statsSuite) TestFindStatsToUpdate() {
 	// Find stats for p5 for a period around finish1
 	start = finish1.Add(-1 * time.Hour)
 	end = finish1.Add(time.Hour)
-	statsList, err = FindStatsToUpdate(FindStatsToUpdateOptions{ProjectID: "p5", Requesters: nil, Start: start, End: end})
+	statsList, err = FindStatsToUpdate(s.T().Context(), FindStatsToUpdateOptions{ProjectID: "p5", Requesters: nil, Start: start, End: end})
 	s.Require().NoError(err)
 	s.Require().Len(statsList, 2)
 	// The results are sorted so we know the order

--- a/model/taskstats/stats_test.go
+++ b/model/taskstats/stats_test.go
@@ -54,7 +54,7 @@ func (s *statsSuite) TestStatsStatus() {
 	s.WithinDuration(expected, status.ProcessedTasksUntil, oneDayOneMinute)
 
 	// Check that we can update the status and read the new values.
-	err = UpdateStatsStatus("p1", baseHour, baseDay, time.Hour)
+	err = UpdateStatsStatus(s.T().Context(), "p1", baseHour, baseDay, time.Hour)
 	s.NoError(err)
 
 	status, err = GetStatsStatus(s.T().Context(), "p1")

--- a/model/taskstats/stats_test.go
+++ b/model/taskstats/stats_test.go
@@ -345,7 +345,7 @@ func (s *statsSuite) insertFinishedTask(project string, requester string, taskNa
 /////////////////////////////////////
 
 func (s *statsSuite) countDocs(ctx context.Context, collection string) int {
-	count, err := db.CountContext(ctx, collection, bson.M{})
+	count, err := db.Count(ctx, collection, bson.M{})
 	s.Require().NoError(err)
 	return count
 }

--- a/model/testlog/test_log_test.go
+++ b/model/testlog/test_log_test.go
@@ -74,7 +74,7 @@ func TestDeleteTestLogsWithLimit(t *testing.T) {
 		require.NoError(t, db.Insert(TestLogCollection, bson.M{"_id": primitive.NewObjectIDFromTimestamp(now.Add(time.Hour)).Hex()}))
 		require.NoError(t, db.Insert(TestLogCollection, bson.M{"_id": primitive.NewObjectIDFromTimestamp(now.Add(-time.Hour)).Hex()}))
 
-		num, err := db.CountContext(t.Context(), TestLogCollection, bson.M{})
+		num, err := db.Count(t.Context(), TestLogCollection, bson.M{})
 		require.NoError(t, err)
 		assert.Equal(t, 2, num)
 
@@ -82,7 +82,7 @@ func TestDeleteTestLogsWithLimit(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 1, num)
 
-		num, err = db.CountContext(t.Context(), TestLogCollection, bson.M{})
+		num, err = db.Count(t.Context(), TestLogCollection, bson.M{})
 		require.NoError(t, err)
 		assert.Equal(t, 1, num)
 	})

--- a/model/testlog/test_log_test.go
+++ b/model/testlog/test_log_test.go
@@ -74,7 +74,7 @@ func TestDeleteTestLogsWithLimit(t *testing.T) {
 		require.NoError(t, db.Insert(TestLogCollection, bson.M{"_id": primitive.NewObjectIDFromTimestamp(now.Add(time.Hour)).Hex()}))
 		require.NoError(t, db.Insert(TestLogCollection, bson.M{"_id": primitive.NewObjectIDFromTimestamp(now.Add(-time.Hour)).Hex()}))
 
-		num, err := db.Count(TestLogCollection, bson.M{})
+		num, err := db.CountContext(t.Context(), TestLogCollection, bson.M{})
 		require.NoError(t, err)
 		assert.Equal(t, 2, num)
 
@@ -82,7 +82,7 @@ func TestDeleteTestLogsWithLimit(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 1, num)
 
-		num, err = db.Count(TestLogCollection, bson.M{})
+		num, err = db.CountContext(t.Context(), TestLogCollection, bson.M{})
 		require.NoError(t, err)
 		assert.Equal(t, 1, num)
 	})

--- a/model/testutil/api.go
+++ b/model/testutil/api.go
@@ -177,7 +177,7 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 			},
 		},
 	}
-	if err = taskQueue.Save(); err != nil {
+	if err = taskQueue.Save(ctx); err != nil {
 		return nil, errors.Wrap(err, "inserting task queue")
 	}
 

--- a/model/testutil/api.go
+++ b/model/testutil/api.go
@@ -118,7 +118,7 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 	projectVars := &model.ProjectVars{
 		Id: project.DisplayName,
 	}
-	if _, err = projectVars.Upsert(); err != nil {
+	if _, err = projectVars.Upsert(ctx); err != nil {
 		return nil, errors.Wrap(err, "inserting project variables")
 	}
 

--- a/model/testutil/integration_test_setup.go
+++ b/model/testutil/integration_test_setup.go
@@ -43,7 +43,7 @@ func CreateTestLocalConfig(ctx context.Context, testSettings *evergreen.Settings
 		return err
 	}
 
-	return projectRef.Upsert()
+	return projectRef.Upsert(ctx)
 }
 
 // findConfig finds the config root in the home directory.

--- a/model/testutil/integration_test_setup.go
+++ b/model/testutil/integration_test_setup.go
@@ -43,7 +43,7 @@ func CreateTestLocalConfig(ctx context.Context, testSettings *evergreen.Settings
 		return err
 	}
 
-	return projectRef.Upsert(ctx)
+	return projectRef.Replace(ctx)
 }
 
 // findConfig finds the config root in the home directory.

--- a/model/user/db.go
+++ b/model/user/db.go
@@ -154,7 +154,7 @@ func UpdateAll(query any, update any) error {
 
 // UpsertOne upserts a user.
 func UpsertOne(ctx context.Context, query any, update any) (*adb.ChangeInfo, error) {
-	return db.UpsertContext(
+	return db.Upsert(
 		ctx,
 		Collection,
 		query,

--- a/model/user/db.go
+++ b/model/user/db.go
@@ -153,8 +153,9 @@ func UpdateAll(query any, update any) error {
 }
 
 // UpsertOne upserts a user.
-func UpsertOne(query any, update any) (*adb.ChangeInfo, error) {
-	return db.Upsert(
+func UpsertOne(ctx context.Context, query any, update any) (*adb.ChangeInfo, error) {
+	return db.UpsertContext(
+		ctx,
 		Collection,
 		query,
 		update,
@@ -235,7 +236,7 @@ func FindByRole(role string) ([]DBUser, error) {
 
 // AddOrUpdateServiceUser upserts a service user by ID. If it's a new user, it
 // generates a new API key for the user.
-func AddOrUpdateServiceUser(u DBUser) error {
+func AddOrUpdateServiceUser(ctx context.Context, u DBUser) error {
 	if !u.OnlyAPI {
 		return errors.New("cannot update a non-service user")
 	}
@@ -255,7 +256,7 @@ func AddOrUpdateServiceUser(u DBUser) error {
 			EmailAddressKey: u.EmailAddress,
 		},
 	}
-	_, err := UpsertOne(query, update)
+	_, err := UpsertOne(ctx, query, update)
 	return err
 }
 
@@ -537,7 +538,7 @@ func ClearAllLoginCaches() error {
 }
 
 // UpsertOneFromExisting creates a new user with the same necessary data as oldUsr.
-func UpsertOneFromExisting(oldUsr *DBUser, newEmail string) (*DBUser, error) {
+func UpsertOneFromExisting(ctx context.Context, oldUsr *DBUser, newEmail string) (*DBUser, error) {
 	splitString := strings.Split(newEmail, "@")
 	if len(splitString) == 1 {
 		return nil, errors.New("email address is missing '@'")
@@ -557,7 +558,7 @@ func UpsertOneFromExisting(oldUsr *DBUser, newEmail string) (*DBUser, error) {
 		PubKeys:          oldUsr.PublicKeys(),
 	}
 
-	_, err := UpsertOne(bson.M{IdKey: newUsername}, bson.M{"$set": bson.M{
+	_, err := UpsertOne(ctx, bson.M{IdKey: newUsername}, bson.M{"$set": bson.M{
 		EmailAddressKey:     newUsr.Email(),
 		FavoriteProjectsKey: newUsr.FavoriteProjects,
 		PatchNumberKey:      newUsr.PatchNumber,

--- a/model/user/db_test.go
+++ b/model/user/db_test.go
@@ -23,7 +23,7 @@ func TestUpsertOneFromExisting(t *testing.T) {
 		FavoriteProjects: []string{"evergreen"},
 		PatchNumber:      12,
 	}
-	newUsr, err := UpsertOneFromExisting(oldUsr, "hello.howareyou@adele.com")
+	newUsr, err := UpsertOneFromExisting(t.Context(), oldUsr, "hello.howareyou@adele.com")
 	assert.NoError(t, err)
 	assert.Equal(t, "hello.howareyou", newUsr.Id)
 	assert.Equal(t, "hello.howareyou@adele.com", newUsr.Email())
@@ -42,7 +42,7 @@ func TestUpsertOneFromExisting(t *testing.T) {
 		PatchNumber: 1,
 	}
 	assert.NoError(t, db.Insert(Collection, existingUsr))
-	newUsr, err = UpsertOneFromExisting(oldUsr, "newly.created@new.com")
+	newUsr, err = UpsertOneFromExisting(t.Context(), oldUsr, "newly.created@new.com")
 	assert.NoError(t, err)
 	assert.Equal(t, "newly.created", newUsr.Id)
 	assert.Equal(t, "newly.created@new.com", newUsr.Email())

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -671,9 +671,9 @@ func TestServiceUserOperations(t *testing.T) {
 		SystemRoles:  []string{"one"},
 		EmailAddress: "myemail@mailplace.com",
 	}
-	assert.EqualError(t, AddOrUpdateServiceUser(u), "cannot update a non-service user")
+	assert.EqualError(t, AddOrUpdateServiceUser(t.Context(), u), "cannot update a non-service user")
 	u.OnlyAPI = true
-	assert.NoError(t, AddOrUpdateServiceUser(u))
+	assert.NoError(t, AddOrUpdateServiceUser(t.Context(), u))
 	dbUser, err := FindOneByIdContext(t.Context(), u.Id)
 	assert.NoError(t, err)
 	assert.True(t, dbUser.OnlyAPI)
@@ -684,7 +684,7 @@ func TestServiceUserOperations(t *testing.T) {
 
 	u.DispName = "another"
 	u.SystemRoles = []string{"one", "two"}
-	assert.NoError(t, AddOrUpdateServiceUser(u))
+	assert.NoError(t, AddOrUpdateServiceUser(t.Context(), u))
 	dbUser, err = FindOneByIdContext(t.Context(), u.Id)
 	assert.NoError(t, err)
 	assert.True(t, dbUser.OnlyAPI)

--- a/model/version.go
+++ b/model/version.go
@@ -666,7 +666,7 @@ func GetVersionsWithOptions(ctx context.Context, projectName string, opts GetVer
 
 	res := []Version{}
 
-	if err := db.Aggregate(VersionCollection, pipeline, &res); err != nil {
+	if err := db.Aggregate(ctx, VersionCollection, pipeline, &res); err != nil {
 		return nil, errors.Wrap(err, "aggregating versions and builds")
 	}
 	return res, nil

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -324,8 +324,8 @@ func VersionFind(query db.Q) ([]Version, error) {
 }
 
 // Count returns the number of hosts that satisfy the given query.
-func VersionCount(query db.Q) (int, error) {
-	return db.CountQ(VersionCollection, query)
+func VersionCount(ctx context.Context, query db.Q) (int, error) {
+	return db.CountQContext(ctx, VersionCollection, query)
 }
 
 // UpdateOne updates one version.

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -325,7 +325,7 @@ func VersionFind(query db.Q) ([]Version, error) {
 
 // Count returns the number of hosts that satisfy the given query.
 func VersionCount(ctx context.Context, query db.Q) (int, error) {
-	return db.CountQContext(ctx, VersionCollection, query)
+	return db.CountQ(ctx, VersionCollection, query)
 }
 
 // UpdateOne updates one version.

--- a/model/version_history.go
+++ b/model/version_history.go
@@ -81,7 +81,7 @@ func FindLastPassingVersionForBuildVariants(ctx context.Context, project *Projec
 
 	var result []bson.M
 
-	err = db.Aggregate(build.Collection, pipeline, &result)
+	err = db.Aggregate(ctx, build.Collection, pipeline, &result)
 	if err != nil {
 		return nil, errors.Wrap(err, "aggregating builds")
 	}

--- a/operations/cli_integration_test.go
+++ b/operations/cli_integration_test.go
@@ -245,14 +245,14 @@ func TestCLIFetchArtifacts(t *testing.T) {
 			TaskId:          "rest_task_test_id1",
 			TaskDisplayName: "task_one",
 			Files:           []artifact.File{{Link: "http://www.google.com/robots.txt"}},
-		}).Upsert()
+		}).Upsert(t.Context())
 		So(err, ShouldBeNil)
 
 		err = (&artifact.Entry{
 			TaskId:          "rest_task_test_id2",
 			TaskDisplayName: "task_two",
 			Files:           []artifact.File{{Link: "http://www.google.com/humans.txt"}},
-		}).Upsert()
+		}).Upsert(t.Context())
 		So(err, ShouldBeNil)
 
 		client, err := NewClientSettings(testSetup.settingsFilePath)

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -467,11 +467,11 @@ func addGithubCheckSubscriptions(ctx context.Context, v *model.Version) error {
 	})
 
 	versionSub := event.NewVersionGithubCheckOutcomeSubscription(v.Id, ghSub)
-	if err := versionSub.Upsert(); err != nil {
+	if err := versionSub.Upsert(ctx); err != nil {
 		catcher.Wrap(err, "inserting version GitHub check subscription")
 	}
 	buildSub := event.NewGithubCheckBuildOutcomeSubscriptionByVersion(v.Id, ghSub)
-	if err := buildSub.Upsert(); err != nil {
+	if err := buildSub.Upsert(ctx); err != nil {
 		catcher.Wrap(err, "inserting build GitHub check subscription")
 	}
 	input := thirdparty.SendGithubStatusInput{
@@ -555,7 +555,7 @@ func AddBuildBreakSubscriptions(ctx context.Context, v *model.Version, projectRe
 	for _, subscriber := range subscribers {
 		newSubscription := subscriptionBase
 		newSubscription.Subscriber = subscriber
-		catcher.Add(newSubscription.Upsert())
+		catcher.Add(newSubscription.Upsert(ctx))
 	}
 	return catcher.Resolve()
 }

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -1428,7 +1428,7 @@ tasks:
 		Task:      "task1",
 		Variant:   ".*",
 	}
-	s.NoError(alias.Upsert())
+	s.NoError(alias.Upsert(s.ctx))
 	v, err := CreateVersionFromConfig(s.ctx, projectInfo, model.VersionMetadata{Revision: *s.rev, Alias: evergreen.GithubPRAlias}, false, nil)
 	s.NoError(err)
 	s.Require().NotNil(v)
@@ -1480,7 +1480,7 @@ tasks:
 		Task:      "task1",
 		Variant:   ".*",
 	}
-	s.NoError(alias.Upsert())
+	s.NoError(alias.Upsert(s.ctx))
 
 	projectInfo := &model.ProjectInfo{
 		Ref:                 s.ref,
@@ -1537,7 +1537,7 @@ task_groups:
 		Task:      "tg1",
 		Variant:   ".*",
 	}
-	s.NoError(alias.Upsert())
+	s.NoError(alias.Upsert(s.ctx))
 
 	projectInfo := &model.ProjectInfo{
 		Ref:                 s.ref,
@@ -1605,7 +1605,7 @@ tasks:
 		Task:      "(task1)|(task2)",
 		Variant:   ".*",
 	}
-	s.NoError(alias.Upsert())
+	s.NoError(alias.Upsert(s.ctx))
 
 	projectInfo := &model.ProjectInfo{
 		Ref:                 s.ref,

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -54,7 +54,7 @@ func TestFetchRevisions(t *testing.T) {
 		Convey("Fetching commits for a disabled repotracker should create no versions", func() {
 			evgProjectRef.RepotrackerDisabled = utility.TruePtr()
 			So(repoTracker.FetchRevisions(ctx), ShouldBeNil)
-			numVersions, err := model.VersionCount(model.VersionAll)
+			numVersions, err := model.VersionCount(t.Context(), model.VersionAll)
 			require.NoError(t, err, "Error finding all versions")
 			So(numVersions, ShouldEqual, 0)
 			evgProjectRef.RepotrackerDisabled = utility.FalsePtr()
@@ -66,7 +66,7 @@ func TestFetchRevisions(t *testing.T) {
 			testConfig.RepoTracker.NumNewRepoRevisionsToFetch = 2
 			require.NoError(t, repoTracker.FetchRevisions(ctx),
 				"Error running repository process %s", repoTracker.Settings.Id)
-			numVersions, err := model.VersionCount(model.VersionAll)
+			numVersions, err := model.VersionCount(t.Context(), model.VersionAll)
 			require.NoError(t, err, "Error finding all versions")
 			So(numVersions, ShouldEqual, 2)
 		})

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -75,7 +75,7 @@ func UpdateProjectAliases(ctx context.Context, projectId string, aliases []restM
 	if catcher.HasErrors() {
 		return catcher.Resolve()
 	}
-	if err := model.UpsertAliasesForProject(aliasesToUpsert, projectId); err != nil {
+	if err := model.UpsertAliasesForProject(ctx, aliasesToUpsert, projectId); err != nil {
 		return errors.Wrap(err, "upserting project aliases")
 	}
 	for _, aliasId := range aliasesToDelete {

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -144,7 +144,7 @@ func (a *AliasSuite) SetupTest() {
 	a.NoError(newProjectRef.Insert())
 	a.NoError(projectConfig.Insert())
 	for _, v := range aliases {
-		a.NoError(v.Upsert())
+		a.NoError(v.Upsert(a.T().Context()))
 	}
 }
 
@@ -212,7 +212,7 @@ func (a *AliasSuite) TestCopyProjectAliases() {
 	a.NoError(err)
 	a.Empty(res)
 
-	a.NoError(model.CopyProjectAliases("project_id", "new_project_id"))
+	a.NoError(model.CopyProjectAliases(a.T().Context(), "project_id", "new_project_id"))
 
 	res, err = FindMergedProjectAliases(a.T().Context(), "project_id", "", nil, false)
 	a.NoError(err)
@@ -335,7 +335,7 @@ func TestValidateFeaturesHaveAliases(t *testing.T) {
 		ProjectID: pRef.RepoRefId,
 		Alias:     evergreen.GithubChecksAlias,
 	}
-	assert.NoError(t, repoAlias1.Upsert())
+	assert.NoError(t, repoAlias1.Upsert(t.Context()))
 	// No error when there are aliases in the repo.
 	assert.NoError(t, validateFeaturesHaveAliases(oldPRef, pRef, aliases))
 

--- a/rest/data/distro_test.go
+++ b/rest/data/distro_test.go
@@ -37,11 +37,11 @@ func TestDeleteDistroById(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, evergreen.HostTerminated, dbHost.Status)
 
-			dbQueue, err := model.LoadTaskQueue("distro")
+			dbQueue, err := model.LoadTaskQueue(t.Context(), "distro")
 			assert.NoError(t, err)
 			assert.Empty(t, dbQueue.Queue)
 
-			events, err := event.FindLatestPrimaryDistroEvents("distro", 10, utility.ZeroTime)
+			events, err := event.FindLatestPrimaryDistroEvents(t.Context(), "distro", 10, utility.ZeroTime)
 			assert.NoError(t, err)
 			assert.Len(t, events, 1)
 		},
@@ -49,7 +49,7 @@ func TestDeleteDistroById(t *testing.T) {
 			err := DeleteDistroById(ctx, &u, "distro-no-task-queue")
 			assert.NoError(t, err)
 
-			events, err := event.FindLatestPrimaryDistroEvents("distro-no-task-queue", 10, utility.ZeroTime)
+			events, err := event.FindLatestPrimaryDistroEvents(t.Context(), "distro-no-task-queue", 10, utility.ZeroTime)
 			assert.NoError(t, err)
 			assert.Len(t, events, 1)
 		},
@@ -58,7 +58,7 @@ func TestDeleteDistroById(t *testing.T) {
 			assert.Error(t, err)
 			assert.Equal(t, "400 (Bad Request): distro 'nonexistent' not found", err.Error())
 
-			events, err := event.FindLatestPrimaryDistroEvents("nonexistent", 10, utility.ZeroTime)
+			events, err := event.FindLatestPrimaryDistroEvents(t.Context(), "nonexistent", 10, utility.ZeroTime)
 			assert.NoError(t, err)
 			assert.Empty(t, events)
 		},
@@ -120,7 +120,7 @@ func TestCopyDistro(t *testing.T) {
 			require.NotNil(t, newDistro)
 			assert.Nil(t, newDistro.Aliases)
 
-			events, err := event.FindLatestPrimaryDistroEvents("new-distro", 10, utility.ZeroTime)
+			events, err := event.FindLatestPrimaryDistroEvents(t.Context(), "new-distro", 10, utility.ZeroTime)
 			assert.NoError(t, err)
 			assert.Len(t, events, 1)
 		},
@@ -134,7 +134,7 @@ func TestCopyDistro(t *testing.T) {
 			assert.Error(t, err)
 			assert.Equal(t, "validator encountered errors: 'ERROR: distro 'distro2' uses an existing identifier'", err.Error())
 
-			events, err := event.FindLatestPrimaryDistroEvents("distro", 10, utility.ZeroTime)
+			events, err := event.FindLatestPrimaryDistroEvents(t.Context(), "distro", 10, utility.ZeroTime)
 			assert.NoError(t, err)
 			assert.Empty(t, events)
 		},
@@ -147,7 +147,7 @@ func TestCopyDistro(t *testing.T) {
 			assert.Error(t, err)
 			assert.Equal(t, "400 (Bad Request): new and existing distro IDs are identical", err.Error())
 
-			events, err := event.FindLatestPrimaryDistroEvents("distro", 10, utility.ZeroTime)
+			events, err := event.FindLatestPrimaryDistroEvents(t.Context(), "distro", 10, utility.ZeroTime)
 			assert.NoError(t, err)
 			assert.Empty(t, events)
 		},
@@ -160,7 +160,7 @@ func TestCopyDistro(t *testing.T) {
 			assert.Error(t, err)
 			assert.Equal(t, "404 (Not Found): distro 'my-distro' not found", err.Error())
 
-			events, err := event.FindLatestPrimaryDistroEvents("new-distro", 10, utility.ZeroTime)
+			events, err := event.FindLatestPrimaryDistroEvents(t.Context(), "new-distro", 10, utility.ZeroTime)
 			assert.NoError(t, err)
 			assert.Empty(t, events)
 		},
@@ -223,7 +223,7 @@ func TestUpdateDistro(t *testing.T) {
 			assert.NotNil(t, dbDistro)
 			assert.Equal(t, *dbDistro, *new)
 
-			dbQueue, err := model.LoadTaskQueue("distro")
+			dbQueue, err := model.LoadTaskQueue(t.Context(), "distro")
 			assert.NoError(t, err)
 			assert.NotEmpty(t, dbQueue.Queue)
 		},
@@ -236,7 +236,7 @@ func TestUpdateDistro(t *testing.T) {
 			assert.NotNil(t, dbDistro)
 			assert.Equal(t, *dbDistro, *new)
 
-			dbQueue, err := model.LoadTaskQueue("distro")
+			dbQueue, err := model.LoadTaskQueue(t.Context(), "distro")
 			assert.NoError(t, err)
 			assert.Empty(t, dbQueue.Queue)
 		},
@@ -291,7 +291,7 @@ func TestCreateDistro(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, newDistro)
 
-			events, err := event.FindLatestPrimaryDistroEvents("new-distro", 10, utility.ZeroTime)
+			events, err := event.FindLatestPrimaryDistroEvents(t.Context(), "new-distro", 10, utility.ZeroTime)
 			assert.NoError(t, err)
 			assert.Len(t, events, 1)
 
@@ -304,7 +304,7 @@ func TestCreateDistro(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NotNil(t, newDistro)
 
-			events, err := event.FindLatestPrimaryDistroEvents("new-distro", 10, utility.ZeroTime)
+			events, err := event.FindLatestPrimaryDistroEvents(t.Context(), "new-distro", 10, utility.ZeroTime)
 			assert.NoError(t, err)
 			assert.Len(t, events, 1)
 
@@ -315,7 +315,7 @@ func TestCreateDistro(t *testing.T) {
 			assert.Error(t, err)
 			assert.Equal(t, "validator encountered errors: 'ERROR: distro 'distro' uses an existing identifier'", err.Error())
 
-			events, err := event.FindLatestPrimaryDistroEvents("distro", 10, utility.ZeroTime)
+			events, err := event.FindLatestPrimaryDistroEvents(t.Context(), "distro", 10, utility.ZeroTime)
 			assert.NoError(t, err)
 			assert.Empty(t, events)
 		},

--- a/rest/data/distro_test.go
+++ b/rest/data/distro_test.go
@@ -87,7 +87,7 @@ func TestDeleteDistroById(t *testing.T) {
 				Distro: d.Id,
 				Queue:  []model.TaskQueueItem{{Id: "task"}},
 			}
-			assert.NoError(t, queue.Save())
+			assert.NoError(t, queue.Save(t.Context()))
 
 			d.Id = "distro-no-task-queue"
 			assert.NoError(t, d.Insert(tctx))
@@ -272,7 +272,7 @@ func TestUpdateDistro(t *testing.T) {
 				Distro: d.Id,
 				Queue:  []model.TaskQueueItem{{Id: "task"}},
 			}
-			assert.NoError(t, queue.Save())
+			assert.NoError(t, queue.Save(t.Context()))
 
 			tCase(t, tctx, &d, &updatedDistro)
 		})

--- a/rest/data/middleware_test.go
+++ b/rest/data/middleware_test.go
@@ -135,7 +135,7 @@ func TestGetProjectIdFromParams(t *testing.T) {
 			Id: "repo_id",
 		},
 	}
-	require.NoError(t, repo.Upsert())
+	require.NoError(t, repo.Upsert(t.Context()))
 	projectId, statusCode, err = GetProjectIdFromParams(ctx, map[string]string{"repoId": repo.ProjectRef.Id})
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, statusCode)

--- a/rest/data/middleware_test.go
+++ b/rest/data/middleware_test.go
@@ -135,7 +135,7 @@ func TestGetProjectIdFromParams(t *testing.T) {
 			Id: "repo_id",
 		},
 	}
-	require.NoError(t, repo.Upsert(t.Context()))
+	require.NoError(t, repo.Replace(t.Context()))
 	projectId, statusCode, err = GetProjectIdFromParams(ctx, map[string]string{"repoId": repo.ProjectRef.Id})
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, statusCode)

--- a/rest/data/notifications.go
+++ b/rest/data/notifications.go
@@ -20,7 +20,7 @@ func GetNotificationsStats(ctx context.Context) (*restModel.APIEventStats, error
 		stats.LastProcessedAt = &e.ProcessedAt
 	}
 
-	n, err := event.CountUnprocessedEvents()
+	n, err := event.CountUnprocessedEvents(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "counting unprocessed events")
 	}

--- a/rest/data/notifications.go
+++ b/rest/data/notifications.go
@@ -26,7 +26,7 @@ func GetNotificationsStats(ctx context.Context) (*restModel.APIEventStats, error
 	}
 	stats.NumUnprocessedEvents = n
 
-	nStats, err := notification.CollectUnsentNotificationStats()
+	nStats, err := notification.CollectUnsentNotificationStats(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "collecting unsent notification stats")
 	}

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -446,7 +446,7 @@ func HideBranch(ctx context.Context, projectID string) error {
 		Enabled:   false,
 		Hidden:    utility.TruePtr(),
 	}
-	if err := skeletonProj.Upsert(ctx); err != nil {
+	if err := skeletonProj.Replace(ctx); err != nil {
 		return errors.Wrapf(err, "updating project '%s'", pRef.Id)
 	}
 	if err := model.UpdateAdminRoles(ctx, pRef, nil, pRef.Admins); err != nil {

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -446,7 +446,7 @@ func HideBranch(ctx context.Context, projectID string) error {
 		Enabled:   false,
 		Hidden:    utility.TruePtr(),
 	}
-	if err := skeletonProj.Upsert(); err != nil {
+	if err := skeletonProj.Upsert(ctx); err != nil {
 		return errors.Wrapf(err, "updating project '%s'", pRef.Id)
 	}
 	if err := model.UpdateAdminRoles(ctx, pRef, nil, pRef.Admins); err != nil {

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -304,7 +304,7 @@ func FindProjectVarsById(ctx context.Context, id string, repoId string, redact b
 // will be fully replaced by those in varsModel. Otherwise, it will only set the
 // value for variables that are explicitly present in varsModel and will not
 // delete variables that are omitted.
-func UpdateProjectVars(projectId string, varsModel *restModel.APIProjectVars, overwrite bool) error {
+func UpdateProjectVars(ctx context.Context, projectId string, varsModel *restModel.APIProjectVars, overwrite bool) error {
 	if varsModel == nil {
 		return nil
 	}
@@ -318,7 +318,7 @@ func UpdateProjectVars(projectId string, varsModel *restModel.APIProjectVars, ov
 		}
 	}
 	if overwrite {
-		if _, err := vars.Upsert(); err != nil {
+		if _, err := vars.Upsert(ctx); err != nil {
 			return errors.Wrapf(err, "overwriting variables for project '%s'", vars.Id)
 		}
 	} else {
@@ -466,7 +466,7 @@ func HideBranch(ctx context.Context, projectID string) error {
 	skeletonProjVars := model.ProjectVars{
 		Id: pRef.Id,
 	}
-	if _, err := skeletonProjVars.Upsert(); err != nil {
+	if _, err := skeletonProjVars.Upsert(ctx); err != nil {
 		return errors.Wrapf(err, "updating vars for project '%s'", pRef.Id)
 	}
 

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -119,7 +119,7 @@ func CreateProject(ctx context.Context, env evergreen.Environment, projectRef *m
 	}
 	// Always warn because created projects are never enabled.
 	warningCatcher := grip.NewBasicCatcher()
-	statusCode, err := model.ValidateEnabledProjectsLimit(projectRef.Id, env.Settings(), nil, projectRef)
+	statusCode, err := model.ValidateEnabledProjectsLimit(ctx, projectRef.Id, env.Settings(), nil, projectRef)
 	if err != nil {
 		if statusCode != http.StatusBadRequest {
 			return false, gimlet.ErrorResponse{

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -288,7 +288,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 			if err != nil {
 				return nil, errors.Wrap(err, "getting evergreen config")
 			}
-			_, err = model.ValidateEnabledProjectsLimit(projectId, config, mergedBeforeRef, mergedSection)
+			_, err = model.ValidateEnabledProjectsLimit(ctx, projectId, config, mergedBeforeRef, mergedSection)
 			if err != nil {
 				return nil, errors.Wrap(err, "validating project creation")
 			}

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -143,7 +143,7 @@ func PromoteVarsToRepo(ctx context.Context, projectIdentifier string, varNames [
 		}
 	}
 
-	if err = UpdateProjectVars(repoId, apiRepoVars, true); err != nil {
+	if err = UpdateProjectVars(ctx, repoId, apiRepoVars, true); err != nil {
 		return errors.Wrapf(err, "adding variables from project '%s' to repo", projectIdentifier)
 	}
 
@@ -180,7 +180,7 @@ func PromoteVarsToRepo(ctx context.Context, projectIdentifier string, varNames [
 		}
 	}
 
-	if err := UpdateProjectVars(projectId, apiProjectVars, true); err != nil {
+	if err := UpdateProjectVars(ctx, projectId, apiProjectVars, true); err != nil {
 		return errors.Wrapf(err, "removing promoted project variables from project '%s'", projectIdentifier)
 	}
 
@@ -366,7 +366,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 				changes.Vars.Vars[key] = value
 			}
 		}
-		if err = UpdateProjectVars(projectId, &changes.Vars, true); err != nil { // destructively modifies vars
+		if err = UpdateProjectVars(ctx, projectId, &changes.Vars, true); err != nil { // destructively modifies vars
 			return nil, errors.Wrapf(err, "updating project variables for project '%s'", projectId)
 		}
 		modified = true

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -71,10 +71,10 @@ func CopyProject(ctx context.Context, env evergreen.Environment, opts restModel.
 	if err := model.CopyProjectVars(ctx, oldId, projectToCopy.Id); err != nil {
 		catcher.Wrapf(err, "copying project vars from project '%s'", oldIdentifier)
 	}
-	if err := model.CopyProjectAliases(oldId, projectToCopy.Id); err != nil {
+	if err := model.CopyProjectAliases(ctx, oldId, projectToCopy.Id); err != nil {
 		catcher.Wrapf(err, "copying aliases from project '%s'", oldIdentifier)
 	}
-	if err := event.CopyProjectSubscriptions(oldId, projectToCopy.Id); err != nil {
+	if err := event.CopyProjectSubscriptions(ctx, oldId, projectToCopy.Id); err != nil {
 		catcher.Wrapf(err, "copying subscriptions from project '%s'", oldIdentifier)
 	}
 	// Set the same admin roles from the old project on the newly copied project.

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -186,7 +186,7 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 			Restricted: utility.FalsePtr(),
 			Admins:     []string{"oldAdmin"},
 		}}
-		assert.NoError(t, repoRef.Upsert(t.Context()))
+		assert.NoError(t, repoRef.Replace(t.Context()))
 
 		pRefThatDefaults := model.ProjectRef{
 			Id:        "myId",
@@ -1005,7 +1005,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			Restricted:       utility.TruePtr(),
 			PRTestingEnabled: utility.TruePtr(),
 		}}
-		assert.NoError(t, repoRef.Upsert(t.Context()))
+		assert.NoError(t, repoRef.Replace(t.Context()))
 
 		pVars := model.ProjectVars{
 			Id:          pRef.Id,
@@ -1241,7 +1241,7 @@ func TestPromoteVarsToRepo(t *testing.T) {
 			Restricted: utility.FalsePtr(),
 			Admins:     []string{"u"},
 		}}
-		assert.NoError(t, repoRef.Upsert(t.Context()))
+		assert.NoError(t, repoRef.Replace(t.Context()))
 
 		rVars := model.ProjectVars{
 			Id:            repoRef.Id,

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -1070,7 +1070,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 				Target: "a@gmail.com",
 			},
 		}
-		assert.NoError(t, existingSub.Upsert())
+		assert.NoError(t, existingSub.Upsert(t.Context()))
 		existingSub2 := event.Subscription{
 			ID:           "existingSub2",
 			Owner:        pRef.Id,
@@ -1098,7 +1098,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 				},
 			},
 		}
-		assert.NoError(t, existingSub2.Upsert())
+		assert.NoError(t, existingSub2.Upsert(t.Context()))
 		t.Run(name, func(t *testing.T) {
 			test(t, pRef)
 		})
@@ -1468,7 +1468,7 @@ func TestCopyProject(t *testing.T) {
 				Target: "a@gmail.com",
 			},
 		}
-		assert.NoError(t, existingSub.Upsert())
+		assert.NoError(t, existingSub.Upsert(t.Context()))
 		t.Run(name, func(t *testing.T) {
 			test(t, pRef)
 		})

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -186,7 +186,7 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 			Restricted: utility.FalsePtr(),
 			Admins:     []string{"oldAdmin"},
 		}}
-		assert.NoError(t, repoRef.Upsert())
+		assert.NoError(t, repoRef.Upsert(t.Context()))
 
 		pRefThatDefaults := model.ProjectRef{
 			Id:        "myId",
@@ -1005,7 +1005,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			Restricted:       utility.TruePtr(),
 			PRTestingEnabled: utility.TruePtr(),
 		}}
-		assert.NoError(t, repoRef.Upsert())
+		assert.NoError(t, repoRef.Upsert(t.Context()))
 
 		pVars := model.ProjectVars{
 			Id:          pRef.Id,
@@ -1241,7 +1241,7 @@ func TestPromoteVarsToRepo(t *testing.T) {
 			Restricted: utility.FalsePtr(),
 			Admins:     []string{"u"},
 		}}
-		assert.NoError(t, repoRef.Upsert())
+		assert.NoError(t, repoRef.Upsert(t.Context()))
 
 		rVars := model.ProjectVars{
 			Id:            repoRef.Id,

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -195,14 +195,14 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 			RepoRefId: "myRepoId",
 			Admins:    []string{"oldAdmin"},
 		}
-		assert.NoError(t, pRefThatDefaults.Upsert(t.Context()))
+		assert.NoError(t, pRefThatDefaults.Replace(t.Context()))
 
 		pRefThatDoesNotDefault := model.ProjectRef{
 			Id:    "myId2",
 			Owner: "evergreen-ci",
 			Repo:  "evergreen",
 		}
-		assert.NoError(t, pRefThatDoesNotDefault.Upsert(t.Context()))
+		assert.NoError(t, pRefThatDoesNotDefault.Replace(t.Context()))
 
 		pVars := model.ProjectVars{
 			Id:          repoRef.Id,
@@ -314,7 +314,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.NoError(t, conflictingRef.Insert())
 			ref.PRTestingEnabled = utility.TruePtr()
 			ref.GithubChecksEnabled = utility.TruePtr()
-			assert.NoError(t, ref.Upsert(t.Context()))
+			assert.NoError(t, ref.Replace(t.Context()))
 			ref.Enabled = true
 			apiProjectRef := restModel.APIProjectRef{}
 			assert.NoError(t, apiProjectRef.BuildFromService(t.Context(), ref))
@@ -1520,7 +1520,7 @@ func TestDeleteContainerSecrets(t *testing.T) {
 		},
 		"RemovesContainerSecretsMissingExternalIDsWithoutModifyingDBProjectRef": func(ctx context.Context, t *testing.T, mv *cocoaMock.Vault, pRef model.ProjectRef) {
 			pRef.ContainerSecrets[0].ExternalID = ""
-			require.NoError(t, pRef.Upsert(t.Context()))
+			require.NoError(t, pRef.Replace(t.Context()))
 			remaining, err := DeleteContainerSecrets(ctx, mv, &pRef, []string{pRef.ContainerSecrets[0].Name})
 			require.NoError(t, err)
 			assert.Len(t, remaining, len(pRef.ContainerSecrets)-1)
@@ -1618,7 +1618,7 @@ func TestUpsertContainerSecrets(t *testing.T) {
 				Value:        "is yummy",
 			}
 			pRef.ContainerSecrets = append(pRef.ContainerSecrets, newSecret)
-			require.NoError(t, pRef.Upsert(t.Context()))
+			require.NoError(t, pRef.Replace(t.Context()))
 			require.NoError(t, UpsertContainerSecrets(ctx, mv, pRef.ContainerSecrets))
 
 			dbProjRef, err := model.FindBranchProjectRef(ctx, pRef.Id)
@@ -1638,7 +1638,7 @@ func TestUpsertContainerSecrets(t *testing.T) {
 		"UpdatesExistingContainerSecretValue": func(ctx context.Context, t *testing.T, mv *cocoaMock.Vault, pRef model.ProjectRef) {
 			const newValue = "new_secret_value"
 			pRef.ContainerSecrets[0].Value = newValue
-			require.NoError(t, pRef.Upsert(t.Context()))
+			require.NoError(t, pRef.Replace(t.Context()))
 			require.NoError(t, UpsertContainerSecrets(ctx, mv, pRef.ContainerSecrets))
 
 			dbProjRef, err := model.FindBranchProjectRef(ctx, pRef.Id)

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -195,14 +195,14 @@ func TestSaveProjectSettingsForSectionForRepo(t *testing.T) {
 			RepoRefId: "myRepoId",
 			Admins:    []string{"oldAdmin"},
 		}
-		assert.NoError(t, pRefThatDefaults.Upsert())
+		assert.NoError(t, pRefThatDefaults.Upsert(t.Context()))
 
 		pRefThatDoesNotDefault := model.ProjectRef{
 			Id:    "myId2",
 			Owner: "evergreen-ci",
 			Repo:  "evergreen",
 		}
-		assert.NoError(t, pRefThatDoesNotDefault.Upsert())
+		assert.NoError(t, pRefThatDoesNotDefault.Upsert(t.Context()))
 
 		pVars := model.ProjectVars{
 			Id:          repoRef.Id,
@@ -314,7 +314,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.NoError(t, conflictingRef.Insert())
 			ref.PRTestingEnabled = utility.TruePtr()
 			ref.GithubChecksEnabled = utility.TruePtr()
-			assert.NoError(t, ref.Upsert())
+			assert.NoError(t, ref.Upsert(t.Context()))
 			ref.Enabled = true
 			apiProjectRef := restModel.APIProjectRef{}
 			assert.NoError(t, apiProjectRef.BuildFromService(t.Context(), ref))
@@ -1520,7 +1520,7 @@ func TestDeleteContainerSecrets(t *testing.T) {
 		},
 		"RemovesContainerSecretsMissingExternalIDsWithoutModifyingDBProjectRef": func(ctx context.Context, t *testing.T, mv *cocoaMock.Vault, pRef model.ProjectRef) {
 			pRef.ContainerSecrets[0].ExternalID = ""
-			require.NoError(t, pRef.Upsert())
+			require.NoError(t, pRef.Upsert(t.Context()))
 			remaining, err := DeleteContainerSecrets(ctx, mv, &pRef, []string{pRef.ContainerSecrets[0].Name})
 			require.NoError(t, err)
 			assert.Len(t, remaining, len(pRef.ContainerSecrets)-1)
@@ -1618,7 +1618,7 @@ func TestUpsertContainerSecrets(t *testing.T) {
 				Value:        "is yummy",
 			}
 			pRef.ContainerSecrets = append(pRef.ContainerSecrets, newSecret)
-			require.NoError(t, pRef.Upsert())
+			require.NoError(t, pRef.Upsert(t.Context()))
 			require.NoError(t, UpsertContainerSecrets(ctx, mv, pRef.ContainerSecrets))
 
 			dbProjRef, err := model.FindBranchProjectRef(ctx, pRef.Id)
@@ -1638,7 +1638,7 @@ func TestUpsertContainerSecrets(t *testing.T) {
 		"UpdatesExistingContainerSecretValue": func(ctx context.Context, t *testing.T, mv *cocoaMock.Vault, pRef model.ProjectRef) {
 			const newValue = "new_secret_value"
 			pRef.ContainerSecrets[0].Value = newValue
-			require.NoError(t, pRef.Upsert())
+			require.NoError(t, pRef.Upsert(t.Context()))
 			require.NoError(t, UpsertContainerSecrets(ctx, mv, pRef.ContainerSecrets))
 
 			dbProjRef, err := model.FindBranchProjectRef(ctx, pRef.Id)

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -386,14 +386,14 @@ func TestGetProjectAliasResults(t *testing.T) {
 		Variant:   "^bv1$",
 		Task:      ".*",
 	}
-	require.NoError(t, alias1.Upsert())
+	require.NoError(t, alias1.Upsert(t.Context()))
 	alias2 := model.ProjectAlias{
 		Alias:     "select_bv2",
 		ProjectID: p.Identifier,
 		Variant:   "^bv2$",
 		Task:      ".*",
 	}
-	require.NoError(t, alias2.Upsert())
+	require.NoError(t, alias2.Upsert(t.Context()))
 
 	variantTasks, err := GetProjectAliasResults(t.Context(), &p, alias1.Alias, false)
 	assert.NoError(t, err)
@@ -628,7 +628,7 @@ func TestHideBranch(t *testing.T) {
 		Variant:   "^bv1$",
 		Task:      ".*",
 	}
-	require.NoError(t, alias.Upsert())
+	require.NoError(t, alias.Upsert(t.Context()))
 
 	vars := &model.ProjectVars{
 		Id:          project.Id,

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -152,7 +152,7 @@ func TestProjectConnectorGetSuite(t *testing.T) {
 				Id: repoProjectId,
 			},
 		}
-		s.Require().NoError(repoWithVars.Upsert(t.Context()))
+		s.Require().NoError(repoWithVars.Replace(t.Context()))
 		repoVars := &model.ProjectVars{
 			Id:          repoProjectId,
 			Vars:        map[string]string{"a": "a_from_repo", "c": "new"},
@@ -607,7 +607,7 @@ func TestHideBranch(t *testing.T) {
 			Repo:  "test_repo",
 		},
 	}
-	assert.NoError(t, repo.Upsert(t.Context()))
+	assert.NoError(t, repo.Replace(t.Context()))
 
 	project := &model.ProjectRef{
 		Identifier:  projectId,

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -152,7 +152,7 @@ func TestProjectConnectorGetSuite(t *testing.T) {
 				Id: repoProjectId,
 			},
 		}
-		s.Require().NoError(repoWithVars.Upsert())
+		s.Require().NoError(repoWithVars.Upsert(t.Context()))
 		repoVars := &model.ProjectVars{
 			Id:          repoProjectId,
 			Vars:        map[string]string{"a": "a_from_repo", "c": "new"},
@@ -607,7 +607,7 @@ func TestHideBranch(t *testing.T) {
 			Repo:  "test_repo",
 		},
 	}
-	assert.NoError(t, repo.Upsert())
+	assert.NoError(t, repo.Upsert(t.Context()))
 
 	project := &model.ProjectRef{
 		Identifier:  projectId,

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -620,7 +620,7 @@ func TestHideBranch(t *testing.T) {
 		Enabled:     true,
 		Hidden:      utility.ToBoolPtr(false),
 	}
-	require.NoError(t, project.Upsert())
+	require.NoError(t, project.Upsert(t.Context()))
 
 	alias := model.ProjectAlias{
 		ProjectID: project.Id,

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -620,7 +620,7 @@ func TestHideBranch(t *testing.T) {
 		Enabled:     true,
 		Hidden:      utility.ToBoolPtr(false),
 	}
-	require.NoError(t, project.Upsert(t.Context()))
+	require.NoError(t, project.Replace(t.Context()))
 
 	alias := model.ProjectAlias{
 		ProjectID: project.Id,

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -301,7 +301,7 @@ func (s *ProjectConnectorGetSuite) TestUpdateProjectVars() {
 		PrivateVars:  map[string]bool{"b": false, "c": true},
 		VarsToDelete: varsToDelete,
 	}
-	s.NoError(UpdateProjectVars(projectId, &newVars, false))
+	s.NoError(UpdateProjectVars(s.T().Context(), projectId, &newVars, false))
 
 	s.Empty(newVars.Vars["b"]) // can't unredact previously redacted variables
 	s.Empty(newVars.Vars["c"])
@@ -337,7 +337,7 @@ func (s *ProjectConnectorGetSuite) TestUpdateProjectVars() {
 	}
 	s.Require().NoError(newProjRef.Insert())
 	// successful upsert
-	s.NoError(UpdateProjectVars(newProjRef.Id, &newVars, false))
+	s.NoError(UpdateProjectVars(s.T().Context(), newProjRef.Id, &newVars, false))
 
 	dbUpsertedVars, err := model.FindOneProjectVars(s.T().Context(), newProjRef.Id)
 	s.NoError(err)

--- a/rest/data/reliability.go
+++ b/rest/data/reliability.go
@@ -19,7 +19,7 @@ func GetTaskReliabilityScores(ctx context.Context, filter reliability.TaskReliab
 		filter.Project = projectID
 	}
 
-	serviceStatsResult, err := reliability.GetTaskReliabilityScores(filter)
+	serviceStatsResult, err := reliability.GetTaskReliabilityScores(ctx, filter)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting task reliability scores")
 	}

--- a/rest/data/subscription.go
+++ b/rest/data/subscription.go
@@ -107,7 +107,7 @@ func SaveSubscriptions(ctx context.Context, owner string, subscriptions []restMo
 
 	catcher := grip.NewSimpleCatcher()
 	for _, subscription := range dbSubscriptions {
-		catcher.Add(subscription.Upsert())
+		catcher.Add(subscription.Upsert(ctx))
 	}
 	return catcher.Resolve()
 }

--- a/rest/data/subscription_test.go
+++ b/rest/data/subscription_test.go
@@ -56,7 +56,7 @@ func TestGetSubscriptions(t *testing.T) {
 	}
 
 	for i := range subs {
-		assert.NoError(subs[i].Upsert())
+		assert.NoError(subs[i].Upsert(t.Context()))
 	}
 
 	apiSubs, err := GetSubscriptions("someone", event.OwnerTypePerson)
@@ -304,7 +304,7 @@ func TestSaveProjectSubscriptions(t *testing.T) {
 					Target: "a@domain.invalid",
 				},
 			}
-			assert.NoError(t, projectSubscription.Upsert())
+			assert.NoError(t, projectSubscription.Upsert(t.Context()))
 			test(t)
 		})
 	}
@@ -474,7 +474,7 @@ func TestDeleteProjectSubscriptions(t *testing.T) {
 			}
 			toDelete := []string{}
 			for _, sub := range subs {
-				assert.NoError(t, sub.Upsert())
+				assert.NoError(t, sub.Upsert(t.Context()))
 				toDelete = append(toDelete, sub.ID)
 			}
 			test(t, toDelete)

--- a/rest/data/task_stats.go
+++ b/rest/data/task_stats.go
@@ -19,7 +19,7 @@ func GetTaskStats(ctx context.Context, filter taskstats.StatsFilter) ([]restMode
 		filter.Project = projectID
 	}
 
-	serviceStatsResult, err := taskstats.GetTaskStats(filter)
+	serviceStatsResult, err := taskstats.GetTaskStats(ctx, filter)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting task stats")
 	}

--- a/rest/data/user.go
+++ b/rest/data/user.go
@@ -163,5 +163,5 @@ func AddOrUpdateServiceUser(ctx context.Context, toUpdate restModel.APIDBUser) e
 	if dbUser == nil {
 		return errors.Wrapf(err, "cannot perform add or update with nil user")
 	}
-	return errors.Wrap(user.AddOrUpdateServiceUser(*dbUser), "updating service user")
+	return errors.Wrap(user.AddOrUpdateServiceUser(ctx, *dbUser), "updating service user")
 }

--- a/rest/route/admin_clear.go
+++ b/rest/route/admin_clear.go
@@ -29,7 +29,7 @@ func (h *clearTaskQueueHandler) Parse(ctx context.Context, r *http.Request) erro
 }
 
 func (h *clearTaskQueueHandler) Run(ctx context.Context) gimlet.Responder {
-	tq, err := model.LoadTaskQueue(h.distro)
+	tq, err := model.LoadTaskQueue(ctx, h.distro)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding task queue for distro '%s'", h.distro))
 	}

--- a/rest/route/admin_test.go
+++ b/rest/route/admin_test.go
@@ -429,7 +429,7 @@ func (s *AdminRouteSuite) TestClearTaskQueueRoute() {
 	resp := route.Run(context.Background())
 	s.Equal(http.StatusOK, resp.Status())
 
-	queueFromDb, err := model.LoadTaskQueue(distro)
+	queueFromDb, err := model.LoadTaskQueue(s.T().Context(), distro)
 	s.NoError(err)
 	s.Empty(queueFromDb.Queue)
 }

--- a/rest/route/admin_test.go
+++ b/rest/route/admin_test.go
@@ -423,7 +423,7 @@ func (s *AdminRouteSuite) TestClearTaskQueueRoute() {
 	}
 	queue := model.NewTaskQueue(distro, tasks, model.DistroQueueInfo{})
 	s.Len(queue.Queue, 3)
-	s.NoError(queue.Save())
+	s.NoError(queue.Save(s.T().Context()))
 
 	route.distro = distro
 	resp := route.Run(context.Background())

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -664,7 +664,7 @@ func (h *attachFilesHandler) Run(ctx context.Context) gimlet.Responder {
 		Files:           artifact.EscapeFiles(h.files),
 	}
 
-	if err = entry.Upsert(); err != nil {
+	if err = entry.Upsert(ctx); err != nil {
 		message := fmt.Sprintf("updating artifact file info for task %s: %v", t.Id, err)
 		grip.Error(message)
 		return gimlet.MakeJSONInternalErrorResponder(errors.New(message))

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -287,7 +287,7 @@ func TestMarkTaskForReset(t *testing.T) {
 				NumAutoRestartedTasks:   1,
 				LastAutoRestartedTaskAt: time.Now().Add(-25 * time.Hour),
 			}
-			require.NoError(t, pRef.Upsert())
+			require.NoError(t, pRef.Upsert(t.Context()))
 			rh.taskID = "t4"
 			resp = rh.Run(ctx)
 			require.NotZero(t, resp)

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -287,7 +287,7 @@ func TestMarkTaskForReset(t *testing.T) {
 				NumAutoRestartedTasks:   1,
 				LastAutoRestartedTaskAt: time.Now().Add(-25 * time.Hour),
 			}
-			require.NoError(t, pRef.Upsert(t.Context()))
+			require.NoError(t, pRef.Replace(t.Context()))
 			rh.taskID = "t4"
 			resp = rh.Run(ctx)
 			require.NotZero(t, resp)

--- a/rest/route/alias_test.go
+++ b/rest/route/alias_test.go
@@ -100,7 +100,7 @@ func TestGetAliasesHandler(t *testing.T) {
 				VersionControlEnabled: utility.TruePtr(),
 			}
 			require.NoError(t, repoRef.Upsert())
-			require.NoError(t, projectRef.Upsert())
+			require.NoError(t, projectRef.Upsert(t.Context()))
 
 			repoAlias := &dbModel.ProjectAlias{
 				ProjectID: repoRef.Id,

--- a/rest/route/alias_test.go
+++ b/rest/route/alias_test.go
@@ -99,7 +99,7 @@ func TestGetAliasesHandler(t *testing.T) {
 				RepoRefId:             "repo_ref",
 				VersionControlEnabled: utility.TruePtr(),
 			}
-			require.NoError(t, repoRef.Upsert(t.Context()))
+			require.NoError(t, repoRef.Replace(t.Context()))
 			require.NoError(t, projectRef.Upsert(t.Context()))
 
 			repoAlias := &dbModel.ProjectAlias{

--- a/rest/route/alias_test.go
+++ b/rest/route/alias_test.go
@@ -112,8 +112,8 @@ func TestGetAliasesHandler(t *testing.T) {
 				Alias:     "project_alias",
 				Variant:   "test_variant",
 			}
-			require.NoError(t, repoAlias.Upsert())
-			require.NoError(t, projectAlias.Upsert())
+			require.NoError(t, repoAlias.Upsert(t.Context()))
+			require.NoError(t, projectAlias.Upsert(t.Context()))
 
 			projectConfig := &dbModel.ProjectConfig{
 				Id:      "project-1",

--- a/rest/route/alias_test.go
+++ b/rest/route/alias_test.go
@@ -100,7 +100,7 @@ func TestGetAliasesHandler(t *testing.T) {
 				VersionControlEnabled: utility.TruePtr(),
 			}
 			require.NoError(t, repoRef.Replace(t.Context()))
-			require.NoError(t, projectRef.Upsert(t.Context()))
+			require.NoError(t, projectRef.Replace(t.Context()))
 
 			repoAlias := &dbModel.ProjectAlias{
 				ProjectID: repoRef.Id,

--- a/rest/route/alias_test.go
+++ b/rest/route/alias_test.go
@@ -99,7 +99,7 @@ func TestGetAliasesHandler(t *testing.T) {
 				RepoRefId:             "repo_ref",
 				VersionControlEnabled: utility.TruePtr(),
 			}
-			require.NoError(t, repoRef.Upsert())
+			require.NoError(t, repoRef.Upsert(t.Context()))
 			require.NoError(t, projectRef.Upsert(t.Context()))
 
 			repoAlias := &dbModel.ProjectAlias{

--- a/rest/route/annotations.go
+++ b/rest/route/annotations.go
@@ -481,7 +481,7 @@ func (h *createdTicketByTaskPutHandler) Parse(ctx context.Context, r *http.Reque
 }
 
 func (h *createdTicketByTaskPutHandler) Run(ctx context.Context) gimlet.Responder {
-	err := annotations.AddCreatedTicket(h.taskId, h.execution, *restModel.APIIssueLinkToService(*h.ticket), h.user.DisplayName())
+	err := annotations.AddCreatedTicket(ctx, h.taskId, h.execution, *restModel.APIIssueLinkToService(*h.ticket), h.user.DisplayName())
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(err)
 	}

--- a/rest/route/annotations_test.go
+++ b/rest/route/annotations_test.go
@@ -770,7 +770,7 @@ func TestCreatedTicketByTaskPutHandlerParse(t *testing.T) {
 			Endpoint: "random",
 		},
 	}
-	assert.NoError(t, p.Upsert())
+	assert.NoError(t, p.Upsert(t.Context()))
 	r, err := http.NewRequest(http.MethodPut, "/task/t1/created_ticket?execution=1", buffer)
 	r = gimlet.SetURLVars(r, map[string]string{"task_id": "t1"})
 	assert.NoError(t, err)

--- a/rest/route/annotations_test.go
+++ b/rest/route/annotations_test.go
@@ -87,7 +87,7 @@ func TestAnnotationsByBuildHandlerRun(t *testing.T) {
 		},
 	}
 	for _, a := range annotations {
-		assert.NoError(t, a.Upsert())
+		assert.NoError(t, a.Upsert(t.Context()))
 	}
 
 	resp = h.Run(ctx)
@@ -178,7 +178,7 @@ func TestAnnotationsByVersionHandlerRun(t *testing.T) {
 		},
 	}
 	for _, a := range annotations {
-		assert.NoError(t, a.Upsert())
+		assert.NoError(t, a.Upsert(t.Context()))
 	}
 
 	resp = h.Run(ctx)
@@ -286,7 +286,7 @@ func TestAnnotationByTaskGetHandlerRun(t *testing.T) {
 	}
 
 	for _, a := range annotations {
-		assert.NoError(t, a.Upsert())
+		assert.NoError(t, a.Upsert(t.Context()))
 	}
 
 	// get the latest execution : 1

--- a/rest/route/annotations_test.go
+++ b/rest/route/annotations_test.go
@@ -770,7 +770,7 @@ func TestCreatedTicketByTaskPutHandlerParse(t *testing.T) {
 			Endpoint: "random",
 		},
 	}
-	assert.NoError(t, p.Upsert(t.Context()))
+	assert.NoError(t, p.Replace(t.Context()))
 	r, err := http.NewRequest(http.MethodPut, "/task/t1/created_ticket?execution=1", buffer)
 	r = gimlet.SetURLVars(r, map[string]string{"task_id": "t1"})
 	assert.NoError(t, err)

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -331,7 +331,7 @@ func (s *GithubWebhookRouteSuite) TestCreateVersionForTag() {
 		RemotePath: "rest/route/testdata/release.yml",
 	}
 	s.NoError(pRef.Insert())
-	s.NoError(projectAlias.Upsert())
+	s.NoError(projectAlias.Upsert(s.T().Context()))
 
 	v, err := s.mock.createVersionForTag(context.Background(), pRef, nil, model.Revision{}, tag)
 	s.NoError(err)

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -132,13 +132,13 @@ func (s *GithubWebhookRouteSuite) TestAddIntentAndFailsWithDuplicate() {
 	ctx := context.Background()
 	resp := s.h.Run(ctx)
 	s.Equal(http.StatusOK, resp.Status())
-	count, err := db.CountQ(patch.IntentCollection, db.Query(bson.M{}))
+	count, err := db.CountQContext(s.T().Context(), patch.IntentCollection, db.Query(bson.M{}))
 	s.NoError(err)
 	s.Equal(1, count)
 
 	resp = s.h.Run(ctx)
 	s.NotEqual(http.StatusOK, resp.Status())
-	count, err = db.CountQ(patch.IntentCollection, db.Query(bson.M{}))
+	count, err = db.CountQContext(s.T().Context(), patch.IntentCollection, db.Query(bson.M{}))
 	s.NoError(err)
 	s.Equal(1, count)
 }

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -132,13 +132,13 @@ func (s *GithubWebhookRouteSuite) TestAddIntentAndFailsWithDuplicate() {
 	ctx := context.Background()
 	resp := s.h.Run(ctx)
 	s.Equal(http.StatusOK, resp.Status())
-	count, err := db.CountQContext(s.T().Context(), patch.IntentCollection, db.Query(bson.M{}))
+	count, err := db.CountQ(s.T().Context(), patch.IntentCollection, db.Query(bson.M{}))
 	s.NoError(err)
 	s.Equal(1, count)
 
 	resp = s.h.Run(ctx)
 	s.NotEqual(http.StatusOK, resp.Status())
-	count, err = db.CountQContext(s.T().Context(), patch.IntentCollection, db.Query(bson.M{}))
+	count, err = db.CountQ(s.T().Context(), patch.IntentCollection, db.Query(bson.M{}))
 	s.NoError(err)
 	s.Equal(1, count)
 }

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -192,7 +192,7 @@ func (h *hostAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 
 	// retrieve the next task off the task queue and attempt to assign it to the host.
 	// If there is already a host that has the task, it will error
-	taskQueue, err := model.LoadTaskQueue(h.host.Distro.Id)
+	taskQueue, err := model.LoadTaskQueue(ctx, h.host.Distro.Id)
 	if err != nil {
 		err = errors.Wrapf(err, "locating distro queue (%s) for host '%s'", h.host.Distro.Id, h.host.Id)
 		grip.Error(err)
@@ -214,7 +214,7 @@ func (h *hostAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 	if nextTask == nil && !shouldRunTeardown {
 		// if we couldn't find a task in the task queue,
 		// check the alias queue...
-		secondaryQueue, err := model.LoadDistroSecondaryTaskQueue(h.host.Distro.Id)
+		secondaryQueue, err := model.LoadDistroSecondaryTaskQueue(ctx, h.host.Distro.Id)
 		if err != nil {
 			return gimlet.MakeJSONErrorResponder(err)
 		}
@@ -311,7 +311,7 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 
 	var amiUpdatedTime time.Time
 	if d.GetDefaultAMI() != currentHost.GetAMI() {
-		amiEvent, err := event.FindLatestAMIModifiedDistroEvent(d.Id)
+		amiEvent, err := event.FindLatestAMIModifiedDistroEvent(ctx, d.Id)
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":   "problem getting AMI event log",
 			"host_id":   currentHost.Id,

--- a/rest/route/host_agent_test.go
+++ b/rest/route/host_agent_test.go
@@ -620,7 +620,7 @@ func TestHostNextTask(t *testing.T) {
 			require.NoError(t, testBuild.Insert())
 			require.NoError(t, pref.Insert())
 			require.NoError(t, sampleHost.Insert(ctx))
-			require.NoError(t, tq.Save())
+			require.NoError(t, tq.Save(t.Context()))
 			require.NoError(t, v.Insert())
 
 			r, ok := makeHostAgentNextTask(env, nil, nil).(*hostAgentNextTask)
@@ -728,7 +728,7 @@ func TestSingleTaskDistroValidation(t *testing.T) {
 	require.NoError(t, b.Insert())
 	require.NoError(t, pref.Insert())
 	require.NoError(t, sampleHost.Insert(ctx))
-	require.NoError(t, tq.Save())
+	require.NoError(t, tq.Save(t.Context()))
 	require.NoError(t, v.Insert())
 
 	r, ok := makeHostAgentNextTask(env, nil, nil).(*hostAgentNextTask)
@@ -1203,7 +1203,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, d data){
 		"an empty task queue should return a nil task": func(ctx context.Context, t *testing.T, env *mock.Environment, d data) {
 			d.Tq1.Queue = []model.TaskQueueItem{}
-			require.NoError(t, d.Tq1.Save())
+			require.NoError(t, d.Tq1.Save(t.Context()))
 			details := &apimodels.GetNextTaskDetails{}
 			task, shouldTeardown, err := assignNextAvailableTask(ctx, env, d.Tq1, model.NewTaskDispatchService(time.Minute), d.Host1, details)
 			require.NoError(t, err)
@@ -1220,7 +1220,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 		},
 		"an invalid task in a task queue should skip it and noop": func(ctx context.Context, t *testing.T, env *mock.Environment, d data) {
 			d.Tq3.Queue = append([]model.TaskQueueItem{{Id: "invalid", DependenciesMet: true}}, d.Tq3.Queue...)
-			require.NoError(t, d.Tq3.Save())
+			require.NoError(t, d.Tq3.Save(t.Context()))
 			details := &apimodels.GetNextTaskDetails{}
 			task, shouldTeardown, err := assignNextAvailableTask(ctx, env, d.Tq3, model.NewTaskDispatchService(time.Minute), d.Host5, details)
 			// The legacy dispatcher does not automatically handle invalid tasks.
@@ -1502,7 +1502,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 				Length:         3,
 				TaskGroupInfos: []model.TaskGroupInfo{{Name: "task-group-1", Count: 3}},
 			}
-			require.NoError(t, d.Tq1.Save())
+			require.NoError(t, d.Tq1.Save(t.Context()))
 			tg1Task3 := &task.Task{
 				Id:                "tg1-task3",
 				Status:            evergreen.TaskUndispatched,
@@ -1736,7 +1736,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 					TaskGroupInfos: []model.TaskGroupInfo{tgInfo1},
 				},
 			}
-			require.NoError(t, data.Tq1.Save())
+			require.NoError(t, data.Tq1.Save(t.Context()))
 			data.Task1 = &task.Task{
 				Id:           "task1",
 				Status:       evergreen.TaskUndispatched,
@@ -1802,7 +1802,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 					TaskGroupInfos: []model.TaskGroupInfo{tgInfo2},
 				},
 			}
-			require.NoError(t, data.Tq2.Save())
+			require.NoError(t, data.Tq2.Save(t.Context()))
 			data.Task3 = &task.Task{
 				Id:           "task3",
 				Status:       evergreen.TaskUndispatched,
@@ -1836,7 +1836,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 					TaskGroupInfos: []model.TaskGroupInfo{},
 				},
 			}
-			require.NoError(t, data.Tq3.Save())
+			require.NoError(t, data.Tq3.Save(t.Context()))
 
 			tCase(ctx, t, env, data)
 		})

--- a/rest/route/host_agent_test.go
+++ b/rest/route/host_agent_test.go
@@ -750,7 +750,7 @@ func TestSingleTaskDistroValidation(t *testing.T) {
 	require.NotZero(t, h)
 	assert.Equal(t, "task1", h.RunningTask)
 
-	tq, err = model.LoadTaskQueue(d.Id)
+	tq, err = model.LoadTaskQueue(t.Context(), d.Id)
 	require.NoError(t, err)
 	require.NotNil(t, tq)
 	assert.Equal(t, 2, tq.Length())
@@ -770,7 +770,7 @@ func TestSingleTaskDistroValidation(t *testing.T) {
 	assert.Equal(t, "", h.RunningTask)
 
 	// task2 should be taken off the queue because it is not an allowed task.
-	tq, err = model.LoadTaskQueue(d.Id)
+	tq, err = model.LoadTaskQueue(t.Context(), d.Id)
 	require.NoError(t, err)
 	require.NotNil(t, tq)
 	assert.Equal(t, 1, tq.Length())
@@ -1210,7 +1210,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.Nil(t, task)
 			assert.False(t, shouldTeardown)
 
-			tq, err := model.LoadTaskQueue(d.Distro1.Id)
+			tq, err := model.LoadTaskQueue(t.Context(), d.Distro1.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 0, tq.Length())
 
@@ -1228,7 +1228,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.Nil(t, task)
 			assert.False(t, shouldTeardown)
 
-			tq, err := model.LoadTaskQueue(d.Distro3.Id)
+			tq, err := model.LoadTaskQueue(t.Context(), d.Distro3.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 3, tq.Length())
 
@@ -1245,7 +1245,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.False(t, shouldTeardown)
 			assert.Equal(t, nextTaskId, task.Id)
 
-			tq, err := model.LoadTaskQueue(d.Distro3.Id)
+			tq, err := model.LoadTaskQueue(t.Context(), d.Distro3.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 1, tq.Length())
 
@@ -1262,7 +1262,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.False(t, shouldTeardown)
 			assert.Equal(t, nextTaskId, task.Id)
 
-			tq, err := model.LoadTaskQueue(d.Distro1.Id)
+			tq, err := model.LoadTaskQueue(t.Context(), d.Distro1.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 1, tq.Length())
 
@@ -1282,7 +1282,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.False(t, shouldTeardown)
 			assert.Equal(t, nextTaskId, task.Id)
 
-			tq, err := model.LoadTaskQueue(d.Distro3.Id)
+			tq, err := model.LoadTaskQueue(t.Context(), d.Distro3.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 0, tq.Length())
 
@@ -1302,7 +1302,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.False(t, shouldTeardown)
 			assert.Equal(t, nextTaskId, task.Id)
 
-			tq, err := model.LoadTaskQueue(d.Distro3.Id)
+			tq, err := model.LoadTaskQueue(t.Context(), d.Distro3.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 0, tq.Length())
 
@@ -1319,7 +1319,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.Nil(t, task)
 			assert.True(t, shouldTeardown)
 
-			tq, err := model.LoadTaskQueue(d.Distro1.Id)
+			tq, err := model.LoadTaskQueue(t.Context(), d.Distro1.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 2, tq.Length())
 
@@ -1336,7 +1336,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.Nil(t, task)
 			assert.True(t, shouldTeardown)
 
-			tq, err := model.LoadTaskQueue(d.Distro2.Id)
+			tq, err := model.LoadTaskQueue(t.Context(), d.Distro2.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 4, tq.Length())
 
@@ -1355,7 +1355,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.False(t, shouldTeardown)
 			assert.Equal(t, nextTaskId, task.Id)
 
-			tq, err := model.LoadTaskQueue(d.Distro3.Id)
+			tq, err := model.LoadTaskQueue(t.Context(), d.Distro3.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 0, tq.Length())
 
@@ -1372,7 +1372,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.False(t, shouldTeardown)
 			assert.Equal(t, nextTaskId, task.Id)
 
-			tq, err := model.LoadTaskQueue(d.Distro3.Id)
+			tq, err := model.LoadTaskQueue(t.Context(), d.Distro3.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 1, tq.Length())
 
@@ -1387,7 +1387,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.False(t, shouldTeardown)
 			assert.Equal(t, nextTaskId, task.Id)
 
-			tq, err = model.LoadTaskQueue(d.Distro3.Id)
+			tq, err = model.LoadTaskQueue(t.Context(), d.Distro3.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 0, tq.Length())
 
@@ -1404,7 +1404,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.False(t, shouldTeardown)
 			assert.Equal(t, nextTaskId, task.Id)
 
-			tq, err := model.LoadTaskQueue(d.Distro3.Id)
+			tq, err := model.LoadTaskQueue(t.Context(), d.Distro3.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 1, tq.Length())
 
@@ -1420,7 +1420,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.False(t, shouldTeardown)
 			assert.Equal(t, nextTaskId, task.Id)
 
-			tq, err = model.LoadTaskQueue(d.Distro3.Id)
+			tq, err = model.LoadTaskQueue(t.Context(), d.Distro3.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 0, tq.Length())
 
@@ -1437,7 +1437,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.False(t, shouldTeardown)
 			assert.Equal(t, nextTaskId, task.Id)
 
-			tq, err := model.LoadTaskQueue(d.Distro3.Id)
+			tq, err := model.LoadTaskQueue(t.Context(), d.Distro3.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 1, tq.Length())
 
@@ -1450,7 +1450,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.Nil(t, task)
 			assert.False(t, shouldTeardown)
 
-			tq, err = model.LoadTaskQueue(d.Distro3.Id)
+			tq, err = model.LoadTaskQueue(t.Context(), d.Distro3.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 1, tq.Length())
 
@@ -1467,7 +1467,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.False(t, shouldTeardown)
 			assert.Equal(t, nextTaskId, task.Id)
 
-			tq, err := model.LoadTaskQueue(d.Distro1.Id)
+			tq, err := model.LoadTaskQueue(t.Context(), d.Distro1.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 1, tq.Length())
 
@@ -1481,7 +1481,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.Nil(t, task)
 			assert.False(t, shouldTeardown)
 
-			tq, err = model.LoadTaskQueue(d.Distro1.Id)
+			tq, err = model.LoadTaskQueue(t.Context(), d.Distro1.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 0, tq.Length())
 
@@ -1529,7 +1529,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.False(t, shouldTeardown)
 			assert.Equal(t, nextTaskId, task.Id)
 
-			tq, err := model.LoadTaskQueue(d.Distro1.Id)
+			tq, err := model.LoadTaskQueue(t.Context(), d.Distro1.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 2, tq.Length())
 
@@ -1545,7 +1545,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.False(t, shouldTeardown)
 			assert.Equal(t, nextTaskId, task.Id)
 
-			tq, err = model.LoadTaskQueue(d.Distro1.Id)
+			tq, err = model.LoadTaskQueue(t.Context(), d.Distro1.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 1, tq.Length())
 
@@ -1560,7 +1560,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			assert.Nil(t, task)
 			assert.False(t, shouldTeardown)
 
-			tq, err = model.LoadTaskQueue(d.Distro1.Id)
+			tq, err = model.LoadTaskQueue(t.Context(), d.Distro1.Id)
 			require.NoError(t, err)
 			assert.Equal(t, 0, tq.Length())
 

--- a/rest/route/host_agent_test.go
+++ b/rest/route/host_agent_test.go
@@ -1273,7 +1273,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 		"tasks with a disabled project should be removed from the queue": func(ctx context.Context, t *testing.T, env *mock.Environment, d data) {
 			// The queue has task3 then task4, task3 is under a disabled project.
 			d.Project2.Enabled = false
-			require.NoError(t, d.Project2.Upsert(t.Context()))
+			require.NoError(t, d.Project2.Replace(t.Context()))
 			nextTaskId := "task4"
 			details := &apimodels.GetNextTaskDetails{}
 			task, shouldTeardown, err := assignNextAvailableTask(ctx, env, d.Tq3, model.NewTaskDispatchService(time.Minute), d.Host5, details)
@@ -1293,7 +1293,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 		"tasks with a project with dispatching disabled should be removed from the queue": func(ctx context.Context, t *testing.T, env *mock.Environment, d data) {
 			// The queue has task3 then task4, task3 is under a disabled project.
 			d.Project2.DispatchingDisabled = utility.TruePtr()
-			require.NoError(t, d.Project2.Upsert(t.Context()))
+			require.NoError(t, d.Project2.Replace(t.Context()))
 			nextTaskId := d.Tq3.Queue[1].Id
 			details := &apimodels.GetNextTaskDetails{}
 			task, shouldTeardown, err := assignNextAvailableTask(ctx, env, d.Tq3, model.NewTaskDispatchService(time.Minute), d.Host5, details)

--- a/rest/route/host_agent_test.go
+++ b/rest/route/host_agent_test.go
@@ -1273,7 +1273,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 		"tasks with a disabled project should be removed from the queue": func(ctx context.Context, t *testing.T, env *mock.Environment, d data) {
 			// The queue has task3 then task4, task3 is under a disabled project.
 			d.Project2.Enabled = false
-			require.NoError(t, d.Project2.Upsert())
+			require.NoError(t, d.Project2.Upsert(t.Context()))
 			nextTaskId := "task4"
 			details := &apimodels.GetNextTaskDetails{}
 			task, shouldTeardown, err := assignNextAvailableTask(ctx, env, d.Tq3, model.NewTaskDispatchService(time.Minute), d.Host5, details)
@@ -1293,7 +1293,7 @@ func TestAssignNextAvailableTask(t *testing.T) {
 		"tasks with a project with dispatching disabled should be removed from the queue": func(ctx context.Context, t *testing.T, env *mock.Environment, d data) {
 			// The queue has task3 then task4, task3 is under a disabled project.
 			d.Project2.DispatchingDisabled = utility.TruePtr()
-			require.NoError(t, d.Project2.Upsert())
+			require.NoError(t, d.Project2.Upsert(t.Context()))
 			nextTaskId := d.Tq3.Queue[1].Id
 			details := &apimodels.GetNextTaskDetails{}
 			task, shouldTeardown, err := assignNextAvailableTask(ctx, env, d.Tq3, model.NewTaskDispatchService(time.Minute), d.Host5, details)

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -568,7 +568,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		"project_identifier": h.newProjectRef.Identifier,
 	}))
 
-	if err = data.UpdateProjectVars(h.newProjectRef.Id, &h.apiNewProjectRef.Variables, false); err != nil { // destructively modifies h.apiNewProjectRef.Variables
+	if err = data.UpdateProjectVars(ctx, h.newProjectRef.Id, &h.apiNewProjectRef.Variables, false); err != nil { // destructively modifies h.apiNewProjectRef.Variables
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "updating variables for project '%s'", h.project))
 	}
 	if err = data.UpdateProjectAliases(ctx, h.newProjectRef.Id, h.apiNewProjectRef.Aliases); err != nil {

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -391,7 +391,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting evergreen settings"))
 		}
-		_, err = dbModel.ValidateEnabledProjectsLimit(h.newProjectRef.Id, settings, h.originalProject, mergedProjectRef)
+		_, err = dbModel.ValidateEnabledProjectsLimit(ctx, h.newProjectRef.Id, settings, h.originalProject, mergedProjectRef)
 		if err != nil {
 			return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "validating project creation for project '%s'", h.newProjectRef.Identifier))
 		}

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -554,7 +554,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	// complete all updates
-	if err = h.newProjectRef.Upsert(ctx); err != nil {
+	if err = h.newProjectRef.Replace(ctx); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "updating project '%s'", h.newProjectRef.Id))
 	}
 

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -1263,7 +1263,7 @@ func (h *getProjectTaskExecutionsHandler) Run(ctx context.Context) gimlet.Respon
 		StartTime:    h.startTime,
 		EndTime:      h.endTime,
 	}
-	numTasks, err := task.CountNumExecutionsForInterval(input)
+	numTasks, err := task.CountNumExecutionsForInterval(ctx, input)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(err)
 	}

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -554,7 +554,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	// complete all updates
-	if err = h.newProjectRef.Upsert(); err != nil {
+	if err = h.newProjectRef.Upsert(ctx); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "updating project '%s'", h.newProjectRef.Id))
 	}
 

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -353,7 +353,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "validating owner and repo"))
 	}
 	if h.newProjectRef.Identifier != h.originalProject.Identifier {
-		if err := h.newProjectRef.ValidateIdentifier(); err != nil {
+		if err := h.newProjectRef.ValidateIdentifier(ctx); err != nil {
 			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "validating project identifier"))
 		}
 	}

--- a/rest/route/project_copy.go
+++ b/rest/route/project_copy.go
@@ -162,7 +162,7 @@ func (p *copyVariablesHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting settings for project '%s' before copying variables", copyToProjectId))
 	}
 
-	if err := data.UpdateProjectVars(copyToProjectId, varsToCopy, p.opts.Overwrite); err != nil {
+	if err := data.UpdateProjectVars(ctx, copyToProjectId, varsToCopy, p.opts.Overwrite); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "copying project vars from source project '%s' to target project '%s'", p.copyFrom, p.opts.CopyTo))
 	}
 

--- a/rest/route/project_copy_test.go
+++ b/rest/route/project_copy_test.go
@@ -235,7 +235,7 @@ func (s *copyVariablesSuite) TestCopyAllVariables() {
 		Vars:        map[string]string{"banana": "yellow"},
 		PrivateVars: map[string]bool{},
 	}
-	_, err := newProjectVar.Upsert()
+	_, err := newProjectVar.Upsert(s.ctx)
 	s.NoError(err)
 	resp := s.route.Run(s.ctx)
 	s.NotNil(resp)

--- a/rest/route/project_copy_test.go
+++ b/rest/route/project_copy_test.go
@@ -172,7 +172,7 @@ func (s *copyVariablesSuite) SetupTest() {
 	repoRef := model.RepoRef{ProjectRef: model.ProjectRef{
 		Id: "repoRef",
 	}}
-	s.NoError(repoRef.Upsert(s.ctx))
+	s.NoError(repoRef.Replace(s.ctx))
 	projectVar1 := &model.ProjectVars{
 		Id:          "projectA",
 		Vars:        map[string]string{"apple": "red", "hello": "world"},

--- a/rest/route/project_copy_test.go
+++ b/rest/route/project_copy_test.go
@@ -172,7 +172,7 @@ func (s *copyVariablesSuite) SetupTest() {
 	repoRef := model.RepoRef{ProjectRef: model.ProjectRef{
 		Id: "repoRef",
 	}}
-	s.NoError(repoRef.Upsert())
+	s.NoError(repoRef.Upsert(s.ctx))
 	projectVar1 := &model.ProjectVars{
 		Id:          "projectA",
 		Vars:        map[string]string{"apple": "red", "hello": "world"},

--- a/rest/route/project_copy_test.go
+++ b/rest/route/project_copy_test.go
@@ -150,6 +150,10 @@ func TestCopyVariablesSuite(t *testing.T) {
 }
 
 func (s *copyVariablesSuite) SetupTest() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "me"})
+	s.cancel = cancel
+
 	s.route = &copyVariablesHandler{usr: &user.DBUser{Id: "admin"}}
 	s.NoError(db.ClearCollections(model.ProjectRefCollection, model.ProjectVarsCollection, fakeparameter.Collection, model.RepoRefCollection, event.EventCollection))
 	pRefs := []model.ProjectRef{
@@ -192,9 +196,6 @@ func (s *copyVariablesSuite) SetupTest() {
 	s.NoError(projectVar1.Insert())
 	s.NoError(projectVar2.Insert())
 	s.NoError(projectVar3.Insert())
-	ctx, cancel := context.WithCancel(context.Background())
-	s.ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "me"})
-	s.cancel = cancel
 }
 
 func (s *copyVariablesSuite) TearDownTest() {

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -1047,7 +1047,7 @@ func TestDeleteProject(t *testing.T) {
 			Repo:  "test_repo",
 		},
 	}
-	assert.NoError(t, repo.Upsert())
+	assert.NoError(t, repo.Upsert(t.Context()))
 
 	// Projects expected to be successfully deleted
 	numGoodProjects := 2

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -1181,7 +1181,7 @@ func TestAttachProjectToRepo(t *testing.T) {
 	assert.Error(t, h.Parse(ctx, req)) // should fail because repoRefId is populated
 
 	pRef.RepoRefId = ""
-	assert.NoError(t, pRef.Upsert())
+	assert.NoError(t, pRef.Upsert(t.Context()))
 	assert.NoError(t, h.Parse(ctx, req))
 
 	assert.NotNil(t, h.user)
@@ -1257,7 +1257,7 @@ func TestDetachProjectFromRepo(t *testing.T) {
 	assert.Error(t, h.Parse(ctx, req)) // should fail because repoRefId isn't populated
 
 	pRef.RepoRefId = repoRef.Id
-	assert.NoError(t, pRef.Upsert())
+	assert.NoError(t, pRef.Upsert(t.Context()))
 	assert.NoError(t, h.Parse(ctx, req))
 
 	assert.NotNil(t, h.user)

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -68,7 +68,7 @@ func (s *ProjectPatchByIDSuite) SetupTest() {
 	s.NoError(err)
 	aliases := getTestAliases()
 	for _, alias := range aliases {
-		s.NoError(alias.Upsert())
+		s.NoError(alias.Upsert(s.T().Context()))
 	}
 	s.NoError(db.Insert(serviceModel.RepositoriesCollection, serviceModel.Repository{
 		Project:      "dimoxinil",
@@ -1080,7 +1080,7 @@ func TestDeleteProject(t *testing.T) {
 			Task:      fmt.Sprintf("task_%d", i),
 		}
 
-		require.NoError(t, projAlias.Upsert())
+		require.NoError(t, projAlias.Upsert(t.Context()))
 	}
 
 	projVars := serviceModel.ProjectVars{

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -64,7 +64,7 @@ func (s *ProjectPatchByIDSuite) SetupTest() {
 	project2.Identifier = "project2"
 	s.NoError(project2.Add(s.T().Context(), &user))
 
-	_, err := getTestVar().Upsert()
+	_, err := getTestVar().Upsert(s.T().Context())
 	s.NoError(err)
 	aliases := getTestAliases()
 	for _, alias := range aliases {
@@ -1087,7 +1087,7 @@ func TestDeleteProject(t *testing.T) {
 		Id:   projects[0].Id,
 		Vars: map[string]string{"hello": "world"},
 	}
-	_, err := projVars.Upsert()
+	_, err := projVars.Upsert(t.Context())
 	require.NoError(t, err)
 
 	pdh := projectDeleteHandler{}

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -1181,7 +1181,7 @@ func TestAttachProjectToRepo(t *testing.T) {
 	assert.Error(t, h.Parse(ctx, req)) // should fail because repoRefId is populated
 
 	pRef.RepoRefId = ""
-	assert.NoError(t, pRef.Upsert(t.Context()))
+	assert.NoError(t, pRef.Replace(t.Context()))
 	assert.NoError(t, h.Parse(ctx, req))
 
 	assert.NotNil(t, h.user)
@@ -1257,7 +1257,7 @@ func TestDetachProjectFromRepo(t *testing.T) {
 	assert.Error(t, h.Parse(ctx, req)) // should fail because repoRefId isn't populated
 
 	pRef.RepoRefId = repoRef.Id
-	assert.NoError(t, pRef.Upsert(t.Context()))
+	assert.NoError(t, pRef.Replace(t.Context()))
 	assert.NoError(t, h.Parse(ctx, req))
 
 	assert.NotNil(t, h.user)

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -1047,7 +1047,7 @@ func TestDeleteProject(t *testing.T) {
 			Repo:  "test_repo",
 		},
 	}
-	assert.NoError(t, repo.Upsert(t.Context()))
+	assert.NoError(t, repo.Replace(t.Context()))
 
 	// Projects expected to be successfully deleted
 	numGoodProjects := 2

--- a/rest/route/status.go
+++ b/rest/route/status.go
@@ -144,7 +144,7 @@ func (h *hostStatsByDistroHandler) Parse(ctx context.Context, r *http.Request) e
 }
 
 func (h *hostStatsByDistroHandler) Run(ctx context.Context) gimlet.Responder {
-	stats, err := host.GetStatsByDistro()
+	stats, err := host.GetStatsByDistro(ctx)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting distro host stats"))
 	}

--- a/rest/route/subscription_test.go
+++ b/rest/route/subscription_test.go
@@ -262,7 +262,7 @@ func (s *SubscriptionRouteSuite) TestDeleteValidation() {
 			Type: "email",
 		},
 	}
-	s.NoError(subscription.Upsert())
+	s.NoError(subscription.Upsert(s.T().Context()))
 	r, err = http.NewRequest(http.MethodDelete, "/subscriptions?id=5949645c9acd9604fdd202da", nil)
 	s.NoError(err)
 	s.NoError(d.Parse(ctx, r))

--- a/rest/route/task_test.go
+++ b/rest/route/task_test.go
@@ -110,9 +110,9 @@ func TestFetchArtifacts(t *testing.T) {
 			},
 		},
 	}
-	assert.NoError(entry.Upsert())
+	assert.NoError(entry.Upsert(t.Context()))
 	entry.Execution = 0
-	assert.NoError(entry.Upsert())
+	assert.NoError(entry.Upsert(t.Context()))
 
 	task2 := task.Task{
 		Id:          "task2",

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -935,7 +935,7 @@ func (h *renameUserHandler) Run(ctx context.Context) gimlet.Responder {
 	githubUID := h.oldUsr.Settings.GithubUser.UID
 	h.oldUsr.Settings.GithubUser.UID = 0
 
-	newUsr, err := user.UpsertOneFromExisting(h.oldUsr, h.newEmail)
+	newUsr, err := user.UpsertOneFromExisting(ctx, h.oldUsr, h.newEmail)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(err)
 	}

--- a/rest/route/user_test.go
+++ b/rest/route/user_test.go
@@ -286,7 +286,7 @@ func TestProjectSettingsUpdateViewRepo(t *testing.T) {
 	repoRef := model.RepoRef{ProjectRef: model.ProjectRef{
 		Id: "myRepo",
 	}}
-	assert.NoError(t, repoRef.Upsert())
+	assert.NoError(t, repoRef.Upsert(t.Context()))
 	scope := gimlet.Scope{
 		ID:        "myRepo_scope",
 		Resources: []string{"myRepo"},

--- a/rest/route/user_test.go
+++ b/rest/route/user_test.go
@@ -286,7 +286,7 @@ func TestProjectSettingsUpdateViewRepo(t *testing.T) {
 	repoRef := model.RepoRef{ProjectRef: model.ProjectRef{
 		Id: "myRepo",
 	}}
-	assert.NoError(t, repoRef.Upsert(t.Context()))
+	assert.NoError(t, repoRef.Replace(t.Context()))
 	scope := gimlet.Scope{
 		ID:        "myRepo_scope",
 		Resources: []string{"myRepo"},

--- a/rest/route/user_test.go
+++ b/rest/route/user_test.go
@@ -393,7 +393,7 @@ func TestGetUserPermissions(t *testing.T) {
 		},
 	}
 	for _, projectRef := range projectRefs {
-		require.NoError(t, projectRef.Upsert(t.Context()))
+		require.NoError(t, projectRef.Replace(t.Context()))
 	}
 	require.NoError(t, u.Insert())
 	require.NoError(t, rm.AddScope(gimlet.Scope{ID: "scope1", Resources: []string{"resource1"}, Type: "project"}))
@@ -617,7 +617,7 @@ func TestRemoveHiddenProjects(t *testing.T) {
 		},
 	}
 	for _, projectRef := range projectRefs {
-		require.NoError(t, projectRef.Upsert(t.Context()))
+		require.NoError(t, projectRef.Replace(t.Context()))
 	}
 
 	permissions := []rolemanager.PermissionSummary{

--- a/rest/route/user_test.go
+++ b/rest/route/user_test.go
@@ -393,7 +393,7 @@ func TestGetUserPermissions(t *testing.T) {
 		},
 	}
 	for _, projectRef := range projectRefs {
-		require.NoError(t, projectRef.Upsert())
+		require.NoError(t, projectRef.Upsert(t.Context()))
 	}
 	require.NoError(t, u.Insert())
 	require.NoError(t, rm.AddScope(gimlet.Scope{ID: "scope1", Resources: []string{"resource1"}, Type: "project"}))
@@ -617,7 +617,7 @@ func TestRemoveHiddenProjects(t *testing.T) {
 		},
 	}
 	for _, projectRef := range projectRefs {
-		require.NoError(t, projectRef.Upsert())
+		require.NoError(t, projectRef.Upsert(t.Context()))
 	}
 
 	permissions := []rolemanager.PermissionSummary{

--- a/scheduler/distro_alias_test.go
+++ b/scheduler/distro_alias_test.go
@@ -60,11 +60,11 @@ func TestDistroAliases(t *testing.T) {
 			require.Equal(t, "one", output[0].Id)
 			require.Equal(t, "other", output[1].Id)
 
-			ct, err := db.Count(model.TaskQueuesCollection, bson.M{})
+			ct, err := db.CountContext(t.Context(), model.TaskQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 1, ct)
 
-			ct, err = db.Count(model.TaskSecondaryQueuesCollection, bson.M{})
+			ct, err = db.CountContext(t.Context(), model.TaskSecondaryQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 0, ct)
 		})
@@ -78,11 +78,11 @@ func TestDistroAliases(t *testing.T) {
 			require.Equal(t, "one", output[0].Id)
 			require.Equal(t, "other", output[1].Id)
 
-			ct, err := db.Count(model.TaskQueuesCollection, bson.M{})
+			ct, err := db.CountContext(t.Context(), model.TaskQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 1, ct)
 
-			ct, err = db.Count(model.TaskSecondaryQueuesCollection, bson.M{})
+			ct, err = db.CountContext(t.Context(), model.TaskSecondaryQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 0, ct)
 		})
@@ -106,11 +106,11 @@ func TestDistroAliases(t *testing.T) {
 			require.Equal(t, "one", output[0].Id)
 			require.Equal(t, "other", output[1].Id)
 
-			ct, err := db.Count(model.TaskSecondaryQueuesCollection, bson.M{})
+			ct, err := db.CountContext(t.Context(), model.TaskSecondaryQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 1, ct)
 
-			ct, err = db.Count(model.TaskQueuesCollection, bson.M{})
+			ct, err = db.CountContext(t.Context(), model.TaskQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 0, ct)
 
@@ -125,11 +125,11 @@ func TestDistroAliases(t *testing.T) {
 			require.Equal(t, "one", output[0].Id)
 			require.Equal(t, "other", output[1].Id)
 
-			ct, err := db.Count(model.TaskSecondaryQueuesCollection, bson.M{})
+			ct, err := db.CountContext(t.Context(), model.TaskSecondaryQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 1, ct)
 
-			ct, err = db.Count(model.TaskQueuesCollection, bson.M{})
+			ct, err = db.CountContext(t.Context(), model.TaskQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 0, ct)
 		})

--- a/scheduler/distro_alias_test.go
+++ b/scheduler/distro_alias_test.go
@@ -60,11 +60,11 @@ func TestDistroAliases(t *testing.T) {
 			require.Equal(t, "one", output[0].Id)
 			require.Equal(t, "other", output[1].Id)
 
-			ct, err := db.CountContext(t.Context(), model.TaskQueuesCollection, bson.M{})
+			ct, err := db.Count(t.Context(), model.TaskQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 1, ct)
 
-			ct, err = db.CountContext(t.Context(), model.TaskSecondaryQueuesCollection, bson.M{})
+			ct, err = db.Count(t.Context(), model.TaskSecondaryQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 0, ct)
 		})
@@ -78,11 +78,11 @@ func TestDistroAliases(t *testing.T) {
 			require.Equal(t, "one", output[0].Id)
 			require.Equal(t, "other", output[1].Id)
 
-			ct, err := db.CountContext(t.Context(), model.TaskQueuesCollection, bson.M{})
+			ct, err := db.Count(t.Context(), model.TaskQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 1, ct)
 
-			ct, err = db.CountContext(t.Context(), model.TaskSecondaryQueuesCollection, bson.M{})
+			ct, err = db.Count(t.Context(), model.TaskSecondaryQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 0, ct)
 		})
@@ -106,11 +106,11 @@ func TestDistroAliases(t *testing.T) {
 			require.Equal(t, "one", output[0].Id)
 			require.Equal(t, "other", output[1].Id)
 
-			ct, err := db.CountContext(t.Context(), model.TaskSecondaryQueuesCollection, bson.M{})
+			ct, err := db.Count(t.Context(), model.TaskSecondaryQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 1, ct)
 
-			ct, err = db.CountContext(t.Context(), model.TaskQueuesCollection, bson.M{})
+			ct, err = db.Count(t.Context(), model.TaskQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 0, ct)
 
@@ -125,11 +125,11 @@ func TestDistroAliases(t *testing.T) {
 			require.Equal(t, "one", output[0].Id)
 			require.Equal(t, "other", output[1].Id)
 
-			ct, err := db.CountContext(t.Context(), model.TaskSecondaryQueuesCollection, bson.M{})
+			ct, err := db.Count(t.Context(), model.TaskSecondaryQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 1, ct)
 
-			ct, err = db.CountContext(t.Context(), model.TaskQueuesCollection, bson.M{})
+			ct, err = db.Count(t.Context(), model.TaskQueuesCollection, bson.M{})
 			require.NoError(t, err)
 			require.Equal(t, 0, ct)
 		})

--- a/scheduler/task_finder_test.go
+++ b/scheduler/task_finder_test.go
@@ -204,7 +204,7 @@ func (s *TaskFinderSuite) TestTasksWithDisabledProjectNeverReturned() {
 		Id:      "exists",
 		Enabled: false,
 	}
-	s.Require().NoError(ref.Upsert())
+	s.Require().NoError(ref.Upsert(s.ctx))
 	runnableTasks, err := s.FindRunnableTasks(s.ctx, s.distro)
 	s.NoError(err)
 	s.Empty(runnableTasks)
@@ -215,7 +215,7 @@ func (s *TaskFinderSuite) TestTasksWithProjectDispatchingDisabledNeverReturned()
 		Id:                  "exists",
 		DispatchingDisabled: utility.TruePtr(),
 	}
-	s.Require().NoError(ref.Upsert())
+	s.Require().NoError(ref.Upsert(s.ctx))
 	runnableTasks, err := s.FindRunnableTasks(s.ctx, s.distro)
 	s.NoError(err)
 	s.Empty(runnableTasks)

--- a/scheduler/task_finder_test.go
+++ b/scheduler/task_finder_test.go
@@ -204,7 +204,7 @@ func (s *TaskFinderSuite) TestTasksWithDisabledProjectNeverReturned() {
 		Id:      "exists",
 		Enabled: false,
 	}
-	s.Require().NoError(ref.Upsert(s.ctx))
+	s.Require().NoError(ref.Replace(s.ctx))
 	runnableTasks, err := s.FindRunnableTasks(s.ctx, s.distro)
 	s.NoError(err)
 	s.Empty(runnableTasks)
@@ -215,7 +215,7 @@ func (s *TaskFinderSuite) TestTasksWithProjectDispatchingDisabledNeverReturned()
 		Id:                  "exists",
 		DispatchingDisabled: utility.TruePtr(),
 	}
-	s.Require().NoError(ref.Upsert(s.ctx))
+	s.Require().NoError(ref.Replace(s.ctx))
 	runnableTasks, err := s.FindRunnableTasks(s.ctx, s.distro)
 	s.NoError(err)
 	s.Empty(runnableTasks)

--- a/scheduler/task_queue_persister.go
+++ b/scheduler/task_queue_persister.go
@@ -42,7 +42,7 @@ func PersistTaskQueue(ctx context.Context, distro string, tasks []task.Task, dis
 	}
 
 	queue := model.NewTaskQueue(distro, taskQueue, distroQueueInfo)
-	err := queue.Save()
+	err := queue.Save(ctx)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/scheduler/task_queue_persister_test.go
+++ b/scheduler/task_queue_persister_test.go
@@ -129,7 +129,7 @@ func TestDBTaskQueuePersister(t *testing.T) {
 			So(PersistTaskQueue(ctx, distroIds[0], []task.Task{tasks[0], tasks[1], tasks[2]}, distroQueueInfo1), ShouldBeNil)
 			So(PersistTaskQueue(ctx, distroIds[1], []task.Task{tasks[3], tasks[4]}, distroQueueInfo2), ShouldBeNil)
 
-			taskQueue, err := model.LoadTaskQueue(distroIds[0])
+			taskQueue, err := model.LoadTaskQueue(t.Context(), distroIds[0])
 			So(err, ShouldBeNil)
 			So(taskQueue.Length(), ShouldEqual, 3)
 
@@ -172,7 +172,7 @@ func TestDBTaskQueuePersister(t *testing.T) {
 			So(taskQueue.Queue[2].ActivatedBy, ShouldEqual, tasks[2].ActivatedBy)
 			So(taskQueue.Queue[2].ExpectedDuration, ShouldEqual, durations[2])
 
-			taskQueue, err = model.LoadTaskQueue(distroIds[1])
+			taskQueue, err = model.LoadTaskQueue(t.Context(), distroIds[1])
 			So(err, ShouldBeNil)
 			So(taskQueue.Length(), ShouldEqual, 2)
 

--- a/service/rest_task.go
+++ b/service/rest_task.go
@@ -127,7 +127,7 @@ func (restapi restAPI) getTaskInfo(w http.ResponseWriter, r *http.Request) {
 	destTask.ModulePaths = srcTask.Details.Modules.Prefixes
 
 	var err error
-	destTask.MinQueuePos, err = model.FindMinimumQueuePositionForTask(destTask.Id)
+	destTask.MinQueuePos, err = model.FindMinimumQueuePositionForTask(r.Context(), destTask.Id)
 	if err != nil {
 		msg := fmt.Sprintf("Error calculating task queue position for '%v'", srcTask.Id)
 		grip.Errorf("%v: %+v", msg, err)

--- a/service/rest_task_test.go
+++ b/service/rest_task_test.go
@@ -117,7 +117,7 @@ func TestGetTaskInfo(t *testing.T) {
 			TaskId: taskId,
 			Files:  []artifact.File{publicFile, noVisibilityFile},
 		}
-		So(taskArtifacts.Upsert(), ShouldBeNil)
+		So(taskArtifacts.Upsert(t.Context()), ShouldBeNil)
 
 		url := "/rest/v1/tasks/" + taskId
 

--- a/service/rest_version.go
+++ b/service/rest_version.go
@@ -425,7 +425,7 @@ func (restapi *restAPI) getVersionStatus(w http.ResponseWriter, r *http.Request)
 	case "": // default to group by tasks
 		fallthrough
 	case "tasks":
-		restapi.getVersionStatusByTask(versionId, w)
+		restapi.getVersionStatusByTask(r.Context(), versionId, w)
 		return
 	case "builds":
 		restapi.getVersionStatusByBuild(r.Context(), versionId, w)
@@ -441,7 +441,7 @@ func (restapi *restAPI) getVersionStatus(w http.ResponseWriter, r *http.Request)
 // grouped on the tasks. The keys of the object are the task names,
 // with each key in the nested object representing a particular build
 // variant.
-func (restapi *restAPI) getVersionStatusByTask(versionId string, w http.ResponseWriter) {
+func (restapi *restAPI) getVersionStatusByTask(ctx context.Context, versionId string, w http.ResponseWriter) {
 	id := "_id"
 
 	pipeline := []bson.M{
@@ -482,7 +482,7 @@ func (restapi *restAPI) getVersionStatusByTask(versionId string, w http.Response
 		Tasks       []task.Task `bson:"tasks"`
 	}
 
-	err := db.Aggregate(task.Collection, pipeline, &groupedTasks)
+	err := db.Aggregate(ctx, task.Collection, pipeline, &groupedTasks)
 	if err != nil {
 		msg := fmt.Sprintf("Error finding status for version '%v'", versionId)
 		grip.Errorf("%v: %+v", msg, err)

--- a/service/task.go
+++ b/service/task.go
@@ -279,7 +279,7 @@ func (uis *UIServer) taskPage(w http.ResponseWriter, r *http.Request) {
 
 	uiTask.DependsOn = deps
 	uiTask.TaskWaiting = taskWaiting
-	uiTask.MinQueuePos, err = model.FindMinimumQueuePositionForTask(uiTask.Id)
+	uiTask.MinQueuePos, err = model.FindMinimumQueuePositionForTask(ctx, uiTask.Id)
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return

--- a/service/task_history.go
+++ b/service/task_history.go
@@ -188,7 +188,7 @@ func (uis *UIServer) variantHistory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	iter := model.NewBuildVariantHistoryIterator(variant, bv.Name, project.Identifier)
-	tasks, versions, err := iter.GetItems(beforeCommit, 50)
+	tasks, versions, err := iter.GetItems(r.Context(), beforeCommit, 50)
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return

--- a/service/ui_plugin_build_baron.go
+++ b/service/ui_plugin_build_baron.go
@@ -55,7 +55,7 @@ func bbSaveNote(w http.ResponseWriter, r *http.Request) {
 
 	n.TaskId = taskId
 	n.UnixNanoTime = time.Now().UnixNano()
-	if err := n.Upsert(); err != nil {
+	if err := n.Upsert(r.Context()); err != nil {
 		gimlet.WriteJSONInternalError(w, err.Error())
 		return
 	}

--- a/service/ui_plugin_build_baron.go
+++ b/service/ui_plugin_build_baron.go
@@ -55,7 +55,7 @@ func bbSaveNote(w http.ResponseWriter, r *http.Request) {
 
 	n.TaskId = taskId
 	n.UnixNanoTime = time.Now().UnixNano()
-	if err := n.Upsert(r.Context()); err != nil {
+	if err := n.Replace(r.Context()); err != nil {
 		gimlet.WriteJSONInternalError(w, err.Error())
 		return
 	}

--- a/service/waterfall.go
+++ b/service/waterfall.go
@@ -588,7 +588,7 @@ func waterfallDataAdaptor(ctx context.Context, vvData versionVariantData, projec
 	finalData.Rows = rows
 
 	// compute the total number of versions that exist
-	finalData.TotalVersions, err = model.VersionCount(model.VersionByProjectId(project.Identifier))
+	finalData.TotalVersions, err = model.VersionCount(ctx, model.VersionByProjectId(project.Identifier))
 	if err != nil {
 		return waterfallData{}, err
 	}

--- a/trigger/build_test.go
+++ b/trigger/build_test.go
@@ -113,7 +113,7 @@ func (s *buildSuite) SetupTest() {
 	}
 
 	for i := range s.subs {
-		s.NoError(s.subs[i].Upsert())
+		s.NoError(s.subs[i].Upsert(s.ctx))
 	}
 
 	ui := &evergreen.UIConfig{

--- a/trigger/build_test.go
+++ b/trigger/build_test.go
@@ -139,7 +139,8 @@ func (s *buildSuite) TestAllTriggers() {
 
 	s.build.Status = evergreen.BuildSucceeded
 	s.data.Status = evergreen.BuildSucceeded
-	s.NoError(db.ReplaceContext(s.ctx, build.Collection, bson.M{"_id": s.build.Id}, &s.build))
+	_, err = db.ReplaceContext(s.ctx, build.Collection, bson.M{"_id": s.build.Id}, &s.build)
+	s.NoError(err)
 
 	n, err = NotificationsFromEvent(s.ctx, &s.event)
 	s.NoError(err)
@@ -147,7 +148,8 @@ func (s *buildSuite) TestAllTriggers() {
 
 	s.build.Status = evergreen.BuildFailed
 	s.data.Status = evergreen.BuildFailed
-	s.NoError(db.ReplaceContext(s.ctx, build.Collection, bson.M{"_id": s.build.Id}, &s.build))
+	_, err = db.ReplaceContext(s.ctx, build.Collection, bson.M{"_id": s.build.Id}, &s.build)
+	s.NoError(err)
 
 	n, err = NotificationsFromEvent(s.ctx, &s.event)
 	s.NoError(err)
@@ -155,7 +157,8 @@ func (s *buildSuite) TestAllTriggers() {
 
 	s.build.Status = evergreen.BuildFailed
 	s.data.Status = evergreen.BuildCreated
-	s.NoError(db.ReplaceContext(s.ctx, build.Collection, bson.M{"_id": s.build.Id}, &s.build))
+	_, err = db.ReplaceContext(s.ctx, build.Collection, bson.M{"_id": s.build.Id}, &s.build)
+	s.NoError(err)
 
 	n, err = NotificationsFromEvent(s.ctx, &s.event)
 	s.NoError(err)
@@ -163,7 +166,8 @@ func (s *buildSuite) TestAllTriggers() {
 
 	s.build.GithubCheckStatus = evergreen.BuildFailed
 	s.data.GithubCheckStatus = evergreen.BuildFailed
-	s.NoError(db.ReplaceContext(s.ctx, build.Collection, bson.M{"_id": s.build.Id}, &s.build))
+	_, err = db.ReplaceContext(s.ctx, build.Collection, bson.M{"_id": s.build.Id}, &s.build)
+	s.NoError(err)
 
 	n, err = NotificationsFromEvent(s.ctx, &s.event)
 	s.NoError(err)

--- a/trigger/host.go
+++ b/trigger/host.go
@@ -264,7 +264,7 @@ func (t *hostTriggers) getTimeZone(ctx context.Context, sub *event.Subscription,
 }
 
 func (t *hostTriggers) spawnHostIdle(ctx context.Context, sub *event.Subscription) (*notification.Notification, error) {
-	shouldNotify, err := t.host.ShouldNotifyStoppedSpawnHostIdle()
+	shouldNotify, err := t.host.ShouldNotifyStoppedSpawnHostIdle(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/trigger/host_test.go
+++ b/trigger/host_test.go
@@ -67,7 +67,7 @@ func (s *hostSuite) SetupTest() {
 	}
 
 	for i := range s.subs {
-		s.NoError(s.subs[i].Upsert())
+		s.NoError(s.subs[i].Upsert(s.ctx))
 	}
 
 	s.uiConfig = &evergreen.UIConfig{

--- a/trigger/patch_test.go
+++ b/trigger/patch_test.go
@@ -125,7 +125,7 @@ func (s *patchSuite) SetupTest() {
 	}
 
 	for i := range s.subs {
-		s.NoError(s.subs[i].Upsert())
+		s.NoError(s.subs[i].Upsert(s.ctx))
 	}
 
 	ui := &evergreen.UIConfig{
@@ -262,7 +262,7 @@ func (s *patchSuite) TestRunChildrenOnPatchOutcome() {
 	}
 
 	for i := range s.subs {
-		s.NoError(s.subs[i].Upsert())
+		s.NoError(s.subs[i].Upsert(s.ctx))
 	}
 	s.data.Status = evergreen.VersionSucceeded
 	n, err := s.t.patchOutcome(s.ctx, &s.subs[0])

--- a/trigger/patch_test.go
+++ b/trigger/patch_test.go
@@ -163,7 +163,8 @@ func (s *patchSuite) TestAllTriggers() {
 
 	s.patch.Status = evergreen.VersionSucceeded
 	s.data.Status = evergreen.VersionSucceeded
-	s.NoError(db.ReplaceContext(s.ctx, patch.Collection, bson.M{"_id": s.patch.Id}, &s.patch))
+	_, err = db.ReplaceContext(s.ctx, patch.Collection, bson.M{"_id": s.patch.Id}, &s.patch)
+	s.NoError(err)
 
 	n, err = NotificationsFromEvent(s.ctx, &s.event)
 	s.NoError(err)
@@ -171,7 +172,8 @@ func (s *patchSuite) TestAllTriggers() {
 
 	s.patch.Status = evergreen.VersionFailed
 	s.data.Status = evergreen.VersionFailed
-	s.NoError(db.ReplaceContext(s.ctx, patch.Collection, bson.M{"_id": s.patch.Id}, &s.patch))
+	_, err = db.ReplaceContext(s.ctx, patch.Collection, bson.M{"_id": s.patch.Id}, &s.patch)
+	s.NoError(err)
 
 	n, err = NotificationsFromEvent(s.ctx, &s.event)
 	s.NoError(err)
@@ -327,7 +329,7 @@ func (s *patchSuite) TestPatchFamilyOutcomeWithAbortedPatch() {
 		},
 	}
 	subscription := event.NewSubscriptionByID(event.ResourceTypePatch, event.TriggerFamilyOutcome, e.ResourceId, subscriber)
-	s.Require().NoError(subscription.Upsert())
+	s.Require().NoError(subscription.Upsert(s.ctx))
 
 	t := makePatchTriggers().(*patchTriggers)
 	t.event = &e
@@ -379,7 +381,7 @@ func (s *patchSuite) TestPatchFamilyOutcomeWithAbortedGitHubMergePatch() {
 		},
 	}
 	subscription := event.NewSubscriptionByID(event.ResourceTypePatch, event.TriggerFamilyOutcome, e.ResourceId, subscriber)
-	s.Require().NoError(subscription.Upsert())
+	s.Require().NoError(subscription.Upsert(s.ctx))
 
 	t := makePatchTriggers().(*patchTriggers)
 	t.event = &e

--- a/trigger/process.go
+++ b/trigger/process.go
@@ -146,7 +146,7 @@ func triggerDownstreamProjectsForTask(ctx context.Context, t *task.Task, e *even
 	if t.Requester != evergreen.RepotrackerVersionRequester {
 		return nil, nil
 	}
-	downstreamProjects, err := model.FindDownstreamProjects(t.Project)
+	downstreamProjects, err := model.FindDownstreamProjects(ctx, t.Project)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding downstream projects of project '%s'", t.Project)
 	}
@@ -230,7 +230,7 @@ func triggerDownstreamProjectsForBuild(ctx context.Context, b *build.Build, e *e
 	if b.Requester != evergreen.RepotrackerVersionRequester {
 		return nil, nil
 	}
-	downstreamProjects, err := model.FindDownstreamProjects(b.Project)
+	downstreamProjects, err := model.FindDownstreamProjects(ctx, b.Project)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding downstream projects of project '%s'", b.Project)
 	}
@@ -299,7 +299,7 @@ func triggerDownstreamProjectsForBuild(ctx context.Context, b *build.Build, e *e
 // TriggerDownstreamProjectsForPush triggers downstream projects for a push event from a repo that does not
 // have repotracker enabled.
 func TriggerDownstreamProjectsForPush(ctx context.Context, projectId string, event *github.PushEvent, processor projectProcessor) error {
-	downstreamProjects, err := model.FindDownstreamProjects(projectId)
+	downstreamProjects, err := model.FindDownstreamProjects(ctx, projectId)
 	if err != nil {
 		return errors.Wrapf(err, "finding downstream projects of project '%s'", projectId)
 	}

--- a/trigger/process_test.go
+++ b/trigger/process_test.go
@@ -327,7 +327,7 @@ func TestProjectTriggerIntegration(t *testing.T) {
 		Variant:   "buildvariant",
 		Task:      "task1",
 	}
-	assert.NoError(alias.Upsert())
+	assert.NoError(alias.Upsert(t.Context()))
 	_, err := model.GetNewRevisionOrderNumber(downstreamProjectRef.Id)
 	assert.NoError(err)
 	downstreamRevision := "9338711cc1acc94ff75889a3b53a936a00e8c385"
@@ -460,7 +460,7 @@ func TestProjectTriggerIntegrationForBuild(t *testing.T) {
 		Variant:   "buildvariant",
 		Task:      "task1",
 	}
-	assert.NoError(alias.Upsert())
+	assert.NoError(alias.Upsert(t.Context()))
 	_, err := model.GetNewRevisionOrderNumber(downstreamProjectRef.Id)
 	assert.NoError(err)
 	downstreamRevision := "9338711cc1acc94ff75889a3b53a936a00e8c385"
@@ -567,7 +567,7 @@ func TestProjectTriggerIntegrationForPush(t *testing.T) {
 		Variant:   "buildvariant",
 		Task:      "task1",
 	}
-	assert.NoError(alias.Upsert())
+	assert.NoError(alias.Upsert(t.Context()))
 	_, err := model.GetNewRevisionOrderNumber(downstreamProjectRef.Id)
 	assert.NoError(err)
 	downstreamRevision := "cf46076567e4949f9fc68e0634139d4ac495c89b"

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -417,7 +417,8 @@ func (s *taskSuite) TestAllTriggers() {
 
 	s.task.Status = evergreen.TaskSucceeded
 	s.data.Status = evergreen.TaskSucceeded
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err = db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 
 	n, err = NotificationsFromEvent(s.ctx, &s.event)
 	s.NoError(err)
@@ -425,14 +426,16 @@ func (s *taskSuite) TestAllTriggers() {
 
 	s.task.Status = evergreen.TaskFailed
 	s.data.Status = evergreen.TaskFailed
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err = db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 
 	n, err = NotificationsFromEvent(s.ctx, &s.event)
 	s.NoError(err)
 	s.Len(n, 5)
 
 	s.task.DisplayOnly = true
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err = db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 	n, err = NotificationsFromEvent(s.ctx, &s.event)
 	s.NoError(err)
 	s.Len(n, 4)
@@ -447,7 +450,8 @@ func (s *taskSuite) TestAbortedTaskDoesNotNotify() {
 	s.NotEmpty(n)
 
 	s.task.Aborted = true
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err = db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 
 	// works even if the task is archived
 	s.NoError(s.task.Archive(ctx))
@@ -554,7 +558,8 @@ func (s *taskSuite) TestFailedOrBlocked() {
 func (s *taskSuite) TestFirstFailureInVersion() {
 	s.data.Status = evergreen.TaskFailed
 	s.task.Status = evergreen.TaskFailed
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err := db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 
 	n, err := s.t.taskFirstFailureInVersion(s.ctx, &s.subs[2])
 	s.NoError(err)
@@ -577,14 +582,16 @@ func (s *taskSuite) TestFirstFailureInVersion() {
 	s.NoError(s.build.Insert())
 	s.task.BuildId = "test2"
 	s.task.BuildVariant = "test2"
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err = db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 	n, err = s.t.taskFirstFailureInVersion(s.ctx, &s.subs[2])
 	s.NoError(err)
 	s.Nil(n)
 
 	// subsequent runs with other tasks in other versions should still generate
 	s.task.Version = "test2"
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err = db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 	n, err = s.t.taskFirstFailureInVersion(s.ctx, &s.subs[2])
 	s.NoError(err)
 	s.NotNil(n)
@@ -593,7 +600,8 @@ func (s *taskSuite) TestFirstFailureInVersion() {
 func (s *taskSuite) TestFirstFailureInBuild() {
 	s.data.Status = evergreen.TaskFailed
 	s.task.Status = evergreen.TaskFailed
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err := db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 
 	n, err := s.t.taskFirstFailureInBuild(s.ctx, &s.subs[2])
 	s.NoError(err)
@@ -616,14 +624,16 @@ func (s *taskSuite) TestFirstFailureInBuild() {
 	s.NoError(s.build.Insert())
 	s.task.BuildId = "test2"
 	s.task.BuildVariant = "test2"
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err = db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 	n, err = s.t.taskFirstFailureInBuild(s.ctx, &s.subs[2])
 	s.NoError(err)
 	s.NotNil(n)
 
 	// subsequent runs with other tasks in other versions should generate
 	s.task.Version = "test2"
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err = db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 	n, err = s.t.taskFirstFailureInBuild(s.ctx, &s.subs[2])
 	s.NoError(err)
 	s.NotNil(n)
@@ -632,7 +642,8 @@ func (s *taskSuite) TestFirstFailureInBuild() {
 func (s *taskSuite) TestFirstFailureInVersionWithName() {
 	s.data.Status = evergreen.TaskFailed
 	s.task.Status = evergreen.TaskFailed
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err := db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 
 	n, err := s.t.taskFirstFailureInVersionWithName(s.ctx, &s.subs[2])
 	s.NoError(err)
@@ -655,14 +666,16 @@ func (s *taskSuite) TestFirstFailureInVersionWithName() {
 	s.NoError(s.build.Insert())
 	s.task.BuildId = "test2"
 	s.task.BuildVariant = "test2"
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err = db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 	n, err = s.t.taskFirstFailureInVersionWithName(s.ctx, &s.subs[2])
 	s.NoError(err)
 	s.Nil(n)
 
 	// subsequent runs in other versions should generate
 	s.task.Version = "test2"
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err = db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 	n, err = s.t.taskFirstFailureInVersionWithName(s.ctx, &s.subs[2])
 	s.NoError(err)
 	s.NotNil(n)
@@ -672,7 +685,8 @@ func (s *taskSuite) TestRegression() {
 	s.data.Status = evergreen.TaskFailed
 	s.task.Status = evergreen.TaskFailed
 	s.task.RevisionOrderNumber = 0
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err := db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 
 	// brand new task fails should generate
 	s.task.RevisionOrderNumber = 1
@@ -757,7 +771,8 @@ func (s *taskSuite) TestRegression() {
 	n, err = s.t.taskRegression(s.ctx, &s.subs[2])
 	s.NoError(err)
 	s.NotNil(n)
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err = db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 
 	// if regression was trigged after an older success, we should generate
 	s.build.Id = "test7"
@@ -939,7 +954,8 @@ func (s *taskSuite) TestRegressionByTestWithReruns() {
 	s.task.Execution = 1
 	s.event.ResourceId = s.task.Id
 	s.data.Status = s.task.Status
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err := db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 
 	s.makeTest(ctx, "", evergreen.TestFailedStatus)
 	s.tryDoubleTrigger(true)
@@ -949,7 +965,8 @@ func (s *taskSuite) TestRegressionByTestWithReruns() {
 	s.task.Status = evergreen.TaskFailed
 	s.task.Execution = 2
 	s.event.ResourceId = s.task.Id
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err = db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 	s.makeTest(ctx, "", evergreen.TestFailedStatus)
 	s.tryDoubleTrigger(false)
 }
@@ -974,7 +991,8 @@ func (s *taskSuite) TestRegressionByTestWithTasksWithoutTests() {
 
 	// force fully move the time of task 25 back 48 hours
 	s.task.FinishTime = time.Now().Add(-48 * time.Hour)
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{task.IdKey: s.task.Id}, &s.task))
+	_, err := db.ReplaceContext(s.ctx, task.Collection, bson.M{task.IdKey: s.task.Id}, &s.task)
+	s.NoError(err)
 
 	s.makeTask(26, evergreen.TaskFailed)
 	s.makeTest(ctx, "", evergreen.TestFailedStatus)
@@ -1190,7 +1208,8 @@ func (s *taskSuite) TestTaskExceedsTime() {
 		EventType: event.TaskFinished,
 	}
 	s.t.data.Status = evergreen.TaskSucceeded
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err := db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 	n, err := s.t.taskExceedsDuration(s.ctx, &s.subs[3])
 	s.NoError(err)
 	s.NotNil(n)
@@ -1201,7 +1220,8 @@ func (s *taskSuite) TestTaskExceedsTime() {
 		StartTime:  now,
 		FinishTime: now.Add(1 * time.Minute),
 	}
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err = db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 	n, err = s.t.taskExceedsDuration(s.ctx, &s.subs[3])
 	s.NoError(err)
 	s.Nil(n)
@@ -1219,14 +1239,16 @@ func (s *taskSuite) TestSuccessfulTaskExceedsTime() {
 		EventType: event.TaskFinished,
 	}
 	s.t.data.Status = evergreen.TaskSucceeded
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err := db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 	n, err := s.t.taskExceedsDuration(s.ctx, &s.subs[3])
 	s.NoError(err)
 	s.NotNil(n)
 
 	// task that is not successful should not generate
 	s.t.data.Status = evergreen.TaskFailed
-	s.NoError(db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task))
+	_, err = db.ReplaceContext(s.ctx, task.Collection, bson.M{"_id": s.task.Id}, &s.task)
+	s.NoError(err)
 	n, err = s.t.taskSuccessfulExceedsDuration(s.ctx, &s.subs[3])
 	s.NoError(err)
 	s.Nil(n)

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -113,7 +113,7 @@ func TestBuildBreakNotificationsFromRepotracker(t *testing.T) {
 		Type:   event.EmailSubscriberType,
 		Target: "committer@example.com",
 	})
-	assert.NoError(sub.Upsert())
+	assert.NoError(sub.Upsert(t.Context()))
 	assert.NoError(repotracker.AddBuildBreakSubscriptions(ctx, &v2, &proj))
 	e = event.EventLogEntry{
 		ResourceType: event.ResourceTypeTask,
@@ -320,7 +320,7 @@ func (s *taskSuite) SetupTest() {
 	}
 
 	for i := range s.subs {
-		s.NoError(s.subs[i].Upsert())
+		s.NoError(s.subs[i].Upsert(s.ctx))
 	}
 
 	ui := &evergreen.UIConfig{
@@ -361,7 +361,7 @@ func (s *taskSuite) TestTriggerEvent() {
 		},
 		Owner: "someone",
 	}
-	s.NoError(sub.Upsert())
+	s.NoError(sub.Upsert(s.ctx))
 	t := task.Task{
 		Id:                  "test",
 		Version:             "test_version_id",
@@ -390,7 +390,7 @@ func (s *taskSuite) TestGithubPREvent() {
 		Type:   event.SlackSubscriberType,
 		Target: "@annie",
 	})
-	s.NoError(sub.Upsert())
+	s.NoError(sub.Upsert(s.ctx))
 	t := task.Task{
 		Id:           "test",
 		Version:      "test_version_id",
@@ -1043,7 +1043,7 @@ func (s *taskSuite) TestRegressionByTestWithRegex() {
 		},
 		Owner: "someone",
 	}
-	s.NoError(sub.Upsert())
+	s.NoError(sub.Upsert(s.ctx))
 
 	v1 := model.Version{
 		Id:        "v1",

--- a/trigger/version_test.go
+++ b/trigger/version_test.go
@@ -151,7 +151,8 @@ func (s *VersionSuite) TestAllTriggers() {
 
 	s.version.Status = evergreen.VersionSucceeded
 	s.data.Status = evergreen.VersionSucceeded
-	s.NoError(db.ReplaceContext(s.ctx, model.VersionCollection, bson.M{"_id": s.version.Id}, &s.version))
+	_, err = db.ReplaceContext(s.ctx, model.VersionCollection, bson.M{"_id": s.version.Id}, &s.version)
+	s.NoError(err)
 
 	n, err = NotificationsFromEvent(s.ctx, &s.event)
 	s.NoError(err)
@@ -159,7 +160,8 @@ func (s *VersionSuite) TestAllTriggers() {
 
 	s.version.Status = evergreen.VersionFailed
 	s.data.Status = evergreen.VersionFailed
-	s.NoError(db.ReplaceContext(s.ctx, model.VersionCollection, bson.M{"_id": s.version.Id}, &s.version))
+	_, err = db.ReplaceContext(s.ctx, model.VersionCollection, bson.M{"_id": s.version.Id}, &s.version)
+	s.NoError(err)
 
 	n, err = NotificationsFromEvent(s.ctx, &s.event)
 	s.NoError(err)
@@ -167,7 +169,8 @@ func (s *VersionSuite) TestAllTriggers() {
 
 	s.version.Status = evergreen.VersionFailed
 	s.data.Status = evergreen.VersionCreated
-	s.NoError(db.ReplaceContext(s.ctx, model.VersionCollection, bson.M{"_id": s.version.Id}, &s.version))
+	_, err = db.ReplaceContext(s.ctx, model.VersionCollection, bson.M{"_id": s.version.Id}, &s.version)
+	s.NoError(err)
 
 	n, err = NotificationsFromEvent(s.ctx, &s.event)
 	s.NoError(err)

--- a/trigger/version_test.go
+++ b/trigger/version_test.go
@@ -121,7 +121,7 @@ func (s *VersionSuite) SetupTest() {
 	}
 
 	for i := range s.subs {
-		s.NoError(s.subs[i].Upsert())
+		s.NoError(s.subs[i].Upsert(s.ctx))
 	}
 
 	ui := &evergreen.UIConfig{

--- a/trigger/volume_test.go
+++ b/trigger/volume_test.go
@@ -72,7 +72,7 @@ func TestVolumeExpiration(t *testing.T) {
 					Target: "foo@bar.com",
 				}),
 			}
-			require.NoError(t, subscriptions[0].Upsert())
+			require.NoError(t, subscriptions[0].Upsert(t.Context()))
 
 			n, err := NotificationsFromEvent(ctx, &event.EventLogEntry{
 				ResourceType: event.ResourceTypeHost,

--- a/units/cache_historical_task_data.go
+++ b/units/cache_historical_task_data.go
@@ -103,7 +103,7 @@ func (j *cacheHistoricalTaskDataJob) Run(ctx context.Context) {
 
 	var statsToUpdate []taskstats.StatsToUpdate
 	timingMsg["find_task_stats_to_update"] = reportTiming(func() {
-		statsToUpdate, err = taskstats.FindStatsToUpdate(taskstats.FindStatsToUpdateOptions{
+		statsToUpdate, err = taskstats.FindStatsToUpdate(ctx, taskstats.FindStatsToUpdateOptions{
 			ProjectID:  j.ProjectID,
 			Requesters: j.Requesters,
 			Start:      update_window_start,

--- a/units/cache_historical_task_data.go
+++ b/units/cache_historical_task_data.go
@@ -149,7 +149,7 @@ func (j *cacheHistoricalTaskDataJob) Run(ctx context.Context) {
 	}
 
 	timingMsg["save_stats_status"] = reportTiming(func() {
-		j.AddError(errors.Wrap(taskstats.UpdateStatsStatus(j.ProjectID, startAt, update_window_end, time.Since(startAt)), "updating daily task stats status"))
+		j.AddError(errors.Wrap(taskstats.UpdateStatsStatus(ctx, j.ProjectID, startAt, update_window_end, time.Since(startAt)), "updating daily task stats status"))
 	}).Seconds()
 }
 

--- a/units/cache_historical_task_data_test.go
+++ b/units/cache_historical_task_data_test.go
@@ -67,7 +67,7 @@ func TestCacheHistoricalTaskDataJob(t *testing.T) {
 				}
 
 				lastJobTime := now.Add(-time.Hour)
-				require.NoError(t, taskstats.UpdateStatsStatus("p0", lastJobTime, lastJobTime, time.Minute))
+				require.NoError(t, taskstats.UpdateStatsStatus(t.Context(), "p0", lastJobTime, lastJobTime, time.Minute))
 			},
 			post: func(ctx context.Context, t *testing.T) {
 				for _, requester := range evergreen.AllRequesterTypes {
@@ -124,7 +124,7 @@ func TestCacheHistoricalTaskDataJob(t *testing.T) {
 				}
 
 				lastJobTime := t0.Add(-2 * time.Hour)
-				require.NoError(t, taskstats.UpdateStatsStatus("p0", lastJobTime, lastJobTime, time.Minute))
+				require.NoError(t, taskstats.UpdateStatsStatus(t.Context(), "p0", lastJobTime, lastJobTime, time.Minute))
 			},
 			post: func(ctx context.Context, t *testing.T) {
 				ts, err := taskstats.GetDailyTaskDoc(t.Context(), taskstats.DBTaskStatsID{
@@ -205,7 +205,7 @@ func TestCacheHistoricalTaskDataJob(t *testing.T) {
 				}
 
 				lastJobTime := now.Add(-2 * time.Hour)
-				require.NoError(t, taskstats.UpdateStatsStatus("p0", lastJobTime, lastJobTime, time.Minute))
+				require.NoError(t, taskstats.UpdateStatsStatus(t.Context(), "p0", lastJobTime, lastJobTime, time.Minute))
 			},
 			post: func(ctx context.Context, t *testing.T) {
 				ts, err := taskstats.GetDailyTaskDoc(t.Context(), taskstats.DBTaskStatsID{

--- a/units/crons.go
+++ b/units/crons.go
@@ -1070,7 +1070,7 @@ func podAllocatorJobs(ctx context.Context, _ evergreen.Environment, ts time.Time
 		}))
 	}
 
-	numInitializing, err := pod.CountByInitializing()
+	numInitializing, err := pod.CountByInitializing(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "counting initializing pods")
 	}

--- a/units/crons_event_test.go
+++ b/units/crons_event_test.go
@@ -278,7 +278,7 @@ func (s *cronsEventSuite) TestEndToEnd() {
 	}
 
 	for i := range subs {
-		s.NoError(subs[i].Upsert())
+		s.NoError(subs[i].Upsert(s.ctx))
 	}
 
 	handler := &mockWebhookHandler{

--- a/units/duplicate_task_check.go
+++ b/units/duplicate_task_check.go
@@ -48,7 +48,7 @@ func NewDuplicateTaskCheckJob(id string) amboy.Job {
 func (j *duplicateTaskCheckJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
-	dups, err := model.FindDuplicateEnqueuedTasks(model.TaskQueuesCollection)
+	dups, err := model.FindDuplicateEnqueuedTasks(ctx, model.TaskQueuesCollection)
 	if err != nil {
 		j.AddError(errors.Wrap(err, "finding task queues with duplicate enqueued tasks"))
 		return

--- a/units/host_allocator_test.go
+++ b/units/host_allocator_test.go
@@ -56,7 +56,7 @@ func TestSingleTaskDistroHostAllocatorJob(t *testing.T) {
 			LengthWithDependenciesMet: 2,
 		},
 	}
-	require.NoError(tq.Save())
+	require.NoError(tq.Save(t.Context()))
 
 	h := host.Host{
 		Id:     "h1",

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -406,7 +406,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		if numCheckRuns > checkRunLimit {
 			return errors.Errorf("total number of checkRuns (%d) exceeds maximum limit (%d)", numCheckRuns, checkRunLimit)
 		}
-		catcher.Wrap(j.createGitHubSubscriptions(patchDoc), "creating GitHub PR patch subscriptions")
+		catcher.Wrap(j.createGitHubSubscriptions(ctx, patchDoc), "creating GitHub PR patch subscriptions")
 	}
 
 	if patchDoc.IsMergeQueuePatch() {
@@ -481,7 +481,7 @@ func (j *patchIntentProcessor) setGitHubPatchingError(err error) error {
 
 // createGitHubSubscriptions creates subscriptions for notifications related to
 // GitHub PR patches.
-func (j *patchIntentProcessor) createGitHubSubscriptions(p *patch.Patch) error {
+func (j *patchIntentProcessor) createGitHubSubscriptions(ctx context.Context, p *patch.Patch) error {
 	catcher := grip.NewBasicCatcher()
 	ghSub := event.NewGithubStatusAPISubscriber(event.GithubPullRequestSubscriber{
 		Owner:    p.GithubPatchData.BaseOwner,
@@ -490,9 +490,9 @@ func (j *patchIntentProcessor) createGitHubSubscriptions(p *patch.Patch) error {
 		Ref:      p.GithubPatchData.HeadHash,
 	})
 	patchSub := event.NewExpiringPatchOutcomeSubscription(j.PatchID.Hex(), ghSub)
-	catcher.Wrap(patchSub.Upsert(), "inserting patch subscription for GitHub PR")
+	catcher.Wrap(patchSub.Upsert(ctx), "inserting patch subscription for GitHub PR")
 	buildSub := event.NewExpiringBuildOutcomeSubscriptionByVersion(j.PatchID.Hex(), ghSub)
-	catcher.Wrap(buildSub.Upsert(), "inserting build subscription for GitHub PR")
+	catcher.Wrap(buildSub.Upsert(ctx), "inserting build subscription for GitHub PR")
 	if p.IsParent() {
 		// add a subscription on each child patch to report it's status to github when it's done.
 		for _, childPatch := range p.Triggers.ChildPatches {
@@ -504,7 +504,7 @@ func (j *patchIntentProcessor) createGitHubSubscriptions(p *patch.Patch) error {
 				ChildId:  childPatch,
 			})
 			patchSub := event.NewExpiringPatchChildOutcomeSubscription(childPatch, childGhStatusSub)
-			catcher.Wrap(patchSub.Upsert(), "inserting child patch subscription for GitHub PR")
+			catcher.Wrap(patchSub.Upsert(ctx), "inserting child patch subscription for GitHub PR")
 		}
 	}
 	return catcher.Resolve()
@@ -520,9 +520,9 @@ func (j *patchIntentProcessor) createGitHubMergeSubscription(ctx context.Context
 	})
 
 	patchSub := event.NewExpiringPatchOutcomeSubscription(j.PatchID.Hex(), ghSub)
-	catcher.Wrap(patchSub.Upsert(), "inserting patch subscription for GitHub merge queue")
+	catcher.Wrap(patchSub.Upsert(ctx), "inserting patch subscription for GitHub merge queue")
 	buildSub := event.NewExpiringBuildOutcomeSubscriptionByVersion(j.PatchID.Hex(), ghSub)
-	catcher.Wrap(buildSub.Upsert(), "inserting build subscription for GitHub merge queue")
+	catcher.Wrap(buildSub.Upsert(ctx), "inserting build subscription for GitHub merge queue")
 
 	input := thirdparty.SendGithubStatusInput{
 		VersionId: j.PatchID.Hex(),

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -170,25 +170,25 @@ func (s *PatchIntentUnitsSuite) SetupTest() {
 		Alias:     evergreen.GithubPRAlias,
 		Variant:   "ubuntu.*",
 		Task:      "dist.*",
-	}).Upsert())
+	}).Upsert(s.ctx))
 	s.NoError((&model.ProjectAlias{
 		ProjectID: "mci",
 		Alias:     evergreen.GithubPRAlias,
 		Variant:   "race.*",
 		Task:      "dist.*",
-	}).Upsert())
+	}).Upsert(s.ctx))
 	s.NoError((&model.ProjectAlias{
 		ProjectID: "mci",
 		Alias:     "doesntexist",
 		Variant:   "fake",
 		Task:      "fake",
-	}).Upsert())
+	}).Upsert(s.ctx))
 	s.NoError((&model.ProjectAlias{
 		ProjectID: "commit-queue-sandbox",
 		Alias:     evergreen.CommitQueueAlias,
 		Variant:   "^ubuntu2004$",
 		Task:      "^bynntask$",
-	}).Upsert())
+	}).Upsert(s.ctx))
 
 	s.NoError((&distro.Distro{Id: "ubuntu1604-test"}).Insert(s.ctx))
 	s.NoError((&distro.Distro{Id: "ubuntu1604-build"}).Insert(s.ctx))
@@ -315,7 +315,7 @@ func (s *PatchIntentUnitsSuite) TestCantFinishCommitQueuePatchWithNoTasksAndVari
 	s.NoError((&model.ProjectAlias{
 		ProjectID: s.project,
 		Alias:     evergreen.CommitQueueAlias,
-	}).Upsert())
+	}).Upsert(s.ctx))
 
 	intent, err := patch.NewCliIntent(patch.CLIIntentParams{
 		User:         s.user,
@@ -1599,7 +1599,7 @@ tasks:
 		Task:      "my-task",
 		Variant:   "my-build-variant",
 	}
-	s.Require().NoError(childPatchAlias.Upsert())
+	s.Require().NoError(childPatchAlias.Upsert(s.ctx))
 
 	p := &patch.Patch{
 		Id:      mgobson.NewObjectId(),
@@ -1669,7 +1669,7 @@ tasks:
 		Task:      "my-task",
 		Variant:   "my-build-variant",
 	}
-	s.Require().NoError(childPatchAlias.Upsert())
+	s.Require().NoError(childPatchAlias.Upsert(s.ctx))
 
 	p := &patch.Patch{
 		Id:      mgobson.NewObjectId(),

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -356,7 +356,7 @@ func (s *PatchIntentUnitsSuite) TestCantFinalizePatchWithDisabledCommitQueue() {
 			Enabled: utility.FalsePtr(),
 		},
 	}
-	s.Require().NoError(disabledMergeQueueProject.Upsert())
+	s.Require().NoError(disabledMergeQueueProject.Upsert(s.ctx))
 
 	org := github.Organization{
 		Login: &orgName,

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -356,7 +356,7 @@ func (s *PatchIntentUnitsSuite) TestCantFinalizePatchWithDisabledCommitQueue() {
 			Enabled: utility.FalsePtr(),
 		},
 	}
-	s.Require().NoError(disabledMergeQueueProject.Upsert(s.ctx))
+	s.Require().NoError(disabledMergeQueueProject.Replace(s.ctx))
 
 	org := github.Organization{
 		Login: &orgName,

--- a/units/pod_allocator.go
+++ b/units/pod_allocator.go
@@ -184,7 +184,7 @@ func (j *podAllocatorJob) systemCanAllocate(ctx context.Context) (canAllocate bo
 	if err != nil {
 		return false, errors.Wrap(err, "getting admin settings")
 	}
-	numInitializing, err := pod.CountByInitializing()
+	numInitializing, err := pod.CountByInitializing(ctx)
 	if err != nil {
 		return false, errors.Wrap(err, "counting initializing pods")
 	}

--- a/units/pod_allocator_test.go
+++ b/units/pod_allocator_test.go
@@ -100,7 +100,7 @@ func TestPodAllocatorJob(t *testing.T) {
 				ExternalName: "repo_creds_external_name",
 				Type:         model.ContainerSecretRepoCreds,
 			})
-			require.NoError(t, pRef.Upsert(t.Context()))
+			require.NoError(t, pRef.Replace(t.Context()))
 
 			_, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(pRef.ContainerSecrets[1].ExternalName).SetValue("repo_creds_value"))
 			require.NoError(t, err)
@@ -242,7 +242,7 @@ func TestPodAllocatorJob(t *testing.T) {
 		},
 		"RunNoopsWhenProjectDoesNotAllowDispatching": func(ctx context.Context, t *testing.T, j *podAllocatorJob, v cocoa.Vault, tsk task.Task, pRef model.ProjectRef) {
 			pRef.Enabled = false
-			require.NoError(t, pRef.Upsert(t.Context()))
+			require.NoError(t, pRef.Replace(t.Context()))
 			require.NoError(t, tsk.Insert())
 
 			j.Run(ctx)

--- a/units/pod_allocator_test.go
+++ b/units/pod_allocator_test.go
@@ -100,7 +100,7 @@ func TestPodAllocatorJob(t *testing.T) {
 				ExternalName: "repo_creds_external_name",
 				Type:         model.ContainerSecretRepoCreds,
 			})
-			require.NoError(t, pRef.Upsert())
+			require.NoError(t, pRef.Upsert(t.Context()))
 
 			_, err := v.CreateSecret(ctx, *cocoa.NewNamedSecret().SetName(pRef.ContainerSecrets[1].ExternalName).SetValue("repo_creds_value"))
 			require.NoError(t, err)
@@ -242,7 +242,7 @@ func TestPodAllocatorJob(t *testing.T) {
 		},
 		"RunNoopsWhenProjectDoesNotAllowDispatching": func(ctx context.Context, t *testing.T, j *podAllocatorJob, v cocoa.Vault, tsk task.Task, pRef model.ProjectRef) {
 			pRef.Enabled = false
-			require.NoError(t, pRef.Upsert())
+			require.NoError(t, pRef.Upsert(t.Context()))
 			require.NoError(t, tsk.Insert())
 
 			j.Run(ctx)

--- a/units/pod_definition_cleanup_test.go
+++ b/units/pod_definition_cleanup_test.go
@@ -141,7 +141,7 @@ func TestPodDefinitionCleanupJob(t *testing.T) {
 		"CleansUpStaleUnusedPodDefinitions": func(ctx context.Context, t *testing.T, j *podDefinitionCleanupJob) {
 			pd := createPodDef(ctx, t, j.podDefMgr, j.ecsClient)
 			pd.LastAccessed = time.Now().Add(-9000 * 24 * time.Hour)
-			require.NoError(t, pd.Upsert(t.Context()))
+			require.NoError(t, pd.Replace(t.Context()))
 
 			j.Run(ctx)
 			require.NoError(t, j.Error())
@@ -185,7 +185,7 @@ func TestPodDefinitionCleanupJob(t *testing.T) {
 
 			pd := createPodDef(ctx, t, j.podDefMgr, j.ecsClient)
 			pd.LastAccessed = time.Now().Add(-9000 * 24 * time.Hour)
-			require.NoError(t, pd.Upsert(t.Context()))
+			require.NoError(t, pd.Replace(t.Context()))
 
 			j.Run(ctx)
 			assert.Error(t, j.Error())

--- a/units/pod_definition_cleanup_test.go
+++ b/units/pod_definition_cleanup_test.go
@@ -141,7 +141,7 @@ func TestPodDefinitionCleanupJob(t *testing.T) {
 		"CleansUpStaleUnusedPodDefinitions": func(ctx context.Context, t *testing.T, j *podDefinitionCleanupJob) {
 			pd := createPodDef(ctx, t, j.podDefMgr, j.ecsClient)
 			pd.LastAccessed = time.Now().Add(-9000 * 24 * time.Hour)
-			require.NoError(t, pd.Upsert())
+			require.NoError(t, pd.Upsert(t.Context()))
 
 			j.Run(ctx)
 			require.NoError(t, j.Error())
@@ -185,7 +185,7 @@ func TestPodDefinitionCleanupJob(t *testing.T) {
 
 			pd := createPodDef(ctx, t, j.podDefMgr, j.ecsClient)
 			pd.LastAccessed = time.Now().Add(-9000 * 24 * time.Hour)
-			require.NoError(t, pd.Upsert())
+			require.NoError(t, pd.Upsert(t.Context()))
 
 			j.Run(ctx)
 			assert.Error(t, j.Error())

--- a/units/spawnhost_expiration_check.go
+++ b/units/spawnhost_expiration_check.go
@@ -95,7 +95,7 @@ func (j *spawnhostExpirationCheckJob) Run(ctx context.Context) {
 
 // tryIdleSpawnHostNotification attempts to insert a subscription and notification for this spawn host.
 func tryIdleSpawnHostNotification(ctx context.Context, h *host.Host) error {
-	shouldNotify, err := h.ShouldNotifyStoppedSpawnHostIdle()
+	shouldNotify, err := h.ShouldNotifyStoppedSpawnHostIdle(ctx)
 	if err != nil || !shouldNotify {
 		return err
 	}

--- a/units/spawnhost_expiration_check.go
+++ b/units/spawnhost_expiration_check.go
@@ -108,7 +108,7 @@ func tryIdleSpawnHostNotification(ctx context.Context, h *host.Host) error {
 	}
 	subscriber := event.NewEmailSubscriber(usr.Email())
 	subscription := event.NewSpawnHostIdleWarningSubscription(h.Id, subscriber)
-	if err = subscription.Upsert(); err != nil {
+	if err = subscription.Upsert(ctx); err != nil {
 		return errors.Wrap(err, "upserting idle spawn host subscription")
 	}
 

--- a/units/stats_host.go
+++ b/units/stats_host.go
@@ -72,8 +72,8 @@ func (j *hostStatsCollector) Run(ctx context.Context) {
 		j.logger = logging.MakeGrip(grip.GetSender())
 	}
 
-	j.AddError(j.statsByDistro())
-	j.AddError(j.statsByProvider())
+	j.AddError(j.statsByDistro(ctx))
+	j.AddError(j.statsByProvider(ctx))
 }
 
 type hostCountStats struct {
@@ -83,8 +83,8 @@ type hostCountStats struct {
 	excess int
 }
 
-func collectHostCountStats() (*hostCountStats, error) {
-	hosts, err := host.GetStatsByDistro()
+func collectHostCountStats(ctx context.Context) (*hostCountStats, error) {
+	hosts, err := host.GetStatsByDistro(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting host stats by distro")
 	}
@@ -112,8 +112,8 @@ func collectHostCountStats() (*hostCountStats, error) {
 	return stats, nil
 }
 
-func (j *hostStatsCollector) statsByDistro() error {
-	stats, err := collectHostCountStats()
+func (j *hostStatsCollector) statsByDistro(ctx context.Context) error {
+	stats, err := collectHostCountStats(ctx)
 
 	if err != nil {
 		return err
@@ -135,8 +135,8 @@ func (j *hostStatsCollector) statsByDistro() error {
 	return nil
 }
 
-func (j *hostStatsCollector) statsByProvider() error {
-	providers, err := host.GetProviderCounts()
+func (j *hostStatsCollector) statsByProvider(ctx context.Context) error {
+	providers, err := host.GetProviderCounts(ctx)
 	if err != nil {
 		return errors.Wrap(err, "getting host stats by provider")
 	}

--- a/units/stats_notifications.go
+++ b/units/stats_notifications.go
@@ -75,7 +75,7 @@ func (j *notificationsStatsCollector) Run(ctx context.Context) {
 		msg["last_processed_at"] = e.ProcessedAt
 	}
 
-	nUnprocessed, err := event.CountUnprocessedEvents()
+	nUnprocessed, err := event.CountUnprocessedEvents(ctx)
 	j.AddError(errors.Wrap(err, "counting unprocessed events"))
 	if j.HasErrors() {
 		return

--- a/units/stats_notifications.go
+++ b/units/stats_notifications.go
@@ -82,7 +82,7 @@ func (j *notificationsStatsCollector) Run(ctx context.Context) {
 	}
 	msg["unprocessed_events"] = nUnprocessed
 
-	stats, err := notification.CollectUnsentNotificationStats()
+	stats, err := notification.CollectUnsentNotificationStats(ctx)
 	j.AddError(errors.Wrap(err, "collecting unsent notification stats"))
 	if j.HasErrors() {
 		return

--- a/units/stats_pod.go
+++ b/units/stats_pod.go
@@ -66,17 +66,17 @@ func (j *podStatsCollector) Run(ctx context.Context) {
 		return
 	}
 
-	j.AddError(j.logStats())
+	j.AddError(j.logStats(ctx))
 }
 
-func (j *podStatsCollector) logStats() error {
+func (j *podStatsCollector) logStats(ctx context.Context) error {
 	statuses := []pod.Status{
 		pod.StatusInitializing,
 		pod.StatusStarting,
 		pod.StatusRunning,
 		pod.StatusDecommissioned,
 	}
-	stats, err := pod.GetStatsByStatus(statuses...)
+	stats, err := pod.GetStatsByStatus(ctx, statuses...)
 	if err != nil {
 		return errors.Wrap(err, "getting statistics by pod status")
 	}

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -5069,7 +5069,7 @@ func TestValidateContainers(t *testing.T) {
 				},
 			}
 
-			require.NoError(t, ref.Upsert(t.Context()))
+			require.NoError(t, ref.Replace(t.Context()))
 			require.NoError(t, projVars.Insert())
 			tCase(t, p, ref)
 		})

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -5069,7 +5069,7 @@ func TestValidateContainers(t *testing.T) {
 				},
 			}
 
-			require.NoError(t, ref.Upsert())
+			require.NoError(t, ref.Upsert(t.Context()))
 			require.NoError(t, projVars.Insert())
 			tCase(t, p, ref)
 		})


### PR DESCRIPTION
DEVPROD-53

### Description
This threads context through the rest of Aggregate, Count, and Upsert queries.

Unfortunately for Upsert queries, we sometimes are instead doing a Replace query under the hood. This happened when I did the Update queries as well. As a temporary workaround, I added a fallback that I'll check back with in a week. I'll update the queries that need to be updated and remove the fallback.

### Testing
Unit tests. I rebased on main on April 8th @ 1:50pm as to prevent silent merge conflicts (e.g. updating a function definition and another PR adds a call to that function definition)
