### PR TITLE
DEVPROD-17177 Format AssumeRole expiration with standard time format

### DIFF
--- a/agent/command/s3_evergreen_credentials.go
+++ b/agent/command/s3_evergreen_credentials.go
@@ -10,8 +10,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const defaultTimeFormat = "2006-01-02 15:04:05.999999999 -0700 MST"
-
 // evergreenCredentialProvider is an AWS credential provider that
 // retrieves credentials from Evergreen.
 type evergreenCredentialProvider struct {
@@ -49,7 +47,7 @@ func (p *evergreenCredentialProvider) Retrieve(ctx context.Context) (aws.Credent
 		return aws.Credentials{}, errors.New("nil credentials returned")
 	}
 
-	expires, err := time.Parse(defaultTimeFormat, creds.Expiration)
+	expires, err := time.Parse(time.RFC3339, creds.Expiration)
 	if err != nil {
 		return aws.Credentials{}, errors.Wrap(err, "parsing expiration time")
 	}

--- a/agent/command/s3_evergreen_credentials.go
+++ b/agent/command/s3_evergreen_credentials.go
@@ -10,6 +10,8 @@ import (
 	"github.com/pkg/errors"
 )
 
+const defaultTimeFormat = "2006-01-02 15:04:05.999999999 -0700 MST"
+
 // evergreenCredentialProvider is an AWS credential provider that
 // retrieves credentials from Evergreen.
 type evergreenCredentialProvider struct {
@@ -47,7 +49,7 @@ func (p *evergreenCredentialProvider) Retrieve(ctx context.Context) (aws.Credent
 		return aws.Credentials{}, errors.New("nil credentials returned")
 	}
 
-	expires, err := time.Parse(time.RFC3339, creds.Expiration)
+	expires, err := time.Parse(defaultTimeFormat, creds.Expiration)
 	if err != nil {
 		return aws.Credentials{}, errors.Wrap(err, "parsing expiration time")
 	}

--- a/agent/command/s3_evergreen_credentials_test.go
+++ b/agent/command/s3_evergreen_credentials_test.go
@@ -21,24 +21,7 @@ func TestEvergreenCredentials(t *testing.T) {
 	})
 
 	t.Run("RoleARN", func(t *testing.T) {
-		expires := time.Now().Add(time.Hour).Format(time.RFC3339)
-		comm.AssumeRoleResponse = &apimodels.AWSCredentials{
-			AccessKeyID:     "assume_access_key",
-			SecretAccessKey: "secret_access_key",
-			SessionToken:    "session_token",
-			Expiration:      expires,
-		}
-
-		provider := createEvergreenCredentials(comm, taskData, "role_arn")
-
-		creds, err := provider.Retrieve(t.Context())
-		require.NoError(t, err)
-		assert.Equal(t, "assume_access_key", creds.AccessKeyID)
-		assert.Equal(t, "secret_access_key", creds.SecretAccessKey)
-		assert.Equal(t, "session_token", creds.SessionToken)
-		assert.Equal(t, expires, creds.Expires.Format(time.RFC3339))
-
-		t.Run("FailsWithInvalidTimeFormat", func(t *testing.T) {
+		t.Run("PassesWithValidTimeFormat", func(t *testing.T) {
 			expires := time.Now().Add(time.Hour).String()
 			comm.AssumeRoleResponse = &apimodels.AWSCredentials{
 				AccessKeyID:     "assume_access_key",
@@ -52,6 +35,25 @@ func TestEvergreenCredentials(t *testing.T) {
 			creds, err := provider.Retrieve(t.Context())
 			require.Error(t, err)
 			assert.Empty(t, creds)
+		})
+
+		t.Run("FailsWithInvalidTimeFormat", func(t *testing.T) {
+			expires := time.Now().Add(time.Hour).Format(time.RFC3339)
+			comm.AssumeRoleResponse = &apimodels.AWSCredentials{
+				AccessKeyID:     "assume_access_key",
+				SecretAccessKey: "secret_access_key",
+				SessionToken:    "session_token",
+				Expiration:      expires,
+			}
+
+			provider := createEvergreenCredentials(comm, taskData, "role_arn")
+
+			creds, err := provider.Retrieve(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, "assume_access_key", creds.AccessKeyID)
+			assert.Equal(t, "secret_access_key", creds.SecretAccessKey)
+			assert.Equal(t, "session_token", creds.SessionToken)
+			assert.Equal(t, expires, creds.Expires.Format(time.RFC3339))
 		})
 	})
 }

--- a/agent/command/s3_evergreen_credentials_test.go
+++ b/agent/command/s3_evergreen_credentials_test.go
@@ -51,7 +51,7 @@ func TestEvergreenCredentials(t *testing.T) {
 
 			creds, err := provider.Retrieve(t.Context())
 			require.Error(t, err)
-			assert.Nil(t, creds)
+			assert.Empty(t, creds)
 		})
 	})
 }

--- a/agent/command/s3_evergreen_credentials_test.go
+++ b/agent/command/s3_evergreen_credentials_test.go
@@ -37,5 +37,21 @@ func TestEvergreenCredentials(t *testing.T) {
 		assert.Equal(t, "secret_access_key", creds.SecretAccessKey)
 		assert.Equal(t, "session_token", creds.SessionToken)
 		assert.Equal(t, expires, creds.Expires.Format(time.RFC3339))
+
+		t.Run("FailsWithInvalidTimeFormat", func(t *testing.T) {
+			expires := time.Now().Add(time.Hour).String()
+			comm.AssumeRoleResponse = &apimodels.AWSCredentials{
+				AccessKeyID:     "assume_access_key",
+				SecretAccessKey: "secret_access_key",
+				SessionToken:    "session_token",
+				Expiration:      expires,
+			}
+
+			provider := createEvergreenCredentials(comm, taskData, "role_arn")
+
+			creds, err := provider.Retrieve(t.Context())
+			require.Error(t, err)
+			assert.Nil(t, creds)
+		})
 	})
 }

--- a/agent/command/s3_evergreen_credentials_test.go
+++ b/agent/command/s3_evergreen_credentials_test.go
@@ -22,22 +22,6 @@ func TestEvergreenCredentials(t *testing.T) {
 
 	t.Run("RoleARN", func(t *testing.T) {
 		t.Run("PassesWithValidTimeFormat", func(t *testing.T) {
-			expires := time.Now().Add(time.Hour).String()
-			comm.AssumeRoleResponse = &apimodels.AWSCredentials{
-				AccessKeyID:     "assume_access_key",
-				SecretAccessKey: "secret_access_key",
-				SessionToken:    "session_token",
-				Expiration:      expires,
-			}
-
-			provider := createEvergreenCredentials(comm, taskData, "role_arn")
-
-			creds, err := provider.Retrieve(t.Context())
-			require.Error(t, err)
-			assert.Empty(t, creds)
-		})
-
-		t.Run("FailsWithInvalidTimeFormat", func(t *testing.T) {
 			expires := time.Now().Add(time.Hour).Format(time.RFC3339)
 			comm.AssumeRoleResponse = &apimodels.AWSCredentials{
 				AccessKeyID:     "assume_access_key",
@@ -54,6 +38,22 @@ func TestEvergreenCredentials(t *testing.T) {
 			assert.Equal(t, "secret_access_key", creds.SecretAccessKey)
 			assert.Equal(t, "session_token", creds.SessionToken)
 			assert.Equal(t, expires, creds.Expires.Format(time.RFC3339))
+		})
+
+		t.Run("FailsWithInvalidTimeFormat", func(t *testing.T) {
+			expires := time.Now().Add(time.Hour).String()
+			comm.AssumeRoleResponse = &apimodels.AWSCredentials{
+				AccessKeyID:     "assume_access_key",
+				SecretAccessKey: "secret_access_key",
+				SessionToken:    "session_token",
+				Expiration:      expires,
+			}
+
+			provider := createEvergreenCredentials(comm, taskData, "role_arn")
+
+			creds, err := provider.Retrieve(t.Context())
+			require.Error(t, err)
+			assert.Empty(t, creds)
 		})
 	})
 }

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1846,6 +1846,6 @@ func (h *awsAssumeRole) Run(ctx context.Context) gimlet.Responder {
 		AccessKeyID:     creds.AccessKeyID,
 		SecretAccessKey: creds.SecretAccessKey,
 		SessionToken:    creds.SessionToken,
-		Expiration:      creds.Expiration.String(),
+		Expiration:      creds.Expiration.Format(time.RFC3339),
 	})
 }

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1846,6 +1846,6 @@ func (h *awsAssumeRole) Run(ctx context.Context) gimlet.Responder {
 		AccessKeyID:     creds.AccessKeyID,
 		SecretAccessKey: creds.SecretAccessKey,
 		SessionToken:    creds.SessionToken,
-		Expiration:      creds.Expiration.Format(time.RFC3339),
+		Expiration:      creds.Expiration.String(),
 	})
 }

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -960,18 +960,15 @@ func TestAWSAssumeRole(t *testing.T) {
 		t.Run(tName, func(t *testing.T) {
 			require.NoError(t, db.ClearCollections(task.Collection))
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			env := &mock.Environment{}
-			require.NoError(t, env.Configure(ctx))
+			require.NoError(t, env.Configure(t.Context()))
 
 			manager := cloud.GetSTSManager(true)
 
 			r, ok := makeAWSAssumeRole(manager).(*awsAssumeRole)
 			require.True(t, ok)
 
-			tCase(ctx, t, r)
+			tCase(t.Context(), t, r)
 		})
 	}
 


### PR DESCRIPTION
DEVPROD-17177

### Description
Some [tasks](https://parsley.mongodb.com/evergreen/mongodb_atlas_cli_master_code_health_compile_patch_487d0d2a201d4f35a266849641c3cf69ce7f175c_680a63903175fa0007637a23_25_04_24_16_15_26/0/task?bookmarks=0,57&shareLine=38) are encountering that the time format is not being parsed correctly when getting the expiration.

### Testing
Add fail unit test
