### PR TITLE
DEVPROD-17368 Update github api limit logs

### DIFF
--- a/repotracker/wrappers.go
+++ b/repotracker/wrappers.go
@@ -85,7 +85,7 @@ func ActivateBuildsForProject(ctx context.Context, project model.ProjectRef, ts 
 // CheckGithubAPIResources returns true when the github API is ready,
 // accessible and with sufficient quota to satisfy our needs
 func CheckGithubAPIResources(ctx context.Context) bool {
-	remaining, err := thirdparty.CheckGithubAPILimit(ctx)
+	remaining, err := thirdparty.CheckGithubResource(ctx)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"runner":  RunnerName,

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1052,9 +1052,9 @@ func GetGithubTokenUser(ctx context.Context, token string, requiredOrg string) (
 	}, isMember, err
 }
 
-// GetGithubAPILimit queries Github for all the API rate limits
-func GetGithubAPILimit(ctx context.Context) (*github.RateLimits, error) {
-	caller := "GetGithubAPILimit"
+// CheckGithubAPILimit queries Github for all the API rate limits
+func CheckGithubAPILimit(ctx context.Context) (*github.RateLimits, error) {
+	caller := "CheckGithubAPILimit"
 	ctx, span := tracer.Start(ctx, caller, trace.WithAttributes(
 		attribute.String(githubEndpointAttribute, caller),
 	))
@@ -1084,9 +1084,9 @@ func GetGithubAPILimit(ctx context.Context) (*github.RateLimits, error) {
 	return limits, nil
 }
 
-// CheckGithubAPILimit queries Github for the number of API requests remaining
-func CheckGithubAPILimit(ctx context.Context) (int64, error) {
-	limits, err := GetGithubAPILimit(ctx)
+// CheckGithubResource queries Github for the number of API requests remaining
+func CheckGithubResource(ctx context.Context) (int64, error) {
+	limits, err := CheckGithubAPILimit(ctx)
 	if err != nil {
 		return int64(0), errors.Wrap(err, "getting github rate limit")
 	}

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -162,7 +162,7 @@ func (s *githubSuite) TestGithubShouldRetry() {
 }
 
 func (s *githubSuite) TestCheckGithubAPILimit() {
-	rem, err := CheckGithubAPILimit(s.ctx)
+	rem, err := CheckGithubResource(s.ctx)
 	s.NoError(err)
 	s.NotNil(rem)
 }

--- a/units/crons.go
+++ b/units/crons.go
@@ -1214,7 +1214,7 @@ func populateQueueGroup(ctx context.Context, env evergreen.Environment, queueGro
 
 func logGithubAPILimit(env evergreen.Environment) amboy.QueueOperation {
 	return func(ctx context.Context, queue amboy.Queue) error {
-		limit, err := thirdparty.GetGithubAPILimit(ctx)
+		limit, err := thirdparty.CheckGithubAPILimit(ctx)
 		if err != nil {
 			return errors.Wrap(err, "checking GitHub API rate limit")
 		}

--- a/units/crons.go
+++ b/units/crons.go
@@ -1220,7 +1220,7 @@ func logGithubAPILimit(env evergreen.Environment) amboy.QueueOperation {
 		}
 
 		grip.Info(message.Fields{
-			"message":           "Evergreen GitHub API rate limit",
+			"message":           "GitHub API rate limit",
 			"remaining":         limit.Core.Remaining,
 			"limit":             limit.Core.Limit,
 			"reset":             limit.Core.Reset.Time,

--- a/units/crons.go
+++ b/units/crons.go
@@ -1212,7 +1212,7 @@ func populateQueueGroup(ctx context.Context, env evergreen.Environment, queueGro
 	return errors.Wrapf(amboy.EnqueueManyUniqueJobs(ctx, queueGroup, jobs), "populating '%s' queue", queueGroupName)
 }
 
-func checkGithubLimit(env evergreen.Environment) amboy.QueueOperation {
+func logGithubAPILimit(env evergreen.Environment) amboy.QueueOperation {
 	return func(ctx context.Context, queue amboy.Queue) error {
 		limit, err := thirdparty.GetGithubAPILimit(ctx)
 		if err != nil {

--- a/units/crons.go
+++ b/units/crons.go
@@ -15,6 +15,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/pod"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
+	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	adb "github.com/mongodb/anser/db"
@@ -1209,4 +1210,24 @@ func populateQueueGroup(ctx context.Context, env evergreen.Environment, queueGro
 	}
 
 	return errors.Wrapf(amboy.EnqueueManyUniqueJobs(ctx, queueGroup, jobs), "populating '%s' queue", queueGroupName)
+}
+
+func checkGithubLimit(env evergreen.Environment) amboy.QueueOperation {
+	return func(ctx context.Context, queue amboy.Queue) error {
+		limit, err := thirdparty.GetGithubAPILimit(ctx)
+		if err != nil {
+			return errors.Wrap(err, "checking GitHub API rate limit")
+		}
+
+		grip.Info(message.Fields{
+			"message":           "Evergreen GitHub API rate limit",
+			"remaining":         limit.Core.Remaining,
+			"limit":             limit.Core.Limit,
+			"reset":             limit.Core.Reset.Time,
+			"minutes_remaining": time.Until(limit.Core.Reset.Time).Minutes(),
+			"percentage":        float32(limit.Core.Remaining) / float32(limit.Core.Limit),
+		})
+
+		return nil
+	}
 }

--- a/units/crons_remote_five_minute.go
+++ b/units/crons_remote_five_minute.go
@@ -51,6 +51,7 @@ func (j *cronsRemoteFiveMinuteJob) Run(ctx context.Context) {
 		PopulateActivationJobs(10),
 		PopulateHostProvisioningConversionJobs(j.env),
 		PopulateHostRestartJasperJobs(j.env),
+		checkGithubLimit(j.env),
 	}
 
 	queue := j.env.RemoteQueue()

--- a/units/crons_remote_five_minute.go
+++ b/units/crons_remote_five_minute.go
@@ -51,7 +51,7 @@ func (j *cronsRemoteFiveMinuteJob) Run(ctx context.Context) {
 		PopulateActivationJobs(10),
 		PopulateHostProvisioningConversionJobs(j.env),
 		PopulateHostRestartJasperJobs(j.env),
-		checkGithubLimit(j.env),
+		logGithubAPILimit(j.env),
 	}
 
 	queue := j.env.RemoteQueue()


### PR DESCRIPTION
DEVPROD-17368

### Description
creates a cron job that logs the limit every 5 minutes on splunk 

### Testing
logs properly on staging 
<img width="629" alt="image" src="https://github.com/user-attachments/assets/8e19a283-b7af-4ec2-82d2-340f179f28f0" />
