### PR TITLE
DEVPROD-53 Thread context for remaining GridFS functions and FindAndModify

### DIFF
--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -454,8 +454,8 @@ func RemoveAllQ(ctx context.Context, collection string, q Q) error {
 
 // FindAndModify runs the specified query and change against the collection,
 // unmarshaling the result into the specified interface.
-func FindAndModify(collection string, query any, sort []string, change db.Change, out any) (*db.ChangeInfo, error) {
-	session, db, err := GetGlobalSessionFactory().GetSession()
+func FindAndModify(ctx context.Context, collection string, query any, sort []string, change db.Change, out any) (*db.ChangeInfo, error) {
+	session, db, err := GetGlobalSessionFactory().GetContextSession(ctx)
 	if err != nil {
 		grip.Errorf("error establishing db connection: %+v", err)
 

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -483,10 +483,8 @@ func WriteGridFile(fsPrefix, name string, source io.Reader) error {
 }
 
 // GetGridFile returns a ReadCloser for a file stored with the given name under the GridFS prefix.
-func GetGridFile(fsPrefix, name string) (io.ReadCloser, error) {
+func GetGridFile(ctx context.Context, fsPrefix, name string) (io.ReadCloser, error) {
 	env := evergreen.GetEnvironment()
-	ctx, cancel := env.Context()
-	defer cancel()
 	bucket, err := pail.NewGridFSBucketWithClient(ctx, env.Client(), pail.GridFSOptions{
 		Database: env.DB().Name(),
 		Name:     fsPrefix,

--- a/db/db_utils.go
+++ b/db/db_utils.go
@@ -109,90 +109,6 @@ func InsertManyUnordered(ctx context.Context, collection string, items ...any) e
 	return errors.Wrapf(errors.WithStack(err), "inserting unordered documents")
 }
 
-// CreateCollections ensures that all the given collections are created,
-// returning an error immediately if creating any one of them fails.
-func CreateCollections(collections ...string) error {
-	session, db, err := GetGlobalSessionFactory().GetSession()
-	if err != nil {
-		return err
-	}
-	defer session.Close()
-
-	const namespaceExistsErrCode = 48
-	for _, collection := range collections {
-		_, err := db.CreateCollection(collection)
-		if err == nil {
-			continue
-		}
-		// If the collection already exists, this does not count as an error.
-		if mongoErr, ok := errors.Cause(err).(mongo.CommandError); ok && mongoErr.HasErrorCode(namespaceExistsErrCode) {
-			continue
-		}
-		if err != nil {
-			return errors.Wrapf(err, "creating collection '%s'", collection)
-		}
-	}
-	return nil
-}
-
-// Clear removes all documents from a specified collection.
-func Clear(collection string) error {
-	session, db, err := GetGlobalSessionFactory().GetSession()
-	if err != nil {
-		return err
-	}
-	defer session.Close()
-
-	_, err = db.C(collection).RemoveAll(bson.M{})
-
-	return err
-}
-
-// ClearCollections clears all documents from all the specified collections,
-// returning an error immediately if clearing any one of them fails.
-func ClearCollections(collections ...string) error {
-	session, db, err := GetGlobalSessionFactory().GetSession()
-	if err != nil {
-		return err
-	}
-	defer session.Close()
-	for _, collection := range collections {
-		_, err := db.C(collection).RemoveAll(bson.M{})
-
-		if err != nil {
-			return errors.Wrapf(err, "Couldn't clear collection '%v'", collection)
-		}
-	}
-	return nil
-}
-
-// DropCollections drops the specified collections, returning an error
-// immediately if dropping any one of them fails.
-func DropCollections(collections ...string) error {
-	session, db, err := GetGlobalSessionFactory().GetSession()
-	if err != nil {
-		return err
-	}
-	defer session.Close()
-	for _, coll := range collections {
-		if err := db.C(coll).DropCollection(); err != nil {
-			return errors.Wrapf(err, "dropping collection '%s'", coll)
-		}
-	}
-	return nil
-}
-
-// EnsureIndex takes in a collection and ensures that the index is created if it
-// does not already exist.
-func EnsureIndex(collection string, index mongo.IndexModel) error {
-	env := evergreen.GetEnvironment()
-	ctx, cancel := env.Context()
-	defer cancel()
-	_, err := env.DB().Collection(collection).Indexes().CreateOne(ctx, index)
-
-	return errors.WithStack(err)
-}
-
 // Remove removes one item matching the query from the specified collection.
 func Remove(ctx context.Context, collection string, query any) error {
 	_, err := evergreen.GetEnvironment().DB().Collection(collection).DeleteOne(ctx,
@@ -467,10 +383,8 @@ func FindAndModify(ctx context.Context, collection string, query any, sort []str
 
 // WriteGridFile writes the data in the source Reader to a GridFS collection with
 // the given prefix and filename.
-func WriteGridFile(fsPrefix, name string, source io.Reader) error {
+func WriteGridFile(ctx context.Context, fsPrefix, name string, source io.Reader) error {
 	env := evergreen.GetEnvironment()
-	ctx, cancel := env.Context()
-	defer cancel()
 	bucket, err := pail.NewGridFSBucketWithClient(ctx, env.Client(), pail.GridFSOptions{
 		Database: env.DB().Name(),
 		Name:     fsPrefix,
@@ -495,10 +409,6 @@ func GetGridFile(ctx context.Context, fsPrefix, name string) (io.ReadCloser, err
 	}
 
 	return bucket.Get(ctx, name)
-}
-
-func ClearGridCollections(fsPrefix string) error {
-	return ClearCollections(fmt.Sprintf("%s.files", fsPrefix), fmt.Sprintf("%s.chunks", fsPrefix))
 }
 
 // Aggregate runs an aggregation pipeline on a collection and unmarshals
@@ -539,4 +449,96 @@ func hasDollarKey(doc bson.Raw) bool {
 	}
 
 	return false
+}
+
+// =============================================
+// ============ Test only functions ============
+// =============================================
+
+// CreateCollections ensures that all the given collections are created,
+// returning an error immediately if creating any one of them fails.
+func CreateCollections(collections ...string) error {
+	session, db, err := GetGlobalSessionFactory().GetSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	const namespaceExistsErrCode = 48
+	for _, collection := range collections {
+		_, err := db.CreateCollection(collection)
+		if err == nil {
+			continue
+		}
+		// If the collection already exists, this does not count as an error.
+		if mongoErr, ok := errors.Cause(err).(mongo.CommandError); ok && mongoErr.HasErrorCode(namespaceExistsErrCode) {
+			continue
+		}
+		if err != nil {
+			return errors.Wrapf(err, "creating collection '%s'", collection)
+		}
+	}
+	return nil
+}
+
+// Clear removes all documents from a specified collection.
+func Clear(collection string) error {
+	session, db, err := GetGlobalSessionFactory().GetSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	_, err = db.C(collection).RemoveAll(bson.M{})
+
+	return err
+}
+
+// ClearCollections clears all documents from all the specified collections,
+// returning an error immediately if clearing any one of them fails.
+func ClearCollections(collections ...string) error {
+	session, db, err := GetGlobalSessionFactory().GetSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+	for _, collection := range collections {
+		_, err := db.C(collection).RemoveAll(bson.M{})
+
+		if err != nil {
+			return errors.Wrapf(err, "Couldn't clear collection '%v'", collection)
+		}
+	}
+	return nil
+}
+
+func ClearGridCollections(fsPrefix string) error {
+	return ClearCollections(fmt.Sprintf("%s.files", fsPrefix), fmt.Sprintf("%s.chunks", fsPrefix))
+}
+
+// DropCollections drops the specified collections, returning an error
+// immediately if dropping any one of them fails.
+func DropCollections(collections ...string) error {
+	session, db, err := GetGlobalSessionFactory().GetSession()
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+	for _, coll := range collections {
+		if err := db.C(coll).DropCollection(); err != nil {
+			return errors.Wrapf(err, "dropping collection '%s'", coll)
+		}
+	}
+	return nil
+}
+
+// EnsureIndex takes in a collection and ensures that the index is created if it
+// does not already exist.
+func EnsureIndex(collection string, index mongo.IndexModel) error {
+	env := evergreen.GetEnvironment()
+	ctx, cancel := env.Context()
+	defer cancel()
+	_, err := env.DB().Collection(collection).Indexes().CreateOne(ctx, index)
+
+	return errors.WithStack(err)
 }

--- a/db/db_utils_test.go
+++ b/db/db_utils_test.go
@@ -82,7 +82,7 @@ func TestDBUtils(t *testing.T) {
 			So(Clear("testfiles.chunks"), ShouldBeNil)
 			So(Clear("testfiles.files"), ShouldBeNil)
 			id := mgobson.NewObjectId().Hex()
-			So(WriteGridFile("testfiles", id, strings.NewReader(id)), ShouldBeNil)
+			So(WriteGridFile(t.Context(), "testfiles", id, strings.NewReader(id)), ShouldBeNil)
 			file, err := GetGridFile(t.Context(), "testfiles", id)
 			So(err, ShouldBeNil)
 			raw, err := io.ReadAll(file)
@@ -457,7 +457,7 @@ func TestDBUtils(t *testing.T) {
 func TestClearGridFSCollections(t *testing.T) {
 	assert := assert.New(t)
 
-	assert.NoError(WriteGridFile("testfiles", "test.txt", strings.NewReader("lorem ipsum")))
+	assert.NoError(WriteGridFile(t.Context(), "testfiles", "test.txt", strings.NewReader("lorem ipsum")))
 
 	reader, err := GetGridFile(t.Context(), "testfiles", "test.txt")
 	assert.NoError(err)

--- a/db/db_utils_test.go
+++ b/db/db_utils_test.go
@@ -390,7 +390,7 @@ func TestDBUtils(t *testing.T) {
 			}
 
 			out := &insertableStruct{}
-			cInfo, err := FindAndModify(
+			cInfo, err := FindAndModify(t.Context(),
 				collection,
 				bson.M{
 					"field_one": in.FieldOne,

--- a/db/db_utils_test.go
+++ b/db/db_utils_test.go
@@ -83,7 +83,7 @@ func TestDBUtils(t *testing.T) {
 			So(Clear("testfiles.files"), ShouldBeNil)
 			id := mgobson.NewObjectId().Hex()
 			So(WriteGridFile("testfiles", id, strings.NewReader(id)), ShouldBeNil)
-			file, err := GetGridFile("testfiles", id)
+			file, err := GetGridFile(t.Context(), "testfiles", id)
 			So(err, ShouldBeNil)
 			raw, err := io.ReadAll(file)
 			So(err, ShouldBeNil)
@@ -459,7 +459,7 @@ func TestClearGridFSCollections(t *testing.T) {
 
 	assert.NoError(WriteGridFile("testfiles", "test.txt", strings.NewReader("lorem ipsum")))
 
-	reader, err := GetGridFile("testfiles", "test.txt")
+	reader, err := GetGridFile(t.Context(), "testfiles", "test.txt")
 	assert.NoError(err)
 	defer reader.Close()
 
@@ -470,7 +470,7 @@ func TestClearGridFSCollections(t *testing.T) {
 
 	assert.NoError(ClearGridCollections("testfiles"))
 
-	reader, err = GetGridFile("testfiles", "test.txt")
+	reader, err = GetGridFile(t.Context(), "testfiles", "test.txt")
 	assert.Error(err)
 	assert.Nil(reader)
 }

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -1160,7 +1160,7 @@ func (r *mutationResolver) RemovePublicKey(ctx context.Context, keyName string) 
 	if !doesPublicKeyNameAlreadyExist(ctx, keyName) {
 		return nil, InputValidationError.Send(ctx, fmt.Sprintf("key name '%s' does not exist", keyName))
 	}
-	err := mustHaveUser(ctx).DeletePublicKey(keyName)
+	err := mustHaveUser(ctx).DeletePublicKey(ctx, keyName)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("deleting public key: %s", err.Error()))
 	}
@@ -1265,7 +1265,7 @@ func (r *mutationResolver) UpdatePublicKey(ctx context.Context, targetKeyName st
 		return nil, err
 	}
 	usr := mustHaveUser(ctx)
-	err = usr.UpdatePublicKey(targetKeyName, updateInfo.Name, updateInfo.Key)
+	err = usr.UpdatePublicKey(ctx, targetKeyName, updateInfo.Name, updateInfo.Key)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("updating public key '%s': %s", targetKeyName, err.Error()))
 	}

--- a/model/host/counters.go
+++ b/model/host/counters.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"context"
 	"time"
 
 	"github.com/evergreen-ci/evergreen/db"
@@ -9,7 +10,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-func (h *Host) IncTaskCount() error {
+func (h *Host) IncTaskCount(ctx context.Context) error {
 	query := bson.M{
 		IdKey: h.Id,
 	}
@@ -21,7 +22,7 @@ func (h *Host) IncTaskCount() error {
 		},
 	}
 
-	info, err := db.FindAndModify(Collection, query, []string{}, change, h)
+	info, err := db.FindAndModify(ctx, Collection, query, []string{}, change, h)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -34,7 +35,7 @@ func (h *Host) IncTaskCount() error {
 
 }
 
-func (h *Host) IncContainerBuildAttempt() error {
+func (h *Host) IncContainerBuildAttempt(ctx context.Context) error {
 	query := bson.M{
 		IdKey: h.Id,
 	}
@@ -46,7 +47,7 @@ func (h *Host) IncContainerBuildAttempt() error {
 		},
 	}
 
-	info, err := db.FindAndModify(Collection, query, []string{}, change, h)
+	info, err := db.FindAndModify(ctx, Collection, query, []string{}, change, h)
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -59,7 +60,7 @@ func (h *Host) IncContainerBuildAttempt() error {
 }
 
 // IncIdleTime increments the host's TotalIdleTime. Noop if idleTime is non-positive.
-func (h *Host) IncIdleTime(idleTime time.Duration) error {
+func (h *Host) IncIdleTime(ctx context.Context, idleTime time.Duration) error {
 	if idleTime <= 0 {
 		return nil
 	}
@@ -75,7 +76,7 @@ func (h *Host) IncIdleTime(idleTime time.Duration) error {
 		},
 	}
 
-	info, err := db.FindAndModify(Collection, query, []string{}, change, h)
+	info, err := db.FindAndModify(ctx, Collection, query, []string{}, change, h)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/model/keyval.go
+++ b/model/keyval.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"context"
+
 	"github.com/evergreen-ci/evergreen/db"
 	adb "github.com/mongodb/anser/db"
 	"github.com/pkg/errors"
@@ -14,7 +16,7 @@ type KeyVal struct {
 	Value int64  `bson:"value" json:"value"`
 }
 
-func (kv *KeyVal) Inc() error {
+func (kv *KeyVal) Inc(ctx context.Context) error {
 	key := kv.Key
 	change := adb.Change{
 		Update: bson.M{
@@ -24,7 +26,7 @@ func (kv *KeyVal) Inc() error {
 		Upsert:    true,
 	}
 
-	_, err := db.FindAndModify(KeyValCollection, bson.M{"_id": key}, nil, change, kv)
+	_, err := db.FindAndModify(ctx, KeyValCollection, bson.M{"_id": key}, nil, change, kv)
 
 	if err != nil {
 		return errors.Wrapf(err, "incrementing key '%s'", key)

--- a/model/legacy_task_history_test.go
+++ b/model/legacy_task_history_test.go
@@ -148,7 +148,7 @@ func TestTaskHistoryPickaxe(t *testing.T) {
 	assert.NoError(t3.Insert(t.Context()))
 	assert.NoError(t4.Insert(t.Context()))
 	for i := 0; i < 5; i++ {
-		_, err := GetNewRevisionOrderNumber(proj.Identifier)
+		_, err := GetNewRevisionOrderNumber(t.Context(), proj.Identifier)
 		assert.NoError(err)
 	}
 

--- a/model/patch/cli_intent.go
+++ b/model/patch/cli_intent.go
@@ -106,7 +106,7 @@ var (
 func (c *cliIntent) Insert(ctx context.Context) error {
 	if len(c.PatchContent) > 0 {
 		patchFileID := mgobson.NewObjectId()
-		if err := db.WriteGridFile(GridFSPrefix, patchFileID.Hex(), strings.NewReader(c.PatchContent)); err != nil {
+		if err := db.WriteGridFile(ctx, GridFSPrefix, patchFileID.Hex(), strings.NewReader(c.PatchContent)); err != nil {
 			return err
 		}
 

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -379,7 +379,7 @@ func ConsolidatePatchesForUser(ctx context.Context, oldAuthor string, newUsr *us
 	}
 	if len(patchesForNewAuthor) > 0 {
 		for _, p := range patchesForNewAuthor {
-			patchNum, err := newUsr.IncPatchNumber()
+			patchNum, err := newUsr.IncPatchNumber(ctx)
 			if err != nil {
 				return errors.Wrap(err, "incrementing patch number to resolve existing patches")
 			}

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -12,7 +12,6 @@ import (
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/anser/bsonutil"
-	adb "github.com/mongodb/anser/db"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -382,32 +381,6 @@ func (p *Patch) SetVariantsTasks(ctx context.Context, variantsTasks []VariantTas
 			},
 		},
 	)
-}
-
-// AddBuildVariants adds more buildvarints to a patch document.
-// This is meant to be used after initial patch creation.
-func (p *Patch) AddBuildVariants(bvs []string) error {
-	change := adb.Change{
-		Update: bson.M{
-			"$addToSet": bson.M{BuildVariantsKey: bson.M{"$each": bvs}},
-		},
-		ReturnNew: true,
-	}
-	_, err := db.FindAndModify(Collection, bson.M{IdKey: p.Id}, nil, change, p)
-	return err
-}
-
-// AddTasks adds more tasks to a patch document.
-// This is meant to be used after initial patch creation, to reconfigure the patch.
-func (p *Patch) AddTasks(tasks []string) error {
-	change := adb.Change{
-		Update: bson.M{
-			"$addToSet": bson.M{TasksKey: bson.M{"$each": tasks}},
-		},
-		ReturnNew: true,
-	}
-	_, err := db.FindAndModify(Collection, bson.M{IdKey: p.Id}, nil, change, p)
-	return err
 }
 
 // UpdateRepeatPatchId updates the repeat patch Id value to be used for subsequent pr patches

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -270,14 +270,14 @@ func (p *Patch) ClearPatchData() {
 
 // FetchPatchFiles dereferences externally-stored patch diffs by fetching them from gridfs
 // and placing their contents into the patch object.
-func (p *Patch) FetchPatchFiles() error {
+func (p *Patch) FetchPatchFiles(ctx context.Context) error {
 	for i, patchPart := range p.Patches {
 		// If the patch isn't stored externally, no need to do anything.
 		if patchPart.PatchSet.PatchFileId == "" {
 			continue
 		}
 
-		rawStr, err := FetchPatchContents(patchPart.PatchSet.PatchFileId)
+		rawStr, err := FetchPatchContents(ctx, patchPart.PatchSet.PatchFileId)
 		if err != nil {
 			return errors.Wrapf(err, "getting patch contents for patchfile '%s'", patchPart.PatchSet.PatchFileId)
 		}
@@ -287,8 +287,8 @@ func (p *Patch) FetchPatchFiles() error {
 	return nil
 }
 
-func FetchPatchContents(patchfileID string) (string, error) {
-	fileReader, err := db.GetGridFile(GridFSPrefix, patchfileID)
+func FetchPatchContents(ctx context.Context, patchfileID string) (string, error) {
+	fileReader, err := db.GetGridFile(ctx, GridFSPrefix, patchfileID)
 	if err != nil {
 		return "", errors.Wrap(err, "getting grid file")
 	}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -390,7 +390,7 @@ func MakePatchedConfig(ctx context.Context, opts GetProjectOpts, projectConfig s
 		var patchFilePath, localConfigPath, renamedFilePath, patchContents string
 		var err error
 		if patchPart.PatchSet.Patch == "" {
-			patchContents, err = patch.FetchPatchContents(patchPart.PatchSet.PatchFileId)
+			patchContents, err = patch.FetchPatchContents(ctx, patchPart.PatchSet.PatchFileId)
 			if err != nil {
 				return nil, errors.Wrap(err, "fetching patch contents")
 			}

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -257,7 +257,7 @@ func TestGetPatchedProjectAndGetPatchedProjectConfig(t *testing.T) {
 				configPatch := resetProjectlessPatchSetup(ctx, t)
 
 				patchFileID := primitive.NewObjectID()
-				So(db.WriteGridFile(patch.GridFSPrefix, patchFileID.Hex(), strings.NewReader(configPatch.Patches[0].PatchSet.Patch)), ShouldBeNil)
+				So(db.WriteGridFile(t.Context(), patch.GridFSPrefix, patchFileID.Hex(), strings.NewReader(configPatch.Patches[0].PatchSet.Patch)), ShouldBeNil)
 				configPatch.Patches[0].PatchSet.Patch = ""
 				configPatch.Patches[0].PatchSet.PatchFileId = patchFileID.Hex()
 

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1662,7 +1662,7 @@ func TestFindProjectsSuite(t *testing.T) {
 			if err := p.Insert(t.Context()); err != nil {
 				return err
 			}
-			if _, err := GetNewRevisionOrderNumber(p.Id); err != nil {
+			if _, err := GetNewRevisionOrderNumber(t.Context(), p.Id); err != nil {
 				return err
 			}
 		}

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -539,8 +539,8 @@ func insertParameterStore(ctx context.Context, vars *ProjectVars) (*ParameterMap
 // deleted unless that variable is explicitly listed in varsToDelete. If this
 // succeeds, projectVars will contain all the project variables, including those
 // that were not explicitly modified.
-func (projectVars *ProjectVars) FindAndModify(varsToDelete []string) (*adb.ChangeInfo, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultParameterStoreAccessTimeout)
+func (projectVars *ProjectVars) FindAndModify(ctx context.Context, varsToDelete []string) (*adb.ChangeInfo, error) {
+	ctx, cancel := context.WithTimeoutCause(ctx, defaultParameterStoreAccessTimeout, errors.New("parameter store access timeout"))
 	defer cancel()
 
 	pm, err := projectVars.findAndModifyParameterStore(ctx, varsToDelete)
@@ -579,7 +579,7 @@ func (projectVars *ProjectVars) FindAndModify(varsToDelete []string) (*adb.Chang
 		update["$unset"] = unsetUpdate
 	}
 
-	change, err := db.FindAndModify(
+	change, err := db.FindAndModify(ctx,
 		ProjectVarsCollection,
 		bson.M{projectVarIdKey: projectVars.Id},
 		nil,

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -447,7 +447,7 @@ func TestProjectVarsFindAndModify(t *testing.T) {
 			}
 			varsToDelete := []string{"d"}
 
-			info, err := newVars.FindAndModify(varsToDelete)
+			info, err := newVars.FindAndModify(t.Context(), varsToDelete)
 			assert.NoError(t, err)
 			require.NotNil(t, info)
 			assert.Equal(t, 1, info.Updated)
@@ -481,7 +481,7 @@ func TestProjectVarsFindAndModify(t *testing.T) {
 				PrivateVars: map[string]bool{"b": false, "a": true},
 			}
 			varsToDelete := []string{"d"}
-			_, err := vars.FindAndModify(varsToDelete)
+			_, err := vars.FindAndModify(t.Context(), varsToDelete)
 			assert.NoError(t, err)
 
 			dbVars, err := FindOneProjectVars(t.Context(), vars.Id)
@@ -512,7 +512,7 @@ func TestProjectVarsFindAndModify(t *testing.T) {
 				PrivateVars: map[string]bool{"b": false, "a": true},
 			}
 			varsToDelete := []string{"d"}
-			_, err := vars.FindAndModify(varsToDelete)
+			_, err := vars.FindAndModify(t.Context(), varsToDelete)
 			assert.NoError(t, err)
 
 			dbVars, err := FindOneProjectVars(t.Context(), vars.Id)
@@ -538,7 +538,7 @@ func TestProjectVarsFindAndModify(t *testing.T) {
 
 			newVars := *vars
 			newVars.Id = newProjRef.Id
-			_, err = newVars.FindAndModify(varsToDelete)
+			_, err = newVars.FindAndModify(t.Context(), varsToDelete)
 			require.NoError(t, err)
 
 			// Original project vars should not be modified at all.

--- a/model/repository.go
+++ b/model/repository.go
@@ -89,9 +89,9 @@ func UpdateLastRevision(ctx context.Context, projectId, revision string) error {
 }
 
 // GetNewRevisionOrderNumber gets a new revision order number for a project.
-func GetNewRevisionOrderNumber(projectId string) (int, error) {
+func GetNewRevisionOrderNumber(ctx context.Context, projectId string) (int, error) {
 	repo := &Repository{}
-	_, err := db.FindAndModify(
+	_, err := db.FindAndModify(ctx,
 		RepositoriesCollection,
 		bson.M{
 			RepoProjectKey: projectId,

--- a/model/repository_test.go
+++ b/model/repository_test.go
@@ -20,33 +20,33 @@ func TestGetNewRevisionOrderNumber(t *testing.T) {
 
 		Convey("The returned commit order number should be 1 for a new"+
 			" project", func() {
-			ron, err := GetNewRevisionOrderNumber(projectName)
+			ron, err := GetNewRevisionOrderNumber(t.Context(), projectName)
 			So(err, ShouldBeNil)
 			So(ron, ShouldEqual, 1)
 		})
 
 		Convey("The returned commit order number should be 1 for monotonically"+
 			" incremental on a new project", func() {
-			ron, err := GetNewRevisionOrderNumber(projectName)
+			ron, err := GetNewRevisionOrderNumber(t.Context(), projectName)
 			So(err, ShouldBeNil)
 			So(ron, ShouldEqual, 1)
-			ron, err = GetNewRevisionOrderNumber(projectName)
+			ron, err = GetNewRevisionOrderNumber(t.Context(), projectName)
 			So(err, ShouldBeNil)
 			So(ron, ShouldEqual, 2)
 		})
 
 		Convey("The returned commit order number should be 1 for monotonically"+
 			" incremental within (but not across) projects", func() {
-			ron, err := GetNewRevisionOrderNumber(projectName)
+			ron, err := GetNewRevisionOrderNumber(t.Context(), projectName)
 			So(err, ShouldBeNil)
 			So(ron, ShouldEqual, 1)
-			ron, err = GetNewRevisionOrderNumber(projectName)
+			ron, err = GetNewRevisionOrderNumber(t.Context(), projectName)
 			So(err, ShouldBeNil)
 			So(ron, ShouldEqual, 2)
-			ron, err = GetNewRevisionOrderNumber(projectName + "-12")
+			ron, err = GetNewRevisionOrderNumber(t.Context(), projectName+"-12")
 			So(err, ShouldBeNil)
 			So(ron, ShouldEqual, 1)
-			ron, err = GetNewRevisionOrderNumber(projectName + "-12")
+			ron, err = GetNewRevisionOrderNumber(t.Context(), projectName+"-12")
 			So(err, ShouldBeNil)
 			So(ron, ShouldEqual, 2)
 		})
@@ -64,7 +64,7 @@ func TestUpdateLastRevision(t *testing.T) {
 			assert.Error(t, UpdateLastRevision(t.Context(), project, revision))
 		},
 		"ValidProject": func(t *testing.T, project string, revision string) {
-			_, err := GetNewRevisionOrderNumber(project)
+			_, err := GetNewRevisionOrderNumber(t.Context(), project)
 			assert.NoError(t, err)
 			assert.NoError(t, UpdateLastRevision(t.Context(), project, revision))
 		},

--- a/model/task/task_annotations.go
+++ b/model/task/task_annotations.go
@@ -21,7 +21,7 @@ func MoveIssueToSuspectedIssue(ctx context.Context, taskId string, taskExecution
 	q := annotations.ByTaskIdAndExecution(taskId, taskExecution)
 	q[bsonutil.GetDottedKeyName(annotations.IssuesKey, annotations.IssueLinkIssueKey)] = issue.IssueKey
 	annotation := &annotations.TaskAnnotation{}
-	_, err := db.FindAndModify(
+	_, err := db.FindAndModify(ctx,
 		annotations.Collection,
 		q,
 		nil,
@@ -89,7 +89,7 @@ func AddIssueToAnnotation(ctx context.Context, taskId string, execution int, iss
 // associated task document as having annotations if this was the last issue removed from the annotation.
 func RemoveIssueFromAnnotation(ctx context.Context, taskId string, execution int, issue annotations.IssueLink) error {
 	annotation := &annotations.TaskAnnotation{}
-	_, err := db.FindAndModify(
+	_, err := db.FindAndModify(ctx,
 		annotations.Collection,
 		annotations.ByTaskIdAndExecution(taskId, execution),
 		nil,

--- a/model/testutil/patch.go
+++ b/model/testutil/patch.go
@@ -54,7 +54,7 @@ func SetupPatches(ctx context.Context, patchMode PatchTestMode, b *build.Build, 
 				PatchSet:   patch.PatchSet{Patch: string(patchContent)},
 			})
 		} else {
-			if err := db.WriteGridFile(patch.GridFSPrefix, ptch.Id.Hex(), strings.NewReader(string(patchContent))); err != nil {
+			if err := db.WriteGridFile(ctx, patch.GridFSPrefix, ptch.Id.Hex(), strings.NewReader(string(patchContent))); err != nil {
 				return nil, err
 			}
 

--- a/model/user/user.go
+++ b/model/user/user.go
@@ -248,7 +248,7 @@ func (u *DBUser) AddPublicKey(ctx context.Context, keyName, keyValue string) err
 	return nil
 }
 
-func (u *DBUser) DeletePublicKey(keyName string) error {
+func (u *DBUser) DeletePublicKey(ctx context.Context, keyName string) error {
 	newUser := DBUser{}
 
 	selector := bson.M{
@@ -265,7 +265,7 @@ func (u *DBUser) DeletePublicKey(keyName string) error {
 		},
 		ReturnNew: true,
 	}
-	change, err := db.FindAndModify(Collection, selector, nil, c, &newUser)
+	change, err := db.FindAndModify(ctx, Collection, selector, nil, c, &newUser)
 
 	if err != nil {
 		return errors.Wrap(err, "couldn't delete public key from user")
@@ -277,7 +277,7 @@ func (u *DBUser) DeletePublicKey(keyName string) error {
 	return nil
 }
 
-func (u *DBUser) UpdatePublicKey(targetKeyName, newKeyName, newKeyValue string) error {
+func (u *DBUser) UpdatePublicKey(ctx context.Context, targetKeyName, newKeyName, newKeyValue string) error {
 	newUser := DBUser{}
 	targetKeySelector := bson.M{
 		IdKey: u.Id,
@@ -296,7 +296,7 @@ func (u *DBUser) UpdatePublicKey(targetKeyName, newKeyName, newKeyValue string) 
 		},
 		ReturnNew: true,
 	}
-	change, err := db.FindAndModify(Collection, targetKeySelector, nil, c, &newUser)
+	change, err := db.FindAndModify(ctx, Collection, targetKeySelector, nil, c, &newUser)
 	if err != nil {
 		return errors.Wrap(err, "updating public key from user")
 	}
@@ -314,9 +314,9 @@ func (u *DBUser) Insert(ctx context.Context) error {
 
 // IncPatchNumber increases the count for the user's patch submissions by one,
 // and then returns the new count.
-func (u *DBUser) IncPatchNumber() (int, error) {
+func (u *DBUser) IncPatchNumber(ctx context.Context) (int, error) {
 	dbUser := &DBUser{}
-	_, err := db.FindAndModify(
+	_, err := db.FindAndModify(ctx,
 		Collection,
 		bson.M{
 			IdKey: u.Id,
@@ -494,8 +494,8 @@ func (u *DBUser) HasDistroCreatePermission() bool {
 	})
 }
 
-func (u *DBUser) DeleteAllRoles() error {
-	info, err := db.FindAndModify(
+func (u *DBUser) DeleteAllRoles(ctx context.Context) error {
+	info, err := db.FindAndModify(ctx,
 		Collection,
 		bson.M{IdKey: u.Id},
 		nil,
@@ -513,11 +513,11 @@ func (u *DBUser) DeleteAllRoles() error {
 	return nil
 }
 
-func (u *DBUser) DeleteRoles(roles []string) error {
+func (u *DBUser) DeleteRoles(ctx context.Context, roles []string) error {
 	if len(roles) == 0 {
 		return nil
 	}
-	info, err := db.FindAndModify(
+	info, err := db.FindAndModify(ctx,
 		Collection,
 		bson.M{IdKey: u.Id},
 		nil,

--- a/model/user/user_test.go
+++ b/model/user/user_test.go
@@ -332,7 +332,7 @@ func (s *UserTestSuite) checkUserNotDestroyed(fromDB *DBUser, expected *DBUser) 
 }
 
 func (s *UserTestSuite) TestUpdatePublicKey() {
-	s.NoError(s.users[5].UpdatePublicKey("key1", "key1", "this is an amazing key"))
+	s.NoError(s.users[5].UpdatePublicKey(s.T().Context(), "key1", "key1", "this is an amazing key"))
 	s.Len(s.users[5].PubKeys, 1)
 	s.Contains(s.users[5].PubKeys[0].Name, "key1")
 	s.Contains(s.users[5].PubKeys[0].Key, "this is an amazing key")
@@ -343,7 +343,7 @@ func (s *UserTestSuite) TestUpdatePublicKey() {
 }
 
 func (s *UserTestSuite) TestUpdatePublicKeyWithSameKeyName() {
-	s.NoError(s.users[5].UpdatePublicKey("key1", "keyAmazing", "this is an amazing key"))
+	s.NoError(s.users[5].UpdatePublicKey(s.T().Context(), "key1", "keyAmazing", "this is an amazing key"))
 	s.Len(s.users[5].PubKeys, 1)
 	s.Contains(s.users[5].PubKeys[0].Name, "keyAmazing")
 	s.Contains(s.users[5].PubKeys[0].Key, "this is an amazing key")
@@ -354,7 +354,7 @@ func (s *UserTestSuite) TestUpdatePublicKeyWithSameKeyName() {
 }
 
 func (s *UserTestSuite) TestUpdatePublicKeyThatDoesntExist() {
-	s.Error(s.users[5].UpdatePublicKey("non-existent-key", "keyAmazing", "this is an amazing key"))
+	s.Error(s.users[5].UpdatePublicKey(s.T().Context(), "non-existent-key", "keyAmazing", "this is an amazing key"))
 	s.Len(s.users[5].PubKeys, 1)
 	s.Contains(s.users[5].PubKeys[0].Name, "key1")
 	s.Contains(s.users[5].PubKeys[0].Key, "ssh-mock 12345")
@@ -365,7 +365,7 @@ func (s *UserTestSuite) TestUpdatePublicKeyThatDoesntExist() {
 }
 
 func (s *UserTestSuite) TestDeletePublicKey() {
-	s.NoError(s.users[1].DeletePublicKey("key1"))
+	s.NoError(s.users[1].DeletePublicKey(s.T().Context(), "key1"))
 	s.Empty(s.users[1].PubKeys)
 	s.Equal("67890", s.users[1].APIKey)
 
@@ -375,7 +375,7 @@ func (s *UserTestSuite) TestDeletePublicKey() {
 }
 
 func (s *UserTestSuite) TestDeletePublicKeyThatDoesntExist() {
-	s.Error(s.users[0].DeletePublicKey("key1"))
+	s.Error(s.users[0].DeletePublicKey(s.T().Context(), "key1"))
 	s.Empty(s.users[0].PubKeys)
 	s.Equal("12345", s.users[0].APIKey)
 

--- a/repotracker/github_poller_test.go
+++ b/repotracker/github_poller_test.go
@@ -128,7 +128,7 @@ func TestGetRevisionsSince(t *testing.T) {
 	testutil.ConfigureIntegrationTest(t, testConfig)
 
 	// Initialize repo revisions for project
-	_, err := model.GetNewRevisionOrderNumber(projectRef.Id)
+	_, err := model.GetNewRevisionOrderNumber(t.Context(), projectRef.Id)
 	require.NoError(t, err)
 
 	// The test repository contains only 3 revisions.

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -703,7 +703,7 @@ func ShellVersionFromRevision(ctx context.Context, ref *model.ProjectRef, metada
 		metadata.User = usr
 	}
 
-	number, err := model.GetNewRevisionOrderNumber(ref.Id)
+	number, err := model.GetNewRevisionOrderNumber(ctx, ref.Id)
 	if err != nil {
 		return nil, err
 	}

--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -208,7 +208,7 @@ func GetRawPatches(ctx context.Context, patchID string) (*restModel.APIRawPatch,
 		}
 	}
 
-	if err = patchDoc.FetchPatchFiles(); err != nil {
+	if err = patchDoc.FetchPatchFiles(ctx); err != nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    errors.Wrap(err, "getting patch contents").Error(),

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -322,7 +322,7 @@ func UpdateProjectVars(ctx context.Context, projectId string, varsModel *restMod
 			return errors.Wrapf(err, "overwriting variables for project '%s'", vars.Id)
 		}
 	} else {
-		_, err := vars.FindAndModify(varsModel.VarsToDelete)
+		_, err := vars.FindAndModify(ctx, varsModel.VarsToDelete)
 		if err != nil {
 			return errors.Wrapf(err, "updating variables for project '%s'", vars.Id)
 		}

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -860,7 +860,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 			assert.Error(t, err)
 			assert.Nil(t, settings)
 
-			_, err = model.GetNewRevisionOrderNumber(ref.Id)
+			_, err = model.GetNewRevisionOrderNumber(t.Context(), ref.Id)
 			assert.NoError(t, err)
 			settings, err = SaveProjectSettingsForSection(ctx, ref.Id, apiChanges, model.ProjectPageTriggersSection, false, "me")
 			assert.NoError(t, err)

--- a/rest/data/project_test.go
+++ b/rest/data/project_test.go
@@ -135,7 +135,7 @@ func TestProjectConnectorGetSuite(t *testing.T) {
 			if err := p.Insert(t.Context()); err != nil {
 				return err
 			}
-			if _, err := model.GetNewRevisionOrderNumber(p.Id); err != nil {
+			if _, err := model.GetNewRevisionOrderNumber(t.Context(), p.Id); err != nil {
 				return err
 			}
 		}

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1009,10 +1009,10 @@ func (h *startTaskHandler) Run(ctx context.Context) gimlet.Responder {
 		msg = fmt.Sprintf("task %s started on host %s", t.Id, foundHost.Id)
 
 		if foundHost.Distro.IsEphemeral() {
-			if err = foundHost.IncTaskCount(); err != nil {
+			if err = foundHost.IncTaskCount(ctx); err != nil {
 				return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "incrementing task count for task '%s' on host '%s'", t.Id, foundHost.Id))
 			}
-			if err = foundHost.IncIdleTime(foundHost.WastedComputeTime()); err != nil {
+			if err = foundHost.IncIdleTime(ctx, foundHost.WastedComputeTime()); err != nil {
 				return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "incrementing total idle time on host '%s'", foundHost.Id))
 			}
 			grip.Info(foundHost.TaskStartMessage())
@@ -1245,7 +1245,7 @@ func (h *keyvalIncHandler) Parse(ctx context.Context, r *http.Request) error {
 
 func (h *keyvalIncHandler) Run(ctx context.Context) gimlet.Responder {
 	keyVal := &model.KeyVal{Key: h.key}
-	if err := keyVal.Inc(); err != nil {
+	if err := keyVal.Inc(ctx); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "doing findAndModify on key '%s'", h.key))
 	}
 	return gimlet.NewJSONResponse(keyVal)

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1116,7 +1116,7 @@ func (h *gitServePatchFileHandler) Parse(ctx context.Context, r *http.Request) e
 }
 
 func (h *gitServePatchFileHandler) Run(ctx context.Context) gimlet.Responder {
-	patchContents, err := patch.FetchPatchContents(h.patchID)
+	patchContents, err := patch.FetchPatchContents(ctx, h.patchID)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "reading patch file from db"))
 	}

--- a/rest/route/keys.go
+++ b/rest/route/keys.go
@@ -184,7 +184,7 @@ func (h *keysDeleteHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Errorf("public key '%s' not found", h.keyName))
 	}
 
-	if err := user.DeletePublicKey(h.keyName); err != nil {
+	if err := user.DeletePublicKey(ctx, h.keyName); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "deleting public key '%s'", h.keyName))
 	}
 

--- a/rest/route/patch_test.go
+++ b/rest/route/patch_test.go
@@ -670,11 +670,11 @@ func TestPatchRawModulesHandler(t *testing.T) {
 	require.NoError(t, db.ClearCollections(patch.Collection))
 	require.NoError(t, db.ClearGridCollections(patch.GridFSPrefix))
 	patchString := `main diff`
-	require.NoError(t, db.WriteGridFile(patch.GridFSPrefix, "testPatch", strings.NewReader(patchString)))
+	require.NoError(t, db.WriteGridFile(t.Context(), patch.GridFSPrefix, "testPatch", strings.NewReader(patchString)))
 	patchString = `module1 diff`
-	require.NoError(t, db.WriteGridFile(patch.GridFSPrefix, "module1Patch", strings.NewReader(patchString)))
+	require.NoError(t, db.WriteGridFile(t.Context(), patch.GridFSPrefix, "module1Patch", strings.NewReader(patchString)))
 	patchString = `module2 diff`
-	require.NoError(t, db.WriteGridFile(patch.GridFSPrefix, "module2Patch", strings.NewReader(patchString)))
+	require.NoError(t, db.WriteGridFile(t.Context(), patch.GridFSPrefix, "module2Patch", strings.NewReader(patchString)))
 	patchId := mgobson.NewObjectId()
 	patchToInsert := patch.Patch{
 		Id: patchId,
@@ -731,9 +731,9 @@ func TestPatchRawHandler(t *testing.T) {
 	require.NoError(t, db.ClearCollections(patch.Collection))
 	require.NoError(t, db.ClearGridCollections(patch.GridFSPrefix))
 	patchString := `main diff`
-	require.NoError(t, db.WriteGridFile(patch.GridFSPrefix, "testPatch", strings.NewReader(patchString)))
+	require.NoError(t, db.WriteGridFile(t.Context(), patch.GridFSPrefix, "testPatch", strings.NewReader(patchString)))
 	patchString = `module1 diff`
-	require.NoError(t, db.WriteGridFile(patch.GridFSPrefix, "module1Patch", strings.NewReader(patchString)))
+	require.NoError(t, db.WriteGridFile(t.Context(), patch.GridFSPrefix, "module1Patch", strings.NewReader(patchString)))
 	patchId := "aabbccddeeff001122334455"
 	patchToInsert := patch.Patch{
 		Id: patch.NewId(patchId),

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -290,7 +290,7 @@ func (h *userPermissionsDeleteHandler) Run(ctx context.Context) gimlet.Responder
 	}
 
 	if h.resourceType == allResourceType {
-		err = u.DeleteAllRoles()
+		err = u.DeleteAllRoles(ctx)
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "deleting all roles for user '%s'", u.Username()))
 		}
@@ -327,7 +327,7 @@ func (h *userPermissionsDeleteHandler) Run(ctx context.Context) gimlet.Responder
 		"resource_type": h.resourceType,
 		"resource_id":   h.resourceId,
 	})
-	err = u.DeleteRoles(rolesToRemove)
+	err = u.DeleteRoles(ctx, rolesToRemove)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "deleting roles for user '%s'", u.Username()))
 	}

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -298,7 +298,7 @@ func (as *APIServer) updatePatchModule(w http.ResponseWriter, r *http.Request) {
 
 	// write the patch content into a GridFS file under a new ObjectId.
 	patchFileId := mgobson.NewObjectId().Hex()
-	err = db.WriteGridFile(patch.GridFSPrefix, patchFileId, strings.NewReader(patchContent))
+	err = db.WriteGridFile(r.Context(), patch.GridFSPrefix, patchFileId, strings.NewReader(patchContent))
 	if err != nil {
 		as.LoggedError(w, r, http.StatusInternalServerError, errors.Wrap(err, "failed to write patch file to db"))
 		return

--- a/service/patch.go
+++ b/service/patch.go
@@ -121,7 +121,7 @@ func (uis *UIServer) diffPage(w http.ResponseWriter, r *http.Request) {
 			http.StatusInternalServerError)
 		return
 	}
-	if err = fullPatch.FetchPatchFiles(); err != nil {
+	if err = fullPatch.FetchPatchFiles(r.Context()); err != nil {
 		http.Error(w, fmt.Sprintf("finding patch files: %s", err.Error()),
 			http.StatusInternalServerError)
 		return
@@ -146,7 +146,7 @@ func (uis *UIServer) fileDiffPage(w http.ResponseWriter, r *http.Request) {
 			http.StatusInternalServerError)
 		return
 	}
-	if err = fullPatch.FetchPatchFiles(); err != nil {
+	if err = fullPatch.FetchPatchFiles(r.Context()); err != nil {
 		http.Error(w, fmt.Sprintf("error finding patch: %s", err.Error()),
 			http.StatusInternalServerError)
 	}
@@ -176,7 +176,7 @@ func (uis *UIServer) rawDiffPage(w http.ResponseWriter, r *http.Request) {
 			http.StatusInternalServerError)
 		return
 	}
-	if err = fullPatch.FetchPatchFiles(); err != nil {
+	if err = fullPatch.FetchPatchFiles(r.Context()); err != nil {
 		http.Error(w, fmt.Sprintf("error fetching patch files: %s", err.Error()),
 			http.StatusInternalServerError)
 		return

--- a/service/rest_patch.go
+++ b/service/rest_patch.go
@@ -35,7 +35,7 @@ func (restapi restAPI) getPatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err := projCtx.Patch.FetchPatchFiles()
+	err := projCtx.Patch.FetchPatchFiles(r.Context())
 	if err != nil {
 		restapi.LoggedError(w, r, http.StatusInternalServerError,
 			errors.Wrap(err, "error occurred fetching patch data"))

--- a/trigger/process_test.go
+++ b/trigger/process_test.go
@@ -328,7 +328,7 @@ func TestProjectTriggerIntegration(t *testing.T) {
 		Task:      "task1",
 	}
 	assert.NoError(alias.Upsert(t.Context()))
-	_, err := model.GetNewRevisionOrderNumber(downstreamProjectRef.Id)
+	_, err := model.GetNewRevisionOrderNumber(t.Context(), downstreamProjectRef.Id)
 	assert.NoError(err)
 	downstreamRevision := "9338711cc1acc94ff75889a3b53a936a00e8c385"
 	assert.NoError(model.UpdateLastRevision(t.Context(), downstreamProjectRef.Id, downstreamRevision))
@@ -461,7 +461,7 @@ func TestProjectTriggerIntegrationForBuild(t *testing.T) {
 		Task:      "task1",
 	}
 	assert.NoError(alias.Upsert(t.Context()))
-	_, err := model.GetNewRevisionOrderNumber(downstreamProjectRef.Id)
+	_, err := model.GetNewRevisionOrderNumber(t.Context(), downstreamProjectRef.Id)
 	assert.NoError(err)
 	downstreamRevision := "9338711cc1acc94ff75889a3b53a936a00e8c385"
 	assert.NoError(model.UpdateLastRevision(t.Context(), downstreamProjectRef.Id, downstreamRevision))
@@ -568,7 +568,7 @@ func TestProjectTriggerIntegrationForPush(t *testing.T) {
 		Task:      "task1",
 	}
 	assert.NoError(alias.Upsert(t.Context()))
-	_, err := model.GetNewRevisionOrderNumber(downstreamProjectRef.Id)
+	_, err := model.GetNewRevisionOrderNumber(t.Context(), downstreamProjectRef.Id)
 	assert.NoError(err)
 	downstreamRevision := "cf46076567e4949f9fc68e0634139d4ac495c89b"
 	assert.NoError(model.UpdateLastRevision(t.Context(), downstreamProjectRef.Id, downstreamRevision))

--- a/trigger/project_triggers_test.go
+++ b/trigger/project_triggers_test.go
@@ -47,7 +47,7 @@ func TestMetadataFromArgsWithVersion(t *testing.T) {
 	_, err := getMetadataFromArgs(t.Context(), args)
 	assert.Error(err)
 
-	_, err = model.GetNewRevisionOrderNumber(ref.Id)
+	_, err = model.GetNewRevisionOrderNumber(t.Context(), ref.Id)
 	assert.NoError(err)
 	assert.NoError(model.UpdateLastRevision(t.Context(), ref.Id, "def"))
 
@@ -80,7 +80,7 @@ func TestMetadataFromArgsWithoutVersion(t *testing.T) {
 	_, err := getMetadataFromArgs(t.Context(), args)
 	assert.Error(err)
 
-	_, err = model.GetNewRevisionOrderNumber(ref.Id)
+	_, err = model.GetNewRevisionOrderNumber(t.Context(), ref.Id)
 	assert.NoError(err)
 	assert.NoError(model.UpdateLastRevision(t.Context(), ref.Id, "def"))
 	metadata, err := getMetadataFromArgs(t.Context(), args)

--- a/units/building_container_image.go
+++ b/units/building_container_image.go
@@ -101,7 +101,7 @@ func (j *buildingContainerImageJob) Run(ctx context.Context) {
 			"operation":    "container build complete",
 			"current_iter": j.parent.ContainerBuildAttempt,
 		})
-		if err = j.parent.IncContainerBuildAttempt(); err != nil {
+		if err = j.parent.IncContainerBuildAttempt(ctx); err != nil {
 			j.AddError(err)
 			grip.Warning(message.WrapError(err, message.Fields{
 				"host_id":      j.parent.Id,

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -368,7 +368,7 @@ func (j *hostTerminationJob) incrementIdleTime(ctx context.Context) error {
 		idleTime += pad
 	}
 
-	return j.host.IncIdleTime(idleTime)
+	return j.host.IncIdleTime(ctx, idleTime)
 }
 
 // checkAndTerminateCloudHost checks if the host is still up according to the

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -958,7 +958,7 @@ func (j *patchIntentProcessor) buildGithubPatchDoc(ctx context.Context, patchDoc
 		},
 	})
 
-	if err = db.WriteGridFile(patch.GridFSPrefix, patchFileID, strings.NewReader(patchContent)); err != nil {
+	if err = db.WriteGridFile(ctx, patch.GridFSPrefix, patchFileID, strings.NewReader(patchContent)); err != nil {
 		return isMember, errors.Wrap(err, "writing patch file to DB")
 	}
 

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -830,7 +830,7 @@ func (j *patchIntentProcessor) buildCliPatchDoc(ctx context.Context, patchDoc *p
 	}
 
 	if len(patchDoc.Patches) > 0 {
-		if patchDoc.Patches[0], err = getModulePatch(patchDoc.Patches[0]); err != nil {
+		if patchDoc.Patches[0], err = getModulePatch(ctx, patchDoc.Patches[0]); err != nil {
 			return errors.Wrap(err, "getting module patch from GridFS")
 		}
 	}
@@ -840,8 +840,8 @@ func (j *patchIntentProcessor) buildCliPatchDoc(ctx context.Context, patchDoc *p
 
 // getModulePatch reads the patch from GridFS, processes it, and
 // stores the resulting summaries in the returned ModulePatch
-func getModulePatch(modulePatch patch.ModulePatch) (patch.ModulePatch, error) {
-	patchContents, err := patch.FetchPatchContents(modulePatch.PatchSet.PatchFileId)
+func getModulePatch(ctx context.Context, modulePatch patch.ModulePatch) (patch.ModulePatch, error) {
+	patchContents, err := patch.FetchPatchContents(ctx, modulePatch.PatchSet.PatchFileId)
 	if err != nil {
 		return modulePatch, errors.Wrap(err, "fetching patch contents")
 	}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -358,7 +358,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	}
 
 	// set the patch number based on patch author
-	patchDoc.PatchNumber, err = j.user.IncPatchNumber()
+	patchDoc.PatchNumber, err = j.user.IncPatchNumber(ctx)
 	if err != nil {
 		return errors.Wrap(err, "computing patch number")
 	}

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1562,7 +1562,7 @@ index ca20f6c..224168e 100644
 +  new line",
 
 `
-	s.Require().NoError(db.WriteGridFile(patch.GridFSPrefix, "testPatch", strings.NewReader(patchString)))
+	s.Require().NoError(db.WriteGridFile(s.ctx, patch.GridFSPrefix, "testPatch", strings.NewReader(patchString)))
 
 	modulePatch := patch.ModulePatch{}
 	modulePatch.PatchSet.PatchFileId = "testPatch"

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1481,7 +1481,7 @@ func (s *PatchIntentUnitsSuite) verifyVersionDoc(patchDoc *patch.Patch, expected
 }
 
 func (s *PatchIntentUnitsSuite) gridFSFileExists(patchFileID string) {
-	patchContents, err := patch.FetchPatchContents(patchFileID)
+	patchContents, err := patch.FetchPatchContents(s.ctx, patchFileID)
 	s.Require().NoError(err)
 	s.NotEmpty(patchContents)
 }
@@ -1566,7 +1566,7 @@ index ca20f6c..224168e 100644
 
 	modulePatch := patch.ModulePatch{}
 	modulePatch.PatchSet.PatchFileId = "testPatch"
-	modulePatch, err := getModulePatch(modulePatch)
+	modulePatch, err := getModulePatch(s.ctx, modulePatch)
 	s.NotEmpty(modulePatch.PatchSet.Summary)
 	s.NoError(err)
 }


### PR DESCRIPTION
DEVPROD-53

### Description
This is the last PR of DEVPROD-53! It threads the context for the two remaining GridFS functions and the FindAndModify function.

I also attempted to move some test-only db queries to our `testutil` package, but it didn't work smoothly since the queries use the `db` package, and the `db` package's tests use the queries.

### Testing
Unit tests.
