### PR TITLE
DEVPROD-16944: do not allow notarizing MacOS clients in patches

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -818,13 +818,13 @@ tasks:
   - <<: *build-and-push-client
     name: build-darwin_amd64
     # Only run this in commits because the MacOS client has to be notarized and
-    # signed. Apple has strict limits on how many files can be notarized.
+    # signed. Apple has strict limits on how many files can be notarized per day.
     patchable: false
     tags: ["build"]
   - <<: *build-and-push-client
     name: build-darwin_arm64
     # Only run this in commits because the MacOS client has to be notarized and
-    # signed. Apple has strict limits on how many files can be notarized.
+    # signed. Apple has strict limits on how many files can be notarized per day.
     patchable: false
     tags: ["build"]
   - <<: *tar-and-push-static-assets

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -817,9 +817,15 @@ tasks:
     tags: ["build"]
   - <<: *build-and-push-client
     name: build-darwin_amd64
+    # Only run this in commits because the MacOS client has to be notarized and
+    # signed. Apple has strict limits on how many files can be notarized.
+    patchable: false
     tags: ["build"]
   - <<: *build-and-push-client
     name: build-darwin_arm64
+    # Only run this in commits because the MacOS client has to be notarized and
+    # signed. Apple has strict limits on how many files can be notarized.
+    patchable: false
     tags: ["build"]
   - <<: *tar-and-push-static-assets
     name: tar-and-push-static-assets


### PR DESCRIPTION
DEVPROD-16944

### Description
The MacOS notary service has strict limits on how many binaries can be notarized per day, but currently, Evergreen notarizes the client every time the `build-darwin_arm64` and `build-darwin_amd64` tasks run. To reduce unnecessary notarizations, don't allow patching the tasks that notarize the client. If someone wants to just compile the binary in MacOS for a patch, they can run the `build-darwin-unsigned_arm64` and `build-darwin-unsigned_amd64` tasks.

I'm going to make some follow-up changes to reduce our usage further and ensure the deploy process is still as smooth as possible.

### Testing
N/A

### Documentation
N/A
