### PR TITLE
DEVPROD-16197 Initialize agent route to send test results data

### DIFF
--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -21,6 +21,7 @@ import (
 	patchmodel "github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/testlog"
+	"github.com/evergreen-ci/evergreen/model/testresult"
 	restmodel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/taskoutput"
 	"github.com/evergreen-ci/evergreen/util"
@@ -578,6 +579,24 @@ func (c *baseCommunicator) SendTestLog(ctx context.Context, taskData TaskData, l
 	logID := logReply.ID
 
 	return logID, nil
+}
+
+// SendTestResults sends test result metadata to the app servers for persistent DB storage.
+func (c *baseCommunicator) SendTestResults(ctx context.Context, taskData TaskData, testResults []testresult.TestResult) error {
+	if len(testResults) == 0 {
+		return nil
+	}
+
+	info := requestInfo{
+		method:   http.MethodPost,
+		taskData: &taskData,
+	}
+	info.setTaskPathSuffix("test_results")
+	resp, err := c.retryRequest(ctx, info, testResults)
+	if err != nil {
+		return util.RespError(resp, errors.Wrap(err, "sending test results").Error())
+	}
+	return nil
 }
 
 func (c *baseCommunicator) SetResultsInfo(ctx context.Context, taskData TaskData, service string, failed bool) error {

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -15,6 +15,7 @@ import (
 	patchmodel "github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/testlog"
+	"github.com/evergreen-ci/evergreen/model/testresult"
 	restmodel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/google/go-github/v70/github"
 	"github.com/mongodb/grip"
@@ -89,6 +90,7 @@ type SharedCommunicator interface {
 
 	// The following operations are used by task commands.
 	SendTestLog(context.Context, TaskData, *testlog.TestLog) (string, error)
+	SendTestResults(context.Context, TaskData, []testresult.TestResult) error
 	GetTaskPatch(context.Context, TaskData, string) (*patchmodel.Patch, error)
 	GetTaskVersion(context.Context, TaskData) (*model.Version, error)
 	GetPatchFile(context.Context, TaskData, string) (string, error)

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -485,6 +485,12 @@ func (c *Mock) SendTestLog(ctx context.Context, td TaskData, log *testlog.TestLo
 	return c.LogID, nil
 }
 
+// SendTestResults appends test results to the local list of test results.
+func (c *Mock) SendTestResults(ctx context.Context, td TaskData, testResults []testresult.TestResult) error {
+	c.LocalTestResults = append(c.LocalTestResults, testResults...)
+	return nil
+}
+
 func (c *Mock) GetManifest(ctx context.Context, td TaskData) (*manifest.Manifest, error) {
 	return &manifest.Manifest{}, nil
 }

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-04-07"
+	AgentVersion = "2025-04-10"
 )
 
 const (

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -821,7 +821,7 @@ func (h *attachTestResultsHandler) Parse(ctx context.Context, r *http.Request) e
 }
 
 func (h *attachTestResultsHandler) Run(ctx context.Context) gimlet.Responder {
-	// TODO: DEVPROD-16200 Implement the new DB/S3-backed Evergreen test results service
+	// TODO: DEVPROD-16200 Implement the new DB/S3-backed Evergreen test results service and delete the below log
 	grip.Debug(message.Fields{
 		"message": "received test results",
 		"results": h.results,

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -104,6 +104,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/task/{task_id}/set_results_info").Version(2).Post().Wrap(requireTask).RouteHandler(makeSetTaskResultsInfoHandler())
 	app.AddRoute("/task/{task_id}/start").Version(2).Post().Wrap(requireTask, requirePodOrHost).RouteHandler(makeStartTask(env))
 	app.AddRoute("/task/{task_id}/test_logs").Version(2).Post().Wrap(requireTask, requirePodOrHost).RouteHandler(makeAttachTestLog(settings))
+	app.AddRoute("/task/{task_id}/test_results").Version(2).Post().Wrap(requireTask, requirePodOrHost).RouteHandler(makeAttachTestResults(settings))
 	app.AddRoute("/task/{task_id}/patch").Version(2).Get().Wrap(requireTask).RouteHandler(makeServePatch())
 	app.AddRoute("/task/{task_id}/version").Version(2).Get().Wrap(requireTask).RouteHandler(makeServeVersion())
 	app.AddRoute("/task/{task_id}/git/patchfile/{patchfile_id}").Version(2).Get().Wrap(requireTask).RouteHandler(makeGitServePatchFile())


### PR DESCRIPTION
DEVPROD-16197

### Description
This introduces the initial boilerplate of the new agent route that will be responsible for sending test results to the app server which will forward the metadata to cedar's DB.
### Testing
Existing tests. Configured a task to use this route in staging and confirmed the test results were formatted correctly in the debug log I added.