### PR TITLE
DEVPROD-16402 Check for ctx cancellation for generate tasks 

### DIFF
--- a/rest/route/task_generate.go
+++ b/rest/route/task_generate.go
@@ -72,6 +72,9 @@ func (h *generateHandler) processFiles(ctx context.Context, r *http.Request) err
 	}
 	var err error
 	if h.files, err = parseJson(r); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		return errors.Wrap(err, "reading raw JSON from request body")
 	}
 

--- a/rest/route/task_generate.go
+++ b/rest/route/task_generate.go
@@ -72,6 +72,7 @@ func (h *generateHandler) processFiles(ctx context.Context, r *http.Request) err
 	}
 	var err error
 	if h.files, err = parseJson(r); err != nil {
+		// make sure the context wasn't canceled while we were reading the request body
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}

--- a/rest/route/task_generate_test.go
+++ b/rest/route/task_generate_test.go
@@ -221,3 +221,19 @@ func TestGeneratePollRun(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.Status())
 	require.False(t, resp.Data().(*apimodels.GeneratePollResponse).Finished)
 }
+
+func TestGenerateHandlerContextCanceledDuringRun(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Immediately cancel the context
+
+	req, err := http.NewRequest(http.MethodPost, "/task/456/generate", nil)
+	require.NoError(t, err)
+
+	h := &generateHandler{}
+	require.NoError(t, h.Parse(ctx, req))
+
+	resp := h.Run(ctx)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Status())
+}


### PR DESCRIPTION
DEVPROD-16402 

### Description
Sometimes, especially when the server is under load and we are retrying, we run into issues where the json body is corrupted. This adds a check to see if the context was canceled before attempting to read the body. This will allow the client to retry in these situations. 

### Testing
existing test 

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
