### PR TITLE
DEVPROD-16346: remove configuration for internal repo as Go module

### DIFF
--- a/makefile
+++ b/makefile
@@ -59,13 +59,6 @@ ifneq ($(lintCache),$(GOLANGCI_LINT_CACHE))
 export GOLANGCI_LINT_CACHE := $(lintCache)
 endif
 
-ifneq (,$(GOPRIVATE))
-# Necessary because some evergreen-ci repos (e.g.
-# evergreen-ci/test-selection-client) are internal/private repos. Setting this
-# ensures go modules can be download from those repos.
-export GOPRIVATE := github.com/evergreen-ci/*
-endif
-
 ifneq (,$(RACE_DETECTOR))
 # cgo is required for using the race detector.
 export CGO_ENABLED := 1

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -204,9 +204,6 @@ functions:
         include_expansions_in_env: ["GOROOT", "github_token"]
         shell: bash
         script: |
-          # Set GitHub app dynamic token to ensure it can clone non-public repos for Go modules.
-          git config --global url."https://x-access-token:${github_token}@github.com/evergreen-ci/".insteadOf https://github.com/evergreen-ci/
-
           # Downloading modules is flaky in the ubuntu1604-arm64 distros, because the TCP connection is sometimes reset
           # by the peer for unknown reasons (this does not happen in other distros). Retry the module download multiple
           # times to reduce the flakiness.
@@ -688,11 +685,6 @@ tasks:
           directory: evergreen
           token: ${github_token}
           shallow_clone: true
-      - command: shell.exec
-        params:
-          script: |
-            # Set GitHub app dynamic token to ensure it can clone non-public repos for Go modules.
-            git config --global url."https://x-access-token:${github_token}@github.com/evergreen-ci/".insteadOf https://github.com/evergreen-ci/
       - command: subprocess.exec
         params:
           working_dir: evergreen


### PR DESCRIPTION
DEVPROD-16346

### Description
Dependabot doesn't work that well with internal repos (you have to add secrets and registry configuration), so we just decided to make evergreen-ci/test-selection-client a public repo. It contains no secrets so it should be fine.

### Testing
* Dependabot version updates are working again.
* Existing tests compile.