### PR TITLE
DEVPROD-16983: update to latest pail version

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-04-22"
+	AgentVersion = "2025-04-23"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/evergreen-ci/cocoa v0.0.0-20250225172339-717c91acad92
 	github.com/evergreen-ci/gimlet v0.0.0-20250410201752-38682bd5bae1
 	github.com/evergreen-ci/juniper v0.0.0-20230901183147-c805ea7351aa
-	github.com/evergreen-ci/pail v0.0.0-20250411132802-95faee445373
+	github.com/evergreen-ci/pail v0.0.0-20250422194947-77498d0ef1da
 	github.com/evergreen-ci/poplar v0.0.0-20250313160224-22f0e4e98238
 	github.com/evergreen-ci/shrub v0.0.0-20250224222152-c8b72a51163b
 	github.com/evergreen-ci/timber v0.0.0-20250225175618-52d1e1841945

--- a/go.sum
+++ b/go.sum
@@ -220,8 +220,8 @@ github.com/evergreen-ci/lru v0.0.0-20250224223041-c0d64dfbee1d h1:MuXYpCV887NYLi
 github.com/evergreen-ci/lru v0.0.0-20250224223041-c0d64dfbee1d/go.mod h1:GkF2zgx62MGjwUKyQOUHSJ5KRekHh0K3TP/fP35cfqM=
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035 h1:oVU/ni/sRq+GAogUMLa7LBGtvVHMVLbisuytxBC5KaY=
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035/go.mod h1:pvK7NM0ZC+sfTLuIiJN4BgM1S9S5Oo79PJReAFFph18=
-github.com/evergreen-ci/pail v0.0.0-20250411132802-95faee445373 h1:8e3ayzCv6080oAAvIc/wTTXjOvmzmpgJGmEHT3VMC+I=
-github.com/evergreen-ci/pail v0.0.0-20250411132802-95faee445373/go.mod h1:1n/7AvvPJghYbmm9WqFoSbZFt2hnQ0QGDpvCKzDCnL4=
+github.com/evergreen-ci/pail v0.0.0-20250422194947-77498d0ef1da h1:rPYn8F0OKbafrK2WiZAyztT85R/nbmEdHvCBSkCu40s=
+github.com/evergreen-ci/pail v0.0.0-20250422194947-77498d0ef1da/go.mod h1:dPgkhi/PFE8ww+Cbs/q74sJDc/oxoBNUaoUqOZIFScc=
 github.com/evergreen-ci/plank v0.0.0-20230207190607-5f47f8a30da1 h1:KkCHAMVyiM3/JHccjC9tAXE0KM80p19hlXJhaiggAdQ=
 github.com/evergreen-ci/plank v0.0.0-20230207190607-5f47f8a30da1/go.mod h1:v8BYoLFIhvElWTc1xtP7aHPBEwTC3dh308PgFBbROaI=
 github.com/evergreen-ci/poplar v0.0.0-20250313160224-22f0e4e98238 h1:985gdUfr8rv5kJij0B39iKgmm6cp/nvVb9/eH64CBBY=


### PR DESCRIPTION
DEVPROD-16983

This commit updates our pail version to the latest in order to gain considerable performance improvements for s3.put