### PR TITLE
DEVPROD-16914 Get latest host information for next task

### DIFF
--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -182,8 +182,20 @@ func (h *hostAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.NewJSONResponse(nextTaskResponse)
 	}
 
-	// if there is already a task assigned to the host send back that task
-	if h.host.RunningTask != "" {
+	// Get the latest host from the database to ensure we have the latest information.
+	updatedHost, err := host.FindOneId(ctx, h.hostID)
+	if err != nil {
+		err = errors.Wrapf(err, "finding host '%s'", h.hostID)
+		grip.Error(err)
+		return gimlet.MakeJSONInternalErrorResponder(err)
+	}
+	if updatedHost == nil {
+		err = errors.Errorf("host '%s' not found", h.hostID)
+		grip.Error(err)
+		return gimlet.MakeJSONErrorResponder(err)
+	}
+	// If there is already a task assigned to the host send back that task.
+	if updatedHost.RunningTask != "" {
 		return sendBackRunningTask(ctx, h.env, h.host, nextTaskResponse)
 	}
 

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -195,7 +195,17 @@ func (h *hostAgentNextTask) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(err)
 	}
 	// If there is already a task assigned to the host send back that task.
-	if updatedHost.RunningTask != "" {
+	if h.host.RunningTask != "" || updatedHost.RunningTask != "" {
+		if updatedHost.RunningTask != h.host.RunningTask {
+			grip.Warning(
+				message.Fields{
+					"message":          "running task changed while waiting for next task",
+					"host":             h.host.Id,
+					"old_running_task": h.host.RunningTask,
+					"new_running_task": updatedHost.RunningTask,
+				},
+			)
+		}
 		return sendBackRunningTask(ctx, h.env, h.host, nextTaskResponse)
 	}
 

--- a/rest/route/host_agent_test.go
+++ b/rest/route/host_agent_test.go
@@ -187,6 +187,7 @@ func TestHostNextTask(t *testing.T) {
 					h.NeedsReprovision = ""
 					rh.details = &apimodels.GetNextTaskDetails{AgentRevision: evergreen.AgentVersion}
 					rh.host = h
+					rh.hostID = h.Id
 					rh.taskDispatcher = model.NewTaskDispatchService(time.Hour)
 					resp := rh.Run(ctx)
 					assert.NotNil(t, resp)
@@ -312,6 +313,7 @@ func TestHostNextTask(t *testing.T) {
 					require.NoError(t, nonLegacyHost.SetProvisionedNotRunning(ctx))
 					rh.details = &apimodels.GetNextTaskDetails{AgentRevision: evergreen.AgentVersion}
 					rh.host = nonLegacyHost
+					rh.hostID = nonLegacyHost.Id
 					rh.taskDispatcher = model.NewTaskDispatchService(time.Hour)
 					resp := rh.Run(ctx)
 					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
@@ -333,6 +335,7 @@ func TestHostNextTask(t *testing.T) {
 
 					// next task action
 					rh.host = dbHost
+					rh.hostID = dbHost.Id
 					resp := rh.Run(ctx)
 					taskResp, ok := resp.Data().(apimodels.NextTaskResponse)
 					require.True(t, ok, resp.Data())
@@ -343,6 +346,7 @@ func TestHostNextTask(t *testing.T) {
 					nonLegacyHost, err := host.FindOneId(ctx, "nonLegacyHost")
 					require.NoError(t, err)
 					rh.host = nonLegacyHost
+					rh.hostID = nonLegacyHost.Id
 					rh.details = &apimodels.GetNextTaskDetails{AgentRevision: evergreen.AgentVersion}
 					resp := rh.Run(ctx)
 					assert.Equal(t, http.StatusOK, resp.Status())
@@ -401,6 +405,7 @@ func TestHostNextTask(t *testing.T) {
 					require.NoError(t, err)
 					require.NotZero(t, h2)
 					rh.host = h2
+					rh.hostID = h2.Id
 					resp := rh.Run(ctx)
 					assert.NotNil(t, resp)
 					assert.Equal(t, http.StatusOK, resp.Status())
@@ -437,6 +442,7 @@ func TestHostNextTask(t *testing.T) {
 					require.NoError(t, anotherHost.Insert(ctx))
 
 					rh.host = &anotherHost
+					rh.hostID = anotherHost.Id
 					resp := rh.Run(ctx)
 					assert.NotNil(t, resp)
 					assert.Equal(t, http.StatusInternalServerError, resp.Status())
@@ -472,6 +478,7 @@ func TestHostNextTask(t *testing.T) {
 					require.NoError(t, anotherHost.Insert(ctx))
 
 					rh.host = &anotherHost
+					rh.hostID = anotherHost.Id
 					resp := rh.Run(ctx)
 					assert.NotNil(t, resp)
 					assert.Equal(t, http.StatusOK, resp.Status())
@@ -627,6 +634,7 @@ func TestHostNextTask(t *testing.T) {
 			require.True(t, ok)
 
 			r.host = &sampleHost
+			r.hostID = sampleHost.Id
 			r.details = &apimodels.GetNextTaskDetails{}
 			r.taskDispatcher = model.NewTaskDispatchService(time.Hour)
 			tCase(ctx, t, r)
@@ -735,6 +743,7 @@ func TestSingleTaskDistroValidation(t *testing.T) {
 	require.True(t, ok)
 
 	r.host = &sampleHost
+	r.hostID = sampleHost.Id
 	r.details = &apimodels.GetNextTaskDetails{}
 	r.taskDispatcher = model.NewTaskDispatchService(time.Hour)
 


### PR DESCRIPTION
DEVPROD-16914

### Description
there is a bug that a host is being assigned two tasks at the same time 
i theorize this is happening because of outdated host information before the task starts

the change simply gets an updated host from the db and checks for running tasks 


the ticket also mentions that there are a lot of tasks that have overlapping start and end times but I think this is because we actually clear the host before actually ending the tasks. We do this to prevent evergreen tasks from being in a weird state where they have been marked complete but the hosts still have this task assigned. 

I think a slight overlap could be a symptom of this 