### PR TITLE
docs: add DPIPE ticket to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,8 @@ DEVPROD-NNNNN
 ### Description
 add description, context, thought process, etc
 
+<!-- Are you adding a Task, Build, Version, or Patch struct? Create a DPIPE ticket to expose this in data warehouse. -->
+
 ### Testing
 add a description of how you tested it
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@ DEVPROD-NNNNN
 ### Description
 add description, context, thought process, etc
 
-<!-- Are you adding a Task, Build, Version, or Patch struct? Create a DPIPE ticket to expose this in data warehouse. -->
+<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->
 
 ### Testing
 add a description of how you tested it


### PR DESCRIPTION
### Description
Adding a mention that a DPIPE Ticket needs to be made. Putting this in the description so it's less likely to be missed.
