### PR TITLE
DEVPROD-53 Thread context for FindAllQ queries

### DIFF
--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -419,12 +419,7 @@ func FindOneQContext(ctx context.Context, collection string, q Q, out any) error
 }
 
 // FindAllQ runs a Q query against the given collection, applying the results to "out."
-func FindAllQ(collection string, q Q, out any) error {
-	return FindAllQContext(context.Background(), collection, q, out)
-}
-
-// FindAllQContext runs a Q query against the given collection, applying the results to "out."
-func FindAllQContext(ctx context.Context, collection string, q Q, out any) error {
+func FindAllQ(ctx context.Context, collection string, q Q, out any) error {
 	if q.maxTime > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, q.maxTime)

--- a/db/db_utils_test.go
+++ b/db/db_utils_test.go
@@ -205,7 +205,7 @@ func TestDBUtils(t *testing.T) {
 			// one and limit to one (meaning only the second struct should be
 			// returned)
 			out := []insertableStruct{}
-			err = FindAllQContext(t.Context(), collection, Query(bson.M{"field_two": 1}).
+			err = FindAllQ(t.Context(), collection, Query(bson.M{"field_two": 1}).
 				Project(bson.M{"field_three": 0}).
 				Sort([]string{"-field_one"}).
 				Limit(1).
@@ -303,7 +303,7 @@ func TestDBUtils(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			out := []insertableStruct{}
-			err = FindAllQContext(t.Context(), collection, Query(bson.M{"field_two": 3}), &out)
+			err = FindAllQ(t.Context(), collection, Query(bson.M{"field_two": 3}), &out)
 			So(err, ShouldBeNil)
 			So(len(out), ShouldEqual, 2)
 

--- a/db/query_test.go
+++ b/db/query_test.go
@@ -56,14 +56,14 @@ func TestQueryExecution(t *testing.T) {
 
 			Convey("BelowFive should return 4 documents", func() {
 				out := []insertableStruct{}
-				err := FindAllQContext(t.Context(), collection, BelowFive, &out)
+				err := FindAllQ(t.Context(), collection, BelowFive, &out)
 				So(err, ShouldBeNil)
 				So(len(out), ShouldEqual, 4)
 			})
 
 			Convey("BelowFiveSorted should return 4 documents, sorted in reverse", func() {
 				out := []insertableStruct{}
-				err := FindAllQContext(t.Context(), collection, BelowFiveSorted, &out)
+				err := FindAllQ(t.Context(), collection, BelowFiveSorted, &out)
 				So(err, ShouldBeNil)
 				So(len(out), ShouldEqual, 4)
 				So(out[0].FieldTwo, ShouldEqual, 4)
@@ -74,14 +74,14 @@ func TestQueryExecution(t *testing.T) {
 
 			Convey("BelowFiveLimit should return 2 documents", func() {
 				out := []insertableStruct{}
-				err := FindAllQContext(t.Context(), collection, BelowFiveLimit, &out)
+				err := FindAllQ(t.Context(), collection, BelowFiveLimit, &out)
 				So(err, ShouldBeNil)
 				So(len(out), ShouldEqual, 2)
 			})
 
 			Convey("JustOneField should return 1 document", func() {
 				out := []bson.M{}
-				err := FindAllQContext(t.Context(), collection, JustOneField, &out)
+				err := FindAllQ(t.Context(), collection, JustOneField, &out)
 				So(err, ShouldBeNil)
 				So(out[0]["three"], ShouldEqual, "COOL")
 			})

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -1099,7 +1099,7 @@ func (r *mutationResolver) AddFavoriteProject(ctx context.Context, opts AddFavor
 func (r *mutationResolver) ClearMySubscriptions(ctx context.Context) (int, error) {
 	usr := mustHaveUser(ctx)
 	username := usr.Username()
-	subs, err := event.FindSubscriptionsByOwner(username, event.OwnerTypePerson)
+	subs, err := event.FindSubscriptionsByOwner(ctx, username, event.OwnerTypePerson)
 	if err != nil {
 		return 0, InternalServerError.Send(ctx, fmt.Sprintf("retrieving subscriptions for user '%s': %s", usr.Id, err.Error()))
 	}

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -299,7 +299,7 @@ func (r *mutationResolver) UpdateHostStatus(ctx context.Context, hostIds []strin
 func (r *mutationResolver) SetPatchVisibility(ctx context.Context, patchIds []string, hidden bool) ([]*restModel.APIPatch, error) {
 	user := mustHaveUser(ctx)
 	updatedPatches := []*restModel.APIPatch{}
-	patches, err := patch.Find(patch.ByStringIds(patchIds))
+	patches, err := patch.Find(ctx, patch.ByStringIds(patchIds))
 
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching patches '%s': %s", patchIds, err.Error()))

--- a/graphql/patch_resolver.go
+++ b/graphql/patch_resolver.go
@@ -50,7 +50,7 @@ func (r *patchResolver) BaseTaskStatuses(ctx context.Context, obj *restModel.API
 // Builds is the resolver for the builds field.
 func (r *patchResolver) Builds(ctx context.Context, obj *restModel.APIPatch) ([]*restModel.APIBuild, error) {
 	versionID := utility.FromStringPtr(obj.Version)
-	builds, err := build.FindBuildsByVersions([]string{versionID})
+	builds, err := build.FindBuildsByVersions(ctx, []string{versionID})
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching builds for version '%s': %s", versionID, err.Error()))
 	}

--- a/graphql/permissions_resolver.go
+++ b/graphql/permissions_resolver.go
@@ -111,7 +111,7 @@ func (r *permissionsResolver) RepoPermissions(ctx context.Context, obj *Permissi
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("repo '%s' not found", options.RepoID))
 	}
 
-	hasRepoViewPermission, err := model.UserHasRepoViewPermission(usr, repo.Id)
+	hasRepoViewPermission, err := model.UserHasRepoViewPermission(ctx, usr, repo.Id)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("checking repo view permission for user '%s' and repo '%s': %s", usr.Id, repo.Id, err.Error()))
 	}

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -30,7 +30,7 @@ import (
 
 // BbGetCreatedTickets is the resolver for the bbGetCreatedTickets field.
 func (r *queryResolver) BbGetCreatedTickets(ctx context.Context, taskID string) ([]*thirdparty.JiraTicket, error) {
-	createdTickets, err := bbGetCreatedTicketsPointers(taskID)
+	createdTickets, err := bbGetCreatedTicketsPointers(ctx, taskID)
 	if err != nil {
 		return nil, err
 	}

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -365,7 +365,7 @@ func (r *queryResolver) Hosts(ctx context.Context, hostID *string, distroID *str
 
 // TaskQueueDistros is the resolver for the taskQueueDistros field.
 func (r *queryResolver) TaskQueueDistros(ctx context.Context) ([]*TaskQueueDistro, error) {
-	queues, err := model.FindAllTaskQueues()
+	queues, err := model.FindAllTaskQueues(ctx)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching all task queues: %s", err.Error()))
 	}

--- a/graphql/resolver.go
+++ b/graphql/resolver.go
@@ -276,7 +276,7 @@ func New(apiURL string) Config {
 
 		if requiredPermission == evergreen.PermissionProjectSettings && permissionInfo.Value == evergreen.ProjectSettingsView.Value {
 			// If we're trying to view a repo project, check if the user has view permission for any branch project instead.
-			hasPermission, err = model.UserHasRepoViewPermission(usr, projectId)
+			hasPermission, err = model.UserHasRepoViewPermission(ctx, usr, projectId)
 			if err != nil {
 				return nil, InternalServerError.Send(ctx, fmt.Sprintf("problem checking repo view permission: %s", err.Error()))
 			}
@@ -312,7 +312,7 @@ func New(apiURL string) Config {
 		}
 
 		// In case this is a repo project, check if the user has view permission for any branch project instead.
-		hasPermission, err = model.UserHasRepoViewPermission(usr, projectId)
+		hasPermission, err = model.UserHasRepoViewPermission(ctx, usr, projectId)
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("problem checking repo view permission: %s", err.Error()))
 		}

--- a/graphql/resolver.go
+++ b/graphql/resolver.go
@@ -52,7 +52,7 @@ func New(apiURL string) Config {
 			patchIds[i] = v.(string)
 		}
 
-		patches, err := patch.Find(patch.ByStringIds(patchIds))
+		patches, err := patch.Find(ctx, patch.ByStringIds(patchIds))
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching patches '%s': %s", patchIds, err.Error()))
 		}

--- a/graphql/task_logs_resolver.go
+++ b/graphql/task_logs_resolver.go
@@ -24,7 +24,7 @@ func (r *taskLogsResolver) AllLogs(ctx context.Context, obj *TaskLogs) ([]*apimo
 func (r *taskLogsResolver) EventLogs(ctx context.Context, obj *TaskLogs) ([]*restModel.TaskAPIEventLogEntry, error) {
 	const logMessageCount = 100
 	// loggedEvents is ordered ts descending
-	loggedEvents, err := event.Find(event.MostRecentTaskEvents(obj.TaskID, logMessageCount))
+	loggedEvents, err := event.Find(ctx, event.MostRecentTaskEvents(obj.TaskID, logMessageCount))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching EventLogs for task '%s': %s", obj.TaskID, err.Error()))
 	}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -670,7 +670,7 @@ func getAPIAliasesForProject(ctx context.Context, projectId string) ([]*restMode
 }
 
 func getAPISubscriptionsForOwner(ctx context.Context, ownerId string, ownerType event.OwnerType) ([]*restModel.APISubscription, error) {
-	subscriptions, err := event.FindSubscriptionsByOwner(ownerId, ownerType)
+	subscriptions, err := event.FindSubscriptionsByOwner(ctx, ownerId, ownerType)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding subscription for owner '%s' and type '%s': %s", ownerId, ownerType, err.Error()))
 	}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -656,7 +656,7 @@ func getRedactedAPIVarsForProject(ctx context.Context, projectId string) (*restM
 }
 
 func getAPIAliasesForProject(ctx context.Context, projectId string) ([]*restModel.APIProjectAlias, error) {
-	aliases, err := model.FindAliasesForProjectFromDb(projectId)
+	aliases, err := model.FindAliasesForProjectFromDb(ctx, projectId)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding aliases for project '%s': %s", projectId, err.Error()))
 	}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -777,8 +777,8 @@ func getValidTaskStatusesFilter(statuses []string) []string {
 	return filteredStatuses
 }
 
-func bbGetCreatedTicketsPointers(taskId string) ([]*thirdparty.JiraTicket, error) {
-	events, err := event.Find(event.TaskEventsForId(taskId))
+func bbGetCreatedTicketsPointers(ctx context.Context, taskId string) ([]*thirdparty.JiraTicket, error) {
+	events, err := event.Find(ctx, event.TaskEventsForId(taskId))
 	if err != nil {
 		return nil, err
 	}

--- a/model/alertrecord/alert_bookkeeping_test.go
+++ b/model/alertrecord/alert_bookkeeping_test.go
@@ -175,7 +175,7 @@ func (s *alertRecordSuite) TestFindOneWithUnsetIDQuery() {
 	s.Equal(2, rec.RevisionOrderNumber)
 
 	records := []AlertRecord{}
-	err = db.FindAllQContext(s.T().Context(), Collection, ByLastFailureTransition(legacyAlertsSubscription, "task", "variant", "project").Limit(999), &records)
+	err = db.FindAllQ(s.T().Context(), Collection, ByLastFailureTransition(legacyAlertsSubscription, "task", "variant", "project").Limit(999), &records)
 	s.NoError(err)
 	s.Len(records, 3)
 }

--- a/model/annotations/db.go
+++ b/model/annotations/db.go
@@ -46,7 +46,7 @@ func FindOne(ctx context.Context, query db.Q) (*TaskAnnotation, error) {
 // Find gets every TaskAnnotation matching the given query.
 func Find(ctx context.Context, query db.Q) ([]TaskAnnotation, error) {
 	annotations := []TaskAnnotation{}
-	err := db.FindAllQContext(ctx, Collection, query, &annotations)
+	err := db.FindAllQ(ctx, Collection, query, &annotations)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding task annotations")
 	}

--- a/model/artifact/db.go
+++ b/model/artifact/db.go
@@ -132,6 +132,6 @@ func FindOne(ctx context.Context, query db.Q) (*Entry, error) {
 // FindAll gets every Entry for the given query
 func FindAll(ctx context.Context, query db.Q) ([]Entry, error) {
 	entries := []Entry{}
-	err := db.FindAllQContext(ctx, Collection, query, &entries)
+	err := db.FindAllQ(ctx, Collection, query, &entries)
 	return entries, err
 }

--- a/model/build/build_test.go
+++ b/model/build/build_test.go
@@ -60,7 +60,7 @@ func TestGenericBuildFinding(t *testing.T) {
 				buildThree := &Build{Id: "buildThree", Project: "b2"}
 				So(buildThree.Insert(t.Context()), ShouldBeNil)
 
-				found, err := Find(ByProject("b1"))
+				found, err := Find(t.Context(), ByProject("b1"))
 				So(err, ShouldBeNil)
 				So(len(found), ShouldEqual, 2)
 				So(buildIdInSlice(found, buildOne.Id), ShouldBeTrue)
@@ -109,7 +109,7 @@ func TestRecentlyFinishedBuilds(t *testing.T) {
 
 			// only the finished ones should be returned
 
-			found, err := Find(ByFinishedAfter(finishTime, "project1", "r1"))
+			found, err := Find(t.Context(), ByFinishedAfter(finishTime, "project1", "r1"))
 			So(err, ShouldBeNil)
 			So(len(found), ShouldEqual, 2)
 			So(buildIdInSlice(found, finishedOne.Id), ShouldBeTrue)
@@ -154,7 +154,7 @@ func TestRecentlyFinishedBuilds(t *testing.T) {
 			// only the one that finished after the specified time should
 			// be returned
 
-			found, err := Find(ByFinishedAfter(finishTime, "project1", "r1"))
+			found, err := Find(t.Context(), ByFinishedAfter(finishTime, "project1", "r1"))
 			So(err, ShouldBeNil)
 			So(len(found), ShouldEqual, 1)
 			So(found[0].Id, ShouldEqual, finishedOne.Id)
@@ -199,7 +199,7 @@ func TestRecentlyFinishedBuilds(t *testing.T) {
 			// only the one with the correct project and requester should be
 			// returned
 
-			found, err := Find(ByFinishedAfter(finishTime, "project1", "r1"))
+			found, err := Find(t.Context(), ByFinishedAfter(finishTime, "project1", "r1"))
 			So(err, ShouldBeNil)
 			So(len(found), ShouldEqual, 1)
 			So(found[0].Id, ShouldEqual, matching.Id)
@@ -319,13 +319,13 @@ func TestBulkInsert(t *testing.T) {
 	}
 
 	assert.Error(t, builds.InsertMany(context.Background(), true))
-	dbBuilds, err := Find(db.Q{})
+	dbBuilds, err := Find(t.Context(), db.Q{})
 	assert.NoError(t, err)
 	assert.Len(t, dbBuilds, 1)
 
 	assert.NoError(t, db.ClearCollections(Collection))
 	assert.Error(t, builds.InsertMany(context.Background(), false))
-	dbBuilds, err = Find(db.Q{})
+	dbBuilds, err = Find(t.Context(), db.Q{})
 	assert.NoError(t, err)
 	assert.Len(t, dbBuilds, 3)
 }

--- a/model/build/db.go
+++ b/model/build/db.go
@@ -204,7 +204,7 @@ func FindBuildsByVersions(ctx context.Context, versionIds []string) ([]Build, er
 // Find returns all builds that satisfy the query.
 func Find(ctx context.Context, query db.Q) ([]Build, error) {
 	builds := []Build{}
-	err := db.FindAllQContext(ctx, Collection, query, &builds)
+	err := db.FindAllQ(ctx, Collection, query, &builds)
 	return builds, err
 }
 

--- a/model/build/db.go
+++ b/model/build/db.go
@@ -196,15 +196,15 @@ func FindOneId(ctx context.Context, id string) (*Build, error) {
 
 // FindBuildsByVersions finds builds matching the version. This only populates a
 // subset of the build fields.
-func FindBuildsByVersions(versionIds []string) ([]Build, error) {
-	return Find(ByVersions(versionIds).
+func FindBuildsByVersions(ctx context.Context, versionIds []string) ([]Build, error) {
+	return Find(ctx, ByVersions(versionIds).
 		WithFields(BuildVariantKey, DisplayNameKey, TasksKey, VersionKey, StatusKey, TimeTakenKey, PredictedMakespanKey, ActualMakespanKey, HasUnfinishedEssentialTaskKey))
 }
 
 // Find returns all builds that satisfy the query.
-func Find(query db.Q) ([]Build, error) {
+func Find(ctx context.Context, query db.Q) ([]Build, error) {
 	builds := []Build{}
-	err := db.FindAllQ(Collection, query, &builds)
+	err := db.FindAllQContext(ctx, Collection, query, &builds)
 	return builds, err
 }
 
@@ -240,7 +240,7 @@ func FindProjectForBuild(ctx context.Context, buildID string) (string, error) {
 }
 
 // FindBuildsForTasks returns all builds that cover the given tasks
-func FindBuildsForTasks(tasks []task.Task) ([]Build, error) {
+func FindBuildsForTasks(ctx context.Context, tasks []task.Task) ([]Build, error) {
 	buildIdsMap := map[string]bool{}
 	var buildIds []string
 	for _, t := range tasks {
@@ -249,7 +249,7 @@ func FindBuildsForTasks(tasks []task.Task) ([]Build, error) {
 	for buildId := range buildIdsMap {
 		buildIds = append(buildIds, buildId)
 	}
-	builds, err := Find(ByIds(buildIds))
+	builds, err := Find(ctx, ByIds(buildIds))
 	if err != nil {
 		return nil, errors.Wrap(err, "getting builds")
 	}

--- a/model/build_variant_history.go
+++ b/model/build_variant_history.go
@@ -66,7 +66,7 @@ func (bvhi *buildVariantHistoryIterator) GetItems(ctx context.Context, beforeCom
 	).Sort([]string{"-" + VersionRevisionOrderNumberKey}).Limit(numRevisions)
 
 	//Get the next numCommits
-	versions, err := VersionFind(versionQuery)
+	versions, err := VersionFind(ctx, versionQuery)
 
 	if err != nil {
 		return nil, nil, err

--- a/model/event/admin_event.go
+++ b/model/event/admin_event.go
@@ -103,8 +103,8 @@ func stripInteriorSections(config *evergreen.Settings) *evergreen.Settings {
 	return configInterface.(*evergreen.Settings)
 }
 
-func FindAdmin(query db.Q) ([]EventLogEntry, error) {
-	eventsRaw, err := Find(query)
+func FindAdmin(ctx context.Context, query db.Q) ([]EventLogEntry, error) {
+	eventsRaw, err := Find(ctx, query)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +166,7 @@ func convertRaw(in rawAdminEventData) (*AdminEventData, error) {
 
 // RevertConfig reverts one config section to the before state of the specified GUID in the event log
 func RevertConfig(ctx context.Context, guid string, user string) error {
-	events, err := FindAdmin(ByAdminGuid(guid))
+	events, err := FindAdmin(ctx, ByAdminGuid(guid))
 	if err != nil {
 		return errors.Wrap(err, "finding events")
 	}

--- a/model/event/admin_event_test.go
+++ b/model/event/admin_event_test.go
@@ -39,7 +39,7 @@ func (s *AdminEventSuite) TestEventLogging() {
 		RepotrackerDisabled: true,
 	}
 	s.NoError(LogAdminEvent(s.T().Context(), before.SectionId(), &before, &after, s.username))
-	dbEvents, err := FindAdmin(RecentAdminEvents(1))
+	dbEvents, err := FindAdmin(s.T().Context(), RecentAdminEvents(1))
 	s.NoError(err)
 	s.Require().Len(dbEvents, 1)
 	eventData := dbEvents[0].Data.(*AdminEventData)
@@ -58,7 +58,7 @@ func (s *AdminEventSuite) TestEventLogging2() {
 	}
 	after := evergreen.Settings{}
 	s.NoError(LogAdminEvent(s.T().Context(), before.SectionId(), &before, &after, s.username))
-	dbEvents, err := FindAdmin(RecentAdminEvents(1))
+	dbEvents, err := FindAdmin(s.T().Context(), RecentAdminEvents(1))
 	s.NoError(err)
 	s.Require().Len(dbEvents, 1)
 	eventData := dbEvents[0].Data.(*AdminEventData)
@@ -81,7 +81,7 @@ func (s *AdminEventSuite) TestEventLogging3() {
 		},
 	}
 	s.NoError(LogAdminEvent(s.T().Context(), before.SectionId(), &before, &after, s.username))
-	dbEvents, err := FindAdmin(RecentAdminEvents(1))
+	dbEvents, err := FindAdmin(s.T().Context(), RecentAdminEvents(1))
 	s.NoError(err)
 	s.Require().Len(dbEvents, 1)
 	eventData := dbEvents[0].Data.(*AdminEventData)
@@ -106,7 +106,7 @@ func (s *AdminEventSuite) TestNoSpuriousLogging() {
 		},
 	}
 	s.NoError(LogAdminEvent(s.T().Context(), before.SectionId(), &before, &after, s.username))
-	dbEvents, err := FindAdmin(RecentAdminEvents(5))
+	dbEvents, err := FindAdmin(s.T().Context(), RecentAdminEvents(5))
 	s.NoError(err)
 	s.Empty(dbEvents)
 }
@@ -119,7 +119,7 @@ func (s *AdminEventSuite) TestNoChanges() {
 		TaskFinder: "legacy",
 	}
 	s.NoError(LogAdminEvent(s.T().Context(), before.SectionId(), &before, &after, s.username))
-	dbEvents, err := FindAdmin(RecentAdminEvents(1))
+	dbEvents, err := FindAdmin(s.T().Context(), RecentAdminEvents(1))
 	s.NoError(err)
 	s.Empty(dbEvents)
 }
@@ -137,7 +137,7 @@ func (s *AdminEventSuite) TestReverting() {
 	s.NoError(after.Set(ctx))
 	s.NoError(LogAdminEvent(s.T().Context(), before.SectionId(), &before, &after, s.username))
 
-	dbEvents, err := FindAdmin(RecentAdminEvents(1))
+	dbEvents, err := FindAdmin(s.T().Context(), RecentAdminEvents(1))
 	s.NoError(err)
 	s.Require().Len(dbEvents, 1)
 	eventData := dbEvents[0].Data.(*AdminEventData)
@@ -181,7 +181,7 @@ func (s *AdminEventSuite) TestRevertingRoot() {
 	s.NoError(evergreen.UpdateConfig(ctx, &after))
 	s.NoError(LogAdminEvent(s.T().Context(), before.SectionId(), &before, &after, s.username))
 
-	dbEvents, err := FindAdmin(RecentAdminEvents(1))
+	dbEvents, err := FindAdmin(s.T().Context(), RecentAdminEvents(1))
 	s.NoError(err)
 	s.Require().Len(dbEvents, 1)
 	eventData := dbEvents[0].Data.(*AdminEventData)
@@ -209,7 +209,7 @@ func TestAdminEventsBeforeQuery(t *testing.T) {
 	now := time.Now()
 	time.Sleep(10 * time.Millisecond)
 	assert.NoError(LogAdminEvent(t.Context(), "service_flags", before, after, "afterNow"))
-	events, err := FindAdmin(AdminEventsBefore(now, 5))
+	events, err := FindAdmin(t.Context(), AdminEventsBefore(now, 5))
 	assert.NoError(err)
 	require.Len(t, events, 1)
 	assert.True(events[0].Timestamp.Before(now))

--- a/model/event/event_finder.go
+++ b/model/event/event_finder.go
@@ -33,7 +33,7 @@ func ResourceTypeKeyIs(key string) bson.M {
 // by one of the query functions, and returns a slice of events.
 func Find(ctx context.Context, query db.Q) ([]EventLogEntry, error) {
 	events := []EventLogEntry{}
-	err := db.FindAllQContext(ctx, EventCollection, query, &events)
+	err := db.FindAllQ(ctx, EventCollection, query, &events)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -48,7 +48,7 @@ func FindPaginatedWithTotalCount(ctx context.Context, query db.Q, limit, page in
 		query = query.Skip(skip)
 	}
 
-	err := db.FindAllQContext(ctx, EventCollection, query, &events)
+	err := db.FindAllQ(ctx, EventCollection, query, &events)
 	if err != nil {
 		return nil, 0, errors.WithStack(err)
 	}
@@ -70,7 +70,7 @@ func FindUnprocessedEvents(ctx context.Context, limit int) ([]EventLogEntry, err
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
-	err := db.FindAllQContext(ctx, EventCollection, query, &out)
+	err := db.FindAllQ(ctx, EventCollection, query, &out)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching unprocessed events")
 	}

--- a/model/event/event_finder.go
+++ b/model/event/event_finder.go
@@ -48,7 +48,7 @@ func FindPaginatedWithTotalCount(ctx context.Context, query db.Q, limit, page in
 		query = query.Skip(skip)
 	}
 
-	err := db.FindAllQ(EventCollection, query, &events)
+	err := db.FindAllQContext(ctx, EventCollection, query, &events)
 	if err != nil {
 		return nil, 0, errors.WithStack(err)
 	}
@@ -64,13 +64,13 @@ func FindPaginatedWithTotalCount(ctx context.Context, query db.Q, limit, page in
 
 // FindUnprocessedEvents returns all unprocessed events in EventCollection.
 // Events are considered unprocessed if their "processed_at" time IsZero
-func FindUnprocessedEvents(limit int) ([]EventLogEntry, error) {
+func FindUnprocessedEvents(ctx context.Context, limit int) ([]EventLogEntry, error) {
 	out := []EventLogEntry{}
 	query := db.Query(unprocessedEvents()).Sort([]string{TimestampKey})
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
-	err := db.FindAllQ(EventCollection, query, &out)
+	err := db.FindAllQContext(ctx, EventCollection, query, &out)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetching unprocessed events")
 	}

--- a/model/event/event_finder.go
+++ b/model/event/event_finder.go
@@ -31,9 +31,9 @@ func ResourceTypeKeyIs(key string) bson.M {
 
 // Find takes a collection storing events and a query, generated
 // by one of the query functions, and returns a slice of events.
-func Find(query db.Q) ([]EventLogEntry, error) {
+func Find(ctx context.Context, query db.Q) ([]EventLogEntry, error) {
 	events := []EventLogEntry{}
-	err := db.FindAllQ(EventCollection, query, &events)
+	err := db.FindAllQContext(ctx, EventCollection, query, &events)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -327,8 +327,8 @@ func AdminEventsBefore(before time.Time, n int) db.Q {
 	return db.Query(filter).Sort([]string{"-" + TimestampKey}).Limit(n)
 }
 
-func FindAllByResourceID(resourceID string) ([]EventLogEntry, error) {
-	return Find(db.Query(bson.M{ResourceIdKey: resourceID}))
+func FindAllByResourceID(ctx context.Context, resourceID string) ([]EventLogEntry, error) {
+	return Find(ctx, db.Query(bson.M{ResourceIdKey: resourceID}))
 }
 
 // Pod events

--- a/model/event/event_test.go
+++ b/model/event/event_test.go
@@ -75,7 +75,7 @@ func (s *eventSuite) TestWithRealData() {
 		},
 	}
 	s.NoError(db.Insert(s.T().Context(), EventCollection, data))
-	entries, err := Find(db.Query(bson.M{idKey: mgobson.ObjectIdHex("5949645c9acd9604fdd202d8")}))
+	entries, err := Find(s.T().Context(), db.Query(bson.M{idKey: mgobson.ObjectIdHex("5949645c9acd9604fdd202d8")}))
 	s.NoError(err)
 	s.Len(entries, 1)
 	s.NotPanics(func() {
@@ -110,7 +110,7 @@ func (s *eventSuite) TestWithRealData() {
 		},
 	}
 	s.NoError(db.Insert(s.T().Context(), EventCollection, data))
-	entries, err = Find(db.Query(bson.M{idKey: mgobson.ObjectIdHex("5949645c9acd9604fdd202d9")}))
+	entries, err = Find(s.T().Context(), db.Query(bson.M{idKey: mgobson.ObjectIdHex("5949645c9acd9604fdd202d9")}))
 	s.NoError(err)
 	s.Len(entries, 1)
 	s.NotPanics(func() {
@@ -134,7 +134,7 @@ func (s *eventSuite) TestWithRealData() {
 	// check that string IDs are preserved in the DB
 	data[idKey] = "elephant"
 	s.NoError(db.Insert(s.T().Context(), EventCollection, data))
-	entries, err = Find(db.Query(bson.M{idKey: "elephant"}))
+	entries, err = Find(s.T().Context(), db.Query(bson.M{idKey: "elephant"}))
 	s.NoError(err)
 	s.Len(entries, 1)
 	s.Equal("elephant", entries[0].ID)
@@ -153,7 +153,7 @@ func (s *eventSuite) TestEventWithNilData() {
 	s.NotPanics(func() {
 		// But reading this back should not panic, if it somehow got into the db
 		s.NoError(db.Insert(s.T().Context(), EventCollection, event))
-		fetchedEvents, err := Find(db.Query(bson.M{}))
+		fetchedEvents, err := Find(s.T().Context(), db.Query(bson.M{}))
 		s.Require().Error(err)
 		s.Nil(fetchedEvents)
 	})

--- a/model/event/event_test.go
+++ b/model/event/event_test.go
@@ -335,7 +335,7 @@ func (s *eventSuite) TestFindUnprocessedEvents() {
 	for i := range data {
 		s.NoError(db.Insert(s.T().Context(), EventCollection, data[i]))
 	}
-	events, err := FindUnprocessedEvents(-1)
+	events, err := FindUnprocessedEvents(s.T().Context(), -1)
 	s.NoError(err)
 	s.Len(events, 1)
 
@@ -504,7 +504,7 @@ func (s *eventSuite) TestLogManyEvents() {
 	}
 	s.NoError(LogManyEvents(s.T().Context(), []EventLogEntry{event1, event2}))
 	events := []EventLogEntry{}
-	s.NoError(db.FindAllQ(EventCollection, db.Query(bson.M{}), &events))
+	s.NoError(db.FindAllQContext(s.T().Context(), EventCollection, db.Query(bson.M{}), &events))
 	s.Len(events, 2)
 	s.Equal("resource_id_1", events[0].ResourceId)
 	s.Equal("some_type", events[0].EventType)

--- a/model/event/event_test.go
+++ b/model/event/event_test.go
@@ -504,7 +504,7 @@ func (s *eventSuite) TestLogManyEvents() {
 	}
 	s.NoError(LogManyEvents(s.T().Context(), []EventLogEntry{event1, event2}))
 	events := []EventLogEntry{}
-	s.NoError(db.FindAllQContext(s.T().Context(), EventCollection, db.Query(bson.M{}), &events))
+	s.NoError(db.FindAllQ(s.T().Context(), EventCollection, db.Query(bson.M{}), &events))
 	s.Len(events, 2)
 	s.Equal("resource_id_1", events[0].ResourceId)
 	s.Equal("some_type", events[0].EventType)

--- a/model/event/host_event_test.go
+++ b/model/event/host_event_test.go
@@ -39,7 +39,7 @@ func TestLoggingHostEvents(t *testing.T) {
 			Limit:   50,
 			SortAsc: false,
 		}
-		eventsForHost, err := Find(HostEvents(hostEventOpts))
+		eventsForHost, err := Find(t.Context(), HostEvents(hostEventOpts))
 		assert.NoError(t, err)
 
 		assert.Len(t, eventsForHost, 6)

--- a/model/event/pod_test.go
+++ b/model/event/pod_test.go
@@ -17,7 +17,7 @@ func TestPodEvents(t *testing.T) {
 			reason := "some reason"
 			LogPodStatusChanged(t.Context(), id, oldStatus, newStatus, reason)
 
-			events, err := Find(MostRecentPodEvents(id, 10))
+			events, err := Find(t.Context(), MostRecentPodEvents(id, 10))
 			require.NoError(t, err)
 			require.Len(t, events, 1)
 
@@ -35,7 +35,7 @@ func TestPodEvents(t *testing.T) {
 			execution := 5
 			LogPodAssignedTask(t.Context(), podID, taskID, 5)
 
-			events, err := Find(MostRecentPodEvents(podID, 10))
+			events, err := Find(t.Context(), MostRecentPodEvents(podID, 10))
 			require.NoError(t, err)
 			require.Len(t, events, 1)
 

--- a/model/event/subscribers_test.go
+++ b/model/event/subscribers_test.go
@@ -58,7 +58,7 @@ func TestSubscribers(t *testing.T) {
 	}
 
 	fetchedSubs := []Subscriber{}
-	assert.NoError(db.FindAllQContext(t.Context(), SubscriptionsCollection, db.Q{}, &fetchedSubs))
+	assert.NoError(db.FindAllQ(t.Context(), SubscriptionsCollection, db.Q{}, &fetchedSubs))
 
 	assert.Len(fetchedSubs, 5)
 
@@ -73,7 +73,7 @@ func TestSubscribers(t *testing.T) {
 		Target: "*boom*",
 	}))
 	fetchedSubs = []Subscriber{}
-	err := db.FindAllQContext(t.Context(), SubscriptionsCollection, db.Q{}, &fetchedSubs)
+	err := db.FindAllQ(t.Context(), SubscriptionsCollection, db.Q{}, &fetchedSubs)
 
 	require.Error(t, err)
 	assert.Contains(err.Error(), "unknown subscriber type 'something completely different'")

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -398,7 +398,7 @@ func FindSubscriptionsByAttributes(ctx context.Context, resourceType string, eve
 	}
 
 	selectorFiltered := []Subscription{}
-	if err := db.FindAllQContext(ctx, SubscriptionsCollection, db.Query(query), &selectorFiltered); err != nil {
+	if err := db.FindAllQ(ctx, SubscriptionsCollection, db.Query(query), &selectorFiltered); err != nil {
 		return nil, errors.Wrap(err, "finding subscriptions for selectors")
 	}
 
@@ -698,7 +698,7 @@ func FindSubscriptionsByOwner(ctx context.Context, owner string, ownerType Owner
 		subscriptionOwnerTypeKey: ownerType,
 	})
 	subscriptions := []Subscription{}
-	err := db.FindAllQContext(ctx, SubscriptionsCollection, query, &subscriptions)
+	err := db.FindAllQ(ctx, SubscriptionsCollection, query, &subscriptions)
 	return subscriptions, errors.Wrapf(err, "retrieving subscriptions for owner '%s'", owner)
 }
 

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -385,7 +385,7 @@ const (
 
 // FindSubscriptionsByAttributes finds all subscriptions of matching resourceType, and whose
 // filter and regex selectors match the attributes of the event.
-func FindSubscriptionsByAttributes(resourceType string, eventAttributes Attributes) ([]Subscription, error) {
+func FindSubscriptionsByAttributes(ctx context.Context, resourceType string, eventAttributes Attributes) ([]Subscription, error) {
 	if eventAttributes.isUnset() {
 		return nil, nil
 	}
@@ -398,7 +398,7 @@ func FindSubscriptionsByAttributes(resourceType string, eventAttributes Attribut
 	}
 
 	selectorFiltered := []Subscription{}
-	if err := db.FindAllQ(SubscriptionsCollection, db.Query(query), &selectorFiltered); err != nil {
+	if err := db.FindAllQContext(ctx, SubscriptionsCollection, db.Query(query), &selectorFiltered); err != nil {
 		return nil, errors.Wrap(err, "finding subscriptions for selectors")
 	}
 
@@ -447,7 +447,7 @@ func regexMatchesValue(regexString string, values []string) bool {
 
 // CopyProjectSubscriptions copies subscriptions from the first project for the second project.
 func CopyProjectSubscriptions(ctx context.Context, oldProject, newProject string) error {
-	subs, err := FindSubscriptionsByOwner(oldProject, OwnerTypeProject)
+	subs, err := FindSubscriptionsByOwner(ctx, oldProject, OwnerTypeProject)
 	if err != nil {
 		return errors.Wrapf(err, "finding subscription for project '%s'", oldProject)
 	}
@@ -686,7 +686,7 @@ func (s *Subscription) String() string {
 	return out
 }
 
-func FindSubscriptionsByOwner(owner string, ownerType OwnerType) ([]Subscription, error) {
+func FindSubscriptionsByOwner(ctx context.Context, owner string, ownerType OwnerType) ([]Subscription, error) {
 	if len(owner) == 0 {
 		return nil, nil
 	}
@@ -698,7 +698,7 @@ func FindSubscriptionsByOwner(owner string, ownerType OwnerType) ([]Subscription
 		subscriptionOwnerTypeKey: ownerType,
 	})
 	subscriptions := []Subscription{}
-	err := db.FindAllQ(SubscriptionsCollection, query, &subscriptions)
+	err := db.FindAllQContext(ctx, SubscriptionsCollection, query, &subscriptions)
 	return subscriptions, errors.Wrapf(err, "retrieving subscriptions for owner '%s'", owner)
 }
 

--- a/model/event/subscriptions_test.go
+++ b/model/event/subscriptions_test.go
@@ -152,7 +152,7 @@ func (s *subscriptionsSuite) SetupTest() {
 
 func (s *subscriptionsSuite) TestUpsert() {
 	out := []Subscription{}
-	s.NoError(db.FindAllQContext(s.T().Context(), SubscriptionsCollection, db.Q{}, &out))
+	s.NoError(db.FindAllQ(s.T().Context(), SubscriptionsCollection, db.Q{}, &out))
 
 	s.Require().Len(out, 6)
 
@@ -174,7 +174,7 @@ func (s *subscriptionsSuite) TestRemove() {
 		s.NoError(RemoveSubscription(s.T().Context(), s.subscriptions[i].ID))
 
 		out := []Subscription{}
-		s.NoError(db.FindAllQContext(s.T().Context(), SubscriptionsCollection, db.Q{}, &out))
+		s.NoError(db.FindAllQ(s.T().Context(), SubscriptionsCollection, db.Q{}, &out))
 		s.Len(out, len(s.subscriptions)-i-1)
 	}
 }

--- a/model/event/subscriptions_test.go
+++ b/model/event/subscriptions_test.go
@@ -275,13 +275,13 @@ func (s *subscriptionsSuite) TestAttributesValuesForSelector() {
 
 func (s *subscriptionsSuite) TestFindSubscriptionsByAttributes() {
 	s.Run("EmptySelectors", func() {
-		subs, err := FindSubscriptionsByAttributes("type2", Attributes{})
+		subs, err := FindSubscriptionsByAttributes(s.T().Context(), "type2", Attributes{})
 		s.NoError(err)
 		s.Empty(subs)
 	})
 
 	s.Run("NothingMatches", func() {
-		subs, err := FindSubscriptionsByAttributes("type1", Attributes{
+		subs, err := FindSubscriptionsByAttributes(s.T().Context(), "type1", Attributes{
 			Object: []string{"nothing_matches"},
 		})
 		s.NoError(err)
@@ -289,7 +289,7 @@ func (s *subscriptionsSuite) TestFindSubscriptionsByAttributes() {
 	})
 
 	s.Run("MatchesMultipleSubscriptions", func() {
-		subs, err := FindSubscriptionsByAttributes("type2", Attributes{
+		subs, err := FindSubscriptionsByAttributes(s.T().Context(), "type2", Attributes{
 			Object: []string{"somethingspecial"},
 		})
 		s.NoError(err)
@@ -301,7 +301,7 @@ func (s *subscriptionsSuite) TestFindSubscriptionsByAttributes() {
 	})
 
 	s.Run("MatchesRegexSelector", func() {
-		subs, err := FindSubscriptionsByAttributes("type1", Attributes{
+		subs, err := FindSubscriptionsByAttributes(s.T().Context(), "type1", Attributes{
 			ID:      []string{"something"},
 			Project: []string{"somethingelse"},
 		})
@@ -513,7 +513,7 @@ func (s *subscriptionsSuite) TestFromSelectors() {
 }
 
 func (s *subscriptionsSuite) TestFindByOwnerForPerson() {
-	subscriptions, err := FindSubscriptionsByOwner("me", OwnerTypePerson)
+	subscriptions, err := FindSubscriptionsByOwner(s.T().Context(), "me", OwnerTypePerson)
 	s.NoError(err)
 	s.Len(subscriptions, 2)
 	for _, sub := range subscriptions {
@@ -523,7 +523,7 @@ func (s *subscriptionsSuite) TestFindByOwnerForPerson() {
 }
 
 func (s *subscriptionsSuite) TestFindByOwnerForProject() {
-	subscriptions, err := FindSubscriptionsByOwner("me", OwnerTypeProject)
+	subscriptions, err := FindSubscriptionsByOwner(s.T().Context(), "me", OwnerTypeProject)
 	s.NoError(err)
 	s.Require().Len(subscriptions, 1)
 	s.Equal("me", subscriptions[0].Owner)
@@ -554,7 +554,7 @@ func (s *subscriptionsSuite) TestCreateOrUpdateGeneralSubscription() {
 		subscriber, "octocat")
 	s.NoError(err)
 
-	subscriptions, err := FindSubscriptionsByOwner("octocat", OwnerTypePerson)
+	subscriptions, err := FindSubscriptionsByOwner(s.T().Context(), "octocat", OwnerTypePerson)
 	s.NoError(err)
 	s.Require().Len(subscriptions, 1)
 	s.Equal(subscriptions[0].ID, subscription.ID)
@@ -608,14 +608,14 @@ func TestCopyProjectSubscriptions(t *testing.T) {
 	for name, test := range map[string]func(t *testing.T){
 		"FromNonExistentProject": func(t *testing.T) {
 			assert.NoError(t, CopyProjectSubscriptions(t.Context(), "not-a-project", "my-new-project"))
-			apiSubs, err := FindSubscriptionsByOwner("my-new-project", OwnerTypeProject)
+			apiSubs, err := FindSubscriptionsByOwner(t.Context(), "my-new-project", OwnerTypeProject)
 			assert.NoError(t, err)
 			require.Empty(t, apiSubs)
 		},
 		"FromExistentProject": func(t *testing.T) {
 			newProjectId := "my-newest-project"
 			assert.NoError(t, CopyProjectSubscriptions(t.Context(), oldProjectId, newProjectId))
-			apiSubs, err := FindSubscriptionsByOwner(oldProjectId, OwnerTypeProject)
+			apiSubs, err := FindSubscriptionsByOwner(t.Context(), oldProjectId, OwnerTypeProject)
 			assert.NoError(t, err)
 			require.Len(t, apiSubs, 1)
 			assert.Equal(t, subs[0].ID, apiSubs[0].ID)
@@ -623,7 +623,7 @@ func TestCopyProjectSubscriptions(t *testing.T) {
 			assert.Equal(t, oldProjectId, apiSubs[0].Selectors[0].Data)
 			assert.Equal(t, oldProjectId, apiSubs[0].Filter.Project)
 
-			apiSubs, err = FindSubscriptionsByOwner(newProjectId, OwnerTypeProject)
+			apiSubs, err = FindSubscriptionsByOwner(t.Context(), newProjectId, OwnerTypeProject)
 			assert.NoError(t, err)
 			require.Len(t, apiSubs, 1)
 			assert.NotEqual(t, subs[0].ID, apiSubs[0].ID)

--- a/model/event/task_event_test.go
+++ b/model/event/task_event_test.go
@@ -37,7 +37,7 @@ func TestLoggingTaskEvents(t *testing.T) {
 			time.Sleep(1 * time.Millisecond)
 			LogHostTaskFinished(t.Context(), taskId, 1, hostId, evergreen.TaskSucceeded)
 
-			eventsForTask, err := Find(TaskEventsInOrder(taskId))
+			eventsForTask, err := Find(t.Context(), TaskEventsInOrder(taskId))
 			So(err, ShouldEqual, nil)
 
 			event := eventsForTask[0]

--- a/model/event/task_event_test.go
+++ b/model/event/task_event_test.go
@@ -114,6 +114,6 @@ func TestLogManyTestEvents(t *testing.T) {
 	require.NoError(db.ClearCollections(EventCollection))
 	LogManyTaskAbortRequests(t.Context(), []string{"task_1", "task_2"}, "example_user")
 	events := []EventLogEntry{}
-	assert.NoError(db.FindAllQContext(t.Context(), EventCollection, db.Query(bson.M{}), &events))
+	assert.NoError(db.FindAllQ(t.Context(), EventCollection, db.Query(bson.M{}), &events))
 	assert.Len(events, 2)
 }

--- a/model/feedback.go
+++ b/model/feedback.go
@@ -37,7 +37,7 @@ func (s *FeedbackSubmission) Insert(ctx context.Context) error {
 func FindFeedbackOfType(ctx context.Context, t string) ([]FeedbackSubmission, error) {
 	out := []FeedbackSubmission{}
 	query := db.Query(bson.M{FeedbackTypeKey: t})
-	err := db.FindAllQContext(ctx, FeedbackCollection, query, &out)
+	err := db.FindAllQ(ctx, FeedbackCollection, query, &out)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding feedback documents")
 	}

--- a/model/feedback.go
+++ b/model/feedback.go
@@ -34,10 +34,10 @@ func (s *FeedbackSubmission) Insert(ctx context.Context) error {
 	return db.Insert(ctx, FeedbackCollection, s)
 }
 
-func FindFeedbackOfType(t string) ([]FeedbackSubmission, error) {
+func FindFeedbackOfType(ctx context.Context, t string) ([]FeedbackSubmission, error) {
 	out := []FeedbackSubmission{}
 	query := db.Query(bson.M{FeedbackTypeKey: t})
-	err := db.FindAllQ(FeedbackCollection, query, &out)
+	err := db.FindAllQContext(ctx, FeedbackCollection, query, &out)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding feedback documents")
 	}

--- a/model/generate.go
+++ b/model/generate.go
@@ -263,7 +263,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 		}
 	}
 
-	existingBuilds, err := build.Find(build.ByVersion(v.Id))
+	existingBuilds, err := build.Find(ctx, build.ByVersion(v.Id))
 	if err != nil {
 		return errors.Wrap(err, "finding builds for version")
 	}
@@ -551,7 +551,7 @@ func (g *GeneratedProject) addDependencyEdgesToGraph(ctx context.Context, newTas
 
 // filterInactiveTasks returns a copy of tasks with the tasks that will not be activated by the generator removed.
 func (g *GeneratedProject) filterInactiveTasks(ctx context.Context, tasks TVPairSet, v *Version, p *Project) (TVPairSet, error) {
-	existingBuilds, err := build.Find(build.ByVersion(v.Id))
+	existingBuilds, err := build.Find(ctx, build.ByVersion(v.Id))
 	if err != nil {
 		return nil, errors.Wrap(err, "finding builds for version")
 	}

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -1041,7 +1041,7 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasksWithBatchtime() {
 	s.Len(pp.BuildVariants, 3)
 	s.Len(pp.Tasks, 6)
 
-	builds, err := build.FindBuildsByVersions([]string{v.Id})
+	builds, err := build.FindBuildsByVersions(s.ctx, []string{v.Id})
 	s.NoError(err)
 	s.Len(builds, 2)
 	for _, b := range builds {
@@ -1150,7 +1150,7 @@ func (s *GenerateSuite) TestSaveWithAlreadyGeneratedTasksAndVariants() {
 	s.Equal("new_task", tasks[2].DisplayName)
 
 	// New build is added.
-	builds, err := build.FindBuildsByVersions([]string{v.Id})
+	builds, err := build.FindBuildsByVersions(s.ctx, []string{v.Id})
 	s.NoError(err)
 	s.Require().Len(builds, 2)
 	s.Equal("new_variant", builds[0].BuildVariant)

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -1141,7 +1141,7 @@ func (s *GenerateSuite) TestSaveWithAlreadyGeneratedTasksAndVariants() {
 
 	tasks := []task.Task{}
 	taskQuery := db.Query(bson.M{task.GeneratedByKey: "generator"}).Sort([]string{task.CreateTimeKey})
-	err = db.FindAllQContext(s.ctx, task.Collection, taskQuery, &tasks)
+	err = db.FindAllQ(s.ctx, task.Collection, taskQuery, &tasks)
 	s.NoError(err)
 	s.Require().Len(tasks, 3)
 	// New task is added both to previously generated variant, and new variant.
@@ -1236,7 +1236,7 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 	s.True(taskWithDepsFound, "task '%s' should have been added to build variant", expectedTask)
 
 	tasks := []task.Task{}
-	s.NoError(db.FindAllQContext(s.ctx, task.Collection, db.Query(bson.M{task.DisplayNameKey: expectedTask}), &tasks))
+	s.NoError(db.FindAllQ(s.ctx, task.Collection, db.Query(bson.M{task.DisplayNameKey: expectedTask}), &tasks))
 	s.Require().Len(tasks, 1)
 	s.Require().Len(tasks[0].DependsOn, 3)
 	expected := map[string]bool{"say-hi-task-id": false, "say-bye-task-id": false, "say_something_else": false}
@@ -1290,7 +1290,7 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependenciesInNewBuilds() {
 	s.NoError(g.Save(s.ctx, s.env.Settings(), p, pp, v))
 
 	tasks := []task.Task{}
-	s.NoError(db.FindAllQContext(s.ctx, task.Collection, db.Query(bson.M{task.VersionKey: v.Id}), &tasks))
+	s.NoError(db.FindAllQ(s.ctx, task.Collection, db.Query(bson.M{task.VersionKey: v.Id}), &tasks))
 	s.Require().Len(tasks, 4)
 	for _, t := range tasks {
 		s.True(t.Activated)
@@ -1850,10 +1850,10 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 	s.True(dtFound, "display task '%s' should have been added", expectedDisplayTask)
 
 	tasks := []task.Task{}
-	s.NoError(db.FindAllQContext(s.ctx, task.Collection, db.Query(bson.M{}), &tasks))
-	s.NoError(db.FindAllQContext(s.ctx, task.Collection, db.Query(bson.M{task.DisplayNameKey: "my_display_task_gen"}), &tasks))
+	s.NoError(db.FindAllQ(s.ctx, task.Collection, db.Query(bson.M{}), &tasks))
+	s.NoError(db.FindAllQ(s.ctx, task.Collection, db.Query(bson.M{task.DisplayNameKey: "my_display_task_gen"}), &tasks))
 	s.Len(tasks, 1)
-	s.NoError(db.FindAllQContext(s.ctx, task.Collection, db.Query(bson.M{task.DisplayNameKey: "my_display_task"}), &tasks))
+	s.NoError(db.FindAllQ(s.ctx, task.Collection, db.Query(bson.M{task.DisplayNameKey: "my_display_task"}), &tasks))
 	s.Len(tasks, 1)
 	s.Len(tasks[0].ExecutionTasks, 1)
 }

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1478,14 +1478,14 @@ func ConsolidateHostsForUser(ctx context.Context, oldUser, newUser string) error
 
 // FindUnexpirableRunning returns all unexpirable spawn hosts that are
 // currently running.
-func FindUnexpirableRunning() ([]Host, error) {
+func FindUnexpirableRunning(ctx context.Context) ([]Host, error) {
 	hosts := []Host{}
 	q := bson.M{
 		StatusKey:       evergreen.HostRunning,
 		StartedByKey:    bson.M{"$ne": evergreen.User},
 		NoExpirationKey: true,
 	}
-	return hosts, db.FindAllQ(Collection, db.Query(q), &hosts)
+	return hosts, db.FindAllQContext(ctx, Collection, db.Query(q), &hosts)
 }
 
 // FindOneByPersistentDNSName returns hosts that have a matching persistent DNS

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1284,7 +1284,7 @@ func FindDistroForHost(ctx context.Context, hostID string) (string, error) {
 
 func findVolumes(ctx context.Context, q bson.M) ([]Volume, error) {
 	volumes := []Volume{}
-	return volumes, db.FindAllQContext(ctx, VolumesCollection, db.Query(q), &volumes)
+	return volumes, db.FindAllQ(ctx, VolumesCollection, db.Query(q), &volumes)
 }
 
 type ClientOptions struct {
@@ -1485,7 +1485,7 @@ func FindUnexpirableRunning(ctx context.Context) ([]Host, error) {
 		StartedByKey:    bson.M{"$ne": evergreen.User},
 		NoExpirationKey: true,
 	}
-	return hosts, db.FindAllQContext(ctx, Collection, db.Query(q), &hosts)
+	return hosts, db.FindAllQ(ctx, Collection, db.Query(q), &hosts)
 }
 
 // FindOneByPersistentDNSName returns hosts that have a matching persistent DNS

--- a/model/host/db_test.go
+++ b/model/host/db_test.go
@@ -89,7 +89,7 @@ func TestFindUnexpirableRunning(t *testing.T) {
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, h *Host){
 		"ReturnsUnexpirableRunningHost": func(ctx context.Context, t *testing.T, h *Host) {
 			require.NoError(t, h.Insert(ctx))
-			hosts, err := FindUnexpirableRunning()
+			hosts, err := FindUnexpirableRunning(ctx)
 			require.NoError(t, err)
 			require.Len(t, hosts, 1)
 			assert.Equal(t, h.Id, hosts[0].Id)
@@ -97,21 +97,21 @@ func TestFindUnexpirableRunning(t *testing.T) {
 		"DoesNotReturnExpirableHost": func(ctx context.Context, t *testing.T, h *Host) {
 			h.NoExpiration = false
 			require.NoError(t, h.Insert(ctx))
-			hosts, err := FindUnexpirableRunning()
+			hosts, err := FindUnexpirableRunning(ctx)
 			require.NoError(t, err)
 			assert.Empty(t, hosts)
 		},
 		"DoesNotReturnNonRunningHost": func(ctx context.Context, t *testing.T, h *Host) {
 			h.Status = evergreen.HostStopped
 			require.NoError(t, h.Insert(ctx))
-			hosts, err := FindUnexpirableRunning()
+			hosts, err := FindUnexpirableRunning(ctx)
 			require.NoError(t, err)
 			assert.Empty(t, hosts)
 		},
 		"DoesNotReturnEvergreenOwnedHosts": func(ctx context.Context, t *testing.T, h *Host) {
 			h.StartedBy = evergreen.User
 			require.NoError(t, h.Insert(ctx))
-			hosts, err := FindUnexpirableRunning()
+			hosts, err := FindUnexpirableRunning(ctx)
 			require.NoError(t, err)
 			assert.Empty(t, hosts)
 		},

--- a/model/legacy_task_history.go
+++ b/model/legacy_task_history.go
@@ -61,7 +61,7 @@ func NewTaskHistoryIterator(name string, buildVariants []string, projectName str
 	return TaskHistoryIterator(&taskHistoryIterator{TaskName: name, BuildVariants: buildVariants, ProjectName: projectName})
 }
 
-func (iter *taskHistoryIterator) findAllVersions(v *Version, numRevisions int, before, include bool) ([]Version, bool, error) {
+func (iter *taskHistoryIterator) findAllVersions(ctx context.Context, v *Version, numRevisions int, before, include bool) ([]Version, bool, error) {
 	versionQuery := bson.M{
 		VersionRequesterKey: bson.M{
 			"$in": evergreen.SystemVersionRequesterTypes,
@@ -93,14 +93,14 @@ func (iter *taskHistoryIterator) findAllVersions(v *Version, numRevisions int, b
 
 	// Get the next numRevisions, plus an additional one to check if have
 	// reached the beginning/end of history
-	versions, err := VersionFind(
+	versions, err := VersionFind(ctx,
 		db.Query(versionQuery).WithFields(
 			VersionIdKey,
 			VersionRevisionOrderNumberKey,
 			VersionRevisionKey,
 			VersionMessageKey,
 			VersionCreateTimeKey,
-		).Sort([]string{order}).Limit(numRevisions + 1))
+		).Sort([]string{order}).Limit(numRevisions+1))
 
 	// Check if there were fewer results returned by the query than what
 	// the limit was set as
@@ -132,13 +132,13 @@ func (iter *taskHistoryIterator) GetChunk(ctx context.Context, v *Version, numBe
 		FailedTests: map[string][]string{},
 	}
 
-	versionsBefore, exhausted, err := iter.findAllVersions(v, numBefore, true, include)
+	versionsBefore, exhausted, err := iter.findAllVersions(ctx, v, numBefore, true, include)
 	if err != nil {
 		return chunk, errors.WithStack(err)
 	}
 	chunk.Exhausted.Before = exhausted
 
-	versionsAfter, exhausted, err := iter.findAllVersions(v, numAfter, false, false)
+	versionsAfter, exhausted, err := iter.findAllVersions(ctx, v, numAfter, false, false)
 	if err != nil {
 		return chunk, errors.WithStack(err)
 	}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -424,7 +424,7 @@ func restartTasks(ctx context.Context, allFinishedTasks []task.Task, caller, ver
 	if err := build.SetBuildStartedForTasks(ctx, allFinishedTasks, caller); err != nil {
 		return errors.Wrap(err, "setting builds started")
 	}
-	builds, err := build.FindBuildsForTasks(allFinishedTasks)
+	builds, err := build.FindBuildsForTasks(ctx, allFinishedTasks)
 	if err != nil {
 		return errors.Wrap(err, "finding builds for tasks")
 	}

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -566,7 +566,7 @@ func TestSetVersionActivation(t *testing.T) {
 	}
 
 	assert.NoError(t, SetVersionActivation(context.Background(), vID, false, "user"))
-	builds, err := build.FindBuildsByVersions([]string{vID})
+	builds, err := build.FindBuildsByVersions(t.Context(), []string{vID})
 	require.NoError(t, err)
 	require.Len(t, builds, 2)
 	for _, b := range builds {
@@ -2197,7 +2197,7 @@ func TestVersionRestart(t *testing.T) {
 	tasks, err := task.Find(ctx, task.ByIds(taskIds))
 	assert.NoError(err)
 	assert.NotEmpty(tasks)
-	builds, err := build.Find(build.ByIds(buildIds))
+	builds, err := build.Find(t.Context(), build.ByIds(buildIds))
 	assert.NoError(err)
 	assert.NotEmpty(builds)
 	for _, t := range tasks {

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -2309,7 +2309,7 @@ func TestDisplayTaskRestart(t *testing.T) {
 		assert.True(dbTask.Activated, dbTask.Id)
 		assert.Equal("caller", dbTask.ActivatedBy)
 
-		dbEvents, err := event.FindAllByResourceID(dbTask.Id)
+		dbEvents, err := event.FindAllByResourceID(t.Context(), dbTask.Id)
 		require.NoError(t, err)
 		require.Len(t, dbEvents, 1)
 		assert.Equal(event.TaskRestarted, dbEvents[0].EventType)

--- a/model/notification/db.go
+++ b/model/notification/db.go
@@ -111,20 +111,20 @@ func Find(ctx context.Context, id string) (*Notification, error) {
 	return &notification, err
 }
 
-func FindByEventID(id string) ([]Notification, error) {
+func FindByEventID(ctx context.Context, id string) ([]Notification, error) {
 	notifications := []Notification{}
 	query := db.Query(bson.M{
 		idKey: primitive.Regex{Pattern: fmt.Sprintf("^%s-", id)},
 	},
 	)
 
-	err := db.FindAllQ(Collection, query, &notifications)
+	err := db.FindAllQContext(ctx, Collection, query, &notifications)
 	return notifications, err
 }
 
-func FindUnprocessed() ([]Notification, error) {
+func FindUnprocessed(ctx context.Context) ([]Notification, error) {
 	notifications := []Notification{}
-	err := db.FindAllQ(Collection, db.Query(bson.M{sentAtKey: bson.M{"$exists": false}}), &notifications)
+	err := db.FindAllQContext(ctx, Collection, db.Query(bson.M{sentAtKey: bson.M{"$exists": false}}), &notifications)
 
 	return notifications, errors.Wrap(err, "finding unprocessed notifications")
 }

--- a/model/notification/db.go
+++ b/model/notification/db.go
@@ -118,13 +118,13 @@ func FindByEventID(ctx context.Context, id string) ([]Notification, error) {
 	},
 	)
 
-	err := db.FindAllQContext(ctx, Collection, query, &notifications)
+	err := db.FindAllQ(ctx, Collection, query, &notifications)
 	return notifications, err
 }
 
 func FindUnprocessed(ctx context.Context) ([]Notification, error) {
 	notifications := []Notification{}
-	err := db.FindAllQContext(ctx, Collection, db.Query(bson.M{sentAtKey: bson.M{"$exists": false}}), &notifications)
+	err := db.FindAllQ(ctx, Collection, db.Query(bson.M{sentAtKey: bson.M{"$exists": false}}), &notifications)
 
 	return notifications, errors.Wrap(err, "finding unprocessed notifications")
 }

--- a/model/notification/notification_test.go
+++ b/model/notification/notification_test.go
@@ -146,7 +146,7 @@ func (s *notificationSuite) TestInsertMany() {
 	}
 
 	out := []Notification{}
-	s.NoError(db.FindAllQContext(s.T().Context(), Collection, db.Q{}, &out))
+	s.NoError(db.FindAllQ(s.T().Context(), Collection, db.Q{}, &out))
 	s.Len(out, 3)
 
 	for _, n := range out {
@@ -211,7 +211,7 @@ func (s *notificationSuite) TestInsertManyUnordered() {
 
 	s.Error(InsertMany(s.T().Context(), slice...))
 	out := []Notification{}
-	s.NoError(db.FindAllQContext(s.T().Context(), Collection, db.Q{}, &out))
+	s.NoError(db.FindAllQ(s.T().Context(), Collection, db.Q{}, &out))
 	s.Len(out, 2)
 }
 

--- a/model/notification/notification_test.go
+++ b/model/notification/notification_test.go
@@ -178,7 +178,7 @@ func (s *notificationSuite) TestInsertMany() {
 		}
 	}
 
-	out2, err := FindByEventID("1")
+	out2, err := FindByEventID(s.T().Context(), "1")
 	s.NoError(err)
 	s.Len(out2, 2)
 }
@@ -419,7 +419,7 @@ func (s *notificationSuite) TestFindUnprocessed() {
 	s.n.SentAt = time.Now()
 	s.NoError(db.Insert(s.T().Context(), Collection, s.n))
 
-	unprocessedNotifications, err := FindUnprocessed()
+	unprocessedNotifications, err := FindUnprocessed(s.T().Context())
 	s.NoError(err)
 	s.Len(unprocessedNotifications, 1)
 	s.Equal("unsent", unprocessedNotifications[0].ID)

--- a/model/patch/cli_intent_test.go
+++ b/model/patch/cli_intent_test.go
@@ -267,7 +267,7 @@ func (s *CliIntentSuite) TestSetProcessed() {
 
 func findCliIntents(ctx context.Context, processed bool) ([]*cliIntent, error) {
 	var intents []*cliIntent
-	err := db.FindAllQContext(ctx, IntentCollection, db.Query(bson.M{cliProcessedKey: processed, cliIntentTypeKey: CliIntentType}), &intents)
+	err := db.FindAllQ(ctx, IntentCollection, db.Query(bson.M{cliProcessedKey: processed, cliIntentTypeKey: CliIntentType}), &intents)
 	if err != nil {
 		return []*cliIntent{}, err
 	}

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -326,7 +326,7 @@ func FindOneId(ctx context.Context, id string) (*Patch, error) {
 // Find runs a patch query, returning all patches that satisfy the query.
 func Find(ctx context.Context, query db.Q) ([]Patch, error) {
 	patches := []Patch{}
-	err := db.FindAllQContext(ctx, Collection, query, &patches)
+	err := db.FindAllQ(ctx, Collection, query, &patches)
 	return patches, err
 }
 

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -324,9 +324,9 @@ func FindOneId(ctx context.Context, id string) (*Patch, error) {
 }
 
 // Find runs a patch query, returning all patches that satisfy the query.
-func Find(query db.Q) ([]Patch, error) {
+func Find(ctx context.Context, query db.Q) ([]Patch, error) {
 	patches := []Patch{}
-	err := db.FindAllQ(Collection, query, &patches)
+	err := db.FindAllQContext(ctx, Collection, query, &patches)
 	return patches, err
 }
 
@@ -373,7 +373,7 @@ func ConsolidatePatchesForUser(ctx context.Context, oldAuthor string, newUsr *us
 
 	// It's not likely that the user would've already created patches for the new user, but if there are any, make
 	// sure that they don't have overlapping patch numbers.
-	patchesForNewAuthor, err := Find(db.Query(byUser(newUsr.Id)))
+	patchesForNewAuthor, err := Find(ctx, db.Query(byUser(newUsr.Id)))
 	if err != nil {
 		return errors.Wrapf(err, "finding existing patches for '%s'", newUsr.Id)
 	}
@@ -399,8 +399,8 @@ func ConsolidatePatchesForUser(ctx context.Context, oldAuthor string, newUsr *us
 }
 
 // FindLatestGithubPRPatch returns the latest PR patch for the given PR, if there is one.
-func FindLatestGithubPRPatch(owner, repo string, prNumber int) (*Patch, error) {
-	patches, err := Find(db.Query(bson.M{
+func FindLatestGithubPRPatch(ctx context.Context, owner, repo string, prNumber int) (*Patch, error) {
+	patches, err := Find(ctx, db.Query(bson.M{
 		AliasKey: bson.M{"$ne": evergreen.CommitQueueAlias},
 		bsonutil.GetDottedKeyName(githubPatchDataKey, thirdparty.GithubPatchBaseOwnerKey): owner,
 		bsonutil.GetDottedKeyName(githubPatchDataKey, thirdparty.GithubPatchBaseRepoKey):  repo,
@@ -441,7 +441,7 @@ func GetFinalizedChildPatchIdsForPatch(ctx context.Context, patchID string) ([]s
 		return nil, nil
 	}
 
-	childPatches, err := Find(ByStringIds(p.Triggers.ChildPatches).WithFields(VersionKey))
+	childPatches, err := Find(ctx, ByStringIds(p.Triggers.ChildPatches).WithFields(VersionKey))
 	if err != nil {
 		return nil, errors.Wrap(err, "getting child patches")
 	}

--- a/model/patch/db_test.go
+++ b/model/patch/db_test.go
@@ -314,7 +314,7 @@ func TestLatestGithubPRPatch(t *testing.T) {
 	}
 
 	assert.NoError(t, db.InsertMany(t.Context(), Collection, patch1, patch2, cqPatch, wrongPRPatch))
-	p, err := FindLatestGithubPRPatch("parks", "rec", 12)
+	p, err := FindLatestGithubPRPatch(t.Context(), "parks", "rec", 12)
 	assert.NoError(t, err)
 	require.NotNil(t, p)
 	assert.Equal(t, p.Id.Hex(), patch2.Id.Hex())

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -267,7 +267,7 @@ func (g *githubIntent) GetCalledBy() string {
 // FindUnprocessedGithubIntents finds all patch intents that have not yet been processed.
 func FindUnprocessedGithubIntents(ctx context.Context) ([]*githubIntent, error) {
 	var intents []*githubIntent
-	err := db.FindAllQContext(ctx, IntentCollection, db.Query(bson.M{processedKey: false, intentTypeKey: GithubIntentType}), &intents)
+	err := db.FindAllQ(ctx, IntentCollection, db.Query(bson.M{processedKey: false, intentTypeKey: GithubIntentType}), &intents)
 	if err != nil {
 		return []*githubIntent{}, err
 	}

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -265,9 +265,9 @@ func (g *githubIntent) GetCalledBy() string {
 }
 
 // FindUnprocessedGithubIntents finds all patch intents that have not yet been processed.
-func FindUnprocessedGithubIntents() ([]*githubIntent, error) {
+func FindUnprocessedGithubIntents(ctx context.Context) ([]*githubIntent, error) {
 	var intents []*githubIntent
-	err := db.FindAllQ(IntentCollection, db.Query(bson.M{processedKey: false, intentTypeKey: GithubIntentType}), &intents)
+	err := db.FindAllQContext(ctx, IntentCollection, db.Query(bson.M{processedKey: false, intentTypeKey: GithubIntentType}), &intents)
 	if err != nil {
 		return []*githubIntent{}, err
 	}

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -110,7 +110,7 @@ var (
 
 // NewGithubIntent creates an Intent from a google/go-github PullRequestEvent,
 // or returns an error if the some part of the struct is invalid
-func NewGithubIntent(msgDeliveryID, patchOwner, calledBy, alias, mergeBase string, pr *github.PullRequest) (Intent, error) {
+func NewGithubIntent(ctx context.Context, msgDeliveryID, patchOwner, calledBy, alias, mergeBase string, pr *github.PullRequest) (Intent, error) {
 	if pr == nil ||
 		pr.Base == nil || pr.Base.Repo == nil ||
 		pr.Head == nil || pr.Head.Repo == nil ||
@@ -155,7 +155,7 @@ func NewGithubIntent(msgDeliveryID, patchOwner, calledBy, alias, mergeBase strin
 	}
 
 	// get the patchId to repeat the definitions from
-	repeat, err := getRepeatPatchId(pr.Base.Repo.Owner.GetLogin(), pr.Base.Repo.GetName(), pr.GetNumber())
+	repeat, err := getRepeatPatchId(ctx, pr.Base.Repo.Owner.GetLogin(), pr.Base.Repo.GetName(), pr.GetNumber())
 	if err != nil {
 		return nil, errors.Wrap(err, "getting patch to repeat definitions from")
 	}
@@ -182,8 +182,8 @@ func NewGithubIntent(msgDeliveryID, patchOwner, calledBy, alias, mergeBase strin
 
 // getRepeatPatchId returns the patch id to repeat the definitions from
 // this information is found on the most recent pr patch
-func getRepeatPatchId(owner, repo string, prNumber int) (string, error) {
-	p, err := FindLatestGithubPRPatch(owner, repo, prNumber)
+func getRepeatPatchId(ctx context.Context, owner, repo string, prNumber int) (string, error) {
+	p, err := FindLatestGithubPRPatch(ctx, owner, repo, prNumber)
 	if err != nil {
 		return "", errors.Errorf("finding latest patch for PR '%s/%s:%d'", owner, repo, prNumber)
 	}

--- a/model/patch/github_merge_test.go
+++ b/model/patch/github_merge_test.go
@@ -61,7 +61,7 @@ func TestGithubMergeIntent(t *testing.T) {
 			assert.NoError(t, err)
 			assert.NoError(t, intent.Insert(t.Context()))
 			intents := []githubMergeIntent{}
-			err = db.FindAllQContext(t.Context(), IntentCollection, db.Query(bson.M{}), &intents)
+			err = db.FindAllQ(t.Context(), IntentCollection, db.Query(bson.M{}), &intents)
 			assert.NoError(t, err)
 			assert.Len(t, intents, 1)
 			assert.Equal(t, intent, &intents[0])
@@ -74,7 +74,7 @@ func TestGithubMergeIntent(t *testing.T) {
 			assert.NoError(t, intent.Insert(t.Context()))
 			assert.NoError(t, intent.SetProcessed(t.Context()))
 			intents := []githubMergeIntent{}
-			err = db.FindAllQContext(t.Context(), IntentCollection, db.Query(bson.M{}), &intents)
+			err = db.FindAllQ(t.Context(), IntentCollection, db.Query(bson.M{}), &intents)
 			assert.NoError(t, err)
 			assert.Len(t, intents, 1)
 			assert.True(t, intents[0].IsProcessed())

--- a/model/patch/github_test.go
+++ b/model/patch/github_test.go
@@ -145,7 +145,7 @@ func (s *GithubSuite) TestInsert() {
 	s.NotNil(intent)
 	s.NoError(intent.Insert(s.T().Context()))
 
-	intents, err := FindUnprocessedGithubIntents()
+	intents, err := FindUnprocessedGithubIntents(s.T().Context())
 	s.NoError(err)
 	s.Len(intents, 1)
 
@@ -185,7 +185,7 @@ func (s *GithubSuite) TestSetProcessed() {
 	s.NoError(intent.Insert(s.T().Context()))
 	s.NoError(intent.SetProcessed(s.T().Context()))
 
-	found, err := FindUnprocessedGithubIntents()
+	found, err := FindUnprocessedGithubIntents(s.T().Context())
 	s.NoError(err)
 	s.Empty(found)
 
@@ -243,7 +243,7 @@ func (s *GithubSuite) TestFindUnprocessedGithubIntents() {
 		s.NoError(intent.Insert(s.T().Context()))
 	}
 
-	found, err := FindUnprocessedGithubIntents()
+	found, err := FindUnprocessedGithubIntents(s.T().Context())
 	s.NoError(err)
 	s.Len(found, 3)
 }

--- a/model/patch/github_test.go
+++ b/model/patch/github_test.go
@@ -190,7 +190,7 @@ func (s *GithubSuite) TestSetProcessed() {
 	s.Empty(found)
 
 	var intents []githubIntent
-	s.NoError(db.FindAllQContext(s.T().Context(), IntentCollection, db.Query(bson.M{processedKey: true}), &intents))
+	s.NoError(db.FindAllQ(s.T().Context(), IntentCollection, db.Query(bson.M{processedKey: true}), &intents))
 	s.Len(intents, 1)
 	s.Equal(s.pr, intents[0].PRNumber)
 	s.Equal(s.hash, intents[0].HeadHash)

--- a/model/patch/github_test.go
+++ b/model/patch/github_test.go
@@ -49,45 +49,45 @@ func (s *GithubSuite) SetupTest() {
 }
 
 func (s *GithubSuite) TestNewGithubIntent() {
-	intent, err := NewGithubIntent("1", "", "", "", "", testutil.NewGithubPR(0, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
+	intent, err := NewGithubIntent(s.T().Context(), "1", "", "", "", "", testutil.NewGithubPR(0, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("2", "", "", "", "", testutil.NewGithubPR(s.pr, "", s.baseHash, s.headRepo, s.hash, s.user, s.title))
+	intent, err = NewGithubIntent(s.T().Context(), "2", "", "", "", "", testutil.NewGithubPR(s.pr, "", s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("2", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, "", s.hash, s.user, s.title))
+	intent, err = NewGithubIntent(s.T().Context(), "2", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, "", s.hash, s.user, s.title))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("2", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, "", s.headRepo, s.hash, s.user, s.title))
+	intent, err = NewGithubIntent(s.T().Context(), "2", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, "", s.headRepo, s.hash, s.user, s.title))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("2", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, "", s.user, s.title))
+	intent, err = NewGithubIntent(s.T().Context(), "2", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, "", s.user, s.title))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("2", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, "", s.title))
+	intent, err = NewGithubIntent(s.T().Context(), "2", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, "", s.title))
 	s.Nil(intent)
 	s.Error(err)
 
 	// Creates new intent with callers
-	intent, err = NewGithubIntent("2", "", AutomatedCaller, "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, "", s.title))
+	intent, err = NewGithubIntent(s.T().Context(), "2", "", AutomatedCaller, "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, "", s.title))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("2", "", ManualCaller, "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, "", s.title))
+	intent, err = NewGithubIntent(s.T().Context(), "2", "", ManualCaller, "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, "", s.title))
 	s.Nil(intent)
 	s.Error(err)
 
 	// PRs can't have an empty title
-	intent, err = NewGithubIntent("2", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, ""))
+	intent, err = NewGithubIntent(s.T().Context(), "2", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, ""))
 	s.Nil(intent)
 	s.Error(err)
 
-	intent, err = NewGithubIntent("4", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
+	intent, err = NewGithubIntent(s.T().Context(), "4", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.Implements((*Intent)(nil), intent)
@@ -130,7 +130,7 @@ func (s *GithubSuite) TestNewGithubIntent() {
 		},
 	}
 	s.NoError(patch.Insert(s.T().Context()))
-	intent, err = NewGithubIntent("4", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
+	intent, err = NewGithubIntent(s.T().Context(), "4", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.Implements((*Intent)(nil), intent)
@@ -140,7 +140,7 @@ func (s *GithubSuite) TestNewGithubIntent() {
 }
 
 func (s *GithubSuite) TestInsert() {
-	intent, err := NewGithubIntent("1", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
+	intent, err := NewGithubIntent(s.T().Context(), "1", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert(s.T().Context()))
@@ -160,7 +160,7 @@ func (s *GithubSuite) TestInsert() {
 }
 
 func (s *GithubSuite) TestFindIntentSpecifically() {
-	intent, err := NewGithubIntent("300", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
+	intent, err := NewGithubIntent(s.T().Context(), "300", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert(s.T().Context()))
@@ -179,7 +179,7 @@ func (s *GithubSuite) TestFindIntentSpecifically() {
 }
 
 func (s *GithubSuite) TestSetProcessed() {
-	intent, err := NewGithubIntent("1", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
+	intent, err := NewGithubIntent(s.T().Context(), "1", "", "", "", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert(s.T().Context()))
@@ -250,7 +250,7 @@ func (s *GithubSuite) TestFindUnprocessedGithubIntents() {
 
 func (s *GithubSuite) TestNewPatch() {
 	s.NoError(db.Clear(IntentCollection))
-	intent, err := NewGithubIntent("4", "", "", "", s.baseHash, testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
+	intent, err := NewGithubIntent(s.T().Context(), "4", "", "", "", s.baseHash, testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert(s.T().Context()))
@@ -284,7 +284,7 @@ func (s *GithubSuite) TestNewPatch() {
 
 func (s *GithubSuite) TestNewPatchWithCustomAlias() {
 	s.NoError(db.Clear(IntentCollection))
-	intent, err := NewGithubIntent("4", "", "", "custom-alias", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
+	intent, err := NewGithubIntent(s.T().Context(), "4", "", "", "custom-alias", "", testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert(s.T().Context()))

--- a/model/patch/patch_test.go
+++ b/model/patch/patch_test.go
@@ -121,23 +121,23 @@ func (s *patchSuite) SetupTest() {
 }
 
 func (s *patchSuite) TestByGithubPRAndCreatedBefore() {
-	patches, err := Find(ByGithubPRAndCreatedBefore(time.Now(), "evergreen-ci", "evergreen", 1))
+	patches, err := Find(s.T().Context(), ByGithubPRAndCreatedBefore(time.Now(), "evergreen-ci", "evergreen", 1))
 	s.NoError(err)
 	s.Empty(patches)
 
-	patches, err = Find(ByGithubPRAndCreatedBefore(time.Now(), "octodog", "evergreen", 9002))
+	patches, err = Find(s.T().Context(), ByGithubPRAndCreatedBefore(time.Now(), "octodog", "evergreen", 9002))
 	s.NoError(err)
 	s.Empty(patches)
 
-	patches, err = Find(ByGithubPRAndCreatedBefore(time.Now(), "", "", 0))
+	patches, err = Find(s.T().Context(), ByGithubPRAndCreatedBefore(time.Now(), "", "", 0))
 	s.NoError(err)
 	s.Empty(patches)
 
-	patches, err = Find(ByGithubPRAndCreatedBefore(s.patches[2].CreateTime, "evergreen-ci", "evergreen", 9001))
+	patches, err = Find(s.T().Context(), ByGithubPRAndCreatedBefore(s.patches[2].CreateTime, "evergreen-ci", "evergreen", 9001))
 	s.NoError(err)
 	s.Len(patches, 2)
 
-	patches, err = Find(ByGithubPRAndCreatedBefore(s.time, "evergreen-ci", "evergreen", 9001))
+	patches, err = Find(s.T().Context(), ByGithubPRAndCreatedBefore(s.time, "evergreen-ci", "evergreen", 9001))
 	s.NoError(err)
 	s.Len(patches, 1)
 }

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -87,7 +87,7 @@ func ValidateTVPairs(p *Project, in []TVPair) error {
 // Given a patch version and a list of variant/task pairs, creates the set of new builds that
 // do not exist yet out of the set of pairs, and adds tasks for builds which already exist.
 func addNewTasksAndBuildsForPatch(ctx context.Context, creationInfo TaskCreationInfo, caller string) error {
-	existingBuilds, err := build.Find(build.ByIds(creationInfo.Version.BuildIds).WithFields(build.IdKey, build.BuildVariantKey, build.CreateTimeKey, build.RequesterKey))
+	existingBuilds, err := build.Find(ctx, build.ByIds(creationInfo.Version.BuildIds).WithFields(build.IdKey, build.BuildVariantKey, build.CreateTimeKey, build.RequesterKey))
 	if err != nil {
 		return err
 	}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -959,7 +959,7 @@ func CancelPatch(ctx context.Context, p *patch.Patch, reason task.AbortInfo) err
 // which are abortable will be aborted, while completed tasks will not be
 // affected.
 func AbortPatchesWithGithubPatchData(ctx context.Context, createdBefore time.Time, closed bool, newPatch, owner, repo string, prNumber int) error {
-	patches, err := patch.Find(patch.ByGithubPRAndCreatedBefore(createdBefore, owner, repo, prNumber))
+	patches, err := patch.Find(ctx, patch.ByGithubPRAndCreatedBefore(createdBefore, owner, repo, prNumber))
 	if err != nil {
 		return errors.Wrap(err, "fetching initial patch")
 	}

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -314,7 +314,7 @@ func TestFinalizePatch(t *testing.T) {
 			require.NotZero(t, dbPatch)
 			assert.True(t, dbPatch.Activated)
 			// ensure the relevant builds/tasks were created
-			builds, err := build.Find(build.All)
+			builds, err := build.Find(t.Context(), build.All)
 			require.NoError(t, err)
 			assert.Len(t, builds, 1)
 			assert.Len(t, builds[0].Tasks, 2)
@@ -414,7 +414,7 @@ func TestFinalizePatch(t *testing.T) {
 			require.NotZero(t, dbPatch)
 			assert.True(t, dbPatch.Activated)
 
-			builds, err := build.Find(build.All)
+			builds, err := build.Find(t.Context(), build.All)
 			require.NoError(t, err)
 			assert.Len(t, builds, 1)
 			assert.Len(t, builds[0].Tasks, 2)

--- a/model/pod/db.go
+++ b/model/pod/db.go
@@ -75,7 +75,7 @@ func Count(ctx context.Context, q db.Q) (int, error) {
 // Find finds all pods matching the given query.
 func Find(ctx context.Context, q db.Q) ([]Pod, error) {
 	pods := []Pod{}
-	return pods, errors.WithStack(db.FindAllQContext(ctx, Collection, q, &pods))
+	return pods, errors.WithStack(db.FindAllQ(ctx, Collection, q, &pods))
 }
 
 // FindOne finds one pod by the given query.

--- a/model/pod/db_test.go
+++ b/model/pod/db_test.go
@@ -14,7 +14,7 @@ import (
 func TestFindByNeedsTermination(t *testing.T) {
 	for tName, tCase := range map[string]func(t *testing.T){
 		"ReturnsEmptyForNoMatches": func(t *testing.T) {
-			pods, err := FindByNeedsTermination()
+			pods, err := FindByNeedsTermination(t.Context())
 			assert.NoError(t, err)
 			assert.Empty(t, pods)
 		},
@@ -44,7 +44,7 @@ func TestFindByNeedsTermination(t *testing.T) {
 			}
 			require.NoError(t, startingPod.Insert(t.Context()))
 
-			pods, err := FindByNeedsTermination()
+			pods, err := FindByNeedsTermination(t.Context())
 			require.NoError(t, err)
 			require.Len(t, pods, 1)
 			assert.Equal(t, stalePod.ID, pods[0].ID)
@@ -56,7 +56,7 @@ func TestFindByNeedsTermination(t *testing.T) {
 			}
 			require.NoError(t, decommissionedPod.Insert(t.Context()))
 
-			pods, err := FindByNeedsTermination()
+			pods, err := FindByNeedsTermination(t.Context())
 			require.NoError(t, err)
 			require.Len(t, pods, 1)
 			assert.Equal(t, decommissionedPod.ID, pods[0].ID)
@@ -71,7 +71,7 @@ func TestFindByNeedsTermination(t *testing.T) {
 			}
 			require.NoError(t, decommissionedPodWithTask.Insert(t.Context()))
 
-			pods, err := FindByNeedsTermination()
+			pods, err := FindByNeedsTermination(t.Context())
 			require.NoError(t, err)
 			require.Empty(t, pods)
 		},
@@ -85,7 +85,7 @@ func TestFindByNeedsTermination(t *testing.T) {
 			}
 			require.NoError(t, stalePod.Insert(t.Context()))
 
-			pods, err := FindByNeedsTermination()
+			pods, err := FindByNeedsTermination(t.Context())
 			require.NoError(t, err)
 			require.Len(t, pods, 1)
 			assert.Equal(t, stalePod.ID, pods[0].ID)
@@ -105,7 +105,7 @@ func TestFindByNeedsTermination(t *testing.T) {
 func TestFindByInitializing(t *testing.T) {
 	for tName, tCase := range map[string]func(t *testing.T){
 		"ReturnsEmptyForNoMatches": func(t *testing.T) {
-			pods, err := FindByInitializing()
+			pods, err := FindByInitializing(t.Context())
 			assert.NoError(t, err)
 			assert.Empty(t, pods)
 		},
@@ -128,7 +128,7 @@ func TestFindByInitializing(t *testing.T) {
 			}
 			require.NoError(t, p3.Insert(t.Context()))
 
-			pods, err := FindByInitializing()
+			pods, err := FindByInitializing(t.Context())
 			require.NoError(t, err)
 			require.Len(t, pods, 2)
 			assert.Equal(t, StatusInitializing, pods[0].Status)
@@ -287,7 +287,7 @@ func TestFindByFamily(t *testing.T) {
 				require.NoError(t, p.Insert(t.Context()))
 			}
 
-			dbPods, err := FindIntentByFamily(family)
+			dbPods, err := FindIntentByFamily(t.Context(), family)
 			require.NoError(t, err)
 			var numMatches int
 			for _, p := range dbPods {
@@ -307,7 +307,7 @@ func TestFindByFamily(t *testing.T) {
 				Family: "family",
 			}
 			require.NoError(t, p.Insert(t.Context()))
-			dbPods, err := FindIntentByFamily(p.Family)
+			dbPods, err := FindIntentByFamily(t.Context(), p.Family)
 			assert.NoError(t, err)
 			assert.Empty(t, dbPods)
 		},
@@ -318,12 +318,12 @@ func TestFindByFamily(t *testing.T) {
 				Family: "family",
 			}
 			require.NoError(t, p.Insert(t.Context()))
-			dbPods, err := FindIntentByFamily("foo")
+			dbPods, err := FindIntentByFamily(t.Context(), "foo")
 			assert.NoError(t, err)
 			assert.Empty(t, dbPods)
 		},
 		"ReturnsNoErrorForNoMatchingPods": func(t *testing.T) {
-			dbPods, err := FindIntentByFamily("nonexistent")
+			dbPods, err := FindIntentByFamily(t.Context(), "nonexistent")
 			assert.NoError(t, err)
 			assert.Empty(t, dbPods)
 		},
@@ -452,7 +452,7 @@ func TestFindByLastCommunicatedBefore(t *testing.T) {
 			}
 			require.NoError(t, p.Insert(t.Context()))
 
-			found, err := FindByLastCommunicatedBefore(time.Now().Add(-10 * time.Minute))
+			found, err := FindByLastCommunicatedBefore(t.Context(), time.Now().Add(-10*time.Minute))
 			require.NoError(t, err)
 			require.Len(t, found, 1)
 			assert.Equal(t, p.ID, found[0].ID)
@@ -467,7 +467,7 @@ func TestFindByLastCommunicatedBefore(t *testing.T) {
 			}
 			require.NoError(t, p.Insert(t.Context()))
 
-			found, err := FindByLastCommunicatedBefore(time.Now().Add(-10 * time.Minute))
+			found, err := FindByLastCommunicatedBefore(t.Context(), time.Now().Add(-10*time.Minute))
 			require.NoError(t, err)
 			require.Len(t, found, 1)
 			assert.Equal(t, p.ID, found[0].ID)
@@ -521,7 +521,7 @@ func TestFindByLastCommunicatedBefore(t *testing.T) {
 				require.NoError(t, p.Insert(t.Context()))
 			}
 
-			found, err := FindByLastCommunicatedBefore(time.Now().Add(-10 * time.Minute))
+			found, err := FindByLastCommunicatedBefore(t.Context(), time.Now().Add(-10*time.Minute))
 			require.NoError(t, err)
 			require.Len(t, found, 2)
 			assert.ElementsMatch(t, []string{pods[2].ID, pods[4].ID}, []string{found[0].ID, found[1].ID})
@@ -536,7 +536,7 @@ func TestFindByLastCommunicatedBefore(t *testing.T) {
 			}
 			require.NoError(t, p.Insert(t.Context()))
 
-			found, err := FindByLastCommunicatedBefore(time.Now().Add(-10 * time.Minute))
+			found, err := FindByLastCommunicatedBefore(t.Context(), time.Now().Add(-10*time.Minute))
 			assert.NoError(t, err)
 			assert.Empty(t, found)
 		},
@@ -550,7 +550,7 @@ func TestFindByLastCommunicatedBefore(t *testing.T) {
 			}
 			require.NoError(t, p.Insert(t.Context()))
 
-			found, err := FindByLastCommunicatedBefore(time.Now().Add(-10 * time.Minute))
+			found, err := FindByLastCommunicatedBefore(t.Context(), time.Now().Add(-10*time.Minute))
 			assert.NoError(t, err)
 			assert.Empty(t, found)
 		},
@@ -564,7 +564,7 @@ func TestFindByLastCommunicatedBefore(t *testing.T) {
 			}
 			require.NoError(t, p.Insert(t.Context()))
 
-			found, err := FindByLastCommunicatedBefore(time.Now().Add(-10 * time.Minute))
+			found, err := FindByLastCommunicatedBefore(t.Context(), time.Now().Add(-10*time.Minute))
 			assert.NoError(t, err)
 			assert.Empty(t, found)
 		},

--- a/model/pod/db_test.go
+++ b/model/pod/db_test.go
@@ -351,7 +351,7 @@ func TestUpdateOneStatus(t *testing.T) {
 	}
 
 	checkEventLog := func(t *testing.T, p Pod) {
-		events, err := event.Find(event.MostRecentPodEvents(p.ID, 10))
+		events, err := event.Find(t.Context(), event.MostRecentPodEvents(p.ID, 10))
 		require.NoError(t, err)
 		require.Len(t, events, 1)
 		assert.Equal(t, p.ID, events[0].ResourceId)

--- a/model/pod/definition/db.go
+++ b/model/pod/definition/db.go
@@ -23,7 +23,7 @@ var (
 // Find finds all pod definitions matching the given query.
 func Find(ctx context.Context, q db.Q) ([]PodDefinition, error) {
 	defs := []PodDefinition{}
-	return defs, errors.WithStack(db.FindAllQContext(ctx, Collection, q, &defs))
+	return defs, errors.WithStack(db.FindAllQ(ctx, Collection, q, &defs))
 }
 
 // FindOne finds one pod definition by the given query.

--- a/model/pod/definition/db.go
+++ b/model/pod/definition/db.go
@@ -21,9 +21,9 @@ var (
 )
 
 // Find finds all pod definitions matching the given query.
-func Find(q db.Q) ([]PodDefinition, error) {
+func Find(ctx context.Context, q db.Q) ([]PodDefinition, error) {
 	defs := []PodDefinition{}
-	return defs, errors.WithStack(db.FindAllQ(Collection, q, &defs))
+	return defs, errors.WithStack(db.FindAllQContext(ctx, Collection, q, &defs))
 }
 
 // FindOne finds one pod definition by the given query.
@@ -78,8 +78,8 @@ func FindOneByFamily(ctx context.Context, family string) (*PodDefinition, error)
 // FindByLastAccessedBefore finds all pod definitions that were last accessed
 // before the TTL. If a positive limit is given, it will return at most that
 // number of results; otherwise, the results are unlimited.
-func FindByLastAccessedBefore(ttl time.Duration, limit int) ([]PodDefinition, error) {
-	return Find(db.Query(bson.M{
+func FindByLastAccessedBefore(ctx context.Context, ttl time.Duration, limit int) ([]PodDefinition, error) {
+	return Find(ctx, db.Query(bson.M{
 		"$or": []bson.M{
 			{
 				LastAccessedKey: bson.M{"$lt": time.Now().Add(-ttl)},

--- a/model/pod/definition/db_test.go
+++ b/model/pod/definition/db_test.go
@@ -132,7 +132,7 @@ func TestFindOneByLastAccessedBefore(t *testing.T) {
 			for _, podDef := range podDefs {
 				require.NoError(t, podDef.Insert(t.Context()))
 			}
-			found, err := FindByLastAccessedBefore(time.Minute, -1)
+			found, err := FindByLastAccessedBefore(t.Context(), time.Minute, -1)
 			require.NoError(t, err)
 			require.Len(t, found, 2)
 			for _, podDef := range found {
@@ -156,7 +156,7 @@ func TestFindOneByLastAccessedBefore(t *testing.T) {
 			for _, podDef := range podDefs {
 				require.NoError(t, podDef.Insert(t.Context()))
 			}
-			found, err := FindByLastAccessedBefore(time.Minute, 1)
+			found, err := FindByLastAccessedBefore(t.Context(), time.Minute, 1)
 			require.NoError(t, err)
 			require.Len(t, found, 1)
 			assert.True(t, utility.StringSliceContains([]string{
@@ -171,7 +171,7 @@ func TestFindOneByLastAccessedBefore(t *testing.T) {
 			}
 			require.NoError(t, podDef.Insert(t.Context()))
 
-			found, err := FindByLastAccessedBefore(time.Minute, -1)
+			found, err := FindByLastAccessedBefore(t.Context(), time.Minute, -1)
 			require.NoError(t, err)
 			assert.Empty(t, found)
 		},
@@ -181,7 +181,7 @@ func TestFindOneByLastAccessedBefore(t *testing.T) {
 			}
 			require.NoError(t, podDef.Insert(t.Context()))
 
-			found, err := FindByLastAccessedBefore(time.Minute, -1)
+			found, err := FindByLastAccessedBefore(t.Context(), time.Minute, -1)
 			require.NoError(t, err)
 			require.Len(t, found, 1)
 			assert.Equal(t, podDef.ID, found[0].ID)

--- a/model/pod/definition/definition_test.go
+++ b/model/pod/definition/definition_test.go
@@ -87,7 +87,7 @@ func TestPodDefinitionCache(t *testing.T) {
 					DefinitionOpts: *defOpts,
 				}))
 
-				pds, err := Find(db.Query(ByExternalID(externalID)))
+				pds, err := Find(t.Context(), db.Query(ByExternalID(externalID)))
 				require.NoError(t, err)
 				require.Len(t, pds, 1, "putting identical item should not have created any new pod definitions")
 
@@ -105,7 +105,7 @@ func TestPodDefinitionCache(t *testing.T) {
 						DefinitionOpts: *defOpts,
 					}))
 				}
-				pds, err := Find(db.Query(bson.M{}))
+				pds, err := Find(t.Context(), db.Query(bson.M{}))
 				require.NoError(t, err)
 				require.Len(t, pds, numPodDefs)
 			},

--- a/model/pod/dispatcher/db.go
+++ b/model/pod/dispatcher/db.go
@@ -40,9 +40,9 @@ func FindOne(ctx context.Context, q db.Q) (*PodDispatcher, error) {
 }
 
 // Find finds all pod dispatchers for the given query.
-func Find(q db.Q) ([]PodDispatcher, error) {
+func Find(ctx context.Context, q db.Q) ([]PodDispatcher, error) {
 	pds := []PodDispatcher{}
-	return pds, errors.WithStack(db.FindAllQ(Collection, q, &pds))
+	return pds, errors.WithStack(db.FindAllQContext(ctx, Collection, q, &pds))
 }
 
 // UpsertOne updates an existing pod dispatcher if it exists based on the

--- a/model/pod/dispatcher/db.go
+++ b/model/pod/dispatcher/db.go
@@ -42,7 +42,7 @@ func FindOne(ctx context.Context, q db.Q) (*PodDispatcher, error) {
 // Find finds all pod dispatchers for the given query.
 func Find(ctx context.Context, q db.Q) ([]PodDispatcher, error) {
 	pds := []PodDispatcher{}
-	return pds, errors.WithStack(db.FindAllQContext(ctx, Collection, q, &pds))
+	return pds, errors.WithStack(db.FindAllQ(ctx, Collection, q, &pds))
 }
 
 // UpsertOne updates an existing pod dispatcher if it exists based on the

--- a/model/pod/dispatcher/db_test.go
+++ b/model/pod/dispatcher/db_test.go
@@ -61,7 +61,7 @@ func TestFind(t *testing.T) {
 
 	for tName, tCase := range map[string]func(t *testing.T, pds []PodDispatcher){
 		"ReturnsEmptyForNoMatches": func(t *testing.T, pds []PodDispatcher) {
-			found, err := Find(db.Query(bson.M{}))
+			found, err := Find(t.Context(), db.Query(bson.M{}))
 			assert.NoError(t, err)
 			assert.Empty(t, found)
 		},
@@ -69,7 +69,7 @@ func TestFind(t *testing.T) {
 			for _, pd := range pds {
 				require.NoError(t, pd.Insert(t.Context()))
 			}
-			found, err := Find(db.Query(bson.M{}))
+			found, err := Find(t.Context(), db.Query(bson.M{}))
 			require.NoError(t, err)
 			require.Len(t, found, 2)
 		},

--- a/model/pod/dispatcher/db_test.go
+++ b/model/pod/dispatcher/db_test.go
@@ -181,7 +181,7 @@ func TestAllocate(t *testing.T) {
 		assert.Equal(t, pd.LastModified, dbDispatcher.LastModified)
 	}
 	checkEventLogged := func(t *testing.T, tsk *task.Task) {
-		dbEvents, err := event.FindAllByResourceID(tsk.Id)
+		dbEvents, err := event.FindAllByResourceID(t.Context(), tsk.Id)
 		require.NoError(t, err)
 		require.Len(t, dbEvents, 1)
 		assert.Equal(t, event.ContainerAllocated, dbEvents[0].EventType)
@@ -274,7 +274,7 @@ func TestAllocate(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Zero(t, dbDispatcher)
 
-			dbEvents, err := event.FindAllByResourceID(tsk.Id)
+			dbEvents, err := event.FindAllByResourceID(t.Context(), tsk.Id)
 			assert.NoError(t, err)
 			assert.Empty(t, dbEvents)
 		},

--- a/model/pod/dispatcher/dispatcher_test.go
+++ b/model/pod/dispatcher/dispatcher_test.go
@@ -175,12 +175,12 @@ func TestAssignNextTask(t *testing.T) {
 		assert.Equal(t, tsk.Id, dbPod.TaskRuntimeInfo.RunningTaskID)
 		assert.Equal(t, pod.StatusDecommissioned, dbPod.Status)
 
-		taskEvents, err := event.FindAllByResourceID(dbTask.Id)
+		taskEvents, err := event.FindAllByResourceID(t.Context(), dbTask.Id)
 		require.NoError(t, err)
 		require.Len(t, taskEvents, 1)
 		assert.Equal(t, event.TaskDispatched, taskEvents[0].EventType)
 
-		podEvents, err := event.FindAllByResourceID(p.ID)
+		podEvents, err := event.FindAllByResourceID(t.Context(), p.ID)
 		require.NoError(t, err)
 		var foundPodAssignedTask bool
 		var foundPodUpdatedStatus bool

--- a/model/pod/pod_test.go
+++ b/model/pod/pod_test.go
@@ -354,7 +354,7 @@ func TestUpdateStatus(t *testing.T) {
 	}
 
 	checkEventLog := func(t *testing.T, p Pod) {
-		events, err := event.Find(event.MostRecentPodEvents(p.ID, 10))
+		events, err := event.Find(t.Context(), event.MostRecentPodEvents(p.ID, 10))
 		require.NoError(t, err)
 		require.Len(t, events, 1)
 		assert.Equal(t, p.ID, events[0].ResourceId)
@@ -650,7 +650,7 @@ func TestClearRunningTask(t *testing.T) {
 		assert.Zero(t, p.TaskRuntimeInfo.RunningTaskID)
 		assert.Zero(t, p.TaskRuntimeInfo.RunningTaskExecution)
 
-		events, err := event.FindAllByResourceID(podID)
+		events, err := event.FindAllByResourceID(t.Context(), podID)
 		require.NoError(t, err)
 		require.Len(t, events, 1)
 		assert.EqualValues(t, event.EventPodClearedTask, events[0].EventType, "should have logged event indicating task is cleared from pod")
@@ -694,7 +694,7 @@ func TestClearRunningTask(t *testing.T) {
 			assert.Zero(t, dbPod.TaskRuntimeInfo.RunningTaskID)
 			assert.Zero(t, dbPod.TaskRuntimeInfo.RunningTaskExecution)
 
-			events, err := event.FindAllByResourceID(p.ID)
+			events, err := event.FindAllByResourceID(t.Context(), p.ID)
 			require.NoError(t, err)
 			assert.Empty(t, events)
 		},

--- a/model/project.go
+++ b/model/project.go
@@ -2140,7 +2140,7 @@ func FetchVersionsBuildsAndTasks(ctx context.Context, project *Project, skip int
 	}
 
 	// fetch all of the builds (with only relevant fields)
-	buildsFromDb, err := build.Find(
+	buildsFromDb, err := build.Find(ctx,
 		build.ByVersions(versionIds).
 			WithFields(
 				build.BuildVariantKey,

--- a/model/project.go
+++ b/model/project.go
@@ -2114,7 +2114,7 @@ func dependenciesForTaskUnit(taskUnits []BuildVariantTaskUnit) []task.Dependency
 // and a map of build ID -> each build's tasks
 func FetchVersionsBuildsAndTasks(ctx context.Context, project *Project, skip int, numVersions int, showTriggered bool) ([]Version, map[string][]build.Build, map[string][]task.Task, error) {
 	// fetch the versions from the db
-	versionsFromDB, err := VersionFind(VersionByProjectAndTrigger(project.Identifier, showTriggered).
+	versionsFromDB, err := VersionFind(ctx, VersionByProjectAndTrigger(project.Identifier, showTriggered).
 		WithFields(
 			VersionRevisionKey,
 			VersionErrorsKey,

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -143,12 +143,12 @@ func mergeProjectConfigAndAliases(projectConfig *ProjectConfig, dbAliases []Proj
 }
 
 // FindAliasesForRepo fetches all aliases for a given project
-func FindAliasesForRepo(repoId string) ([]ProjectAlias, error) {
+func FindAliasesForRepo(ctx context.Context, repoId string) ([]ProjectAlias, error) {
 	out := []ProjectAlias{}
 	q := db.Query(bson.M{
 		projectIDKey: repoId,
 	})
-	err := db.FindAllQ(ProjectAliasCollection, q, &out)
+	err := db.FindAllQContext(ctx, ProjectAliasCollection, q, &out)
 	if err != nil {
 		return nil, err
 	}
@@ -269,7 +269,7 @@ func ConstructMergedAliasesByPrecedence(ctx context.Context, projectRef *Project
 	uncoveredAliases := uncoveredAliasTypes(aliasesToReturn)
 	if len(uncoveredAliases) > 0 && repoId != "" {
 		// Get repo aliases and merge with project aliases
-		repoAliases, err := FindAliasesForRepo(repoId)
+		repoAliases, err := FindAliasesForRepo(ctx, repoId)
 		if err != nil {
 			return nil, errors.Wrap(err, "finding repo aliases")
 		}

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -92,12 +92,12 @@ const (
 type ProjectAliases []ProjectAlias
 
 // FindAliasesForProjectFromDb fetches all aliases for a given project without merging with aliases from the parser project
-func FindAliasesForProjectFromDb(projectID string) ([]ProjectAlias, error) {
+func FindAliasesForProjectFromDb(ctx context.Context, projectID string) ([]ProjectAlias, error) {
 	var out []ProjectAlias
 	q := db.Query(bson.M{
 		projectIDKey: projectID,
 	})
-	err := db.FindAllQ(ProjectAliasCollection, q, &out)
+	err := db.FindAllQContext(ctx, ProjectAliasCollection, q, &out)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding project aliases")
 	}
@@ -241,11 +241,11 @@ const patchAliasKey = "patch_alias"
 
 // ConstructMergedAliasesByPrecedence will construct a merged list of aliases based on what aliases
 // are found at the project level, repo level, and project config level.
-func ConstructMergedAliasesByPrecedence(projectRef *ProjectRef, projectConfig *ProjectConfig, repoId string) ([]ProjectAlias, error) {
+func ConstructMergedAliasesByPrecedence(ctx context.Context, projectRef *ProjectRef, projectConfig *ProjectConfig, repoId string) ([]ProjectAlias, error) {
 	var projectAliases []ProjectAlias
 	var err error
 	if projectRef != nil {
-		projectAliases, err = FindAliasesForProjectFromDb(projectRef.Id)
+		projectAliases, err = FindAliasesForProjectFromDb(ctx, projectRef.Id)
 		if err != nil {
 			return nil, errors.Wrap(err, "finding project aliases")
 		}
@@ -382,7 +382,7 @@ func HasMatchingGitTagAliasAndRemotePath(ctx context.Context, projectId, tag str
 
 // CopyProjectAliases finds the aliases for a given project and inserts them for the new project.
 func CopyProjectAliases(ctx context.Context, oldProjectId, newProjectId string) error {
-	aliases, err := FindAliasesForProjectFromDb(oldProjectId)
+	aliases, err := FindAliasesForProjectFromDb(ctx, oldProjectId)
 	if err != nil {
 		return errors.Wrapf(err, "finding aliases for project '%s'", oldProjectId)
 	}

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -158,13 +158,13 @@ func FindAliasesForRepo(ctx context.Context, repoId string) ([]ProjectAlias, err
 
 // findMatchingAliasForRepo finds all aliases with a given name for a repo.
 // Typically FindAliasInProjectRepoOrConfig should be used.
-func findMatchingAliasForRepo(repoID, alias string) ([]ProjectAlias, error) {
+func findMatchingAliasForRepo(ctx context.Context, repoID, alias string) ([]ProjectAlias, error) {
 	var out []ProjectAlias
 	q := db.Query(bson.M{
 		projectIDKey: repoID,
 		aliasKey:     alias,
 	})
-	err := db.FindAllQ(ProjectAliasCollection, q, &out)
+	err := db.FindAllQContext(ctx, ProjectAliasCollection, q, &out)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding project aliases for repo")
 	}
@@ -173,13 +173,13 @@ func findMatchingAliasForRepo(repoID, alias string) ([]ProjectAlias, error) {
 
 // findMatchingAliasForProjectRef finds all aliases with a given name for a project.
 // Typically FindAliasInProjectRepoOrConfig should be used.
-func findMatchingAliasForProjectRef(projectID, alias string) ([]ProjectAlias, error) {
+func findMatchingAliasForProjectRef(ctx context.Context, projectID, alias string) ([]ProjectAlias, error) {
 	var out []ProjectAlias
 	q := db.Query(bson.M{
 		projectIDKey: projectID,
 		aliasKey:     alias,
 	})
-	err := db.FindAllQ(ProjectAliasCollection, q, &out)
+	err := db.FindAllQContext(ctx, ProjectAliasCollection, q, &out)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding project aliases")
 	}
@@ -338,7 +338,7 @@ func FindAliasInProjectRepoOrProjectConfig(ctx context.Context, projectID, alias
 // findAliasInProjectOrRepoFromDb finds all aliases with a given name for a project without merging with parser project.
 // If the project has no aliases, the repo is checked for aliases.
 func findAliasInProjectOrRepoFromDb(ctx context.Context, projectID, alias string) ([]ProjectAlias, error) {
-	aliases, err := findMatchingAliasForProjectRef(projectID, alias)
+	aliases, err := findMatchingAliasForProjectRef(ctx, projectID, alias)
 	if err != nil {
 		return aliases, errors.Wrapf(err, "finding aliases for project ref '%s'", projectID)
 	}
@@ -360,7 +360,7 @@ func tryGetRepoAliases(ctx context.Context, projectID string, alias string, alia
 		return aliases, nil
 	}
 
-	aliases, err = findMatchingAliasForRepo(project.RepoRefId, alias)
+	aliases, err = findMatchingAliasForRepo(ctx, project.RepoRefId, alias)
 	if err != nil {
 		return aliases, errors.Wrapf(err, "finding aliases for repo '%s'", project.RepoRefId)
 	}

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -97,7 +97,7 @@ func FindAliasesForProjectFromDb(ctx context.Context, projectID string) ([]Proje
 	q := db.Query(bson.M{
 		projectIDKey: projectID,
 	})
-	err := db.FindAllQContext(ctx, ProjectAliasCollection, q, &out)
+	err := db.FindAllQ(ctx, ProjectAliasCollection, q, &out)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding project aliases")
 	}
@@ -148,7 +148,7 @@ func FindAliasesForRepo(ctx context.Context, repoId string) ([]ProjectAlias, err
 	q := db.Query(bson.M{
 		projectIDKey: repoId,
 	})
-	err := db.FindAllQContext(ctx, ProjectAliasCollection, q, &out)
+	err := db.FindAllQ(ctx, ProjectAliasCollection, q, &out)
 	if err != nil {
 		return nil, err
 	}
@@ -164,7 +164,7 @@ func findMatchingAliasForRepo(ctx context.Context, repoID, alias string) ([]Proj
 		projectIDKey: repoID,
 		aliasKey:     alias,
 	})
-	err := db.FindAllQContext(ctx, ProjectAliasCollection, q, &out)
+	err := db.FindAllQ(ctx, ProjectAliasCollection, q, &out)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding project aliases for repo")
 	}
@@ -179,7 +179,7 @@ func findMatchingAliasForProjectRef(ctx context.Context, projectID, alias string
 		projectIDKey: projectID,
 		aliasKey:     alias,
 	})
-	err := db.FindAllQContext(ctx, ProjectAliasCollection, q, &out)
+	err := db.FindAllQ(ctx, ProjectAliasCollection, q, &out)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding project aliases")
 	}

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -207,7 +207,7 @@ func (s *ProjectAliasSuite) TestFindAliasInProject() {
 	s.NoError(a2.Upsert(s.T().Context()))
 	s.NoError(a3.Upsert(s.T().Context()))
 
-	found, err := findMatchingAliasForProjectRef("project-1", "alias-1")
+	found, err := findMatchingAliasForProjectRef(s.T().Context(), "project-1", "alias-1")
 	s.NoError(err)
 	s.Len(found, 2)
 }

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -154,12 +154,12 @@ func (s *ProjectAliasSuite) TestRemove() {
 	}
 	var out []ProjectAlias
 	q := db.Query(bson.M{})
-	s.NoError(db.FindAllQContext(s.T().Context(), ProjectAliasCollection, q, &out))
+	s.NoError(db.FindAllQ(s.T().Context(), ProjectAliasCollection, q, &out))
 	s.Len(out, 10)
 
 	for i, a := range s.aliases {
 		s.NoError(RemoveProjectAlias(s.T().Context(), a.ID.Hex()))
-		s.NoError(db.FindAllQContext(s.T().Context(), ProjectAliasCollection, q, &out))
+		s.NoError(db.FindAllQ(s.T().Context(), ProjectAliasCollection, q, &out))
 		s.Len(out, 10-i-1)
 	}
 }

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -176,7 +176,7 @@ func (s *ProjectAliasSuite) TestFindAliasesForProject() {
 	}
 	s.NoError(a1.Upsert(s.T().Context()))
 
-	out, err := FindAliasesForProjectFromDb("project-1")
+	out, err := FindAliasesForProjectFromDb(s.T().Context(), "project-1")
 	s.NoError(err)
 	s.Len(out, 2)
 }
@@ -373,7 +373,7 @@ func TestFindMergedAliasesFromProjectRepoOrProjectConfig(t *testing.T) {
 			tempRef := ProjectRef{ // This ref has nothing else enabled so merging should only return project aliases
 				Id: pRef.Id,
 			}
-			res, err := ConstructMergedAliasesByPrecedence(&tempRef, &projectConfig, "")
+			res, err := ConstructMergedAliasesByPrecedence(t.Context(), &tempRef, &projectConfig, "")
 			assert.NoError(t, err)
 			require.Len(t, res, 2)
 			assert.Equal(t, res[0].ProjectID, pRef.Id)
@@ -384,7 +384,7 @@ func TestFindMergedAliasesFromProjectRepoOrProjectConfig(t *testing.T) {
 			assert.NoError(t, UpsertAliasesForProject(t.Context(), cqAliases, pRef.RepoRefId))
 			assert.NoError(t, UpsertAliasesForProject(t.Context(), gitTagAliases, pRef.RepoRefId))
 			assert.NoError(t, UpsertAliasesForProject(t.Context(), githubChecksAlias, pRef.RepoRefId))
-			res, err := ConstructMergedAliasesByPrecedence(&pRef, &projectConfig, pRef.RepoRefId)
+			res, err := ConstructMergedAliasesByPrecedence(t.Context(), &pRef, &projectConfig, pRef.RepoRefId)
 			assert.NoError(t, err)
 			// Uses aliases from project, repo, and config
 			require.Len(t, res, 6)
@@ -410,7 +410,7 @@ func TestFindMergedAliasesFromProjectRepoOrProjectConfig(t *testing.T) {
 			assert.NoError(t, UpsertAliasesForProject(t.Context(), cqAliases, pRef.Id))
 			assert.NoError(t, UpsertAliasesForProject(t.Context(), cqAliases, pRef.RepoRefId))
 			assert.NoError(t, UpsertAliasesForProject(t.Context(), patchAliases, pRef.RepoRefId))
-			res, err := ConstructMergedAliasesByPrecedence(&pRef, &projectConfig, pRef.RepoRefId)
+			res, err := ConstructMergedAliasesByPrecedence(t.Context(), &pRef, &projectConfig, pRef.RepoRefId)
 			assert.NoError(t, err)
 			// Ignores config aliases because they're already used
 			require.Len(t, res, 4)
@@ -554,12 +554,12 @@ func (s *ProjectAliasSuite) TestUpsertAliasesForProject() {
 	}
 	s.NoError(UpsertAliasesForProject(s.T().Context(), s.aliases, "new-project"))
 
-	found, err := FindAliasesForProjectFromDb("new-project")
+	found, err := FindAliasesForProjectFromDb(s.T().Context(), "new-project")
 	s.NoError(err)
 	s.Len(found, 10)
 
 	// verify old aliases not overwritten
-	found, err = FindAliasesForProjectFromDb("old-project")
+	found, err = FindAliasesForProjectFromDb(s.T().Context(), "old-project")
 	s.NoError(err)
 	s.Len(found, 10)
 }

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -321,7 +321,7 @@ func MostRecentProjectEvents(ctx context.Context, id string, n int) (ProjectChan
 
 // ProjectEventsBefore returns the n most recent project events for the given project ID
 // that occurred before the given time.
-func ProjectEventsBefore(id string, before time.Time, n int) (ProjectChangeEvents, error) {
+func ProjectEventsBefore(ctx context.Context, id string, before time.Time, n int) (ProjectChangeEvents, error) {
 	filter := event.ResourceTypeKeyIs(event.EventResourceTypeProject)
 	filter[event.ResourceIdKey] = id
 	filter[event.TimestampKey] = bson.M{
@@ -330,7 +330,7 @@ func ProjectEventsBefore(id string, before time.Time, n int) (ProjectChangeEvent
 
 	query := db.Query(filter).Sort([]string{"-" + event.TimestampKey}).Limit(n)
 	events := ProjectChangeEvents{}
-	err := db.FindAllQ(event.EventCollection, query, &events)
+	err := db.FindAllQContext(ctx, event.EventCollection, query, &events)
 
 	return events, err
 }

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -314,7 +314,7 @@ func MostRecentProjectEvents(ctx context.Context, id string, n int) (ProjectChan
 
 	query := db.Query(filter).Sort([]string{"-" + event.TimestampKey}).Limit(n)
 	events := ProjectChangeEvents{}
-	err := db.FindAllQContext(ctx, event.EventCollection, query, &events)
+	err := db.FindAllQ(ctx, event.EventCollection, query, &events)
 
 	return events, err
 }
@@ -330,7 +330,7 @@ func ProjectEventsBefore(ctx context.Context, id string, before time.Time, n int
 
 	query := db.Query(filter).Sort([]string{"-" + event.TimestampKey}).Limit(n)
 	events := ProjectChangeEvents{}
-	err := db.FindAllQContext(ctx, event.EventCollection, query, &events)
+	err := db.FindAllQ(ctx, event.EventCollection, query, &events)
 
 	return events, err
 }

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -308,13 +308,13 @@ func (e *ProjectChangeEventEntry) SetBSON(raw mgobson.Raw) error {
 }
 
 // MostRecentProjectEvents returns the n most recent project events for the given project ID.
-func MostRecentProjectEvents(id string, n int) (ProjectChangeEvents, error) {
+func MostRecentProjectEvents(ctx context.Context, id string, n int) (ProjectChangeEvents, error) {
 	filter := event.ResourceTypeKeyIs(event.EventResourceTypeProject)
 	filter[event.ResourceIdKey] = id
 
 	query := db.Query(filter).Sort([]string{"-" + event.TimestampKey}).Limit(n)
 	events := ProjectChangeEvents{}
-	err := db.FindAllQ(event.EventCollection, query, &events)
+	err := db.FindAllQContext(ctx, event.EventCollection, query, &events)
 
 	return events, err
 }

--- a/model/project_event_test.go
+++ b/model/project_event_test.go
@@ -73,7 +73,7 @@ func (s *ProjectEventSuite) TestModifyProjectEvent() {
 
 	s.NoError(LogProjectModified(s.T().Context(), projectId, username, &before, &after))
 
-	projectEvents, err := MostRecentProjectEvents(projectId, 5)
+	projectEvents, err := MostRecentProjectEvents(s.T().Context(), projectId, 5)
 	s.NoError(err)
 	s.Require().Len(projectEvents, 1)
 
@@ -126,7 +126,7 @@ func (s *ProjectEventSuite) TestModifyProjectEventRedactsAllVars() {
 
 	s.NoError(LogProjectModified(s.T().Context(), projectId, username, &before, &after))
 
-	projectEvents, err := MostRecentProjectEvents(projectId, 5)
+	projectEvents, err := MostRecentProjectEvents(s.T().Context(), projectId, 5)
 	s.NoError(err)
 	s.Require().Len(projectEvents, 1)
 
@@ -178,7 +178,7 @@ func (s *ProjectEventSuite) TestModifyProjectNonEvent() {
 
 	s.NoError(LogProjectModified(s.T().Context(), projectId, username, &before, &after))
 
-	projectEvents, err := MostRecentProjectEvents(projectId, 5)
+	projectEvents, err := MostRecentProjectEvents(s.T().Context(), projectId, 5)
 	s.NoError(err)
 	s.Require().Empty(projectEvents)
 }
@@ -186,7 +186,7 @@ func (s *ProjectEventSuite) TestModifyProjectNonEvent() {
 func (s *ProjectEventSuite) TestAddProject() {
 	s.NoError(LogProjectAdded(s.T().Context(), projectId, username))
 
-	projectEvents, err := MostRecentProjectEvents(projectId, 5)
+	projectEvents, err := MostRecentProjectEvents(s.T().Context(), projectId, 5)
 	s.NoError(err)
 
 	s.Require().Len(projectEvents, 1)

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -874,7 +874,7 @@ func (p *ProjectRef) DetachFromRepo(ctx context.Context, u *user.DBUser) error {
 	}
 
 	// Handle each category of aliases as its own case
-	repoAliases, err := FindAliasesForRepo(before.ProjectRef.RepoRefId)
+	repoAliases, err := FindAliasesForRepo(ctx, before.ProjectRef.RepoRefId)
 	catcher.Wrap(err, "finding repo aliases")
 
 	hasInternalAliases := map[string]bool{}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1516,7 +1516,7 @@ func FindAnyRestrictedProjectRef(ctx context.Context) (*ProjectRef, error) {
 func FindAllMergedTrackedProjectRefs(ctx context.Context) ([]ProjectRef, error) {
 	projectRefs := []ProjectRef{}
 	q := db.Query(bson.M{ProjectRefHiddenKey: bson.M{"$ne": true}})
-	err := db.FindAllQContext(ctx, ProjectRefCollection, q, &projectRefs)
+	err := db.FindAllQ(ctx, ProjectRefCollection, q, &projectRefs)
 	if err != nil {
 		return nil, err
 	}
@@ -1533,7 +1533,7 @@ func FindAllMergedEnabledTrackedProjectRefs(ctx context.Context) ([]ProjectRef, 
 		ProjectRefHiddenKey:  bson.M{"$ne": true},
 		ProjectRefEnabledKey: true,
 	})
-	err := db.FindAllQContext(ctx, ProjectRefCollection, q, &projectRefs)
+	err := db.FindAllQ(ctx, ProjectRefCollection, q, &projectRefs)
 	if err != nil {
 		return nil, err
 	}
@@ -1621,7 +1621,7 @@ func FindProjectRefsByIds(ctx context.Context, ids ...string) ([]ProjectRef, err
 func findProjectRefsQ(ctx context.Context, filter bson.M, merged bool) ([]ProjectRef, error) {
 	projectRefs := []ProjectRef{}
 	q := db.Query(filter)
-	err := db.FindAllQContext(ctx, ProjectRefCollection, q, &projectRefs)
+	err := db.FindAllQ(ctx, ProjectRefCollection, q, &projectRefs)
 	if err != nil {
 		return nil, err
 	}
@@ -1719,7 +1719,7 @@ func filterProjectsByBranch(pRefs []ProjectRef, branch string) []ProjectRef {
 // UserHasRepoViewPermission returns true if the user has permission to view any branch project settings.
 func UserHasRepoViewPermission(ctx context.Context, u *user.DBUser, repoRefId string) (bool, error) {
 	projectRefs := []ProjectRef{}
-	err := db.FindAllQContext(ctx,
+	err := db.FindAllQ(ctx,
 		ProjectRefCollection,
 		db.Query(bson.M{
 			ProjectRefRepoRefIdKey: repoRefId,
@@ -1945,7 +1945,7 @@ func FindNonHiddenProjects(ctx context.Context, key string, limit int, sortDir i
 	}
 
 	q := db.Query(filter).Sort([]string{sortSpec}).Limit(limit)
-	err := db.FindAllQContext(ctx, ProjectRefCollection, q, &projectRefs)
+	err := db.FindAllQ(ctx, ProjectRefCollection, q, &projectRefs)
 
 	return projectRefs, errors.Wrapf(err, "fetching projects starting at project '%s'", key)
 }
@@ -1996,7 +1996,7 @@ func FindMergedProjectRefsForRepo(ctx context.Context, repoRef *RepoRef) ([]Proj
 			{ProjectRefRepoRefIdKey: repoRef.Id},
 		},
 	})
-	err := db.FindAllQContext(ctx, ProjectRefCollection, q, &projectRefs)
+	err := db.FindAllQ(ctx, ProjectRefCollection, q, &projectRefs)
 	if err != nil {
 		return nil, err
 	}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1302,7 +1302,7 @@ func (p *ProjectRef) createNewRepoRef(ctx context.Context, u *user.DBUser) (repo
 		return nil, errors.Wrap(err, "inserting project variables for repo")
 	}
 
-	commonAliases, err := getCommonAliases(enabledProjectIds)
+	commonAliases, err := getCommonAliases(ctx, enabledProjectIds)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting common project aliases")
 	}
@@ -1315,10 +1315,10 @@ func (p *ProjectRef) createNewRepoRef(ctx context.Context, u *user.DBUser) (repo
 	return repoRef, nil
 }
 
-func getCommonAliases(projectIds []string) (ProjectAliases, error) {
+func getCommonAliases(ctx context.Context, projectIds []string) (ProjectAliases, error) {
 	commonAliases := []ProjectAlias{}
 	for i, id := range projectIds {
-		aliases, err := FindAliasesForProjectFromDb(id)
+		aliases, err := FindAliasesForProjectFromDb(ctx, id)
 		if err != nil {
 			return nil, errors.Wrap(err, "finding aliases for project")
 		}
@@ -2070,7 +2070,7 @@ func GetProjectSettings(ctx context.Context, p *ProjectRef) (*ProjectSettings, e
 	if projectVars == nil {
 		projectVars = &ProjectVars{}
 	}
-	projectAliases, err := FindAliasesForProjectFromDb(p.Id)
+	projectAliases, err := FindAliasesForProjectFromDb(ctx, p.Id)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding aliases for project '%s'", p.Id)
 	}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -863,7 +863,7 @@ func (p *ProjectRef) DetachFromRepo(ctx context.Context, u *user.DBUser) error {
 
 	if len(before.Subscriptions) == 0 {
 		// Save repo subscriptions as project subscriptions if none exist
-		subs, err := event.FindSubscriptionsByOwner(before.ProjectRef.RepoRefId, event.OwnerTypeProject)
+		subs, err := event.FindSubscriptionsByOwner(ctx, before.ProjectRef.RepoRefId, event.OwnerTypeProject)
 		catcher.Wrap(err, "finding repo subscriptions")
 
 		for _, s := range subs {
@@ -2074,7 +2074,7 @@ func GetProjectSettings(ctx context.Context, p *ProjectRef) (*ProjectSettings, e
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding aliases for project '%s'", p.Id)
 	}
-	subscriptions, err := event.FindSubscriptionsByOwner(p.Id, event.OwnerTypeProject)
+	subscriptions, err := event.FindSubscriptionsByOwner(ctx, p.Id, event.OwnerTypeProject)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding subscription for project '%s'", p.Id)
 	}

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -871,7 +871,7 @@ func TestAttachToNewRepo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, userFromDB.SystemRoles, 1)
 	assert.Contains(t, userFromDB.SystemRoles, GetRepoAdminRole(pRefFromDB.RepoRefId))
-	hasPermission, err := UserHasRepoViewPermission(u, pRefFromDB.RepoRefId)
+	hasPermission, err := UserHasRepoViewPermission(t.Context(), u, pRefFromDB.RepoRefId)
 	assert.NoError(t, err)
 	assert.True(t, hasPermission)
 	// Attaching a different project to this repo will result in Github conflicts being unset.
@@ -977,7 +977,7 @@ func TestAttachToRepo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, u)
 	assert.Contains(t, u.Roles(), GetRepoAdminRole(pRefFromDB.RepoRefId))
-	hasPermission, err := UserHasRepoViewPermission(u, pRefFromDB.RepoRefId)
+	hasPermission, err := UserHasRepoViewPermission(t.Context(), u, pRefFromDB.RepoRefId)
 	assert.NoError(t, err)
 	assert.True(t, hasPermission)
 
@@ -1070,7 +1070,7 @@ func TestDetachFromRepo(t *testing.T) {
 			dbUser, err = user.FindOneByIdContext(t.Context(), "me")
 			assert.NoError(t, err)
 			assert.NotNil(t, dbUser)
-			hasPermission, err := UserHasRepoViewPermission(dbUser, pRefFromDB.RepoRefId)
+			hasPermission, err := UserHasRepoViewPermission(t.Context(), dbUser, pRefFromDB.RepoRefId)
 			assert.NoError(t, err)
 			assert.False(t, hasPermission)
 		},
@@ -4143,7 +4143,7 @@ func TestUserHasRepoViewPermission(t *testing.T) {
 			require.NoError(t, roleManager.UpdateRole(wrongProjectRole))
 
 			assert.NoError(t, usr.AddRole(t.Context(), wrongProjectRole.ID))
-			hasPermission, err := UserHasRepoViewPermission(usr, "myRepoId")
+			hasPermission, err := UserHasRepoViewPermission(t.Context(), usr, "myRepoId")
 			assert.NoError(t, err)
 			assert.False(t, hasPermission)
 		},
@@ -4156,7 +4156,7 @@ func TestUserHasRepoViewPermission(t *testing.T) {
 			require.NoError(t, roleManager.UpdateRole(wrongPermissionRole))
 
 			assert.NoError(t, usr.AddRole(t.Context(), wrongPermissionRole.ID))
-			hasPermission, err := UserHasRepoViewPermission(usr, "myRepoId")
+			hasPermission, err := UserHasRepoViewPermission(t.Context(), usr, "myRepoId")
 			assert.NoError(t, err)
 			assert.False(t, hasPermission)
 		},
@@ -4169,7 +4169,7 @@ func TestUserHasRepoViewPermission(t *testing.T) {
 			require.NoError(t, roleManager.UpdateRole(viewBranchRole))
 
 			assert.NoError(t, usr.AddRole(t.Context(), viewBranchRole.ID))
-			hasPermission, err := UserHasRepoViewPermission(usr, "myRepoId")
+			hasPermission, err := UserHasRepoViewPermission(t.Context(), usr, "myRepoId")
 			assert.NoError(t, err)
 			assert.True(t, hasPermission)
 		},

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -908,7 +908,7 @@ func TestAttachToNewRepo(t *testing.T) {
 }
 
 func checkRepoAttachmentEventLog(t *testing.T, project ProjectRef, attachmentType string) {
-	events, err := MostRecentProjectEvents(project.Id, 10)
+	events, err := MostRecentProjectEvents(t.Context(), project.Id, 10)
 	require.NoError(t, err)
 	require.Len(t, events, 1)
 	assert.Equal(t, project.Id, events[0].ResourceId)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1110,7 +1110,7 @@ func TestDetachFromRepo(t *testing.T) {
 
 			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 			checkRepoAttachmentEventLog(t, *pRef, event.EventTypeProjectDetachedFromRepo)
-			aliases, err := FindAliasesForProjectFromDb(pRef.Id)
+			aliases, err := FindAliasesForProjectFromDb(t.Context(), pRef.Id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 1)
 			assert.Equal(t, aliases[0].Alias, projectAlias.Alias)
@@ -1122,7 +1122,7 @@ func TestDetachFromRepo(t *testing.T) {
 			assert.NoError(t, RemoveProjectAlias(ctx, projectAlias.ID.Hex()))
 
 			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
-			aliases, err = FindAliasesForProjectFromDb(pRef.Id)
+			aliases, err = FindAliasesForProjectFromDb(t.Context(), pRef.Id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 1)
 			assert.Equal(t, aliases[0].Alias, repoAlias.Alias)
@@ -1141,7 +1141,7 @@ func TestDetachFromRepo(t *testing.T) {
 
 			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 			checkRepoAttachmentEventLog(t, *pRef, event.EventTypeProjectDetachedFromRepo)
-			aliases, err := FindAliasesForProjectFromDb(pRef.Id)
+			aliases, err := FindAliasesForProjectFromDb(t.Context(), pRef.Id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 3)
 			gitTagCount := 0
@@ -1334,7 +1334,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 			assert.NotEmpty(t, varsFromDb.Id)
 		},
 		ProjectPageGithubAndCQSection: func(t *testing.T, id string) {
-			aliases, err := FindAliasesForProjectFromDb(id)
+			aliases, err := FindAliasesForProjectFromDb(t.Context(), id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 5)
 			assert.NoError(t, DefaultSectionToRepo(t.Context(), id, ProjectPageGithubAndCQSection, "me"))
@@ -1345,7 +1345,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 			assert.Nil(t, pRefFromDb.PRTestingEnabled)
 			assert.Nil(t, pRefFromDb.GithubChecksEnabled)
 			assert.Nil(t, pRefFromDb.GitTagAuthorizedUsers)
-			aliases, err = FindAliasesForProjectFromDb(id)
+			aliases, err = FindAliasesForProjectFromDb(t.Context(), id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 1)
 			// assert that only patch aliases are left
@@ -1361,7 +1361,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 			assert.Nil(t, pRefFromDb.NotifyOnBuildFailure)
 		},
 		ProjectPagePatchAliasSection: func(t *testing.T, id string) {
-			aliases, err := FindAliasesForProjectFromDb(id)
+			aliases, err := FindAliasesForProjectFromDb(t.Context(), id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 5)
 
@@ -1371,7 +1371,7 @@ func TestDefaultRepoBySection(t *testing.T) {
 			assert.NotNil(t, pRefFromDb)
 			assert.Nil(t, pRefFromDb.PatchTriggerAliases)
 
-			aliases, err = FindAliasesForProjectFromDb(id)
+			aliases, err = FindAliasesForProjectFromDb(t.Context(), id)
 			assert.NoError(t, err)
 			assert.Len(t, aliases, 4)
 			// assert that no patch aliases are left

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1195,7 +1195,7 @@ func TestDetachFromRepo(t *testing.T) {
 			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 			checkRepoAttachmentEventLog(t, *pRef, event.EventTypeProjectDetachedFromRepo)
 
-			subs, err := event.FindSubscriptionsByOwner(pRef.Id, event.OwnerTypeProject)
+			subs, err := event.FindSubscriptionsByOwner(t.Context(), pRef.Id, event.OwnerTypeProject)
 			assert.NoError(t, err)
 			require.Len(t, subs, 1)
 			assert.Equal(t, subs[0].Owner, pRef.Id)
@@ -1206,7 +1206,7 @@ func TestDetachFromRepo(t *testing.T) {
 			assert.NoError(t, event.RemoveSubscription(ctx, projectSubscription.ID))
 			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 
-			subs, err = event.FindSubscriptionsByOwner(pRef.Id, event.OwnerTypeProject)
+			subs, err = event.FindSubscriptionsByOwner(t.Context(), pRef.Id, event.OwnerTypeProject)
 			assert.NoError(t, err)
 			assert.Len(t, subs, 1)
 			assert.Equal(t, subs[0].Owner, pRef.Id)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1989,7 +1989,7 @@ func TestCreateNewRepoRef(t *testing.T) {
 	assert.NotContains(t, repoRef.Admins, "bob")
 	assert.NotContains(t, repoRef.Admins, "other bob")
 	assert.Contains(t, repoRef.Admins, "me")
-	users, err := user.FindByRole(GetRepoAdminRole(repoRef.Id))
+	users, err := user.FindByRole(t.Context(), GetRepoAdminRole(repoRef.Id))
 	assert.NoError(t, err)
 	require.Len(t, users, 1)
 	assert.Equal(t, "me", users[0].Id)

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -2003,7 +2003,7 @@ func TestCreateNewRepoRef(t *testing.T) {
 	assert.Equal(t, "green", projectVars.Vars["ever"])
 	assert.True(t, projectVars.PrivateVars["sdc"])
 
-	projectAliases, err = FindAliasesForRepo(repoRef.Id)
+	projectAliases, err = FindAliasesForRepo(t.Context(), repoRef.Id)
 	assert.NoError(t, err)
 	assert.Len(t, projectAliases, 2)
 	for _, a := range projectAliases {

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1727,60 +1727,60 @@ func (s *FindProjectsSuite) TearDownSuite() {
 }
 
 func (s *FindProjectsSuite) TestFetchTooManyAsc() {
-	projects, err := FindNonHiddenProjects("", 8, 1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "", 8, 1)
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 7)
 }
 
 func (s *FindProjectsSuite) TestFetchTooManyDesc() {
-	projects, err := FindNonHiddenProjects("zzz", 8, -1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "zzz", 8, -1)
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 7)
 }
 
 func (s *FindProjectsSuite) TestFetchExactNumber() {
-	projects, err := FindNonHiddenProjects("", 3, 1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "", 3, 1)
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 3)
 }
 
 func (s *FindProjectsSuite) TestFetchTooFewAsc() {
-	projects, err := FindNonHiddenProjects("", 2, 1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "", 2, 1)
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 2)
 }
 
 func (s *FindProjectsSuite) TestFetchTooFewDesc() {
-	projects, err := FindNonHiddenProjects("zzz", 2, -1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "zzz", 2, -1)
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 2)
 }
 
 func (s *FindProjectsSuite) TestFetchKeyWithinBoundAsc() {
-	projects, err := FindNonHiddenProjects("projectB", 1, 1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "projectB", 1, 1)
 	s.NoError(err)
 	s.Len(projects, 1)
 }
 
 func (s *FindProjectsSuite) TestFetchKeyWithinBoundDesc() {
-	projects, err := FindNonHiddenProjects("projectD", 1, -1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "projectD", 1, -1)
 	s.NoError(err)
 	s.Len(projects, 1)
 }
 
 func (s *FindProjectsSuite) TestFetchKeyOutOfBoundAsc() {
-	projects, err := FindNonHiddenProjects("zzz", 1, 1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "zzz", 1, 1)
 	s.NoError(err)
 	s.Empty(projects)
 }
 
 func (s *FindProjectsSuite) TestFetchKeyOutOfBoundDesc() {
-	projects, err := FindNonHiddenProjects("aaa", 1, -1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "aaa", 1, -1)
 	s.NoError(err)
 	s.Empty(projects)
 }

--- a/model/repo_ref.go
+++ b/model/repo_ref.go
@@ -64,7 +64,7 @@ func (r *RepoRef) Replace(ctx context.Context) error {
 
 func FindAllRepoRefs(ctx context.Context) ([]RepoRef, error) {
 	repoRefs := []RepoRef{}
-	err := db.FindAllQ(RepoRefCollection, db.Query(nil), &repoRefs)
+	err := db.FindAllQContext(ctx, RepoRefCollection, db.Query(nil), &repoRefs)
 	return repoRefs, err
 }
 

--- a/model/repo_ref.go
+++ b/model/repo_ref.go
@@ -64,7 +64,7 @@ func (r *RepoRef) Replace(ctx context.Context) error {
 
 func FindAllRepoRefs(ctx context.Context) ([]RepoRef, error) {
 	repoRefs := []RepoRef{}
-	err := db.FindAllQContext(ctx, RepoRefCollection, db.Query(nil), &repoRefs)
+	err := db.FindAllQ(ctx, RepoRefCollection, db.Query(nil), &repoRefs)
 	return repoRefs, err
 }
 

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -819,7 +819,7 @@ func GetRecentTasks(ctx context.Context, period time.Duration) ([]Task, error) {
 	)
 
 	tasks := []Task{}
-	err := db.FindAllQContext(ctx, Collection, query, &tasks)
+	err := db.FindAllQ(ctx, Collection, query, &tasks)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting recently-finished tasks")
 	}
@@ -1456,7 +1456,7 @@ func FindOneIdWithFields(ctx context.Context, id string, projected ...string) (*
 // findAllTaskIDs returns a list of task IDs associated with the given query.
 func findAllTaskIDs(ctx context.Context, q db.Q) ([]string, error) {
 	tasks := []Task{}
-	err := db.FindAllQContext(ctx, Collection, q, &tasks)
+	err := db.FindAllQ(ctx, Collection, q, &tasks)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding tasks")
 	}
@@ -1502,7 +1502,7 @@ func FindAllTaskIDsFromBuild(ctx context.Context, buildId string) ([]string, err
 func FindAllTasksFromVersionWithDependencies(ctx context.Context, versionId string) ([]Task, error) {
 	q := db.Query(ByVersion(versionId)).WithFields(IdKey, DependsOnKey)
 	tasks := []Task{}
-	err := db.FindAllQContext(ctx, Collection, q, &tasks)
+	err := db.FindAllQ(ctx, Collection, q, &tasks)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding task IDs for version '%s'", versionId)
 	}
@@ -1549,7 +1549,7 @@ func FindTaskGroupFromBuild(ctx context.Context, buildId, taskGroup string) ([]T
 func FindOldWithDisplayTasks(ctx context.Context, filter bson.M) ([]Task, error) {
 	tasks := []Task{}
 	query := db.Query(filter)
-	err := db.FindAllQContext(ctx, OldCollection, query, &tasks)
+	err := db.FindAllQ(ctx, OldCollection, query, &tasks)
 
 	return tasks, err
 }
@@ -1603,7 +1603,7 @@ func Find(ctx context.Context, filter bson.M) ([]Task, error) {
 		filter[DisplayOnlyKey] = bson.M{"$ne": true}
 	}
 	query := db.Query(filter)
-	err := db.FindAllQContext(ctx, Collection, query, &tasks)
+	err := db.FindAllQ(ctx, Collection, query, &tasks)
 
 	return tasks, err
 }
@@ -1615,7 +1615,7 @@ func FindWithFields(ctx context.Context, filter bson.M, fields ...string) ([]Tas
 		filter[DisplayOnlyKey] = bson.M{"$ne": true}
 	}
 	query := db.Query(filter).WithFields(fields...)
-	err := db.FindAllQContext(ctx, Collection, query, &tasks)
+	err := db.FindAllQ(ctx, Collection, query, &tasks)
 
 	return tasks, err
 }
@@ -1627,7 +1627,7 @@ func FindWithSort(ctx context.Context, filter bson.M, sort []string) ([]Task, er
 		filter[DisplayOnlyKey] = bson.M{"$ne": true}
 	}
 	query := db.Query(filter).Sort(sort)
-	err := db.FindAllQContext(ctx, Collection, query, &tasks)
+	err := db.FindAllQ(ctx, Collection, query, &tasks)
 
 	return tasks, err
 }
@@ -1635,14 +1635,14 @@ func FindWithSort(ctx context.Context, filter bson.M, sort []string) ([]Task, er
 // Find returns really all tasks that satisfy the query.
 func FindAll(ctx context.Context, query db.Q) ([]Task, error) {
 	tasks := []Task{}
-	err := db.FindAllQContext(ctx, Collection, query, &tasks)
+	err := db.FindAllQ(ctx, Collection, query, &tasks)
 	return tasks, err
 }
 
 // Find returns really all tasks that satisfy the query.
 func FindAllOld(ctx context.Context, query db.Q) ([]Task, error) {
 	tasks := []Task{}
-	err := db.FindAllQContext(ctx, OldCollection, query, &tasks)
+	err := db.FindAllQ(ctx, OldCollection, query, &tasks)
 	return tasks, err
 }
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1653,7 +1653,7 @@ func TestDeactivateStepbackTasksForProject(t *testing.T) {
 		wrongTaskNameTask, wrongVariantTask, runningStepbackTask, notStepbackTask))
 	assert.NoError(t, DeactivateStepbackTask(ctx, "p1", "myVariant", "myTask", "me"))
 
-	events, err := event.Find(db.Q{})
+	events, err := event.Find(t.Context(), db.Q{})
 	assert.NoError(t, err)
 	assert.Len(t, events, 3)
 	var numDeactivated, numAborted int
@@ -2393,7 +2393,7 @@ func TestActivateTasks(t *testing.T) {
 			assert.EqualValues(t, 0, task.Priority)
 			if utility.StringSliceContains(updatedIDs, task.Id) {
 				assert.True(t, task.Activated)
-				events, err := event.FindAllByResourceID(task.Id)
+				events, err := event.FindAllByResourceID(t.Context(), task.Id)
 				require.NoError(t, err)
 				assert.Len(t, events, 1)
 			} else {
@@ -2402,7 +2402,7 @@ func TestActivateTasks(t *testing.T) {
 						assert.Equal(t, origTask.Activated, task.Activated, "task '%s' mismatch", task.Id)
 					}
 				}
-				events, err := event.FindAllByResourceID(task.Id)
+				events, err := event.FindAllByResourceID(t.Context(), task.Id)
 				require.NoError(t, err)
 				assert.Empty(t, events)
 			}
@@ -2428,7 +2428,7 @@ func TestActivateTasks(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Empty(t, activatedDependencyIDs)
 
-		events, err := event.FindAllByResourceID(task.Id)
+		events, err := event.FindAllByResourceID(t.Context(), task.Id)
 		require.NoError(t, err)
 		assert.Empty(t, events)
 
@@ -3974,7 +3974,7 @@ func TestArchive(t *testing.T) {
 		require.NoError(t, err)
 		require.NotZero(t, dbTask)
 
-		events, err := event.FindAllByResourceID(hostID)
+		events, err := event.FindAllByResourceID(t.Context(), hostID)
 		require.NoError(t, err)
 		assert.NotEmpty(t, events)
 
@@ -4107,7 +4107,7 @@ func TestArchiveFailedOnly(t *testing.T) {
 		require.NoError(t, err)
 		require.NotZero(t, dbTask)
 
-		events, err := event.FindAllByResourceID(hostID)
+		events, err := event.FindAllByResourceID(t.Context(), hostID)
 		require.NoError(t, err)
 		assert.NotEmpty(t, events)
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1549,7 +1549,7 @@ func updateVersionGithubStatus(ctx context.Context, v *Version, builds []build.B
 // unfinished essential tasks. It assumes that the build statuses have already
 // been updated prior to this.
 func updateVersionStatus(ctx context.Context, v *Version) (string, error) {
-	builds, err := build.Find(build.ByVersion(v.Id))
+	builds, err := build.Find(ctx, build.ByVersion(v.Id))
 	if err != nil {
 		return "", errors.Wrapf(err, "getting builds for version '%s'", v.Id)
 	}
@@ -1739,7 +1739,7 @@ func UpdateVersionAndPatchStatusForBuilds(ctx context.Context, buildIds []string
 	if len(buildIds) == 0 {
 		return nil
 	}
-	builds, err := build.Find(build.ByIds(buildIds))
+	builds, err := build.Find(ctx, build.ByIds(buildIds))
 	if err != nil {
 		return errors.Wrapf(err, "fetching builds")
 	}

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1903,7 +1903,7 @@ func TestUpdateVersionGithubStatus(t *testing.T) {
 
 	assert.NoError(t, updateVersionGithubStatus(t.Context(), v, builds))
 
-	e, err := event.FindUnprocessedEvents(-1)
+	e, err := event.FindUnprocessedEvents(t.Context(), -1)
 	assert.NoError(t, err)
 	require.Len(t, e, 1)
 }
@@ -1925,7 +1925,7 @@ func TestUpdateBuildGithubStatus(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, evergreen.BuildSucceeded, b.GithubCheckStatus)
 
-	e, err := event.FindUnprocessedEvents(-1)
+	e, err := event.FindUnprocessedEvents(t.Context(), -1)
 	assert.NoError(t, err)
 	require.Len(t, e, 1)
 }
@@ -4156,7 +4156,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatus(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(evergreen.BuildFailed, b.Status)
 
-	e, err := event.FindUnprocessedEvents(-1)
+	e, err := event.FindUnprocessedEvents(t.Context(), -1)
 	assert.NoError(err)
 	assert.Len(e, 7)
 }
@@ -4237,7 +4237,7 @@ func TestMarkEndRequiresAllTasksToFinishToUpdateBuildStatusWithCompileTask(t *te
 	assert.NoError(err)
 	assert.Equal(evergreen.BuildFailed, b.Status)
 
-	e, err := event.FindUnprocessedEvents(-1)
+	e, err := event.FindUnprocessedEvents(t.Context(), -1)
 	assert.NoError(err)
 	assert.Len(e, 4)
 }
@@ -4318,7 +4318,7 @@ func TestMarkEndWithBlockedDependenciesTriggersNotifications(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(evergreen.BuildFailed, b.Status)
 
-	e, err := event.FindUnprocessedEvents(-1)
+	e, err := event.FindUnprocessedEvents(t.Context(), -1)
 	assert.NoError(err)
 	assert.Len(e, 4)
 }

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -428,7 +428,7 @@ func FindMinimumQueuePositionForTask(ctx context.Context, taskId string) (int, e
 
 func FindAllTaskQueues(ctx context.Context) ([]TaskQueue, error) {
 	taskQueues := []TaskQueue{}
-	err := db.FindAllQContext(ctx, TaskQueuesCollection, db.Query(bson.M{}), &taskQueues)
+	err := db.FindAllQ(ctx, TaskQueuesCollection, db.Query(bson.M{}), &taskQueues)
 	return taskQueues, err
 }
 

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -426,9 +426,9 @@ func FindMinimumQueuePositionForTask(ctx context.Context, taskId string) (int, e
 	return results[0].Index + 1, err
 }
 
-func FindAllTaskQueues() ([]TaskQueue, error) {
+func FindAllTaskQueues(ctx context.Context) ([]TaskQueue, error) {
 	taskQueues := []TaskQueue{}
-	err := db.FindAllQ(TaskQueuesCollection, db.Query(bson.M{}), &taskQueues)
+	err := db.FindAllQContext(ctx, TaskQueuesCollection, db.Query(bson.M{}), &taskQueues)
 	return taskQueues, err
 }
 

--- a/model/testlog/test_log.go
+++ b/model/testlog/test_log.go
@@ -64,9 +64,9 @@ func FindOneTestLog(ctx context.Context, name, task string, execution int) (*Tes
 	return tl, errors.WithStack(err)
 }
 
-func findAllTestLogs(query db.Q) ([]TestLog, error) {
+func findAllTestLogs(ctx context.Context, query db.Q) ([]TestLog, error) {
 	var result []TestLog
-	if err := db.FindAllQ(TestLogCollection, query, &result); err != nil {
+	if err := db.FindAllQContext(ctx, TestLogCollection, query, &result); err != nil {
 		return nil, errors.Wrap(err, "finding test logs")
 	}
 	return result, nil
@@ -77,7 +77,7 @@ func DeleteTestLogsWithLimit(ctx context.Context, env evergreen.Environment, ts 
 		return 0, errors.Errorf("cannot delete more than %d documents in a single operation", maxDeleteCount)
 	}
 
-	docsToDelete, err := findAllTestLogs(db.Query(bson.M{TestLogIdKey: bson.M{"$lt": primitive.NewObjectIDFromTimestamp(ts).Hex()}}).WithFields(TestLogIdKey).Limit(limit))
+	docsToDelete, err := findAllTestLogs(ctx, db.Query(bson.M{TestLogIdKey: bson.M{"$lt": primitive.NewObjectIDFromTimestamp(ts).Hex()}}).WithFields(TestLogIdKey).Limit(limit))
 	if err != nil {
 		return 0, errors.Wrap(err, "getting docs to delete")
 	}

--- a/model/testlog/test_log.go
+++ b/model/testlog/test_log.go
@@ -66,7 +66,7 @@ func FindOneTestLog(ctx context.Context, name, task string, execution int) (*Tes
 
 func findAllTestLogs(ctx context.Context, query db.Q) ([]TestLog, error) {
 	var result []TestLog
-	if err := db.FindAllQContext(ctx, TestLogCollection, query, &result); err != nil {
+	if err := db.FindAllQ(ctx, TestLogCollection, query, &result); err != nil {
 		return nil, errors.Wrap(err, "finding test logs")
 	}
 	return result, nil

--- a/model/user/db.go
+++ b/model/user/db.go
@@ -224,9 +224,9 @@ func FindBySlackUsername(ctx context.Context, userName string) (*DBUser, error) 
 	return &u, nil
 }
 
-func FindByRole(role string) ([]DBUser, error) {
+func FindByRole(ctx context.Context, role string) ([]DBUser, error) {
 	res := []DBUser{}
-	err := db.FindAllQ(
+	err := db.FindAllQContext(ctx,
 		Collection,
 		db.Query(bson.M{RolesKey: role}),
 		&res,
@@ -261,9 +261,9 @@ func AddOrUpdateServiceUser(ctx context.Context, u DBUser) error {
 }
 
 // FindHumanUsersByRoles returns human users that have any of the given roles.
-func FindHumanUsersByRoles(roles []string) ([]DBUser, error) {
+func FindHumanUsersByRoles(ctx context.Context, roles []string) ([]DBUser, error) {
 	res := []DBUser{}
-	err := db.FindAllQ(
+	err := db.FindAllQContext(ctx,
 		Collection,
 		db.Query(bson.M{
 			RolesKey:   bson.M{"$in": roles},

--- a/model/user/db.go
+++ b/model/user/db.go
@@ -120,7 +120,7 @@ func FindOneByIdContext(ctx context.Context, id string) (*DBUser, error) {
 // Find gets all DBUser for the given query.
 func Find(ctx context.Context, query db.Q) ([]DBUser, error) {
 	us := []DBUser{}
-	err := db.FindAllQContext(ctx, Collection, query, &us)
+	err := db.FindAllQ(ctx, Collection, query, &us)
 	return us, err
 }
 
@@ -226,7 +226,7 @@ func FindBySlackUsername(ctx context.Context, userName string) (*DBUser, error) 
 
 func FindByRole(ctx context.Context, role string) ([]DBUser, error) {
 	res := []DBUser{}
-	err := db.FindAllQContext(ctx,
+	err := db.FindAllQ(ctx,
 		Collection,
 		db.Query(bson.M{RolesKey: role}),
 		&res,
@@ -263,7 +263,7 @@ func AddOrUpdateServiceUser(ctx context.Context, u DBUser) error {
 // FindHumanUsersByRoles returns human users that have any of the given roles.
 func FindHumanUsersByRoles(ctx context.Context, roles []string) ([]DBUser, error) {
 	res := []DBUser{}
-	err := db.FindAllQContext(ctx,
+	err := db.FindAllQ(ctx,
 		Collection,
 		db.Query(bson.M{
 			RolesKey:   bson.M{"$in": roles},

--- a/model/version.go
+++ b/model/version.go
@@ -344,14 +344,14 @@ func VersionGetHistory(ctx context.Context, versionId string, N int) ([]Version,
 	// Versions in the same push event, assuming that no two push events happen at the exact same time
 	// Never want more than 2N+1 versions, so make sure we add a limit
 
-	siblingVersions, err := VersionFind(db.Query(
+	siblingVersions, err := VersionFind(ctx, db.Query(
 		bson.M{
 			VersionRevisionOrderNumberKey: v.RevisionOrderNumber,
 			VersionRequesterKey: bson.M{
 				"$in": evergreen.SystemVersionRequesterTypes,
 			},
 			VersionIdentifierKey: v.Identifier,
-		}).Sort([]string{VersionRevisionOrderNumberKey}).Limit(2*N + 1))
+		}).Sort([]string{VersionRevisionOrderNumberKey}).Limit(2*N+1))
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
@@ -369,7 +369,7 @@ func VersionGetHistory(ctx context.Context, versionId string, N int) ([]Version,
 	if versionIndex < N {
 		// There are less than N later versions from the same push event
 		// N subsequent versions plus the specified one
-		subsequentVersions, err := VersionFind(
+		subsequentVersions, err := VersionFind(ctx,
 			//TODO encapsulate this query in version pkg
 			db.Query(bson.M{
 				VersionRevisionOrderNumberKey: bson.M{"$gt": v.RevisionOrderNumber},
@@ -377,7 +377,7 @@ func VersionGetHistory(ctx context.Context, versionId string, N int) ([]Version,
 					"$in": evergreen.SystemVersionRequesterTypes,
 				},
 				VersionIdentifierKey: v.Identifier,
-			}).Sort([]string{VersionRevisionOrderNumberKey}).Limit(N - versionIndex))
+			}).Sort([]string{VersionRevisionOrderNumberKey}).Limit(N-versionIndex))
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}
@@ -391,7 +391,7 @@ func VersionGetHistory(ctx context.Context, versionId string, N int) ([]Version,
 	}
 
 	if numSiblings-versionIndex < N {
-		previousVersions, err := VersionFind(db.Query(bson.M{
+		previousVersions, err := VersionFind(ctx, db.Query(bson.M{
 			VersionRevisionOrderNumberKey: bson.M{"$lt": v.RevisionOrderNumber},
 			VersionRequesterKey: bson.M{
 				"$in": evergreen.SystemVersionRequesterTypes,
@@ -699,7 +699,7 @@ func GetVersionsToModify(ctx context.Context, projectName string, opts ModifyVer
 	} else {
 		match[VersionCreateTimeKey] = bson.M{"$gte": startTime, "$lte": endTime}
 	}
-	versions, err := VersionFind(db.Query(match))
+	versions, err := VersionFind(ctx, db.Query(match))
 	if err != nil {
 		return nil, errors.Wrap(err, "finding versions")
 	}

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -312,7 +312,7 @@ func VersionFindOneId(ctx context.Context, id string) (*Version, error) {
 
 func VersionFind(ctx context.Context, query db.Q) ([]Version, error) {
 	versions := []Version{}
-	err := db.FindAllQContext(ctx, VersionCollection, query, &versions)
+	err := db.FindAllQ(ctx, VersionCollection, query, &versions)
 	return versions, err
 }
 

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -310,16 +310,9 @@ func VersionFindOneId(ctx context.Context, id string) (*Version, error) {
 	return VersionFindOne(ctx, VersionById(id))
 }
 
-func VersionFindByIds(ids []string) ([]Version, error) {
-	return VersionFind(db.Query(bson.M{
-		VersionIdKey: bson.M{
-			"$in": ids,
-		}}))
-}
-
-func VersionFind(query db.Q) ([]Version, error) {
+func VersionFind(ctx context.Context, query db.Q) ([]Version, error) {
 	versions := []Version{}
-	err := db.FindAllQ(VersionCollection, query, &versions)
+	err := db.FindAllQContext(ctx, VersionCollection, query, &versions)
 	return versions, err
 }
 
@@ -401,8 +394,8 @@ func GetVersionAuthorID(ctx context.Context, versionID string) (string, error) {
 	return v.AuthorID, nil
 }
 
-func FindLastPeriodicBuild(projectID, definitionID string) (*Version, error) {
-	versions, err := VersionFind(db.Query(bson.M{
+func FindLastPeriodicBuild(ctx context.Context, projectID, definitionID string) (*Version, error) {
+	versions, err := VersionFind(ctx, db.Query(bson.M{
 		VersionPeriodicBuildIDKey: definitionID,
 		VersionIdentifierKey:      projectID,
 	}).Sort([]string{"-" + VersionCreateTimeKey}).Limit(1))

--- a/model/version_test.go
+++ b/model/version_test.go
@@ -117,7 +117,7 @@ func TestFindLastPeriodicBuild(t *testing.T) {
 	}
 	assert.NoError(v4.Insert(t.Context()))
 
-	mostRecent, err := FindLastPeriodicBuild("myProj", "a")
+	mostRecent, err := FindLastPeriodicBuild(t.Context(), "myProj", "a")
 	assert.NoError(err)
 	assert.Equal(v2.Id, mostRecent.Id)
 }

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -866,7 +866,7 @@ func TestBuildBreakSubscriptions(t *testing.T) {
 		Branch:     "branch",
 	}
 	assert.NoError(AddBuildBreakSubscriptions(t.Context(), &v1, &proj1))
-	assert.NoError(db.FindAllQContext(t.Context(), event.SubscriptionsCollection, db.Q{}, &subs))
+	assert.NoError(db.FindAllQ(t.Context(), event.SubscriptionsCollection, db.Q{}, &subs))
 	assert.Empty(subs)
 
 	// just a project
@@ -907,7 +907,7 @@ func TestBuildBreakSubscriptions(t *testing.T) {
 	}
 	assert.NoError(u4.Insert(t.Context()))
 	assert.NoError(AddBuildBreakSubscriptions(t.Context(), &v1, &proj2))
-	assert.NoError(db.FindAllQContext(t.Context(), event.SubscriptionsCollection, db.Q{}, &subs))
+	assert.NoError(db.FindAllQ(t.Context(), event.SubscriptionsCollection, db.Q{}, &subs))
 	assert.Len(subs, 2)
 
 	// project has it enabled, but user doesn't want notifications
@@ -921,7 +921,7 @@ func TestBuildBreakSubscriptions(t *testing.T) {
 		AuthorID:   u4.Id,
 	}
 	assert.NoError(AddBuildBreakSubscriptions(t.Context(), &v3, &proj2))
-	assert.NoError(db.FindAllQContext(t.Context(), event.SubscriptionsCollection, db.Q{}, &subs))
+	assert.NoError(db.FindAllQ(t.Context(), event.SubscriptionsCollection, db.Q{}, &subs))
 	targetString, ok := subs[0].Subscriber.Target.(*string)
 	assert.True(ok)
 	assert.EqualValues("@hello.itsme", utility.FromStringPtr(targetString))

--- a/rest/data/admin.go
+++ b/rest/data/admin.go
@@ -155,8 +155,8 @@ func RestartFailedTasks(ctx context.Context, queue amboy.Queue, opts model.Resta
 	}, nil
 }
 
-func GetAdminEventLog(before time.Time, n int) ([]restModel.APIAdminEvent, error) {
-	events, err := event.FindAdmin(event.AdminEventsBefore(before, n))
+func GetAdminEventLog(ctx context.Context, before time.Time, n int) ([]restModel.APIAdminEvent, error) {
+	events, err := event.FindAdmin(ctx, event.AdminEventsBefore(before, n))
 	if err != nil {
 		return nil, err
 	}

--- a/rest/data/admin_test.go
+++ b/rest/data/admin_test.go
@@ -192,7 +192,7 @@ func (s *AdminDataSuite) TestSetAndGetSettings() {
 	s.EqualValues(testSettings.Tracer.CollectorInternalEndpoint, settingsFromConnector.Tracer.CollectorInternalEndpoint)
 
 	// spot check events in the event log
-	events, err := event.FindAdmin(event.RecentAdminEvents(1000))
+	events, err := event.FindAdmin(s.T().Context(), event.RecentAdminEvents(1000))
 	s.NoError(err)
 	foundNotifyEvent := false
 	foundFlagsEvent := false

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -29,7 +29,7 @@ func FindMergedProjectAliases(ctx context.Context, projectId, repoId string, ali
 			return nil, errors.Wrapf(err, "finding project config for project '%s'", projectId)
 		}
 	}
-	aliases, err := model.ConstructMergedAliasesByPrecedence(projectRef, projectConfig, repoId)
+	aliases, err := model.ConstructMergedAliasesByPrecedence(ctx, projectRef, projectConfig, repoId)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding merged aliases for project '%s'", projectId)
 	}

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -122,7 +122,7 @@ func updateAliasesForSection(ctx context.Context, projectId string, updatedAlias
 // validateFeaturesHaveAliases returns an error if project/repo aliases are not defined for a Github/CQ feature.
 // Does not error if version control is enabled. To check for version control, we pass in the original project ref
 // along with the newly changed project ref because the new project ref only contains github / CQ section data.
-func validateFeaturesHaveAliases(originalProjectRef *model.ProjectRef, newProjectRef *model.ProjectRef, aliases []restModel.APIProjectAlias) error {
+func validateFeaturesHaveAliases(ctx context.Context, originalProjectRef *model.ProjectRef, newProjectRef *model.ProjectRef, aliases []restModel.APIProjectAlias) error {
 	if originalProjectRef.IsVersionControlEnabled() {
 		return nil
 	}
@@ -133,7 +133,7 @@ func validateFeaturesHaveAliases(originalProjectRef *model.ProjectRef, newProjec
 	}
 
 	if newProjectRef.UseRepoSettings() {
-		repoAliases, err := model.FindAliasesForRepo(newProjectRef.RepoRefId)
+		repoAliases, err := model.FindAliasesForRepo(ctx, newProjectRef.RepoRefId)
 		if err != nil {
 			return err
 		}

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -258,7 +258,7 @@ func (a *AliasSuite) TestUpdateProjectAliases() {
 }
 
 func (a *AliasSuite) TestUpdateAliasesForSection() {
-	originalAliases, err := model.FindAliasesForProjectFromDb("project_id")
+	originalAliases, err := model.FindAliasesForProjectFromDb(a.T().Context(), "project_id")
 	a.NoError(err)
 	a.Len(originalAliases, 4)
 
@@ -287,7 +287,7 @@ func (a *AliasSuite) TestUpdateAliasesForSection() {
 	a.NoError(err)
 	a.True(modified)
 
-	aliasesFromDb, err := model.FindAliasesForProjectFromDb("project_id")
+	aliasesFromDb, err := model.FindAliasesForProjectFromDb(a.T().Context(), "project_id")
 	a.NoError(err)
 	a.Len(aliasesFromDb, 4)
 	for _, alias := range aliasesFromDb {
@@ -301,7 +301,7 @@ func (a *AliasSuite) TestUpdateAliasesForSection() {
 	modified, err = updateAliasesForSection(a.T().Context(), "project_id", updatedAliases, originalAliases, model.ProjectPageGithubAndCQSection)
 	a.NoError(err)
 	a.True(modified)
-	aliasesFromDb, err = model.FindAliasesForProjectFromDb("project_id")
+	aliasesFromDb, err = model.FindAliasesForProjectFromDb(a.T().Context(), "project_id")
 	a.NoError(err)
 	a.Len(aliasesFromDb, 4) // adds internal alias
 }

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -326,7 +326,7 @@ func TestValidateFeaturesHaveAliases(t *testing.T) {
 	}
 
 	// Errors when there aren't aliases for all enabled features.
-	err := validateFeaturesHaveAliases(oldPRef, pRef, aliases)
+	err := validateFeaturesHaveAliases(t.Context(), oldPRef, pRef, aliases)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "GitHub checks")
 
@@ -337,16 +337,16 @@ func TestValidateFeaturesHaveAliases(t *testing.T) {
 	}
 	assert.NoError(t, repoAlias1.Upsert(t.Context()))
 	// No error when there are aliases in the repo.
-	assert.NoError(t, validateFeaturesHaveAliases(oldPRef, pRef, aliases))
+	assert.NoError(t, validateFeaturesHaveAliases(t.Context(), oldPRef, pRef, aliases))
 
 	pRef.GitTagVersionsEnabled = utility.TruePtr()
 	pRef.CommitQueue.Enabled = utility.TruePtr()
-	err = validateFeaturesHaveAliases(oldPRef, pRef, aliases)
+	err = validateFeaturesHaveAliases(t.Context(), oldPRef, pRef, aliases)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Git tag")
 	assert.Contains(t, err.Error(), "Commit queue")
 
 	// No error when version control is enabled.
 	oldPRef.VersionControlEnabled = utility.TruePtr()
-	assert.NoError(t, validateFeaturesHaveAliases(oldPRef, pRef, aliases))
+	assert.NoError(t, validateFeaturesHaveAliases(t.Context(), oldPRef, pRef, aliases))
 }

--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -40,7 +40,7 @@ func FindPatchesByProject(ctx context.Context, projectId string, ts time.Time, l
 	if err != nil {
 		return nil, errors.Wrapf(err, "fetching project '%s'", projectId)
 	}
-	patches, err := patch.Find(patch.PatchesByProject(id, ts, limit))
+	patches, err := patch.Find(ctx, patch.PatchesByProject(id, ts, limit))
 	if err != nil {
 		return nil, errors.Wrapf(err, "fetching patches for project '%s'", id)
 	}
@@ -152,7 +152,7 @@ func SetPatchActivated(ctx context.Context, patchId string, user string, activat
 
 // FindPatchesByUser finds patches for the input user as ordered by creation time
 func FindPatchesByUser(ctx context.Context, user string, ts time.Time, limit int) ([]restModel.APIPatch, error) {
-	patches, err := patch.Find(patch.ByUserPaginated(user, ts, limit))
+	patches, err := patch.Find(ctx, patch.ByUserPaginated(user, ts, limit))
 	if err != nil {
 		return nil, errors.Wrapf(err, "fetching patches for user '%s'", user)
 	}

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -453,7 +453,7 @@ func HideBranch(ctx context.Context, projectID string) error {
 		return errors.Wrapf(err, "removing project admin roles")
 	}
 
-	projectAliases, err := model.FindAliasesForProjectFromDb(pRef.Id)
+	projectAliases, err := model.FindAliasesForProjectFromDb(ctx, pRef.Id)
 	if err != nil {
 		return errors.Wrapf(err, "finding aliases for project '%s'", pRef.Id)
 	}

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -354,7 +354,7 @@ func GetEventsById(ctx context.Context, id string, before time.Time, n int) ([]r
 	if n == 0 {
 		n = EventLogLimit
 	}
-	events, err := model.ProjectEventsBefore(id, before, n)
+	events, err := model.ProjectEventsBefore(ctx, id, before, n)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -378,7 +378,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 			return nil, err
 		}
 
-		if err = validateFeaturesHaveAliases(mergedBeforeRef, mergedSection, changes.Aliases); err != nil {
+		if err = validateFeaturesHaveAliases(ctx, mergedBeforeRef, mergedSection, changes.Aliases); err != nil {
 			return nil, err
 		}
 		if err = mergedSection.ValidateGitHubPermissionGroupsByRequester(); err != nil {

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -332,7 +332,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 				catcher.Wrap(err, "updating repo admin roles")
 			}
 			newProjectRef.Admins = repoRef.Admins
-			branchProjects, err := model.FindMergedProjectRefsForRepo(repoRef)
+			branchProjects, err := model.FindMergedProjectRefsForRepo(ctx, repoRef)
 			if err != nil {
 				return nil, errors.Wrapf(err, "finding branch projects for repo")
 			}

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -772,7 +772,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 				settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageNotificationsSection, false, "me")
 				require.NoError(t, err)
 				require.NotNil(t, settings)
-				subsFromDb, err := event.FindSubscriptionsByOwner(ref.Id, event.OwnerTypeProject)
+				subsFromDb, err := event.FindSubscriptionsByOwner(t.Context(), ref.Id, event.OwnerTypeProject)
 				require.NoError(t, err)
 				require.Len(t, subsFromDb, 2)
 				assert.Equal(t, event.TriggerSuccess, subsFromDb[0].Trigger)
@@ -825,7 +825,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 				settings, err := SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageNotificationsSection, false, "me")
 				require.NoError(t, err)
 				require.NotNil(t, settings)
-				subsFromDb, err := event.FindSubscriptionsByOwner(ref.Id, event.OwnerTypeProject)
+				subsFromDb, err := event.FindSubscriptionsByOwner(t.Context(), ref.Id, event.OwnerTypeProject)
 				require.NoError(t, err)
 				require.Len(t, subsFromDb, 1)
 				// Check if webhooks Authorization header is the new value.

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -1127,11 +1127,11 @@ func TestPromoteVarsToRepo(t *testing.T) {
 			assert.Equal(t, "2", repoVarsFromDB.Vars["b"])
 			assert.Equal(t, "3", repoVarsFromDB.Vars["c"])
 
-			projectEvents, err := model.MostRecentProjectEvents(ref.Id, 10)
+			projectEvents, err := model.MostRecentProjectEvents(t.Context(), ref.Id, 10)
 			assert.NoError(t, err)
 			assert.Len(t, projectEvents, 1)
 
-			repoEvents, err := model.MostRecentProjectEvents(ref.RepoRefId, 10)
+			repoEvents, err := model.MostRecentProjectEvents(t.Context(), ref.RepoRefId, 10)
 			assert.NoError(t, err)
 			assert.Len(t, repoEvents, 1)
 		},
@@ -1156,11 +1156,11 @@ func TestPromoteVarsToRepo(t *testing.T) {
 			assert.Equal(t, "1", repoVarsFromDB.Vars["a"])
 			assert.Equal(t, "2", repoVarsFromDB.Vars["b"])
 
-			projectEvents, err := model.MostRecentProjectEvents(ref.Id, 10)
+			projectEvents, err := model.MostRecentProjectEvents(t.Context(), ref.Id, 10)
 			assert.NoError(t, err)
 			assert.Len(t, projectEvents, 1)
 
-			repoEvents, err := model.MostRecentProjectEvents(ref.RepoRefId, 10)
+			repoEvents, err := model.MostRecentProjectEvents(t.Context(), ref.RepoRefId, 10)
 			assert.NoError(t, err)
 			assert.Len(t, repoEvents, 1)
 		},
@@ -1186,11 +1186,11 @@ func TestPromoteVarsToRepo(t *testing.T) {
 			assert.True(t, repoVarsFromDB.PrivateVars["d"])
 			assert.True(t, repoVarsFromDB.AdminOnlyVars["d"])
 
-			projectEvents, err := model.MostRecentProjectEvents(ref.Id, 10)
+			projectEvents, err := model.MostRecentProjectEvents(t.Context(), ref.Id, 10)
 			assert.NoError(t, err)
 			assert.Empty(t, projectEvents)
 
-			repoEvents, err := model.MostRecentProjectEvents(ref.RepoRefId, 10)
+			repoEvents, err := model.MostRecentProjectEvents(t.Context(), ref.RepoRefId, 10)
 			assert.NoError(t, err)
 			assert.Empty(t, repoEvents)
 		},
@@ -1221,11 +1221,11 @@ func TestPromoteVarsToRepo(t *testing.T) {
 			assert.True(t, repoVarsFromDB.PrivateVars["d"])
 			assert.True(t, repoVarsFromDB.AdminOnlyVars["d"])
 
-			projectEvents, err := model.MostRecentProjectEvents(ref.Id, 10)
+			projectEvents, err := model.MostRecentProjectEvents(t.Context(), ref.Id, 10)
 			assert.NoError(t, err)
 			assert.Empty(t, projectEvents)
 
-			repoEvents, err := model.MostRecentProjectEvents(ref.RepoRefId, 10)
+			repoEvents, err := model.MostRecentProjectEvents(t.Context(), ref.RepoRefId, 10)
 			assert.NoError(t, err)
 			assert.Empty(t, repoEvents)
 		},

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -574,7 +574,7 @@ func TestRequestS3Creds(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(notification.Collection, evergreen.ConfigCollection))
 	assert.Error(t, RequestS3Creds(ctx, "", ""))
 	assert.NoError(t, RequestS3Creds(ctx, "identifier", "user@email.com"))
-	n, err := notification.FindUnprocessed()
+	n, err := notification.FindUnprocessed(t.Context())
 	assert.NoError(t, err)
 	assert.Empty(t, n)
 	projectCreationConfig := evergreen.ProjectCreationConfig{
@@ -582,7 +582,7 @@ func TestRequestS3Creds(t *testing.T) {
 	}
 	assert.NoError(t, projectCreationConfig.Set(ctx))
 	assert.NoError(t, RequestS3Creds(ctx, "identifier", "user@email.com"))
-	n, err = notification.FindUnprocessed()
+	n, err = notification.FindUnprocessed(t.Context())
 	assert.NoError(t, err)
 	assert.Len(t, n, 1)
 	assert.Equal(t, event.JIRAIssueSubscriberType, n[0].Subscriber.Type)

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -653,7 +653,7 @@ func TestHideBranch(t *testing.T) {
 	}
 	assert.Equal(t, skeletonProj, *hiddenProj)
 
-	projAliases, err := model.FindAliasesForProjectFromDb(project.Id)
+	projAliases, err := model.FindAliasesForProjectFromDb(t.Context(), project.Id)
 	assert.NoError(t, err)
 	assert.Empty(t, projAliases)
 

--- a/rest/data/subscription.go
+++ b/rest/data/subscription.go
@@ -113,7 +113,7 @@ func SaveSubscriptions(ctx context.Context, owner string, subscriptions []restMo
 }
 
 // GetSubscriptions returns the subscriptions that belong to a user
-func GetSubscriptions(owner string, ownerType event.OwnerType) ([]restModel.APISubscription, error) {
+func GetSubscriptions(ctx context.Context, owner string, ownerType event.OwnerType) ([]restModel.APISubscription, error) {
 	if len(owner) == 0 {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
@@ -121,7 +121,7 @@ func GetSubscriptions(owner string, ownerType event.OwnerType) ([]restModel.APIS
 		}
 	}
 
-	subs, err := event.FindSubscriptionsByOwner(owner, ownerType)
+	subs, err := event.FindSubscriptionsByOwner(ctx, owner, ownerType)
 	if err != nil {
 		return nil, errors.Wrapf(err, "finding subscriptions for user '%s'", owner)
 	}

--- a/rest/data/subscription_test.go
+++ b/rest/data/subscription_test.go
@@ -59,19 +59,19 @@ func TestGetSubscriptions(t *testing.T) {
 		assert.NoError(subs[i].Upsert(t.Context()))
 	}
 
-	apiSubs, err := GetSubscriptions("someone", event.OwnerTypePerson)
+	apiSubs, err := GetSubscriptions(t.Context(), "someone", event.OwnerTypePerson)
 	assert.NoError(err)
 	assert.Len(apiSubs, 1)
 
-	apiSubs, err = GetSubscriptions("someoneelse", event.OwnerTypePerson)
+	apiSubs, err = GetSubscriptions(t.Context(), "someoneelse", event.OwnerTypePerson)
 	assert.NoError(err)
 	assert.Len(apiSubs, 1)
 
-	apiSubs, err = GetSubscriptions("who", event.OwnerTypePerson)
+	apiSubs, err = GetSubscriptions(t.Context(), "who", event.OwnerTypePerson)
 	assert.NoError(err)
 	assert.Empty(apiSubs)
 
-	apiSubs, err = GetSubscriptions("", event.OwnerTypePerson)
+	apiSubs, err = GetSubscriptions(t.Context(), "", event.OwnerTypePerson)
 	assert.EqualError(err, "400 (Bad Request): no subscription owner provided")
 	assert.Empty(apiSubs)
 }
@@ -203,7 +203,7 @@ func TestSaveProjectSubscriptions(t *testing.T) {
 				[]restModel.APISubscription{subscription},
 				false))
 
-			dbSubs, err := GetSubscriptions(utility.FromStringPtr(subscription.Owner), event.OwnerTypeProject)
+			dbSubs, err := GetSubscriptions(t.Context(), utility.FromStringPtr(subscription.Owner), event.OwnerTypeProject)
 			assert.NoError(t, err)
 			require.Len(t, dbSubs, 1)
 			require.Equal(t, event.TriggerOutcome, utility.FromStringPtr(dbSubs[0].Trigger))
@@ -230,7 +230,7 @@ func TestSaveProjectSubscriptions(t *testing.T) {
 				[]restModel.APISubscription{subscription},
 				false))
 
-			dbSubs, err := GetSubscriptions(utility.FromStringPtr(subscription.Owner), event.OwnerTypeProject)
+			dbSubs, err := GetSubscriptions(t.Context(), utility.FromStringPtr(subscription.Owner), event.OwnerTypeProject)
 			assert.NoError(t, err)
 			require.Len(t, dbSubs, 1)
 			require.Equal(t, event.TriggerFamilyOutcome, utility.FromStringPtr(dbSubs[0].Trigger))
@@ -261,7 +261,7 @@ func TestSaveProjectSubscriptions(t *testing.T) {
 			subscription.Selectors[0].Data = newData
 			assert.NoError(t, SaveSubscriptions(t.Context(), utility.FromStringPtr(subscription.Owner), []restModel.APISubscription{subscription}, true))
 
-			dbSubs, err := GetSubscriptions(utility.FromStringPtr(subscription.Owner), event.OwnerTypeProject)
+			dbSubs, err := GetSubscriptions(t.Context(), utility.FromStringPtr(subscription.Owner), event.OwnerTypeProject)
 			assert.NoError(t, err)
 			require.Len(t, dbSubs, 1)
 			require.Equal(t, dbSubs[0].Selectors[0].Data, newData)
@@ -368,7 +368,7 @@ func TestSaveVersionSubscriptions(t *testing.T) {
 			}
 			assert.NoError(t, SaveSubscriptions(t.Context(), "me", []restModel.APISubscription{subscription}, false))
 
-			dbSubs, err := GetSubscriptions("me", event.OwnerTypePerson)
+			dbSubs, err := GetSubscriptions(t.Context(), "me", event.OwnerTypePerson)
 			assert.NoError(t, err)
 			require.Len(t, dbSubs, 1)
 			require.Equal(t, event.TriggerOutcome, utility.FromStringPtr(dbSubs[0].Trigger))
@@ -396,7 +396,7 @@ func TestSaveVersionSubscriptions(t *testing.T) {
 			}
 			assert.NoError(t, SaveSubscriptions(t.Context(), "me", []restModel.APISubscription{subscription}, false))
 
-			dbSubs, err := GetSubscriptions("me", event.OwnerTypePerson)
+			dbSubs, err := GetSubscriptions(t.Context(), "me", event.OwnerTypePerson)
 			assert.NoError(t, err)
 			require.Len(t, dbSubs, 1)
 			require.Equal(t, event.TriggerFamilyOutcome, utility.FromStringPtr(dbSubs[0].Trigger))
@@ -429,7 +429,7 @@ func TestDeleteProjectSubscriptions(t *testing.T) {
 		},
 		"ValidOwner": func(t *testing.T, ids []string) {
 			assert.NoError(t, DeleteSubscriptions(t.Context(), "my-project", []string{ids[0]}))
-			subs, err := event.FindSubscriptionsByOwner("my-project", event.OwnerTypeProject)
+			subs, err := event.FindSubscriptionsByOwner(t.Context(), "my-project", event.OwnerTypeProject)
 			assert.NoError(t, err)
 			assert.Empty(t, subs)
 		},

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -270,7 +270,7 @@ func getChildPatchesData(ctx context.Context, p patch.Patch) ([]DownstreamTasks,
 	if len(p.Triggers.ChildPatches) <= 0 {
 		return nil, nil, nil
 	}
-	childPatches, err := patch.Find(patch.ByStringIds(p.Triggers.ChildPatches))
+	childPatches, err := patch.Find(ctx, patch.ByStringIds(p.Triggers.ChildPatches))
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "getting child patches")
 	}

--- a/rest/route/admin_events.go
+++ b/rest/route/admin_events.go
@@ -53,7 +53,7 @@ func (h *adminEventsGet) Parse(ctx context.Context, r *http.Request) error {
 func (h *adminEventsGet) Run(ctx context.Context) gimlet.Responder {
 	resp := gimlet.NewResponseBuilder()
 
-	events, err := data.GetAdminEventLog(h.Timestamp, h.Limit+1)
+	events, err := data.GetAdminEventLog(ctx, h.Timestamp, h.Limit+1)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "getting admin event log"))
 	}

--- a/rest/route/admin_test.go
+++ b/rest/route/admin_test.go
@@ -269,7 +269,7 @@ func (s *AdminRouteSuite) TestRevertRoute() {
 	before := testutil.NewEnvironment(ctx, s.T()).Settings()
 	_, err := data.SetEvergreenSettings(ctx, &changes, before, user, true)
 	s.NoError(err)
-	dbEvents, err := event.FindAdmin(event.RecentAdminEvents(1))
+	dbEvents, err := event.FindAdmin(s.T().Context(), event.RecentAdminEvents(1))
 	s.NoError(err)
 	s.GreaterOrEqual(len(dbEvents), 1)
 	eventData := dbEvents[0].Data.(*event.AdminEventData)

--- a/rest/route/alias_test.go
+++ b/rest/route/alias_test.go
@@ -29,7 +29,7 @@ func TestGetAliasesHandler(t *testing.T) {
 			assert.Equal(t, "project_alias", utility.FromStringPtr(foundAlias.Alias))
 		},
 		"ReturnsRepoLevelAliases": func(ctx context.Context, t *testing.T, h *aliasGetHandler) {
-			projectAliases, err := dbModel.FindAliasesForProjectFromDb("project_ref")
+			projectAliases, err := dbModel.FindAliasesForProjectFromDb(ctx, "project_ref")
 			require.NoError(t, err)
 			require.Len(t, projectAliases, 1)
 			require.NoError(t, dbModel.RemoveProjectAlias(ctx, projectAliases[0].ID.Hex()))

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -126,7 +126,7 @@ func (s *DistroPatchSetupByIDSuite) TestRunValidId() {
 	s.Require().True(ok)
 	s.Equal(apiDistro.Setup, utility.ToStringPtr("New set-up script"))
 
-	dbEvents, err := event.FindAllByResourceID(h.distroID)
+	dbEvents, err := event.FindAllByResourceID(s.T().Context(), h.distroID)
 	s.Require().NoError(err)
 	s.Require().Len(dbEvents, 1)
 	eventData, ok := dbEvents[0].Data.(*event.DistroEventData)

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -665,7 +665,7 @@ func (gh *githubHookApi) createPRPatch(ctx context.Context, owner, repo, calledB
 // When the next github patch intent is created for that PR, it will look at this field on the last pr patch
 // to determine if the task definitions should be reused from the specified ID or the default definition
 func keepPRPatchDefinition(ctx context.Context, owner, repo string, prNumber int) error {
-	p, err := patch.FindLatestGithubPRPatch(owner, repo, prNumber)
+	p, err := patch.FindLatestGithubPRPatch(ctx, owner, repo, prNumber)
 	if err != nil || p == nil {
 		return errors.Wrap(err, "getting most recent patch for pr")
 	}
@@ -673,7 +673,7 @@ func keepPRPatchDefinition(ctx context.Context, owner, repo string, prNumber int
 }
 
 func resetPRPatchDefinition(ctx context.Context, owner, repo string, prNumber int) error {
-	p, err := patch.FindLatestGithubPRPatch(owner, repo, prNumber)
+	p, err := patch.FindLatestGithubPRPatch(ctx, owner, repo, prNumber)
 	if err != nil {
 		return errors.Wrap(err, "getting most recent patch for pr")
 	}
@@ -684,7 +684,7 @@ func resetPRPatchDefinition(ctx context.Context, owner, repo string, prNumber in
 }
 
 func (gh *githubHookApi) refreshPatchStatus(ctx context.Context, owner, repo string, prNumber int) error {
-	p, err := patch.FindLatestGithubPRPatch(owner, repo, prNumber)
+	p, err := patch.FindLatestGithubPRPatch(ctx, owner, repo, prNumber)
 	if err != nil {
 		return errors.Wrap(err, "finding patch")
 	}
@@ -731,7 +731,7 @@ func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequ
 		return errors.Wrapf(err, "getting merge base between branches '%s' and '%s'", pr.Base.GetLabel(), pr.Head.GetLabel())
 	}
 
-	ghi, err := patch.NewGithubIntent(gh.msgID, owner, calledBy, alias, mergeBase, pr)
+	ghi, err := patch.NewGithubIntent(ctx, gh.msgID, owner, calledBy, alias, mergeBase, pr)
 	if err != nil {
 		return errors.Wrap(err, "creating GitHub patch intent")
 	}
@@ -755,7 +755,7 @@ func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequ
 		}
 	}
 
-	conflictingPatches, err := getOtherPatchesWithHash(pr.Head.GetSHA(), pr.GetNumber())
+	conflictingPatches, err := getOtherPatchesWithHash(ctx, pr.Head.GetSHA(), pr.GetNumber())
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":           "error getting same hash patches",
@@ -1100,8 +1100,8 @@ func (gh *githubHookApi) createVersionForTag(ctx context.Context, pRef model.Pro
 	return gh.sc.CreateVersionFromConfig(ctx, &projectInfo, metadata)
 }
 
-func getOtherPatchesWithHash(githash string, prNum int) ([]patch.Patch, error) {
-	patches, err := patch.Find(patch.ByGithash(githash))
+func getOtherPatchesWithHash(ctx context.Context, githash string, prNum int) ([]patch.Patch, error) {
+	patches, err := patch.Find(ctx, patch.ByGithash(githash))
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting same hash patches")
 	}

--- a/rest/route/host_spawn_test.go
+++ b/rest/route/host_spawn_test.go
@@ -301,7 +301,7 @@ func TestHostModifyHandlers(t *testing.T) {
 	}()
 
 	checkSubscriptions := func(t *testing.T, userID string, numSubs int) {
-		subscriptions, err := data.GetSubscriptions(userID, event.OwnerTypePerson)
+		subscriptions, err := data.GetSubscriptions(t.Context(), userID, event.OwnerTypePerson)
 		assert.NoError(t, err)
 		assert.Len(t, subscriptions, numSubs)
 	}

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -865,7 +865,7 @@ func (h *projectIDGetHandler) Run(ctx context.Context) gimlet.Responder {
 	if projectModel.Aliases, err = data.FindMergedProjectAliases(ctx, project.Id, repoId, nil, h.includeProjectConfig); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding aliases for project '%s'", project.Id))
 	}
-	if projectModel.Subscriptions, err = data.GetSubscriptions(project.Id, event.OwnerTypeProject); err != nil {
+	if projectModel.Subscriptions, err = data.GetSubscriptions(ctx, project.Id, event.OwnerTypeProject); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting subscriptions for project '%s'", project.Id))
 	}
 	return gimlet.NewJSONResponse(projectModel)

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -69,7 +69,7 @@ func (p *projectGetHandler) Parse(ctx context.Context, r *http.Request) error {
 }
 
 func (p *projectGetHandler) Run(ctx context.Context) gimlet.Responder {
-	projects, err := dbModel.FindNonHiddenProjects(p.key, p.limit+1, 1)
+	projects, err := dbModel.FindNonHiddenProjects(ctx, p.key, p.limit+1, 1)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "Database error"))
 	}

--- a/rest/route/project_copy_test.go
+++ b/rest/route/project_copy_test.go
@@ -244,7 +244,7 @@ func (s *copyVariablesSuite) TestCopyAllVariables() {
 	projectVars, err := model.FindOneProjectVars(s.ctx, "projectB")
 	s.NoError(err)
 	s.Len(projectVars.Vars, 1)
-	events, err := model.MostRecentProjectEvents(s.route.opts.CopyTo, 100)
+	events, err := model.MostRecentProjectEvents(s.ctx, s.route.opts.CopyTo, 100)
 	s.NoError(err)
 	s.Len(events, 0)
 
@@ -258,7 +258,7 @@ func (s *copyVariablesSuite) TestCopyAllVariables() {
 	s.Equal("world", projectVars.Vars["hello"])
 	s.Equal("red", projectVars.Vars["apple"])
 	s.True(projectVars.PrivateVars["hello"])
-	events, err = model.MostRecentProjectEvents(s.route.opts.CopyTo, 100)
+	events, err = model.MostRecentProjectEvents(s.ctx, s.route.opts.CopyTo, 100)
 	s.NoError(err)
 	s.Len(events, 1)
 }
@@ -277,7 +277,7 @@ func (s *copyVariablesSuite) TestCopyAllVariablesWithOverlap() {
 	s.Len(result.Vars, 2)
 	s.Equal("", result.Vars["hello"]) // redacted
 	s.Equal("red", result.Vars["apple"])
-	events, err := model.MostRecentProjectEvents(s.route.opts.CopyTo, 100)
+	events, err := model.MostRecentProjectEvents(s.ctx, s.route.opts.CopyTo, 100)
 	s.NoError(err)
 	s.Len(events, 0)
 
@@ -293,7 +293,7 @@ func (s *copyVariablesSuite) TestCopyAllVariablesWithOverlap() {
 	s.Equal("red", projectVars.Vars["apple"])
 	s.False(projectVars.PrivateVars["apple"])
 	s.Equal("yellow", projectVars.Vars["banana"]) // unchanged
-	events, err = model.MostRecentProjectEvents(s.route.opts.CopyTo, 100)
+	events, err = model.MostRecentProjectEvents(s.ctx, s.route.opts.CopyTo, 100)
 	s.NoError(err)
 	s.Len(events, 1)
 
@@ -314,7 +314,7 @@ func (s *copyVariablesSuite) TestCopyVariablesWithOverwrite() {
 	s.Len(result.Vars, 2)
 	s.Equal("", result.Vars["hello"]) // redacted
 	s.Equal("red", result.Vars["apple"])
-	events, err := model.MostRecentProjectEvents(s.route.opts.CopyTo, 100)
+	events, err := model.MostRecentProjectEvents(s.ctx, s.route.opts.CopyTo, 100)
 	s.NoError(err)
 	s.Len(events, 0)
 
@@ -331,7 +331,7 @@ func (s *copyVariablesSuite) TestCopyVariablesWithOverwrite() {
 	s.False(projectVars.PrivateVars["apple"])
 	_, ok := projectVars.Vars["banana"] // no longer exists
 	s.False(ok)
-	events, err = model.MostRecentProjectEvents(s.route.opts.CopyTo, 100)
+	events, err = model.MostRecentProjectEvents(s.ctx, s.route.opts.CopyTo, 100)
 	s.NoError(err)
 	s.Len(events, 1)
 }
@@ -352,7 +352,7 @@ func (s *copyVariablesSuite) TestCopyToRepo() {
 	s.Equal("red", projectVars.Vars["apple"])
 	s.Equal("cubs", projectVars.Vars["chicago"])
 	s.True(projectVars.PrivateVars["hello"])
-	events, err := model.MostRecentProjectEvents(s.route.opts.CopyTo, 100)
+	events, err := model.MostRecentProjectEvents(s.ctx, s.route.opts.CopyTo, 100)
 	s.NoError(err)
 	s.Len(events, 1)
 }
@@ -373,7 +373,7 @@ func (s *copyVariablesSuite) TestCopyFromRepo() {
 	s.Equal("red", projectVars.Vars["apple"])
 	s.Equal("cubs", projectVars.Vars["chicago"])
 	s.True(projectVars.PrivateVars["hello"])
-	events, err := model.MostRecentProjectEvents(s.route.opts.CopyTo, 100)
+	events, err := model.MostRecentProjectEvents(s.ctx, s.route.opts.CopyTo, 100)
 	s.NoError(err)
 	s.Len(events, 1)
 }

--- a/rest/route/project_copy_test.go
+++ b/rest/route/project_copy_test.go
@@ -121,7 +121,7 @@ func (s *ProjectCopySuite) TestCopyToNewProject() {
 	s.Require().Len(newProject.Admins, 2)
 	s.Contains(utility.FromStringPtrSlice(newProject.Admins), "my-user")
 	s.Contains(utility.FromStringPtrSlice(newProject.Admins), "me")
-	usrs, err := user.FindByRole(model.GetProjectAdminRole(utility.FromStringPtr(newProject.Id)))
+	usrs, err := user.FindByRole(s.T().Context(), model.GetProjectAdminRole(utility.FromStringPtr(newProject.Id)))
 	s.NoError(err)
 	s.Len(usrs, 2)
 

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -1206,7 +1206,7 @@ func TestAttachProjectToRepo(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, u)
 	assert.Contains(t, u.Roles(), serviceModel.GetRepoAdminRole(p.RepoRefId))
-	hasPermission, err := serviceModel.UserHasRepoViewPermission(u, p.RepoRefId)
+	hasPermission, err := serviceModel.UserHasRepoViewPermission(t.Context(), u, p.RepoRefId)
 	assert.NoError(t, err)
 	assert.True(t, hasPermission)
 

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -1113,7 +1113,7 @@ func TestDeleteProject(t *testing.T) {
 		}
 		assert.Equal(t, skeletonProj, *hiddenProj)
 
-		projAliases, err := serviceModel.FindAliasesForProjectFromDb(projects[i].Id)
+		projAliases, err := serviceModel.FindAliasesForProjectFromDb(t.Context(), projects[i].Id)
 		assert.NoError(t, err)
 		assert.Empty(t, projAliases)
 

--- a/rest/route/subscription.go
+++ b/rest/route/subscription.go
@@ -93,7 +93,7 @@ func (s *subscriptionGetHandler) Parse(ctx context.Context, r *http.Request) err
 }
 
 func (s *subscriptionGetHandler) Run(ctx context.Context) gimlet.Responder {
-	subs, err := data.GetSubscriptions(s.owner, event.OwnerType(s.ownerType))
+	subs, err := data.GetSubscriptions(ctx, s.owner, event.OwnerType(s.ownerType))
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting subscriptions for owner '%s' and owner type '%s'", s.owner, s.ownerType))
 	}

--- a/rest/route/subscription_test.go
+++ b/rest/route/subscription_test.go
@@ -65,7 +65,7 @@ func (s *SubscriptionRouteSuite) TestSubscriptionPost() {
 
 	s.NotNil(resp)
 
-	dbSubscriptions, err := event.FindSubscriptionsByOwner("me", event.OwnerTypePerson)
+	dbSubscriptions, err := event.FindSubscriptionsByOwner(s.T().Context(), "me", event.OwnerTypePerson)
 	s.NoError(err)
 	s.Require().Len(dbSubscriptions, 1)
 	s.Equal(event.ResourceTypeTask, dbSubscriptions[0].ResourceType)
@@ -100,7 +100,7 @@ func (s *SubscriptionRouteSuite) TestSubscriptionPost() {
 	s.NotNil(resp)
 	s.Equal(http.StatusOK, resp.Status())
 
-	dbSubscriptions, err = event.FindSubscriptionsByOwner("me", event.OwnerTypePerson)
+	dbSubscriptions, err = event.FindSubscriptionsByOwner(s.T().Context(), "me", event.OwnerTypePerson)
 	s.NoError(err)
 	s.Len(dbSubscriptions, 1)
 	s.Equal(event.ResourceTypePatch, dbSubscriptions[0].ResourceType)
@@ -135,7 +135,7 @@ func (s *SubscriptionRouteSuite) TestProjectSubscription() {
 	s.NotNil(resp)
 	s.Equal(http.StatusOK, resp.Status())
 
-	dbSubscriptions, err := event.FindSubscriptionsByOwner("myproj", event.OwnerTypeProject)
+	dbSubscriptions, err := event.FindSubscriptionsByOwner(s.T().Context(), "myproj", event.OwnerTypeProject)
 	s.NoError(err)
 	s.Require().Len(dbSubscriptions, 1)
 	s.Equal(event.ResourceTypeTask, dbSubscriptions[0].ResourceType)

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -412,7 +412,7 @@ func (h *allUsersPermissionsGetHandler) Run(ctx context.Context) gimlet.Responde
 		}
 	}
 	// Get users with roles.
-	usersWithRoles, err := user.FindHumanUsersByRoles(roleIds)
+	usersWithRoles, err := user.FindHumanUsersByRoles(ctx, roleIds)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrapf(err, "finding users for roles %v", roleIds))
 	}
@@ -727,7 +727,7 @@ func (h *usersWithRoleGetHandler) Parse(ctx context.Context, r *http.Request) er
 }
 
 func (h *usersWithRoleGetHandler) Run(ctx context.Context) gimlet.Responder {
-	users, err := user.FindByRole(h.role)
+	users, err := user.FindByRole(ctx, h.role)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}

--- a/rest/route/user_test.go
+++ b/rest/route/user_test.go
@@ -140,7 +140,7 @@ func (s *UserRouteSuite) TestSaveFeedback() {
 	s.NotNil(resp)
 	s.Equal(http.StatusOK, resp.Status())
 
-	feedback, err := model.FindFeedbackOfType("someType")
+	feedback, err := model.FindFeedbackOfType(s.T().Context(), "someType")
 	s.NoError(err)
 	s.Len(feedback, 1)
 	s.Equal("me", feedback[0].User)
@@ -869,7 +869,7 @@ func TestRenameUser(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Len(t, volumes, 1)
 
-			patches, err := patch.Find(db.Query(mgobson.M{patch.AuthorKey: "new_me"}))
+			patches, err := patch.Find(t.Context(), db.Query(mgobson.M{patch.AuthorKey: "new_me"}))
 			assert.NoError(t, err)
 			assert.Len(t, patches, 3)
 			for _, p := range patches {
@@ -906,7 +906,7 @@ func TestRenameUser(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Len(t, volumes, 1)
 
-			patches, err := patch.Find(db.Query(mgobson.M{patch.AuthorKey: "new_me"}))
+			patches, err := patch.Find(t.Context(), db.Query(mgobson.M{patch.AuthorKey: "new_me"}))
 			assert.NoError(t, err)
 			assert.Len(t, patches, 2)
 		},

--- a/rest/route/user_test.go
+++ b/rest/route/user_test.go
@@ -316,7 +316,7 @@ func TestProjectSettingsUpdateViewRepo(t *testing.T) {
 	assert.NoError(t, err)
 	require.Len(t, dbUser.SystemRoles, 1)
 	assert.Contains(t, dbUser.SystemRoles, roles[0].ID)
-	hasPermission, err := model.UserHasRepoViewPermission(dbUser, "myRepo")
+	hasPermission, err := model.UserHasRepoViewPermission(t.Context(), dbUser, "myRepo")
 	assert.NoError(t, err)
 	assert.True(t, hasPermission)
 }

--- a/rest/route/version.go
+++ b/rest/route/version.go
@@ -191,9 +191,9 @@ func (h *buildsForVersionHandler) Run(ctx context.Context) gimlet.Responder {
 	var err error
 
 	if h.variant == "" {
-		builds, err = build.Find(build.ByVersion(h.versionId))
+		builds, err = build.Find(ctx, build.ByVersion(h.versionId))
 	} else {
-		builds, err = build.Find(build.ByVersionAndVariant(h.versionId, h.variant))
+		builds, err = build.Find(ctx, build.ByVersionAndVariant(h.versionId, h.variant))
 	}
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "getting builds"))

--- a/service/admin.go
+++ b/service/admin.go
@@ -79,7 +79,7 @@ func (uis *UIServer) adminEvents(w http.ResponseWriter, r *http.Request) {
 			template = "admin_events.html"
 		}
 	}
-	events, err := data.GetAdminEventLog(time.Now(), 15)
+	events, err := data.GetAdminEventLog(ctx, time.Now(), 15)
 	if err != nil {
 		grip.Error(errors.Wrap(err, "unable to retrieve admin events"))
 	}

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -334,7 +334,7 @@ func (as *APIServer) listPatches(w http.ResponseWriter, r *http.Request) {
 	if n > 0 {
 		query = query.Limit(n)
 	}
-	patches, err := patch.Find(query)
+	patches, err := patch.Find(r.Context(), query)
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError,
 			errors.Wrapf(err, "error finding patches for user %s", dbUser.Id))

--- a/service/event_log.go
+++ b/service/event_log.go
@@ -24,7 +24,7 @@ func (uis *UIServer) fullEventLogs(w http.ResponseWriter, r *http.Request) {
 	var err error
 	switch resourceType {
 	case event.ResourceTypeTask:
-		loggedEvents, err = event.Find(event.MostRecentTaskEvents(resourceID, 100))
+		loggedEvents, err = event.Find(r.Context(), event.MostRecentTaskEvents(resourceID, 100))
 	case event.ResourceTypeHost:
 		if u == nil {
 			uis.RedirectToLogin(w, r)
@@ -46,13 +46,13 @@ func (uis *UIServer) fullEventLogs(w http.ResponseWriter, r *http.Request) {
 			Limit:   5000,
 			SortAsc: false,
 		}
-		loggedEvents, err = event.Find(event.HostEvents(hostEventsOpts))
+		loggedEvents, err = event.Find(r.Context(), event.HostEvents(hostEventsOpts))
 	case event.ResourceTypeAdmin:
 		if u == nil {
 			uis.RedirectToLogin(w, r)
 			return
 		}
-		loggedEvents, err = event.Find(event.RecentAdminEvents(100))
+		loggedEvents, err = event.Find(r.Context(), event.RecentAdminEvents(100))
 	case event.EventResourceTypeProject:
 		if u == nil {
 			uis.RedirectToLogin(w, r)

--- a/service/event_log.go
+++ b/service/event_log.go
@@ -80,7 +80,7 @@ func (uis *UIServer) fullEventLogs(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		var loggedProjectEvents model.ProjectChangeEvents
-		loggedProjectEvents, err = model.MostRecentProjectEvents(resourceID, 200)
+		loggedProjectEvents, err = model.MostRecentProjectEvents(r.Context(), resourceID, 200)
 		for _, event := range loggedProjectEvents {
 			loggedEvents = append(loggedEvents, event.EventLogEntry)
 		}

--- a/service/host.go
+++ b/service/host.go
@@ -70,7 +70,7 @@ func (uis *UIServer) hostPage(w http.ResponseWriter, r *http.Request) {
 		Limit:   50,
 		SortAsc: false,
 	}
-	events, err := event.Find(event.HostEvents(hostEventOpts))
+	events, err := event.Find(r.Context(), event.HostEvents(hostEventOpts))
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return

--- a/service/host_test.go
+++ b/service/host_test.go
@@ -52,7 +52,7 @@ func TestModifyHostStatusWithUpdateStatus(t *testing.T) {
 			Limit:   1,
 			SortAsc: false,
 		}
-		events, err := event.Find(event.HostEvents(hostEventOpts))
+		events, err := event.Find(t.Context(), event.HostEvents(hostEventOpts))
 		assert.NoError(err)
 		assert.Len(events, 1)
 		hostevent, ok := events[0].Data.(*event.HostEventData)

--- a/service/models.go
+++ b/service/models.go
@@ -112,7 +112,7 @@ func getBuildVariantHistory(ctx context.Context, buildId string, before int, aft
 		return nil, errors.Errorf("no build with id %v", buildId)
 	}
 
-	lessRecentBuilds, err := build.Find(
+	lessRecentBuilds, err := build.Find(ctx,
 		build.ByBeforeRevision(b.Project, b.BuildVariant, b.RevisionOrderNumber).
 			WithFields(build.IdKey, build.TasksKey, build.StatusKey, build.VersionKey, build.ActivatedKey).
 			Limit(before))
@@ -120,7 +120,7 @@ func getBuildVariantHistory(ctx context.Context, buildId string, before int, aft
 		return nil, errors.WithStack(err)
 	}
 
-	moreRecentBuilds, err := build.Find(
+	moreRecentBuilds, err := build.Find(ctx,
 		build.ByAfterRevision(b.Project, b.BuildVariant, b.RevisionOrderNumber).
 			WithFields(build.IdKey, build.TasksKey, build.StatusKey, build.VersionKey, build.ActivatedKey).
 			Limit(after))

--- a/service/rest_version.go
+++ b/service/rest_version.go
@@ -151,8 +151,8 @@ func (restapi restAPI) getRecentVersions(w http.ResponseWriter, r *http.Request)
 	// only look for versions if the project can be found, otherwise continue without error
 	if err == nil {
 		// add one to limit to determine if a new page is necessary
-		versions, err = model.VersionFind(model.VersionBySystemRequesterOrdered(projectId, start).
-			Limit(l + 1))
+		versions, err = model.VersionFind(r.Context(), model.VersionBySystemRequesterOrdered(projectId, start).
+			Limit(l+1))
 		if err != nil {
 			msg := fmt.Sprintf("Error finding recent versions of project '%v'", projectIdentifier)
 			grip.Error(errors.Wrap(err, msg))

--- a/service/rest_version.go
+++ b/service/rest_version.go
@@ -223,7 +223,7 @@ func (restapi restAPI) getRecentVersions(w http.ResponseWriter, r *http.Request)
 }
 
 func (r *recentVersionsContent) populateBuildsAndTasks(ctx context.Context, versionIds []string, versionIdx map[string]int) error {
-	builds, err := build.FindBuildsByVersions(versionIds)
+	builds, err := build.FindBuildsByVersions(ctx, versionIds)
 	if err != nil {
 		return errors.Wrap(err, "Error finding recent versions")
 	}
@@ -517,7 +517,7 @@ func (restapi *restAPI) getVersionStatusByTask(ctx context.Context, versionId st
 // particular task.
 func (restapi restAPI) getVersionStatusByBuild(ctx context.Context, versionId string, w http.ResponseWriter) {
 	// Get all of the builds corresponding to this version
-	builds, err := build.Find(
+	builds, err := build.Find(ctx,
 		build.ByVersion(versionId).WithFields(build.BuildVariantKey, bsonutil.GetDottedKeyName(build.TasksKey, build.TaskCacheIdKey)),
 	)
 	if err != nil {

--- a/service/stats.go
+++ b/service/stats.go
@@ -273,7 +273,7 @@ func (uis *UIServer) taskTimingJSON(w http.ResponseWriter, r *http.Request) {
 	orderedVersionIDs := make([]string, 0, len(versionIds))
 	// Populate the versions field if with commits, otherwise patches field
 	if utility.StringSliceContains(evergreen.SystemVersionRequesterTypes, request) {
-		versions, err := model.VersionFind(model.VersionByIds(versionIds).
+		versions, err := model.VersionFind(r.Context(), model.VersionByIds(versionIds).
 			WithFields(model.VersionIdKey, model.VersionCreateTimeKey, model.VersionMessageKey,
 				model.VersionAuthorKey, model.VersionRevisionKey))
 		if err != nil {

--- a/service/stats.go
+++ b/service/stats.go
@@ -165,7 +165,7 @@ func (uis *UIServer) taskTimingJSON(w http.ResponseWriter, r *http.Request) {
 		// TODO: switch this to be a query on the builds TaskCache
 		var builds []build.Build
 
-		builds, err = build.Find(build.ByProjectAndVariant(project.Identifier, buildVariant, request, statuses).
+		builds, err = build.Find(r.Context(), build.ByProjectAndVariant(project.Identifier, buildVariant, request, statuses).
 			WithFields(build.IdKey, build.CreateTimeKey, build.VersionKey,
 				build.TimeTakenKey, build.FinishTimeKey, build.StartTimeKey, build.StatusKey).
 			Sort([]string{"-" + build.CreateTimeKey}).

--- a/service/stats.go
+++ b/service/stats.go
@@ -289,7 +289,7 @@ func (uis *UIServer) taskTimingJSON(w http.ResponseWriter, r *http.Request) {
 		data.Versions = versions
 	} else {
 		// patches
-		patches, err := patch.Find(patch.ByVersions(versionIds).
+		patches, err := patch.Find(r.Context(), patch.ByVersions(versionIds).
 			WithFields(patch.IdKey, patch.CreateTimeKey, patch.DescriptionKey, patch.AuthorKey, patch.VersionKey, patch.GithashKey))
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusNotFound, errors.Wrap(err, "error finding past patches"))

--- a/service/task.go
+++ b/service/task.go
@@ -519,7 +519,7 @@ func (uis *UIServer) taskLog(w http.ResponseWriter, r *http.Request) {
 
 	logType := r.FormValue("type")
 	if logType == "EV" {
-		loggedEvents, err := event.Find(event.MostRecentTaskEvents(projCtx.Task.Id, DefaultLogMessages))
+		loggedEvents, err := event.Find(r.Context(), event.MostRecentTaskEvents(projCtx.Task.Id, DefaultLogMessages))
 		if err != nil {
 			uis.LoggedError(w, r, http.StatusInternalServerError, err)
 			return

--- a/service/task_history_test.go
+++ b/service/task_history_test.go
@@ -72,7 +72,7 @@ func (s *TaskHistorySuite) SetupTest() {
 
 func (s *TaskHistorySuite) TestGetVersionsInWindow() {
 	radius := 20
-	versions, err := getVersionsInWindow("surround", s.projectID, radius, &s.middleVersion)
+	versions, err := getVersionsInWindow(s.T().Context(), "surround", s.projectID, radius, &s.middleVersion)
 	s.Require().NoError(err)
 
 	for i := 0; i < radius; i++ {
@@ -89,7 +89,7 @@ func (s *TaskHistorySuite) TestGetVersionsInWindow() {
 
 func (s *TaskHistorySuite) TestSurroundingVersions() {
 	radius := 20
-	versionsAfter, err := surroundingVersions(&s.middleVersion, s.projectID, radius, false)
+	versionsAfter, err := surroundingVersions(s.T().Context(), &s.middleVersion, s.projectID, radius, false)
 	s.NoError(err)
 	s.Require().Len(versionsAfter, radius)
 	for i, version := range versionsAfter {
@@ -97,7 +97,7 @@ func (s *TaskHistorySuite) TestSurroundingVersions() {
 		s.True(version.CreateTime.Equal(s.versionsAfter[(len(s.versionsAfter)-radius)+i].CreateTime))
 	}
 
-	versionsBefore, err := surroundingVersions(&s.middleVersion, s.projectID, radius, true)
+	versionsBefore, err := surroundingVersions(s.T().Context(), &s.middleVersion, s.projectID, radius, true)
 	s.NoError(err)
 	s.Len(versionsBefore, radius)
 	for i, version := range versionsBefore {
@@ -106,14 +106,14 @@ func (s *TaskHistorySuite) TestSurroundingVersions() {
 }
 
 func (s *TaskHistorySuite) TestSurroundingVersionsSort() {
-	versionsAfter, err := surroundingVersions(&s.versionsBefore[0], s.projectID, 2, false)
+	versionsAfter, err := surroundingVersions(s.T().Context(), &s.versionsBefore[0], s.projectID, 2, false)
 	s.NoError(err)
 	s.Require().Len(versionsAfter, 2)
 	// sorted ascending, then reversed
 	s.Equal(52, versionsAfter[0].RevisionOrderNumber)
 	s.Equal(51, versionsAfter[1].RevisionOrderNumber)
 
-	versionsBefore, err := surroundingVersions(&s.versionsAfter[49], s.projectID, 2, true)
+	versionsBefore, err := surroundingVersions(s.T().Context(), &s.versionsAfter[49], s.projectID, 2, true)
 	s.NoError(err)
 	s.Require().Len(versionsBefore, 2)
 	// sorted descending

--- a/service/timeline.go
+++ b/service/timeline.go
@@ -173,7 +173,7 @@ func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 }
 
 func getBuildInfo(ctx context.Context, buildIds []string) ([]BuildInfo, error) {
-	dbBuilds, err := build.Find(build.ByIds(buildIds))
+	dbBuilds, err := build.Find(ctx, build.ByIds(buildIds))
 	if err != nil {
 		return nil, errors.Wrap(err, "can't get builds")
 	}

--- a/service/timeline.go
+++ b/service/timeline.go
@@ -89,7 +89,7 @@ func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 	user := gimlet.GetVars(r)["user_id"]
 	var patches []patch.Patch
 	if len(user) > 0 {
-		patches, err = patch.Find(patch.ByUserAndCommitQueue(user, filterCommitQueue).
+		patches, err = patch.Find(r.Context(), patch.ByUserAndCommitQueue(user, filterCommitQueue).
 			Project(patch.ExcludePatchDiff).
 			Sort([]string{"-" + patch.CreateTimeKey}).
 			Skip(skip).Limit(DefaultLimit))
@@ -107,7 +107,7 @@ func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 				"Error fetching project %v", projectID))
 			return
 		}
-		patches, err = patch.Find(patch.ByProjectAndCommitQueue(project.Identifier, filterCommitQueue).
+		patches, err = patch.Find(r.Context(), patch.ByProjectAndCommitQueue(project.Identifier, filterCommitQueue).
 			Sort([]string{"-" + patch.CreateTimeKey}).
 			Project(patch.ExcludePatchDiff).
 			Skip(skip).Limit(DefaultLimit))

--- a/service/timeline.go
+++ b/service/timeline.go
@@ -147,7 +147,7 @@ func (uis *UIServer) patchTimelineJson(w http.ResponseWriter, r *http.Request) {
 			Alias:         patch.Alias,
 		})
 	}
-	versions, err := model.VersionFind(model.VersionByIds(versionIds))
+	versions, err := model.VersionFind(r.Context(), model.VersionByIds(versionIds))
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "Error fetching versions for patches"))
 		return

--- a/service/ui_plugin_build_baron.go
+++ b/service/ui_plugin_build_baron.go
@@ -80,7 +80,7 @@ func bbGetNote(w http.ResponseWriter, r *http.Request) {
 func (uis *UIServer) bbGetCreatedTickets(w http.ResponseWriter, r *http.Request) {
 	taskId := gimlet.GetVars(r)["task_id"]
 
-	events, err := event.Find(event.TaskEventsForId(taskId))
+	events, err := event.Find(r.Context(), event.TaskEventsForId(taskId))
 	if err != nil {
 		gimlet.WriteJSONInternalError(w, err.Error())
 		return

--- a/service/version.go
+++ b/service/version.go
@@ -432,7 +432,7 @@ func (uis *UIServer) versionFind(w http.ResponseWriter, r *http.Request) {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
 	}
-	foundVersions, err := model.VersionFind(model.VersionByProjectIdAndRevisionPrefix(id, revision).Limit(2))
+	foundVersions, err := model.VersionFind(r.Context(), model.VersionByProjectIdAndRevisionPrefix(id, revision).Limit(2))
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return

--- a/service/version.go
+++ b/service/version.go
@@ -107,7 +107,7 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	dbBuilds, err := build.Find(build.ByIds(projCtx.Version.BuildIds))
+	dbBuilds, err := build.Find(r.Context(), build.ByIds(projCtx.Version.BuildIds))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -119,7 +119,7 @@ func (uis *UIServer) versionPage(w http.ResponseWriter, r *http.Request) {
 		versionAsUI.PatchInfo = &uiPatch{Patch: *projCtx.Patch}
 		// diff builds for each build in the version
 		var baseBuilds []build.Build
-		baseBuilds, err = build.Find(build.ByRevisionWithSystemVersionRequester(projCtx.Version.Revision))
+		baseBuilds, err = build.Find(r.Context(), build.ByRevisionWithSystemVersionRequester(projCtx.Version.Revision))
 		if err != nil {
 			http.Error(w,
 				fmt.Sprintf("error loading base builds for patch: %v", err),
@@ -283,7 +283,7 @@ func (uis *UIServer) modifyVersion(w http.ResponseWriter, r *http.Request) {
 		RepoOwner: projCtx.ProjectRef.Owner,
 		Repo:      projCtx.ProjectRef.Repo,
 	}
-	dbBuilds, err := build.Find(build.ByIds(projCtx.Version.BuildIds))
+	dbBuilds, err := build.Find(r.Context(), build.ByIds(projCtx.Version.BuildIds))
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, err)
 		return
@@ -374,7 +374,7 @@ func (uis *UIServer) versionHistory(w http.ResponseWriter, r *http.Request) {
 		}
 		versions = append(versions, &versionAsUI)
 
-		dbBuilds, err := build.Find(build.ByIds(version.BuildIds))
+		dbBuilds, err := build.Find(r.Context(), build.ByIds(version.BuildIds))
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/trigger/process.go
+++ b/trigger/process.go
@@ -35,7 +35,7 @@ func NotificationsFromEvent(ctx context.Context, e *event.EventLogEntry) ([]noti
 		return nil, errors.Wrapf(err, "fetching data for event '%s' (resource type: '%s', event type: '%s')", e.ID, e.ResourceType, e.EventType)
 	}
 
-	subscriptions, err := event.FindSubscriptionsByAttributes(e.ResourceType, h.Attributes())
+	subscriptions, err := event.FindSubscriptionsByAttributes(ctx, e.ResourceType, h.Attributes())
 	subIDs := make([]string, 0, len(subscriptions))
 	for _, sub := range subscriptions {
 		subIDs = append(subIDs, sub.ID)

--- a/trigger/process_test.go
+++ b/trigger/process_test.go
@@ -351,7 +351,7 @@ func TestProjectTriggerIntegration(t *testing.T) {
 		assert.Equal("task", v.TriggerType)
 		assert.Equal(e.ID, v.TriggerEvent)
 	}
-	builds, err := build.Find(build.ByVersion(downstreamVersions[0].Id))
+	builds, err := build.Find(t.Context(), build.ByVersion(downstreamVersions[0].Id))
 	assert.NoError(err)
 	assert.NotEmpty(builds)
 	for _, b := range builds {
@@ -484,7 +484,7 @@ func TestProjectTriggerIntegrationForBuild(t *testing.T) {
 		assert.Equal("build", v.TriggerType)
 		assert.Equal(e.ID, v.TriggerEvent)
 	}
-	builds, err := build.Find(build.ByVersion(downstreamVersions[0].Id))
+	builds, err := build.Find(t.Context(), build.ByVersion(downstreamVersions[0].Id))
 	assert.NoError(err)
 	assert.NotEmpty(builds)
 	for _, b := range builds {
@@ -599,7 +599,7 @@ func TestProjectTriggerIntegrationForPush(t *testing.T) {
 	assert.Equal("3585388b1591dfca47ac26a5b9a564ec8f138a5e", dbVersions[0].TriggerSHA)
 	assert.Equal("upstream", dbVersions[0].TriggerID)
 
-	builds, err := build.Find(build.ByVersion(dbVersions[0].Id))
+	builds, err := build.Find(t.Context(), build.ByVersion(dbVersions[0].Id))
 	assert.NoError(err)
 	assert.NotEmpty(builds)
 	for _, b := range builds {

--- a/trigger/process_test.go
+++ b/trigger/process_test.go
@@ -335,7 +335,7 @@ func TestProjectTriggerIntegration(t *testing.T) {
 
 	downstreamVersions, err := EvalProjectTriggers(ctx, &e, TriggerDownstreamVersion)
 	assert.NoError(err)
-	dbVersions, err := model.VersionFind(model.BaseVersionByProjectIdAndRevision(downstreamProjectRef.Id, downstreamRevision))
+	dbVersions, err := model.VersionFind(t.Context(), model.BaseVersionByProjectIdAndRevision(downstreamProjectRef.Id, downstreamRevision))
 	assert.NoError(err)
 	require.Len(downstreamVersions, 1)
 	require.Len(dbVersions, 1)
@@ -468,7 +468,7 @@ func TestProjectTriggerIntegrationForBuild(t *testing.T) {
 
 	downstreamVersions, err := EvalProjectTriggers(ctx, &e, TriggerDownstreamVersion)
 	assert.NoError(err)
-	dbVersions, err := model.VersionFind(model.BaseVersionByProjectIdAndRevision(downstreamProjectRef.Id, downstreamRevision))
+	dbVersions, err := model.VersionFind(t.Context(), model.BaseVersionByProjectIdAndRevision(downstreamProjectRef.Id, downstreamRevision))
 	assert.NoError(err)
 	require.Len(downstreamVersions, 1)
 	require.Len(dbVersions, 1)
@@ -586,7 +586,7 @@ func TestProjectTriggerIntegrationForPush(t *testing.T) {
 	}
 	err = TriggerDownstreamProjectsForPush(ctx, "upstream", pushEvent, TriggerDownstreamVersion)
 	assert.NoError(err)
-	dbVersions, err := model.VersionFind(model.BaseVersionByProjectIdAndRevision(downstreamProjectRef.Id, downstreamRevision))
+	dbVersions, err := model.VersionFind(t.Context(), model.BaseVersionByProjectIdAndRevision(downstreamProjectRef.Id, downstreamRevision))
 	assert.NoError(err)
 	require.Len(dbVersions, 1)
 	assert.True(utility.FromBoolPtr(dbVersions[0].Activated))

--- a/units/crons.go
+++ b/units/crons.go
@@ -114,7 +114,7 @@ func PopulatePodHealthCheckJobs() amboy.QueueOperation {
 			return nil
 		}
 
-		pods, err := pod.FindByLastCommunicatedBefore(time.Now().Add(-podReachabilityThreshold))
+		pods, err := pod.FindByLastCommunicatedBefore(ctx, time.Now().Add(-podReachabilityThreshold))
 		if err != nil {
 			return errors.Wrap(err, "finding pods that have not communicated recently")
 		}
@@ -1109,7 +1109,7 @@ func podAllocatorJobs(ctx context.Context, _ evergreen.Environment, ts time.Time
 }
 
 func podCreationJobs(ctx context.Context, _ evergreen.Environment, ts time.Time) ([]amboy.Job, error) {
-	pods, err := pod.FindByInitializing()
+	pods, err := pod.FindByInitializing(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding initializing pods")
 	}
@@ -1123,7 +1123,7 @@ func podCreationJobs(ctx context.Context, _ evergreen.Environment, ts time.Time)
 }
 
 func podTerminationJobs(ctx context.Context, _ evergreen.Environment, ts time.Time) ([]amboy.Job, error) {
-	pods, err := pod.FindByNeedsTermination()
+	pods, err := pod.FindByNeedsTermination(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding pods that need to be terminated")
 	}
@@ -1138,7 +1138,7 @@ func podTerminationJobs(ctx context.Context, _ evergreen.Environment, ts time.Ti
 // podDefinitionCreationJobs populates the jobs to create pod
 // definitions.
 func podDefinitionCreationJobs(ctx context.Context, env evergreen.Environment, ts time.Time) ([]amboy.Job, error) {
-	pods, err := pod.FindByInitializing()
+	pods, err := pod.FindByInitializing(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding initializing pods")
 	}

--- a/units/crons.go
+++ b/units/crons.go
@@ -144,7 +144,7 @@ func sendNotificationJobs(ctx context.Context, _ evergreen.Environment, ts time.
 		return nil, nil
 	}
 
-	unprocessedNotifications, err := notification.FindUnprocessed()
+	unprocessedNotifications, err := notification.FindUnprocessed(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding unprocessed notifications")
 	}

--- a/units/crons.go
+++ b/units/crons.go
@@ -166,7 +166,7 @@ func eventNotifierJobs(ctx context.Context, env evergreen.Environment, ts time.T
 		return nil, nil
 	}
 
-	events, err := event.FindUnprocessedEvents(-1)
+	events, err := event.FindUnprocessedEvents(ctx, -1)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding all unprocessed events")
 	}

--- a/units/crons_event_test.go
+++ b/units/crons_event_test.go
@@ -161,7 +161,7 @@ func (s *cronsEventSuite) TestSenderDegradedModeDoesntDispatchJobs() {
 	s.Empty(jobs)
 
 	out := []notification.Notification{}
-	s.NoError(db.FindAllQContext(s.ctx, notification.Collection, db.Q{}, &out))
+	s.NoError(db.FindAllQ(s.ctx, notification.Collection, db.Q{}, &out))
 	s.Len(out, 6)
 	for i := range out {
 		s.Equal("notification is disabled", out[i].Error)
@@ -298,7 +298,7 @@ func (s *cronsEventSuite) TestEndToEnd() {
 	s.Require().True(amboy.WaitInterval(s.ctx, q, 10*time.Millisecond))
 
 	out := []notification.Notification{}
-	s.NoError(db.FindAllQContext(s.ctx, notification.Collection, db.Q{}, &out))
+	s.NoError(db.FindAllQ(s.ctx, notification.Collection, db.Q{}, &out))
 	s.Require().Len(out, 1)
 
 	s.NotZero(out[0].SentAt, "%+v", out[0])

--- a/units/github_status_api_test.go
+++ b/units/github_status_api_test.go
@@ -125,7 +125,7 @@ func (s *githubStatusUpdateSuite) TestForPatchCreated() {
 }
 
 func (s *githubStatusUpdateSuite) TestForProcessingError() {
-	intent, err := patch.NewGithubIntent("1", "", "", "", "", testutil.NewGithubPR(448,
+	intent, err := patch.NewGithubIntent(s.ctx, "1", "", "", "", "", testutil.NewGithubPR(448,
 		"evergreen-ci/evergreen", "7c38f3f63c05675329518c148d3a176e1da6ec2d", "tychoish/evergreen", "776f608b5b12cd27b8d931c8ee4ca0c13f857299", "tychoish", "Title"))
 	s.NoError(err)
 	s.NotNil(intent)

--- a/units/github_status_refresh.go
+++ b/units/github_status_refresh.go
@@ -110,7 +110,7 @@ func (j *githubStatusRefreshJob) fetch(ctx context.Context) error {
 		}
 	}
 
-	j.builds, err = build.Find(build.ByVersion(j.FetchID))
+	j.builds, err = build.Find(ctx, build.ByVersion(j.FetchID))
 	if err != nil {
 		return errors.Wrap(err, "finding builds")
 	}

--- a/units/github_status_refresh.go
+++ b/units/github_status_refresh.go
@@ -116,7 +116,7 @@ func (j *githubStatusRefreshJob) fetch(ctx context.Context) error {
 	}
 
 	if len(j.patch.Triggers.ChildPatches) > 0 {
-		j.childPatches, err = patch.Find(patch.ByStringIds(j.patch.Triggers.ChildPatches))
+		j.childPatches, err = patch.Find(ctx, patch.ByStringIds(j.patch.Triggers.ChildPatches))
 		if err != nil {
 			return errors.Wrap(err, "finding child patches")
 		}

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -30,7 +30,7 @@ func TestHostTerminationJob(t *testing.T) {
 			Limit:   50,
 			SortAsc: false,
 		}
-		events, err := event.Find(event.HostEvents(hostEventOpts))
+		events, err := event.Find(t.Context(), event.HostEvents(hostEventOpts))
 		require.NoError(t, err)
 		require.NotEmpty(t, events)
 		var foundTerminationEvent bool

--- a/units/migrate_volume_test.go
+++ b/units/migrate_volume_test.go
@@ -134,7 +134,7 @@ func TestVolumeMigrateJob(t *testing.T) {
 			assert.Equal(t, evergreen.HostRunning, initialHost.Status)
 			assert.Equal(t, initialHost.HomeVolumeID, volume.ID)
 
-			events, err := event.FindAllByResourceID(h.Id)
+			events, err := event.FindAllByResourceID(t.Context(), h.Id)
 			assert.NoError(t, err)
 			require.Len(t, events, 1)
 			assert.Equal(t, event.EventVolumeMigrationFailed, events[0].EventType)
@@ -177,7 +177,7 @@ func TestVolumeMigrateJob(t *testing.T) {
 			assert.Equal(t, evergreen.HostStopped, initialHost.Status)
 			assert.Equal(t, "", initialHost.HomeVolumeID)
 
-			events, err := event.FindAllByResourceID(h.Id)
+			events, err := event.FindAllByResourceID(t.Context(), h.Id)
 			assert.NoError(t, err)
 			assert.Len(t, events, 3)
 		},

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1217,7 +1217,7 @@ func (s *PatchIntentUnitsSuite) TestProcessGitHubIntentWithMergeBase() {
 	}
 	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings())
 	// SHA ed42b5e51e81724c5258686a0b9d515a99696eac is newer than the oldest allowed merge base and should be accepted
-	intent, err := patch.NewGithubIntent("id", "auto", "", "", "ed42b5e51e81724c5258686a0b9d515a99696eac", pr)
+	intent, err := patch.NewGithubIntent(s.ctx, "id", "auto", "", "", "ed42b5e51e81724c5258686a0b9d515a99696eac", pr)
 
 	s.NoError(err)
 	s.Require().NotNil(intent)
@@ -1228,7 +1228,7 @@ func (s *PatchIntentUnitsSuite) TestProcessGitHubIntentWithMergeBase() {
 	s.Empty(j.gitHubError)
 
 	// SHA 4aa79c5e7ef7af351764b843a2c05fab98c23881 is older than the oldest allowed merge base and should be rejected
-	intent, err = patch.NewGithubIntent("another_id", "auto", "", "", "4aa79c5e7ef7af351764b843a2c05fab98c23881", pr)
+	intent, err = patch.NewGithubIntent(s.ctx, "another_id", "auto", "", "", "4aa79c5e7ef7af351764b843a2c05fab98c23881", pr)
 
 	s.NoError(err)
 	s.Require().NotNil(intent)
@@ -1492,7 +1492,7 @@ func (s *PatchIntentUnitsSuite) TestRunInDegradedModeWithGithubIntent() {
 	}
 	s.NoError(evergreen.SetServiceFlags(s.ctx, flags))
 
-	intent, err := patch.NewGithubIntent("1", "", "", "", "", testutil.NewGithubPR(s.prNumber, s.repo, s.baseHash, s.headRepo, s.hash, "tychoish", "title1"))
+	intent, err := patch.NewGithubIntent(s.ctx, "1", "", "", "", "", testutil.NewGithubPR(s.prNumber, s.repo, s.baseHash, s.headRepo, s.hash, "tychoish", "title1"))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert(s.ctx))
@@ -1524,7 +1524,7 @@ func (s *PatchIntentUnitsSuite) TestGithubPRTestFromUnknownUserDoesntCreateVersi
 	s.Require().NoError(evergreen.SetServiceFlags(s.ctx, flags))
 
 	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings())
-	intent, err := patch.NewGithubIntent("1", "", "", "", "", testutil.NewGithubPR(s.prNumber, "evergreen-ci/evergreen", s.baseHash, s.headRepo, "8a425038834326c212d65289e0c9e80e48d07e7e", "octocat", "title1"))
+	intent, err := patch.NewGithubIntent(s.ctx, "1", "", "", "", "", testutil.NewGithubPR(s.prNumber, "evergreen-ci/evergreen", s.baseHash, s.headRepo, "8a425038834326c212d65289e0c9e80e48d07e7e", "octocat", "title1"))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert(s.ctx))

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1510,7 +1510,7 @@ func (s *PatchIntentUnitsSuite) TestRunInDegradedModeWithGithubIntent() {
 	s.NoError(err)
 	s.Nil(patchDoc)
 
-	unprocessedIntents, err := patch.FindUnprocessedGithubIntents()
+	unprocessedIntents, err := patch.FindUnprocessedGithubIntents(s.ctx)
 	s.Require().NoError(err)
 	s.Require().Len(unprocessedIntents, 1)
 
@@ -1546,7 +1546,7 @@ func (s *PatchIntentUnitsSuite) TestGithubPRTestFromUnknownUserDoesntCreateVersi
 	s.NoError(err)
 	s.Nil(versionDoc)
 
-	unprocessedIntents, err := patch.FindUnprocessedGithubIntents()
+	unprocessedIntents, err := patch.FindUnprocessedGithubIntents(s.ctx)
 	s.NoError(err)
 	s.Require().Empty(unprocessedIntents)
 }

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1174,7 +1174,7 @@ func (s *PatchIntentUnitsSuite) TestProcessMergeGroupIntent() {
 	s.verifyVersionDoc(dbPatch, evergreen.GithubMergeRequester, evergreen.GithubMergeUser, baseSHA, 1)
 
 	out := []event.Subscription{}
-	s.NoError(db.FindAllQContext(s.ctx, event.SubscriptionsCollection, db.Query(bson.M{}), &out))
+	s.NoError(db.FindAllQ(s.ctx, event.SubscriptionsCollection, db.Query(bson.M{}), &out))
 	s.Len(out, 2)
 	for _, subscription := range out {
 		s.Equal("github_merge", subscription.Subscriber.Type)
@@ -1302,7 +1302,7 @@ func (s *PatchIntentUnitsSuite) TestProcessCliPatchIntent() {
 	s.gridFSFileExists(dbPatch.Patches[0].PatchSet.PatchFileId)
 
 	out := []event.Subscription{}
-	s.NoError(db.FindAllQContext(s.ctx, event.SubscriptionsCollection, db.Query(bson.M{}), &out))
+	s.NoError(db.FindAllQ(s.ctx, event.SubscriptionsCollection, db.Query(bson.M{}), &out))
 	s.Require().Empty(out)
 }
 
@@ -1370,7 +1370,7 @@ func (s *PatchIntentUnitsSuite) TestProcessCliPatchIntentWithoutFinalizing() {
 	s.gridFSFileExists(dbPatch.Patches[0].PatchSet.PatchFileId)
 
 	out := []event.Subscription{}
-	s.NoError(db.FindAllQContext(s.ctx, event.SubscriptionsCollection, db.Query(bson.M{}), &out))
+	s.NoError(db.FindAllQ(s.ctx, event.SubscriptionsCollection, db.Query(bson.M{}), &out))
 	s.Require().Empty(out)
 }
 

--- a/units/periodic_builds_test.go
+++ b/units/periodic_builds_test.go
@@ -61,7 +61,7 @@ func TestPeriodicBuildsJob(t *testing.T) {
 	// test that a version is created when the job runs
 	j.Run(ctx)
 	assert.NoError(j.Error())
-	createdVersion, err := model.FindLastPeriodicBuild(sampleProject.Id, sampleProject.PeriodicBuilds[0].ID)
+	createdVersion, err := model.FindLastPeriodicBuild(t.Context(), sampleProject.Id, sampleProject.PeriodicBuilds[0].ID)
 	assert.NoError(err)
 	assert.Equal(evergreen.AdHocRequester, createdVersion.Requester)
 	assert.Equal(prevVersion.Revision, createdVersion.Revision)

--- a/units/pod_definition_cleanup.go
+++ b/units/pod_definition_cleanup.go
@@ -139,7 +139,7 @@ func (j *podDefinitionCleanupJob) cleanupStrandedPodDefinitions(ctx context.Cont
 }
 
 func (j *podDefinitionCleanupJob) cleanupStalePodDefinitions(ctx context.Context, limit int) (numDeleted int, err error) {
-	podDefs, err := definition.FindByLastAccessedBefore(podDefinitionTTL, limit)
+	podDefs, err := definition.FindByLastAccessedBefore(ctx, podDefinitionTTL, limit)
 	if err != nil {
 		return 0, errors.Wrapf(err, "finding pod definitions last accessed before %s", time.Now().Add(-podDefinitionTTL))
 	}

--- a/units/pod_definition_creation.go
+++ b/units/pod_definition_creation.go
@@ -85,7 +85,7 @@ func (j *podDefinitionCreationJob) Run(ctx context.Context) {
 		return
 	}
 
-	dependents, err := pod.FindIntentByFamily(j.Family)
+	dependents, err := pod.FindIntentByFamily(ctx, j.Family)
 	if err != nil {
 		j.AddRetryableError(errors.Wrapf(err, "finding dependent intent pods with family '%s'", j.Family))
 		return
@@ -158,7 +158,7 @@ func (j *podDefinitionCreationJob) populateIfUnset(ctx context.Context) error {
 // decommissionDependentIntentPods decommissions all intent pods that depend on
 // the pod definition created by this job.
 func (j *podDefinitionCreationJob) decommissionDependentIntentPods(ctx context.Context) error {
-	podsToDecommission, err := pod.FindIntentByFamily(j.Family)
+	podsToDecommission, err := pod.FindIntentByFamily(ctx, j.Family)
 	if err != nil {
 		return errors.Wrap(err, "finding intent pods to decommission")
 	}

--- a/units/spawnhost_expiration_check_test.go
+++ b/units/spawnhost_expiration_check_test.go
@@ -86,7 +86,7 @@ func TestTryIdleSpawnHostNotification(t *testing.T) {
 	assert.NoError(t, tryIdleSpawnHostNotification(t.Context(), h))
 
 	fetchedSubs := []event.Subscription{}
-	assert.NoError(t, db.FindAllQContext(t.Context(), event.SubscriptionsCollection, db.Q{}, &fetchedSubs))
+	assert.NoError(t, db.FindAllQ(t.Context(), event.SubscriptionsCollection, db.Q{}, &fetchedSubs))
 	require.Len(t, fetchedSubs, 1)
 	assert.Equal(t, u.EmailAddress, utility.FromStringPtr(fetchedSubs[0].Subscriber.Target.(*string)))
 	assert.Equal(t, event.EmailSubscriberType, fetchedSubs[0].Subscriber.Type)
@@ -95,7 +95,7 @@ func TestTryIdleSpawnHostNotification(t *testing.T) {
 	// Trying to re-insert the subscription doesn't create a new subscription.
 	assert.NoError(t, tryIdleSpawnHostNotification(t.Context(), h))
 	fetchedSubs = []event.Subscription{}
-	assert.NoError(t, db.FindAllQContext(t.Context(), event.SubscriptionsCollection, db.Q{}, &fetchedSubs))
+	assert.NoError(t, db.FindAllQ(t.Context(), event.SubscriptionsCollection, db.Q{}, &fetchedSubs))
 	require.Len(t, fetchedSubs, 1)
 
 	events, err := event.FindAllByResourceID(t.Context(), h.Id)

--- a/units/spawnhost_expiration_check_test.go
+++ b/units/spawnhost_expiration_check_test.go
@@ -98,7 +98,7 @@ func TestTryIdleSpawnHostNotification(t *testing.T) {
 	assert.NoError(t, db.FindAllQContext(t.Context(), event.SubscriptionsCollection, db.Q{}, &fetchedSubs))
 	require.Len(t, fetchedSubs, 1)
 
-	events, err := event.FindAllByResourceID(h.Id)
+	events, err := event.FindAllByResourceID(t.Context(), h.Id)
 	assert.NoError(t, err)
 	assert.Len(t, events, 2)
 }

--- a/units/spawnhost_expiration_warning_test.go
+++ b/units/spawnhost_expiration_warning_test.go
@@ -95,7 +95,7 @@ func (s *spawnHostExpirationSuite) SetupTest() {
 
 func (s *spawnHostExpirationSuite) TestEventsAreLogged() {
 	s.j.Run(s.ctx)
-	events, err := event.FindUnprocessedEvents(-1)
+	events, err := event.FindUnprocessedEvents(s.T().Context(), -1)
 	s.NoError(err)
 	s.Len(events, 6)
 
@@ -136,19 +136,19 @@ func (s *spawnHostExpirationSuite) TestEventsAreLogged() {
 
 func (s *spawnHostExpirationSuite) TestDuplicateEventsAreNotLoggedWithinRenotificationInterval() {
 	s.j.Run(s.ctx)
-	events, err := event.FindUnprocessedEvents(-1)
+	events, err := event.FindUnprocessedEvents(s.T().Context(), -1)
 	s.NoError(err)
 	s.Len(events, 6, "should log expected events on first run")
 
 	s.j.Run(s.ctx)
-	eventsAfterRerun, err := event.FindUnprocessedEvents(-1)
+	eventsAfterRerun, err := event.FindUnprocessedEvents(s.T().Context(), -1)
 	s.NoError(err)
 	s.Len(eventsAfterRerun, len(events), "should not log duplicate events on second run")
 }
 
 func (s *spawnHostExpirationSuite) TestDuplicateEventsAreLoggedAfterRenotificationIntervalElapses() {
 	s.j.Run(s.ctx)
-	events, err := event.FindUnprocessedEvents(-1)
+	events, err := event.FindUnprocessedEvents(s.T().Context(), -1)
 	s.NoError(err)
 	s.Len(events, 6, "should log expected events on first run")
 
@@ -174,12 +174,12 @@ func (s *spawnHostExpirationSuite) TestDuplicateEventsAreLoggedAfterRenotificati
 	s.Equal(numHostsToRenotify, res.Updated, "should have updated the alert records for expiration warnings so that they are old")
 
 	s.j.Run(s.ctx)
-	eventsAfterRerun, err := event.FindUnprocessedEvents(-1)
+	eventsAfterRerun, err := event.FindUnprocessedEvents(s.T().Context(), -1)
 	s.NoError(err)
 	s.Len(eventsAfterRerun, len(events)+numHostsToRenotify, "should log new expiration warnings when renotification interval has passed")
 
 	s.j.Run(s.ctx)
-	eventsAfterSecondRerun, err := event.FindUnprocessedEvents(-1)
+	eventsAfterSecondRerun, err := event.FindUnprocessedEvents(s.T().Context(), -1)
 	s.NoError(err)
 	s.Len(eventsAfterSecondRerun, len(events)+numHostsToRenotify, "should not log any more expiration warnings when the host was recently renotified")
 }
@@ -189,7 +189,7 @@ func (s *spawnHostExpirationSuite) TestCanceledJob() {
 	cancel()
 
 	s.j.Run(ctx)
-	events, err := event.FindUnprocessedEvents(-1)
+	events, err := event.FindUnprocessedEvents(s.T().Context(), -1)
 	s.NoError(err)
 	s.Empty(events)
 }

--- a/units/spawnhost_modify_test.go
+++ b/units/spawnhost_modify_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func checkSpawnHostModificationEvent(t *testing.T, hostID, expectedEvent string, expectedSuccess bool) {
-	events, err := event.FindAllByResourceID(hostID)
+	events, err := event.FindAllByResourceID(t.Context(), hostID)
 	require.NoError(t, err)
 
 	var foundEvent bool

--- a/units/stats_queue.go
+++ b/units/stats_queue.go
@@ -45,7 +45,7 @@ func makeQueueStatsCollector() *queueStatsCollector {
 	return j
 }
 
-func (j *queueStatsCollector) Run(_ context.Context) {
+func (j *queueStatsCollector) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
 	env := evergreen.GetEnvironment()
@@ -54,7 +54,7 @@ func (j *queueStatsCollector) Run(_ context.Context) {
 		return
 	}
 
-	queues, err := model.FindAllTaskQueues()
+	queues, err := model.FindAllTaskQueues(ctx)
 	if err != nil {
 		j.AddError(err)
 		return

--- a/units/unexpirable_spawnhost_stats.go
+++ b/units/unexpirable_spawnhost_stats.go
@@ -60,7 +60,7 @@ func NewUnexpirableSpawnHostStatsJob(ts string) amboy.Job {
 func (j *unexpirableSpawnHostStatsJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
-	hosts, err := host.FindUnexpirableRunning()
+	hosts, err := host.FindUnexpirableRunning(ctx)
 	if err != nil {
 		j.AddRetryableError(errors.Wrap(err, "finding unexpirable running hosts"))
 		return

--- a/units/volume_expiration_warning_test.go
+++ b/units/volume_expiration_warning_test.go
@@ -33,7 +33,7 @@ func TestVolumeExpiration(t *testing.T) {
 	j := makeVolumeExpirationWarningsJob()
 	j.Run(context.Background())
 
-	events, err := event.FindUnprocessedEvents(-1)
+	events, err := event.FindUnprocessedEvents(t.Context(), -1)
 	assert.NoError(t, err)
 	// one event each for v0, v1, v2
 	assert.Len(t, events, 3)

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -279,7 +279,7 @@ func CheckProject(ctx context.Context, project *model.Project, config *model.Pro
 	}
 	verrs = append(verrs, CheckProjectSettings(ctx, evergreen.GetEnvironment().Settings(), project, ref, isConfigDefined)...)
 	// Check project aliases
-	aliases, err := model.ConstructMergedAliasesByPrecedence(ref, config, ref.RepoRefId)
+	aliases, err := model.ConstructMergedAliasesByPrecedence(ctx, ref, config, ref.RepoRefId)
 	if err != nil {
 		return append(verrs, ValidationError{
 			Message: "problem finding aliases; validation will not check alias coverage",


### PR DESCRIPTION
DEVPROD-53

### Description
This threads the context for the remaining FindAllQ queries. This leaves only very rarely used (dropcollection, etc) queries left, and a gimlet migration in [DEVPROD-15398](https://jira.mongodb.org/browse/DEVPROD-15398).

### Testing
Unit testing.
