### PR TITLE
DEVPROD-15896 Don't copy aliases for distro copy

### DIFF
--- a/rest/data/distro.go
+++ b/rest/data/distro.go
@@ -112,6 +112,7 @@ func CopyDistro(ctx context.Context, u *user.DBUser, opts restModel.CopyDistroOp
 	}
 
 	distroToCopy.Id = opts.NewDistroId
+	distroToCopy.Aliases = nil
 	return NewDistro(ctx, distroToCopy, u)
 }
 

--- a/rest/data/distro_test.go
+++ b/rest/data/distro_test.go
@@ -117,6 +117,7 @@ func TestCopyDistro(t *testing.T) {
 			newDistro, err := distro.FindOneId(ctx, "new-distro")
 			assert.NoError(t, err)
 			assert.NotNil(t, newDistro)
+			assert.Nil(t, newDistro.Aliases)
 
 			events, err := event.FindLatestPrimaryDistroEvents("new-distro", 10, utility.ZeroTime)
 			assert.NoError(t, err)
@@ -191,6 +192,7 @@ func TestCopyDistro(t *testing.T) {
 				Provider: evergreen.ProviderNameStatic,
 				WorkDir:  "/tmp",
 				User:     "admin",
+				Aliases:  []string{"alias1", "alias2"},
 			}
 			assert.NoError(t, d.Insert(tctx))
 

--- a/rest/data/distro_test.go
+++ b/rest/data/distro_test.go
@@ -14,6 +14,7 @@ import (
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDeleteDistroById(t *testing.T) {
@@ -116,7 +117,7 @@ func TestCopyDistro(t *testing.T) {
 
 			newDistro, err := distro.FindOneId(ctx, "new-distro")
 			assert.NoError(t, err)
-			assert.NotNil(t, newDistro)
+			require.NotNil(t, newDistro)
 			assert.Nil(t, newDistro.Aliases)
 
 			events, err := event.FindLatestPrimaryDistroEvents("new-distro", 10, utility.ZeroTime)

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -307,6 +307,9 @@ func (h *distroCopyHandler) Run(ctx context.Context) gimlet.Responder {
 		toCopy.SingleTaskDistro = true
 	}
 
+	// Do not copy aliases because it could lead to the wrong distros being used.
+	toCopy.Aliases = nil
+
 	err = data.NewDistro(ctx, toCopy, user)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating and inserting new distro '%s'", h.newDistroID))

--- a/rest/route/distro.go
+++ b/rest/route/distro.go
@@ -262,7 +262,7 @@ func makeCopyDistro() gimlet.RouteHandler {
 // Factory creates an instance of the handler.
 //
 //	@Summary		Copy an existing distro
-//	@Description	Create a new distro by copying an existing distro. Specifying "single task distro" will mark the copied distro as a single task distro.
+//	@Description	Create a new distro by copying an existing distro. Specifying "single task distro" will mark the copied distro as a single task distro. Aliases will not be copied.
 //	@Tags			distros
 //	@Router			/distros/{distro_id}/copy/{new_distro_id} [put]
 //	@Security		Api-User || Api-Key

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -1369,6 +1369,7 @@ func getMockDistrosdata() error {
 			DispatcherSettings: distro.DispatcherSettings{
 				Version: evergreen.DispatcherVersionRevisedWithDependencies,
 			},
+			Aliases: []string{"alias1", "alias2"},
 		},
 	}
 	for _, d := range distros {
@@ -1482,6 +1483,7 @@ func (s *distroCopySuite) TestRunValidCopy() {
 	s.NotNil(copied)
 	s.Equal("newDistro", copied.Id)
 	s.Equal(true, copied.SingleTaskDistro)
+	s.Nil(copied.Aliases)
 }
 
 func (s *distroCopySuite) TestRunInvalidCopyNonexistentID() {


### PR DESCRIPTION
DEVPROD-15896

### Description
alias being copied could lead to confusion in what distro is used so they will not be copied in route and ui

### Testing
unit tests