### PR TITLE
DEVPROD-17136: move elastic IP association to separate job

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -79,6 +79,10 @@ type Manager interface {
 	// is due for a particular host
 	TimeTilNextPayment(*host.Host) time.Duration
 
+	// AssociateIP associates an IP address allocated to a host with the host's
+	// network interface.
+	AssociateIP(context.Context, *host.Host) error
+
 	// CleanupIP cleans up the IP address resources for a host, if it has any.
 	// If calling TerminateInstance, CleanupIP is not needed.
 	CleanupIP(context.Context, *host.Host) error

--- a/cloud/cloud_host.go
+++ b/cloud/cloud_host.go
@@ -54,6 +54,10 @@ func (cloudHost *CloudHost) GetDNSName(ctx context.Context) (string, error) {
 	return cloudHost.CloudMgr.GetDNSName(ctx, cloudHost.Host)
 }
 
+func (cloudHost *CloudHost) AssociateIP(ctx context.Context, h *host.Host) error {
+	return cloudHost.CloudMgr.AssociateIP(ctx, cloudHost.Host)
+}
+
 func (cloudHost *CloudHost) CleanupIP(ctx context.Context) error {
 	return cloudHost.CloudMgr.CleanupIP(ctx, cloudHost.Host)
 }

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -296,6 +296,10 @@ func (m *dockerManager) Configure(ctx context.Context, s *evergreen.Settings) er
 	return nil
 }
 
+func (m *dockerManager) AssociateIP(context.Context, *host.Host) error {
+	return errors.New("can't associate IP with Docker provider")
+}
+
 func (m *dockerManager) CleanupIP(context.Context, *host.Host) error {
 	return nil
 }

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1389,7 +1389,7 @@ func (m *ec2Manager) TimeTilNextPayment(host *host.Host) time.Duration {
 }
 
 func (m *ec2Manager) AssociateIP(ctx context.Context, h *host.Host) error {
-	if h.IPAssociationID == "" {
+	if h.IPAllocationID == "" {
 		return nil
 	}
 	if err := m.setupClient(ctx); err != nil {

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -431,25 +431,6 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 	instance := reservation.Instances[0]
 	h.Id = *instance.InstanceId
 
-	if useElasticIP && h.IPAllocationID != "" {
-		// Associate the IP address that was allocated for this host. This is
-		// necessary for the host to be usable because otherwise, it has no IP
-		// address.
-		// Unfortunately, this step is prone to timing issues because EC2 only
-		// allows an IP address to be associated with the host after the
-		// EC2 instance reaches the "running" state. If AWS is slow at getting
-		// the host to "running", this could run out of attempts to associate
-		// the IP address and the host would end up unusable.
-		// TODO (DEVPROD-17136): consider making this step more resilient
-		// against AWS timing problems.
-		// kim: TODO: remove and replace with job
-		// grip.Error(message.WrapError(associateIPAddressForHost(ctx, m.client, h), message.Fields{
-		//     "message":       "host was created and allocated an elastic IP address but could not associate the host with the IP address; host will not be usable",
-		//     "host_id":       h.Id,
-		//     "allocation_id": h.IPAllocationID,
-		// }))
-	}
-
 	return nil
 }
 

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -992,8 +992,11 @@ func (c *awsClientImpl) ReleaseAddress(ctx context.Context, input *ec2.ReleaseAd
 }
 
 func (c *awsClientImpl) AssociateAddress(ctx context.Context, input *ec2.AssociateAddressInput) (*ec2.AssociateAddressOutput, error) {
-	// kim: TODO: reduce retries and start with greater delay, move to separate
-	// job to add some delay and support more retries over time.
+	retryOpts := awsClientDefaultRetryOptions()
+	// Cap the delay between attempts because the host needs an IP address for
+	// it to be usable, so waiting longer increases the risk that the host will
+	// fail provisioning due to taking too long.
+	retryOpts.MaxDelay = 30 * time.Second
 	var output *ec2.AssociateAddressOutput
 	var err error
 	err = utility.Retry(

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -950,6 +950,7 @@ func (c *awsClientImpl) AllocateAddress(ctx context.Context, input *ec2.Allocate
 				if errors.As(err, &apiErr) {
 					grip.Debug(message.WrapError(apiErr, msg))
 				}
+				// kim: TODO: adjust retries to not retry on RequestLimitExceeded. Some other host can have the IP.
 				if strings.Contains(apiErr.Error(), ec2InsufficientAddressCapacity) || strings.Contains(apiErr.Error(), ec2AddressLimitExceeded) {
 					return false, err
 				}
@@ -965,6 +966,8 @@ func (c *awsClientImpl) AllocateAddress(ctx context.Context, input *ec2.Allocate
 }
 
 func (c *awsClientImpl) ReleaseAddress(ctx context.Context, input *ec2.ReleaseAddressInput) (*ec2.ReleaseAddressOutput, error) {
+	// kim: TODO: adjust retries to have greater delay, which may reduce
+	// RequestLimitExceeded and "IP still in use" errors.
 	var output *ec2.ReleaseAddressOutput
 	var err error
 	err = utility.Retry(
@@ -989,6 +992,8 @@ func (c *awsClientImpl) ReleaseAddress(ctx context.Context, input *ec2.ReleaseAd
 }
 
 func (c *awsClientImpl) AssociateAddress(ctx context.Context, input *ec2.AssociateAddressInput) (*ec2.AssociateAddressOutput, error) {
+	// kim: TODO: reduce retries and start with greater delay, move to separate
+	// job to add some delay and support more retries over time.
 	var output *ec2.AssociateAddressOutput
 	var err error
 	err = utility.Retry(

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -342,8 +342,9 @@ func (m *ec2FleetManager) StartInstance(context.Context, *host.Host, string) err
 	return errors.New("can't start instances for EC2 fleet provider")
 }
 
+// AssociateIP associates the host with its allocated IP address.
 func (m *ec2FleetManager) AssociateIP(ctx context.Context, h *host.Host) error {
-	if h.IPAssociationID == "" {
+	if h.IPAllocationID == "" {
 		return nil
 	}
 	if err := m.setupClient(ctx); err != nil {
@@ -574,24 +575,6 @@ func (m *ec2FleetManager) spawnFleetHost(ctx context.Context, h *host.Host, ec2S
 	}
 	h.Id = instanceID
 
-	if useElasticIP && h.IPAllocationID != "" {
-		// Associate the IP address that was allocated for this host. This is
-		// necessary for the host to be usable because otherwise, it has no IP
-		// address.
-		// Unfortunately, this step is prone to timing issues because EC2 only
-		// allows an IP address to be associated with the host after the
-		// EC2 instance reaches the "running" state. If AWS is slow at getting
-		// the host to "running", this could run out of attempts to associate
-		// the IP address and the host would end up unusable.
-		// TODO (DEVPROD-17136): consider making this step more resilient
-		// against AWS timing problems.
-		// kim: TODO: remove and replace with job
-		// grip.Error(message.WrapError(associateIPAddressForHost(ctx, m.client, h), message.Fields{
-		//     "message":       "host was created and allocated elastic IP address but could not associate the host with the IP address; host will not be usable",
-		//     "host_id":       h.Id,
-		//     "allocation_id": h.IPAllocationID,
-		// }))
-	}
 	return nil
 }
 

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -342,6 +342,16 @@ func (m *ec2FleetManager) StartInstance(context.Context, *host.Host, string) err
 	return errors.New("can't start instances for EC2 fleet provider")
 }
 
+func (m *ec2FleetManager) AssociateIP(ctx context.Context, h *host.Host) error {
+	if h.IPAssociationID == "" {
+		return nil
+	}
+	if err := m.setupClient(ctx); err != nil {
+		return errors.Wrap(err, "creating client")
+	}
+	return errors.Wrapf(associateIPAddressForHost(ctx, m.client, h), "associating allocated IP address '%s' with host '%s'", h.IPAllocationID, h.Id)
+}
+
 // CleanupIP disassociates the IP address from the host's network interface and
 // releases the IP address back into the IPAM pool.
 func (m *ec2FleetManager) CleanupIP(ctx context.Context, h *host.Host) error {
@@ -575,11 +585,12 @@ func (m *ec2FleetManager) spawnFleetHost(ctx context.Context, h *host.Host, ec2S
 		// the IP address and the host would end up unusable.
 		// TODO (DEVPROD-17136): consider making this step more resilient
 		// against AWS timing problems.
-		grip.Error(message.WrapError(associateIPAddressForHost(ctx, m.client, h), message.Fields{
-			"message":       "host was created and allocated elastic IP address but could not associate the host with the IP address; host will not be usable",
-			"host_id":       h.Id,
-			"allocation_id": h.IPAllocationID,
-		}))
+		// kim: TODO: remove and replace with job
+		// grip.Error(message.WrapError(associateIPAddressForHost(ctx, m.client, h), message.Fields{
+		//     "message":       "host was created and allocated elastic IP address but could not associate the host with the IP address; host will not be usable",
+		//     "host_id":       h.Id,
+		//     "allocation_id": h.IPAllocationID,
+		// }))
 	}
 	return nil
 }

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -868,6 +868,8 @@ func releaseIPAddressForHost(ctx context.Context, c AWSClient, h *host.Host) err
 }
 
 // associateIPAddressForHost associates the allocated IP address with the host.
+// kim: TODO: change this to enqueue a job in a dedicated queue group queue
+// rather than synchronously associate the IP. See units.hostIPAssociationJob.
 func associateIPAddressForHost(ctx context.Context, c AWSClient, h *host.Host) error {
 	flags, err := evergreen.GetServiceFlags(ctx)
 	if err != nil {

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -868,8 +868,6 @@ func releaseIPAddressForHost(ctx context.Context, c AWSClient, h *host.Host) err
 }
 
 // associateIPAddressForHost associates the allocated IP address with the host.
-// kim: TODO: change this to enqueue a job in a dedicated queue group queue
-// rather than synchronously associate the IP. See units.hostIPAssociationJob.
 func associateIPAddressForHost(ctx context.Context, c AWSClient, h *host.Host) error {
 	flags, err := evergreen.GetServiceFlags(ctx)
 	if err != nil {

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -453,6 +453,10 @@ func (m *mockManager) CheckInstanceType(ctx context.Context, instanceType string
 	return nil
 }
 
+func (m *mockManager) AssociateIP(ctx context.Context, h *host.Host) error {
+	return nil
+}
+
 func (m *mockManager) CleanupIP(ctx context.Context, h *host.Host) error {
 	return nil
 }

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -150,6 +150,10 @@ func (staticMgr *staticManager) CheckInstanceType(context.Context, string) error
 	return errors.New("can't specify instance type with static provider")
 }
 
+func (staticMgr *staticManager) AssociateIP(context.Context, *host.Host) error {
+	return errors.New("can't associate IP with static provider")
+}
+
 func (staticMgr *staticManager) CleanupIP(context.Context, *host.Host) error {
 	return nil
 }

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1763,7 +1763,7 @@ func SyncPermanentExemptions(ctx context.Context, permanentlyExempt []string) er
 // but are not yet assoicated with that IP address.
 func FindByNeedsIPAssociation(ctx context.Context) ([]Host, error) {
 	q := bson.M{
-		StatusKey:          evergreen.HostStarting, // kim: NOTE: probably best to wait until host is "starting" to avoid host replacement racing with this.
+		StatusKey:          evergreen.HostStarting,
 		IPAllocationIDKey:  bson.M{"$exists": true},
 		IPAssociationIDKey: bson.M{"$exists": false},
 	}

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1758,3 +1758,14 @@ func SyncPermanentExemptions(ctx context.Context, permanentlyExempt []string) er
 
 	return catcher.Resolve()
 }
+
+// FindByNeedsIPAssociation finds all hosts that have an IP address allocated
+// but are not yet assoicated with that IP address.
+func FindByNeedsIPAssociation(ctx context.Context) ([]Host, error) {
+	q := bson.M{
+		StatusKey:          evergreen.HostStarting, // kim: NOTE: probably best to wait until host is "starting" to avoid host replacement racing with this.
+		IPAllocationIDKey:  bson.M{"$exists": true},
+		IPAssociationIDKey: bson.M{"$exists": false},
+	}
+	return Find(ctx, q)
+}

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1760,7 +1760,7 @@ func SyncPermanentExemptions(ctx context.Context, permanentlyExempt []string) er
 }
 
 // FindByNeedsIPAssociation finds all hosts that have an IP address allocated
-// but are not yet assoicated with that IP address.
+// but are not yet associated with that IP address.
 func FindByNeedsIPAssociation(ctx context.Context) ([]Host, error) {
 	q := bson.M{
 		StatusKey:          evergreen.HostStarting,

--- a/units/crons_remote_fifteen_second.go
+++ b/units/crons_remote_fifteen_second.go
@@ -71,6 +71,8 @@ func (j *cronsRemoteFifteenSecondJob) Run(ctx context.Context) {
 	}
 	catcher.Wrap(amboy.EnqueueManyUniqueJobs(ctx, j.env.RemoteQueue(), allJobs), "populating main queue")
 
+	catcher.Add(populateQueueGroup(ctx, j.env, hostIPAssociationQueueGroup, hostIPAssociationJobs, ts))
+
 	// Create dedicated queues for pod allocation.
 	catcher.Add(populateQueueGroup(ctx, j.env, podAllocationQueueGroup, podAllocatorJobs, ts))
 	catcher.Add(populateQueueGroup(ctx, j.env, podDefinitionCreationQueueGroup, podDefinitionCreationJobs, ts))

--- a/units/host_ip_association.go
+++ b/units/host_ip_association.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	hostIPAssociationJobName     = "host-ip-association"
-	hostIPAssociationMaxAttempts = 5
+	hostIPAssociationMaxAttempts = 3
 )
 
 func init() {

--- a/units/host_ip_association.go
+++ b/units/host_ip_association.go
@@ -1,0 +1,106 @@
+package units
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+	"github.com/pkg/errors"
+)
+
+const (
+	hostIPAssociationJobName     = "host-ip-association"
+	hostIPAssociationMaxAttempts = 5
+)
+
+func init() {
+	registry.AddJobType(hostIPAssociationJobName, func() amboy.Job {
+		return makeHostIPAssociationJob()
+	})
+}
+
+type hostIPAssociationJob struct {
+	job.Base
+
+	HostID string `bson:"host_id" json:"host_id" yaml:"host_id"`
+
+	env  evergreen.Environment
+	host *host.Host
+}
+
+func makeHostIPAssociationJob() *hostIPAssociationJob {
+	return &hostIPAssociationJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    hostIPAssociationJobName,
+				Version: 0,
+			},
+		},
+	}
+}
+
+// NewHostIPAssociationJob creates a job to associate an allocated IP address
+// with the host's network interface.
+func NewHostIPAssociationJob(env evergreen.Environment, h *host.Host, ts string) amboy.Job {
+	j := makeHostIPAssociationJob()
+	j.env = env
+	j.host = h
+	j.HostID = h.Id
+	j.SetID(fmt.Sprintf("%s.%s.%s", hostIPAssociationJobName, h.Id, ts))
+	j.SetScopes([]string{fmt.Sprintf("%s.%s", hostIPAssociationJobName, h.Id)})
+	j.SetEnqueueAllScopes(true)
+	j.UpdateRetryInfo(amboy.JobRetryOptions{
+		Retryable:   utility.TruePtr(),
+		MaxAttempts: utility.ToIntPtr(hostIPAssociationMaxAttempts),
+	})
+	return j
+}
+
+// kim: TODO: manually test job associates address
+func (j *hostIPAssociationJob) Run(ctx context.Context) {
+	defer j.MarkComplete()
+
+	if err := j.populate(ctx); err != nil {
+		j.AddError(errors.Wrap(err, "populating job"))
+		return
+	}
+
+	if j.host.IPAllocationID == "" || j.host.IPAssociationID != "" {
+		return
+	}
+	if j.host.Status != evergreen.HostStarting {
+		return
+	}
+
+	cloudHost, err := cloud.GetCloudHost(ctx, j.host, j.env)
+	if err != nil {
+		j.AddError(errors.Wrapf(err, "getting cloud host for host '%s'", j.host.Id))
+		return
+	}
+	if err := cloudHost.AssociateIP(ctx, j.host); err != nil {
+		j.AddRetryableError(errors.Wrapf(err, "associating IP for host '%s'", j.host.Id))
+	}
+}
+
+func (j *hostIPAssociationJob) populate(ctx context.Context) error {
+	if j.env == nil {
+		j.env = evergreen.GetEnvironment()
+	}
+	if j.host == nil {
+		h, err := host.FindOneId(ctx, j.HostID)
+		if err != nil {
+			return errors.Wrapf(err, "finding host '%s'", j.HostID)
+		}
+		if h == nil {
+			return errors.Errorf("host '%s' not found", j.HostID)
+		}
+		j.host = h
+	}
+	return nil
+}

--- a/units/host_ip_association.go
+++ b/units/host_ip_association.go
@@ -65,12 +65,11 @@ func NewHostIPAssociationJob(env evergreen.Environment, h *host.Host, ts string)
 	return j
 }
 
-// kim: TODO: manually test job associates address
 func (j *hostIPAssociationJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
 	if err := j.populate(ctx); err != nil {
-		j.AddError(errors.Wrap(err, "populating job"))
+		j.AddError(errors.Wrap(err, "populating job fields"))
 		return
 	}
 

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -460,7 +460,6 @@ func (j *createHostJob) spawnAndReplaceHost(ctx context.Context, cloudMgr cloud.
 	}
 
 	if j.host.IPAllocationID != "" {
-		// kim: TODO: manually test this job enqueueing in staging
 		appCtx, _ := j.env.Context()
 		hostIPAssociationQueueGroup, _ := j.env.RemoteQueueGroup().Get(appCtx, hostIPAssociationQueueGroup)
 		if hostIPAssociationQueueGroup != nil {


### PR DESCRIPTION
DEVPROD-17136

### Description
After looking at preliminary data in prod for elastic IPs, I can see that associating the allocated elastic IP with the host's network interface is slow and typically takes 15-30 seconds after the host has been requested. Basically all of this time is spent waiting on EC2 to get the host to the "running" state (which is a prerequisite in EC2 to associating the elastic IP). If associating the elastic IP takes a really long time, the host creation job will slow down and may increase the likelihood of leaking hosts during app server restarts (the host will leak if the host creation job doesn't get to updating the host in the DB). To work around this, I moved this step to a separate job.

* Move elastic IP association to separate job.
* Adjust retries on elastic IP operations to reduce repeated failed requests that are forced to wait on EC2 to do something on their end.

### Testing
* Tested in staging to verify that the host's network interface gets associated with the elastic IP.
* Like the previous PRs, holding off on adding unit tests because the implementation isn't that stable and I might fully rewrite large portions of it depending on how the rollout goes.