### PR TITLE
DEVPROD-17176 Document requester types

### DIFF
--- a/docs/Project-Configuration/Evergreen-Data-for-Analytics.md
+++ b/docs/Project-Configuration/Evergreen-Data-for-Analytics.md
@@ -27,7 +27,7 @@ Daily aggregated statistics for task executions run in Evergreen. Tasks are aggr
 | project\_id                  | VARCHAR | Unique project identifier.
 | variant                      | VARCHAR | Name of the build variant on which the tasks ran.
 | task\_name                   | VARCHAR | Display name of the tasks.
-| request\_type                | VARCHAR | Name of the trigger that requested the task executions. Will always be one of: `patch_request`, `github_pull_request`, `gitter_request` (mainline), `trigger_request`, `github_merge_request` (GitHub merge queue), or `ad_hoc` (periodic build).
+| request\_type                | VARCHAR | Name of the trigger that requested the task executions. Will always be one of: `patch_request`, `github_pull_request`, `git_tag_request`, `gitter_request` (mainline), `trigger_request`, `github_merge_request` (GitHub merge queue), or `ad_hoc` (periodic build).
 | finish\_date                 | VARCHAR | Date, in ISO format `YYYY-MM-DD`, on which the tasks ran.
 | num\_success                 | BIGINT  | Number of successful task executions in the group.
 | num\_failed                  | BIGINT  | Number of failed task executions in the group.
@@ -53,7 +53,7 @@ Daily aggregated statistics for test executions run in Evergreen. Test stats are
 | variant                   | VARCHAR | Name of the build variant on which the tests ran.
 | task\_name                | VARCHAR | Name of the task that the test ran under. This is the display task name for tasks that are part of a display task.
 | test\_name                | VARCHAR | Display name of the tests.
-| request\_type             | VARCHAR | Name of the trigger that requested the task execution. Will always be one of: `patch_request`, `github_pull_request`, `gitter_request` (mainline), `trigger_request`, `github_merge_request` (GitHub merge queue), or `ad_hoc` (periodic build).
+| request\_type             | VARCHAR | Name of the trigger that requested the task execution. Will always be one of: `patch_request`, `github_pull_request`, `git_tag_request`, `gitter_request` (mainline), `trigger_request`, `github_merge_request` (GitHub merge queue), or `ad_hoc` (periodic build).
 | num\_pass                 | BIGINT  | Number of passing tests.
 | num\_fail                 | BIGINT  | Number of failing tests.
 | num\_status\_swaps        | BIGINT  | Number of test status changes between subsequent runs. Only available for tests that ran after 2024-09-15.
@@ -78,7 +78,7 @@ Finished Evergreen tasks, partitioned by the project and date (in ISO format). F
 | build\_id                     | VARCHAR        | ID of the build containing the task.
 | order                         | BIGINT         | Order number of the task's version. For patches this is the user's current patch submission count. For mainline versions this is the number of versions for that repository so far.
 | revision                      | VARCHAR        | Git commit SHA.
-| requester                     | VARCHAR        | Name of the trigger that requested the task execution. Will always be one of: `patch_request`, `github_pull_request`, `gitter_request` (mainline), `trigger_request`, `github_merge_request` (GitHub merge queue), or `ad_hoc` (periodic build).
+| requester                     | VARCHAR        | Name of the trigger that requested the task execution. Will always be one of: `patch_request`, `github_pull_request`, `git_tag_request`, `gitter_request` (mainline), `trigger_request`, `github_merge_request` (GitHub merge queue), or `ad_hoc` (periodic build).
 | tags                          | ARRAY(VARCHAR) | Array of task tags from project configuration.
 | priority                      | BIGINT         | Scheduling priority of the task.
 | task\_group                   | VARCHAR        | Name of the task group that contains this task.
@@ -174,7 +174,7 @@ Note that this is an estimated cost based solely on compute (`BoxUsage`) usage p
 | display\_name                 | VARCHAR        | Display name of the task, will be the parent task's display name if part of a display task.
 | build\_variant                | VARCHAR        | Name of the task's build variant.
 | build\_variant\_display\_name | VARCHAR        | Display name of the task's build variant.
-| requester                     | VARCHAR        | Name of the trigger that requested the task execution. Will always be one of: `patch_request`, `github_pull_request`, `gitter_request` (mainline), `trigger_request`, `github_merge_request` (GitHub merge queue), or `ad_hoc` (periodic build).
+| requester                     | VARCHAR        | Name of the trigger that requested the task execution. Will always be one of: `patch_request`, `github_pull_request`, `git_tag_request`, `gitter_request` (mainline), `trigger_request`, `github_merge_request` (GitHub merge queue), or `ad_hoc` (periodic build).
 | activated\_by                 | VARCHAR        | User or service that activated this task.
 | tags                          | ARRAY(VARCHAR) | Array of task tags from project configuration.
 | host\_id                      | VARCHAR        | ID of the host that ran this task.

--- a/docs/Project-Configuration/Evergreen-Data-for-Analytics.md
+++ b/docs/Project-Configuration/Evergreen-Data-for-Analytics.md
@@ -27,7 +27,7 @@ Daily aggregated statistics for task executions run in Evergreen. Tasks are aggr
 | project\_id                  | VARCHAR | Unique project identifier.
 | variant                      | VARCHAR | Name of the build variant on which the tasks ran.
 | task\_name                   | VARCHAR | Display name of the tasks.
-| request\_type                | VARCHAR | Name of the trigger that requested the task executions. Will always be one of: `patch_request`, `github_pull_request`, `git_tag_request`, `gitter_request` (mainline), `trigger_request`, `github_merge_request` (GitHub merge queue), or `ad_hoc` (periodic build).
+| request\_type                | VARCHAR | Name of the trigger that requested the task executions. Will always be one of [these values](../Reference/Glossary.md#requesters).
 | finish\_date                 | VARCHAR | Date, in ISO format `YYYY-MM-DD`, on which the tasks ran.
 | num\_success                 | BIGINT  | Number of successful task executions in the group.
 | num\_failed                  | BIGINT  | Number of failed task executions in the group.
@@ -53,7 +53,7 @@ Daily aggregated statistics for test executions run in Evergreen. Test stats are
 | variant                   | VARCHAR | Name of the build variant on which the tests ran.
 | task\_name                | VARCHAR | Name of the task that the test ran under. This is the display task name for tasks that are part of a display task.
 | test\_name                | VARCHAR | Display name of the tests.
-| request\_type             | VARCHAR | Name of the trigger that requested the task execution. Will always be one of: `patch_request`, `github_pull_request`, `git_tag_request`, `gitter_request` (mainline), `trigger_request`, `github_merge_request` (GitHub merge queue), or `ad_hoc` (periodic build).
+| request\_type             | VARCHAR | Name of the trigger that requested the task execution. Will always be one of [these values](../Reference/Glossary.md#requesters).
 | num\_pass                 | BIGINT  | Number of passing tests.
 | num\_fail                 | BIGINT  | Number of failing tests.
 | num\_status\_swaps        | BIGINT  | Number of test status changes between subsequent runs. Only available for tests that ran after 2024-09-15.
@@ -78,7 +78,7 @@ Finished Evergreen tasks, partitioned by the project and date (in ISO format). F
 | build\_id                     | VARCHAR        | ID of the build containing the task.
 | order                         | BIGINT         | Order number of the task's version. For patches this is the user's current patch submission count. For mainline versions this is the number of versions for that repository so far.
 | revision                      | VARCHAR        | Git commit SHA.
-| requester                     | VARCHAR        | Name of the trigger that requested the task execution. Will always be one of: `patch_request`, `github_pull_request`, `git_tag_request`, `gitter_request` (mainline), `trigger_request`, `github_merge_request` (GitHub merge queue), or `ad_hoc` (periodic build).
+| requester                     | VARCHAR        | Name of the trigger that requested the task execution. Will always be one of [these values](../Reference/Glossary.md#requesters).
 | tags                          | ARRAY(VARCHAR) | Array of task tags from project configuration.
 | priority                      | BIGINT         | Scheduling priority of the task.
 | task\_group                   | VARCHAR        | Name of the task group that contains this task.
@@ -174,7 +174,7 @@ Note that this is an estimated cost based solely on compute (`BoxUsage`) usage p
 | display\_name                 | VARCHAR        | Display name of the task, will be the parent task's display name if part of a display task.
 | build\_variant                | VARCHAR        | Name of the task's build variant.
 | build\_variant\_display\_name | VARCHAR        | Display name of the task's build variant.
-| requester                     | VARCHAR        | Name of the trigger that requested the task execution. Will always be one of: `patch_request`, `github_pull_request`, `git_tag_request`, `gitter_request` (mainline), `trigger_request`, `github_merge_request` (GitHub merge queue), or `ad_hoc` (periodic build).
+| requester                     | VARCHAR        | Name of the trigger that requested the task execution. Will always be one of [these values](../Reference/Glossary.md#requesters).
 | activated\_by                 | VARCHAR        | User or service that activated this task.
 | tags                          | ARRAY(VARCHAR) | Array of task tags from project configuration.
 | host\_id                      | VARCHAR        | ID of the host that ran this task.

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -380,6 +380,7 @@ Parameters:
 
 The call to AssumeRole includes an external ID formatted as
 `<project_id>-<requester>`. This cannot be modified by the user.
+The list of requesters can be found [here](../Reference/Glossary.md#requesters).
 The originating role is: 
 `arn:aws:iam::<evergreen_account_id>:role/evergreen.role.production`
 and your role should only trust that exact role. You should add an

--- a/docs/Reference/Glossary.md
+++ b/docs/Reference/Glossary.md
@@ -9,6 +9,7 @@
 * **distro**: A distro is a set of hosts that runs tasks. A static distro is configured with a list of IP addresses, while a dynamic distro scales with demand.
 * **expansions**: Expansions are Evergreen- and user-specified variables that can be used in the project configuration file. They can be set by the `expansions.update` command, in the variant, on the project page, and on the distro page.
 * **function**: Commands may be grouped together in functions.
+* **requester**: The type of patch or version. Valid requester types are documented [here](#requesters)
 * **patch build**: A patch build is a version not triggered by a commit to a repository. It either runs tasks on a base commit plus some diff if submitted by the CLI or on a git branch if created by a GitHub pull request.
 * **project configuration file**: The project configuration file is a file parsed by Evergreen that defines commands, functions, build variants, and tasks.
 * **stepback** When a task fails and the offending commit is unknown, Evergreen will perform linear or bisection stepback depending on the project settings. Linear incrementally runs the same task in previous versions in O(n) tasks while bisection performs binary search in O(logn) tasks.
@@ -18,3 +19,19 @@
 * **user configuration file**: The user configuration file is a file parsed by the Evergreen CLI. It contains the user’s API key and various settings.
 * **version**: A version, which corresponds to a vertical slice of tasks on the waterfall, is all tasks for a given commit or patch build.
 * **working directory**: The working directory is the temporary directory which Evergreen creates to run a task. It is available as [an expansion](../Project-Configuration/Project-Configuration-Files#default-expansions).
+
+
+## Requesters
+
+The requester is field in the version/patch document that indicates how the version was created. These are secure, immutable fields that are set upon creation.
+
+Here is a list of valid requester types:
+
+- github_pull_request: A pull request from GitHub.
+- github_merge_request: A merge request from GitHub.
+- git_tag_request: A tag from GitHub.
+- gitter_request: A commit on the tracking GitHub branch.
+- trigger_request: Trigger patches.
+- ad_hoc: Periodic builds.
+- patch_request: CLI requests.
+

--- a/docs/Reference/Glossary.md
+++ b/docs/Reference/Glossary.md
@@ -35,3 +35,4 @@ Here is a list of valid requester types:
 - ad_hoc: Periodic builds.
 - patch_request: CLI requests.
 
+Using our [REST API](../API/REST-V2-Usage.mdx) you can find the requester type of a version or patch.

--- a/docs/Reference/Glossary.md
+++ b/docs/Reference/Glossary.md
@@ -9,7 +9,7 @@
 * **distro**: A distro is a set of hosts that runs tasks. A static distro is configured with a list of IP addresses, while a dynamic distro scales with demand.
 * **expansions**: Expansions are Evergreen- and user-specified variables that can be used in the project configuration file. They can be set by the `expansions.update` command, in the variant, on the project page, and on the distro page.
 * **function**: Commands may be grouped together in functions.
-* **requester**: The type of patch or version. Valid requester types are documented [here](#requesters)
+* **requester**: The type of patch or version. Valid requester types are documented [here](#requesters).
 * **patch build**: A patch build is a version not triggered by a commit to a repository. It either runs tasks on a base commit plus some diff if submitted by the CLI or on a git branch if created by a GitHub pull request.
 * **project configuration file**: The project configuration file is a file parsed by Evergreen that defines commands, functions, build variants, and tasks.
 * **stepback** When a task fails and the offending commit is unknown, Evergreen will perform linear or bisection stepback depending on the project settings. Linear incrementally runs the same task in previous versions in O(n) tasks while bisection performs binary search in O(logn) tasks.
@@ -23,7 +23,7 @@
 
 ## Requesters
 
-The requester is field in the version/patch document that indicates how the version was created. These are secure, immutable fields that are set upon creation.
+The requester is field in the version/patch document that indicates how it was created. These are secure, immutable fields that are set upon creation.
 
 Here is a list of valid requester types:
 

--- a/docs/Reference/Glossary.md
+++ b/docs/Reference/Glossary.md
@@ -20,19 +20,18 @@
 * **version**: A version, which corresponds to a vertical slice of tasks on the waterfall, is all tasks for a given commit or patch build.
 * **working directory**: The working directory is the temporary directory which Evergreen creates to run a task. It is available as [an expansion](../Project-Configuration/Project-Configuration-Files#default-expansions).
 
-
 ## Requesters
 
-The requester is field in the version/patch document that indicates how it was created. These are secure, immutable fields that are set upon creation.
+The requester is a field in the version/patch document that indicates how it was created. These immutable values are set upon creation. They are used to provide elevated permissions to certain versions/patches. For example, a project can have [admin only](../Project-Configuration/Project-and-Distro-Settings.md#variables) variables that only get provided to versions/patches by admins or from mainline commits. They can also be used with [ec2.assume_role](../Project-Configuration/Project-Commands.md#ec2assume_role) to allow specific requesters to assume a role (e.g.mainline commits) and prevent others from not (e.g. CLI requests.).
 
 Here is a list of valid requester types:
 
-- github_pull_request: A pull request from GitHub.
-- github_merge_request: A merge request from GitHub.
-- git_tag_request: A tag from GitHub.
-- gitter_request: A commit on the tracking GitHub branch.
-- trigger_request: Trigger patches.
-- ad_hoc: Periodic builds.
-- patch_request: CLI requests.
+- `github_pull_request`: A pull request from GitHub.
+- `github_merge_request`: A merge request from GitHub.
+- `git_tag_request`: A tag from GitHub.
+- `gitter_request`: A commit on the tracking GitHub branch.
+- `trigger_request`: Trigger patches.
+- `ad_hoc`: Periodic builds.
+- `patch_request`: CLI requests.
 
 Using our [REST API](../API/REST-V2-Usage.mdx) you can find the requester type of a version or patch.

--- a/docs/Reference/Glossary.md
+++ b/docs/Reference/Glossary.md
@@ -22,7 +22,7 @@
 
 ## Requesters
 
-The requester is a field in the version/patch document that indicates how it was created. These immutable values are set upon creation. They are used to provide elevated permissions to certain versions/patches. For example, a project can have [admin only](../Project-Configuration/Project-and-Distro-Settings.md#variables) variables that only get provided to versions/patches by admins or from mainline commits. They can also be used with [ec2.assume_role](../Project-Configuration/Project-Commands.md#ec2assume_role) to allow specific requesters to assume a role (e.g.mainline commits) and prevent others from not (e.g. CLI requests.).
+The requester is a field in the version/patch document that indicates how it was created. These immutable values are set upon creation. They can be used to control what tasks [allow requesters](../Project-Configuration/Project-Configuration-Files.md#allowed-requesters) to run the task (note: the names used for `allowed_requesters` are slightly different than their actual names). There are some shorthands to [limit when a task or variant will run](../Project-Configuration/Project-Configuration-Files.md#limiting-when-a-task-or-variant-will-run). They can also used to provide elevated permissions to certain versions/patches. For example, a project can have [admin only](../Project-Configuration/Project-and-Distro-Settings.md#variables) variables that only get provided to versions/patches by admins or from mainline commits. They can also be used with [ec2.assume_role](../Project-Configuration/Project-Commands.md#ec2assume_role) to allow specific requesters to assume a role (e.g.mainline commits) and prevent others from not (e.g. CLI requests.).
 
 Here is a list of valid requester types:
 


### PR DESCRIPTION
DEVPROD-17176

### Description
This adds some documentation to our requester types. This came up because a user thought a version/patch was a certain requester type, but it wasn't. Although it's accessible via our rest api, we don't really document what they mean (which is important for security for AssumeRole ExternalIDs)