### PR TITLE
DEVPROD-16904 Add Cedar DB connection to Evergreen

### DIFF
--- a/config_cedar.go
+++ b/config_cedar.go
@@ -9,8 +9,8 @@ import (
 )
 
 type CedarConfig struct {
-	DbURL       string `bson:"db_url" json:"db_url" yaml:"db_url"`
-	DbName      string `bson:"db_name" json:"db_name" yaml:"db_name"`
+	DBURL       string `bson:"db_url" json:"db_url" yaml:"db_url"`
+	DBName      string `bson:"db_name" json:"db_name" yaml:"db_name"`
 	BaseURL     string `bson:"base_url" json:"base_url" yaml:"base_url"`
 	GRPCBaseURL string `bson:"grpc_base_url" json:"grpc_base_url" yaml:"grpc_base_url"`
 	RPCPort     string `bson:"rpc_port" json:"rpc_port" yaml:"rpc_port"`

--- a/config_cedar.go
+++ b/config_cedar.go
@@ -10,6 +10,7 @@ import (
 
 type CedarConfig struct {
 	DbURL       string `bson:"db_url" json:"db_url" yaml:"db_url"`
+	DbName      string `bson:"db_name" json:"db_name" yaml:"db_name"`
 	BaseURL     string `bson:"base_url" json:"base_url" yaml:"base_url"`
 	GRPCBaseURL string `bson:"grpc_base_url" json:"grpc_base_url" yaml:"grpc_base_url"`
 	RPCPort     string `bson:"rpc_port" json:"rpc_port" yaml:"rpc_port"`

--- a/config_cedar.go
+++ b/config_cedar.go
@@ -9,6 +9,7 @@ import (
 )
 
 type CedarConfig struct {
+	DbURL       string `bson:"db_url" json:"db_url" yaml:"db_url"`
 	BaseURL     string `bson:"base_url" json:"base_url" yaml:"base_url"`
 	GRPCBaseURL string `bson:"grpc_base_url" json:"grpc_base_url" yaml:"grpc_base_url"`
 	RPCPort     string `bson:"rpc_port" json:"rpc_port" yaml:"rpc_port"`

--- a/db/cedar_db_utils.go
+++ b/db/cedar_db_utils.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"errors"
+
 	"github.com/evergreen-ci/evergreen"
 	"github.com/mongodb/anser/db"
 )

--- a/db/cedar_db_utils.go
+++ b/db/cedar_db_utils.go
@@ -1,0 +1,76 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"github.com/evergreen-ci/evergreen"
+	"github.com/mongodb/anser/db"
+)
+
+type cedarShimFactoryImpl struct {
+	env evergreen.Environment
+	db  string
+}
+
+func GetCedarGlobalSessionFactory() SessionFactory {
+	env := evergreen.GetEnvironment()
+	return &cedarShimFactoryImpl{
+		env: env,
+		db:  env.Settings().Cedar.DbName,
+	}
+}
+
+// GetCedarContextSession creates a cedar database session and connection that uses the associated
+// context in its operations.
+func (s *cedarShimFactoryImpl) GetContextSession(ctx context.Context) (db.Session, db.Database, error) {
+	if s.env == nil {
+		return nil, nil, errors.New("undefined environment")
+	}
+
+	session := s.env.CedarContextSession(ctx)
+	if session == nil {
+		return nil, nil, errors.New("context session is not defined")
+	}
+
+	return session, session.DB(s.db), nil
+}
+
+// GetSession creates a database connection using the global environment's
+// session (and context through the session).
+func (s *cedarShimFactoryImpl) GetSession() (db.Session, db.Database, error) {
+	if s.env == nil {
+		return nil, nil, errors.New("undefined environment")
+	}
+
+	session := s.env.Session()
+	if session == nil {
+		return nil, nil, errors.New("session is not defined")
+	}
+
+	return session, session.DB(s.db), nil
+}
+
+// FindOneQContextCedar runs a Q query against the given collection, applying the results to "out."
+// Only reads one document from the DB.
+func FindOneQContextCedar(ctx context.Context, collection string, q Q, out any) error {
+	if q.maxTime > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, q.maxTime)
+		defer cancel()
+	}
+
+	session, db, err := GetCedarGlobalSessionFactory().GetContextSession(ctx)
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	return db.C(collection).
+		Find(q.filter).
+		Select(q.projection).
+		Sort(q.sort...).
+		Skip(q.skip).
+		Limit(1).
+		Hint(q.hint).
+		One(out)
+}

--- a/db/cedar_db_utils.go
+++ b/db/cedar_db_utils.go
@@ -13,11 +13,12 @@ type cedarShimFactoryImpl struct {
 	db  string
 }
 
+// GetCedarGlobalSessionFactory initializes a session factory to connect to the Cedar database.
 func GetCedarGlobalSessionFactory() SessionFactory {
 	env := evergreen.GetEnvironment()
 	return &cedarShimFactoryImpl{
 		env: env,
-		db:  env.Settings().Cedar.DbName,
+		db:  env.Settings().Cedar.DBName,
 	}
 }
 
@@ -36,7 +37,7 @@ func (s *cedarShimFactoryImpl) GetContextSession(ctx context.Context) (db.Sessio
 	return session, session.DB(s.db), nil
 }
 
-// GetSession creates a database connection using the global environment's
+// GetSession creates a Cedar database connection using the global environment's
 // session (and context through the session).
 func (s *cedarShimFactoryImpl) GetSession() (db.Session, db.Database, error) {
 	if s.env == nil {

--- a/db/cedar_db_utils.go
+++ b/db/cedar_db_utils.go
@@ -21,7 +21,7 @@ func GetCedarGlobalSessionFactory() SessionFactory {
 	}
 }
 
-// GetCedarContextSession creates a cedar database session and connection that uses the associated
+// GetContextSession creates a cedar database session and connection that uses the associated
 // context in its operations.
 func (s *cedarShimFactoryImpl) GetContextSession(ctx context.Context) (db.Session, db.Database, error) {
 	if s.env == nil {
@@ -49,29 +49,4 @@ func (s *cedarShimFactoryImpl) GetSession() (db.Session, db.Database, error) {
 	}
 
 	return session, session.DB(s.db), nil
-}
-
-// FindOneQContextCedar runs a Q query against the given collection, applying the results to "out."
-// Only reads one document from the DB.
-func FindOneQContextCedar(ctx context.Context, collection string, q Q, out any) error {
-	if q.maxTime > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, q.maxTime)
-		defer cancel()
-	}
-
-	session, db, err := GetCedarGlobalSessionFactory().GetContextSession(ctx)
-	if err != nil {
-		return err
-	}
-	defer session.Close()
-
-	return db.C(collection).
-		Find(q.filter).
-		Select(q.projection).
-		Sort(q.sort...).
-		Skip(q.skip).
-		Limit(1).
-		Hint(q.hint).
-		One(out)
 }

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -37,6 +37,7 @@ type shimFactoryImpl struct {
 	db  string
 }
 
+// GetGlobalSessionFactory initializes a session factory to connect to the Evergreen database.
 func GetGlobalSessionFactory() SessionFactory {
 	env := evergreen.GetEnvironment()
 	return &shimFactoryImpl{

--- a/environment.go
+++ b/environment.go
@@ -413,7 +413,7 @@ func (e *envState) initCedarDB(ctx context.Context, tracer trace.Tracer) error {
 	defer span.End()
 
 	var err error
-	url := e.settings.Cedar.DbURL
+	url := e.settings.Cedar.DBURL
 	if url == "" {
 		url = DefaultCedarDatabaseURL
 	}
@@ -485,7 +485,7 @@ func (e *envState) CedarDB() *mongo.Database {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	return e.cedarClient.Database(e.settings.Cedar.DbName)
+	return e.cedarClient.Database(e.settings.Cedar.DBName)
 }
 
 // SharedDB returns a database that is shared between multiple instances

--- a/environment.go
+++ b/environment.go
@@ -113,10 +113,12 @@ type Environment interface {
 	// DB returns a database that is dedicated to this instance of
 	// Evergreen.
 	DB() *mongo.Database
+	// CedarDB returns a database that is dedicated to our Cedar
+	// database cluster.
+	CedarDB() *mongo.Database
 	// SharedDB returns a database that is shared between multiple
 	// instances of Evergreen. Returns nil when no shared database
 	// is configured.
-	CedarDB() *mongo.Database
 	SharedDB() *mongo.Database
 
 	// The Environment provides access to several amboy queues for
@@ -477,7 +479,8 @@ func (e *envState) DB() *mongo.Database {
 	return e.client.Database(e.dbName)
 }
 
-// CedarDB returns a database that is dedicated to the cluster's Cedar DB instance.
+// CedarDB returns a database that is dedicated to our Cedar
+// database cluster.
 func (e *envState) CedarDB() *mongo.Database {
 	e.mu.RLock()
 	defer e.mu.RUnlock()

--- a/globals.go
+++ b/globals.go
@@ -653,6 +653,7 @@ const (
 	DefaultDatabaseReadMode  = "majority"
 
 	DefaultAmboyDatabaseURL = "mongodb://localhost:27017"
+	DefaultCedarDatabaseURL = "mongodb://localhost:27017"
 
 	// version requester types
 	PatchVersionRequester       = "patch_request"

--- a/mock/environment.go
+++ b/mock/environment.go
@@ -239,6 +239,12 @@ func (e *Environment) ContextSession(_ context.Context) db.Session {
 	return e.DBSession
 }
 
+func (e *Environment) CedarContextSession(_ context.Context) db.Session {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return e.DBSession
+}
+
 func (e *Environment) Client() *mongo.Client {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
@@ -246,6 +252,13 @@ func (e *Environment) Client() *mongo.Client {
 }
 
 func (e *Environment) DB() *mongo.Database {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	return e.MongoClient.Database(e.DatabaseName)
+}
+
+func (e *Environment) CedarDB() *mongo.Database {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1412,6 +1412,10 @@ Admin Settings
 										<label>DB URL</label>
 										<input type="text" ng-model="Settings.cedar.db_url">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>DB Name</label>
+										<input type="text" ng-model="Settings.cedar.db_name">
+									</md-input-container>
 								</md-card-content>
 							</md-card>
 						</section>

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -1408,6 +1408,10 @@ Admin Settings
 										<label>API Key</label>
 										<input type="text" ng-model="Settings.cedar.api_key">
 									</md-input-container>
+									<md-input-container class="control" style="width:45%;">
+										<label>DB URL</label>
+										<input type="text" ng-model="Settings.cedar.db_url">
+									</md-input-container>
 								</md-card-content>
 							</md-card>
 						</section>


### PR DESCRIPTION
DEVPROD-16904

### Description
Evergreen will need R/W ability directly to Cedar DB cluster once it assumes the responsibility of handling the test result service. Added this.

### Testing
Hard coded a REST route to fetch some Cedar data and confirmed it worked. Will update admin settings accordingly in prod before merging if approved.
