### PR TITLE
DEVPROD-16696: allow use of repo ref id for external id

### DIFF
--- a/agent/command/assume_ec2_role.go
+++ b/agent/command/assume_ec2_role.go
@@ -26,6 +26,8 @@ type ec2AssumeRole struct {
 	// Defaults to 900s (15 minutes).
 	DurationSeconds int32 `mapstructure:"duration_seconds"`
 
+	RepoID string `mapstructure:"repo_id" plugin:"expand"`
+
 	base
 }
 
@@ -60,6 +62,11 @@ func (r *ec2AssumeRole) Execute(ctx context.Context, comm client.Communicator, l
 	request := apimodels.AssumeRoleRequest{
 		RoleARN: r.RoleARN,
 	}
+
+	if r.RepoID == "true" {
+		request.RepoID = true
+	}
+
 	if r.DurationSeconds > 0 {
 		request.DurationSeconds = utility.ToInt32Ptr(r.DurationSeconds)
 	}

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -210,6 +210,8 @@ type AssumeRoleRequest struct {
 	// DurationSeconds is an optional field of the duration of the role session.
 	// It defaults to 15 minutes.
 	DurationSeconds *int32 `json:"duration_seconds"`
+
+	RepoID bool `json:"repo_id"`
 }
 
 // Validate checks that the request has valid values.

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-04-10"
+	AgentVersion = "2025-04-11"
 )
 
 const (

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1837,6 +1837,7 @@ func (h *awsAssumeRole) Run(ctx context.Context) gimlet.Responder {
 		RoleARN:         h.body.RoleARN,
 		Policy:          h.body.Policy,
 		DurationSeconds: h.body.DurationSeconds,
+		RepoID:          h.body.RepoID,
 	})
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "assuming role for task '%s'", h.taskID))


### PR DESCRIPTION
DRAFT DO NOT MERGE OR REVIEW

DEVPROD-16696

This commit adjusts the assume role command to take an optional 'RepoID' field. If set to true, the assume role call will set the external id to be '${repoRefId}-${requester}' instead of '${projectId}-${requester}'. If there is no repoRefId tracked for this project, the command will error out.