### PR TITLE
DEVPROD-16051: add admin setting to map AWS account to role to assume

### DIFF
--- a/config_cloud.go
+++ b/config_cloud.go
@@ -38,6 +38,9 @@ func (c *CloudProviders) Set(ctx context.Context) error {
 func (c *CloudProviders) ValidateAndDefault() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.Wrap(c.AWS.Pod.Validate(), "invalid ECS config")
+	for i, m := range c.AWS.AccountRoles {
+		catcher.Wrapf(m.Validate(), "invalid account role mapping at index %d", i)
+	}
 	return catcher.Resolve()
 }
 
@@ -76,6 +79,24 @@ type AWSConfig struct {
 
 	// Pod represents configuration for using pods in AWS.
 	Pod AWSPodConfig `bson:"pod" json:"pod" yaml:"pod"`
+
+	AccountRoles []AWSAccountRoleMapping `bson:"account_roles" json:"account_roles" yaml:"account_roles"`
+}
+
+// AccountRoleMapping is a mapping of an AWS account to the role that needs to
+// be assumed to make authorized API calls in that account.
+type AWSAccountRoleMapping struct {
+	// Account is the identifier for the AWS account.
+	Account string
+	// Role is the the role to assume to make authorized API calls.
+	Role string
+}
+
+func (m *AWSAccountRoleMapping) Validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(m.Account == "", "account must not be empty")
+	catcher.NewWhen(m.Role == "", "role must not be empty")
+	return catcher.Resolve()
 }
 
 type S3Credentials struct {

--- a/config_cloud.go
+++ b/config_cloud.go
@@ -87,9 +87,9 @@ type AWSConfig struct {
 // be assumed to make authorized API calls in that account.
 type AWSAccountRoleMapping struct {
 	// Account is the identifier for the AWS account.
-	Account string
+	Account string `bson:"account" json:"account" yaml:"account"`
 	// Role is the the role to assume to make authorized API calls.
-	Role string
+	Role string `bson:"role" json:"role" yaml:"role"`
 }
 
 func (m *AWSAccountRoleMapping) Validate() error {

--- a/public/static/js/admin.js
+++ b/public/static/js/admin.js
@@ -237,6 +237,33 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
     $scope.invalidSubnet = "";
   }
 
+  $scope.addAccountRoleMapping = function () {
+    if ($scope.Settings.providers == null) {
+      $scope.Settings.providers = {
+        "aws": {
+          "account_roles": []
+        }
+      };
+    }
+    if ($scope.Settings.providers.aws == null) {
+      $scope.Settings.providers.aws = {
+        "account_roles": []
+      }
+    }
+    if ($scope.Settings.providers.aws.account_roles == null) {
+      $scope.Settings.providers.aws.account_roles = []
+    }
+
+    if (!$scope.validAccountRoleMapping($scope.new_account_role_mapping)) {
+      $scope.invalidAccountRoleMapping = "Account and role are required.";
+      return
+    }
+
+    $scope.Settings.providers.aws.account_roles.push($scope.new_account_role_mapping);
+    $scope.new_account_role_mapping = {};
+    $scope.invalidAccountRoleMapping = "";
+  }
+
   $scope.addProjectToPrefixMapping = function () {
     if ($scope.Settings.buckets == null) {
       $scope.Settings.buckets = {
@@ -303,6 +330,14 @@ mciModule.controller('AdminSettingsController', ['$scope', '$window', '$http', '
 
   $scope.validSubnet = function (subnet) {
     return subnet && subnet.az && subnet.subnet_id;
+  }
+
+  $scope.deleteAccountRoleMapping = function (index) {
+    $scope.Settings.providers.aws.account_roles.splice(index, 1);
+  }
+
+  $scope.validAccountRoleMapping = function (mapping) {
+    return mapping && mapping.account && mapping.role;
   }
 
   $scope.deleteProjectToPrefixMapping = function (index) {

--- a/rest/data/admin_test.go
+++ b/rest/data/admin_test.go
@@ -160,6 +160,10 @@ func (s *AdminDataSuite) TestSetAndGetSettings() {
 	s.Equal(testSettings.Providers.AWS.ParserProject.GeneratedJSONPrefix, settingsFromConnector.Providers.AWS.ParserProject.GeneratedJSONPrefix)
 	s.Equal(testSettings.Providers.AWS.PersistentDNS.HostedZoneID, settingsFromConnector.Providers.AWS.PersistentDNS.HostedZoneID)
 	s.Equal(testSettings.Providers.AWS.PersistentDNS.Domain, settingsFromConnector.Providers.AWS.PersistentDNS.Domain)
+	s.Require().Len(testSettings.Providers.AWS.AccountRoles, len(settingsFromConnector.Providers.AWS.AccountRoles))
+	for i := range testSettings.Providers.AWS.AccountRoles {
+		s.Equal(testSettings.Providers.AWS.AccountRoles[i], settingsFromConnector.Providers.AWS.AccountRoles[i])
+	}
 	s.EqualValues(testSettings.Providers.Docker.APIVersion, settingsFromConnector.Providers.Docker.APIVersion)
 	s.EqualValues(testSettings.RepoTracker.MaxConcurrentRequests, settingsFromConnector.RepoTracker.MaxConcurrentRequests)
 	s.EqualValues(testSettings.Scheduler.TaskFinder, settingsFromConnector.Scheduler.TaskFinder)

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -184,6 +184,11 @@ func TestModelConversion(t *testing.T) {
 		assert.EqualValues(cp.WindowsVersion, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.ECS.CapacityProviders[i].WindowsVersion))
 	}
 	assert.EqualValues(testSettings.Providers.AWS.Pod.SecretsManager.SecretPrefix, utility.FromStringPtr(apiSettings.Providers.AWS.Pod.SecretsManager.SecretPrefix))
+	require.Len(apiSettings.Providers.AWS.AccountRoles, len(testSettings.Providers.AWS.AccountRoles))
+	for i, ar := range testSettings.Providers.AWS.AccountRoles {
+		assert.Equal(ar.Account, utility.FromStringPtr(apiSettings.Providers.AWS.AccountRoles[i].Account))
+		assert.Equal(ar.Role, utility.FromStringPtr(apiSettings.Providers.AWS.AccountRoles[i].Role))
+	}
 	assert.EqualValues(testSettings.Providers.Docker.APIVersion, utility.FromStringPtr(apiSettings.Providers.Docker.APIVersion))
 	assert.EqualValues(testSettings.RepoTracker.MaxConcurrentRequests, apiSettings.RepoTracker.MaxConcurrentRequests)
 	assert.EqualValues(testSettings.Scheduler.TaskFinder, utility.FromStringPtr(apiSettings.Scheduler.TaskFinder))

--- a/rest/route/admin_test.go
+++ b/rest/route/admin_test.go
@@ -183,6 +183,10 @@ func (s *AdminRouteSuite) TestAdminRoute() {
 	s.Equal(len(testSettings.Providers.AWS.EC2Keys), len(settings.Providers.AWS.EC2Keys))
 	s.EqualValues(testSettings.Providers.AWS.PersistentDNS.HostedZoneID, settings.Providers.AWS.PersistentDNS.HostedZoneID)
 	s.EqualValues(testSettings.Providers.AWS.PersistentDNS.Domain, settings.Providers.AWS.PersistentDNS.Domain)
+	s.Require().Len(testSettings.Providers.AWS.AccountRoles, len(settings.Providers.AWS.AccountRoles))
+	for i := range testSettings.Providers.AWS.AccountRoles {
+		s.Equal(testSettings.Providers.AWS.AccountRoles[i], settings.Providers.AWS.AccountRoles[i])
+	}
 	s.EqualValues(testSettings.Providers.Docker.APIVersion, settings.Providers.Docker.APIVersion)
 	s.EqualValues(testSettings.RepoTracker.MaxConcurrentRequests, settings.RepoTracker.MaxConcurrentRequests)
 	s.EqualValues(testSettings.Scheduler.TaskFinder, settings.Scheduler.TaskFinder)

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1797,6 +1797,52 @@ Admin Settings
 											</section>
 										</md-card-content>
 									</md-card>
+									<md-card style="margin-bottom:20px;">
+										<md-card-title>
+											<md-card-title-text>
+												<span>Account Role Mappings</span>
+											</md-card-title-text>
+										</md-card-title>
+										<md-card-content>
+											<div id="account-role-mappings" class="form-group"
+												ng-repeat="(index, mapping) in Settings.providers.aws.account_roles">
+												<section layout="row" flex>
+													<md-input-container class="control" flex=30>
+														<input class="control" type="text" ng-model="mapping.account"
+															placeholder="Account">
+													</md-input-container>
+													<md-input-container class="control" flex=30>
+														<input class="control" type="text" ng-model="mapping.role"
+															placeholder="Role">
+													</md-input-container>
+													<div style="margin-top: 1%;">
+														<button class="btn btn-default btn-danger" type="button"
+															style="float: left" ng-click="deleteAccountRoleMapping(index)">
+															<i class="fa fa-trash"></i>
+														</button>
+													</div>
+												</section>
+											</div>
+											<section layout="row" flex>
+												<md-input-container class="control" flex=30>
+													<input class="control" type="text" ng-model="new_account_role_mapping.account"
+														placeholder="Account">
+												</md-input-container>
+												<md-input-container class="control" flex=30>
+													<input class="control" type="text" ng-model="new_account_role_mapping.role"
+														placeholder="Role">
+												</md-input-container>
+												<div style="margin-top: 1%;">
+													<button class="plus-button btn btn-primary"
+														ng-disabled="!validAccountRoleMapping(new_account_role_mapping)" type="button"
+														style="float: left" ng-click="addAccountRoleMapping()">
+														<i class="fa fa-plus"></i>
+													</button>
+													<label class="control">[[ invalidAccountRoleMapping ]]</label>
+												</div>
+											</section>
+										</md-card-content>
+									</md-card>
 									<md-input-container class="control" style="width:45%;">
 										<label>EC2 Key</label>
 										<input type="text" ng-model="Settings.providers.aws.ec2_keys[0].key">

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -344,6 +344,12 @@ func MockConfig() *evergreen.Settings {
 						SecretPrefix: "secret_prefix",
 					},
 				},
+				AccountRoles: []evergreen.AWSAccountRoleMapping{
+					{
+						Account: "account",
+						Role:    "role",
+					},
+				},
 			},
 			Docker: evergreen.DockerConfig{
 				APIVersion: "docker_version",


### PR DESCRIPTION
DEVPROD-16051

### Description
For CISA, distros for release tasks have to run in a separate account from Kernel-Build. It's also the case that in the long-term, runtime environments would like to eventually have **all** distros to run in a different account than Kernel-Build. This adds an admin setting so Evergreen can deduce what AWS role needs to be assumed for each account so that it can make authorized AWS API calls. There will be a follow up PR to add the associated distro setting for the account.

If you're wondering why not just put the role directly in the distro settings, it's because of long-term maintenance concerns if the role ever changes. Volumes/hosts can be long-lived and need to know the _current_ role that should be used for AWS API calls (e.g. if someone has had an unexpirable volume for 10 years and leaves the company, it has to be terminated using the current role for its AWS account, not the role from 10 years ago). Since volumes are not actually associated with a distro (just with an AWS account/region), using the admin settings gives Evergreen a source of up-to-date info on what role to use depending on which account the volume was originally created in.

### Testing
* Tested in staging that the setting appeared to work.
* Added unit tests.
