### PR TITLE
DEVPROD-16870: Make case sensitivity configurable in Waterfall aggregations

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -81717,8 +81717,14 @@ func (ec *executionContext) unmarshalInputWaterfallOptions(ctx context.Context, 
 	if _, present := asMap["limit"]; !present {
 		asMap["limit"] = 5
 	}
+	if _, present := asMap["variantCaseInsensitive"]; !present {
+		asMap["variantCaseInsensitive"] = false
+	}
+	if _, present := asMap["taskCaseInsensitive"]; !present {
+		asMap["taskCaseInsensitive"] = false
+	}
 
-	fieldsInOrder := [...]string{"date", "limit", "minOrder", "maxOrder", "projectIdentifier", "requesters", "revision", "statuses", "tasks", "variants"}
+	fieldsInOrder := [...]string{"date", "limit", "minOrder", "maxOrder", "projectIdentifier", "requesters", "revision", "statuses", "tasks", "variants", "variantCaseInsensitive", "taskCaseInsensitive"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -81820,6 +81826,20 @@ func (ec *executionContext) unmarshalInputWaterfallOptions(ctx context.Context, 
 				return it, err
 			}
 			it.Variants = data
+		case "variantCaseInsensitive":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("variantCaseInsensitive"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.VariantCaseInsensitive = data
+		case "taskCaseInsensitive":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("taskCaseInsensitive"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TaskCaseInsensitive = data
 		}
 	}
 

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -81717,14 +81717,8 @@ func (ec *executionContext) unmarshalInputWaterfallOptions(ctx context.Context, 
 	if _, present := asMap["limit"]; !present {
 		asMap["limit"] = 5
 	}
-	if _, present := asMap["variantCaseInsensitive"]; !present {
-		asMap["variantCaseInsensitive"] = false
-	}
-	if _, present := asMap["taskCaseInsensitive"]; !present {
-		asMap["taskCaseInsensitive"] = false
-	}
 
-	fieldsInOrder := [...]string{"date", "limit", "minOrder", "maxOrder", "projectIdentifier", "requesters", "revision", "statuses", "tasks", "variants", "variantCaseInsensitive", "taskCaseInsensitive"}
+	fieldsInOrder := [...]string{"date", "limit", "minOrder", "maxOrder", "projectIdentifier", "requesters", "revision", "statuses", "tasks", "taskCaseSensitive", "variants", "variantCaseSensitive"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -81819,6 +81813,13 @@ func (ec *executionContext) unmarshalInputWaterfallOptions(ctx context.Context, 
 				return it, err
 			}
 			it.Tasks = data
+		case "taskCaseSensitive":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("taskCaseSensitive"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TaskCaseSensitive = data
 		case "variants":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("variants"))
 			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
@@ -81826,20 +81827,13 @@ func (ec *executionContext) unmarshalInputWaterfallOptions(ctx context.Context, 
 				return it, err
 			}
 			it.Variants = data
-		case "variantCaseInsensitive":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("variantCaseInsensitive"))
+		case "variantCaseSensitive":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("variantCaseSensitive"))
 			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.VariantCaseInsensitive = data
-		case "taskCaseInsensitive":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("taskCaseInsensitive"))
-			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.TaskCaseInsensitive = data
+			it.VariantCaseSensitive = data
 		}
 	}
 

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -653,15 +653,17 @@ type WaterfallOptions struct {
 	// Return versions with an order greater than minOrder. Used for paginating backward.
 	MinOrder *int `json:"minOrder,omitempty"`
 	// Return versions with an order lower than maxOrder. Used for paginating forward.
-	MaxOrder               *int     `json:"maxOrder,omitempty"`
-	ProjectIdentifier      string   `json:"projectIdentifier"`
-	Requesters             []string `json:"requesters,omitempty"`
-	Revision               *string  `json:"revision,omitempty"`
-	Statuses               []string `json:"statuses,omitempty"`
-	Tasks                  []string `json:"tasks,omitempty"`
-	Variants               []string `json:"variants,omitempty"`
-	VariantCaseInsensitive *bool    `json:"variantCaseInsensitive,omitempty"`
-	TaskCaseInsensitive    *bool    `json:"taskCaseInsensitive,omitempty"`
+	MaxOrder          *int     `json:"maxOrder,omitempty"`
+	ProjectIdentifier string   `json:"projectIdentifier"`
+	Requesters        []string `json:"requesters,omitempty"`
+	Revision          *string  `json:"revision,omitempty"`
+	Statuses          []string `json:"statuses,omitempty"`
+	Tasks             []string `json:"tasks,omitempty"`
+	// Toggle case sensitivity when matching on task names. Note that if false, performance will be slower.
+	TaskCaseSensitive *bool    `json:"taskCaseSensitive,omitempty"`
+	Variants          []string `json:"variants,omitempty"`
+	// Toggle case sensitivity when matching on variant names. Note that if false, performance will be slower.
+	VariantCaseSensitive *bool `json:"variantCaseSensitive,omitempty"`
 }
 
 type WaterfallPagination struct {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -653,13 +653,15 @@ type WaterfallOptions struct {
 	// Return versions with an order greater than minOrder. Used for paginating backward.
 	MinOrder *int `json:"minOrder,omitempty"`
 	// Return versions with an order lower than maxOrder. Used for paginating forward.
-	MaxOrder          *int     `json:"maxOrder,omitempty"`
-	ProjectIdentifier string   `json:"projectIdentifier"`
-	Requesters        []string `json:"requesters,omitempty"`
-	Revision          *string  `json:"revision,omitempty"`
-	Statuses          []string `json:"statuses,omitempty"`
-	Tasks             []string `json:"tasks,omitempty"`
-	Variants          []string `json:"variants,omitempty"`
+	MaxOrder               *int     `json:"maxOrder,omitempty"`
+	ProjectIdentifier      string   `json:"projectIdentifier"`
+	Requesters             []string `json:"requesters,omitempty"`
+	Revision               *string  `json:"revision,omitempty"`
+	Statuses               []string `json:"statuses,omitempty"`
+	Tasks                  []string `json:"tasks,omitempty"`
+	Variants               []string `json:"variants,omitempty"`
+	VariantCaseInsensitive *bool    `json:"variantCaseInsensitive,omitempty"`
+	TaskCaseInsensitive    *bool    `json:"taskCaseInsensitive,omitempty"`
 }
 
 type WaterfallPagination struct {

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -974,13 +974,15 @@ func (r *queryResolver) Waterfall(ctx context.Context, options WaterfallOptions)
 	}
 
 	opts := model.WaterfallOptions{
-		Limit:      limit,
-		MaxOrder:   maxOrderOpt,
-		MinOrder:   minOrderOpt,
-		Requesters: requesters,
-		Statuses:   utility.FilterSlice(options.Statuses, func(s string) bool { return s != "" }),
-		Tasks:      utility.FilterSlice(options.Tasks, func(s string) bool { return s != "" }),
-		Variants:   utility.FilterSlice(options.Variants, func(s string) bool { return s != "" }),
+		Limit:                limit,
+		MaxOrder:             maxOrderOpt,
+		MinOrder:             minOrderOpt,
+		Requesters:           requesters,
+		Statuses:             utility.FilterSlice(options.Statuses, func(s string) bool { return s != "" }),
+		Tasks:                utility.FilterSlice(options.Tasks, func(s string) bool { return s != "" }),
+		TaskCaseSensitive:    utility.FromBoolTPtr(options.TaskCaseSensitive), // Default to true for performance reasons.
+		Variants:             utility.FilterSlice(options.Variants, func(s string) bool { return s != "" }),
+		VariantCaseSensitive: utility.FromBoolTPtr(options.TaskCaseSensitive), // Default to true for performance reasons.
 	}
 
 	mostRecentWaterfallVersion, err := model.GetMostRecentWaterfallVersion(ctx, projectId)

--- a/graphql/schema/types/waterfall.graphql
+++ b/graphql/schema/types/waterfall.graphql
@@ -12,6 +12,8 @@ input WaterfallOptions {
   statuses: [String!]
   tasks: [String!]
   variants: [String!]
+  variantCaseInsensitive: Boolean = false
+  taskCaseInsensitive: Boolean = false
 }
 
 type WaterfallTask {

--- a/graphql/schema/types/waterfall.graphql
+++ b/graphql/schema/types/waterfall.graphql
@@ -11,9 +11,11 @@ input WaterfallOptions {
   revision: String
   statuses: [String!]
   tasks: [String!]
+  "Toggle case sensitivity when matching on task names. Note that if false, performance will be slower."
+  taskCaseSensitive: Boolean
   variants: [String!]
-  variantCaseInsensitive: Boolean = false
-  taskCaseInsensitive: Boolean = false
+  "Toggle case sensitivity when matching on variant names. Note that if false, performance will be slower."
+  variantCaseSensitive: Boolean
 }
 
 type WaterfallTask {

--- a/model/waterfall.go
+++ b/model/waterfall.go
@@ -47,13 +47,15 @@ type WaterfallBuildVariant struct {
 }
 
 type WaterfallOptions struct {
-	Limit      int      `bson:"-" json:"-"`
-	MaxOrder   int      `bson:"-" json:"-"`
-	MinOrder   int      `bson:"-" json:"-"`
-	Requesters []string `bson:"-" json:"-"`
-	Statuses   []string `bson:"-" json:"-"`
-	Tasks      []string `bson:"-" json:"-"`
-	Variants   []string `bson:"-" json:"-"`
+	Limit                  int      `bson:"-" json:"-"`
+	MaxOrder               int      `bson:"-" json:"-"`
+	MinOrder               int      `bson:"-" json:"-"`
+	Requesters             []string `bson:"-" json:"-"`
+	Statuses               []string `bson:"-" json:"-"`
+	Tasks                  []string `bson:"-" json:"-"`
+	Variants               []string `bson:"-" json:"-"`
+	VariantCaseInsensitive bool     `bson:"-" json:"-"`
+	TaskCaseInsensitive    bool     `bson:"-" json:"-"`
 }
 
 // Older versions don't have their build display names saved in the version document.
@@ -93,7 +95,7 @@ func getBuildDisplayNames(match bson.M) bson.M {
 
 // This pipeline matches on versions that have a build with an ID or display name that matches variants
 // It checks if the version with order number versionSearchCutoff is old enough to require a join with the builds collection in order to obtain build variant display names.
-func getBuildVariantFilterPipeline(ctx context.Context, variants []string, match bson.M, projectId string, versionSearchCutoff int) ([]bson.M, error) {
+func getBuildVariantFilterPipeline(ctx context.Context, variants []string, caseInsensitive bool, match bson.M, projectId string, versionSearchCutoff int) ([]bson.M, error) {
 	pipeline := []bson.M{}
 	match[bsonutil.GetDottedKeyName(VersionBuildVariantsKey, VersionBuildStatusDisplayNameKey)] = bson.M{"$exists": true}
 	pipeline = append(pipeline, bson.M{"$match": match})
@@ -117,15 +119,26 @@ func getBuildVariantFilterPipeline(ctx context.Context, variants []string, match
 	pipeline = append(pipeline, bson.M{"$sort": bson.M{VersionRevisionOrderNumberKey: -1}})
 
 	variantsAsRegex := strings.Join(variants, "|")
+
+	var buildVariantMatch []bson.M
+	if caseInsensitive {
+		buildVariantMatch = []bson.M{
+			{VersionBuildStatusVariantKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
+			{VersionBuildStatusDisplayNameKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
+		}
+	} else {
+		buildVariantMatch = []bson.M{
+			{VersionBuildStatusVariantKey: bson.M{"$regex": variantsAsRegex}},
+			{VersionBuildStatusDisplayNameKey: bson.M{"$regex": variantsAsRegex}},
+		}
+	}
+
 	pipeline = append(pipeline, bson.M{
 		"$match": bson.M{
 			VersionBuildVariantsKey: bson.M{
 				"$elemMatch": bson.M{
 					VersionBuildStatusActivatedKey: true,
-					"$or": []bson.M{
-						{VersionBuildStatusVariantKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
-						{VersionBuildStatusDisplayNameKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
-					},
+					"$or":                          buildVariantMatch,
 				},
 			},
 		},
@@ -166,15 +179,28 @@ func GetActiveVersionsByTaskFilters(ctx context.Context, projectId string, opts 
 
 	if len(opts.Tasks) > 0 {
 		taskNamesAsRegex := strings.Join(opts.Tasks, "|")
-		match[task.DisplayNameKey] = bson.M{"$regex": taskNamesAsRegex, "$options": "i"}
+		if opts.TaskCaseInsensitive {
+			match[task.DisplayNameKey] = bson.M{"$regex": taskNamesAsRegex, "$options": "i"}
+		} else {
+			match[task.DisplayNameKey] = bson.M{"$regex": taskNamesAsRegex}
+		}
+
 	}
 
 	if len(opts.Variants) > 0 {
 		variantsAsRegex := strings.Join(opts.Variants, "|")
-		match["$or"] = []bson.M{
-			{task.BuildVariantKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
-			{task.BuildVariantDisplayNameKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
+		if opts.VariantCaseInsensitive {
+			match["$or"] = []bson.M{
+				{task.BuildVariantKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
+				{task.BuildVariantDisplayNameKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
+			}
+		} else {
+			match["$or"] = []bson.M{
+				{task.BuildVariantKey: bson.M{"$regex": variantsAsRegex}},
+				{task.BuildVariantDisplayNameKey: bson.M{"$regex": variantsAsRegex}},
+			}
 		}
+
 	}
 
 	pipeline := []bson.M{{"$match": match}}
@@ -281,7 +307,7 @@ func GetActiveWaterfallVersions(ctx context.Context, projectId string, opts Wate
 			versionSearchCutoff = mostRecentVersion.RevisionOrderNumber - MaxWaterfallVersionLimit
 		}
 
-		buildVariantPipeline, err := getBuildVariantFilterPipeline(ctx, opts.Variants, match, projectId, versionSearchCutoff)
+		buildVariantPipeline, err := getBuildVariantFilterPipeline(ctx, opts.Variants, opts.VariantCaseInsensitive, match, projectId, versionSearchCutoff)
 		if err != nil {
 			return nil, errors.Wrap(err, "creating build variant filter pipeline")
 		}

--- a/model/waterfall_test.go
+++ b/model/waterfall_test.go
@@ -68,10 +68,10 @@ func TestGetActiveWaterfallVersions(t *testing.T) {
 		},
 		"Finds active versions with given build variant (case sensitive)": func(t *testing.T, ctx context.Context) {
 			versions, err := GetActiveWaterfallVersions(t.Context(), projectId, WaterfallOptions{
-				Limit:                  4,
-				Requesters:             evergreen.SystemVersionRequesterTypes,
-				Variants:               []string{"Build Variant 1"},
-				VariantCaseInsensitive: false,
+				Limit:                4,
+				Requesters:           evergreen.SystemVersionRequesterTypes,
+				Variants:             []string{"Build Variant 1"},
+				VariantCaseSensitive: true,
 			})
 			assert.NoError(t, err)
 			require.Len(t, versions, 1)
@@ -79,20 +79,20 @@ func TestGetActiveWaterfallVersions(t *testing.T) {
 		},
 		"Finds active versions with given build variant, no results (case sensitive)": func(t *testing.T, ctx context.Context) {
 			versions, err := GetActiveWaterfallVersions(t.Context(), projectId, WaterfallOptions{
-				Limit:                  4,
-				Requesters:             evergreen.SystemVersionRequesterTypes,
-				Variants:               []string{"build variant 1"},
-				VariantCaseInsensitive: false,
+				Limit:                4,
+				Requesters:           evergreen.SystemVersionRequesterTypes,
+				Variants:             []string{"build variant 1"},
+				VariantCaseSensitive: true,
 			})
 			assert.NoError(t, err)
 			assert.Len(t, versions, 0)
 		},
 		"Finds active versions with given build variant (case insensitive)": func(t *testing.T, ctx context.Context) {
 			versions, err := GetActiveWaterfallVersions(t.Context(), projectId, WaterfallOptions{
-				Limit:                  4,
-				Requesters:             evergreen.SystemVersionRequesterTypes,
-				Variants:               []string{"build variant 1"},
-				VariantCaseInsensitive: true,
+				Limit:                4,
+				Requesters:           evergreen.SystemVersionRequesterTypes,
+				Variants:             []string{"build variant 1"},
+				VariantCaseSensitive: false,
 			})
 			assert.NoError(t, err)
 			require.Len(t, versions, 1)
@@ -517,10 +517,10 @@ func TestGetActiveVersionsByTaskFilters(t *testing.T) {
 		"Applies a task name filter (case sensitive)": func(t *testing.T, ctx context.Context) {
 			versions, err := GetActiveVersionsByTaskFilters(ctx, "a_project",
 				WaterfallOptions{
-					Limit:               5,
-					Requesters:          evergreen.SystemVersionRequesterTypes,
-					Tasks:               []string{"Task 80"},
-					TaskCaseInsensitive: false,
+					Limit:             5,
+					Requesters:        evergreen.SystemVersionRequesterTypes,
+					Tasks:             []string{"Task 80"},
+					TaskCaseSensitive: true,
 				}, 1002)
 			assert.NoError(t, err)
 			require.Len(t, versions, 1)
@@ -529,10 +529,10 @@ func TestGetActiveVersionsByTaskFilters(t *testing.T) {
 		"Applies a task name filter, no results (case sensitive)": func(t *testing.T, ctx context.Context) {
 			versions, err := GetActiveVersionsByTaskFilters(ctx, "a_project",
 				WaterfallOptions{
-					Limit:               5,
-					Requesters:          evergreen.SystemVersionRequesterTypes,
-					Tasks:               []string{"task 80"},
-					TaskCaseInsensitive: false,
+					Limit:             5,
+					Requesters:        evergreen.SystemVersionRequesterTypes,
+					Tasks:             []string{"task 80"},
+					TaskCaseSensitive: true,
 				}, 1002)
 			assert.NoError(t, err)
 			assert.Len(t, versions, 0)
@@ -540,10 +540,10 @@ func TestGetActiveVersionsByTaskFilters(t *testing.T) {
 		"Applies a task name filter (case insensitive)": func(t *testing.T, ctx context.Context) {
 			versions, err := GetActiveVersionsByTaskFilters(ctx, "a_project",
 				WaterfallOptions{
-					Limit:               5,
-					Requesters:          evergreen.SystemVersionRequesterTypes,
-					Tasks:               []string{"task 80"},
-					TaskCaseInsensitive: true,
+					Limit:             5,
+					Requesters:        evergreen.SystemVersionRequesterTypes,
+					Tasks:             []string{"task 80"},
+					TaskCaseSensitive: false,
 				}, 1002)
 			assert.NoError(t, err)
 			require.Len(t, versions, 1)
@@ -587,12 +587,12 @@ func TestGetActiveVersionsByTaskFilters(t *testing.T) {
 		"Applies a task name and build variant filter (case sensitive)": func(t *testing.T, ctx context.Context) {
 			versions, err := GetActiveVersionsByTaskFilters(ctx, "a_project",
 				WaterfallOptions{
-					Limit:                  5,
-					Requesters:             evergreen.SystemVersionRequesterTypes,
-					Tasks:                  []string{"Task 100"},
-					Variants:               []string{"Build Variant 1"},
-					TaskCaseInsensitive:    false,
-					VariantCaseInsensitive: false,
+					Limit:                5,
+					Requesters:           evergreen.SystemVersionRequesterTypes,
+					Tasks:                []string{"Task 100"},
+					Variants:             []string{"Build Variant 1"},
+					TaskCaseSensitive:    true,
+					VariantCaseSensitive: true,
 				}, 1002)
 			assert.NoError(t, err)
 			require.Len(t, versions, 1)
@@ -601,12 +601,12 @@ func TestGetActiveVersionsByTaskFilters(t *testing.T) {
 		"Applies a task name and build variant filter (case insensitive)": func(t *testing.T, ctx context.Context) {
 			versions, err := GetActiveVersionsByTaskFilters(ctx, "a_project",
 				WaterfallOptions{
-					Limit:                  5,
-					Requesters:             evergreen.SystemVersionRequesterTypes,
-					Tasks:                  []string{"task 100"},
-					Variants:               []string{"build variant 1"},
-					TaskCaseInsensitive:    true,
-					VariantCaseInsensitive: true,
+					Limit:                5,
+					Requesters:           evergreen.SystemVersionRequesterTypes,
+					Tasks:                []string{"task 100"},
+					Variants:             []string{"build variant 1"},
+					TaskCaseSensitive:    false,
+					VariantCaseSensitive: false,
 				}, 1002)
 			assert.NoError(t, err)
 			require.Len(t, versions, 1)


### PR DESCRIPTION
DEVPROD-16870

### Description
Add parameters that allows case sensitivity to be configurable in Waterfall pipelines.

By default, if no parameter is supplied, case sensitive will be enabled by default. This is a significantly faster query than case insensitive. 

### Context
This is for P3 ticket: [DEVPROD-16699](https://jira.mongodb.org/browse/DEVPROD-16699).

After building the new task index, the queries can actually finish now as opposed to never finishing after 5 minutes, but it's still slow. Making queries case sensitive can significantly improve query speed. For example, when I tested Max's query on production, execution could be as fast as <50ms.

<img width="1015" alt="Screenshot 2025-04-23 at 2 09 51 PM" src="https://github.com/user-attachments/assets/30771103-2776-4527-89e2-eef472948a28" />

### Testing
- Added unit tests (also rewrote them into test case format because hard to read)
