### PR TITLE
DEVPROD-15806 Fix home directory not found on windows

### DIFF
--- a/agent/directory.go
+++ b/agent/directory.go
@@ -16,6 +16,7 @@ import (
 	"github.com/evergreen-ci/evergreen/agent/globals"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/utility"
+	"github.com/mitchellh/go-homedir"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/recovery"
@@ -300,11 +301,13 @@ func (a *Agent) SetHomeDirectory() {
 		return
 	}
 
-	usr, err := user.Current()
+	userHome, err := homedir.Dir()
 	if err != nil {
-		grip.Warning(errors.Wrap(err, "getting current user to set the home directory"))
-		return
+		// workaround for cygwin if we're on windows but couldn't get a homedir
+		if runtime.GOOS == "windows" && len(os.Getenv("HOME")) > 0 {
+			userHome = os.Getenv("HOME")
+		}
 	}
 
-	a.opts.HomeDirectory = usr.HomeDir
+	a.opts.HomeDirectory = userHome
 }

--- a/agent/directory.go
+++ b/agent/directory.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/evergreen-ci/evergreen/agent/globals"
 	"github.com/evergreen-ci/evergreen/apimodels"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/utility"
-	"github.com/mitchellh/go-homedir"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/recovery"
@@ -301,12 +301,9 @@ func (a *Agent) SetHomeDirectory() {
 		return
 	}
 
-	userHome, err := homedir.Dir()
+	userHome, err := util.GetUserHome()
 	if err != nil {
-		// workaround for cygwin if we're on windows but couldn't get a homedir
-		if runtime.GOOS == "windows" && len(os.Getenv("HOME")) > 0 {
-			userHome = os.Getenv("HOME")
-		}
+		grip.Warning(errors.Wrap(err, "setting the agent's home directory"))
 	}
 
 	a.opts.HomeDirectory = userHome

--- a/cmd/evergreen/evergreen.go
+++ b/cmd/evergreen/evergreen.go
@@ -3,15 +3,14 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 
 	// this *must* be included in the binary so that the legacy
 	// plugins are built into the binary.
 	_ "github.com/evergreen-ci/evergreen/plugin"
+	"github.com/evergreen-ci/evergreen/util"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/operations"
-	"github.com/mitchellh/go-homedir"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/send"
@@ -69,13 +68,7 @@ func buildApp() *cli.App {
 		operations.PatchCancel(),
 	}
 
-	userHome, err := homedir.Dir()
-	if err != nil {
-		// workaround for cygwin if we're on windows but couldn't get a homedir
-		if runtime.GOOS == "windows" && len(os.Getenv("HOME")) > 0 {
-			userHome = os.Getenv("HOME")
-		}
-	}
+	userHome, _ := util.GetUserHome()
 	confPath := filepath.Join(userHome, evergreen.DefaultEvergreenConfig)
 
 	// These are global options. Use this to configure logging or

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-04-14"
+	AgentVersion = "2025-04-17"
 )
 
 const (

--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-04-08"
+	ClientVersion = "2025-04-17"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/model.go
+++ b/operations/model.go
@@ -13,8 +13,8 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/rest/client"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/kardianos/osext"
-	"github.com/mitchellh/go-homedir"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
@@ -37,13 +37,7 @@ type ClientProjectConf struct {
 func findConfigFilePath(fn string) (string, error) {
 	currentBinPath, _ := osext.Executable()
 
-	userHome, err := homedir.Dir()
-	if err != nil {
-		// workaround for cygwin if we're on windows but couldn't get a homedir
-		if runtime.GOOS == "windows" && len(os.Getenv("HOME")) > 0 {
-			userHome = os.Getenv("HOME")
-		}
-	}
+	userHome, _ := util.GetUserHome()
 
 	if fn != "" {
 		if isValidPath(fn) {

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -691,10 +691,6 @@ tasks:
       - command: shell.exec
         params:
           script: |
-            # TODO (DEVPROD-15806): removing these files is a temporary workaround to ensure the git
-            # configuration/credentials files are clean on Windows. Once DEVPROD-15806 is addressed, this can be removed.
-            rm -f ~/.gitconfig
-            rm -f ~/.git-credentials
             # Set GitHub app dynamic token to ensure it can clone non-public repos for Go modules.
             git config --global url."https://x-access-token:${github_token}@github.com/evergreen-ci/".insteadOf https://github.com/evergreen-ci/
       - command: subprocess.exec

--- a/util/filepath.go
+++ b/util/filepath.go
@@ -1,12 +1,27 @@
 package util
 
 import (
+	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+
+	"github.com/mitchellh/go-homedir"
 )
 
 // ConsistentFilepath returns a filepath that always uses forward slashes ('/')
 // rather than platform-dependent file path separators.
 func ConsistentFilepath(parts ...string) string {
 	return strings.Replace(filepath.Join(parts...), "\\", "/", -1)
+}
+
+func GetUserHome() (string, error) {
+	userHome, err := homedir.Dir()
+	if err != nil {
+		// workaround for cygwin if we're on windows but couldn't get a homedir
+		if runtime.GOOS == "windows" && len(os.Getenv("HOME")) > 0 {
+			userHome = os.Getenv("HOME")
+		}
+	}
+	return userHome, err
 }


### PR DESCRIPTION
DEVPROD-15806

### Description
The ~/.gitconfig and ~/.git-credentials files weren't being cleaned up on windows because they weren't located at the current user's home directory, they were located at C:/cygwin/home/<user>. 

### Testing
Tested it on staging by adding something to the git config and then making sure that the "Cleared git config." is logged on both ubuntu and windows. 

I am also adding windows tasks to the patch associated with this PR. 
