### PR TITLE
DEVPROD-16223: fix Jira test

### DIFF
--- a/scripts/setup-credentials.sh
+++ b/scripts/setup-credentials.sh
@@ -7,7 +7,7 @@ set -o errexit
 
 echo "building creds file!"
 
-cat > creds.yml <<EOF
+cat >creds.yml <<EOF
 database:
   url: "mongodb://localhost:27017"
   db: "mci"
@@ -38,7 +38,7 @@ notify:
 jira:
   host: "$JIRA_SERVER"
   oauth1:
-    private_key: "$JIRA_PRIVATE_KEY"
+    private_key: $JIRA_PRIVATE_KEY
     access_token: "$JIRA_ACCESS_TOKEN"
     token_secret: "$JIRA_TOKEN_SECRET"
     consumer_key: "$JIRA_CONSUMER_KEY"
@@ -83,8 +83,8 @@ expansions:
 EOF
 
 # Write the GitHub app key to a file for easier formatting
-echo "$GITHUB_APP_KEY" > app_key.txt
+echo "$GITHUB_APP_KEY" >app_key.txt
 # Linux and MacOS friendly command to add 4 spaces to the start of each line
 sed -i'' -e 's/^/    /' app_key.txt
 # Append the formatted GitHub app key to the creds.yml file
-cat app_key.txt >> creds.yml
+cat app_key.txt >>creds.yml

--- a/scripts/setup-credentials.sh
+++ b/scripts/setup-credentials.sh
@@ -7,7 +7,7 @@ set -o errexit
 
 echo "building creds file!"
 
-cat >creds.yml <<EOF
+cat > creds.yml <<EOF
 database:
   url: "mongodb://localhost:27017"
   db: "mci"
@@ -83,8 +83,8 @@ expansions:
 EOF
 
 # Write the GitHub app key to a file for easier formatting
-echo "$GITHUB_APP_KEY" >app_key.txt
+echo "$GITHUB_APP_KEY" > app_key.txt
 # Linux and MacOS friendly command to add 4 spaces to the start of each line
 sed -i'' -e 's/^/    /' app_key.txt
 # Append the formatted GitHub app key to the creds.yml file
-cat app_key.txt >>creds.yml
+cat app_key.txt >> creds.yml

--- a/thirdparty/jira.go
+++ b/thirdparty/jira.go
@@ -212,6 +212,20 @@ func (jiraHandler *JiraHandler) GetJIRATicket(key string) (*JiraTicket, error) {
 	}
 
 	if res.StatusCode >= 300 || res.StatusCode < 200 {
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			grip.Error(message.WrapError(err, message.Fields{
+				"message": "kim: could not read response body for non-OK HTTP request",
+				"status":  res.Status,
+				"body":    string(body),
+			}))
+		} else {
+			grip.Info(message.Fields{
+				"message": "kim: got response body for non-OK HTTP request",
+				"status":  res.Status,
+				"body":    string(body),
+			})
+		}
 		return nil, errors.Errorf("HTTP request returned unexpected status `%v`", res.Status)
 	}
 

--- a/thirdparty/jira.go
+++ b/thirdparty/jira.go
@@ -212,20 +212,6 @@ func (jiraHandler *JiraHandler) GetJIRATicket(key string) (*JiraTicket, error) {
 	}
 
 	if res.StatusCode >= 300 || res.StatusCode < 200 {
-		body, err := io.ReadAll(res.Body)
-		if err != nil {
-			grip.Error(message.WrapError(err, message.Fields{
-				"message": "kim: could not read response body for non-OK HTTP request",
-				"status":  res.Status,
-				"body":    string(body),
-			}))
-		} else {
-			grip.Info(message.Fields{
-				"message": "kim: got response body for non-OK HTTP request",
-				"status":  res.Status,
-				"body":    string(body),
-			})
-		}
 		return nil, errors.Errorf("HTTP request returned unexpected status `%v`", res.Status)
 	}
 


### PR DESCRIPTION
DEVPROD-16223

### Description
IT gave us a new set of Jira credentials, so I replaced them in the project vars for our Jira integration tests. However, the `creds.yml` file isn't happy with the private key because it's a multiline string. To work around this, I changed the YAML creation script so that the project var formats the private key as a multiline YAML string, like this:
```
private_key: |
  some
  multiline string
```

### Testing
`TestJiraIntegration` passes with changes.