### PR TITLE
DEVPROD-16829 Add single task distro to host stats by distro

### DIFF
--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -44,7 +44,8 @@ var (
 	IsClusterKey             = bsonutil.MustHaveTag(Distro{}, "IsCluster")
 	IceCreamSettingsKey      = bsonutil.MustHaveTag(Distro{}, "IceCreamSettings")
 	// ImageID is not equivalent to AMI. It is the identifier of the base image for the distro.
-	ImageIDKey = bsonutil.MustHaveTag(Distro{}, "ImageID")
+	ImageIDKey          = bsonutil.MustHaveTag(Distro{}, "ImageID")
+	SingleTaskDistroKey = bsonutil.MustHaveTag(Distro{}, "SingleTaskDistro")
 )
 
 var (

--- a/model/host/stats.go
+++ b/model/host/stats.go
@@ -25,6 +25,8 @@ type StatsByDistro struct {
 	NumTasks int `bson:"num_tasks_running" json:"num_tasks_running"`
 	// MaxHosts reports the pool size of the distro.
 	MaxHosts int `bson:"max_hosts" json:"max_hosts"`
+	// SingleTaskDistro is true if the distro is a single task distro.
+	SingleTaskDistro bool `bson:"single_task_distro" json:"single_task_distro"`
 }
 
 func (d *StatsByDistro) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(d) }
@@ -137,17 +139,21 @@ func statsByDistroPipeline() []bson.M {
 					// Grab any provider, since all hosts in a distro have the same provider
 					"$first": "$" + bsonutil.GetDottedKeyName(DistroKey, distro.ProviderKey),
 				},
+				"single_task_distro": bson.M{
+					"$first": "$" + bsonutil.GetDottedKeyName(DistroKey, distro.SingleTaskDistroKey),
+				},
 			},
 		},
 		{
 			"$project": bson.M{
-				"distro":            "$_id.distro",
-				"status":            "$_id.status",
-				"max_hosts":         1,
-				"count":             1,
-				"num_tasks_running": bson.M{"$size": "$tasks"},
-				"_id":               0,
-				"provider":          1,
+				"distro":             "$_id.distro",
+				"status":             "$_id.status",
+				"max_hosts":          1,
+				"count":              1,
+				"num_tasks_running":  bson.M{"$size": "$tasks"},
+				"_id":                0,
+				"provider":           1,
+				"single_task_distro": 1,
 			},
 		},
 	}


### PR DESCRIPTION
DEVPROD-16829

### Description
adds a field to host stat for splunk board

### Testing
unit testing with aggregation 