### PR TITLE
DEVPROD-16708: create admin setting for IPAM pool ID

### DIFF
--- a/config_cloud.go
+++ b/config_cloud.go
@@ -81,6 +81,9 @@ type AWSConfig struct {
 	Pod AWSPodConfig `bson:"pod" json:"pod" yaml:"pod"`
 
 	AccountRoles []AWSAccountRoleMapping `bson:"account_roles" json:"account_roles" yaml:"account_roles"`
+
+	// IPAMPoolID is the ID for the IP address management (IPAM) pool in AWS.
+	IPAMPoolID string `bson:"ipam_pool_id" json:"ipam_pool_id" yaml:"ipam_pool_id"`
 }
 
 // AccountRoleMapping is a mapping of an AWS account to the role that needs to

--- a/rest/data/admin_test.go
+++ b/rest/data/admin_test.go
@@ -164,6 +164,7 @@ func (s *AdminDataSuite) TestSetAndGetSettings() {
 	for i := range testSettings.Providers.AWS.AccountRoles {
 		s.Equal(testSettings.Providers.AWS.AccountRoles[i], settingsFromConnector.Providers.AWS.AccountRoles[i])
 	}
+	s.Equal(testSettings.Providers.AWS.IPAMPoolID, settingsFromConnector.Providers.AWS.IPAMPoolID)
 	s.EqualValues(testSettings.Providers.Docker.APIVersion, settingsFromConnector.Providers.Docker.APIVersion)
 	s.EqualValues(testSettings.RepoTracker.MaxConcurrentRequests, settingsFromConnector.RepoTracker.MaxConcurrentRequests)
 	s.EqualValues(testSettings.Scheduler.TaskFinder, settingsFromConnector.Scheduler.TaskFinder)

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1571,6 +1571,7 @@ type APIAWSConfig struct {
 	MaxVolumeSizePerUser *int                       `json:"max_volume_size"`
 	Pod                  *APIAWSPodConfig           `json:"pod"`
 	AccountRoles         []APIAWSAccountRoleMapping `json:"account_roles"`
+	IPAMPoolID           *string                    `json:"ipam_pool_id"`
 }
 
 func (a *APIAWSConfig) BuildFromService(h any) error {
@@ -1620,6 +1621,7 @@ func (a *APIAWSConfig) BuildFromService(h any) error {
 			roleMappings = append(roleMappings, api)
 		}
 		a.AccountRoles = roleMappings
+		a.IPAMPoolID = utility.ToStringPtr(v.IPAMPoolID)
 	default:
 		return errors.Errorf("programmatic error: expected AWS config but got type %T", h)
 	}
@@ -1707,6 +1709,8 @@ func (a *APIAWSConfig) ToService() (any, error) {
 		roleMappings = append(roleMappings, m.ToService())
 	}
 	config.AccountRoles = roleMappings
+
+	config.IPAMPoolID = utility.FromStringPtr(a.IPAMPoolID)
 
 	return config, nil
 }

--- a/rest/route/admin_test.go
+++ b/rest/route/admin_test.go
@@ -187,6 +187,7 @@ func (s *AdminRouteSuite) TestAdminRoute() {
 	for i := range testSettings.Providers.AWS.AccountRoles {
 		s.Equal(testSettings.Providers.AWS.AccountRoles[i], settings.Providers.AWS.AccountRoles[i])
 	}
+	s.EqualValues(testSettings.Providers.AWS.IPAMPoolID, settings.Providers.AWS.IPAMPoolID)
 	s.EqualValues(testSettings.Providers.Docker.APIVersion, settings.Providers.Docker.APIVersion)
 	s.EqualValues(testSettings.RepoTracker.MaxConcurrentRequests, settings.RepoTracker.MaxConcurrentRequests)
 	s.EqualValues(testSettings.Scheduler.TaskFinder, settings.Scheduler.TaskFinder)

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1905,6 +1905,10 @@ Admin Settings
 											ng-trim="false" rows="3" md-select-on-focus></textarea>
 									</md-input-container>
 									<md-input-container class="control" style="width:45%;">
+										<label>IPAM Pool ID</label>
+										<input type="number" ng-model="Settings.providers.aws.ipam_pool_id">
+									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
 										<label>Allowed Container Images</label>
 										<textarea ng-model="Settings.providers.aws.pod.ecs.allowed_images" ng-list="&#10;" ng-trim="false" rows="3"
 											md-select-on-focus></textarea>

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1906,54 +1906,54 @@ Admin Settings
 									</md-input-container>
 									<md-input-container class="control" style="width:45%;">
 										<label>IPAM Pool ID</label>
-										<input type="number" ng-model="Settings.providers.aws.ipam_pool_id">
+										<input type="text" ng-model="Settings.providers.aws.ipam_pool_id">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
+									<md-input-container class="control" style="width:45%; margin-left: 50px;">
 										<label>Allowed Container Images</label>
 										<textarea ng-model="Settings.providers.aws.pod.ecs.allowed_images" ng-list="&#10;" ng-trim="false" rows="3"
 											md-select-on-focus></textarea>
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left: 50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Pod ECS Max CPU Units Per Pod</label>
 										<input type="number" ng-model="Settings.providers.aws.pod.ecs.max_cpu">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
+									<md-input-container class="control" style="width:45%; margin-left: 50px;">
 										<label>Pod ECS Max Memory (MB) Per Pod</label>
 										<input type="number" ng-model="Settings.providers.aws.pod.ecs.max_memory_mb">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left: 50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Pod Role</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.role">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
+									<md-input-container class="control" style="width:45%; margin-left: 50px;">
 										<label>Pod Region</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.region">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left: 50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Pod Secrets Manager Secret Prefix</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.secrets_manager.secret_prefix">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
+									<md-input-container class="control" style="width:45%; margin-left: 50px;">
 										<label>Pod ECS Task Definition Prefix</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.ecs.task_definition_prefix">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left: 50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Pod ECS Task Role</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.ecs.task_role">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
+									<md-input-container class="control" style="width:45%; margin-left: 50px;">
 										<label>Pod ECS Execution Role</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.ecs.execution_role">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left: 50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Pod ECS Log Region</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.ecs.log_region">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%;">
+									<md-input-container class="control" style="width:45%; margin-left: 50px;">
 										<label>Pod ECS Log Group Name</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.ecs.log_group">
 									</md-input-container>
-									<md-input-container class="control" style="width:45%; margin-left: 50px;">
+									<md-input-container class="control" style="width:45%;">
 										<label>Pod ECS Log Stream Prefix</label>
 										<input type="text" ng-model="Settings.providers.aws.pod.ecs.log_stream_prefix">
 									</md-input-container>

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -350,6 +350,7 @@ func MockConfig() *evergreen.Settings {
 						Role:    "role",
 					},
 				},
+				IPAMPoolID: "pool_id",
 			},
 			Docker: evergreen.DockerConfig{
 				APIVersion: "docker_version",


### PR DESCRIPTION
DEVPROD-16584

### Description
Evergreen is going to start using IPv4 addresses from a pool of addresses, rather than just getting one automatically allocated by AWS. Add an admin setting to specify the IPAM pool from which Evergreen can get addresses.

### Testing
* Unit tests.
* Tested in local Evergreen that the admin setting worked.
