### PR TITLE
DEVPROD-16402 Check if json is valid before unmarshaling for generate 

### DIFF
--- a/rest/route/task_generate.go
+++ b/rest/route/task_generate.go
@@ -3,6 +3,7 @@ package route
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 
 	"github.com/evergreen-ci/evergreen"
@@ -35,19 +36,29 @@ func (h *generateHandler) Factory() gimlet.RouteHandler {
 
 func (h *generateHandler) Parse(ctx context.Context, r *http.Request) error {
 	var err error
-	if h.files, err = parseJson(r); err != nil {
-		return errors.Wrap(err, "reading raw JSON from request body")
+
+	body := utility.NewRequestReader(r)
+	defer body.Close()
+
+	bytes, err := io.ReadAll(body)
+	if err != nil {
+		return errors.Wrap(err, "Error reading request body")
 	}
+
+	if !json.Valid(bytes) {
+		return errors.New("Invalid JSON format detected; potential incomplete or corrupted data. This may be an indication that evergreen is under high load.")
+	}
+
+	files := []json.RawMessage{}
+	if err := json.Unmarshal(bytes, &files); err != nil {
+		return errors.Wrap(err, "Unmarshaling request body")
+	}
+
+	h.files = files
 	h.taskID = gimlet.GetVars(r)["task_id"]
 
 	err = validateFileSize(h.files, h.env.Settings().TaskLimits.MaxGenerateTaskJSONSize)
 	return errors.Wrap(err, "validating JSON size")
-}
-
-func parseJson(r *http.Request) ([]json.RawMessage, error) {
-	var files []json.RawMessage
-	err := utility.ReadJSON(r.Body, &files)
-	return files, err
 }
 
 func validateFileSize(files []json.RawMessage, maxSizeInMB int) error {

--- a/rest/route/task_generate_test.go
+++ b/rest/route/task_generate_test.go
@@ -57,6 +57,22 @@ func TestValidate(t *testing.T) {
 	assert.NoError(validateFileSize(files, 1))
 }
 
+func TestValidateWithBadJson(t *testing.T) {
+	assert := assert.New(t)
+	jsonBytes := []byte(`
+[
+{
+  "this": "is missing closing brace"
+`)
+	buffer := bytes.NewBuffer(jsonBytes)
+	request, err := http.NewRequest("", "", buffer)
+	assert.NoError(err)
+	files, err := parseJson(request)
+	assert.Error(err)
+	assert.EqualError(err, "Invalid JSON format detected; potential incomplete or corrupted data. This may be an indication that evergreen is under high load.")
+	assert.Nil(files)
+}
+
 func TestGenerateExecuteWithSmallFileInDB(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
DEVPROD-16402 

### Description
Before unmarshaling the body for /generate, check if it's valid. That way we can return a more descriptive error. 

### Testing
Existing tests 


