### PR TITLE
DEVPROD-16479: do not assign SSH key pair to hosts without public IPv4 addresses

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -39,8 +39,10 @@ type EC2ProviderSettings struct {
 	IPv6 bool `mapstructure:"ipv6" json:"ipv6,omitempty" bson:"ipv6,omitempty"`
 
 	// DoNotAssignPublicIPv4Address, if true, skips assigning a public IPv4
-	// address to hosts. Does not apply if the host is using IPv6 or spawn hosts
-	// which need an IPv4 address for SSH.
+	// address to task hosts. An AWS SSH key will be assigned to the host only
+	// if a public IPv4 address is also assigned.
+	// Does not apply if the host is using IPv6 or if the host is a spawn host
+	// or host.create host, which need an IPv4 address for SSH.
 	DoNotAssignPublicIPv4Address bool `mapstructure:"do_not_assign_public_ipv4_address" json:"do_not_assign_public_ipv4_address,omitempty" bson:"do_not_assign_public_ipv4_address,omitempty"`
 
 	// KeyName is the AWS SSH key name.

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -271,6 +271,9 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 
 	assignPublicIPv4 := shouldAssignPublicIPv4Address(h, ec2Settings)
 	if assignPublicIPv4 {
+		// Only set an SSH key for the host if the host actually has a public
+		// IPv4 address. Hosts that don't have a public IPv4 address aren't
+		// reachable with SSH even if a key is set.
 		input.KeyName = aws.String(ec2Settings.KeyName)
 	}
 	if ec2Settings.IsVpc {

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -499,14 +499,6 @@ func (m *ec2FleetManager) uploadLaunchTemplate(ctx context.Context, h *host.Host
 	return nil
 }
 
-func shouldAssignPublicIPv4Address(h *host.Host, ec2Settings *EC2ProviderSettings) bool {
-	if h.UserHost || h.SpawnOptions.SpawnedByTask {
-		return true
-	}
-
-	return !ec2Settings.DoNotAssignPublicIPv4Address && !ec2Settings.IPv6
-}
-
 func (m *ec2FleetManager) requestFleet(ctx context.Context, h *host.Host, ec2Settings *EC2ProviderSettings) (string, error) {
 	var overrides []types.FleetLaunchTemplateOverridesRequest
 	var err error

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -439,6 +439,9 @@ func (m *ec2FleetManager) uploadLaunchTemplate(ctx context.Context, h *host.Host
 
 	assignPublicIPv4 := shouldAssignPublicIPv4Address(h, ec2Settings)
 	if assignPublicIPv4 {
+		// Only set an SSH key for the host if the host actually has a public
+		// IPv4 address. Hosts that don't have a public IPv4 address aren't
+		// reachable with SSH even if a key is set.
 		launchTemplate.KeyName = aws.String(ec2Settings.KeyName)
 	}
 	if ec2Settings.IsVpc {

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -428,7 +428,6 @@ func (m *ec2FleetManager) uploadLaunchTemplate(ctx context.Context, h *host.Host
 
 	launchTemplate := &types.RequestLaunchTemplateData{
 		ImageId:             aws.String(ec2Settings.AMI),
-		KeyName:             aws.String(ec2Settings.KeyName),
 		InstanceType:        types.InstanceType(ec2Settings.InstanceType),
 		BlockDeviceMappings: blockDevices,
 		TagSpecifications:   makeTagTemplate(makeTags(h)),
@@ -438,11 +437,14 @@ func (m *ec2FleetManager) uploadLaunchTemplate(ctx context.Context, h *host.Host
 		launchTemplate.IamInstanceProfile = &types.LaunchTemplateIamInstanceProfileSpecificationRequest{Arn: aws.String(ec2Settings.IAMInstanceProfileARN)}
 	}
 
+	assignPublicIPv4 := !ec2Settings.DoNotAssignPublicIPv4Address && !ec2Settings.IPv6
+	if h.UserHost || h.SpawnOptions.SpawnedByTask {
+		assignPublicIPv4 = true
+	}
+	if assignPublicIPv4 {
+		launchTemplate.KeyName = aws.String(ec2Settings.KeyName)
+	}
 	if ec2Settings.IsVpc {
-		assignPublicIPv4 := !ec2Settings.DoNotAssignPublicIPv4Address
-		if h.UserHost {
-			assignPublicIPv4 = true
-		}
 		launchTemplate.NetworkInterfaces = []types.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{
 			{
 				AssociatePublicIpAddress: aws.Bool(assignPublicIPv4),

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -278,11 +278,9 @@ func (s *EC2Suite) TestMakeDeviceMappingsTemplate() {
 
 func (s *EC2Suite) TestConfigure() {
 	settings := &evergreen.Settings{}
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
 
 	// No region specified.
-	s.Require().NoError(s.onDemandManager.Configure(ctx, settings))
+	s.Require().NoError(s.onDemandManager.Configure(s.ctx, settings))
 	ec2m, ok := s.onDemandManager.(*ec2Manager)
 	s.Require().True(ok)
 	s.Equal(evergreen.DefaultEC2Region, ec2m.region)
@@ -293,7 +291,7 @@ func (s *EC2Suite) TestConfigure() {
 		region: "test-region",
 	}
 	onDemandWithRegionManager := &ec2Manager{env: s.env, EC2ManagerOptions: onDemandWithRegionOpts}
-	s.Require().NoError(onDemandWithRegionManager.Configure(ctx, settings))
+	s.Require().NoError(onDemandWithRegionManager.Configure(s.ctx, settings))
 	s.Equal(onDemandWithRegionOpts.region, onDemandWithRegionManager.region)
 }
 
@@ -305,10 +303,7 @@ func (s *EC2Suite) TestSpawnHostInvalidInput() {
 		},
 	}
 
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
-	spawned, err := s.onDemandManager.SpawnHost(ctx, h)
+	spawned, err := s.onDemandManager.SpawnHost(s.ctx, h)
 	s.Nil(spawned)
 	s.Error(err)
 	s.EqualError(err, "can't spawn EC2 instance for distro 'id': distro provider is 'foo'")
@@ -338,9 +333,7 @@ func (s *EC2Suite) TestSpawnHostClassicOnDemand() {
 	s.h.Distro.ProviderSettingsList = []*birch.Document{validEC2ProviderSettings()}
 	s.Require().NoError(s.h.Insert(s.ctx))
 
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-	_, err := s.onDemandManager.SpawnHost(ctx, s.h)
+	_, err := s.onDemandManager.SpawnHost(s.ctx, s.h)
 	s.NoError(err)
 
 	manager, ok := s.onDemandManager.(*ec2Manager)
@@ -372,10 +365,7 @@ func (s *EC2Suite) TestSpawnHostVPCOnDemand() {
 	h.Distro.ProviderSettingsList = []*birch.Document{providerSettings}
 	s.Require().NoError(h.Insert(s.ctx))
 
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
-	_, err := s.onDemandManager.SpawnHost(ctx, h)
+	_, err := s.onDemandManager.SpawnHost(s.ctx, h)
 	s.NoError(err)
 
 	manager, ok := s.onDemandManager.(*ec2Manager)
@@ -438,10 +428,7 @@ func (s *EC2Suite) TestSpawnHostForTask() {
 	}
 	s.Require().NoError(newVars.Insert())
 
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
-	_, err := s.onDemandManager.SpawnHost(ctx, h)
+	_, err := s.onDemandManager.SpawnHost(s.ctx, h)
 	s.NoError(err)
 
 	manager, ok := s.onDemandManager.(*ec2Manager)
@@ -477,9 +464,7 @@ func (s *EC2Suite) TestSpawnHostForTaskWithoutPublicIPv4Address() {
 	s.h.Distro.ProviderSettingsList = []*birch.Document{providerSettings}
 	s.Require().NoError(s.h.Insert(s.ctx))
 
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-	_, err := s.onDemandManager.SpawnHost(ctx, s.h)
+	_, err := s.onDemandManager.SpawnHost(s.ctx, s.h)
 	s.NoError(err)
 
 	manager, ok := s.onDemandManager.(*ec2Manager)
@@ -520,23 +505,20 @@ func (s *EC2Suite) TestModifyHost() {
 		InstanceType:       "instance-type-2",
 	}
 
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
 	s.h.Status = evergreen.HostRunning
-	s.Require().NoError(s.h.Insert(ctx))
-	s.Error(s.onDemandManager.ModifyHost(ctx, s.h, changes))
-	s.Require().NoError(s.h.Remove(ctx))
+	s.Require().NoError(s.h.Insert(s.ctx))
+	s.Error(s.onDemandManager.ModifyHost(s.ctx, s.h, changes))
+	s.Require().NoError(s.h.Remove(s.ctx))
 
 	s.h.CreationTime = time.Now()
 	s.h.ExpirationTime = s.h.CreationTime.Add(time.Hour * 24 * 7)
 	s.h.NoExpiration = false
 	s.h.Status = evergreen.HostStopped
-	s.Require().NoError(s.h.Insert(ctx))
+	s.Require().NoError(s.h.Insert(s.ctx))
 
 	// updating instance tags and instance type
-	s.NoError(s.onDemandManager.ModifyHost(ctx, s.h, changes))
-	found, err := host.FindOne(ctx, host.ById(s.h.Id))
+	s.NoError(s.onDemandManager.ModifyHost(s.ctx, s.h, changes))
+	found, err := host.FindOne(s.ctx, host.ById(s.h.Id))
 	s.NoError(err)
 	s.Equal([]host.Tag{{Key: "key-2", Value: "val-2", CanBeModified: true}}, found.InstanceTags)
 	s.Equal(changes.InstanceType, found.InstanceType)
@@ -546,8 +528,8 @@ func (s *EC2Suite) TestModifyHost() {
 	changes = host.HostModifyOptions{
 		AddHours: time.Hour * 24,
 	}
-	s.NoError(s.onDemandManager.ModifyHost(ctx, s.h, changes))
-	found, err = host.FindOne(ctx, host.ById(s.h.Id))
+	s.NoError(s.onDemandManager.ModifyHost(s.ctx, s.h, changes))
+	found, err = host.FindOne(s.ctx, host.ById(s.h.Id))
 	s.NoError(err)
 	s.True(found.ExpirationTime.Equal(prevExpirationTime.Add(changes.AddHours)))
 
@@ -555,18 +537,18 @@ func (s *EC2Suite) TestModifyHost() {
 	changes = host.HostModifyOptions{
 		AddHours: time.Hour * 24 * evergreen.SpawnHostExpireDays,
 	}
-	s.Error(s.onDemandManager.ModifyHost(ctx, s.h, changes))
+	s.Error(s.onDemandManager.ModifyHost(s.ctx, s.h, changes))
 
 	// trying to update host expiration before now should error
 	changes = host.HostModifyOptions{
 		AddHours: time.Hour * -24 * 2 * evergreen.SpawnHostExpireDays,
 	}
-	s.Error(s.onDemandManager.ModifyHost(ctx, s.h, changes))
+	s.Error(s.onDemandManager.ModifyHost(s.ctx, s.h, changes))
 
 	// modifying host to have no expiration
 	changes = host.HostModifyOptions{NoExpiration: utility.TruePtr()}
-	s.NoError(s.onDemandManager.ModifyHost(ctx, s.h, changes))
-	found, err = host.FindOne(ctx, host.ById(s.h.Id))
+	s.NoError(s.onDemandManager.ModifyHost(s.ctx, s.h, changes))
+	found, err = host.FindOne(s.ctx, host.ById(s.h.Id))
 	s.NoError(err)
 	s.Require().NotZero(found)
 	s.True(found.NoExpiration)
@@ -575,8 +557,8 @@ func (s *EC2Suite) TestModifyHost() {
 
 	// reverting a host back to having an expiration
 	changes = host.HostModifyOptions{NoExpiration: utility.FalsePtr()}
-	s.NoError(s.onDemandManager.ModifyHost(ctx, s.h, changes))
-	found, err = host.FindOne(ctx, host.ById(s.h.Id))
+	s.NoError(s.onDemandManager.ModifyHost(s.ctx, s.h, changes))
+	found, err = host.FindOne(s.ctx, host.ById(s.h.Id))
 	s.NoError(err)
 	s.Require().NotZero(found)
 	s.False(found.NoExpiration)
@@ -584,10 +566,10 @@ func (s *EC2Suite) TestModifyHost() {
 	s.Zero(found.PublicIPv4)
 
 	// modifying host to have no expiration when it's currently stopped
-	s.NoError(s.h.SetStatus(ctx, evergreen.HostStopped, "user", ""))
+	s.NoError(s.h.SetStatus(s.ctx, evergreen.HostStopped, "user", ""))
 	changes = host.HostModifyOptions{NoExpiration: utility.TruePtr()}
-	s.NoError(s.onDemandManager.ModifyHost(ctx, s.h, changes))
-	found, err = host.FindOne(ctx, host.ById(s.h.Id))
+	s.NoError(s.onDemandManager.ModifyHost(s.ctx, s.h, changes))
+	found, err = host.FindOne(s.ctx, host.ById(s.h.Id))
 	s.NoError(err)
 	s.Require().NotZero(found)
 	s.True(found.NoExpiration)
@@ -601,15 +583,15 @@ func (s *EC2Suite) TestModifyHost() {
 	}
 	s.Require().NoError(volumeToMount.Insert())
 	s.h.Zone = "us-east-1a"
-	s.Require().NoError(s.h.Remove(ctx))
-	s.Require().NoError(s.h.Insert(ctx))
+	s.Require().NoError(s.h.Remove(s.ctx))
+	s.Require().NoError(s.h.Insert(s.ctx))
 	changes = host.HostModifyOptions{
 		AttachVolume: "thang",
 	}
-	s.NoError(s.onDemandManager.ModifyHost(ctx, s.h, changes))
-	_, err = host.FindOne(ctx, host.ById(s.h.Id))
+	s.NoError(s.onDemandManager.ModifyHost(s.ctx, s.h, changes))
+	_, err = host.FindOne(s.ctx, host.ById(s.h.Id))
 	s.NoError(err)
-	s.Require().NoError(s.h.Remove(ctx))
+	s.Require().NoError(s.h.Remove(s.ctx))
 }
 
 func (s *EC2Suite) TestModifyHostWithNewTemporaryExemption() {
@@ -741,12 +723,10 @@ func (s *EC2Suite) TestModifyHostInvalidSchedule() {
 }
 
 func (s *EC2Suite) TestGetInstanceInformation() {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-	s.Require().NoError(s.h.Insert(ctx))
+	s.Require().NoError(s.h.Insert(s.ctx))
 
 	s.h.Distro.Provider = evergreen.ProviderNameEc2OnDemand
-	info, err := s.onDemandManager.GetInstanceState(ctx, s.h)
+	info, err := s.onDemandManager.GetInstanceState(s.ctx, s.h)
 	s.NoError(err)
 	s.Equal(StatusRunning, info.Status)
 
@@ -759,40 +739,31 @@ func (s *EC2Suite) TestGetInstanceInformation() {
 }
 
 func (s *EC2Suite) TestTerminateInstance() {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
-	s.NoError(s.h.Insert(ctx))
-	s.NoError(s.onDemandManager.TerminateInstance(ctx, s.h, evergreen.User, ""))
-	found, err := host.FindOne(ctx, host.ById("h1"))
+	s.NoError(s.h.Insert(s.ctx))
+	s.NoError(s.onDemandManager.TerminateInstance(s.ctx, s.h, evergreen.User, ""))
+	found, err := host.FindOne(s.ctx, host.ById("h1"))
 	s.Equal(evergreen.HostTerminated, found.Status)
 	s.NoError(err)
 }
 
 func (s *EC2Suite) TestTerminateInstanceWithUserDataBootstrappedHost() {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
 	s.h.Distro.BootstrapSettings.Method = distro.BootstrapMethodUserData
-	s.NoError(s.h.Insert(ctx))
+	s.NoError(s.h.Insert(s.ctx))
 
-	creds, err := s.h.GenerateJasperCredentials(ctx, s.env)
+	creds, err := s.h.GenerateJasperCredentials(s.ctx, s.env)
 	s.Require().NoError(err)
-	s.Require().NoError(s.h.SaveJasperCredentials(ctx, s.env, creds))
+	s.Require().NoError(s.h.SaveJasperCredentials(s.ctx, s.env, creds))
 
-	_, err = s.h.JasperCredentials(ctx, s.env)
+	_, err = s.h.JasperCredentials(s.ctx, s.env)
 	s.Require().NoError(err)
 
-	s.NoError(s.onDemandManager.TerminateInstance(ctx, s.h, evergreen.User, ""))
+	s.NoError(s.onDemandManager.TerminateInstance(s.ctx, s.h, evergreen.User, ""))
 
-	_, err = s.h.JasperCredentials(ctx, s.env)
+	_, err = s.h.JasperCredentials(s.ctx, s.env)
 	s.Error(err)
 }
 
 func (s *EC2Suite) TestStopInstance() {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
 	unstoppableHosts := []*host.Host{
 		{
 			Id:     "host-provisioning",
@@ -801,10 +772,10 @@ func (s *EC2Suite) TestStopInstance() {
 	}
 	for _, h := range unstoppableHosts {
 		h.Distro = s.distro
-		s.Require().NoError(h.Insert(ctx))
+		s.Require().NoError(h.Insert(s.ctx))
 	}
 	for _, h := range unstoppableHosts {
-		s.Error(s.onDemandManager.StopInstance(ctx, h, false, evergreen.User))
+		s.Error(s.onDemandManager.StopInstance(s.ctx, h, false, evergreen.User))
 	}
 
 	stoppableHosts := []*host.Host{
@@ -823,21 +794,18 @@ func (s *EC2Suite) TestStopInstance() {
 	}
 	for _, h := range stoppableHosts {
 		h.Distro = s.distro
-		s.Require().NoError(h.Insert(ctx))
+		s.Require().NoError(h.Insert(s.ctx))
 	}
 
 	for _, h := range stoppableHosts {
-		s.NoError(s.onDemandManager.StopInstance(ctx, h, false, evergreen.User))
-		found, err := host.FindOne(ctx, host.ById(h.Id))
+		s.NoError(s.onDemandManager.StopInstance(s.ctx, h, false, evergreen.User))
+		found, err := host.FindOne(s.ctx, host.ById(h.Id))
 		s.NoError(err)
 		s.Equal(evergreen.HostStopped, found.Status)
 	}
 }
 
 func (s *EC2Suite) TestStopInstanceAndShouldKeepOff() {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
 	stoppableHosts := []*host.Host{
 		{
 			Id:     "host-stopping",
@@ -854,12 +822,12 @@ func (s *EC2Suite) TestStopInstanceAndShouldKeepOff() {
 	}
 	for _, h := range stoppableHosts {
 		h.Distro = s.distro
-		s.Require().NoError(h.Insert(ctx))
+		s.Require().NoError(h.Insert(s.ctx))
 	}
 
 	for _, h := range stoppableHosts {
-		s.NoError(s.onDemandManager.StopInstance(ctx, h, true, evergreen.User))
-		found, err := host.FindOne(ctx, host.ById(h.Id))
+		s.NoError(s.onDemandManager.StopInstance(s.ctx, h, true, evergreen.User))
+		found, err := host.FindOne(s.ctx, host.ById(h.Id))
 		s.NoError(err)
 		s.Equal(evergreen.HostStopped, found.Status)
 		s.True(found.SleepSchedule.ShouldKeepOff)
@@ -867,9 +835,6 @@ func (s *EC2Suite) TestStopInstanceAndShouldKeepOff() {
 }
 
 func (s *EC2Suite) TestStartInstance() {
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
-
 	manager, ok := s.onDemandManager.(*ec2Manager)
 	s.Require().True(ok)
 	mock, ok := manager.client.(*awsClientMock)
@@ -884,10 +849,10 @@ func (s *EC2Suite) TestStartInstance() {
 	}
 	for _, h := range unstartableHosts {
 		h.Distro = s.distro
-		s.Require().NoError(h.Insert(ctx))
+		s.Require().NoError(h.Insert(s.ctx))
 	}
 	for _, h := range unstartableHosts {
-		s.Error(s.onDemandManager.StartInstance(ctx, h, evergreen.User))
+		s.Error(s.onDemandManager.StartInstance(s.ctx, h, evergreen.User))
 	}
 
 	startableHosts := []*host.Host{
@@ -905,12 +870,12 @@ func (s *EC2Suite) TestStartInstance() {
 	}
 	for _, h := range startableHosts {
 		h.Distro = s.distro
-		s.NoError(h.Insert(ctx))
+		s.NoError(h.Insert(s.ctx))
 	}
 	for _, h := range startableHosts {
-		s.NoError(s.onDemandManager.StartInstance(ctx, h, evergreen.User))
+		s.NoError(s.onDemandManager.StartInstance(s.ctx, h, evergreen.User))
 
-		found, err := host.FindOne(ctx, host.ById(h.Id))
+		found, err := host.FindOne(s.ctx, host.ById(h.Id))
 		s.NoError(err)
 		s.Equal(evergreen.HostRunning, found.Status)
 		s.Equal("public_dns_name", found.Host)
@@ -992,8 +957,6 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 			},
 		},
 	}
-	ctx, cancel := context.WithCancel(s.ctx)
-	defer cancel()
 	manager, ok := s.onDemandManager.(*ec2Manager)
 	s.Require().True(ok)
 	mock, ok := manager.client.(*awsClientMock)
@@ -1051,7 +1014,7 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 	batchManager, ok := s.onDemandManager.(BatchManager)
 	s.True(ok)
 	s.NotNil(batchManager)
-	statuses, err := batchManager.GetInstanceStatuses(ctx, hosts)
+	statuses, err := batchManager.GetInstanceStatuses(s.ctx, hosts)
 	s.NoError(err, "does not error if some of the instances do not exist")
 	s.Equal(map[string]CloudStatus{
 		"i-1": StatusNonExistent,
@@ -1158,7 +1121,7 @@ func (s *EC2Suite) TestGetInstanceStatuses() {
 			},
 		},
 	}
-	statuses, err = batchManager.GetInstanceStatuses(ctx, hosts)
+	statuses, err = batchManager.GetInstanceStatuses(s.ctx, hosts)
 	s.NoError(err)
 	s.Len(mock.DescribeInstancesInput.InstanceIds, 4)
 	s.Equal("i-1", mock.DescribeInstancesInput.InstanceIds[0])
@@ -1282,12 +1245,9 @@ func (s *EC2Suite) TestUserDataExpand() {
 }
 
 func (s *EC2Suite) TestCacheHostData() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	ec2m := s.onDemandManager.(*ec2Manager)
 
-	s.Require().NoError(s.h.Insert(ctx))
+	s.Require().NoError(s.h.Insert(s.ctx))
 
 	instance := &types.Instance{Placement: &types.Placement{}}
 	instance.Placement.AvailabilityZone = aws.String("us-east-1a")
@@ -1329,7 +1289,7 @@ func (s *EC2Suite) TestCacheHostData() {
 		},
 	}, s.h.Volumes)
 
-	h, err := host.FindOneId(ctx, "h1")
+	h, err := host.FindOneId(s.ctx, "h1")
 	s.Require().NoError(err)
 	s.Require().NotNil(h)
 	s.Equal(*instance.Placement.AvailabilityZone, h.Zone)
@@ -1452,10 +1412,7 @@ func (s *EC2Suite) TestSetNextSubnet() {
 }
 
 func (s *EC2Suite) TestCreateVolume() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	volume, err := s.onDemandManager.CreateVolume(ctx, s.volume)
+	volume, err := s.onDemandManager.CreateVolume(s.ctx, s.volume)
 	s.NoError(err)
 
 	manager, ok := s.onDemandManager.(*ec2Manager)
@@ -1466,17 +1423,14 @@ func (s *EC2Suite) TestCreateVolume() {
 	input := *mock.CreateVolumeInput
 	s.EqualValues("standard", input.VolumeType)
 
-	foundVolume, err := host.FindVolumeByID(ctx, volume.ID)
+	foundVolume, err := host.FindVolumeByID(s.ctx, volume.ID)
 	s.NotNil(foundVolume)
 	s.NoError(err)
 }
 
 func (s *EC2Suite) TestDeleteVolume() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	s.NoError(s.volume.Insert())
-	s.NoError(s.onDemandManager.DeleteVolume(ctx, s.volume))
+	s.NoError(s.onDemandManager.DeleteVolume(s.ctx, s.volume))
 
 	manager, ok := s.onDemandManager.(*ec2Manager)
 	s.Require().True(ok)
@@ -1486,21 +1440,18 @@ func (s *EC2Suite) TestDeleteVolume() {
 	input := *mock.DeleteVolumeInput
 	s.Equal("test-volume", *input.VolumeId)
 
-	foundVolume, err := host.FindVolumeByID(ctx, s.volume.ID)
+	foundVolume, err := host.FindVolumeByID(s.ctx, s.volume.ID)
 	s.Nil(foundVolume)
 	s.NoError(err)
 }
 
 func (s *EC2Suite) TestAttachVolume() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	s.Require().NoError(s.h.Insert(ctx))
+	s.Require().NoError(s.h.Insert(s.ctx))
 	newAttachment := host.VolumeAttachment{
 		VolumeID:   "test-volume",
 		DeviceName: "test-device-name",
 	}
-	s.NoError(s.onDemandManager.AttachVolume(ctx, s.h, &newAttachment))
+	s.NoError(s.onDemandManager.AttachVolume(s.ctx, s.h, &newAttachment))
 
 	manager, ok := s.onDemandManager.(*ec2Manager)
 	s.Require().True(ok)
@@ -1512,21 +1463,19 @@ func (s *EC2Suite) TestAttachVolume() {
 	s.Equal("test-volume", *input.VolumeId)
 	s.Equal("test-device-name", *input.Device)
 
-	host, err := host.FindOneId(ctx, s.h.Id)
+	host, err := host.FindOneId(s.ctx, s.h.Id)
 	s.NotNil(host)
 	s.NoError(err)
 	s.Contains(host.Volumes, newAttachment)
 }
 
 func (s *EC2Suite) TestAttachVolumeGenerateDeviceName() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	s.Require().NoError(s.h.Insert(ctx))
+	s.Require().NoError(s.h.Insert(s.ctx))
 	newAttachment := &host.VolumeAttachment{
 		VolumeID: "test-volume",
 	}
 
-	s.NoError(s.onDemandManager.AttachVolume(ctx, s.h, newAttachment))
+	s.NoError(s.onDemandManager.AttachVolume(s.ctx, s.h, newAttachment))
 
 	s.Equal("test-volume", newAttachment.VolumeID)
 	s.NotEqual("", newAttachment.DeviceName)
@@ -1534,18 +1483,15 @@ func (s *EC2Suite) TestAttachVolumeGenerateDeviceName() {
 }
 
 func (s *EC2Suite) TestDetachVolume() {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	oldAttachment := host.VolumeAttachment{
 		VolumeID:   s.volume.ID,
 		DeviceName: "test-device-name",
 	}
 	s.h.Volumes = []host.VolumeAttachment{oldAttachment}
-	s.Require().NoError(s.h.Insert(ctx))
+	s.Require().NoError(s.h.Insert(s.ctx))
 	s.Require().NoError(s.volume.Insert())
 
-	s.NoError(s.onDemandManager.DetachVolume(ctx, s.h, "test-volume"))
+	s.NoError(s.onDemandManager.DetachVolume(s.ctx, s.h, "test-volume"))
 
 	manager, ok := s.onDemandManager.(*ec2Manager)
 	s.Require().True(ok)
@@ -1556,7 +1502,7 @@ func (s *EC2Suite) TestDetachVolume() {
 	s.Equal("h1", *input.InstanceId)
 	s.Equal("test-volume", *input.VolumeId)
 
-	host, err := host.FindOneId(ctx, s.h.Id)
+	host, err := host.FindOneId(s.ctx, s.h.Id)
 	s.NotNil(host)
 	s.NoError(err)
 	s.NotContains(host.Volumes, oldAttachment)

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -747,3 +747,14 @@ func isEC2InstanceNotFound(err error) bool {
 	}
 	return false
 }
+
+func shouldAssignPublicIPv4Address(h *host.Host, ec2Settings *EC2ProviderSettings) bool {
+	if h.UserHost || h.SpawnOptions.SpawnedByTask {
+		// Spawn hosts and host.create hosts need to have a public IPv4 address
+		// because SSH is currently the only means for the user/task to access
+		// the host.
+		return true
+	}
+
+	return !ec2Settings.DoNotAssignPublicIPv4Address && !ec2Settings.IPv6
+}


### PR DESCRIPTION
DEVPROD-16479

### Description
It came up while setting up the separate AWS accounts (#8908) that ideally, the separate AWS account shouldn't have an SSH key put on the host since tasks in that account aren't allowed to have SSH access. SSH won't work if the host doesn't have a public IPv4 address assigned to it, so it seems fine to not set an SSH key when the host doesn't have a public IPv4 address.

* For task hosts that have public IPv4 addresses disabled, do not set any SSH key.
* For host.create hosts, also ensure that they have public IPv4 addresses assigned just like spawn hosts (because there's no other way for a task to access the host).

### Testing
* Updated unit tests.
* Tested in staging to verify that:
    * Setting the `do_not_assign_public_ipv4_address` distro setting resulted in a task host that had no public IPv4 address and no SSH access.
    * Starting a spawn host still worked and could be SSH'd into, even if its distro had IPv4 addresses disabled for task hosts.