### PR TITLE
docs: regex tasks typo

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -45,7 +45,7 @@ When specifying tasks or variants, _both_ must be specified:
 ```bash
 evergreen patch --regex_variants "enterprise.*" // not valid, will not select any tasks
 evergreen patch -t unittest // not valid, will not select any tasks
-evergreen patch -rv "enterprise.*" --regex-tasks test-.* // valid
+evergreen patch -rv "enterprise.*" --regex_tasks test-.* // valid
 evergreen patch --regex_variants "enterprise.*" -t unittest // valid
 ```
 


### PR DESCRIPTION
### Documentation
Small typo in regex tasks usage.
