### PR TITLE
DEVPROD-16944: activate MacOS client tasks in a cron

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -817,15 +817,19 @@ tasks:
     tags: ["build"]
   - <<: *build-and-push-client
     name: build-darwin_amd64
-    # Only run this in commits because the MacOS client has to be notarized and
-    # signed. Apple has strict limits on how many files can be notarized per day.
-    patchable: false
+    # Run this only on a daily cron because the MacOS client has to be notarized
+    # and signed. Apple has strict limits on how many files can be notarized per
+    # day. Using a daily cron ensures that the daily deploy will still have some
+    # commit to deploy if there was one, without notarizing all of them.
+    cron: "0 11 * * *" # 11 AM UTC
     tags: ["build"]
   - <<: *build-and-push-client
     name: build-darwin_arm64
-    # Only run this in commits because the MacOS client has to be notarized and
-    # signed. Apple has strict limits on how many files can be notarized per day.
-    patchable: false
+    # Run this only on a daily cron because the MacOS client has to be notarized
+    # and signed. Apple has strict limits on how many files can be notarized per
+    # day. Using a daily cron ensures that the daily deploy will still have some
+    # commit to deploy if there was one, without notarizing all of them.
+    cron: "0 11 * * *" # 11 AM UTC
     tags: ["build"]
   - <<: *tar-and-push-static-assets
     name: tar-and-push-static-assets


### PR DESCRIPTION
DEVPROD-16944

### Description
To reduce the amount of times the Evergreen client gets notarized per day, we're going to stop notarizing/signing MacOS clients on every commit and instead notarize only once per day in the morning. This ensures that on the morning of the deploy, if there was any commit yesterday, it'll be ready to deploy.

It's still fine to deploy a commit that's not the cron-activated one. So if the deployer wants to deploy something other than the commit that ran the cron MacOS task, they can do it as long as they schedule/run the MacOS task on that commit before deploying to prod. https://github.com/10gen/kernel-tools/pull/462 adds a check to make sure the MacOS task is activated before deploying to prod and https://github.com/10gen/kernel-tools/pull/463 introduces a convenience to the deploy script to auto-activate the MacOS task, so it should be reasonably convenient to do that.

### Testing
N/A

### Documentation
Will document the new deploy consideration and inform deployers of what to do.