### PR TITLE
DEVPROD-16710: acquire elastic IP addresses from IPAM for hosts

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -300,7 +300,9 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 		input.IamInstanceProfile = &types.IamInstanceProfileSpecification{Arn: aws.String(ec2Settings.IAMInstanceProfileARN)}
 	}
 
-	useElasticIP := shouldAssignPublicIPv4Address(h, ec2Settings) && canUseElasticIP(m.settings, ec2Settings, h)
+	assignPublicIPv4 := shouldAssignPublicIPv4Address(h, ec2Settings)
+
+	useElasticIP := assignPublicIPv4 && canUseElasticIP(m.settings, ec2Settings, h)
 	if useElasticIP && h.IPAllocationID == "" {
 		// If the host can't be allocated an IP address, continue on error
 		// because the host should fall back to using an AWS-provided IP
@@ -312,7 +314,6 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 		}))
 	}
 
-	assignPublicIPv4 := shouldAssignPublicIPv4Address(h, ec2Settings)
 	if assignPublicIPv4 {
 		// Only set an SSH key for the host if the host actually has a public
 		// IPv4 address. Hosts that don't have a public IPv4 address aren't

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -82,6 +82,10 @@ type EC2ProviderSettings struct {
 
 	// FleetOptions specifies options for creating host with Fleet. It is ignored by other managers.
 	FleetOptions FleetConfig `mapstructure:"fleet_options" json:"fleet_options,omitempty" bson:"fleet_options,omitempty"`
+
+	// IPAMEnabled determines if instance can use IP Address Manager (IPAM) for
+	// their IP addresses.
+	IPAMEnabled bool `mapstructure:"ipam_enabled" json:"ipam_enabled,omitempty" bson:"ipam_enabled,omitempty"`
 }
 
 // Validate that essential EC2ProviderSettings fields are not empty.
@@ -283,6 +287,7 @@ func (m *ec2Manager) setupClient(ctx context.Context) error {
 }
 
 func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Settings *EC2ProviderSettings, blockDevices []types.BlockDeviceMapping) error {
+	// kim: TODO: add logic to allocate/associate address.
 	input := &ec2.RunInstancesInput{
 		MinCount:            aws.Int32(1),
 		MaxCount:            aws.Int32(1),

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -83,9 +83,9 @@ type EC2ProviderSettings struct {
 	// FleetOptions specifies options for creating host with Fleet. It is ignored by other managers.
 	FleetOptions FleetConfig `mapstructure:"fleet_options" json:"fleet_options,omitempty" bson:"fleet_options,omitempty"`
 
-	// IPAMEnabled determines if instance can use IP Address Manager (IPAM) for
-	// their IP addresses.
-	IPAMEnabled bool `mapstructure:"ipam_enabled" json:"ipam_enabled,omitempty" bson:"ipam_enabled,omitempty"`
+	// ElasticIPsEnabled determines if hosts can use elastic IPs to obtain their
+	// IP addresses.
+	ElasticIPsEnabled bool `mapstructure:"elastic_ips_enabled" json:"elastic_ips_enabled,omitempty" bson:"elastic_ips_enabled,omitempty"`
 }
 
 // Validate that essential EC2ProviderSettings fields are not empty.

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -112,6 +112,15 @@ type AWSClient interface {
 
 	GetVolumeIDs(context.Context, *host.Host) ([]string, error)
 
+	// AllocateAddress is a wrapper for ec2.AllocateAddress.
+	AllocateAddress(context.Context, *ec2.AllocateAddressInput) (*ec2.AllocateAddressOutput, error)
+	// AssociateAddress is a wrapper for ec2.AssociateAddress.
+	AssociateAddress(context.Context, *ec2.AssociateAddressInput) (*ec2.AssociateAddressOutput, error)
+	// DisassociateAddress is a wrapper for ec2.DisassociateAddress.
+	DisassociateAddress(context.Context, *ec2.DisassociateAddressInput) (*ec2.DisassociateAddressOutput, error)
+	// ReleaseAddress is a wrapper for ec2.ReleaseAddress.
+	ReleaseAddress(context.Context, *ec2.ReleaseAddressInput) (*ec2.ReleaseAddressOutput, error)
+
 	GetPublicDNSName(ctx context.Context, h *host.Host) (string, error)
 
 	// ChangeResourceRecordSets is a wrapper for route53.ChangeResourceRecordSets.
@@ -921,6 +930,102 @@ func (c *awsClientImpl) GetPublicDNSName(ctx context.Context, h *host.Host) (str
 	return *instance.PublicDnsName, nil
 }
 
+func (c *awsClientImpl) AllocateAddress(ctx context.Context, input *ec2.AllocateAddressInput) (*ec2.AllocateAddressOutput, error) {
+	var output *ec2.AllocateAddressOutput
+	var err error
+	err = utility.Retry(
+		ctx,
+		func() (bool, error) {
+			msg := makeAWSLogMessage("AllocateAddress", fmt.Sprintf("%T", c), input)
+			output, err = c.ec2Client.AllocateAddress(ctx, input)
+			if err != nil {
+				var apiErr smithy.APIError
+				if errors.As(err, &apiErr) {
+					grip.Debug(message.WrapError(apiErr, msg))
+				}
+				return true, err
+			}
+			grip.Info(msg)
+			return false, nil
+		}, awsClientDefaultRetryOptions())
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+func (c *awsClientImpl) AssociateAddress(ctx context.Context, input *ec2.AssociateAddressInput) (*ec2.AssociateAddressOutput, error) {
+	var output *ec2.AssociateAddressOutput
+	var err error
+	err = utility.Retry(
+		ctx,
+		func() (bool, error) {
+			msg := makeAWSLogMessage("AssociateAddress", fmt.Sprintf("%T", c), input)
+			output, err = c.ec2Client.AssociateAddress(ctx, input)
+			if err != nil {
+				var apiErr smithy.APIError
+				if errors.As(err, &apiErr) {
+					grip.Debug(message.WrapError(apiErr, msg))
+				}
+				return true, err
+			}
+			grip.Info(msg)
+			return false, nil
+		}, awsClientDefaultRetryOptions())
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+func (c *awsClientImpl) DisassociateAddress(ctx context.Context, input *ec2.DisassociateAddressInput) (*ec2.DisassociateAddressOutput, error) {
+	var output *ec2.DisassociateAddressOutput
+	var err error
+	err = utility.Retry(
+		ctx,
+		func() (bool, error) {
+			msg := makeAWSLogMessage("DisassociateAddress", fmt.Sprintf("%T", c), input)
+			output, err = c.ec2Client.DisassociateAddress(ctx, input)
+			if err != nil {
+				var apiErr smithy.APIError
+				if errors.As(err, &apiErr) {
+					grip.Debug(message.WrapError(apiErr, msg))
+				}
+				return true, err
+			}
+			grip.Info(msg)
+			return false, nil
+		}, awsClientDefaultRetryOptions())
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+func (c *awsClientImpl) ReleaseAddress(ctx context.Context, input *ec2.ReleaseAddressInput) (*ec2.ReleaseAddressOutput, error) {
+	var output *ec2.ReleaseAddressOutput
+	var err error
+	err = utility.Retry(
+		ctx,
+		func() (bool, error) {
+			msg := makeAWSLogMessage("ReleaseAddress", fmt.Sprintf("%T", c), input)
+			output, err = c.ec2Client.ReleaseAddress(ctx, input)
+			if err != nil {
+				var apiErr smithy.APIError
+				if errors.As(err, &apiErr) {
+					grip.Debug(message.WrapError(apiErr, msg))
+				}
+				return true, err
+			}
+			grip.Info(msg)
+			return false, nil
+		}, awsClientDefaultRetryOptions())
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
 func (c *awsClientImpl) ChangeResourceRecordSets(ctx context.Context, input *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
 	var output *route53.ChangeResourceRecordSetsOutput
 	var err error
@@ -1030,6 +1135,14 @@ type awsClientMock struct { //nolint
 	*ec2.CreateLaunchTemplateInput
 	*ec2.DeleteLaunchTemplateInput
 	*ec2.CreateFleetInput
+	*ec2.AllocateAddressInput
+	*ec2.AllocateAddressOutput
+	*ec2.AssociateAddressInput
+	*ec2.AssociateAddressOutput
+	*ec2.DisassociateAddressInput
+	*ec2.DisassociateAddressOutput
+	*ec2.ReleaseAddressInput
+	*ec2.ReleaseAddressOutput
 	*sts.AssumeRoleInput
 	*sts.GetCallerIdentityOutput
 
@@ -1359,6 +1472,26 @@ func (c *awsClientMock) GetPublicDNSName(ctx context.Context, h *host.Host) (str
 	}
 
 	return "public_dns_name", nil
+}
+
+func (c *awsClientMock) AllocateAddress(ctx context.Context, input *ec2.AllocateAddressInput) (*ec2.AllocateAddressOutput, error) {
+	c.AllocateAddressInput = input
+	return c.AllocateAddressOutput, nil
+}
+
+func (c *awsClientMock) AssociateAddress(ctx context.Context, input *ec2.AssociateAddressInput) (*ec2.AssociateAddressOutput, error) {
+	c.AssociateAddressInput = input
+	return c.AssociateAddressOutput, nil
+}
+
+func (c *awsClientMock) DisassociateAddress(ctx context.Context, input *ec2.DisassociateAddressInput) (*ec2.DisassociateAddressOutput, error) {
+	c.DisassociateAddressInput = input
+	return c.DisassociateAddressOutput, nil
+}
+
+func (c *awsClientMock) ReleaseAddress(ctx context.Context, input *ec2.ReleaseAddressInput) (*ec2.ReleaseAddressOutput, error) {
+	c.ReleaseAddressInput = input
+	return c.ReleaseAddressOutput, nil
 }
 
 func (c *awsClientMock) ChangeResourceRecordSets(ctx context.Context, input *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -944,10 +944,6 @@ func (c *awsClientImpl) AllocateAddress(ctx context.Context, input *ec2.Allocate
 			msg := makeAWSLogMessage("AllocateAddress", fmt.Sprintf("%T", c), input)
 			output, err = c.ec2Client.AllocateAddress(ctx, input)
 			if err != nil {
-				grip.Error(message.WrapError(err, message.Fields{
-					"message": "kim: AllocateAddress error",
-					"input":   *input,
-				}))
 				var apiErr smithy.APIError
 				if errors.As(err, &apiErr) {
 					grip.Debug(message.WrapError(apiErr, msg))
@@ -975,10 +971,6 @@ func (c *awsClientImpl) AssociateAddress(ctx context.Context, input *ec2.Associa
 			msg := makeAWSLogMessage("AssociateAddress", fmt.Sprintf("%T", c), input)
 			output, err = c.ec2Client.AssociateAddress(ctx, input)
 			if err != nil {
-				grip.Error(message.WrapError(err, message.Fields{
-					"message": "kim: AssociateAddress error",
-					"input":   *input,
-				}))
 				var apiErr smithy.APIError
 				if errors.As(err, &apiErr) {
 					grip.Debug(message.WrapError(apiErr, msg))

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -936,6 +936,8 @@ func (c *awsClientImpl) AllocateAddress(ctx context.Context, input *ec2.Allocate
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			// kim: TODO: handle non-retryable errors, like if there's no
+			// addresses in the pool.
 			msg := makeAWSLogMessage("AllocateAddress", fmt.Sprintf("%T", c), input)
 			output, err = c.ec2Client.AllocateAddress(ctx, input)
 			if err != nil {
@@ -954,12 +956,16 @@ func (c *awsClientImpl) AllocateAddress(ctx context.Context, input *ec2.Allocate
 	return output, nil
 }
 
+// kim: TODO: consider using fewer retries for IPAM API calls to avoid taking up
+// too much time.
 func (c *awsClientImpl) AssociateAddress(ctx context.Context, input *ec2.AssociateAddressInput) (*ec2.AssociateAddressOutput, error) {
 	var output *ec2.AssociateAddressOutput
 	var err error
 	err = utility.Retry(
 		ctx,
 		func() (bool, error) {
+			// kim: TODO: handle non-retryable errors, like if the address is
+			// already associated.
 			msg := makeAWSLogMessage("AssociateAddress", fmt.Sprintf("%T", c), input)
 			output, err = c.ec2Client.AssociateAddress(ctx, input)
 			if err != nil {

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -116,10 +116,6 @@ type AWSClient interface {
 	AllocateAddress(context.Context, *ec2.AllocateAddressInput) (*ec2.AllocateAddressOutput, error)
 	// AssociateAddress is a wrapper for ec2.AssociateAddress.
 	AssociateAddress(context.Context, *ec2.AssociateAddressInput) (*ec2.AssociateAddressOutput, error)
-	// DisassociateAddress is a wrapper for ec2.DisassociateAddress.
-	DisassociateAddress(context.Context, *ec2.DisassociateAddressInput) (*ec2.DisassociateAddressOutput, error)
-	// ReleaseAddress is a wrapper for ec2.ReleaseAddress.
-	ReleaseAddress(context.Context, *ec2.ReleaseAddressInput) (*ec2.ReleaseAddressOutput, error)
 
 	GetPublicDNSName(ctx context.Context, h *host.Host) (string, error)
 
@@ -989,54 +985,6 @@ func (c *awsClientImpl) AssociateAddress(ctx context.Context, input *ec2.Associa
 	return output, nil
 }
 
-func (c *awsClientImpl) DisassociateAddress(ctx context.Context, input *ec2.DisassociateAddressInput) (*ec2.DisassociateAddressOutput, error) {
-	var output *ec2.DisassociateAddressOutput
-	var err error
-	err = utility.Retry(
-		ctx,
-		func() (bool, error) {
-			msg := makeAWSLogMessage("DisassociateAddress", fmt.Sprintf("%T", c), input)
-			output, err = c.ec2Client.DisassociateAddress(ctx, input)
-			if err != nil {
-				var apiErr smithy.APIError
-				if errors.As(err, &apiErr) {
-					grip.Debug(message.WrapError(apiErr, msg))
-				}
-				return true, err
-			}
-			grip.Info(msg)
-			return false, nil
-		}, awsClientDefaultRetryOptions())
-	if err != nil {
-		return nil, err
-	}
-	return output, nil
-}
-
-func (c *awsClientImpl) ReleaseAddress(ctx context.Context, input *ec2.ReleaseAddressInput) (*ec2.ReleaseAddressOutput, error) {
-	var output *ec2.ReleaseAddressOutput
-	var err error
-	err = utility.Retry(
-		ctx,
-		func() (bool, error) {
-			msg := makeAWSLogMessage("ReleaseAddress", fmt.Sprintf("%T", c), input)
-			output, err = c.ec2Client.ReleaseAddress(ctx, input)
-			if err != nil {
-				var apiErr smithy.APIError
-				if errors.As(err, &apiErr) {
-					grip.Debug(message.WrapError(apiErr, msg))
-				}
-				return true, err
-			}
-			grip.Info(msg)
-			return false, nil
-		}, awsClientDefaultRetryOptions())
-	if err != nil {
-		return nil, err
-	}
-	return output, nil
-}
-
 func (c *awsClientImpl) ChangeResourceRecordSets(ctx context.Context, input *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {
 	var output *route53.ChangeResourceRecordSetsOutput
 	var err error
@@ -1150,10 +1098,6 @@ type awsClientMock struct { //nolint
 	*ec2.AllocateAddressOutput
 	*ec2.AssociateAddressInput
 	*ec2.AssociateAddressOutput
-	*ec2.DisassociateAddressInput
-	*ec2.DisassociateAddressOutput
-	*ec2.ReleaseAddressInput
-	*ec2.ReleaseAddressOutput
 	*sts.AssumeRoleInput
 	*sts.GetCallerIdentityOutput
 
@@ -1493,16 +1437,6 @@ func (c *awsClientMock) AllocateAddress(ctx context.Context, input *ec2.Allocate
 func (c *awsClientMock) AssociateAddress(ctx context.Context, input *ec2.AssociateAddressInput) (*ec2.AssociateAddressOutput, error) {
 	c.AssociateAddressInput = input
 	return c.AssociateAddressOutput, nil
-}
-
-func (c *awsClientMock) DisassociateAddress(ctx context.Context, input *ec2.DisassociateAddressInput) (*ec2.DisassociateAddressOutput, error) {
-	c.DisassociateAddressInput = input
-	return c.DisassociateAddressOutput, nil
-}
-
-func (c *awsClientMock) ReleaseAddress(ctx context.Context, input *ec2.ReleaseAddressInput) (*ec2.ReleaseAddressOutput, error) {
-	c.ReleaseAddressInput = input
-	return c.ReleaseAddressOutput, nil
 }
 
 func (c *awsClientMock) ChangeResourceRecordSets(ctx context.Context, input *route53.ChangeResourceRecordSetsInput) (*route53.ChangeResourceRecordSetsOutput, error) {

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -759,3 +759,17 @@ func shouldAssignPublicIPv4Address(h *host.Host, ec2Settings *EC2ProviderSetting
 
 	return !ec2Settings.DoNotAssignPublicIPv4Address && !ec2Settings.IPv6
 }
+
+func canUseIPAM(settings *evergreen.Settings, ec2Settings *EC2ProviderSettings, h *host.Host) bool {
+	if h.UserHost || h.SpawnOptions.SpawnedByTask {
+		// Spawn hosts and host.create hosts do not need to use IPAM because the
+		// feature is primarily intended for task hosts.
+		return false
+	}
+	// kim: TODO: needs DEVPROD-16708 for admin setting.
+	if settings.Providers.AWS.IPAMPoolID == "" {
+		return false
+	}
+
+	return ec2Settings.IPAMEnabled
+}

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -780,7 +780,7 @@ func canUseElasticIP(settings *evergreen.Settings, ec2Settings *EC2ProviderSetti
 		return false
 	}
 
-	return ec2Settings.IPAMEnabled
+	return ec2Settings.ElasticIPsEnabled
 }
 
 // allocateIPAddressForHost allocates an elastic IP address from an IPAM pool

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -37,6 +37,8 @@ var (
 	TagKey                                 = bsonutil.MustHaveTag(Host{}, "Tag")
 	DistroKey                              = bsonutil.MustHaveTag(Host{}, "Distro")
 	ProviderKey                            = bsonutil.MustHaveTag(Host{}, "Provider")
+	IPAllocationIDKey                      = bsonutil.MustHaveTag(Host{}, "IPAllocationID")
+	IPAssociationIDKey                     = bsonutil.MustHaveTag(Host{}, "IPAssociationID")
 	IPKey                                  = bsonutil.MustHaveTag(Host{}, "IP")
 	IPv4Key                                = bsonutil.MustHaveTag(Host{}, "IPv4")
 	PersistentDNSNameKey                   = bsonutil.MustHaveTag(Host{}, "PersistentDNSName")

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -48,10 +48,10 @@ type Host struct {
 	Distro          distro.Distro `bson:"distro" json:"distro"`
 	Provider        string        `bson:"host_type" json:"host_type"`
 	// IPAllocationID is the ID for the IP allocated to this host.
-	// Only set for hosts using IPAM.
+	// Only set for hosts using elastic IPs.
 	IPAllocationID string `bson:"ip_allocation_id,omitempty" json:"ip_allocation_id,omitempty"`
 	// IPAssociationID is the ID for the association link between this host and
-	// its IP. Only set for hosts using IPAM.
+	// its IP. Only set for hosts using elastic IPs.
 	IPAssociationID string `bson:"ip_association_id,omitempty" json:"ip_association_id,omitempty"`
 	// IP holds the IPv6 address when applicable.
 	IP string `bson:"ip_address" json:"ip_address"`

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -51,6 +51,9 @@ type Host struct {
 	IP string `bson:"ip_address" json:"ip_address"`
 	// IPv4 is the host's private IPv4 address.
 	IPv4 string `bson:"ipv4_address" json:"ipv4_address"`
+	// IPAllocationID is the ID associated with the IP allocated for this host.
+	// Only sets for hosts using IPAM.
+	IPAllocationID string `bson:"ip_allocation_id,omitempty" json:"ip_allocation_id,omitempty"`
 	// PersistentDNSName is the long-lived DNS name of the host, which should
 	// never change once set.
 	PersistentDNSName string `bson:"persistent_dns_name,omitempty" json:"persistent_dns_name,omitempty"`

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -430,17 +430,6 @@ func (j *createHostJob) isImageBuilt(ctx context.Context) (bool, error) {
 
 // spawnAndUpdateHost attempts to spawn the host and update the host document.
 func (j *createHostJob) spawnAndReplaceHost(ctx context.Context, cloudMgr cloud.Manager) (replaced bool, err error) {
-	// Use a context that ignores cancellation because this is a set of critical
-	// operations that, in an ideal world, would occur atomically.
-	// Unfortunately, they don't occur atomically, so if any
-	// external resources are created in the cloud provider during SpawnHost
-	// when the job context cancels (e.g. due to an app server shutdown), it's
-	// best to try continuing onward, because those resources must be saved back
-	// to the host document. Trying to save the info reduces the likelihood of
-	// resource leaks.
-	// kim: TODO: determine whether this is really worth adding. Probably not
-	// ctx = context.WithoutCancel(ctx)
-
 	if _, err = cloudMgr.SpawnHost(ctx, j.host); err != nil {
 		return false, errors.Wrapf(err, "spawning host '%s'", j.host.Id)
 	}


### PR DESCRIPTION
DEVPROD-16710

### Description
Think of this as just a POC. There will be follow-up work to investigate how it behaves at scale + make it more resilient to problems.

We've been asked to start using elastic IP addresses from an IPAM pool (basically a pool of IP addresses owned by MongoDB) because AWS will start charging us for using IP addresses that they provide to us as a convenience via `AssociatePublicIpAddress`. To support elastic IPs, Evergreen's host lifecycle has to be modified significantly to both ensure that hosts get assigned elastic IPs _and_ that we clean up the elastic IPs properly. For now, I only wrote the logic to give a host an elastic IP, which isn't actually enough to enable the feature yet because those IPs have to be cleaned up. Later PRs will deal with the issue of cleaning them up and other problems that may come up.

Just a warning that I might significantly rewrite this implementation depending on what issues come up in prod. I foresee that there will likely be multiple problems so I'll need some time to experiment with it in prod.

* Use elastic IPs from an IPAM pool for task hosts with EC2 on-demand and fleet. Put behind a distro feature flag for now.
* Fall back to using an AWS-provided IP address if Evergreen can't allocate an elastic IP for the host.

### Testing
* Tested in staging and verified that a host could start with an elastic IP address and fell back to using a regular AWS-provided IP address if it couldn't get an elastic IP.
* I intentionally didn't add tests because I'm not actually that convinced this will work smoothly. I'll add unit tests once we determine how well it behaves in prod.

### Documentation
N/A