### PR TITLE
DEVPROD-17321: do not retry deleting already-deleted launch template

### DIFF
--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -785,6 +785,10 @@ func (c *awsClientImpl) DeleteLaunchTemplate(ctx context.Context, input *ec2.Del
 				if errors.As(err, &apiErr) {
 					grip.Debug(message.WrapError(apiErr, msg))
 				}
+				if strings.Contains(err.Error(), ec2TemplateNotFound) {
+					// The template does not exist, so it's already deleted.
+					return false, nil
+				}
 				return true, err
 			}
 			grip.Info(msg)

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -35,6 +35,7 @@ const (
 	EC2VolumeNotFound       = "InvalidVolume.NotFound"
 	EC2VolumeResizeRate     = "VolumeModificationRateExceeded"
 	ec2TemplateNameExists   = "InvalidLaunchTemplateName.AlreadyExistsException"
+	ec2TemplateNotFound     = "InvalidLaunchTemplateId.NotFound"
 
 	// ec2InsufficientAddressCapacity means that there are no IP addresses
 	// available to allocate.


### PR DESCRIPTION
DEVPROD-17321

### Description
The cloud cleanup job was unusually slow today because the logic to clean up old launch templates was slow repeatedly trying to delete launch templates that had already been deleted. I modified the retry handling to not retry if the launch template is already deleted.

### Testing
Didn't really seem worth testing, I mostly read Splunk and looked at [the EC2 error code list](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html#api-error-codes-table-server) to understand what the error meant.