### PR TITLE
DEVPROD-12908 Add weak cache for thirdparty.GetCommitEvent

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/evergreen-ci/poplar v0.0.0-20250313160224-22f0e4e98238
 	github.com/evergreen-ci/shrub v0.0.0-20250224222152-c8b72a51163b
 	github.com/evergreen-ci/timber v0.0.0-20250225175618-52d1e1841945
-	github.com/evergreen-ci/utility v0.0.0-20250404164817-04ef334e215a
+	github.com/evergreen-ci/utility v0.0.0-20250424141600-fde5f3a474b7
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/gonzojive/httpcache v0.0.0-20220509000156-e80a5e6a69fe
 	github.com/google/go-github/v52 v52.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -237,6 +237,10 @@ github.com/evergreen-ci/timber v0.0.0-20250225175618-52d1e1841945/go.mod h1:j76U
 github.com/evergreen-ci/utility v0.0.0-20230104160902-3f0e05a638bd/go.mod h1:vkCEVgfCMIDajzbG/PHZURszI2Y1SuFqNWX9EUxmLLI=
 github.com/evergreen-ci/utility v0.0.0-20250404164817-04ef334e215a h1:k7FLEvTQf9RfrdbVIdtjnArl7E3f3KdsCI+xUAzjc44=
 github.com/evergreen-ci/utility v0.0.0-20250404164817-04ef334e215a/go.mod h1:AGAekBl7zMjMvHB6yqkVkE81JuHBxBPaPozF49DsU70=
+github.com/evergreen-ci/utility v0.0.0-20250424132646-c73faa7645ce h1:Zkbb/4GfP5YgI3sU49FTGeDu98rj9R/rcHQPwgdWXAU=
+github.com/evergreen-ci/utility v0.0.0-20250424132646-c73faa7645ce/go.mod h1:AGAekBl7zMjMvHB6yqkVkE81JuHBxBPaPozF49DsU70=
+github.com/evergreen-ci/utility v0.0.0-20250424141600-fde5f3a474b7 h1:UmNnwNAyI0oHVsfC6Ft9pQgEphUEYIqFl4vBbIuRtZk=
+github.com/evergreen-ci/utility v0.0.0-20250424141600-fde5f3a474b7/go.mod h1:AGAekBl7zMjMvHB6yqkVkE81JuHBxBPaPozF49DsU70=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=

--- a/go.sum
+++ b/go.sum
@@ -235,10 +235,6 @@ github.com/evergreen-ci/test-selection-client v0.0.0-20250331142509-2af2d0f91c8b
 github.com/evergreen-ci/timber v0.0.0-20250225175618-52d1e1841945 h1:brav0wdGU4QGOGlzLPjT5UdxzJBDwytmLC+FdF7EG7c=
 github.com/evergreen-ci/timber v0.0.0-20250225175618-52d1e1841945/go.mod h1:j76Uq4ABEq6Eulrq1otaNJGxWh/lo74IlfxWvAeOZb4=
 github.com/evergreen-ci/utility v0.0.0-20230104160902-3f0e05a638bd/go.mod h1:vkCEVgfCMIDajzbG/PHZURszI2Y1SuFqNWX9EUxmLLI=
-github.com/evergreen-ci/utility v0.0.0-20250404164817-04ef334e215a h1:k7FLEvTQf9RfrdbVIdtjnArl7E3f3KdsCI+xUAzjc44=
-github.com/evergreen-ci/utility v0.0.0-20250404164817-04ef334e215a/go.mod h1:AGAekBl7zMjMvHB6yqkVkE81JuHBxBPaPozF49DsU70=
-github.com/evergreen-ci/utility v0.0.0-20250424132646-c73faa7645ce h1:Zkbb/4GfP5YgI3sU49FTGeDu98rj9R/rcHQPwgdWXAU=
-github.com/evergreen-ci/utility v0.0.0-20250424132646-c73faa7645ce/go.mod h1:AGAekBl7zMjMvHB6yqkVkE81JuHBxBPaPozF49DsU70=
 github.com/evergreen-ci/utility v0.0.0-20250424141600-fde5f3a474b7 h1:UmNnwNAyI0oHVsfC6Ft9pQgEphUEYIqFl4vBbIuRtZk=
 github.com/evergreen-ci/utility v0.0.0-20250424141600-fde5f3a474b7/go.mod h1:AGAekBl7zMjMvHB6yqkVkE81JuHBxBPaPozF49DsU70=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=

--- a/model/version.go
+++ b/model/version.go
@@ -786,7 +786,7 @@ func constructManifest(ctx context.Context, v *Version, projectRef *ProjectRef, 
 			}
 		}
 
-		mfstModule, err := getManifestModule(v, projectRef, module)
+		mfstModule, err := getManifestModule(ctx, v, projectRef, module)
 		if err != nil {
 			return nil, errors.Wrapf(err, "module '%s'", module.Name)
 		}
@@ -797,14 +797,14 @@ func constructManifest(ctx context.Context, v *Version, projectRef *ProjectRef, 
 	return newManifest, nil
 }
 
-func getManifestModule(v *Version, projectRef *ProjectRef, module Module) (*manifest.Module, error) {
+func getManifestModule(ctx context.Context, v *Version, projectRef *ProjectRef, module Module) (*manifest.Module, error) {
 	owner, repo, err := module.GetOwnerAndRepo()
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting owner and repo for '%s'", module.Name)
 	}
 
 	if module.Ref == "" {
-		ghCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		ghCtx, cancel := context.WithTimeout(ctx, time.Minute)
 		defer cancel()
 
 		revisionTime := time.Unix(0, 0)
@@ -842,7 +842,7 @@ func getManifestModule(v *Version, projectRef *ProjectRef, module Module) (*mani
 		}, nil
 	}
 
-	ghCtx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ghCtx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
 	sha := module.Ref

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -661,7 +661,7 @@ func getCommitComparison(ctx context.Context, owner, repo, baseRevision, current
 }
 
 // ghCommitCache is a cache for commits.
-var ghCommitCache = ttlcache.WithOtel(ttlcache.NewInMemory[*github.RepositoryCommit](), "github-get-commit-event")
+var ghCommitCache = ttlcache.WithOtel(ttlcache.NewWeakInMemory[github.RepositoryCommit](), "github-get-commit-event")
 
 func GetCommitEvent(ctx context.Context, owner, repo, githash string) (*github.RepositoryCommit, error) {
 	caller := "GetCommitEvent"
@@ -676,7 +676,7 @@ func GetCommitEvent(ctx context.Context, owner, repo, githash string) (*github.R
 	ghCommitKey := fmt.Sprintf("%s/%s/%s", owner, repo, githash)
 	commit, found := ghCommitCache.Get(ctx, ghCommitKey, 0)
 	span.SetAttributes(attribute.Bool(githubLocalCachedAttribute, found))
-	if found {
+	if found && commit != nil {
 		return commit, nil
 	}
 

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -410,6 +410,12 @@ func getInstallationTokenWithDefaultOwnerRepo(ctx context.Context, opts *github.
 	return githubapp.CreateCachedInstallationTokenWithDefaultOwnerRepo(ctx, settings, defaultGitHubAPIRequestLifetime, opts)
 }
 
+// ghCommitsCache is a cache for commit slices. The reason we use two separate caches
+// is because we want the first cache to allow for garabage collection since it's a slice of
+// pointers. The second cache is a simple int that we don't need garbage collection for.
+var ghCommitsCache = ttlcache.WithOtel(ttlcache.NewInMemory[[]*github.RepositoryCommit](), "github-get-commits-event")
+var ghCommitsNextPageCache = ttlcache.WithOtel(ttlcache.NewInMemory[int](), "github-get-commits-event-next-page")
+
 // GetGithubCommits returns a slice of GithubCommit objects from
 // the given commitsURL when provided a valid oauth token
 func GetGithubCommits(ctx context.Context, owner, repo, ref string, until time.Time, commitPage int) ([]*github.RepositoryCommit, int, error) {
@@ -421,6 +427,15 @@ func GetGithubCommits(ctx context.Context, owner, repo, ref string, until time.T
 		attribute.String(githubRefAttribute, ref),
 	))
 	defer span.End()
+
+	ghCommitsKey := fmt.Sprintf("%s/%s/%s/%s", owner, repo, ref, until.Format(time.RFC3339))
+	commits, found := ghCommitsCache.Get(ctx, ghCommitsKey, 0)
+	span.SetAttributes(attribute.Bool(githubLocalCachedAttribute, found))
+	if found {
+		// nextPage is guaranteed to be populated if the other cache is populated.
+		nextPage, _ := ghCommitsNextPageCache.Get(ctx, ghCommitsKey, 0)
+		return commits, nextPage, nil
+	}
 
 	token, err := getInstallationToken(ctx, owner, repo, nil)
 	if err != nil {
@@ -452,6 +467,9 @@ func GetGithubCommits(ctx context.Context, owner, repo, ref string, until time.T
 		grip.Error(errMsg)
 		return nil, 0, APIResponseError{errMsg}
 	}
+
+	ghCommitsCache.Put(ctx, ghCommitsKey, commits, time.Now().Add(time.Hour*24))
+	ghCommitsNextPageCache.Put(ctx, ghCommitsKey, resp.NextPage, time.Now().Add(time.Hour*24))
 
 	return commits, resp.NextPage, nil
 }
@@ -660,8 +678,8 @@ func getCommitComparison(ctx context.Context, owner, repo, baseRevision, current
 	return compare, nil
 }
 
-// ghCommitEventCache is a cache for commit events.
-var ghCommitEventCache = ttlcache.WithOtel(ttlcache.NewInMemory[*github.RepositoryCommit](), "github-get-commit-event")
+// ghCommitCache is a cache for commits.
+var ghCommitCache = ttlcache.WithOtel(ttlcache.NewInMemory[*github.RepositoryCommit](), "github-get-commit-event")
 
 func GetCommitEvent(ctx context.Context, owner, repo, githash string) (*github.RepositoryCommit, error) {
 	caller := "GetCommitEvent"
@@ -673,8 +691,8 @@ func GetCommitEvent(ctx context.Context, owner, repo, githash string) (*github.R
 	))
 	defer span.End()
 
-	ghCommitEventCacheKey := fmt.Sprintf("%s/%s/%s", owner, repo, githash)
-	commit, found := ghCommitEventCache.Get(ctx, ghCommitEventCacheKey, 0)
+	ghCommitKey := fmt.Sprintf("%s/%s/%s", owner, repo, githash)
+	commit, found := ghCommitCache.Get(ctx, ghCommitKey, 0)
 	span.SetAttributes(attribute.Bool(githubLocalCachedAttribute, found))
 	if found {
 		return commit, nil
@@ -728,7 +746,7 @@ func GetCommitEvent(ctx context.Context, owner, repo, githash string) (*github.R
 		return nil, errors.New("commit not found in github")
 	}
 
-	ghCommitEventCache.Put(ctx, ghCommitEventCacheKey, commit, time.Now().Add(time.Hour*24))
+	ghCommitCache.Put(ctx, ghCommitKey, commit, time.Now().Add(time.Hour*24))
 	return commit, nil
 }
 

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -660,7 +660,8 @@ func getCommitComparison(ctx context.Context, owner, repo, baseRevision, current
 	return compare, nil
 }
 
-// ghCommitCache is a weak cache for GitHub commits.
+// ghCommitCache is a weak cache for GitHub commits. We can use a cache because
+// the commit data doesn't change.
 var ghCommitCache = ttlcache.WithOtel(ttlcache.NewWeakInMemory[github.RepositoryCommit](), "github-get-commit-event")
 
 func GetCommitEvent(ctx context.Context, owner, repo, githash string) (*github.RepositoryCommit, error) {

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -728,6 +728,10 @@ func GetCommitEvent(ctx context.Context, owner, repo, githash string) (*github.R
 		return nil, errors.New("commit not found in github")
 	}
 
+	// We use 24 hours as the expiration time for the item in the cache
+	// because the cache only holds weak pointers to the items in it.
+	// This means that the items in the cache can be garbage collected
+	// if there are no strong references to them.
 	ghCommitCache.Put(ctx, ghCommitKey, commit, time.Now().Add(time.Hour*24))
 	return commit, nil
 }

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -660,7 +660,7 @@ func getCommitComparison(ctx context.Context, owner, repo, baseRevision, current
 	return compare, nil
 }
 
-// ghCommitCache is a cache for commits.
+// ghCommitCache is a weak cache for GitHub commits.
 var ghCommitCache = ttlcache.WithOtel(ttlcache.NewWeakInMemory[github.RepositoryCommit](), "github-get-commit-event")
 
 func GetCommitEvent(ctx context.Context, owner, repo, githash string) (*github.RepositoryCommit, error) {

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -293,6 +294,19 @@ func (s *githubSuite) TestGetCommitEvent() {
 		s.Equal("richardsamuels", *commit.Author.Login)
 		s.Equal("ddf48e044c307e3f8734279be95f2d9d7134410f", *commit.SHA)
 		s.Len(commit.Files, 16)
+	})
+
+	ghCommitKey := fmt.Sprintf("%s/%s/%s", "evergreen-ci", "evergreen", "ddf48e044c307e3f8734279be95f2d9d7134410f")
+	s.Run("StoresItInCache", func() {
+		commit, found := ghCommitCache.Get(s.ctx, ghCommitKey, 0)
+		s.True(found)
+		s.NotNil(commit)
+	})
+	s.Run("ReleasedFromCache", func() {
+		runtime.GC()
+		commit, found := ghCommitCache.Get(s.ctx, ghCommitKey, 0)
+		s.False(found)
+		s.Nil(commit)
 	})
 }
 


### PR DESCRIPTION
DEVPROD-12908

### Description
This adds a weak pointer cache for thirdparty.GetCommitEvent

### Testing
I deployed on staging and got some events, but we just don't see the load under the function like in prod (and it's difficult to simulate it)