### PR TITLE
DEVPROD-16713: release elastic IP when host is terminated

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -41,7 +41,8 @@ type Manager interface {
 	// SetPortMappings sets the port mappings for the container
 	SetPortMappings(context.Context, *host.Host, *host.Host) error
 
-	// TerminateInstance destroys the host in the underlying provider
+	// TerminateInstance destroys the host in the underlying provider and cleans
+	// up IP resources associated with the host, if any (see CleanupIP).
 	TerminateInstance(context.Context, *host.Host, string, string) error
 
 	// StopInstance stops an instance.
@@ -77,6 +78,10 @@ type Manager interface {
 	// TimeTilNextPayment returns how long there is until the next payment
 	// is due for a particular host
 	TimeTilNextPayment(*host.Host) time.Duration
+
+	// CleanupIP cleans up the IP address resources for a host, if it has any.
+	// If calling TerminateInstance, CleanupIP is not needed.
+	CleanupIP(context.Context, *host.Host) error
 
 	// Cleanup triggers the manager to clean up resources left behind by day-to-day operations.
 	Cleanup(context.Context) error

--- a/cloud/cloud_host.go
+++ b/cloud/cloud_host.go
@@ -53,3 +53,7 @@ func (cloudHost *CloudHost) GetInstanceState(ctx context.Context) (CloudInstance
 func (cloudHost *CloudHost) GetDNSName(ctx context.Context) (string, error) {
 	return cloudHost.CloudMgr.GetDNSName(ctx, cloudHost.Host)
 }
+
+func (cloudHost *CloudHost) CleanupIP(ctx context.Context) error {
+	return cloudHost.CloudMgr.CleanupIP(ctx, cloudHost.Host)
+}

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -296,6 +296,10 @@ func (m *dockerManager) Configure(ctx context.Context, s *evergreen.Settings) er
 	return nil
 }
 
+func (m *dockerManager) CleanupIP(context.Context, *host.Host) error {
+	return nil
+}
+
 // Cleanup is a noop for the docker provider.
 func (m *dockerManager) Cleanup(context.Context) error {
 	return nil

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1388,10 +1388,10 @@ func (m *ec2Manager) TimeTilNextPayment(host *host.Host) time.Duration {
 // releases the IP address back into the IPAM pool.
 func (m *ec2Manager) CleanupIP(ctx context.Context, h *host.Host) error {
 	if err := disassociateIPAddressForHost(ctx, m.client, h); err != nil {
-		return errors.Wrapf(err, "disassociating host IP address with association ID '%s'", h.IPAssociationID)
+		return err
 	}
 	if err := releaseIPAddressForHost(ctx, m.client, h); err != nil {
-		return errors.Wrapf(err, "releasing host IP address with allocation ID '%s'", h.IPAllocationID)
+		return err
 	}
 	return nil
 }

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -300,21 +300,8 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 		input.IamInstanceProfile = &types.IamInstanceProfileSpecification{Arn: aws.String(ec2Settings.IAMInstanceProfileARN)}
 	}
 
-	useElasticIP := shouldAssignPublicIPv4Address(h, ec2Settings) && canUseElasticIP(m.settings, ec2Settings, h)
-	if useElasticIP && h.IPAllocationID == "" {
-		// If the host can't be allocated an IP address, continue on error
-		// because the host should fall back to using an AWS-provided IP
-		// address. Using an elastic IP address is a best-effort attempt to save
-		// money.
-		grip.Notice(message.WrapError(allocateIPAddressForHost(ctx, m.settings, m.client, h), message.Fields{
-			"message": "could not allocate elastic IP address for host, falling back to using AWS-managed IP",
-			"host_id": h.Id,
-		}))
-	}
-
 	assignPublicIPv4 := shouldAssignPublicIPv4Address(h, ec2Settings)
-
-	useElasticIP := assignPublicIPv4 && canUseElasticIP(m.settings, ec2Settings, h)
+	useElasticIP := assignPublicIPv4 && canUseElasticIP(m.settings, ec2Settings, m.account, h)
 	if useElasticIP && h.IPAllocationID == "" {
 		// If the host can't be allocated an IP address, continue on error
 		// because the host should fall back to using an AWS-provided IP

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -929,15 +929,33 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 		}))
 	}
 
-	if h.IPAssociationID != "" {
-		grip.Error(message.WrapError(disassociateIPAddressForHost(ctx, m.client, h), message.Fields{
-			"message":        "could not disassociate elastic IP address from host",
-			"host_id":        h.Id,
-			"association_id": h.IPAssociationID,
-			"allocation_id":  h.IPAllocationID,
-		}))
-	}
+	grip.Info(message.Fields{
+		"message":        "kim: start disassociating IP address",
+		"provider":       h.Distro.Provider,
+		"host_id":        h.Id,
+		"association_id": h.IPAssociationID,
+		"allocation_id":  h.IPAllocationID,
+	})
+	grip.Error(message.WrapError(disassociateIPAddressForHost(ctx, m.client, h), message.Fields{
+		"message":        "could not disassociate elastic IP address from host",
+		"provider":       h.Distro.Provider,
+		"host_id":        h.Id,
+		"association_id": h.IPAssociationID,
+		"allocation_id":  h.IPAllocationID,
+	}))
+	grip.Info(message.Fields{
+		"message":        "kim: finished disassociating IP address",
+		"provider":       h.Distro.Provider,
+		"host_id":        h.Id,
+		"association_id": h.IPAssociationID,
+		"allocation_id":  h.IPAllocationID,
+	})
 
+	grip.Info(message.Fields{
+		"message":  "kim: start terminating host",
+		"provider": h.Distro.Provider,
+		"host_id":  h.Id,
+	})
 	resp, err := m.client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
 		InstanceIds: []string{h.Id},
 	})
@@ -951,6 +969,11 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 		}))
 		return err
 	}
+	grip.Info(message.Fields{
+		"message":  "kim: finished terminating host",
+		"provider": h.Distro.Provider,
+		"host_id":  h.Id,
+	})
 
 	for _, stateChange := range resp.TerminatingInstances {
 		grip.Info(message.Fields{
@@ -963,14 +986,27 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 		})
 	}
 
-	if h.IPAllocationID != "" {
-		grip.Error(message.WrapError(releaseIPAddressForHost(ctx, m.client, h), message.Fields{
-			"message":        "could not release elastic IP address from host",
-			"host_id":        h.Id,
-			"association_id": h.IPAssociationID,
-			"allocation_id":  h.IPAllocationID,
-		}))
-	}
+	grip.Info(message.Fields{
+		"message":        "kim: start releasing IP address",
+		"provider":       h.Distro.Provider,
+		"host_id":        h.Id,
+		"association_id": h.IPAssociationID,
+		"allocation_id":  h.IPAllocationID,
+	})
+	grip.Error(message.WrapError(releaseIPAddressForHost(ctx, m.client, h), message.Fields{
+		"message":        "could not release elastic IP address from host",
+		"provider":       h.Distro.Provider,
+		"host_id":        h.Id,
+		"association_id": h.IPAssociationID,
+		"allocation_id":  h.IPAllocationID,
+	}))
+	grip.Info(message.Fields{
+		"message":        "kim: finished releasing IP address",
+		"provider":       h.Distro.Provider,
+		"host_id":        h.Id,
+		"association_id": h.IPAssociationID,
+		"allocation_id":  h.IPAllocationID,
+	})
 
 	for _, vol := range h.Volumes {
 		volDB, err := host.FindVolumeByID(ctx, vol.VolumeID)

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -929,13 +929,6 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 		}))
 	}
 
-	grip.Info(message.Fields{
-		"message":        "kim: start disassociating IP address",
-		"provider":       h.Distro.Provider,
-		"host_id":        h.Id,
-		"association_id": h.IPAssociationID,
-		"allocation_id":  h.IPAllocationID,
-	})
 	grip.Error(message.WrapError(disassociateIPAddressForHost(ctx, m.client, h), message.Fields{
 		"message":        "could not disassociate elastic IP address from host",
 		"provider":       h.Distro.Provider,
@@ -943,19 +936,7 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 		"association_id": h.IPAssociationID,
 		"allocation_id":  h.IPAllocationID,
 	}))
-	grip.Info(message.Fields{
-		"message":        "kim: finished disassociating IP address",
-		"provider":       h.Distro.Provider,
-		"host_id":        h.Id,
-		"association_id": h.IPAssociationID,
-		"allocation_id":  h.IPAllocationID,
-	})
 
-	grip.Info(message.Fields{
-		"message":  "kim: start terminating host",
-		"provider": h.Distro.Provider,
-		"host_id":  h.Id,
-	})
 	resp, err := m.client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
 		InstanceIds: []string{h.Id},
 	})
@@ -969,11 +950,6 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 		}))
 		return err
 	}
-	grip.Info(message.Fields{
-		"message":  "kim: finished terminating host",
-		"provider": h.Distro.Provider,
-		"host_id":  h.Id,
-	})
 
 	for _, stateChange := range resp.TerminatingInstances {
 		grip.Info(message.Fields{
@@ -986,13 +962,6 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 		})
 	}
 
-	grip.Info(message.Fields{
-		"message":        "kim: start releasing IP address",
-		"provider":       h.Distro.Provider,
-		"host_id":        h.Id,
-		"association_id": h.IPAssociationID,
-		"allocation_id":  h.IPAllocationID,
-	})
 	grip.Error(message.WrapError(releaseIPAddressForHost(ctx, m.client, h), message.Fields{
 		"message":        "could not release elastic IP address from host",
 		"provider":       h.Distro.Provider,
@@ -1000,13 +969,6 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 		"association_id": h.IPAssociationID,
 		"allocation_id":  h.IPAllocationID,
 	}))
-	grip.Info(message.Fields{
-		"message":        "kim: finished releasing IP address",
-		"provider":       h.Distro.Provider,
-		"host_id":        h.Id,
-		"association_id": h.IPAssociationID,
-		"allocation_id":  h.IPAllocationID,
-	})
 
 	for _, vol := range h.Volumes {
 		volDB, err := host.FindVolumeByID(ctx, vol.VolumeID)

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -1002,6 +1002,9 @@ func (c *awsClientImpl) DisassociateAddress(ctx context.Context, input *ec2.Disa
 				if errors.As(err, &apiErr) {
 					grip.Debug(message.WrapError(apiErr, msg))
 				}
+				if strings.Contains(err.Error(), ec2AssociationIDNotFound) {
+					return false, err
+				}
 				return true, err
 			}
 			grip.Info(msg)

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -288,13 +288,33 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 		return errors.Wrap(err, "creating client")
 	}
 
+	grip.Info(message.Fields{
+		"message":        "kim: start disassociating IP address",
+		"provider":       h.Distro.Provider,
+		"host_id":        h.Id,
+		"association_id": h.IPAssociationID,
+		"allocation_id":  h.IPAllocationID,
+	})
 	grip.Error(message.WrapError(disassociateIPAddressForHost(ctx, m.client, h), message.Fields{
 		"message":        "could not disassociate elastic IP address from host",
+		"provider":       h.Distro.Provider,
 		"host_id":        h.Id,
 		"association_id": h.IPAssociationID,
 		"allocation_id":  h.IPAllocationID,
 	}))
+	grip.Info(message.Fields{
+		"message":        "kim: finished disassociating IP address",
+		"provider":       h.Distro.Provider,
+		"host_id":        h.Id,
+		"association_id": h.IPAssociationID,
+		"allocation_id":  h.IPAllocationID,
+	})
 
+	grip.Info(message.Fields{
+		"message":  "kim: start terminating host",
+		"provider": h.Distro.Provider,
+		"host_id":  h.Id,
+	})
 	resp, err := m.client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
 		InstanceIds: []string{h.Id},
 	})
@@ -308,6 +328,11 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 		}))
 		return err
 	}
+	grip.Info(message.Fields{
+		"message":  "kim: finished terminating host",
+		"provider": h.Distro.Provider,
+		"host_id":  h.Id,
+	})
 
 	for _, stateChange := range resp.TerminatingInstances {
 		grip.Info(message.Fields{
@@ -320,12 +345,27 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 		})
 	}
 
+	grip.Info(message.Fields{
+		"message":        "kim: start releasing IP address",
+		"provider":       h.Distro.Provider,
+		"host_id":        h.Id,
+		"association_id": h.IPAssociationID,
+		"allocation_id":  h.IPAllocationID,
+	})
 	grip.Error(message.WrapError(releaseIPAddressForHost(ctx, m.client, h), message.Fields{
 		"message":        "could not release elastic IP address from host",
+		"provider":       h.Distro.Provider,
 		"host_id":        h.Id,
 		"association_id": h.IPAssociationID,
 		"allocation_id":  h.IPAllocationID,
 	}))
+	grip.Info(message.Fields{
+		"message":        "kim: finished releasing IP address",
+		"provider":       h.Distro.Provider,
+		"host_id":        h.Id,
+		"association_id": h.IPAssociationID,
+		"allocation_id":  h.IPAllocationID,
+	})
 
 	return errors.Wrap(h.Terminate(ctx, user, reason), "terminating instance in DB")
 }

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -435,7 +435,7 @@ func (m *ec2FleetManager) spawnFleetSpotHost(ctx context.Context, h *host.Host, 
 		}))
 	}()
 
-	useElasticIP := shouldAssignPublicIPv4Address(h, ec2Settings) && canUseElasticIP(m.env.Settings(), ec2Settings, h)
+	useElasticIP := shouldAssignPublicIPv4Address(h, ec2Settings) && canUseElasticIP(m.env.Settings(), ec2Settings, m.account, h)
 	if useElasticIP && h.IPAllocationID == "" {
 		// If the host can't be allocated an IP address, continue on error
 		// because the host should fall back to using an AWS-provided IP

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -346,10 +346,10 @@ func (m *ec2FleetManager) StartInstance(context.Context, *host.Host, string) err
 // releases the IP address back into the IPAM pool.
 func (m *ec2FleetManager) CleanupIP(ctx context.Context, h *host.Host) error {
 	if err := disassociateIPAddressForHost(ctx, m.client, h); err != nil {
-		return errors.Wrapf(err, "disassociating host IP address with association ID '%s'", h.IPAssociationID)
+		return err
 	}
 	if err := releaseIPAddressForHost(ctx, m.client, h); err != nil {
-		return errors.Wrapf(err, "releasing host IP address with allocation ID '%s'", h.IPAllocationID)
+		return err
 	}
 	return nil
 }

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -288,13 +288,6 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 		return errors.Wrap(err, "creating client")
 	}
 
-	grip.Info(message.Fields{
-		"message":        "kim: start disassociating IP address",
-		"provider":       h.Distro.Provider,
-		"host_id":        h.Id,
-		"association_id": h.IPAssociationID,
-		"allocation_id":  h.IPAllocationID,
-	})
 	grip.Error(message.WrapError(disassociateIPAddressForHost(ctx, m.client, h), message.Fields{
 		"message":        "could not disassociate elastic IP address from host",
 		"provider":       h.Distro.Provider,
@@ -302,19 +295,7 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 		"association_id": h.IPAssociationID,
 		"allocation_id":  h.IPAllocationID,
 	}))
-	grip.Info(message.Fields{
-		"message":        "kim: finished disassociating IP address",
-		"provider":       h.Distro.Provider,
-		"host_id":        h.Id,
-		"association_id": h.IPAssociationID,
-		"allocation_id":  h.IPAllocationID,
-	})
 
-	grip.Info(message.Fields{
-		"message":  "kim: start terminating host",
-		"provider": h.Distro.Provider,
-		"host_id":  h.Id,
-	})
 	resp, err := m.client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
 		InstanceIds: []string{h.Id},
 	})
@@ -328,11 +309,6 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 		}))
 		return err
 	}
-	grip.Info(message.Fields{
-		"message":  "kim: finished terminating host",
-		"provider": h.Distro.Provider,
-		"host_id":  h.Id,
-	})
 
 	for _, stateChange := range resp.TerminatingInstances {
 		grip.Info(message.Fields{
@@ -345,13 +321,6 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 		})
 	}
 
-	grip.Info(message.Fields{
-		"message":        "kim: start releasing IP address",
-		"provider":       h.Distro.Provider,
-		"host_id":        h.Id,
-		"association_id": h.IPAssociationID,
-		"allocation_id":  h.IPAllocationID,
-	})
 	grip.Error(message.WrapError(releaseIPAddressForHost(ctx, m.client, h), message.Fields{
 		"message":        "could not release elastic IP address from host",
 		"provider":       h.Distro.Provider,
@@ -359,13 +328,6 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 		"association_id": h.IPAssociationID,
 		"allocation_id":  h.IPAllocationID,
 	}))
-	grip.Info(message.Fields{
-		"message":        "kim: finished releasing IP address",
-		"provider":       h.Distro.Provider,
-		"host_id":        h.Id,
-		"association_id": h.IPAssociationID,
-		"allocation_id":  h.IPAllocationID,
-	})
 
 	return errors.Wrap(h.Terminate(ctx, user, reason), "terminating instance in DB")
 }

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -288,6 +288,13 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 		return errors.Wrap(err, "creating client")
 	}
 
+	grip.Error(message.WrapError(disassociateIPAddressForHost(ctx, m.client, h), message.Fields{
+		"message":        "could not disassociate elastic IP address from host",
+		"host_id":        h.Id,
+		"association_id": h.IPAssociationID,
+		"allocation_id":  h.IPAllocationID,
+	}))
+
 	resp, err := m.client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
 		InstanceIds: []string{h.Id},
 	})
@@ -303,25 +310,22 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 	}
 
 	for _, stateChange := range resp.TerminatingInstances {
-		if stateChange.InstanceId == nil {
-			grip.Error(message.Fields{
-				"message":       "state change missing instance ID",
-				"user":          user,
-				"host_provider": h.Distro.Provider,
-				"host_id":       h.Id,
-				"distro":        h.Distro.Id,
-			})
-			return errors.New("TerminateInstances response did not contain an instance ID")
-		}
 		grip.Info(message.Fields{
 			"message":       "terminated instance",
 			"user":          user,
 			"host_provider": h.Distro.Provider,
-			"instance_id":   *stateChange.InstanceId,
+			"instance_id":   aws.ToString(stateChange.InstanceId),
 			"host_id":       h.Id,
 			"distro":        h.Distro.Id,
 		})
 	}
+
+	grip.Error(message.WrapError(releaseIPAddressForHost(ctx, m.client, h), message.Fields{
+		"message":        "could not release elastic IP address from host",
+		"host_id":        h.Id,
+		"association_id": h.IPAssociationID,
+		"allocation_id":  h.IPAllocationID,
+	}))
 
 	return errors.Wrap(h.Terminate(ctx, user, reason), "terminating instance in DB")
 }
@@ -334,6 +338,18 @@ func (m *ec2FleetManager) StopInstance(context.Context, *host.Host, bool, string
 // StartInstance should do nothing for EC2 Fleet.
 func (m *ec2FleetManager) StartInstance(context.Context, *host.Host, string) error {
 	return errors.New("can't start instances for EC2 fleet provider")
+}
+
+// CleanupIP disassociates the IP address from the host's network interface and
+// releases the IP address back into the IPAM pool.
+func (m *ec2FleetManager) CleanupIP(ctx context.Context, h *host.Host) error {
+	if err := disassociateIPAddressForHost(ctx, m.client, h); err != nil {
+		return errors.Wrapf(err, "disassociating host IP address with association ID '%s'", h.IPAssociationID)
+	}
+	if err := releaseIPAddressForHost(ctx, m.client, h); err != nil {
+		return errors.Wrapf(err, "releasing host IP address with allocation ID '%s'", h.IPAllocationID)
+	}
+	return nil
 }
 
 func (m *ec2FleetManager) Cleanup(ctx context.Context) error {

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -834,7 +834,7 @@ func releaseIPAddressForHost(ctx context.Context, c AWSClient, h *host.Host) err
 	_, err := c.ReleaseAddress(ctx, &ec2.ReleaseAddressInput{
 		AllocationId: aws.String(h.IPAllocationID),
 	})
-	return err
+	return errors.Wrapf(err, "releasing host IP address with allocation ID '%s'", h.IPAllocationID)
 }
 
 // associateIPAddressForHost associates the allocated IP address with the host.
@@ -871,5 +871,5 @@ func disassociateIPAddressForHost(ctx context.Context, c AWSClient, h *host.Host
 	_, err := c.DisassociateAddress(ctx, &ec2.DisassociateAddressInput{
 		AssociationId: aws.String(h.IPAssociationID),
 	})
-	return err
+	return errors.Wrapf(err, "disassociating host IP address with association ID '%s'", h.IPAssociationID)
 }

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -45,9 +45,6 @@ const (
 	// ec2ResourceAlreadyAssociated means an elastic IP is already associated
 	// with another resource.
 	ec2ResourceAlreadyAssociated = "Resource.AlreadyAssociated"
-	// ec2AssociationIDNotFound means that the association ID between a host and
-	// its elastic IP does not exist.
-	ec2AssociationIDNotFound = "InvalidAssociationID.NotFound"
 
 	r53InvalidInput       = "InvalidInput"
 	r53InvalidChangeBatch = "InvalidChangeBatch"

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -770,13 +770,18 @@ func shouldAssignPublicIPv4Address(h *host.Host, ec2Settings *EC2ProviderSetting
 	return !ec2Settings.DoNotAssignPublicIPv4Address && !ec2Settings.IPv6
 }
 
-func canUseElasticIP(settings *evergreen.Settings, ec2Settings *EC2ProviderSettings, h *host.Host) bool {
+func canUseElasticIP(settings *evergreen.Settings, ec2Settings *EC2ProviderSettings, account string, h *host.Host) bool {
 	if h.UserHost || h.SpawnOptions.SpawnedByTask {
 		// Spawn hosts and host.create hosts should not use an elastic IP
 		// because the feature is primarily intended for task hosts.
 		return false
 	}
 	if settings.Providers.AWS.IPAMPoolID == "" {
+		return false
+	}
+	if account != "" {
+		// The IPAM pool is only available to the default AWS account. Other AWS
+		// accounts do not have an IPAM pool so cannot use elastic IPs.
 		return false
 	}
 

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -763,9 +763,7 @@ func isEC2InstanceNotFound(err error) bool {
 }
 
 func shouldAssignPublicIPv4Address(h *host.Host, ec2Settings *EC2ProviderSettings) bool {
-	// kim: TODO: revert when done testing in spawn hosts.
-	// if h.UserHost || h.SpawnOptions.SpawnedByTask {
-	if h.SpawnOptions.SpawnedByTask {
+	if h.UserHost || h.SpawnOptions.SpawnedByTask {
 		// Spawn hosts and host.create hosts need to have a public IPv4 address
 		// because SSH is currently the only means for the user/task to access
 		// the host.
@@ -776,9 +774,7 @@ func shouldAssignPublicIPv4Address(h *host.Host, ec2Settings *EC2ProviderSetting
 }
 
 func canUseElasticIP(settings *evergreen.Settings, ec2Settings *EC2ProviderSettings, account string, h *host.Host) bool {
-	// kim: TODO: revert when done testing in spawn hosts.
-	// if h.UserHost || h.SpawnOptions.SpawnedByTask {
-	if h.SpawnOptions.SpawnedByTask {
+	if h.UserHost || h.SpawnOptions.SpawnedByTask {
 		// Spawn hosts and host.create hosts should not use an elastic IP
 		// because the feature is primarily intended for task hosts.
 		return false
@@ -866,15 +862,15 @@ func associateIPAddressForHost(ctx context.Context, c AWSClient, h *host.Host) e
 	return nil
 }
 
-// disassociateIPAddressForHost disassociates the elastic IP address from the
-// host, if it has an elastic IP.
+// disassociateIPAddressForHost initiates the process of disassociating the
+// elastic IP address from the host, if it has an elastic IP. This is not
+// synchronous, so the address is not guaranteed to be disassociated when this
+// returns.
 func disassociateIPAddressForHost(ctx context.Context, c AWSClient, h *host.Host) error {
 	if h.IPAssociationID == "" {
 		return nil
 	}
 
-	// kim: NOTE: this is not synchronous, so the address is not guaranteed to
-	// be disassociated when this returns.
 	_, err := c.DisassociateAddress(ctx, &ec2.DisassociateAddressInput{
 		AssociationId: aws.String(h.IPAssociationID),
 	})

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -453,6 +453,10 @@ func (m *mockManager) CheckInstanceType(ctx context.Context, instanceType string
 	return nil
 }
 
+func (m *mockManager) CleanupIP(ctx context.Context, h *host.Host) error {
+	return nil
+}
+
 // Cleanup is a noop for the mock provider.
 func (m *mockManager) Cleanup(context.Context) error {
 	return nil

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -150,6 +150,10 @@ func (staticMgr *staticManager) CheckInstanceType(context.Context, string) error
 	return errors.New("can't specify instance type with static provider")
 }
 
+func (staticMgr *staticManager) CleanupIP(context.Context, *host.Host) error {
+	return nil
+}
+
 // Cleanup is a noop for the static provider.
 func (staticMgr *staticManager) Cleanup(context.Context) error {
 	return nil


### PR DESCRIPTION
DEVPROD-16713

### Description
Builds off of #8967. Again, this is more like a POC and I might significantly rewrite this if it doesn't work well in prod.

#8967 added logic to use an elastic IP from an IPAM pool when creating a task host. This one cleans up the elastic IP when the host is terminated. This cleanup is best-effort when the host terminates but it's inevitable that we'll leak some elastic IPs (notably can leak due to unavoidable races in the host lifecycle or if the host's network interface holds onto the address for too long). There will be a follow-up to add reaper-like behavior to detect and clean up idle elastic IPs.

* Clean up elastic IP for an EC2 task host if it has one.
* Clean up elastic IP if an intent host has one (i.e. it couldn't create the EC2 host but did still allocate an elastic IP.)

### Testing
* Tested in staging that starting a host with an elastic IP and then terminating it cleaned up the IP address and released it back into the IPAM pool.
* Like #8967, I intentionally didn't add tests because I'm not actually that convinced this will work smoothly. I'll add unit tests once we determine how well it behaves in prod.
