### PR TITLE
DEVPROD-16259 Remove AssumeRole cache

### DIFF
--- a/cloud/sts.go
+++ b/cloud/sts.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/evergreen-ci/utility/ttlcache"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 )
@@ -51,8 +50,6 @@ type AssumeRoleOptions struct {
 	// DurationSeconds is an optional field of the duration of the role session.
 	// It defaults to 15 minutes.
 	DurationSeconds *int32
-	// CanCache signals whether to cache the credentials.
-	CanCache bool
 }
 
 // AssumeRoleCredentials are the credentials to be returned from
@@ -63,15 +60,6 @@ type AssumeRoleCredentials struct {
 	SessionToken    string
 	Expiration      time.Time
 }
-
-// assumeRoleCache holds AWSCredentials for assumed roles.
-var assumeRoleCache = ttlcache.WithOtel(ttlcache.NewInMemory[AssumeRoleCredentials](), "aws-assume-role")
-
-// minAssumeRoleCacheLifetime is the minimum lifetime of an assumed role
-// when retrieved from the cache. This can be used in situations where it's
-// known that the credentials don't need to be used for a long time. Such as
-// S3 operations that only need valid credentials at the beginning of the operations.
-const minAssumeRoleCacheLifetime = 2 * time.Minute
 
 // AssumeRole gets the credentials for a role as the given task. It handles
 // the AWS API call and generating the ExternalID for the request.
@@ -87,15 +75,6 @@ func (s *stsManagerImpl) AssumeRole(ctx context.Context, taskID string, opts Ass
 		return AssumeRoleCredentials{}, errors.New("task not found")
 	}
 	externalID := createExternalID(t)
-	cacheID := externalID
-	if opts.Policy != nil {
-		cacheID += *opts.Policy
-	}
-	if opts.CanCache {
-		if output, found := assumeRoleCache.Get(ctx, cacheID, minAssumeRoleCacheLifetime); found {
-			return output, nil
-		}
-	}
 	output, err := s.client.AssumeRole(ctx, &sts.AssumeRoleInput{
 		RoleArn:         &opts.RoleARN,
 		Policy:          opts.Policy,
@@ -114,9 +93,6 @@ func (s *stsManagerImpl) AssumeRole(ctx context.Context, taskID string, opts Ass
 		SecretAccessKey: *output.Credentials.SecretAccessKey,
 		SessionToken:    *output.Credentials.SessionToken,
 		Expiration:      *output.Credentials.Expiration,
-	}
-	if opts.CanCache {
-		assumeRoleCache.Put(ctx, cacheID, creds, creds.Expiration)
 	}
 	return creds, nil
 }

--- a/cloud/sts_test.go
+++ b/cloud/sts_test.go
@@ -39,7 +39,6 @@ func TestAssumeRole(t *testing.T) {
 				RoleARN:         roleARN,
 				Policy:          &policy,
 				DurationSeconds: aws.Int32(int32(time.Hour.Seconds())),
-				CanCache:        true,
 			})
 			require.NoError(t, err)
 			// Return credentials
@@ -52,29 +51,6 @@ func TestAssumeRole(t *testing.T) {
 			assert.Equal(t, roleARN, utility.FromStringPtr(awsClientMock.AssumeRoleInput.RoleArn))
 			assert.Equal(t, policy, utility.FromStringPtr(awsClientMock.AssumeRoleInput.Policy))
 			assert.Equal(t, externalID, utility.FromStringPtr(awsClientMock.AssumeRoleInput.ExternalId))
-
-			oldExpiration := creds.Expiration
-
-			t.Run("NotCached", func(t *testing.T) {
-				creds, err := manager.AssumeRole(t.Context(), taskID, AssumeRoleOptions{
-					RoleARN: roleARN,
-					Policy:  &policy,
-				})
-				require.NoError(t, err)
-				// Return new credentials
-				assert.NotEqual(t, oldExpiration, creds.Expiration)
-			})
-
-			t.Run("Cached", func(t *testing.T) {
-				creds, err := manager.AssumeRole(t.Context(), taskID, AssumeRoleOptions{
-					RoleARN:  roleARN,
-					Policy:   &policy,
-					CanCache: true,
-				})
-				require.NoError(t, err)
-				// Return cached credentials
-				assert.Equal(t, oldExpiration, creds.Expiration)
-			})
 		},
 	}
 	for tName, tCase := range testCases {

--- a/config_bucket.go
+++ b/config_bucket.go
@@ -26,24 +26,6 @@ func (b BucketType) validate() error {
 	}
 }
 
-// ProjectToPrefixMapping relates a project to a bucket path prefix.
-type ProjectToPrefixMapping struct {
-	// ProjectID is the project's ID.
-	ProjectID string `yaml:"project_id" bson:"project_id" json:"project_id"`
-	// Prefix is the bucket path prefix that the project should have access to.
-	Prefix string `yaml:"prefix" bson:"prefix" json:"prefix"`
-}
-
-// ProjectToBucketMapping relates a project to a bucket.
-type ProjectToBucketMapping struct {
-	// ProjectID is the project's ID.
-	ProjectID string `yaml:"project_id" bson:"project_id" json:"project_id"`
-	// Bucket is the bucket that the project should have access to.
-	Bucket string `yaml:"bucket" bson:"bucket" json:"bucket"`
-	// Prefix is an optional bucket path prefix that the project should have access to.
-	Prefix string `yaml:"prefix" bson:"prefix" json:"prefix"`
-}
-
 // BucketsConfig represents the admin config section for interally-owned
 // Evergreen data bucket storage.
 type BucketsConfig struct {


### PR DESCRIPTION
DEVPROD-16259

### Description
I removed the user facing code (admin page, on our config structs) but there's this unused cache option that I also added. I don't forsee us using this cache- since it really only gets called by users `ec2.assume_role` and to cache it, the would need to set times that allow for it to be cached (e.g. if all their calls ask for credentials that expire in 1h, they can be cached since the minimum time the next credentials need to for is 1 hour).

We could cache ec2.assume_role by extending every request by ~10minutes, but I don't think it's needed right now.

### Testing
Existing tests (removed old test)
