### PR TITLE
DEVPROD-17313: pre-allocate elastic IPs into a collection

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -79,6 +79,8 @@ type Manager interface {
 	// is due for a particular host
 	TimeTilNextPayment(*host.Host) time.Duration
 
+	// AllocateIP allocates a new IP address.
+	AllocateIP(context.Context) (*host.IPAddress, error)
 	// AssociateIP associates an IP address allocated to a host with the host's
 	// network interface.
 	AssociateIP(context.Context, *host.Host) error

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -296,6 +296,10 @@ func (m *dockerManager) Configure(ctx context.Context, s *evergreen.Settings) er
 	return nil
 }
 
+func (m *dockerManager) AllocateIP(context.Context) (*host.IPAddress, error) {
+	return nil, errors.New("can't allocate IP with Docker provider")
+}
+
 func (m *dockerManager) AssociateIP(context.Context, *host.Host) error {
 	return errors.New("can't associate IP with Docker provider")
 }

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 // EC2ProviderSettings describes properties of managed instances.
@@ -1367,6 +1368,32 @@ func (m *ec2Manager) GetDNSName(ctx context.Context, h *host.Host) (string, erro
 // TimeTilNextPayment returns how long until the next payment is due for a host.
 func (m *ec2Manager) TimeTilNextPayment(host *host.Host) time.Duration {
 	return timeTilNextEC2Payment(host)
+}
+
+// TODO (DEVPROD-17195): remove temporary method once all elastic IPs are
+// allocated into collection.
+func (m *ec2Manager) AllocateIP(ctx context.Context) (*host.IPAddress, error) {
+	if err := m.setupClient(ctx); err != nil {
+		return nil, errors.Wrap(err, "creating client")
+	}
+
+	flags, err := evergreen.GetServiceFlags(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting service flags")
+	}
+	if flags.ElasticIPsDisabled {
+		return nil, errors.Errorf("elastic IP features are disabled, cannot allocate IP")
+	}
+	allocationID, err := allocateIPAddress(ctx, m.client, m.settings.Providers.AWS.IPAMPoolID)
+	if err != nil {
+		return nil, errors.Wrap(err, "allocating IP address")
+	}
+	ipAddr := &host.IPAddress{
+		ID:           primitive.NewObjectID().Hex(),
+		AllocationID: allocationID,
+	}
+
+	return ipAddr, nil
 }
 
 func (m *ec2Manager) AssociateIP(ctx context.Context, h *host.Host) error {

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -951,7 +951,7 @@ func (c *awsClientImpl) AllocateAddress(ctx context.Context, input *ec2.Allocate
 					grip.Debug(message.WrapError(apiErr, msg))
 				}
 				errMsg := err.Error()
-				if strings.Contains(errMsg, ec2InsufficientAddressCapacity) || strings.Contains(errMsg, ec2AddressLimitExceeded) {
+				if strings.Contains(errMsg, EC2InsufficientAddressCapacity) || strings.Contains(errMsg, EC2AddressLimitExceeded) {
 					return false, err
 				}
 				return true, err

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -36,12 +36,12 @@ const (
 	EC2VolumeResizeRate     = "VolumeModificationRateExceeded"
 	ec2TemplateNameExists   = "InvalidLaunchTemplateName.AlreadyExistsException"
 
-	// ec2InsufficientAddressCapacity means that there are no IP addresses
+	// EC2InsufficientAddressCapacity means that there are no IP addresses
 	// available to allocate.
-	ec2InsufficientAddressCapacity = "InsufficientAddressCapacity"
+	EC2InsufficientAddressCapacity = "InsufficientAddressCapacity"
 	// ec2InsufficientAddressCapacity means that the account has reached its
 	// limit on the number of elastic IPs it can allocate.
-	ec2AddressLimitExceeded = "AddressLimitExceeded"
+	EC2AddressLimitExceeded = "AddressLimitExceeded"
 	// ec2ResourceAlreadyAssociated means an elastic IP is already associated
 	// with another resource.
 	ec2ResourceAlreadyAssociated = "Resource.AlreadyAssociated"
@@ -803,7 +803,15 @@ func allocateIPAddressForHost(ctx context.Context, settings *evergreen.Settings,
 		return nil
 	}
 
-	ctx, span := tracer.Start(ctx, "allocateIPAddressForHost")
+	allocationID, err := allocateIPAddress(ctx, c, settings.Providers.AWS.IPAMPoolID)
+	if err := h.SetIPAllocationID(ctx, allocationID); err != nil {
+		return errors.Wrapf(err, "setting IP allocation ID '%s' for host", allocationID)
+	}
+	return nil
+}
+
+func allocateIPAddress(ctx context.Context, c AWSClient, ipamPoolID string) (string, error) {
+	ctx, span := tracer.Start(ctx, "allocateIPAddress")
 	defer span.End()
 
 	hostname, err := os.Hostname()
@@ -811,7 +819,7 @@ func allocateIPAddressForHost(ctx context.Context, settings *evergreen.Settings,
 		hostname = "unknown"
 	}
 	input := &ec2.AllocateAddressInput{
-		IpamPoolId: aws.String(settings.Providers.AWS.IPAMPoolID),
+		IpamPoolId: aws.String(ipamPoolID),
 		TagSpecifications: []types.TagSpecification{
 			{
 				ResourceType: types.ResourceTypeElasticIp,
@@ -825,19 +833,16 @@ func allocateIPAddressForHost(ctx context.Context, settings *evergreen.Settings,
 
 	allocateAddrOut, err := c.AllocateAddress(ctx, input)
 	if err != nil {
-		return errors.Wrap(err, "allocating new IP address for host")
+		return "", errors.Wrap(err, "allocating new IP address for host")
 	}
 	if allocateAddrOut == nil {
-		return errors.New("address allocation returned nil result")
+		return "", errors.New("address allocation returned nil result")
 	}
 	allocationID := aws.ToString(allocateAddrOut.AllocationId)
 	if allocationID == "" {
-		return errors.New("address allocation did not return an allocation ID")
+		return "", errors.New("address allocation did not return an allocation ID")
 	}
-	if err := h.SetIPAllocationID(ctx, allocationID); err != nil {
-		return errors.Wrapf(err, "setting IP allocation ID '%s' for host", allocationID)
-	}
-	return nil
+	return allocationID, nil
 }
 
 // releaseIPAddressForHost releases the elastic IP address that was associated

--- a/cloud/mock.go
+++ b/cloud/mock.go
@@ -453,6 +453,10 @@ func (m *mockManager) CheckInstanceType(ctx context.Context, instanceType string
 	return nil
 }
 
+func (m *mockManager) AllocateIP(context.Context) (*host.IPAddress, error) {
+	return nil, errors.Errorf("cannot allocate IP with mock manager")
+}
+
 func (m *mockManager) AssociateIP(ctx context.Context, h *host.Host) error {
 	return nil
 }

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -150,6 +150,10 @@ func (staticMgr *staticManager) CheckInstanceType(context.Context, string) error
 	return errors.New("can't specify instance type with static provider")
 }
 
+func (staticMgr *staticManager) AllocateIP(context.Context) (*host.IPAddress, error) {
+	return nil, errors.New("can't allocate IP with static provider")
+}
+
 func (staticMgr *staticManager) AssociateIP(context.Context, *host.Host) error {
 	return errors.New("can't associate IP with static provider")
 }

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -24,8 +24,9 @@ import (
 
 const (
 	// Collection is the name of the MongoDB collection that stores hosts.
-	Collection        = "hosts"
-	VolumesCollection = "volumes"
+	Collection          = "hosts"
+	VolumesCollection   = "volumes"
+	IPAddressCollection = "ip_addresses"
 )
 
 var (

--- a/model/host/ip_address.go
+++ b/model/host/ip_address.go
@@ -1,0 +1,21 @@
+package host
+
+import (
+	"context"
+
+	"github.com/evergreen-ci/evergreen/db"
+)
+
+// IPAddress represents a single public IPv4 address available to use for a
+// host.
+type IPAddress struct {
+	ID string `bson:"_id"`
+	// AllocationID is the unique identifier for the allocated IP address.
+	AllocationID string `bson:"allocation_id"`
+	// HostID is the host that the IP address is associated with, if any.
+	HostID string `bson:"host_id,omitempty"`
+}
+
+func (a *IPAddress) Insert(ctx context.Context) error {
+	return db.Insert(ctx, IPAddressCollection, a)
+}

--- a/units/crons.go
+++ b/units/crons.go
@@ -1198,6 +1198,12 @@ func sleepSchedulerJobs(ctx context.Context, env evergreen.Environment, ts time.
 	return []amboy.Job{NewSleepSchedulerJob(env, ts.Format(TSFormat))}, nil
 }
 
+func populateIPAddressAllocatorJobs(env evergreen.Environment) amboy.QueueOperation {
+	return func(ctx context.Context, queue amboy.Queue) error {
+		return amboy.EnqueueUniqueJob(ctx, queue, NewIPAddressAllocatorJob(env, utility.RoundPartOfMinute(0).Format(TSFormat)))
+	}
+}
+
 func populateQueueGroup(ctx context.Context, env evergreen.Environment, queueGroupName string, factory cronJobFactory, ts time.Time) error {
 	appCtx, _ := env.Context()
 	queueGroup, err := env.RemoteQueueGroup().Get(appCtx, queueGroupName)

--- a/units/crons_remote_five_minute.go
+++ b/units/crons_remote_five_minute.go
@@ -52,6 +52,7 @@ func (j *cronsRemoteFiveMinuteJob) Run(ctx context.Context) {
 		PopulateHostProvisioningConversionJobs(j.env),
 		PopulateHostRestartJasperJobs(j.env),
 		logGithubAPILimit(j.env),
+		populateIPAddressAllocatorJobs(j.env),
 	}
 
 	queue := j.env.RemoteQueue()

--- a/units/ip_address_allocator.go
+++ b/units/ip_address_allocator.go
@@ -1,0 +1,128 @@
+package units
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
+)
+
+const ipAddressAllocatorJobName = "ip-address-allocator"
+
+func init() {
+	registry.AddJobType(ipAddressAllocatorJobName, func() amboy.Job {
+		return makeIPAddressAllocator()
+	})
+}
+
+type ipAddressAllocator struct {
+	job.Base `bson:"job_base" json:"job_base"`
+
+	env evergreen.Environment
+}
+
+func makeIPAddressAllocator() *ipAddressAllocator {
+	return &ipAddressAllocator{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    ipAddressAllocatorJobName,
+				Version: 0,
+			},
+		},
+	}
+}
+
+// NewIPAddressAllocatorJob returns a job to allocate IP addresses.
+func NewIPAddressAllocatorJob(env evergreen.Environment, ts string) amboy.Job {
+	j := makeIPAddressAllocator()
+	j.env = env
+	j.SetID(fmt.Sprintf("%s.%s", ipAddressAllocatorJobName, ts))
+	j.SetScopes([]string{ipAddressAllocatorJobName})
+	j.SetEnqueueAllScopes(true)
+	return j
+}
+
+// TODO (DEVPROD-17195): remove this temporary job once all elastic IPs are
+// allocated into collection.
+func (j *ipAddressAllocator) Run(ctx context.Context) {
+	defer j.MarkComplete()
+
+	j.populate()
+
+	poolID := j.env.Settings().Providers.AWS.IPAMPoolID
+	if poolID == "" {
+		return
+	}
+
+	const maxNumToAllocatePerJob = 500
+	const waitBetweenAllocations = 500 * time.Millisecond
+	timer := time.NewTimer(waitBetweenAllocations)
+	numAllocated := 0
+	for {
+		select {
+		case <-timer.C:
+			if err := j.allocateIPAddress(ctx); err != nil {
+				if strings.Contains(err.Error(), cloud.EC2InsufficientAddressCapacity) || strings.Contains(err.Error(), cloud.EC2AddressLimitExceeded) {
+					// If the IP couldn't be allocated because the IPAM pool has
+					// been exhausted, then the job is done.
+					grip.Debug(message.Fields{
+						"message": "no elastic IPs left to allocate, no-oping the job",
+						"ticket":  "DEVPROD-17313",
+						"job":     j.ID(),
+					})
+					return
+				}
+				j.AddError(errors.Wrap(err, "allocating IP address"))
+				return
+			}
+			numAllocated++
+			if numAllocated >= maxNumToAllocatePerJob {
+				return
+			}
+			timer.Reset(waitBetweenAllocations)
+		case <-ctx.Done():
+			j.AddError(ctx.Err())
+			return
+		}
+	}
+}
+
+func (j *ipAddressAllocator) populate() error {
+	if j.env == nil {
+		j.env = evergreen.GetEnvironment()
+	}
+	return nil
+}
+
+func (j *ipAddressAllocator) allocateIPAddress(ctx context.Context) error {
+	mgrOpts := cloud.ManagerOpts{
+		Provider: evergreen.ProviderNameEc2Fleet,
+		Region:   evergreen.DefaultEC2Region,
+	}
+	mgr, err := cloud.GetManager(ctx, j.env, mgrOpts)
+	if err != nil {
+		return errors.Wrap(err, "getting cloud manager")
+	}
+	ipAddr, err := mgr.AllocateIP(ctx)
+	if err != nil {
+		return errors.Wrap(err, "allocating IP address")
+	}
+	// Intentionally ignore the context cancellation error here, since inserting
+	// the IP address should be a fairly quick operation and the address is
+	// already allocated. It's better to just try inserting the
+	// already-allocated address rather than trying to exit early for SIGTERM.
+	insertCtx := context.WithoutCancel(ctx)
+	if err := ipAddr.Insert(insertCtx); err != nil {
+		return errors.Wrapf(err, "inserting IP address with allocation ID '%s'", ipAddr.AllocationID)
+	}
+	return nil
+}


### PR DESCRIPTION
DEVPROD-17313

### Description
From the rollout in DEVPROD-16798, it's pretty clear that using elastic IPs with an IPAM pool in the "normal" way won't scale because it uses too many AWS API calls. This results in serious rate limit issues if elastic IPs are used on more than a small subset of hosts. Because of this and the fact that AWS cannot raise our rate limit, I'm going to try optimizing down the number of API calls down to see if it can scale to be used more widely in Evergreen's host pool.

As a first step, I'm going to try optimizing away the calls to allocate/release elastic IPs. In the "normal" implementation, Evergreen allocates an elastic IP whenever it creates a host and releases the elastic IP when terminating that host. Instead, Evergreen will pre-allocate all the addresses in a background job, store them in a collection, and then reuse those allocated addresses over and over again. As long as Evergreen never releases them, those pre-allocated IPs can be reused presumably forever. There will be follow-up PRs to use this pre-allocated collection of elastic IPs instead of the AWS API.

* Add temporary job to slowly pre-allocate all the IP addresses out of IPAM and store them in a DB collection.

### Testing
Ran the job in staging to verify that it allocated the elastic IPs and stored them in the collection.
