### PR TITLE
DEVPROD-16717: add OTel tracing for elastic IPs

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -287,6 +287,9 @@ func (m *ec2Manager) setupClient(ctx context.Context) error {
 }
 
 func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Settings *EC2ProviderSettings, blockDevices []types.BlockDeviceMapping) error {
+	ctx, span := tracer.Start(ctx, "spawnOnDemandHost")
+	defer span.End()
+
 	input := &ec2.RunInstancesInput{
 		MinCount:            aws.Int32(1),
 		MaxCount:            aws.Int32(1),

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -255,7 +255,7 @@ func TestFleet(t *testing.T) {
 			assert.Equal(t, "public_dns_name", dnsName)
 		},
 		"SpawnFleetSpotHost": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
-			assert.NoError(t, m.spawnFleetSpotHost(ctx, &host.Host{Tag: "ht_1"}, &EC2ProviderSettings{}))
+			assert.NoError(t, m.spawnFleetHost(ctx, &host.Host{Tag: "ht_1"}, &EC2ProviderSettings{}))
 
 			mockClient := m.client.(*awsClientMock)
 			assert.Equal(t, "ht_1", *mockClient.DeleteLaunchTemplateInput.LaunchTemplateName)

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -795,9 +795,6 @@ func canUseElasticIP(settings *evergreen.Settings, ec2Settings *EC2ProviderSetti
 // allocateIPAddressForHost allocates an elastic IP address from an IPAM pool
 // for the host.
 func allocateIPAddressForHost(ctx context.Context, settings *evergreen.Settings, c AWSClient, h *host.Host) error {
-	ctx, span := tracer.Start(ctx, "allocateIPAddressForHost")
-	defer span.End()
-
 	flags, err := evergreen.GetServiceFlags(ctx)
 	if err != nil {
 		return errors.Wrap(err, "getting service flags")
@@ -805,6 +802,9 @@ func allocateIPAddressForHost(ctx context.Context, settings *evergreen.Settings,
 	if flags.ElasticIPsDisabled {
 		return nil
 	}
+
+	ctx, span := tracer.Start(ctx, "allocateIPAddressForHost")
+	defer span.End()
 
 	hostname, err := os.Hostname()
 	if err != nil {
@@ -855,6 +855,9 @@ func releaseIPAddressForHost(ctx context.Context, c AWSClient, h *host.Host) err
 		return errors.Errorf("elastic IP features are disabled, host will leak IP allocation '%s'", h.IPAllocationID)
 	}
 
+	ctx, span := tracer.Start(ctx, "releaseIPAddressForHost")
+	defer span.End()
+
 	if _, err := c.ReleaseAddress(ctx, &ec2.ReleaseAddressInput{
 		AllocationId: aws.String(h.IPAllocationID),
 	}); err != nil {
@@ -866,9 +869,6 @@ func releaseIPAddressForHost(ctx context.Context, c AWSClient, h *host.Host) err
 
 // associateIPAddressForHost associates the allocated IP address with the host.
 func associateIPAddressForHost(ctx context.Context, c AWSClient, h *host.Host) error {
-	ctx, span := tracer.Start(ctx, "associateIPAddressForHost")
-	defer span.End()
-
 	flags, err := evergreen.GetServiceFlags(ctx)
 	if err != nil {
 		return errors.Wrap(err, "getting service flags")
@@ -876,6 +876,9 @@ func associateIPAddressForHost(ctx context.Context, c AWSClient, h *host.Host) e
 	if flags.ElasticIPsDisabled {
 		return errors.New("elastic IP features are disabled, host will not have an IP address")
 	}
+
+	ctx, span := tracer.Start(ctx, "associateIPAddressForHost")
+	defer span.End()
 
 	assocAddrOut, err := c.AssociateAddress(ctx, &ec2.AssociateAddressInput{
 		InstanceId:   aws.String(h.Id),
@@ -913,6 +916,9 @@ func disassociateIPAddressForHost(ctx context.Context, c AWSClient, h *host.Host
 	if flags.ElasticIPsDisabled {
 		return errors.Errorf("elastic IP features are disabled, host will not disassociate elastic IP '%s'", h.IPAssociationID)
 	}
+
+	ctx, span := tracer.Start(ctx, "disassociateIPAddressForHost")
+	defer span.End()
 
 	if _, err := c.DisassociateAddress(ctx, &ec2.DisassociateAddressInput{
 		AssociationId: aws.String(h.IPAssociationID),

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -795,6 +795,9 @@ func canUseElasticIP(settings *evergreen.Settings, ec2Settings *EC2ProviderSetti
 // allocateIPAddressForHost allocates an elastic IP address from an IPAM pool
 // for the host.
 func allocateIPAddressForHost(ctx context.Context, settings *evergreen.Settings, c AWSClient, h *host.Host) error {
+	ctx, span := tracer.Start(ctx, "allocateIPAddressForHost")
+	defer span.End()
+
 	flags, err := evergreen.GetServiceFlags(ctx)
 	if err != nil {
 		return errors.Wrap(err, "getting service flags")
@@ -863,6 +866,9 @@ func releaseIPAddressForHost(ctx context.Context, c AWSClient, h *host.Host) err
 
 // associateIPAddressForHost associates the allocated IP address with the host.
 func associateIPAddressForHost(ctx context.Context, c AWSClient, h *host.Host) error {
+	ctx, span := tracer.Start(ctx, "associateIPAddressForHost")
+	defer span.End()
+
 	flags, err := evergreen.GetServiceFlags(ctx)
 	if err != nil {
 		return errors.Wrap(err, "getting service flags")

--- a/cloud/otel.go
+++ b/cloud/otel.go
@@ -1,0 +1,12 @@
+package cloud
+
+import (
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen"
+	"go.opentelemetry.io/otel"
+)
+
+var packageName = fmt.Sprintf("%s%s", evergreen.PackageName, "/cloud")
+
+var tracer = otel.GetTracerProvider().Tracer(packageName)

--- a/globals.go
+++ b/globals.go
@@ -521,6 +521,7 @@ const (
 	ProjectIDOtelAttribute         = "evergreen.project.id"
 	RepoRefIDOtelAttribute         = "evergreen.project.repo_ref_id"
 	DistroIDOtelAttribute          = "evergreen.distro.id"
+	DistroProviderOtelAttribute    = "evergreen.distro.provider"
 	HostIDOtelAttribute            = "evergreen.host.id"
 	HostnameOtelAttribute          = "evergreen.host.hostname"
 	HostStartedByOtelAttribute     = "evergreen.host.started_by"

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -293,6 +293,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 	span.SetAttributes(
 		attribute.String(evergreen.DistroIDOtelAttribute, j.host.Distro.Id),
 		attribute.String(evergreen.HostIDOtelAttribute, j.host.Id),
+		attribute.String(evergreen.DistroProviderOtelAttribute, j.host.Distro.Provider),
 		attribute.Bool(fmt.Sprintf("%s.spawned_host", provisioningCreateHostAttributePrefix), false),
 	)
 


### PR DESCRIPTION
DEVPROD-16717

### Description
Add OTel tracing for elastic IP features so we can track how long the operations take.

### Testing
Tested in staging to verify the spans appeared in the relevant Amboy jobs.
