### PR TITLE
DEVPROD-16171: Optimize Task.test query for test failure filtering

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -385,10 +385,6 @@ var TestFailureStatuses = []string{
 	TestSilentlyFailedStatus,
 }
 
-func IsFailedTestStatus(status string) bool {
-	return utility.StringSliceContains(TestFailureStatuses, status)
-}
-
 var TaskStatuses = []string{
 	TaskStarted,
 	TaskSucceeded,

--- a/globals.go
+++ b/globals.go
@@ -380,6 +380,15 @@ const (
 	PresignMinimumValidTime = 15 * time.Minute
 )
 
+var TestFailureStatuses = []string{
+	TestFailedStatus,
+	TestSilentlyFailedStatus,
+}
+
+func IsFailedTestStatus(status string) bool {
+	return utility.StringSliceContains(TestFailureStatuses, status)
+}
+
 var TaskStatuses = []string{
 	TaskStarted,
 	TaskSucceeded,

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -579,9 +579,9 @@ func (r *taskResolver) TaskLogs(ctx context.Context, obj *restModel.APITask) (*T
 
 // Tests is the resolver for the tests field.
 func (r *taskResolver) Tests(ctx context.Context, obj *restModel.APITask, opts *TestFilterOptions) (*TaskTestResult, error) {
-	if len(opts.Statuses) > 0 {
+	if opts != nil && len(opts.Statuses) > 0 {
 		queryingFailingTestsOnly := true
-		if opts != nil && len(opts.Statuses) <= len(evergreen.TestFailureStatuses) {
+		if len(opts.Statuses) <= len(evergreen.TestFailureStatuses) {
 			for _, status := range opts.Statuses {
 				if !evergreen.IsFailedTestStatus(status) {
 					queryingFailingTestsOnly = false

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -580,17 +580,8 @@ func (r *taskResolver) TaskLogs(ctx context.Context, obj *restModel.APITask) (*T
 // Tests is the resolver for the tests field.
 func (r *taskResolver) Tests(ctx context.Context, obj *restModel.APITask, opts *TestFilterOptions) (*TaskTestResult, error) {
 	if opts != nil && len(opts.Statuses) > 0 {
-		queryingFailingTestsOnly := true
-		if len(opts.Statuses) <= len(evergreen.TestFailureStatuses) {
-			for _, status := range opts.Statuses {
-				if !evergreen.IsFailedTestStatus(status) {
-					queryingFailingTestsOnly = false
-					break
-				}
-			}
-		}
-
-		if queryingFailingTestsOnly && !obj.ResultsFailed {
+		diffFailureStatuses := utility.GetSetDifference(opts.Statuses, evergreen.TestFailureStatuses)
+		if len(diffFailureStatuses) == 0 && !obj.ResultsFailed {
 			return &TaskTestResult{
 				TestResults:       []*restModel.APITest{},
 				TotalTestCount:    0,

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -579,6 +579,7 @@ func (r *taskResolver) TaskLogs(ctx context.Context, obj *restModel.APITask) (*T
 
 // Tests is the resolver for the tests field.
 func (r *taskResolver) Tests(ctx context.Context, obj *restModel.APITask, opts *TestFilterOptions) (*TaskTestResult, error) {
+	// Return early if it is known that there are no test results to return.
 	if opts != nil && len(opts.Statuses) > 0 {
 		diffFailureStatuses := utility.GetSetDifference(opts.Statuses, evergreen.TestFailureStatuses)
 		if len(diffFailureStatuses) == 0 && !obj.ResultsFailed {

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -579,21 +579,24 @@ func (r *taskResolver) TaskLogs(ctx context.Context, obj *restModel.APITask) (*T
 
 // Tests is the resolver for the tests field.
 func (r *taskResolver) Tests(ctx context.Context, obj *restModel.APITask, opts *TestFilterOptions) (*TaskTestResult, error) {
-	queryingFailingTestsOnly := true
-	if opts != nil && len(opts.Statuses) <= len(evergreen.TestFailureStatuses) {
-		for _, status := range opts.Statuses {
-			if !evergreen.IsFailedTestStatus(status) {
-				queryingFailingTestsOnly = false
-				break
+	if len(opts.Statuses) > 0 {
+		queryingFailingTestsOnly := true
+		if opts != nil && len(opts.Statuses) <= len(evergreen.TestFailureStatuses) {
+			for _, status := range opts.Statuses {
+				if !evergreen.IsFailedTestStatus(status) {
+					queryingFailingTestsOnly = false
+					break
+				}
 			}
 		}
-	}
-	if queryingFailingTestsOnly && !obj.ResultsFailed {
-		return &TaskTestResult{
-			TestResults:       []*restModel.APITest{},
-			TotalTestCount:    0,
-			FilteredTestCount: 0,
-		}, nil
+
+		if queryingFailingTestsOnly && !obj.ResultsFailed {
+			return &TaskTestResult{
+				TestResults:       []*restModel.APITest{},
+				TotalTestCount:    0,
+				FilteredTestCount: 0,
+			}, nil
+		}
 	}
 	taskID := utility.FromStringPtr(obj.Id)
 	dbTask, err := task.FindOneIdAndExecution(ctx, taskID, obj.Execution)

--- a/graphql/tests/task/tests/data.json
+++ b/graphql/tests/task/tests/data.json
@@ -661,7 +661,8 @@
       "display_name": "commit-task",
       "execution": 0,
       "order": 101,
-      "results_service": "local"
+      "results_service": "local",
+      "results_failed": true
     },
     {
       "_id": "commit_task_base",


### PR DESCRIPTION
DEVPROD-16171

### Description
These code changes optimize test failure filtering by checking `Task.ResultsFailed` before querying additional services.