### PR TITLE
DEVPROD-5867 Add signed visibility for self-tests log artifacts

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -142,12 +142,9 @@ variables:
       - func: get-project-and-modules
       - func: run-make
         vars: { target: "${task_name}" }
-      - func: assume-role
-        vars:
-          assume_role_arn: ${client_assume_role_arn}
       - command: s3.put
         params:
-          role_arn: ${assume_role_arn}
+          role_arn: ${client_assume_role_arn}
           local_files_include_filter_prefix: evergreen/clients
           local_files_include_filter: "*_*/evergreen*"
           remote_file: evergreen/clients/${version_id}/
@@ -161,12 +158,9 @@ variables:
       - func: get-project-and-modules
       - func: run-make
         vars: { target: "bin/static_assets.tgz" }
-      - func: assume-role
-        vars:
-          assume_role_arn: ${client_assume_role_arn}
       - command: s3.put
         params:
-          role_arn: ${assume_role_arn}
+          role_arn: ${client_assume_role_arn}
           local_file: evergreen/bin/static_assets.tgz
           remote_file: evergreen/clients/${version_id}/static_assets.tgz
           content_type: application/gzip

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -15,9 +15,7 @@ post:
     display_name: Upload smoke test's app server logs to S3
     type: system
     params:
-      aws_key: ${AWS_ACCESS_KEY_ID}
-      aws_secret: ${AWS_SECRET_ACCESS_KEY}
-      aws_session_token: ${AWS_SESSION_TOKEN}
+      role_arn: ${assume_role_arn}
       local_file: evergreen/app_server.log
       remote_file: evergreen/${task_id}/app_server.log
       bucket: mciuploads
@@ -29,9 +27,7 @@ post:
     display_name: Upload smoke test agent logs to S3
     type: system
     params:
-      aws_key: ${AWS_ACCESS_KEY_ID}
-      aws_secret: ${AWS_SECRET_ACCESS_KEY}
-      aws_session_token: ${AWS_SESSION_TOKEN}
+      role_arn: ${assume_role_arn}
       local_files_include_filter: evergreen/smoke*.log
       remote_file: evergreen/${task_id}/
       bucket: mciuploads
@@ -127,9 +123,7 @@ variables:
       - command: s3.put
         type: system
         params:
-          aws_key: ${AWS_ACCESS_KEY_ID}
-          aws_secret: ${AWS_SECRET_ACCESS_KEY}
-          aws_session_token: ${AWS_SESSION_TOKEN}
+          role_arn: ${assume_role_arn}
           local_file: evergreen/bin/generate-lint.json
           remote_file: evergreen/${build_id}-${build_variant}/bin/generate-lint.json
           bucket: mciuploads
@@ -153,9 +147,7 @@ variables:
           assume_role_arn: ${client_assume_role_arn}
       - command: s3.put
         params:
-          aws_key: ${AWS_ACCESS_KEY_ID}
-          aws_secret: ${AWS_SECRET_ACCESS_KEY}
-          aws_session_token: ${AWS_SESSION_TOKEN}
+          role_arn: ${assume_role_arn}
           local_files_include_filter_prefix: evergreen/clients
           local_files_include_filter: "*_*/evergreen*"
           remote_file: evergreen/clients/${version_id}/
@@ -174,9 +166,7 @@ variables:
           assume_role_arn: ${client_assume_role_arn}
       - command: s3.put
         params:
-          aws_key: ${AWS_ACCESS_KEY_ID}
-          aws_secret: ${AWS_SECRET_ACCESS_KEY}
-          aws_session_token: ${AWS_SESSION_TOKEN}
+          role_arn: ${assume_role_arn}
           local_file: evergreen/bin/static_assets.tgz
           remote_file: evergreen/clients/${version_id}/static_assets.tgz
           content_type: application/gzip
@@ -724,9 +714,7 @@ tasks:
             $GOPATH/bin/swag init -g service/service.go
       - command: s3.get
         params:
-          aws_key: ${AWS_ACCESS_KEY_ID}
-          aws_secret: ${AWS_SECRET_ACCESS_KEY}
-          aws_session_token: ${AWS_SESSION_TOKEN}
+          role_arn: ${assume_role_arn}
           local_file: evergreen/docs/swagger.old.sum
           remote_file: evergreen/latest/swagger.sum
           bucket: mciuploads
@@ -743,9 +731,7 @@ tasks:
             OUTPUT_SUM_FILE: docs/swagger.sum
       - command: s3.put
         params:
-          aws_key: ${AWS_ACCESS_KEY_ID}
-          aws_secret: ${AWS_SECRET_ACCESS_KEY}
-          aws_session_token: ${AWS_SESSION_TOKEN}
+          role_arn: ${assume_role_arn}
           local_file: evergreen/docs/swagger.json
           remote_file: evergreen/${task_id}/${execution}/swagger.json
           bucket: mciuploads
@@ -754,9 +740,7 @@ tasks:
           display_name: swagger.json
       - command: s3.put
         params:
-          aws_key: ${AWS_ACCESS_KEY_ID}
-          aws_secret: ${AWS_SECRET_ACCESS_KEY}
-          aws_session_token: ${AWS_SESSION_TOKEN}
+          role_arn: ${assume_role_arn}
           local_file: evergreen/docs/swagger.json
           remote_file: evergreen/latest/swagger.json
           bucket: mciuploads
@@ -766,9 +750,7 @@ tasks:
           patchable: false
       - command: s3.put
         params:
-          aws_key: ${AWS_ACCESS_KEY_ID}
-          aws_secret: ${AWS_SECRET_ACCESS_KEY}
-          aws_session_token: ${AWS_SESSION_TOKEN}
+          role_arn: ${assume_role_arn}
           local_file: evergreen/docs/swagger.sum
           remote_file: evergreen/latest/swagger.sum
           bucket: mciuploads
@@ -794,9 +776,7 @@ tasks:
             graphql/schema/*.graphql > docs/merged-schema.graphql
       - command: s3.put
         params:
-          aws_key: ${AWS_ACCESS_KEY_ID}
-          aws_secret: ${AWS_SECRET_ACCESS_KEY}
-          aws_session_token: ${AWS_SESSION_TOKEN}
+          role_arn: ${assume_role_arn}
           local_file: evergreen/docs/merged-schema.graphql
           remote_file: evergreen/latest/merged-schema.graphql
           bucket: mciuploads

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -23,6 +23,7 @@ post:
       bucket: mciuploads
       content_type: text/plain
       permissions: private
+      visibility: signed
       display_name: Evergreen smoke test application server logs
   - command: s3.put
     display_name: Upload smoke test agent logs to S3
@@ -36,6 +37,7 @@ post:
       bucket: mciuploads
       content_type: text/plain
       permissions: private
+      visibility: signed
       display_name: (Evergreen smoke test agent logs)
 
 #######################################
@@ -132,7 +134,8 @@ variables:
           remote_file: evergreen/${build_id}-${build_variant}/bin/generate-lint.json
           bucket: mciuploads
           content_type: application/json
-          permissions: public-read
+          permissions: private
+          visibility: signed
           display_name: generate-lint.json
       - command: generate.tasks
         params:

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -7,6 +7,7 @@ ignore:
 
 pre_error_fails_task: true
 pre:
+  # These credentials are used in integration tests.
   - func: assume-role
 
 post:


### PR DESCRIPTION
DEVPROD-5867

### Description
Our smoke tests upload as private but without signed visibility (meaning you can't view them without aws creds), our lint lots upload as public-read (but they probably don't need to be on the public internet).

### Testing
Unit tests. Tested with changes in #8988 on staging and I was able to look at our smoke test logs!