### PR TITLE
DEVPROD-16051: support different AWS accounts for distros

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -110,12 +110,11 @@ type BatchManager interface {
 // of the proper type.
 type ManagerOpts struct {
 	Provider string
+	// Account is the account where API calls are being made.
+	Account string
 	// Region is the geographical region where the cloud operations should
 	// occur.
 	Region string
-	// kim: TODO: make sure this is set where needed.
-	// Account is account where API calls are being made.
-	Account string
 }
 
 // GetSettings returns an uninitialized ProviderSettings based on the given
@@ -141,27 +140,21 @@ func GetManager(ctx context.Context, env evergreen.Environment, mgrOpts ManagerO
 
 	switch mgrOpts.Provider {
 	case evergreen.ProviderNameEc2OnDemand:
-		// kim: TODO: use env.Settings() account role mappings to deduce role to
-		// use.
 		provider = &ec2Manager{
 			env: env,
 			EC2ManagerOptions: &EC2ManagerOptions{
-				client: &awsClientImpl{},
-				region: mgrOpts.Region,
-				// kim: TODO: make sure callers set Account if set by
-				// distro.
-				role: mgrOpts.Account,
+				client:  &awsClientImpl{},
+				account: mgrOpts.Account,
+				region:  mgrOpts.Region,
 			},
 		}
 	case evergreen.ProviderNameEc2Fleet:
 		provider = &ec2FleetManager{
 			env: env,
 			EC2FleetManagerOptions: &EC2FleetManagerOptions{
-				client: &awsClientImpl{},
-				region: mgrOpts.Region,
-				// kim: TODO: make sure callers set Account if set by
-				// distro.
-				role: mgrOpts.Account,
+				client:  &awsClientImpl{},
+				account: mgrOpts.Account,
+				region:  mgrOpts.Region,
 			},
 		}
 	case evergreen.ProviderNameStatic:
@@ -210,7 +203,7 @@ func GetManagerOptions(d distro.Distro) (ManagerOpts, error) {
 		return getEC2ManagerOptionsFromSettings(d, s), nil
 	}
 	if d.Provider == evergreen.ProviderNameMock {
-		return getMockManagerOptions(d.Provider, d.ProviderSettingsList)
+		return getMockManagerOptions(d)
 	}
 	return ManagerOpts{Provider: d.Provider}, nil
 }

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -113,8 +113,9 @@ type ManagerOpts struct {
 	// Region is the geographical region where the cloud operations should
 	// occur.
 	Region string
-	// Role is the permissions role used to make authorized cloud API calls.
-	Role string
+	// kim: TODO: make sure this is set where needed.
+	// Account is account where API calls are being made.
+	Account string
 }
 
 // GetSettings returns an uninitialized ProviderSettings based on the given
@@ -140,14 +141,16 @@ func GetManager(ctx context.Context, env evergreen.Environment, mgrOpts ManagerO
 
 	switch mgrOpts.Provider {
 	case evergreen.ProviderNameEc2OnDemand:
+		// kim: TODO: use env.Settings() account role mappings to deduce role to
+		// use.
 		provider = &ec2Manager{
 			env: env,
 			EC2ManagerOptions: &EC2ManagerOptions{
 				client: &awsClientImpl{},
 				region: mgrOpts.Region,
-				// kim: TODO: make sure callers set AssumeRoleARN if set by
+				// kim: TODO: make sure callers set Account if set by
 				// distro.
-				role: mgrOpts.Role,
+				role: mgrOpts.Account,
 			},
 		}
 	case evergreen.ProviderNameEc2Fleet:
@@ -156,9 +159,9 @@ func GetManager(ctx context.Context, env evergreen.Environment, mgrOpts ManagerO
 			EC2FleetManagerOptions: &EC2FleetManagerOptions{
 				client: &awsClientImpl{},
 				region: mgrOpts.Region,
-				// kim: TODO: make sure callers set AssumeRoleARN if set by
+				// kim: TODO: make sure callers set Account if set by
 				// distro.
-				role: mgrOpts.Role,
+				role: mgrOpts.Account,
 			},
 		}
 	case evergreen.ProviderNameStatic:
@@ -204,7 +207,7 @@ func GetManagerOptions(d distro.Distro) (ManagerOpts, error) {
 			return ManagerOpts{}, errors.Wrapf(err, "getting EC2 provider settings from distro")
 		}
 
-		return getEC2ManagerOptionsFromSettings(d.Provider, s), nil
+		return getEC2ManagerOptionsFromSettings(d, s), nil
 	}
 	if d.Provider == evergreen.ProviderNameMock {
 		return getMockManagerOptions(d.Provider, d.ProviderSettingsList)

--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -110,7 +110,11 @@ type BatchManager interface {
 // of the proper type.
 type ManagerOpts struct {
 	Provider string
-	Region   string
+	// Region is the geographical region where the cloud operations should
+	// occur.
+	Region string
+	// Role is the permissions role used to make authorized cloud API calls.
+	Role string
 }
 
 // GetSettings returns an uninitialized ProviderSettings based on the given
@@ -141,6 +145,9 @@ func GetManager(ctx context.Context, env evergreen.Environment, mgrOpts ManagerO
 			EC2ManagerOptions: &EC2ManagerOptions{
 				client: &awsClientImpl{},
 				region: mgrOpts.Region,
+				// kim: TODO: make sure callers set AssumeRoleARN if set by
+				// distro.
+				role: mgrOpts.Role,
 			},
 		}
 	case evergreen.ProviderNameEc2Fleet:
@@ -149,6 +156,9 @@ func GetManager(ctx context.Context, env evergreen.Environment, mgrOpts ManagerO
 			EC2FleetManagerOptions: &EC2FleetManagerOptions{
 				client: &awsClientImpl{},
 				region: mgrOpts.Region,
+				// kim: TODO: make sure callers set AssumeRoleARN if set by
+				// distro.
+				role: mgrOpts.Role,
 			},
 		}
 	case evergreen.ProviderNameStatic:

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -80,23 +80,6 @@ type EC2ProviderSettings struct {
 
 	// FleetOptions specifies options for creating host with Fleet. It is ignored by other managers.
 	FleetOptions FleetConfig `mapstructure:"fleet_options" json:"fleet_options,omitempty" bson:"fleet_options,omitempty"`
-
-	// AssumeRoleARN is the role to assume when making AWS API calls.
-	// kim: TODO: consider long-term implications of storing role ARNs, which
-	// could be modified in the future, as opposed to storing account IDs.
-	// - Role ARNs are very straightforward since it tells you what role to use
-	// to make an API call today. However, if they're changed later on, it's
-	// extremely difficult to fix existing hosts/volumes to use the new ARN.
-	// - Account IDs are immutable and can be mapped in admin settings to their
-	// exact role ARNs to assume, which allows us to change the role ARNs later
-	// on associated with each account. However, they're less straightforward to
-	// use since you can't pass in the string directly (need to map distro to
-	// admin setings, and not all places may pass the admin settings in).
-	// **Slightly prefer this one because it avoids storing a role ARN in the
-	// host/volume doc.**
-	// kim: TODO: consider moving this to general distro settings because it
-	// applies to the entire distro, it's not region-specific.
-	// AssumeRoleARN string `mapstructure:"assume_role_arn,omitempty" json:"assume_role_arn,omitempty" bson:"assume_role_arn,omitempty"`
 }
 
 // Validate that essential EC2ProviderSettings fields are not empty.
@@ -270,7 +253,6 @@ func (m *ec2Manager) Configure(ctx context.Context, settings *evergreen.Settings
 		m.region = evergreen.DefaultEC2Region
 	}
 
-	// kim: TODO: test that mapping works.
 	role, err := getRoleForAccount(settings, m.account)
 	if err != nil {
 		return errors.Wrap(err, "getting role for account")

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -276,6 +276,10 @@ func (m *ec2Manager) Configure(ctx context.Context, settings *evergreen.Settings
 		return errors.Wrap(err, "getting role for account")
 	}
 	m.role = role
+	grip.Info(message.Fields{
+		"message": "kim: using role for EC2 manager",
+		"role":    m.role,
+	})
 
 	return nil
 }
@@ -295,7 +299,7 @@ func getRoleForAccount(settings *evergreen.Settings, account string) (string, er
 }
 
 func (m *ec2Manager) setupClient(ctx context.Context) error {
-	return m.client.Create(ctx, m.region, m.role)
+	return m.client.Create(ctx, m.role, m.region)
 }
 
 func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Settings *EC2ProviderSettings, blockDevices []types.BlockDeviceMapping) error {

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -258,10 +258,6 @@ func (m *ec2Manager) Configure(ctx context.Context, settings *evergreen.Settings
 		return errors.Wrap(err, "getting role for account")
 	}
 	m.role = role
-	grip.Info(message.Fields{
-		"message": "kim: using role for EC2 manager",
-		"role":    m.role,
-	})
 
 	return nil
 }

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -96,7 +96,7 @@ type EC2ProviderSettings struct {
 	// host/volume doc.**
 	// kim: TODO: consider moving this to general distro settings because it
 	// applies to the entire distro, it's not region-specific.
-	AssumeRoleARN string `mapstructure:"assume_role_arn,omitempty" json:"assume_role_arn,omitempty" bson:"assume_role_arn,omitempty"`
+	// AssumeRoleARN string `mapstructure:"assume_role_arn,omitempty" json:"assume_role_arn,omitempty" bson:"assume_role_arn,omitempty"`
 }
 
 // Validate that essential EC2ProviderSettings fields are not empty.

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -33,7 +33,7 @@ var noReservationError = errors.New("no reservation returned for instance")
 // AWSClient is a wrapper for aws-sdk-go so we can use a mock in testing.
 type AWSClient interface {
 	// Create a new aws-sdk-client or mock if one does not exist, otherwise no-op.
-	Create(context.Context, string) error
+	Create(ctx context.Context, region, role string) error
 
 	// RunInstances is a wrapper for ec2.RunInstances.
 	RunInstances(context.Context, *ec2.RunInstancesInput) (*ec2.RunInstancesOutput, error)
@@ -149,10 +149,12 @@ func awsClientDefaultRetryOptions() utility.RetryOptions {
 var configCache map[string]*aws.Config = make(map[string]*aws.Config)
 
 // Create a new aws-sdk-client if one does not exist, otherwise no-op.
-func (c *awsClientImpl) Create(ctx context.Context, region string) error {
+func (c *awsClientImpl) Create(ctx context.Context, region, role string) error {
 	if region == "" {
 		return errors.New("region must not be empty")
 	}
+	// kim: TODO: use role for credentials provider
+	// kim: TODO: use role ARN as part of unique ID for caching.
 
 	if configCache[region] == nil {
 		config, err := config.LoadDefaultConfig(ctx,
@@ -1025,7 +1027,7 @@ type awsClientMock struct { //nolint
 }
 
 // Create a new mock client.
-func (c *awsClientMock) Create(ctx context.Context, region string) error {
+func (c *awsClientMock) Create(ctx context.Context, region, role string) error {
 	return nil
 }
 

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/aws/smithy-go"
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -167,9 +168,8 @@ func (c *awsClientImpl) Create(ctx context.Context, role, region string) error {
 		// well. Theretically, it should renew the credentials when they expire.
 		opts := []func(*config.LoadOptions) error{config.WithRegion(region)}
 		if role != "" {
-			// kim: TODO: confirm that this doesn't require any explicit
-			// configuration to assume the role.
-			stsConfig, err := config.LoadDefaultConfig(ctx)
+			// Assuming a role to make API calls requires an explicit region.
+			stsConfig, err := config.LoadDefaultConfig(ctx, config.WithRegion(evergreen.DefaultEC2Region))
 			if err != nil {
 				return errors.Wrapf(err, "loading config for assuming role '%s'", role)
 			}

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -164,8 +164,6 @@ func (c *awsClientImpl) Create(ctx context.Context, role, region string) error {
 
 	configID := getConfigCacheID(role, region)
 	if configCache[configID] == nil {
-		// kim: TODO: confirm that it's okay to cache the credential provider as
-		// well. Theretically, it should renew the credentials when they expire.
 		opts := []func(*config.LoadOptions) error{config.WithRegion(region)}
 		if role != "" {
 			// Assuming a role to make API calls requires an explicit region.
@@ -789,9 +787,6 @@ func (c *awsClientImpl) DeleteLaunchTemplate(ctx context.Context, input *ec2.Del
 
 // CreateFleet is a wrapper for ec2.CreateFleet.
 func (c *awsClientImpl) CreateFleet(ctx context.Context, input *ec2.CreateFleetInput) (*ec2.CreateFleetOutput, error) {
-	grip.Info(message.Fields{
-		"message": "kim: creating fleet host",
-	})
 	var output *ec2.CreateFleetOutput
 	var err error
 	input.ClientToken = aws.String(utility.RandomString())

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
 	"github.com/aws/smithy-go"
-	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -157,7 +156,7 @@ func getConfigCacheID(role, region string) string {
 }
 
 // Create a new aws-sdk-client if one does not exist, otherwise no-op.
-func (c *awsClientImpl) Create(ctx context.Context, region, role string) error {
+func (c *awsClientImpl) Create(ctx context.Context, role, region string) error {
 	if region == "" {
 		return errors.New("region must not be empty")
 	}
@@ -171,7 +170,7 @@ func (c *awsClientImpl) Create(ctx context.Context, region, role string) error {
 			// kim: TODO: figure out STS credentials options:
 			// - No explicit credentials needed to assume the role?
 			// - Is it always assuming a role in the current account in us-east-1?
-			stsConfig, err := config.LoadDefaultConfig(ctx, config.WithRegion(evergreen.DefaultEC2Region))
+			stsConfig, err := config.LoadDefaultConfig(ctx)
 			if err != nil {
 				return errors.Wrapf(err, "loading config for assuming role '%s'", role)
 			}
@@ -791,6 +790,9 @@ func (c *awsClientImpl) DeleteLaunchTemplate(ctx context.Context, input *ec2.Del
 
 // CreateFleet is a wrapper for ec2.CreateFleet.
 func (c *awsClientImpl) CreateFleet(ctx context.Context, input *ec2.CreateFleetInput) (*ec2.CreateFleetOutput, error) {
+	grip.Info(message.Fields{
+		"message": "kim: creating fleet host",
+	})
 	var output *ec2.CreateFleetOutput
 	var err error
 	input.ClientToken = aws.String(utility.RandomString())

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -160,16 +160,15 @@ func (c *awsClientImpl) Create(ctx context.Context, role, region string) error {
 	if region == "" {
 		return errors.New("region must not be empty")
 	}
-	// kim: TODO: use role for credentials provider
-	// kim: TODO: use role ARN as part of unique ID for caching.
 
 	configID := getConfigCacheID(role, region)
 	if configCache[configID] == nil {
+		// kim: TODO: confirm that it's okay to cache the credential provider as
+		// well. Theretically, it should renew the credentials when they expire.
 		opts := []func(*config.LoadOptions) error{config.WithRegion(region)}
 		if role != "" {
-			// kim: TODO: figure out STS credentials options:
-			// - No explicit credentials needed to assume the role?
-			// - Is it always assuming a role in the current account in us-east-1?
+			// kim: TODO: confirm that this doesn't require any explicit
+			// configuration to assume the role.
 			stsConfig, err := config.LoadDefaultConfig(ctx)
 			if err != nil {
 				return errors.Wrapf(err, "loading config for assuming role '%s'", role)

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -35,7 +35,7 @@ var noReservationError = errors.New("no reservation returned for instance")
 // AWSClient is a wrapper for aws-sdk-go so we can use a mock in testing.
 type AWSClient interface {
 	// Create a new aws-sdk-client or mock if one does not exist, otherwise no-op.
-	Create(ctx context.Context, region, role string) error
+	Create(ctx context.Context, role, region string) error
 
 	// RunInstances is a wrapper for ec2.RunInstances.
 	RunInstances(context.Context, *ec2.RunInstancesInput) (*ec2.RunInstancesOutput, error)
@@ -1045,7 +1045,7 @@ type awsClientMock struct { //nolint
 }
 
 // Create a new mock client.
-func (c *awsClientMock) Create(ctx context.Context, region, role string) error {
+func (c *awsClientMock) Create(ctx context.Context, role, region string) error {
 	return nil
 }
 

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -97,11 +97,21 @@ func (m *ec2FleetManager) Configure(ctx context.Context, settings *evergreen.Set
 		m.region = evergreen.DefaultEC2Region
 	}
 
+	role, err := getRoleForAccount(settings, m.account)
+	if err != nil {
+		return errors.Wrap(err, "getting role for account")
+	}
+	m.role = role
+	grip.Info(message.Fields{
+		"message": "kim: using role for EC2 fleet manager",
+		"role":    m.role,
+	})
+
 	return nil
 }
 
 func (m *ec2FleetManager) setupClient(ctx context.Context) error {
-	return m.client.Create(ctx, m.region, m.role)
+	return m.client.Create(ctx, m.role, m.region)
 }
 
 func (m *ec2FleetManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, error) {

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -102,7 +102,7 @@ func (m *ec2FleetManager) Configure(ctx context.Context, settings *evergreen.Set
 		return errors.Wrap(err, "getting role for account")
 	}
 	m.role = role
-	grip.Info(message.Fields{
+	grip.InfoWhen(m.role != "", message.Fields{
 		"message": "kim: using role for EC2 fleet manager",
 		"role":    m.role,
 	})

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -102,10 +102,6 @@ func (m *ec2FleetManager) Configure(ctx context.Context, settings *evergreen.Set
 		return errors.Wrap(err, "getting role for account")
 	}
 	m.role = role
-	grip.InfoWhen(m.role != "", message.Fields{
-		"message": "kim: using role for EC2 fleet manager",
-		"role":    m.role,
-	})
 
 	return nil
 }

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -78,9 +78,10 @@ func (c instanceTypeSubnetCache) getAZs(ctx context.Context, settings *evergreen
 }
 
 type EC2FleetManagerOptions struct {
-	client AWSClient
-	region string
-	role   string
+	client  AWSClient
+	region  string
+	account string
+	role    string
 }
 
 type ec2FleetManager struct {

--- a/cloud/ec2_integration_test.go
+++ b/cloud/ec2_integration_test.go
@@ -68,7 +68,7 @@ func TestSpawnEC2InstanceOnDemand(t *testing.T) {
 
 	m := &ec2Manager{env: env, EC2ManagerOptions: opts}
 	require.NoError(m.Configure(ctx, testConfig))
-	require.NoError(m.client.Create(ctx, evergreen.DefaultEC2Region))
+	require.NoError(m.setupClient(ctx))
 
 	d := fetchTestDistro()
 	h := host.NewIntent(host.CreateOptions{

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1391,12 +1391,12 @@ func (s *EC2Suite) TestGetEC2ManagerOptions() {
 			birch.EC.String("aws_access_key_id", "key"),
 			birch.EC.String("aws_secret_access_key", "secret"),
 		)},
-		ProviderAccountID: "account",
+		ProviderAccount: "account",
 	}
 
 	managerOpts, err := GetManagerOptions(d1)
 	s.NoError(err)
-	s.Equal(d1.ProviderAccountID, managerOpts.Account)
+	s.Equal(d1.ProviderAccount, managerOpts.Account)
 	s.Equal(evergreen.DefaultEC2Region, managerOpts.Region)
 }
 

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -632,7 +632,7 @@ func validateEc2DescribeInstancesOutput(describeInstancesResponse *ec2.DescribeI
 	return catcher.Resolve()
 }
 
-func getEC2ManagerOptionsFromSettings(d *distro.Distro, settings *EC2ProviderSettings) ManagerOpts {
+func getEC2ManagerOptionsFromSettings(d distro.Distro, settings *EC2ProviderSettings) ManagerOpts {
 	region := settings.Region
 	if region == "" {
 		region = evergreen.DefaultEC2Region

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -632,15 +632,15 @@ func validateEc2DescribeInstancesOutput(describeInstancesResponse *ec2.DescribeI
 	return catcher.Resolve()
 }
 
-func getEC2ManagerOptionsFromSettings(provider string, settings *EC2ProviderSettings) ManagerOpts {
+func getEC2ManagerOptionsFromSettings(d *distro.Distro, settings *EC2ProviderSettings) ManagerOpts {
 	region := settings.Region
 	if region == "" {
 		region = evergreen.DefaultEC2Region
 	}
 	return ManagerOpts{
-		Provider: provider,
+		Provider: d.Provider,
+		Account:  d.ProviderAccountID,
 		Region:   region,
-		Role:     settings.AssumeRoleARN,
 	}
 }
 

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -639,7 +639,7 @@ func getEC2ManagerOptionsFromSettings(d distro.Distro, settings *EC2ProviderSett
 	}
 	return ManagerOpts{
 		Provider: d.Provider,
-		Account:  d.ProviderAccountID,
+		Account:  d.ProviderAccount,
 		Region:   region,
 	}
 }

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -640,6 +640,7 @@ func getEC2ManagerOptionsFromSettings(provider string, settings *EC2ProviderSett
 	return ManagerOpts{
 		Provider: provider,
 		Region:   region,
+		Role:     settings.AssumeRoleARN,
 	}
 }
 

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/evergreen-ci/birch"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -460,13 +459,16 @@ func (m *mockManager) Cleanup(context.Context) error {
 }
 
 // Get mock region from ProviderSettingsList
-func getMockManagerOptions(provider string, providerSettingsList []*birch.Document) (ManagerOpts, error) {
-	opts := ManagerOpts{Provider: provider}
-	if len(providerSettingsList) == 0 {
+func getMockManagerOptions(d distro.Distro) (ManagerOpts, error) {
+	opts := ManagerOpts{
+		Provider: d.Provider,
+		Account:  d.ProviderAccountID,
+	}
+	if len(d.ProviderSettingsList) == 0 {
 		return opts, nil
 	}
 
-	region, ok := providerSettingsList[0].Lookup("region").StringValueOK()
+	region, ok := d.ProviderSettingsList[0].Lookup("region").StringValueOK()
 	if !ok {
 		return ManagerOpts{}, errors.New("cannot get region from provider settings")
 	}

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -462,7 +462,7 @@ func (m *mockManager) Cleanup(context.Context) error {
 func getMockManagerOptions(d distro.Distro) (ManagerOpts, error) {
 	opts := ManagerOpts{
 		Provider: d.Provider,
-		Account:  d.ProviderAccountID,
+		Account:  d.ProviderAccount,
 	}
 	if len(d.ProviderSettingsList) == 0 {
 		return opts, nil

--- a/cloud/sts.go
+++ b/cloud/sts.go
@@ -122,7 +122,7 @@ func (s *stsManagerImpl) AssumeRole(ctx context.Context, taskID string, opts Ass
 }
 
 func (s *stsManagerImpl) setupClient(ctx context.Context) error {
-	return s.client.Create(ctx, evergreen.DefaultEC2Region, "")
+	return s.client.Create(ctx, "", evergreen.DefaultEC2Region)
 }
 
 // GetCallerIdentityARN gets the caller identity's ARN.

--- a/cloud/sts.go
+++ b/cloud/sts.go
@@ -76,7 +76,7 @@ const minAssumeRoleCacheLifetime = 2 * time.Minute
 // AssumeRole gets the credentials for a role as the given task. It handles
 // the AWS API call and generating the ExternalID for the request.
 func (s *stsManagerImpl) AssumeRole(ctx context.Context, taskID string, opts AssumeRoleOptions) (AssumeRoleCredentials, error) {
-	if err := s.client.Create(ctx, evergreen.DefaultEC2Region); err != nil {
+	if err := s.client.Create(ctx, evergreen.DefaultEC2Region, ""); err != nil {
 		return AssumeRoleCredentials{}, errors.Wrapf(err, "creating AWS client")
 	}
 	t, err := task.FindOneId(ctx, taskID)
@@ -123,7 +123,7 @@ func (s *stsManagerImpl) AssumeRole(ctx context.Context, taskID string, opts Ass
 
 // GetCallerIdentityARN gets the caller identity's ARN.
 func (s *stsManagerImpl) GetCallerIdentityARN(ctx context.Context) (string, error) {
-	if err := s.client.Create(ctx, evergreen.DefaultEC2Region); err != nil {
+	if err := s.client.Create(ctx, evergreen.DefaultEC2Region, ""); err != nil {
 		return "", errors.Wrapf(err, "creating AWS client")
 	}
 	output, err := s.client.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})

--- a/cloud/sts.go
+++ b/cloud/sts.go
@@ -76,7 +76,7 @@ const minAssumeRoleCacheLifetime = 2 * time.Minute
 // AssumeRole gets the credentials for a role as the given task. It handles
 // the AWS API call and generating the ExternalID for the request.
 func (s *stsManagerImpl) AssumeRole(ctx context.Context, taskID string, opts AssumeRoleOptions) (AssumeRoleCredentials, error) {
-	if err := s.client.Create(ctx, evergreen.DefaultEC2Region, ""); err != nil {
+	if err := s.setupClient(ctx); err != nil {
 		return AssumeRoleCredentials{}, errors.Wrapf(err, "creating AWS client")
 	}
 	t, err := task.FindOneId(ctx, taskID)
@@ -121,9 +121,13 @@ func (s *stsManagerImpl) AssumeRole(ctx context.Context, taskID string, opts Ass
 	return creds, nil
 }
 
+func (s *stsManagerImpl) setupClient(ctx context.Context) error {
+	return s.client.Create(ctx, evergreen.DefaultEC2Region, "")
+}
+
 // GetCallerIdentityARN gets the caller identity's ARN.
 func (s *stsManagerImpl) GetCallerIdentityARN(ctx context.Context) (string, error) {
-	if err := s.client.Create(ctx, evergreen.DefaultEC2Region, ""); err != nil {
+	if err := s.setupClient(ctx); err != nil {
 		return "", errors.Wrapf(err, "creating AWS client")
 	}
 	output, err := s.client.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})

--- a/cloud/volume.go
+++ b/cloud/volume.go
@@ -42,11 +42,6 @@ func GetEC2ManagerForVolume(ctx context.Context, vol *host.Volume) (Manager, err
 	mgrOpts := ManagerOpts{
 		Provider: provider,
 		Region:   AztoRegion(vol.AvailabilityZone),
-		// kim: NOTE: doesn't have role to assume, but that's potentially okay.
-		// May need to propagate it down from the associated host's distro, or
-		// otherwise store that in the volume document. That's future proofing
-		// though, realistically I don't think volume management will need to
-		// use a separate account for now.
 	}
 	env := evergreen.GetEnvironment()
 	mgr, err := GetManager(ctx, env, mgrOpts)

--- a/cloud/volume.go
+++ b/cloud/volume.go
@@ -42,6 +42,11 @@ func GetEC2ManagerForVolume(ctx context.Context, vol *host.Volume) (Manager, err
 	mgrOpts := ManagerOpts{
 		Provider: provider,
 		Region:   AztoRegion(vol.AvailabilityZone),
+		// kim: NOTE: doesn't have role to assume, but that's potentially okay.
+		// May need to propagate it down from the associated host's distro, or
+		// otherwise store that in the volume document. That's future proofing
+		// though, realistically I don't think volume management will need to
+		// use a separate account for now.
 	}
 	env := evergreen.GetEnvironment()
 	mgr, err := GetManager(ctx, env, mgrOpts)

--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -20,6 +20,7 @@ var (
 	NoteKey                  = bsonutil.MustHaveTag(Distro{}, "Note")
 	ArchKey                  = bsonutil.MustHaveTag(Distro{}, "Arch")
 	ProviderKey              = bsonutil.MustHaveTag(Distro{}, "Provider")
+	ProviderAccountKey       = bsonutil.MustHaveTag(Distro{}, "ProviderAccount")
 	ProviderSettingsListKey  = bsonutil.MustHaveTag(Distro{}, "ProviderSettingsList")
 	SetupAsSudoKey           = bsonutil.MustHaveTag(Distro{}, "SetupAsSudo")
 	SetupKey                 = bsonutil.MustHaveTag(Distro{}, "Setup")

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -31,8 +31,8 @@ type Distro struct {
 	WorkDir              string            `bson:"work_dir" json:"work_dir,omitempty" mapstructure:"work_dir,omitempty"`
 	Provider             string            `bson:"provider" json:"provider,omitempty" mapstructure:"provider,omitempty"`
 	ProviderSettingsList []*birch.Document `bson:"provider_settings,omitempty" json:"provider_settings,omitempty" mapstructure:"provider_settings,omitempty"`
-	// ProviderAccountID is the identifier for the provider's account.
-	ProviderAccountID     string                `bson:"provider_account_id,omitempty" json:"provider_account_id,omitempty" mapstructure:"provider_account_id,omitempty"`
+	// ProviderAccount is the identifier for the provider's account.
+	ProviderAccount       string                `bson:"provider_account,omitempty" json:"provider_account,omitempty" mapstructure:"provider_account,omitempty"`
 	SetupAsSudo           bool                  `bson:"setup_as_sudo,omitempty" json:"setup_as_sudo,omitempty" mapstructure:"setup_as_sudo,omitempty"`
 	Setup                 string                `bson:"setup,omitempty" json:"setup,omitempty" mapstructure:"setup,omitempty"`
 	User                  string                `bson:"user,omitempty" json:"user,omitempty" mapstructure:"user,omitempty"`

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -24,13 +24,15 @@ import (
 )
 
 type Distro struct {
-	Id                    string                `bson:"_id" json:"_id,omitempty" mapstructure:"_id,omitempty"`
-	AdminOnly             bool                  `bson:"admin_only,omitempty" json:"admin_only,omitempty" mapstructure:"admin_only,omitempty"`
-	Aliases               []string              `bson:"aliases,omitempty" json:"aliases,omitempty" mapstructure:"aliases,omitempty"`
-	Arch                  string                `bson:"arch" json:"arch,omitempty" mapstructure:"arch,omitempty"`
-	WorkDir               string                `bson:"work_dir" json:"work_dir,omitempty" mapstructure:"work_dir,omitempty"`
-	Provider              string                `bson:"provider" json:"provider,omitempty" mapstructure:"provider,omitempty"`
-	ProviderSettingsList  []*birch.Document     `bson:"provider_settings,omitempty" json:"provider_settings,omitempty" mapstructure:"provider_settings,omitempty"`
+	Id                   string            `bson:"_id" json:"_id,omitempty" mapstructure:"_id,omitempty"`
+	AdminOnly            bool              `bson:"admin_only,omitempty" json:"admin_only,omitempty" mapstructure:"admin_only,omitempty"`
+	Aliases              []string          `bson:"aliases,omitempty" json:"aliases,omitempty" mapstructure:"aliases,omitempty"`
+	Arch                 string            `bson:"arch" json:"arch,omitempty" mapstructure:"arch,omitempty"`
+	WorkDir              string            `bson:"work_dir" json:"work_dir,omitempty" mapstructure:"work_dir,omitempty"`
+	Provider             string            `bson:"provider" json:"provider,omitempty" mapstructure:"provider,omitempty"`
+	ProviderSettingsList []*birch.Document `bson:"provider_settings,omitempty" json:"provider_settings,omitempty" mapstructure:"provider_settings,omitempty"`
+	// ProviderAccountID is the identifier for the provider's account.
+	ProviderAccountID     string                `bson:"provider_account_id,omitempty" json:"provider_account_id,omitempty" mapstructure:"provider_account_id,omitempty"`
 	SetupAsSudo           bool                  `bson:"setup_as_sudo,omitempty" json:"setup_as_sudo,omitempty" mapstructure:"setup_as_sudo,omitempty"`
 	Setup                 string                `bson:"setup,omitempty" json:"setup,omitempty" mapstructure:"setup,omitempty"`
 	User                  string                `bson:"user,omitempty" json:"user,omitempty" mapstructure:"user,omitempty"`

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1403,12 +1403,10 @@ func hostsByClientPipeline(pipeline []bson.M, limit int) []bson.M {
 			"$group": bson.M{
 				"_id": bson.M{
 					"provider": bsonutil.GetDottedKeyName("$host", DistroKey, distro.ProviderKey),
-					// kim: TODO: test in staging that this works as expected to
-					// check that the host status is running.
-					"account": bsonutil.GetDottedKeyName("$host", DistroKey, distro.ProviderAccountKey),
-					"region":  bsonutil.GetDottedKeyName("$settings_list", awsRegionKey),
-					"key":     bsonutil.GetDottedKeyName("$settings_list", awsKeyKey),
-					"secret":  bsonutil.GetDottedKeyName("$settings_list", awsSecretKey),
+					"account":  bsonutil.GetDottedKeyName("$host", DistroKey, distro.ProviderAccountKey),
+					"region":   bsonutil.GetDottedKeyName("$settings_list", awsRegionKey),
+					"key":      bsonutil.GetDottedKeyName("$settings_list", awsKeyKey),
+					"secret":   bsonutil.GetDottedKeyName("$settings_list", awsSecretKey),
 				},
 				"hosts": bson.M{"$push": "$host"},
 			},

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1403,7 +1403,8 @@ func hostsByClientPipeline(pipeline []bson.M, limit int) []bson.M {
 			"$group": bson.M{
 				"_id": bson.M{
 					"provider": bsonutil.GetDottedKeyName("$host", DistroKey, distro.ProviderKey),
-					// kim: TODO: test that this works as expected.
+					// kim: TODO: test in staging that this works as expected to
+					// check that the host status is running.
 					"account": bsonutil.GetDottedKeyName("$host", DistroKey, distro.ProviderAccountKey),
 					"region":  bsonutil.GetDottedKeyName("$settings_list", awsRegionKey),
 					"key":     bsonutil.GetDottedKeyName("$settings_list", awsKeyKey),

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1289,6 +1289,7 @@ func findVolumes(ctx context.Context, q bson.M) ([]Volume, error) {
 
 type ClientOptions struct {
 	Provider string `bson:"provider"`
+	Account  string `bson:"account"`
 	Region   string `bson:"region"`
 }
 
@@ -1402,9 +1403,11 @@ func hostsByClientPipeline(pipeline []bson.M, limit int) []bson.M {
 			"$group": bson.M{
 				"_id": bson.M{
 					"provider": bsonutil.GetDottedKeyName("$host", DistroKey, distro.ProviderKey),
-					"region":   bsonutil.GetDottedKeyName("$settings_list", awsRegionKey),
-					"key":      bsonutil.GetDottedKeyName("$settings_list", awsKeyKey),
-					"secret":   bsonutil.GetDottedKeyName("$settings_list", awsSecretKey),
+					// kim: TODO: test that this works as expected.
+					"account": bsonutil.GetDottedKeyName("$host", DistroKey, distro.ProviderAccountKey),
+					"region":  bsonutil.GetDottedKeyName("$settings_list", awsRegionKey),
+					"key":     bsonutil.GetDottedKeyName("$settings_list", awsKeyKey),
+					"secret":  bsonutil.GetDottedKeyName("$settings_list", awsSecretKey),
 				},
 				"hosts": bson.M{"$push": "$host"},
 			},

--- a/model/host/db_test.go
+++ b/model/host/db_test.go
@@ -287,14 +287,23 @@ func TestFindStartingHostsByClient(t *testing.T) {
 						ProviderSettingsList: []*birch.Document{birch.NewDocument()},
 					},
 				},
+				{
+					Id:     "h4",
+					Status: evergreen.HostStarting,
+					Distro: distro.Distro{
+						Provider:             evergreen.ProviderNameEc2Fleet,
+						ProviderAccount:      "account",
+						ProviderSettingsList: []*birch.Document{birch.NewDocument()},
+					},
+				},
 			}
 			for _, h := range hosts {
 				require.NoError(t, h.Insert(ctx))
 			}
 
-			hostsByClient, err := FindStartingHostsByClient(ctx, 10)
+			hostsByClient, err := FindStartingHostsByClient(ctx, 100)
 			assert.NoError(t, err)
-			assert.Len(t, hostsByClient, 3)
+			assert.Len(t, hostsByClient, 4)
 			for _, hostsByClient := range hostsByClient {
 				foundHosts := hostsByClient.Hosts
 				clientOptions := hostsByClient.Options
@@ -317,6 +326,12 @@ func TestFindStartingHostsByClient(t *testing.T) {
 					require.Len(t, foundHosts, 2)
 					compareHosts(t, hosts[2], foundHosts[0])
 					compareHosts(t, hosts[3], foundHosts[1])
+				case ClientOptions{
+					Provider: evergreen.ProviderNameEc2Fleet,
+					Account:  "account",
+				}:
+					require.Len(t, foundHosts, 1)
+					compareHosts(t, hosts[4], foundHosts[0])
 				default:
 					assert.Fail(t, "unrecognized client options")
 				}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -68,7 +68,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	stsManager := cloud.GetSTSManager(false)
 
 	// AWS Role ARN from IRSA
-	awsRoleARN := os.Getenv("AWS_ROLE_ARN")
+	awsRoleARN := os.Getenv(evergreen.AWSRoleARNEnvVar)
 
 	// Agent protocol routes
 	app.AddRoute("/agent/cedar_config").Version(2).Get().Wrap(requirePodOrHost).RouteHandler(makeAgentCedarConfig(settings.Cedar))

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -88,6 +88,7 @@ clientsLoop:
 			continue
 		}
 		mgrOpts := cloud.ManagerOpts{
+			Account:  clientOpts.Account,
 			Provider: clientOpts.Provider,
 			Region:   clientOpts.Region,
 		}


### PR DESCRIPTION
DEVPROD-16051

### Description
This adds a distro setting to specify which AWS account to use. Implicitly, we've been assuming the AWS account is always Kernel-Build and that it can make API calls using IRSA (i.e. without passing explicit auth to the AWS SDK). However, as distros shift towards using different accounts, they'll need to assume an explicit IAM role in order to make those same AWS API calls into a different account.

The general way that separate AWS accounts work is:
* Set distro setting for the account name.
* In the admin settings, add a mapping between the account name and the role ARN to assume.
* EC2 cloud provider implementations will assume the role associated with the distro's account when making AWS API calls.

#### Changes
* Add optional distro setting for explicit account name. Propagate that option down to EC2 cloud provider implementations and EC2 client.
* When getting the host statuses in bulk, consider the AWS account of the hosts to ensure that it looks for the instance status in the correct account.
* Add small helper functions for creating the EC2 client to reduce copy-pasting.

### Testing
Added unit tests and tested in staging to ensure that:
* [Host in a separate account](https://spruce-staging.corp.mongodb.com/host/i-07d94e7a64b8cc9df) started, ran a task, and terminated.
* AWS API calls to the separate account still succeeded after ~15 minutes of app uptime, to ensure that the assume role credentials are initialized and refreshed when they expire.