### PR TITLE
DEVPROD-16944: move cron to build variant task

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -817,20 +817,10 @@ tasks:
     tags: ["build"]
   - <<: *build-and-push-client
     name: build-darwin_amd64
-    # Run this only on a daily cron because the MacOS client has to be notarized
-    # and signed. Apple has strict limits on how many files can be notarized per
-    # day. Using a daily cron ensures that the daily deploy will still have some
-    # commit to deploy if there was one, without notarizing all of them.
-    cron: "0 11 * * *" # 11 AM UTC
-    tags: ["build"]
+    tags: ["build-macos"]
   - <<: *build-and-push-client
     name: build-darwin_arm64
-    # Run this only on a daily cron because the MacOS client has to be notarized
-    # and signed. Apple has strict limits on how many files can be notarized per
-    # day. Using a daily cron ensures that the daily deploy will still have some
-    # commit to deploy if there was one, without notarizing all of them.
-    cron: "0 11 * * *" # 11 AM UTC
-    tags: ["build"]
+    tags: ["build-macos"]
   - <<: *tar-and-push-static-assets
     name: tar-and-push-static-assets
     tags: ["build"]
@@ -973,6 +963,13 @@ buildvariants:
       - ubuntu2204-small
     tasks:
       - name: ".build"
+      - name: ".build-macos"
+        # Run MacOS compile/notarization tasks on a daily cron because the MacOS
+        # client has to be notarized and signed. Apple has strict limits on how
+        # many files can be notarized per day. Using a daily cron ensures that
+        # the daily deploy will still have some commit to deploy if there was
+        # one, without notarizing all of them.
+        cron: "0 11 * * *" # 11 AM UTC
       - name: ".build-staging"
         activate: false
       - name: ".build-unsigned"
@@ -984,6 +981,7 @@ buildvariants:
       - name: build-and-push
         execution_tasks:
           - ".build"
+          - ".build-macos"
       - name: build-and-push-staging
         execution_tasks:
           - ".build-staging"


### PR DESCRIPTION
DEVPROD-16944

### Description
Small fix for #8961- seems like you can't define a cron on the task, only on the build variant or build variant task list. It's a little weird because `evergreen validate` doesn't give a warning or anything 🤷 

### Testing
Don't have a direct way to test cron other than read the parser project structure and see what happens when it's committed.

### Documentation
N/A