### PR TITLE
DEVPROD-16402 Update utility and change error 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/evergreen-ci/poplar v0.0.0-20250313160224-22f0e4e98238
 	github.com/evergreen-ci/shrub v0.0.0-20250224222152-c8b72a51163b
 	github.com/evergreen-ci/timber v0.0.0-20250225175618-52d1e1841945
-	github.com/evergreen-ci/utility v0.0.0-20250317160201-a1e224d4bba9
+	github.com/evergreen-ci/utility v0.0.0-20250404164817-04ef334e215a
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/gonzojive/httpcache v0.0.0-20220509000156-e80a5e6a69fe
 	github.com/google/go-github/v52 v52.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,8 @@ github.com/evergreen-ci/timber v0.0.0-20250225175618-52d1e1841945/go.mod h1:j76U
 github.com/evergreen-ci/utility v0.0.0-20230104160902-3f0e05a638bd/go.mod h1:vkCEVgfCMIDajzbG/PHZURszI2Y1SuFqNWX9EUxmLLI=
 github.com/evergreen-ci/utility v0.0.0-20250317160201-a1e224d4bba9 h1:BorPIkUXW8r5yYw2LQgK51c4FHhes3APSZvFwLahcrs=
 github.com/evergreen-ci/utility v0.0.0-20250317160201-a1e224d4bba9/go.mod h1:AGAekBl7zMjMvHB6yqkVkE81JuHBxBPaPozF49DsU70=
+github.com/evergreen-ci/utility v0.0.0-20250404164817-04ef334e215a h1:k7FLEvTQf9RfrdbVIdtjnArl7E3f3KdsCI+xUAzjc44=
+github.com/evergreen-ci/utility v0.0.0-20250404164817-04ef334e215a/go.mod h1:AGAekBl7zMjMvHB6yqkVkE81JuHBxBPaPozF49DsU70=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/rest/route/project_validate.go
+++ b/rest/route/project_validate.go
@@ -48,7 +48,7 @@ func (v *validateProjectHandler) Parse(ctx context.Context, r *http.Request) err
 	}
 
 	if !json.Valid(bytes) {
-		return errors.New("Invalid JSON format detected; potential incomplete or corrupted data. This may be an indication that evergreen is under high load.")
+		return errors.New("Invalid JSON format detected; potential incomplete or corrupted data.")
 	}
 
 	input := validator.ValidationInput{}


### PR DESCRIPTION
DEVPROD-16402

### Description
[this evergreen-ci/utility](https://github.com/evergreen-ci/utility/pull/77) fixes an issue we were facing where the json body would be corrupted on retries in certain situations. This changes an error message becuase this should now no longer be happening under load, and upgrades utility. 

