### PR TITLE
DEVPROD-16198 Add write operations to test results interface

### DIFF
--- a/model/testresult/cedar_service.go
+++ b/model/testresult/cedar_service.go
@@ -30,8 +30,7 @@ func newCedarService(env evergreen.Environment) *cedarService {
 }
 
 func (s *cedarService) AppendTestResults(ctx context.Context, results []TestResult) error {
-	// TODO: DEVPROD-16200 implement service
-	return nil
+	return errors.New("not implemented")
 }
 
 func (s *cedarService) GetMergedTaskTestResults(ctx context.Context, taskOpts []TaskOptions, filterOpts *FilterOptions) (TaskTestResults, error) {

--- a/model/testresult/cedar_service.go
+++ b/model/testresult/cedar_service.go
@@ -29,6 +29,11 @@ func newCedarService(env evergreen.Environment) *cedarService {
 	return &cedarService{baseURL: fmt.Sprintf("%s://%s", httpScheme, cedarSettings.BaseURL)}
 }
 
+func (s *cedarService) AppendTestResults(ctx context.Context, results []TestResult) error {
+	// TODO: DEVPROD-16200 implement service
+	return nil
+}
+
 func (s *cedarService) GetMergedTaskTestResults(ctx context.Context, taskOpts []TaskOptions, filterOpts *FilterOptions) (TaskTestResults, error) {
 	data, status, err := testresults.Get(ctx, s.convertOpts(taskOpts, filterOpts))
 	if err != nil {

--- a/model/testresult/db.go
+++ b/model/testresult/db.go
@@ -35,7 +35,7 @@ var (
 	failedCountKey = bsonutil.MustHaveTag(TaskTestResultsStats{}, "FailedCount")
 )
 
-func (id dbTaskTestResultsID) appendResults(ctx context.Context, env evergreen.Environment, results []TestResult) error {
+func (id dbTaskTestResultsID) appendResults(ctx context.Context, results []TestResult) error {
 	var failedCount int
 	for _, result := range results {
 		if result.Status == evergreen.TestFailedStatus {
@@ -50,11 +50,11 @@ func (id dbTaskTestResultsID) appendResults(ctx context.Context, env evergreen.E
 			bsonutil.GetDottedKeyName(statsKey, failedCountKey): failedCount,
 		},
 	}
-	_, err := env.DB().Collection(Collection).UpdateOne(ctx, bson.M{idKey: id}, update, options.Update().SetUpsert(true))
+	_, err := evergreen.GetEnvironment().DB().Collection(Collection).UpdateOne(ctx, bson.M{idKey: id}, update, options.Update().SetUpsert(true))
 	return errors.Wrap(err, "appending DB test results")
 }
 
-func appendDBResults(ctx context.Context, env evergreen.Environment, results []TestResult) error {
+func appendDBResults(ctx context.Context, results []TestResult) error {
 	ids := map[dbTaskTestResultsID][]TestResult{}
 	for _, result := range results {
 		id := dbTaskTestResultsID{
@@ -65,7 +65,7 @@ func appendDBResults(ctx context.Context, env evergreen.Environment, results []T
 	}
 
 	for id, results := range ids {
-		if err := id.appendResults(ctx, env, results); err != nil {
+		if err := id.appendResults(ctx, results); err != nil {
 			return err
 		}
 	}

--- a/model/testresult/local_service.go
+++ b/model/testresult/local_service.go
@@ -41,10 +41,12 @@ func (s *localService) AppendTestResults(ctx context.Context, results []TestResu
 		ids[id] = append(ids[id], result)
 	}
 
+	catcher := grip.NewBasicCatcher()
 	for id, results := range ids {
-		if err := s.appendResults(ctx, results, id); err != nil {
-			return err
-		}
+		catcher.Add(s.appendResults(ctx, results, id))
+	}
+	if catcher.HasErrors() {
+		return errors.Wrap(catcher.Resolve(), "appending test results")
 	}
 
 	return nil

--- a/model/testresult/local_service.go
+++ b/model/testresult/local_service.go
@@ -17,8 +17,8 @@ const maxSampleSize = 10
 
 // InsertLocal inserts the given test results into the local test results store
 // for testing and local development.
-func InsertLocal(ctx context.Context, env evergreen.Environment, results ...TestResult) error {
-	return errors.Wrap(appendDBResults(ctx, env, results), "inserting local test results")
+func InsertLocal(ctx context.Context, results ...TestResult) error {
+	return errors.Wrap(appendDBResults(ctx, results), "inserting local test results")
 }
 
 // ClearLocal clears the local test results store.
@@ -34,6 +34,10 @@ type localService struct {
 // newLocalService returns a local test results service implementation.
 func newLocalService(env evergreen.Environment) *localService {
 	return &localService{env: env}
+}
+
+func (s *localService) AppendTestResults(ctx context.Context, results []TestResult) error {
+	return errors.Wrap(appendDBResults(ctx, results), "inserting local test results")
 }
 
 func (s *localService) GetMergedTaskTestResults(ctx context.Context, taskOpts []TaskOptions, filterOpts *FilterOptions) (TaskTestResults, error) {

--- a/model/testresult/local_service_test.go
+++ b/model/testresult/local_service_test.go
@@ -16,7 +16,7 @@ func TestLocalService(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	env := testutil.NewEnvironment(ctx, t)
-	svc := newLocalService(env)
+	svc := NewLocalService(env)
 	require.NoError(t, ClearLocal(ctx, env))
 	defer func() {
 		assert.NoError(t, ClearLocal(ctx, env))
@@ -221,7 +221,7 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	env := testutil.NewEnvironment(ctx, t)
-	svc := newLocalService(env)
+	svc := NewLocalService(env)
 	defer func() {
 		assert.NoError(t, ClearLocal(ctx, env))
 	}()

--- a/model/testresult/local_service_test.go
+++ b/model/testresult/local_service_test.go
@@ -33,7 +33,7 @@ func TestLocalService(t *testing.T) {
 		}
 		savedResults0[i] = result
 	}
-	require.NoError(t, InsertLocal(ctx, env, savedResults0...))
+	require.NoError(t, svc.AppendTestResults(ctx, savedResults0))
 
 	task1 := TaskOptions{TaskID: "task1", Execution: 0}
 	savedResults1 := make([]TestResult, 10)
@@ -43,8 +43,7 @@ func TestLocalService(t *testing.T) {
 		result.Execution = task1.Execution
 		savedResults1[i] = result
 	}
-	require.NoError(t, InsertLocal(ctx, env, savedResults1...))
-
+	require.NoError(t, svc.AppendTestResults(ctx, savedResults1))
 	task2 := TaskOptions{TaskID: "task2", Execution: 1}
 	savedResults2 := make([]TestResult, 10)
 	for i := 0; i < len(savedResults2); i++ {
@@ -53,8 +52,7 @@ func TestLocalService(t *testing.T) {
 		result.Execution = task2.Execution
 		savedResults2[i] = result
 	}
-	require.NoError(t, InsertLocal(ctx, env, savedResults2...))
-
+	require.NoError(t, svc.AppendTestResults(ctx, savedResults2))
 	task3 := TaskOptions{TaskID: "task3", Execution: 0}
 	savedResults3 := make([]TestResult, maxSampleSize)
 	for i := 0; i < len(savedResults3); i++ {
@@ -66,8 +64,7 @@ func TestLocalService(t *testing.T) {
 		}
 		savedResults3[i] = result
 	}
-	require.NoError(t, InsertLocal(ctx, env, savedResults3...))
-
+	require.NoError(t, svc.AppendTestResults(ctx, savedResults3))
 	task4 := TaskOptions{TaskID: "task4", Execution: 1}
 	savedResults4 := make([]TestResult, maxSampleSize)
 	for i := 0; i < len(savedResults3); i++ {
@@ -77,8 +74,7 @@ func TestLocalService(t *testing.T) {
 		result.Status = evergreen.TestFailedStatus
 		savedResults4[i] = result
 	}
-	require.NoError(t, InsertLocal(ctx, env, savedResults4...))
-
+	require.NoError(t, svc.AppendTestResults(ctx, savedResults4))
 	emptyTask := TaskOptions{TaskID: "DNE", Execution: 0}
 
 	t.Run("GetMergedTaskTestResults", func(t *testing.T) {
@@ -288,7 +284,7 @@ func TestLocalFilterAndSortTestResults(t *testing.T) {
 			Status:   "Fail",
 		},
 	}
-	require.NoError(t, InsertLocal(ctx, env, baseResults...))
+	require.NoError(t, svc.AppendTestResults(ctx, baseResults))
 	resultsWithBaseStatus := getResults()
 	require.Len(t, resultsWithBaseStatus, len(baseResults))
 	for i := range resultsWithBaseStatus {

--- a/model/testresult/service_interface.go
+++ b/model/testresult/service_interface.go
@@ -34,7 +34,7 @@ func getServiceImpl(env evergreen.Environment, service string) (testResultsServi
 	case TestResultsServiceCedar:
 		return newCedarService(env), nil
 	case TestResultsServiceLocal:
-		return newLocalService(env), nil
+		return NewLocalService(env), nil
 	default:
 		return nil, errors.Errorf("unsupported test results service '%s'", service)
 	}

--- a/model/testresult/service_interface.go
+++ b/model/testresult/service_interface.go
@@ -22,6 +22,7 @@ type testResultsService interface {
 	GetMergedTaskTestResultsStats(context.Context, []TaskOptions) (TaskTestResultsStats, error)
 	GetMergedFailedTestSample(context.Context, []TaskOptions) ([]string, error)
 	GetFailedTestSamples(context.Context, []TaskOptions, []string) ([]TaskTestResultsFailedSample, error)
+	AppendTestResults(context.Context, []TestResult) error
 }
 
 func getServiceImpl(env evergreen.Environment, service string) (testResultsService, error) {

--- a/model/testresult/testresult_test.go
+++ b/model/testresult/testresult_test.go
@@ -30,7 +30,7 @@ func TestGetMergedTaskTestResults(t *testing.T) {
 	}()
 	srv, handler := newMockCedarServer(env)
 	defer srv.Close()
-	svc := newLocalService(env)
+	svc := NewLocalService(env)
 
 	task0 := TaskOptions{
 		TaskID:         "task0",
@@ -204,7 +204,7 @@ func TestGetMergedTaskTestResultsStats(t *testing.T) {
 	}()
 	srv, handler := newMockCedarServer(env)
 	defer srv.Close()
-	svc := newLocalService(env)
+	svc := NewLocalService(env)
 
 	task0 := TaskOptions{
 		TaskID:         "task0",
@@ -334,7 +334,7 @@ func TestGetMergedFailedTestSample(t *testing.T) {
 	}()
 	srv, handler := newMockCedarServer(env)
 	defer srv.Close()
-	svc := newLocalService(env)
+	svc := NewLocalService(env)
 
 	task0 := TaskOptions{
 		TaskID:         "task0",
@@ -454,7 +454,7 @@ func TestGetFailedTestSamples(t *testing.T) {
 	}()
 	srv, handler := newMockCedarServer(env)
 	defer srv.Close()
-	svc := newLocalService(env)
+	svc := NewLocalService(env)
 
 	task0 := TaskOptions{
 		TaskID:         "task0",

--- a/model/testresult/testresult_test.go
+++ b/model/testresult/testresult_test.go
@@ -30,6 +30,7 @@ func TestGetMergedTaskTestResults(t *testing.T) {
 	}()
 	srv, handler := newMockCedarServer(env)
 	defer srv.Close()
+	svc := newLocalService(env)
 
 	task0 := TaskOptions{
 		TaskID:         "task0",
@@ -46,7 +47,7 @@ func TestGetMergedTaskTestResults(t *testing.T) {
 		}
 		savedResults0[i] = result
 	}
-	require.NoError(t, InsertLocal(ctx, env, savedResults0...))
+	require.NoError(t, svc.AppendTestResults(ctx, savedResults0))
 
 	task1 := TaskOptions{
 		TaskID:         "task1",
@@ -60,7 +61,7 @@ func TestGetMergedTaskTestResults(t *testing.T) {
 		result.Execution = task1.Execution
 		savedResults1[i] = result
 	}
-	require.NoError(t, InsertLocal(ctx, env, savedResults1...))
+	require.NoError(t, svc.AppendTestResults(ctx, savedResults1))
 
 	task2 := TaskOptions{
 		TaskID:         "task2",
@@ -74,7 +75,7 @@ func TestGetMergedTaskTestResults(t *testing.T) {
 		result.Execution = task2.Execution
 		savedResults2[i] = result
 	}
-	require.NoError(t, InsertLocal(ctx, env, savedResults2...))
+	require.NoError(t, svc.AppendTestResults(ctx, savedResults2))
 
 	externalServiceTask := TaskOptions{
 		TaskID:         "external_service_task",
@@ -203,6 +204,7 @@ func TestGetMergedTaskTestResultsStats(t *testing.T) {
 	}()
 	srv, handler := newMockCedarServer(env)
 	defer srv.Close()
+	svc := newLocalService(env)
 
 	task0 := TaskOptions{
 		TaskID:         "task0",
@@ -219,7 +221,7 @@ func TestGetMergedTaskTestResultsStats(t *testing.T) {
 		}
 		savedResults0[i] = result
 	}
-	require.NoError(t, InsertLocal(ctx, env, savedResults0...))
+	require.NoError(t, svc.AppendTestResults(ctx, savedResults0))
 
 	task1 := TaskOptions{
 		TaskID:         "task1",
@@ -233,7 +235,7 @@ func TestGetMergedTaskTestResultsStats(t *testing.T) {
 		result.Execution = task1.Execution
 		savedResults1[i] = result
 	}
-	require.NoError(t, InsertLocal(ctx, env, savedResults1...))
+	require.NoError(t, svc.AppendTestResults(ctx, savedResults1))
 
 	externalServiceTask := TaskOptions{
 		TaskID:         "external_service_task",
@@ -332,6 +334,7 @@ func TestGetMergedFailedTestSample(t *testing.T) {
 	}()
 	srv, handler := newMockCedarServer(env)
 	defer srv.Close()
+	svc := newLocalService(env)
 
 	task0 := TaskOptions{
 		TaskID:         "task0",
@@ -345,7 +348,7 @@ func TestGetMergedFailedTestSample(t *testing.T) {
 		result.Execution = task0.Execution
 		result.Status = evergreen.TestFailedStatus
 		sample0[i] = result.GetDisplayTestName()
-		require.NoError(t, InsertLocal(ctx, env, result))
+		require.NoError(t, svc.AppendTestResults(ctx, []TestResult{result}))
 	}
 
 	task1 := TaskOptions{
@@ -360,7 +363,7 @@ func TestGetMergedFailedTestSample(t *testing.T) {
 		result.Execution = task1.Execution
 		result.Status = evergreen.TestFailedStatus
 		sample1[i] = result.GetDisplayTestName()
-		require.NoError(t, InsertLocal(ctx, env, result))
+		require.NoError(t, svc.AppendTestResults(ctx, []TestResult{result}))
 	}
 
 	externalServiceTask := TaskOptions{
@@ -451,6 +454,7 @@ func TestGetFailedTestSamples(t *testing.T) {
 	}()
 	srv, handler := newMockCedarServer(env)
 	defer srv.Close()
+	svc := newLocalService(env)
 
 	task0 := TaskOptions{
 		TaskID:         "task0",
@@ -464,7 +468,7 @@ func TestGetFailedTestSamples(t *testing.T) {
 		result.Execution = task0.Execution
 		result.Status = evergreen.TestFailedStatus
 		sample0[i] = result.GetDisplayTestName()
-		require.NoError(t, InsertLocal(ctx, env, result))
+		require.NoError(t, svc.AppendTestResults(ctx, []TestResult{result}))
 	}
 
 	task1 := TaskOptions{
@@ -479,7 +483,7 @@ func TestGetFailedTestSamples(t *testing.T) {
 		result.Execution = task1.Execution
 		result.Status = evergreen.TestFailedStatus
 		sample1[i] = result.GetDisplayTestName()
-		require.NoError(t, InsertLocal(ctx, env, result))
+		require.NoError(t, svc.AppendTestResults(ctx, []TestResult{result}))
 	}
 
 	externalServiceTask := TaskOptions{

--- a/operations/cli_integration_test.go
+++ b/operations/cli_integration_test.go
@@ -289,6 +289,7 @@ func TestCLITestHistory(t *testing.T) {
 		assert.NoError(t, testresult.ClearLocal(ctx, env))
 	}()
 	testutil.ConfigureIntegrationTest(t, testConfig)
+	svc := testresult.NewLocalService(env)
 	Convey("with API test server running", t, func() {
 		testSetup := setupCLITestHarness(ctx)
 		defer testSetup.testServer.Close()
@@ -351,7 +352,7 @@ func TestCLITestHistory(t *testing.T) {
 					TestStartTime: startTime,
 					TestEndTime:   endTime,
 				}
-				require.NoError(t, testresult.InsertLocal(ctx, passingResult, failedResult))
+				require.NoError(t, svc.AppendTestResults(ctx, []testresult.TestResult{passingResult, failedResult}))
 			}
 		})
 	})

--- a/operations/cli_integration_test.go
+++ b/operations/cli_integration_test.go
@@ -351,7 +351,7 @@ func TestCLITestHistory(t *testing.T) {
 					TestStartTime: startTime,
 					TestEndTime:   endTime,
 				}
-				require.NoError(t, testresult.InsertLocal(ctx, evergreen.GetEnvironment(), passingResult, failedResult))
+				require.NoError(t, testresult.InsertLocal(ctx, passingResult, failedResult))
 			}
 		})
 	})

--- a/service/rest_task_test.go
+++ b/service/rest_task_test.go
@@ -61,7 +61,7 @@ func insertTaskForTesting(ctx context.Context, env evergreen.Environment, taskId
 
 	if len(testResults) > 0 {
 		task.ResultsService = testresult.TestResultsServiceLocal
-		if err := testresult.InsertLocal(ctx, env, testResults...); err != nil {
+		if err := testresult.InsertLocal(ctx, testResults...); err != nil {
 			return nil, err
 		}
 	}

--- a/service/rest_task_test.go
+++ b/service/rest_task_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func insertTaskForTesting(ctx context.Context, env evergreen.Environment, taskId, versionId, projectName string, testResults []testresult.TestResult) (*task.Task, error) {
+	svc := testresult.NewLocalService(env)
 	task := &task.Task{
 		Id:                  taskId,
 		CreateTime:          time.Now().Add(-20 * time.Minute),
@@ -61,7 +62,7 @@ func insertTaskForTesting(ctx context.Context, env evergreen.Environment, taskId
 
 	if len(testResults) > 0 {
 		task.ResultsService = testresult.TestResultsServiceLocal
-		if err := testresult.InsertLocal(ctx, testResults...); err != nil {
+		if err := svc.AppendTestResults(ctx, testResults); err != nil {
 			return nil, err
 		}
 	}
@@ -273,7 +274,7 @@ func TestGetTaskStatus(t *testing.T) {
 	require.NoError(t, env.Configure(ctx))
 	router, err := newTestUIRouter(ctx, env)
 	require.NoError(t, err, "error setting up router")
-
+	svc := testresult.NewLocalService(env)
 	Convey("When finding the status of a particular task", t, func() {
 		require.NoError(t, db.ClearCollections(task.Collection),
 			"Error clearing '%v' collection", task.Collection)
@@ -300,7 +301,7 @@ func TestGetTaskStatus(t *testing.T) {
 			TestEndTime:   time.Now().Add(-1 * time.Minute),
 		}
 		require.NoError(t, testTask.Insert(t.Context()))
-		require.NoError(t, testresult.InsertLocal(ctx, env, testResult))
+		require.NoError(t, svc.AppendTestResults(ctx, []testresult.TestResult{testResult}))
 
 		url := "/rest/v1/tasks/" + taskId + "/status"
 

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -832,13 +832,14 @@ func (s *taskSuite) makeTest(ctx context.Context, testName, testStatus string) {
 	if len(testName) == 0 {
 		testName = "test_0"
 	}
+	svc := testresult.NewLocalService(s.env)
 
-	s.Require().NoError(testresult.InsertLocal(ctx, testresult.TestResult{
+	s.Require().NoError(svc.AppendTestResults(ctx, []testresult.TestResult{{
 		TestName:  testName,
 		TaskID:    s.task.Id,
 		Execution: s.task.Execution,
 		Status:    testStatus,
-	}))
+	}}))
 	s.Require().NoError(s.task.SetResultsInfo(ctx, testresult.TestResultsServiceLocal, testStatus == evergreen.TestFailedStatus))
 }
 
@@ -1093,14 +1094,8 @@ func (s *taskSuite) TestRegressionByTestWithRegex() {
 		ResultsFailed:  true,
 	}
 	s.NoError(t2.Insert(s.ctx))
-	s.Require().NoError(testresult.InsertLocal(
-		ctx,
-		s.env,
-		testresult.TestResult{TaskID: "t1", TestName: "test1", Status: evergreen.TestFailedStatus},
-		testresult.TestResult{TaskID: "t1", TestName: "something", Status: evergreen.TestSucceededStatus},
-		testresult.TestResult{TaskID: "t2", TestName: "test1", Status: evergreen.TestSucceededStatus},
-		testresult.TestResult{TaskID: "t2", TestName: "something", Status: evergreen.TestFailedStatus},
-	))
+	svc := testresult.NewLocalService(s.env)
+	s.Require().NoError(svc.AppendTestResults(ctx, []testresult.TestResult{{TaskID: "t1", TestName: "test1", Status: evergreen.TestFailedStatus}, {TaskID: "t1", TestName: "something", Status: evergreen.TestSucceededStatus}, {TaskID: "t2", TestName: "test1", Status: evergreen.TestSucceededStatus}, {TaskID: "t2", TestName: "something", Status: evergreen.TestFailedStatus}}))
 
 	ref := model.ProjectRef{
 		Id: "myproj",
@@ -1362,6 +1357,7 @@ func TestTaskRegressionByTestDisplayTask(t *testing.T) {
 		assert.NoError(t, db.ClearCollections(task.Collection, alertrecord.Collection, build.Collection, model.VersionCollection, model.ProjectRefCollection))
 		assert.NoError(t, testresult.ClearLocal(ctx, env))
 	}()
+	svc := testresult.NewLocalService(env)
 
 	b := build.Build{Id: "b0"}
 	require.NoError(t, b.Insert(t.Context()))
@@ -1423,7 +1419,7 @@ func TestTaskRegressionByTestDisplayTask(t *testing.T) {
 	for _, task := range tasks {
 		require.NoError(t, task.Insert(t.Context()))
 	}
-	require.NoError(t, testresult.InsertLocal(ctx, testresult.TestResult{TaskID: "et0_0", TestName: "f0", Status: evergreen.TestFailedStatus}, testresult.TestResult{TaskID: "et1_0", TestName: "f1", Status: evergreen.TestSucceededStatus}, testresult.TestResult{TaskID: "et1_1", TestName: "f0", Status: evergreen.TestFailedStatus}))
+	require.NoError(t, svc.AppendTestResults(ctx, []testresult.TestResult{{TaskID: "et0_0", TestName: "f0", Status: evergreen.TestFailedStatus}, {TaskID: "et1_0", TestName: "f1", Status: evergreen.TestSucceededStatus}, {TaskID: "et1_1", TestName: "f0", Status: evergreen.TestFailedStatus}}))
 
 	tr := taskTriggers{event: &event.EventLogEntry{ID: "e0"}, jiraMappings: &evergreen.JIRANotificationsConfig{}}
 	subscriber := event.Subscriber{Type: event.JIRAIssueSubscriberType, Target: &event.JIRAIssueSubscriber{}}
@@ -1443,11 +1439,11 @@ func TestTaskRegressionByTestDisplayTask(t *testing.T) {
 
 	// alert for the second run of the display task with the same execution task (et0) failing with a new test (f1)
 	tr.task = &tasks[3]
-	require.NoError(t, testresult.InsertLocal(ctx, testresult.TestResult{
+	require.NoError(t, svc.AppendTestResults(ctx, []testresult.TestResult{{
 		TaskID:   "et0_1",
 		TestName: "f1",
 		Status:   evergreen.TestFailedStatus,
-	}))
+	}}))
 	require.NoError(t, tasks[4].SetResultsInfo(ctx, testresult.TestResultsServiceLocal, true))
 	notification, err = tr.taskRegressionByTest(ctx, &event.Subscription{ID: "s1", Subscriber: subscriber, Trigger: "t1"})
 	assert.NoError(t, err)

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -833,7 +833,7 @@ func (s *taskSuite) makeTest(ctx context.Context, testName, testStatus string) {
 		testName = "test_0"
 	}
 
-	s.Require().NoError(testresult.InsertLocal(ctx, s.env, testresult.TestResult{
+	s.Require().NoError(testresult.InsertLocal(ctx, testresult.TestResult{
 		TestName:  testName,
 		TaskID:    s.task.Id,
 		Execution: s.task.Execution,
@@ -1423,13 +1423,7 @@ func TestTaskRegressionByTestDisplayTask(t *testing.T) {
 	for _, task := range tasks {
 		require.NoError(t, task.Insert(t.Context()))
 	}
-	require.NoError(t, testresult.InsertLocal(
-		ctx,
-		env,
-		testresult.TestResult{TaskID: "et0_0", TestName: "f0", Status: evergreen.TestFailedStatus},
-		testresult.TestResult{TaskID: "et1_0", TestName: "f1", Status: evergreen.TestSucceededStatus},
-		testresult.TestResult{TaskID: "et1_1", TestName: "f0", Status: evergreen.TestFailedStatus},
-	))
+	require.NoError(t, testresult.InsertLocal(ctx, testresult.TestResult{TaskID: "et0_0", TestName: "f0", Status: evergreen.TestFailedStatus}, testresult.TestResult{TaskID: "et1_0", TestName: "f1", Status: evergreen.TestSucceededStatus}, testresult.TestResult{TaskID: "et1_1", TestName: "f0", Status: evergreen.TestFailedStatus}))
 
 	tr := taskTriggers{event: &event.EventLogEntry{ID: "e0"}, jiraMappings: &evergreen.JIRANotificationsConfig{}}
 	subscriber := event.Subscriber{Type: event.JIRAIssueSubscriberType, Target: &event.JIRAIssueSubscriber{}}
@@ -1449,7 +1443,7 @@ func TestTaskRegressionByTestDisplayTask(t *testing.T) {
 
 	// alert for the second run of the display task with the same execution task (et0) failing with a new test (f1)
 	tr.task = &tasks[3]
-	require.NoError(t, testresult.InsertLocal(ctx, env, testresult.TestResult{
+	require.NoError(t, testresult.InsertLocal(ctx, testresult.TestResult{
 		TaskID:   "et0_1",
 		TestName: "f1",
 		Status:   evergreen.TestFailedStatus,


### PR DESCRIPTION
DEVPROD-16198

### Description
Boilerplate for the interface that will be used to append test results, to be implemented in [DEVPROD-16200](https://jira.mongodb.org/browse/DEVPROD-16200).
### Testing
Existing tests