### PR TITLE
DEVPROD-17327: do not send test results to server (yet)

### DIFF
--- a/agent/command/results_utils.go
+++ b/agent/command/results_utils.go
@@ -92,10 +92,6 @@ func attachTestResults(ctx context.Context, conf *internal.TaskConfig, td client
 		return errors.Wrap(err, "setting results info in the task")
 	}
 
-	if err = comm.SendTestResults(ctx, td, results); err != nil {
-		return errors.Wrap(err, "sending test results")
-	}
-
 	return nil
 }
 

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-04-24"
+	AgentVersion = "2025-04-30"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-17327

### Description
We added a new agent route to send test results to the server in [DEVPROD-17019](https://jira.mongodb.org/browse/DEVPROD-17019). Using the Evergreen-native test results service is disabled but the flag is checked on the server side. A large test results payload will exceed the HTTP server's max request size limit causing the task to fail, even though it successfully uploads the test results to Cedar. This removes the call to the agent route in the test results command.

<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

### Testing
Staging.

### Documentation
N/A
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
