### PR TITLE
DEVPROD-16307: close s3.get temporary tar file before removing

### DIFF
--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -336,8 +336,6 @@ func (c *s3get) get(ctx context.Context) error {
 		return errors.Wrapf(err, "creating temporary file")
 	}
 
-	defer f.Close()
-
 	catcher := grip.NewBasicCatcher()
 
 	catcher.Wrapf(c.fetchAndExtractTarball(ctx, f), "fetching and extracting targz")
@@ -347,6 +345,10 @@ func (c *s3get) get(ctx context.Context) error {
 }
 
 func (c *s3get) fetchAndExtractTarball(ctx context.Context, f *os.File) error {
+	// it's important that we close the file after this function runs because
+	// we must close a file before we can remove it on Windows.
+	defer f.Close()
+
 	if err := c.bucket.GetToWriter(ctx, c.RemoteFile, f); err != nil {
 		return errors.Wrapf(err, "downloading remote file '%s' to local file '%s'", c.RemoteFile, f.Name())
 	}

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-03-31"
+	AgentVersion = "2025-04-01"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-16307

This commit adjusts s3.get to explicitly close the temporary file we create before attempting to remove it. Calling remove before closing the file is fine on Linux and MacOS, but on Windows this is not allowed and causes the error "The process cannot access the file because it is being used by another process."