### PR TITLE
DEVPROD-12545 Remove patch ID parameter from agent route

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -697,7 +697,7 @@ func (c *gitFetchProject) fetch(ctx context.Context,
 	var err error
 	if evergreen.IsPatchRequester(conf.Task.Requester) {
 		logger.Execution().Info("Fetching patch.")
-		p, err = comm.GetTaskPatch(ctx, td, "")
+		p, err = comm.GetTaskPatch(ctx, td)
 		if err != nil {
 			return errors.Wrap(err, "getting patch for task")
 		}

--- a/agent/command/git_push.go
+++ b/agent/command/git_push.go
@@ -65,7 +65,7 @@ func (c *gitPush) Execute(ctx context.Context, comm client.Communicator, logger 
 
 	var p *patch.Patch
 	td := client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}
-	p, err = comm.GetTaskPatch(ctx, td, "")
+	p, err = comm.GetTaskPatch(ctx, td)
 	if err != nil {
 		return errors.Wrap(err, "getting task patch")
 	}

--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -444,22 +444,18 @@ func (c *baseCommunicator) makeSender(ctx context.Context, tsk *task.Task, confi
 // and unmarhals it into a patch struct. The GET request is attempted
 // multiple times upon failure. If patchId is not specified, the task's
 // patch is returned.
-func (c *baseCommunicator) GetTaskPatch(ctx context.Context, taskData TaskData, patchId string) (*patchmodel.Patch, error) {
-	patch := patchmodel.Patch{}
+func (c *baseCommunicator) GetTaskPatch(ctx context.Context, taskData TaskData) (*patchmodel.Patch, error) {
 	info := requestInfo{
 		method:   http.MethodGet,
 		taskData: &taskData,
 	}
-	suffix := "patch"
-	if patchId != "" {
-		suffix = fmt.Sprintf("%s?patch=%s", suffix, patchId)
-	}
-	info.setTaskPathSuffix(suffix)
+	info.setTaskPathSuffix("patch")
 	resp, err := c.retryRequest(ctx, info, nil)
 	if err != nil {
-		return nil, util.RespError(resp, errors.Wrapf(err, "getting patch '%s' for task", patchId).Error())
+		return nil, util.RespError(resp, errors.Wrapf(err, "getting patch for task").Error())
 	}
 
+	patch := patchmodel.Patch{}
 	if err = utility.ReadJSON(resp.Body, &patch); err != nil {
 		return nil, errors.Wrap(err, "reading patch for task from response")
 	}
@@ -475,8 +471,7 @@ func (c *baseCommunicator) GetTaskVersion(ctx context.Context, taskData TaskData
 		method:   http.MethodGet,
 		taskData: &taskData,
 	}
-	suffix := "version"
-	info.setTaskPathSuffix(suffix)
+	info.setTaskPathSuffix("version")
 	resp, err := c.retryRequest(ctx, info, nil)
 	if err != nil {
 		return nil, util.RespError(resp, errors.Wrap(err, "getting version for task").Error())

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -90,7 +90,7 @@ type SharedCommunicator interface {
 	// The following operations are used by task commands.
 	SendTestLog(context.Context, TaskData, *testlog.TestLog) (string, error)
 	SendTestResults(context.Context, TaskData, []testresult.TestResult) error
-	GetTaskPatch(context.Context, TaskData, string) (*patchmodel.Patch, error)
+	GetTaskPatch(context.Context, TaskData) (*patchmodel.Patch, error)
 	GetTaskVersion(context.Context, TaskData) (*model.Version, error)
 	GetPatchFile(context.Context, TaskData, string) (string, error)
 

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -406,7 +406,7 @@ func (c *Mock) GetPatchFile(ctx context.Context, td TaskData, patchFileID string
 	return out, nil
 }
 
-func (c *Mock) GetTaskPatch(ctx context.Context, td TaskData, patchId string) (*patchModel.Patch, error) {
+func (c *Mock) GetTaskPatch(ctx context.Context, td TaskData) (*patchModel.Patch, error) {
 	if c.GetTaskPatchResponse != nil {
 		return c.GetTaskPatchResponse, nil
 	}

--- a/agent/task_context.go
+++ b/agent/task_context.go
@@ -362,7 +362,7 @@ func (a *Agent) makeTaskConfig(ctx context.Context, tc *taskContext) (*internal.
 	var confPatch *patch.Patch
 	if evergreen.IsGitHubPatchRequester(tsk.Requester) {
 		grip.Info("Fetching patch document for GitHub PR request.")
-		confPatch, err = a.comm.GetTaskPatch(ctx, tc.task, "")
+		confPatch, err = a.comm.GetTaskPatch(ctx, tc.task)
 		if err != nil {
 			return nil, errors.Wrap(err, "fetching patch for GitHub PR request")
 		}

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1128,8 +1128,7 @@ func (h *gitServePatchFileHandler) Run(ctx context.Context) gimlet.Responder {
 
 // GET /task/{task_id}/patch
 type servePatchHandler struct {
-	taskID  string
-	patchID string
+	taskID string
 }
 
 func makeServePatch() gimlet.RouteHandler {
@@ -1144,35 +1143,29 @@ func (h *servePatchHandler) Parse(ctx context.Context, r *http.Request) error {
 	if h.taskID = gimlet.GetVars(r)["task_id"]; h.taskID == "" {
 		return errors.New("missing task ID")
 	}
-	if patchParam, exists := r.URL.Query()["patch"]; exists {
-		h.patchID = patchParam[0]
-	}
 	return nil
 }
 
 func (h *servePatchHandler) Run(ctx context.Context) gimlet.Responder {
-	if h.patchID == "" {
-		t, err := task.FindOneId(ctx, h.taskID)
-		if err != nil {
-			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding task '%s'", h.taskID))
-		}
-		if t == nil {
-			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-				StatusCode: http.StatusNotFound,
-				Message:    fmt.Sprintf("task '%s' not found", h.taskID),
-			})
-		}
-		h.patchID = t.Version
+	t, err := task.FindOneId(ctx, h.taskID)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding task '%s'", h.taskID))
+	}
+	if t == nil {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("task '%s' not found", h.taskID),
+		})
 	}
 
-	p, err := patch.FindOne(ctx, patch.ByVersion(h.patchID))
+	p, err := patch.FindOne(ctx, patch.ByVersion(t.Version))
 	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding patch '%s'", h.patchID))
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding patch '%s'", t.Version))
 	}
 	if p == nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
-			Message:    fmt.Sprintf("patch with ID '%s' not found", h.patchID),
+			Message:    fmt.Sprintf("patch with ID '%s' not found", t.Version),
 		})
 	}
 


### PR DESCRIPTION
DEVPROD-12545

### Description
Our `GET /task/{task_id}/patch` (formally `GET /task/{task_id}/git/patch`) allowed passing in a patch id to get it. This was used inside the commit queue to compile multiple patch files and their changes at once when we run the patch. Since it's been removed, this is dead code and allows this route to do more than it needs to do.

### Testing
Unit tests