### PR TITLE
DEVPROD-15648: check if user is distro admin before spawning host

### DIFF
--- a/graphql/image_resolver.go
+++ b/graphql/image_resolver.go
@@ -21,7 +21,7 @@ func (r *imageResolver) Distros(ctx context.Context, obj *model.APIImage) ([]*mo
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding distros for image '%s': %s", imageID, err.Error()))
 	}
 
-	userHasDistroCreatePermission := userHasDistroCreatePermission(usr)
+	userHasDistroCreatePermission := usr.HasDistroCreatePermission()
 
 	apiDistros := []*model.APIDistro{}
 	for _, d := range distros {

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -763,6 +763,7 @@ func (r *mutationResolver) SpawnHost(ctx context.Context, spawnHostInput *SpawnH
 			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("distro '%s' not found", options.DistroID))
 		}
 		if d.AdminOnly {
+			// Admin-only distros can only be spawned by distro admins.
 			return nil, Forbidden.Send(ctx, fmt.Sprintf("not authorized to spawn host in admin-only distro '%s'", options.DistroID))
 		}
 	}

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -754,8 +754,7 @@ func (r *mutationResolver) SpawnHost(ctx context.Context, spawnHostInput *SpawnH
 		return nil, err
 	}
 
-	hasDistroCreatePermission := usr.HasDistroCreatePermission()
-	if !hasDistroCreatePermission {
+	if !usr.HasDistroCreatePermission() {
 		d, err := distro.FindOneId(ctx, options.DistroID)
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching distro '%s': %s", options.DistroID, err.Error()))

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -754,7 +754,7 @@ func (r *mutationResolver) SpawnHost(ctx context.Context, spawnHostInput *SpawnH
 		return nil, err
 	}
 
-	hasDistroCreatePermission := userHasDistroCreatePermission(usr)
+	hasDistroCreatePermission := usr.HasDistroCreatePermission()
 	if !hasDistroCreatePermission {
 		d, err := distro.FindOneId(ctx, options.DistroID)
 		if err != nil {

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -754,6 +754,20 @@ func (r *mutationResolver) SpawnHost(ctx context.Context, spawnHostInput *SpawnH
 		return nil, err
 	}
 
+	hasDistroCreatePermission := userHasDistroCreatePermission(usr)
+	if !hasDistroCreatePermission {
+		d, err := distro.FindOneId(ctx, options.DistroID)
+		if err != nil {
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching distro '%s': %s", options.DistroID, err.Error()))
+		}
+		if d == nil {
+			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("distro '%s' not found", options.DistroID))
+		}
+		if d.AdminOnly {
+			return nil, Forbidden.Send(ctx, fmt.Sprintf("not authorized to spawn host in admin-only distro '%s'", options.DistroID))
+		}
+	}
+
 	spawnHost, err := data.NewIntentHost(ctx, options, usr, evergreen.GetEnvironment())
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("spawning host: %s", err.Error()))

--- a/graphql/permissions_resolver.go
+++ b/graphql/permissions_resolver.go
@@ -19,7 +19,7 @@ func (r *permissionsResolver) CanCreateDistro(ctx context.Context, obj *Permissi
 	if usr == nil {
 		return false, ResourceNotFound.Send(ctx, fmt.Sprintf("user '%s' not found", obj.UserID))
 	}
-	return userHasDistroCreatePermission(usr), nil
+	return usr.HasDistroCreatePermission(), nil
 }
 
 // CanCreateProject is the resolver for the canCreateProject field.

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -164,7 +164,7 @@ func (r *queryResolver) Distros(ctx context.Context, onlySpawnable bool) ([]*res
 		distros = d
 	}
 
-	userHasDistroCreatePermission := userHasDistroCreatePermission(usr)
+	userHasDistroCreatePermission := usr.HasDistroCreatePermission()
 
 	for _, d := range distros {
 		// Omit admin-only distros if user lacks permissions

--- a/graphql/resolver.go
+++ b/graphql/resolver.go
@@ -123,7 +123,8 @@ func New(apiURL string) Config {
 
 		// If directive is checking for create permissions, no distro ID is required.
 		if access == DistroSettingsAccessCreate {
-			if userHasDistroCreatePermission(user) {
+
+			if user.HasDistroCreatePermission() {
 				return next(ctx)
 			}
 			return nil, Forbidden.Send(ctx, fmt.Sprintf("user '%s' does not have create distro permissions", user.Username()))

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1055,15 +1055,6 @@ func handleDistroOnSaveOperation(ctx context.Context, distroID string, onSave Di
 	return len(hosts), nil
 }
 
-func userHasDistroCreatePermission(u *user.DBUser) bool {
-	return u.HasPermission(gimlet.PermissionOpts{
-		Resource:      evergreen.SuperUserPermissionsID,
-		ResourceType:  evergreen.SuperUserResourceType,
-		Permission:    evergreen.PermissionDistroCreate,
-		RequiredLevel: evergreen.DistroCreate.Value,
-	})
-}
-
 func userHasDistroPermission(u *user.DBUser, distroId string, requiredLevel int) bool {
 	opts := gimlet.PermissionOpts{
 		Resource:      distroId,

--- a/graphql/util_test.go
+++ b/graphql/util_test.go
@@ -202,38 +202,6 @@ func TestGetDisplayStatus(t *testing.T) {
 	assert.Equal(t, evergreen.VersionAborted, status)
 }
 
-func TestUserHasDistroCreatePermission(t *testing.T) {
-	assert.NoError(t, db.ClearCollections(user.Collection, evergreen.RoleCollection, evergreen.ScopeCollection))
-
-	env := evergreen.GetEnvironment()
-	roleManager := env.RoleManager()
-
-	usr := user.DBUser{
-		Id: "basic_user",
-	}
-	assert.NoError(t, usr.Insert())
-	assert.False(t, userHasDistroCreatePermission(&usr))
-
-	createRole := gimlet.Role{
-		ID:          "create_distro",
-		Name:        "create_distro",
-		Scope:       "superuser_scope",
-		Permissions: map[string]int{"distro_create": 10},
-	}
-	require.NoError(t, roleManager.UpdateRole(createRole))
-	require.NoError(t, usr.AddRole(t.Context(), "create_distro"))
-
-	superUserScope := gimlet.Scope{
-		ID:        "superuser_scope",
-		Name:      "superuser scope",
-		Type:      evergreen.SuperUserResourceType,
-		Resources: []string{evergreen.SuperUserPermissionsID},
-	}
-	require.NoError(t, roleManager.AddScope(superUserScope))
-
-	assert.True(t, userHasDistroCreatePermission(&usr))
-}
-
 func TestConcurrentlyBuildVersionsMatchingTasksMap(t *testing.T) {
 	ctx := context.Background()
 	assert.NoError(t, db.ClearCollections(task.Collection))

--- a/model/user/user.go
+++ b/model/user/user.go
@@ -483,7 +483,8 @@ func (u *DBUser) HasProjectCreatePermission() (bool, error) {
 }
 
 // HasDistroCreatePermission returns true if the user has permission to create
-// distros.
+// distros. This can also operate as a check for whether the user is a distro
+// admin, since only distro admins can create new distros.
 func (u *DBUser) HasDistroCreatePermission() bool {
 	return u.HasPermission(gimlet.PermissionOpts{
 		Resource:      evergreen.SuperUserPermissionsID,

--- a/model/user/user.go
+++ b/model/user/user.go
@@ -482,6 +482,17 @@ func (u *DBUser) HasProjectCreatePermission() (bool, error) {
 	return false, nil
 }
 
+// HasDistroCreatePermission returns true if the user has permission to create
+// distros.
+func (u *DBUser) HasDistroCreatePermission() bool {
+	return u.HasPermission(gimlet.PermissionOpts{
+		Resource:      evergreen.SuperUserPermissionsID,
+		ResourceType:  evergreen.SuperUserResourceType,
+		Permission:    evergreen.PermissionDistroCreate,
+		RequiredLevel: evergreen.DistroCreate.Value,
+	})
+}
+
 func (u *DBUser) DeleteAllRoles() error {
 	info, err := db.FindAndModify(
 		Collection,

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/parsley"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
@@ -632,9 +631,7 @@ func (s *UserTestSuite) TestHasPermission() {
 }
 
 func (s *UserTestSuite) TestHasDistroCreatePermission() {
-	env := &mock.Environment{}
-	s.Require().NoError(env.Configure(s.T().Context()))
-	roleManager := env.RoleManager()
+	roleManager := s.env.RoleManager()
 
 	usr := DBUser{
 		Id: "basic_user",
@@ -649,7 +646,7 @@ func (s *UserTestSuite) TestHasDistroCreatePermission() {
 		Permissions: map[string]int{evergreen.PermissionDistroCreate: evergreen.DistroCreate.Value},
 	}
 	s.Require().NoError(roleManager.UpdateRole(createRole))
-	s.Require().NoError(usr.AddRole(s.T().Context(), "create_distro"))
+	s.Require().NoError(usr.AddRole(s.T().Context(), createRole.ID))
 
 	superUserScope := gimlet.Scope{
 		ID:        "superuser_scope",

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -12,6 +12,7 @@ import (
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/units"
@@ -356,12 +357,7 @@ func (h *hostFilterGetHandler) Run(ctx context.Context) gimlet.Responder {
 	dbUser := MustHaveUser(ctx)
 	username := ""
 	// only admins see hosts that aren't theirs
-	if h.params.Mine || !dbUser.HasPermission(gimlet.PermissionOpts{
-		Resource:      evergreen.SuperUserPermissionsID,
-		ResourceType:  evergreen.SuperUserResourceType,
-		Permission:    evergreen.PermissionDistroCreate,
-		RequiredLevel: evergreen.DistroCreate.Value,
-	}) {
+	if h.params.Mine || !userHasDistroCreatePermission(dbUser) {
 		username = dbUser.Username()
 	}
 
@@ -380,6 +376,15 @@ func (h *hostFilterGetHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	return resp
+}
+
+func userHasDistroCreatePermission(u *user.DBUser) bool {
+	return u.HasPermission(gimlet.PermissionOpts{
+		Resource:      evergreen.SuperUserPermissionsID,
+		ResourceType:  evergreen.SuperUserResourceType,
+		Permission:    evergreen.PermissionDistroCreate,
+		RequiredLevel: evergreen.DistroCreate.Value,
+	})
 }
 
 // GET /hosts/{host_id}/provisioning_options

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -12,7 +12,6 @@ import (
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/units"
@@ -357,7 +356,7 @@ func (h *hostFilterGetHandler) Run(ctx context.Context) gimlet.Responder {
 	dbUser := MustHaveUser(ctx)
 	username := ""
 	// only admins see hosts that aren't theirs
-	if h.params.Mine || !userHasDistroCreatePermission(dbUser) {
+	if h.params.Mine || !dbUser.HasDistroCreatePermission() {
 		username = dbUser.Username()
 	}
 
@@ -376,15 +375,6 @@ func (h *hostFilterGetHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	return resp
-}
-
-func userHasDistroCreatePermission(u *user.DBUser) bool {
-	return u.HasPermission(gimlet.PermissionOpts{
-		Resource:      evergreen.SuperUserPermissionsID,
-		ResourceType:  evergreen.SuperUserResourceType,
-		Permission:    evergreen.PermissionDistroCreate,
-		RequiredLevel: evergreen.DistroCreate.Value,
-	})
 }
 
 // GET /hosts/{host_id}/provisioning_options

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -78,7 +78,10 @@ func (hph *hostPostHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding distro '%s'", hph.options.DistroID))
 		}
 		if d == nil {
-			return gimlet.MakeJSONErrorResponder(errors.Errorf("distro '%s' not found", hph.options.DistroID))
+			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+				StatusCode: http.StatusNotFound,
+				Message:    errors.Errorf("distro '%s' not found", hph.options.DistroID).Error(),
+			})
 		}
 		if d.AdminOnly {
 			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -81,7 +81,10 @@ func (hph *hostPostHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.MakeJSONErrorResponder(errors.Errorf("distro '%s' not found", hph.options.DistroID))
 		}
 		if d.AdminOnly {
-			return gimlet.MakeJSONErrorResponder(errors.Errorf("insufficient permissions to spawn admin-only distro '%s'", hph.options.DistroID))
+			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+				StatusCode: http.StatusForbidden,
+				Message:    errors.Errorf("not authorized to spawn admin-only distro '%s'", hph.options.DistroID).Error(),
+			})
 		}
 	}
 

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -72,7 +72,7 @@ func (hph *hostPostHandler) Run(ctx context.Context) gimlet.Responder {
 		hph.options.SetDefaultTimeZone(user.Settings.Timezone)
 	}
 
-	if !userHasDistroCreatePermission(user) {
+	if !user.HasDistroCreatePermission() {
 		d, err := distro.FindOneId(ctx, hph.options.DistroID)
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding distro '%s'", hph.options.DistroID))

--- a/rest/route/host_spawn_test.go
+++ b/rest/route/host_spawn_test.go
@@ -28,110 +28,6 @@ import (
 )
 
 func TestHostPostHandler(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	require.NoError(t, db.ClearCollections(distro.Collection, host.Collection))
-
-	env := &mock.Environment{}
-	assert.NoError(t, env.Configure(ctx))
-	env.EvergreenSettings.Spawnhost.SpawnHostsPerUser = 10
-	env.EvergreenSettings.Spawnhost.UnexpirableHostsPerUser = 5
-	var err error
-	env.RemoteGroup, err = queue.NewLocalQueueGroup(ctx, queue.LocalQueueGroupOptions{
-		DefaultQueue: queue.LocalQueueOptions{Constructor: func(context.Context) (amboy.Queue, error) {
-			return queue.NewLocalLimitedSize(2, 1048), nil
-		}}})
-	assert.NoError(t, err)
-
-	doc := birch.NewDocument(
-		birch.EC.String("ami", "ami-123"),
-		birch.EC.String("region", evergreen.DefaultEC2Region),
-	)
-	d := &distro.Distro{
-		Id:                   "distro",
-		SpawnAllowed:         true,
-		Provider:             evergreen.ProviderNameEc2OnDemand,
-		ProviderSettingsList: []*birch.Document{doc},
-	}
-	require.NoError(t, d.Insert(ctx))
-	assert.NoError(t, err)
-	h := &hostPostHandler{
-		env: env,
-		options: &model.HostRequestOptions{
-			TaskID:   "task",
-			DistroID: "distro",
-			KeyName:  "ssh-rsa YWJjZDEyMzQK",
-		},
-	}
-	u := &user.DBUser{
-		Id:       "user",
-		Settings: user.UserSettings{Timezone: "Asia/Macau"},
-	}
-	ctx = gimlet.AttachUser(ctx, u)
-
-	resp := h.Run(ctx)
-	assert.NotNil(t, t, resp)
-	assert.Equal(t, http.StatusOK, resp.Status())
-
-	h0 := resp.Data().(*model.APIHost)
-	d0, err := distro.FindOneId(ctx, "distro")
-	assert.NoError(t, err)
-	userdata, ok := d0.ProviderSettingsList[0].Lookup("user_data").StringValueOK()
-	assert.False(t, ok)
-	assert.Empty(t, userdata)
-	assert.Empty(t, h0.InstanceTags)
-	assert.Empty(t, h0.InstanceType)
-
-	resp = h.Run(ctx)
-	assert.NotNil(t, resp)
-	assert.Equal(t, http.StatusOK, resp.Status())
-
-	doc = birch.NewDocument(
-		birch.EC.String("ami", "ami-123"),
-		birch.EC.String("user_data", "#!/bin/bash\necho my script"),
-		birch.EC.String("region", evergreen.DefaultEC2Region),
-	)
-	d.ProviderSettingsList = []*birch.Document{doc}
-	assert.NoError(t, d.ReplaceOne(ctx))
-
-	h1 := resp.Data().(*model.APIHost)
-	d1, err := distro.FindOneId(ctx, "distro")
-	assert.NoError(t, err)
-	userdata, ok = d1.ProviderSettingsList[0].Lookup("user_data").StringValueOK()
-	assert.True(t, ok)
-	assert.Equal(t, "#!/bin/bash\necho my script", userdata)
-	assert.Empty(t, h1.InstanceTags)
-	assert.Empty(t, h1.InstanceType)
-
-	h.options.InstanceTags = []host.Tag{
-		{
-			Key:           "ssh-rsa YWJjZDEyMzQK",
-			Value:         "value",
-			CanBeModified: true,
-		},
-	}
-	resp = h.Run(ctx)
-	assert.NotNil(t, resp)
-	assert.Equal(t, http.StatusOK, resp.Status())
-
-	h2 := resp.Data().(*model.APIHost)
-	assert.Equal(t, []host.Tag{{Key: "ssh-rsa YWJjZDEyMzQK", Value: "value", CanBeModified: true}}, h2.InstanceTags)
-	assert.Empty(t, h2.InstanceType)
-
-	d.Provider = evergreen.ProviderNameMock
-	assert.NoError(t, d.ReplaceOne(ctx))
-	env.EvergreenSettings.Providers.AWS.AllowedInstanceTypes = append(env.EvergreenSettings.Providers.AWS.AllowedInstanceTypes, "test_instance_type")
-	h.options.InstanceType = "test_instance_type"
-	h.options.UserData = ""
-	resp = h.Run(ctx)
-	require.NotNil(t, resp)
-	assert.Equal(t, http.StatusOK, resp.Status())
-
-	h3, ok := resp.Data().(*model.APIHost)
-	require.True(t, ok)
-	assert.Equal(t, "test_instance_type", *h3.InstanceType)
-
 	checkUnexpirableHostSchedule := func(t *testing.T, h *host.Host, opts host.SleepScheduleOptions) {
 		assert.True(t, h.NoExpiration)
 		assert.Equal(t, opts.WholeWeekdaysOff, h.SleepSchedule.WholeWeekdaysOff)
@@ -142,107 +38,258 @@ func TestHostPostHandler(t *testing.T) {
 		assert.NotZero(t, h.SleepSchedule.NextStopTime)
 	}
 
-	t.Run("UnexpirableHostSetsDefaultSchedule", func(t *testing.T) {
-		h.options.NoExpiration = true
-		resp := h.Run(ctx)
-		require.NotZero(t, resp)
-		assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro){
+		"SpawnsHostForTask": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			rh.options.TaskID = "task"
+			rh.options.KeyName = "ssh-rsa YWJjZDEyMzQK"
 
-		apiHost, ok := resp.Data().(*model.APIHost)
-		require.True(t, ok)
+			resp := rh.Run(ctx)
+			require.NotNil(t, t, resp)
+			assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
 
-		dbHost, err := host.FindOneId(ctx, utility.FromStringPtr(apiHost.Id))
-		require.NoError(t, err)
-		require.NotZero(t, dbHost)
+			dbHost := resp.Data().(*model.APIHost)
+			dbDistro, err := distro.FindOneId(ctx, d.Id)
+			assert.NoError(t, err)
+			require.NotZero(t, dbDistro)
+			userdata, ok := dbDistro.ProviderSettingsList[0].Lookup("user_data").StringValueOK()
+			assert.False(t, ok)
+			assert.Empty(t, userdata)
+			assert.Empty(t, dbHost.InstanceTags)
+			assert.Empty(t, dbHost.InstanceType)
+		},
+		"SpawnsHostWithUserData": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			doc := birch.NewDocument(
+				birch.EC.String("ami", "ami-123"),
+				birch.EC.String("user_data", "#!/bin/bash\necho my script"),
+				birch.EC.String("region", evergreen.DefaultEC2Region),
+			)
+			d.ProviderSettingsList = []*birch.Document{doc}
+			assert.NoError(t, d.ReplaceOne(ctx))
 
-		var defaultSchedule host.SleepScheduleOptions
-		defaultSchedule.SetDefaultSchedule()
-		defaultSchedule.SetDefaultTimeZone(u.Settings.Timezone)
-		checkUnexpirableHostSchedule(t, dbHost, defaultSchedule)
-	})
-	t.Run("UnexpirableHostSetsExplicitScheduleWithUserDefaultTimeZone", func(t *testing.T) {
-		h.options.NoExpiration = true
-		expectedOpts := host.SleepScheduleOptions{
-			WholeWeekdaysOff: []time.Weekday{time.Monday, time.Tuesday},
-			DailyStartTime:   "01:00",
-			DailyStopTime:    "05:00",
-		}
-		h.options.SleepScheduleOptions = expectedOpts
-		resp := h.Run(ctx)
-		require.NotZero(t, resp)
-		assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
+			resp := rh.Run(ctx)
+			require.NotNil(t, t, resp)
+			assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
 
-		apiHost, ok := resp.Data().(*model.APIHost)
-		require.True(t, ok)
+			dbHost := resp.Data().(*model.APIHost)
+			dbDistro, err := distro.FindOneId(ctx, "distro")
+			assert.NoError(t, err)
+			userdata, ok := dbDistro.ProviderSettingsList[0].Lookup("user_data").StringValueOK()
+			assert.True(t, ok)
+			assert.Equal(t, "#!/bin/bash\necho my script", userdata)
+			assert.Empty(t, dbHost.InstanceTags)
+			assert.Empty(t, dbHost.InstanceType)
+		},
+		"SpawnsHostWithInstanceTags": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			rh.options.InstanceTags = []host.Tag{
+				{
+					Key:           "ssh-rsa YWJjZDEyMzQK",
+					Value:         "value",
+					CanBeModified: true,
+				},
+			}
+			resp := rh.Run(ctx)
+			require.NotNil(t, resp)
+			assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
 
-		dbHost, err := host.FindOneId(ctx, utility.FromStringPtr(apiHost.Id))
-		require.NoError(t, err)
-		require.NotZero(t, dbHost)
+			dbHost := resp.Data().(*model.APIHost)
+			assert.Equal(t, []host.Tag{{Key: "ssh-rsa YWJjZDEyMzQK", Value: "value", CanBeModified: true}}, dbHost.InstanceTags)
+			assert.Empty(t, dbHost.InstanceType)
+		},
+		"SpawnsHostWithExplicitInstanceType": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			d.Provider = evergreen.ProviderNameMock
+			require.NoError(t, d.ReplaceOne(ctx))
 
-		expectedOpts.TimeZone = u.Settings.Timezone
-		checkUnexpirableHostSchedule(t, dbHost, expectedOpts)
-	})
-	t.Run("UnexpirableHostSetsExplicitTimeZoneWithDefaultSchedule", func(t *testing.T) {
-		h.options.NoExpiration = true
-		h.options.SleepScheduleOptions = host.SleepScheduleOptions{
-			TimeZone: "Asia/Seoul",
-		}
-		resp := h.Run(ctx)
-		require.NotZero(t, resp)
-		assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
+			env.EvergreenSettings.Providers.AWS.AllowedInstanceTypes = append(env.EvergreenSettings.Providers.AWS.AllowedInstanceTypes, "test_instance_type")
 
-		apiHost, ok := resp.Data().(*model.APIHost)
-		require.True(t, ok)
+			rh.options.InstanceType = "test_instance_type"
+			rh.options.UserData = ""
+			resp := rh.Run(ctx)
+			require.NotNil(t, resp)
+			assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
 
-		dbHost, err := host.FindOneId(ctx, utility.FromStringPtr(apiHost.Id))
-		require.NoError(t, err)
-		require.NotZero(t, dbHost)
+			dbHost, ok := resp.Data().(*model.APIHost)
+			require.True(t, ok)
+			assert.Equal(t, rh.options.InstanceType, *dbHost.InstanceType)
+		},
+		"AdminOnlyDistroCannotBeSpawnedByNonAdmin": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			assert.False(t, u.HasDistroCreatePermission())
 
-		var defaultSchedule host.SleepScheduleOptions
-		defaultSchedule.SetDefaultSchedule()
-		defaultSchedule.SetDefaultTimeZone("Asia/Seoul")
-		checkUnexpirableHostSchedule(t, dbHost, defaultSchedule)
-	})
-	t.Run("UnexpirableHostSetsExplicitScheduleAndExplicitTimeZone", func(t *testing.T) {
-		h.options.NoExpiration = true
-		expectedOpts := host.SleepScheduleOptions{
-			WholeWeekdaysOff: []time.Weekday{time.Monday, time.Tuesday},
-			DailyStartTime:   "01:00",
-			DailyStopTime:    "05:00",
-			TimeZone:         "Asia/Macau",
-		}
-		h.options.SleepScheduleOptions = expectedOpts
-		resp := h.Run(ctx)
-		require.NotZero(t, resp)
-		assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
+			d.AdminOnly = true
+			require.NoError(t, d.ReplaceOne(ctx))
 
-		apiHost, ok := resp.Data().(*model.APIHost)
-		require.True(t, ok)
+			resp := rh.Run(ctx)
+			require.NotZero(t, resp)
+			assert.Equal(t, http.StatusForbidden, resp.Status(), resp.Data())
+		},
+		"AdminOnlyDistroCanBeSpawnedByDistroAdmin": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			createDistroRole := gimlet.Role{
+				ID:          "create_distro",
+				Name:        "create_distro",
+				Scope:       "superuser_scope",
+				Permissions: map[string]int{evergreen.PermissionDistroCreate: evergreen.DistroCreate.Value},
+			}
+			require.NoError(t, env.RoleManager().UpdateRole(createDistroRole))
+			require.NoError(t, u.AddRole(ctx, createDistroRole.ID))
 
-		dbHost, err := host.FindOneId(ctx, utility.FromStringPtr(apiHost.Id))
-		require.NoError(t, err)
-		require.NotZero(t, dbHost)
+			superuserScope := gimlet.Scope{
+				ID:        "superuser_scope",
+				Name:      "superuser scope",
+				Type:      evergreen.SuperUserResourceType,
+				Resources: []string{evergreen.SuperUserPermissionsID},
+			}
+			require.NoError(t, env.RoleManager().AddScope(superuserScope))
 
-		checkUnexpirableHostSchedule(t, dbHost, expectedOpts)
-	})
-	t.Run("UnexpirableHostSetsOnlyTimeZoneAndUsesDefaultSchedule", func(t *testing.T) {
-		h.options.NoExpiration = true
-		h.options.SleepScheduleOptions = host.SleepScheduleOptions{
-			TimeZone: "Asia/Macau",
-		}
-		resp := h.Run(ctx)
-		require.NotZero(t, resp)
-		assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
-	})
-	t.Run("ExpirableHostCannotSetSleepSchedule", func(t *testing.T) {
-		h.options.NoExpiration = false
-		var defaultSchedule host.SleepScheduleOptions
-		defaultSchedule.SetDefaultSchedule()
-		h.options.SleepScheduleOptions = defaultSchedule
-		resp := h.Run(ctx)
-		require.NotZero(t, resp)
-		assert.NotEqual(t, http.StatusOK, resp.Status(), resp.Data())
-	})
+			assert.True(t, u.HasDistroCreatePermission())
+
+			resp := rh.Run(ctx)
+			require.NotZero(t, resp)
+			assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
+		},
+		"UnexpirableHostSetsDefaultSchedule": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			rh.options.NoExpiration = true
+			resp := rh.Run(ctx)
+			require.NotZero(t, resp)
+			assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
+
+			apiHost, ok := resp.Data().(*model.APIHost)
+			require.True(t, ok)
+
+			dbHost, err := host.FindOneId(ctx, utility.FromStringPtr(apiHost.Id))
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+
+			var defaultSchedule host.SleepScheduleOptions
+			defaultSchedule.SetDefaultSchedule()
+			defaultSchedule.SetDefaultTimeZone(u.Settings.Timezone)
+			checkUnexpirableHostSchedule(t, dbHost, defaultSchedule)
+		},
+		"UnexpirableHostSetsExplicitScheduleWithUserDefaultTimeZone": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			rh.options.NoExpiration = true
+			expectedOpts := host.SleepScheduleOptions{
+				WholeWeekdaysOff: []time.Weekday{time.Monday, time.Tuesday},
+				DailyStartTime:   "01:00",
+				DailyStopTime:    "05:00",
+			}
+			rh.options.SleepScheduleOptions = expectedOpts
+			resp := rh.Run(ctx)
+			require.NotZero(t, resp)
+			assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
+
+			apiHost, ok := resp.Data().(*model.APIHost)
+			require.True(t, ok)
+
+			dbHost, err := host.FindOneId(ctx, utility.FromStringPtr(apiHost.Id))
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+
+			expectedOpts.TimeZone = u.Settings.Timezone
+			checkUnexpirableHostSchedule(t, dbHost, expectedOpts)
+		},
+		"UnexpirableHostSetsExplicitTimeZoneWithDefaultSchedule": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			rh.options.NoExpiration = true
+			rh.options.SleepScheduleOptions = host.SleepScheduleOptions{
+				TimeZone: "Asia/Seoul",
+			}
+			resp := rh.Run(ctx)
+			require.NotZero(t, resp)
+			assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
+
+			apiHost, ok := resp.Data().(*model.APIHost)
+			require.True(t, ok)
+
+			dbHost, err := host.FindOneId(ctx, utility.FromStringPtr(apiHost.Id))
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+
+			var defaultSchedule host.SleepScheduleOptions
+			defaultSchedule.SetDefaultSchedule()
+			defaultSchedule.SetDefaultTimeZone("Asia/Seoul")
+			checkUnexpirableHostSchedule(t, dbHost, defaultSchedule)
+		},
+		"UnexpirableHostSetsExplicitScheduleAndExplicitTimeZone": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			rh.options.NoExpiration = true
+			expectedOpts := host.SleepScheduleOptions{
+				WholeWeekdaysOff: []time.Weekday{time.Monday, time.Tuesday},
+				DailyStartTime:   "01:00",
+				DailyStopTime:    "05:00",
+				TimeZone:         "Asia/Macau",
+			}
+			rh.options.SleepScheduleOptions = expectedOpts
+			resp := rh.Run(ctx)
+			require.NotZero(t, resp)
+			assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
+
+			apiHost, ok := resp.Data().(*model.APIHost)
+			require.True(t, ok)
+
+			dbHost, err := host.FindOneId(ctx, utility.FromStringPtr(apiHost.Id))
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+
+			checkUnexpirableHostSchedule(t, dbHost, expectedOpts)
+		},
+		"UnexpirableHostSetsOnlyTimeZoneAndUsesDefaultSchedule": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			rh.options.NoExpiration = true
+			rh.options.SleepScheduleOptions = host.SleepScheduleOptions{
+				TimeZone: "Asia/Macau",
+			}
+			resp := rh.Run(ctx)
+			require.NotZero(t, resp)
+			assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
+		},
+		"ExpirableHostCannotSetSleepSchedule": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			rh.options.NoExpiration = false
+			var defaultSchedule host.SleepScheduleOptions
+			defaultSchedule.SetDefaultSchedule()
+			rh.options.SleepScheduleOptions = defaultSchedule
+			resp := rh.Run(ctx)
+			require.NotZero(t, resp)
+			assert.NotEqual(t, http.StatusOK, resp.Status(), resp.Data())
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx := t.Context()
+
+			require.NoError(t, db.ClearCollections(distro.Collection, host.Collection))
+			env := &mock.Environment{}
+			assert.NoError(t, env.Configure(ctx))
+			env.EvergreenSettings.Spawnhost.SpawnHostsPerUser = 10
+			env.EvergreenSettings.Spawnhost.UnexpirableHostsPerUser = 5
+			var err error
+			env.RemoteGroup, err = queue.NewLocalQueueGroup(ctx, queue.LocalQueueGroupOptions{
+				DefaultQueue: queue.LocalQueueOptions{Constructor: func(context.Context) (amboy.Queue, error) {
+					return queue.NewLocalLimitedSize(2, 1048), nil
+				}}})
+			require.NoError(t, err)
+
+			doc := birch.NewDocument(
+				birch.EC.String("ami", "ami-123"),
+				birch.EC.String("region", evergreen.DefaultEC2Region),
+			)
+			d := &distro.Distro{
+				Id:                   "distro",
+				SpawnAllowed:         true,
+				Provider:             evergreen.ProviderNameEc2OnDemand,
+				ProviderSettingsList: []*birch.Document{doc},
+			}
+			require.NoError(t, d.Insert(ctx))
+			assert.NoError(t, err)
+			rh := &hostPostHandler{
+				env: env,
+				options: &model.HostRequestOptions{
+					DistroID: d.Id,
+					KeyName:  "ssh-rsa YWJjZDEyMzQK",
+				},
+			}
+			u := &user.DBUser{
+				Id:       "user",
+				Settings: user.UserSettings{Timezone: "Asia/Macau"},
+			}
+			ctx = gimlet.AttachUser(ctx, u)
+
+			tCase(ctx, t, env, rh, u, d)
+		})
+	}
 }
 
 func TestHostModifyHandlers(t *testing.T) {


### PR DESCRIPTION
DEVPROD-15648

### Description
Only allow a user to spawn a host in an admin-only distro if the user has distro create permissions. This requirement applies to both GraphQL and the REST API.

* Enforce requirement that user is a distro admin before spawning a host in an admin-only distro.
* Refactor check for distro admin permissions into helper method.

### Testing
* Tested in staging that trying to spawn the host through `evergreen host create` without distro create permissions resulted in an error.
* Updated existing unit test for distro admin check.