### PR TITLE
DEVPROD-15254: send status checks for aborted merge queue patches

### DIFF
--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -202,20 +202,24 @@ type GithubCheckSubscriber struct {
 	Ref   string `bson:"ref"`
 }
 
+func (s *GithubCheckSubscriber) String() string {
+	return fmt.Sprintf("%s-%s-%s", s.Owner, s.Repo, s.Ref)
+}
+
 type GithubMergeSubscriber struct {
 	Owner string `bson:"owner"`
 	Repo  string `bson:"repo"`
 	Ref   string `bson:"ref"`
 }
 
+func (s *GithubMergeSubscriber) String() string {
+	return fmt.Sprintf("%s-%s-%s", s.Owner, s.Repo, s.Ref)
+}
+
 type ChildPatchSubscriber struct {
 	ParentStatus string `bson:"parent_status"`
 	ChildPatchId string `bson:"child_patch_id"`
 	Requester    string `bson:"requester"`
-}
-
-func (s *GithubCheckSubscriber) String() string {
-	return fmt.Sprintf("%s-%s-%s", s.Owner, s.Repo, s.Ref)
 }
 
 func NewRunChildPatchSubscriber(s ChildPatchSubscriber) Subscriber {

--- a/model/version.go
+++ b/model/version.go
@@ -333,17 +333,6 @@ type DuplicateVersions struct {
 	Versions []Version           `bson:"versions"`
 }
 
-func IsAborted(ctx context.Context, id string) (bool, error) {
-	v, err := VersionFindOne(ctx, VersionById(id))
-	if err != nil {
-		return false, errors.Errorf("finding version '%s'", id)
-	}
-	if v == nil {
-		return false, errors.Errorf("version '%s' not found", id)
-	}
-	return v.Aborted, nil
-}
-
 func VersionGetHistory(ctx context.Context, versionId string, N int) ([]Version, error) {
 	v, err := VersionFindOne(ctx, VersionById(versionId))
 	if err != nil {


### PR DESCRIPTION
DEVPROD-15254

### Description
There's a feature to abort merge queue patches early when at least one task fails. If the merge queue patch was aborted and the GitHub repo sets up `evergreen` (the patch-level status check) as a required status check in their settings, the merge queue item would never update the status check to failed because the patch trigger logic [suppressed notifications for patch aborts](https://github.com/evergreen-ci/evergreen/blob/f84b3ff0bdf324924445806e5f76f3195d02fdc9/trigger/patch.go#L338-L345). That check would stay stuck pending until GitHub eventually times out the merge queue item. I fixed this check so to allow the notification if the subscription is for updating the merge queue status check.

* Do not suppress notification if the patch is aborted for merge queue status check subscriptions.
* Add a `String()` method for the merge check subscriber since I noticed the resulting notifications need it to generate their ID.

### Testing
* Updated unit tests.
* Tested in [merge queue sandbox](https://github.com/evergreen-ci/github-merge-queue-sandbox/pull/35) that if a merge queue patch fails and its status is aborted, it'll still update the `evergreen` status check to failed rather than leaving the status check pending like it did before.
