### PR TITLE
DEVPROD-11837 Use AuthorID for queries 

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1610,8 +1610,8 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 		return nil, nil, errors.Wrap(err, "inserting tasks")
 	}
 	numTasksModified := numEstimatedActivatedGeneratedTasks + len(newActivatedTaskIds)
-	if err = task.UpdateSchedulingLimit(ctx, creationInfo.Version.Author, creationInfo.Version.Requester, numTasksModified, true); err != nil {
-		return nil, nil, errors.Wrapf(err, "fetching user '%s' and updating their scheduling limit", creationInfo.Version.Author)
+	if err = task.UpdateSchedulingLimit(ctx, creationInfo.Version.AuthorID, creationInfo.Version.Requester, numTasksModified, true); err != nil {
+		return nil, nil, errors.Wrapf(err, "fetching user '%s' and updating their scheduling limit", creationInfo.Version.AuthorID)
 	}
 	grip.Error(message.WrapError(batchTimeCatcher.Resolve(), message.Fields{
 		"message": "unable to get all activation times",
@@ -1746,7 +1746,7 @@ func addNewTasksToExistingBuilds(ctx context.Context, creationInfo TaskCreationI
 			return nil, nil, errors.Wrapf(err, "updating task cache for '%s'", b.Id)
 		}
 	}
-	if err = task.CheckUsersPatchTaskLimit(ctx, creationInfo.Version.Requester, creationInfo.Version.Author, false, activatedTasks...); err != nil {
+	if err = task.CheckUsersPatchTaskLimit(ctx, creationInfo.Version.Requester, creationInfo.Version.AuthorID, false, activatedTasks...); err != nil {
 		return nil, nil, errors.Wrap(err, "updating patch task limit for user")
 	}
 	if len(buildIdsToActivate) > 0 {

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -738,7 +738,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 			numActivatedTasks += utility.FromIntPtr(t.EstimatedNumActivatedGeneratedTasks)
 		}
 	}
-	if err = task.UpdateSchedulingLimit(ctx, creationInfo.Version.Author, creationInfo.Version.Requester, numActivatedTasks, true); err != nil {
+	if err = task.UpdateSchedulingLimit(ctx, creationInfo.Version.AuthorID, creationInfo.Version.Requester, numActivatedTasks, true); err != nil {
 		return nil, errors.Wrapf(err, "fetching user '%s' and updating their scheduling limit", creationInfo.Version.Author)
 	}
 

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -781,7 +781,8 @@ func TestAddNewPatch(t *testing.T) {
 		Revision:   "1234",
 		Requester:  evergreen.PatchVersionRequester,
 		CreateTime: time.Now(),
-		Author:     "test.user",
+		Author:     "Test User",
+		AuthorID:   "test.user",
 	}
 	baseCommitTime := time.Date(2018, time.July, 15, 16, 45, 0, 0, time.UTC)
 	baseVersion := &Version{

--- a/model/version.go
+++ b/model/version.go
@@ -22,20 +22,27 @@ import (
 )
 
 type Version struct {
-	Id                  string    `bson:"_id" json:"id,omitempty"`
-	CreateTime          time.Time `bson:"create_time" json:"create_time,omitempty"`
-	StartTime           time.Time `bson:"start_time" json:"start_time,omitempty"`
-	FinishTime          time.Time `bson:"finish_time" json:"finish_time,omitempty"`
-	Revision            string    `bson:"gitspec" json:"revision,omitempty"`
-	Author              string    `bson:"author" json:"author,omitempty"`
-	AuthorEmail         string    `bson:"author_email" json:"author_email,omitempty"`
-	Message             string    `bson:"message" json:"message,omitempty"`
-	Status              string    `bson:"status" json:"status,omitempty"`
-	RevisionOrderNumber int       `bson:"order,omitempty" json:"order,omitempty"`
-	Ignored             bool      `bson:"ignored" json:"ignored"`
-	Owner               string    `bson:"owner_name" json:"owner_name,omitempty"`
-	Repo                string    `bson:"repo_name" json:"repo_name,omitempty"`
-	Branch              string    `bson:"branch_name" json:"branch_name,omitempty"`
+	Id         string    `bson:"_id" json:"id,omitempty"`
+	CreateTime time.Time `bson:"create_time" json:"create_time,omitempty"`
+	StartTime  time.Time `bson:"start_time" json:"start_time,omitempty"`
+	FinishTime time.Time `bson:"finish_time" json:"finish_time,omitempty"`
+	Revision   string    `bson:"gitspec" json:"revision,omitempty"`
+	// Author is a reference to the Evergreen user that authored
+	// this commit, if they can be identified. This may refer to the user's
+	// ID or their display name.
+	Author string `bson:"author" json:"author,omitempty"`
+	// AuthorID is an optional reference to the Evergreen user that authored
+	// this commit, if they can be identified. This always refers to the user's
+	// ID.
+	AuthorID            string `bson:"author_id,omitempty" json:"author_id,omitempty"`
+	AuthorEmail         string `bson:"author_email" json:"author_email,omitempty"`
+	Message             string `bson:"message" json:"message,omitempty"`
+	Status              string `bson:"status" json:"status,omitempty"`
+	RevisionOrderNumber int    `bson:"order,omitempty" json:"order,omitempty"`
+	Ignored             bool   `bson:"ignored" json:"ignored"`
+	Owner               string `bson:"owner_name" json:"owner_name,omitempty"`
+	Repo                string `bson:"repo_name" json:"repo_name,omitempty"`
+	Branch              string `bson:"branch_name" json:"branch_name,omitempty"`
 	// BuildVariants contains information about build variant activation. This
 	// is not always loaded in version document queries because it can be large.
 	// See (Version).GetBuildVariants to fetch this field.
@@ -75,10 +82,6 @@ type Version struct {
 	// this field is omitted in the database
 	Errors   []string `bson:"errors,omitempty" json:"errors,omitempty"`
 	Warnings []string `bson:"warnings,omitempty" json:"warnings,omitempty"`
-
-	// AuthorID is an optional reference to the Evergreen user that authored
-	// this comment, if they can be identified
-	AuthorID string `bson:"author_id,omitempty" json:"author_id,omitempty"`
 
 	SatisfiedTriggers []string `bson:"satisfied_triggers,omitempty" json:"satisfied_triggers,omitempty"`
 	// Fields set if triggered by an upstream build


### PR DESCRIPTION
DEVPROD-11837

### Description
Some queries were incorrectly using Author and not AuthorID. This adds coomments explaining that Author sometimes refers to the display name and fixes queries that were using it.  

### Testing
Updated existing test. 

