### PR TITLE
DEVPROD-17313: use pre-allocated elastic IP addresses

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -311,7 +311,7 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 		// because the host should fall back to using an AWS-provided IP
 		// address. Using an elastic IP address is a best-effort attempt to save
 		// money.
-		grip.Notice(message.WrapError(allocateIPAddressForHost(ctx, m.settings, m.client, h), message.Fields{
+		grip.Notice(message.WrapError(allocateIPAddressForHost(ctx, h), message.Fields{
 			"message": "could not allocate elastic IP address for host, falling back to using AWS-managed IP",
 			"host_id": h.Id,
 		}))
@@ -948,7 +948,7 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 		})
 	}
 
-	grip.Error(message.WrapError(releaseIPAddressForHost(ctx, m.client, h), message.Fields{
+	grip.Error(message.WrapError(releaseIPAddressForHost(ctx, h), message.Fields{
 		"message":        "could not release elastic IP address from host",
 		"provider":       h.Distro.Provider,
 		"host_id":        h.Id,
@@ -1412,7 +1412,7 @@ func (m *ec2Manager) CleanupIP(ctx context.Context, h *host.Host) error {
 	if err := disassociateIPAddressForHost(ctx, m.client, h); err != nil {
 		return err
 	}
-	if err := releaseIPAddressForHost(ctx, m.client, h); err != nil {
+	if err := releaseIPAddressForHost(ctx, h); err != nil {
 		return err
 	}
 	return nil

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -1400,10 +1400,7 @@ func (m *ec2Manager) AssociateIP(ctx context.Context, h *host.Host) error {
 
 // CleanupIP releases the host's IP address.
 func (m *ec2Manager) CleanupIP(ctx context.Context, h *host.Host) error {
-	if err := releaseIPAddressForHost(ctx, h); err != nil {
-		return err
-	}
-	return nil
+	return releaseIPAddressForHost(ctx, h)
 }
 
 // Cleanup is a noop for the EC2 provider.

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -915,14 +915,6 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 		}))
 	}
 
-	grip.Error(message.WrapError(disassociateIPAddressForHost(ctx, m.client, h), message.Fields{
-		"message":        "could not disassociate elastic IP address from host",
-		"provider":       h.Distro.Provider,
-		"host_id":        h.Id,
-		"association_id": h.IPAssociationID,
-		"allocation_id":  h.IPAllocationID,
-	}))
-
 	resp, err := m.client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
 		InstanceIds: []string{h.Id},
 	})
@@ -1406,12 +1398,8 @@ func (m *ec2Manager) AssociateIP(ctx context.Context, h *host.Host) error {
 	return errors.Wrapf(associateIPAddressForHost(ctx, m.client, h), "associating allocated IP address '%s' with host '%s'", h.IPAllocationID, h.Id)
 }
 
-// CleanupIP disassociates the IP address from the host's network interface and
-// releases the IP address back into the IPAM pool.
+// CleanupIP releases the host's IP address.
 func (m *ec2Manager) CleanupIP(ctx context.Context, h *host.Host) error {
-	if err := disassociateIPAddressForHost(ctx, m.client, h); err != nil {
-		return err
-	}
 	if err := releaseIPAddressForHost(ctx, h); err != nil {
 		return err
 	}

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -374,10 +374,7 @@ func (m *ec2FleetManager) AssociateIP(ctx context.Context, h *host.Host) error {
 
 // CleanupIP releases the host's IP address.
 func (m *ec2FleetManager) CleanupIP(ctx context.Context, h *host.Host) error {
-	if err := releaseIPAddressForHost(ctx, h); err != nil {
-		return err
-	}
-	return nil
+	return releaseIPAddressForHost(ctx, h)
 }
 
 func (m *ec2FleetManager) Cleanup(ctx context.Context) error {

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -289,14 +289,6 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 		return errors.Wrap(err, "creating client")
 	}
 
-	grip.Error(message.WrapError(disassociateIPAddressForHost(ctx, m.client, h), message.Fields{
-		"message":        "could not disassociate elastic IP address from host",
-		"provider":       h.Distro.Provider,
-		"host_id":        h.Id,
-		"association_id": h.IPAssociationID,
-		"allocation_id":  h.IPAllocationID,
-	}))
-
 	resp, err := m.client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
 		InstanceIds: []string{h.Id},
 	})
@@ -380,12 +372,8 @@ func (m *ec2FleetManager) AssociateIP(ctx context.Context, h *host.Host) error {
 	return errors.Wrapf(associateIPAddressForHost(ctx, m.client, h), "associating allocated IP address '%s' with host '%s'", h.IPAllocationID, h.Id)
 }
 
-// CleanupIP disassociates the IP address from the host's network interface and
-// releases the IP address back into the IPAM pool.
+// CleanupIP releases the host's IP address.
 func (m *ec2FleetManager) CleanupIP(ctx context.Context, h *host.Host) error {
-	if err := disassociateIPAddressForHost(ctx, m.client, h); err != nil {
-		return err
-	}
 	if err := releaseIPAddressForHost(ctx, h); err != nil {
 		return err
 	}

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -322,7 +322,7 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 		})
 	}
 
-	grip.Error(message.WrapError(releaseIPAddressForHost(ctx, m.client, h), message.Fields{
+	grip.Error(message.WrapError(releaseIPAddressForHost(ctx, h), message.Fields{
 		"message":        "could not release elastic IP address from host",
 		"provider":       h.Distro.Provider,
 		"host_id":        h.Id,
@@ -386,7 +386,7 @@ func (m *ec2FleetManager) CleanupIP(ctx context.Context, h *host.Host) error {
 	if err := disassociateIPAddressForHost(ctx, m.client, h); err != nil {
 		return err
 	}
-	if err := releaseIPAddressForHost(ctx, m.client, h); err != nil {
+	if err := releaseIPAddressForHost(ctx, h); err != nil {
 		return err
 	}
 	return nil
@@ -592,7 +592,7 @@ func (m *ec2FleetManager) spawnFleetHost(ctx context.Context, h *host.Host, ec2S
 		// guaranteed to succeed. For example, if the IPAM pool has no addresses
 		// available currently, Evergreen still needs a usable host, so the
 		// launch template has to fall back to using an AWS-managed IP address.
-		grip.Notice(message.WrapError(allocateIPAddressForHost(ctx, m.settings, m.client, h), message.Fields{
+		grip.Notice(message.WrapError(allocateIPAddressForHost(ctx, h), message.Fields{
 			"message": "could not allocate elastic IP address for host, falling back to using AWS-managed IP",
 			"host_id": h.Id,
 		}))

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -795,7 +795,6 @@ func canUseElasticIP(settings *evergreen.Settings, ec2Settings *EC2ProviderSetti
 }
 
 // allocateIPAddressForHost allocates an unused elastic IP address for the host.
-// kim: TODO: test new logic for using collection.
 func allocateIPAddressForHost(ctx context.Context, h *host.Host) error {
 	flags, err := evergreen.GetServiceFlags(ctx)
 	if err != nil {
@@ -860,7 +859,6 @@ func allocateIPAddress(ctx context.Context, c AWSClient, ipamPoolID string) (str
 
 // releaseIPAddressForHost releases the elastic IP address that was associated
 // with the host, if it has an elastic IP.
-// kim: TODO: test new logic for using collection.
 func releaseIPAddressForHost(ctx context.Context, h *host.Host) error {
 	if h.IPAllocationID == "" {
 		return nil

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -776,8 +776,7 @@ func shouldAssignPublicIPv4Address(h *host.Host, ec2Settings *EC2ProviderSetting
 }
 
 func canUseElasticIP(settings *evergreen.Settings, ec2Settings *EC2ProviderSettings, account string, h *host.Host) bool {
-	// if h.UserHost || h.SpawnOptions.SpawnedByTask {
-	if h.SpawnOptions.SpawnedByTask {
+	if h.UserHost || h.SpawnOptions.SpawnedByTask {
 		// Spawn hosts and host.create hosts should not use an elastic IP
 		// because the feature is primarily intended for task hosts.
 		return false

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -804,17 +804,11 @@ func allocateIPAddressForHost(ctx context.Context, h *host.Host) error {
 		return nil
 	}
 
-	ipAddr, err := host.FindUnusedIPAddress(ctx)
+	// This intentionally uses the host tag to identify the host instead of the
+	// host ID because the host ID changes after a host is created.
+	ipAddr, err := host.AssignUnusedIPAddress(ctx, h.Tag)
 	if err != nil {
 		return errors.Wrap(err, "allocating IP address")
-	}
-	if ipAddr == nil {
-		return nil
-	}
-	// This intentionally uses the host tag to identify the host instead of the host ID because the
-	// host ID changes after a host is created.
-	if err := ipAddr.SetHostTag(ctx, h.Tag); err != nil {
-		return errors.Wrapf(err, "setting host ID for IP address '%s'", ipAddr)
 	}
 	if err := h.SetIPAllocationID(ctx, ipAddr.AllocationID); err != nil {
 		return errors.Wrapf(err, "setting IP allocation ID '%s' for host", ipAddr.AllocationID)

--- a/model/host/db.go
+++ b/model/host/db.go
@@ -123,6 +123,10 @@ var (
 	SleepSchedulePermanentlyExemptKey      = bsonutil.MustHaveTag(SleepScheduleInfo{}, "PermanentlyExempt")
 	SleepScheduleTemporarilyExemptUntilKey = bsonutil.MustHaveTag(SleepScheduleInfo{}, "TemporarilyExemptUntil")
 	SleepScheduleShouldKeepOffKey          = bsonutil.MustHaveTag(SleepScheduleInfo{}, "ShouldKeepOff")
+
+	ipAddressIDKey           = bsonutil.MustHaveTag(IPAddress{}, "ID")
+	ipAddressAllocationIDKey = bsonutil.MustHaveTag(IPAddress{}, "AllocationID")
+	ipAddressHostTagKey      = bsonutil.MustHaveTag(IPAddress{}, "HostTag")
 )
 
 var (

--- a/model/host/ip_address.go
+++ b/model/host/ip_address.go
@@ -92,7 +92,7 @@ func FindUnusedIPAddress(ctx context.Context) (*IPAddress, error) {
 func FindIPAddressByAllocationID(ctx context.Context, allocationID string) (*IPAddress, error) {
 	ipAddr := &IPAddress{}
 	err := db.FindOneQContext(ctx, IPAddressCollection, db.Query(bson.M{
-		ipAddressHostTagKey: allocationID,
+		ipAddressAllocationIDKey: allocationID,
 	}), ipAddr)
 	if adb.ResultsNotFound(err) {
 		return nil, nil

--- a/model/host/ip_address.go
+++ b/model/host/ip_address.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/evergreen-ci/evergreen/db"
+	adb "github.com/mongodb/anser/db"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 // IPAddress represents a single public IPv4 address available to use for a
@@ -12,10 +14,88 @@ type IPAddress struct {
 	ID string `bson:"_id"`
 	// AllocationID is the unique identifier for the allocated IP address.
 	AllocationID string `bson:"allocation_id"`
-	// HostID is the host that the IP address is associated with, if any.
-	HostID string `bson:"host_id,omitempty"`
+	// HostTag is the unique tag (i.e. the intent host ID) for the host that the IP
+	// address is associated with, if any.
+	HostTag string `bson:"host_tag,omitempty"`
 }
 
 func (a *IPAddress) Insert(ctx context.Context) error {
 	return db.Insert(ctx, IPAddressCollection, a)
+}
+
+// SetHostTag sets the host tag for the IP address if it is not already set. If
+// a host tag is already set, this will return an error.
+func (a *IPAddress) SetHostTag(ctx context.Context, hostTag string) error {
+	if err := db.UpdateContext(ctx, IPAddressCollection, bson.M{
+		ipAddressIDKey: a.ID,
+		ipAddressHostTagKey: bson.M{
+			"$exists": false,
+		},
+	}, bson.M{
+		"$set": bson.M{
+			ipAddressHostTagKey: hostTag,
+		},
+	}); err != nil {
+		return err
+	}
+
+	a.HostTag = hostTag
+	return nil
+}
+
+// UnsetHostTag unsets the host tag for the IP address if it's set. If a host
+// tag is not set to the expected IP address's host ID, this will return an
+// error.
+func (a *IPAddress) UnsetHostTag(ctx context.Context) error {
+	if err := db.UpdateContext(ctx, IPAddressCollection, bson.M{
+		ipAddressIDKey:      a.ID,
+		ipAddressHostTagKey: a.HostTag,
+	}, bson.M{
+		"$unset": bson.M{
+			ipAddressHostTagKey: 1,
+		},
+	}); err != nil {
+		return err
+	}
+
+	a.HostTag = ""
+	return nil
+}
+
+// FindUnusedIPAddress finds any IP address that's not currently being used by a
+// host.
+func FindUnusedIPAddress(ctx context.Context) (*IPAddress, error) {
+	ipAddrs := make([]IPAddress, 0, 1)
+	err := db.Aggregate(ctx, IPAddressCollection, []bson.M{
+		{
+			"$match": bson.M{
+				ipAddressHostTagKey: bson.M{
+					"$exists": false,
+				},
+			},
+		},
+		{
+			"$sample": bson.M{"size": 1},
+		},
+	}, &ipAddrs)
+	if err != nil {
+		return nil, err
+	}
+	if len(ipAddrs) == 0 {
+		return nil, nil
+	}
+	return &ipAddrs[0], nil
+}
+
+// FindIPAddressByAllocationID finds an IP address by the IP address's
+// allocation ID.
+func FindIPAddressByAllocationID(ctx context.Context, allocationID string) (*IPAddress, error) {
+	ipAddr := &IPAddress{}
+	err := db.FindOneQContext(ctx, IPAddressCollection, db.Query(bson.M{
+		ipAddressHostTagKey: allocationID,
+	}), ipAddr)
+	if adb.ResultsNotFound(err) {
+		return nil, nil
+	}
+	return ipAddr, err
 }


### PR DESCRIPTION
DEVPROD-17313

### Description
Follow-up to #9003, which introduced a collection of pre-allocated IP addresses. This changes the elastic IP logic to use the `ip_addresses` collection of pre-allocated IPs to find a free IP address. This saves on making AWS API calls to the IPAM pool for every host created/terminated by making DB calls instead.

* Use collection of pre-allocated IP addresses to assign elastic IPs to hosts.
* Unset the host from the IP address when terminating it to let it be reused.
* Remove `DisassociateAddress` step from host termination - this is no longer necessary because unassigning the host from its IP address is sufficient to allow the address to be reused by a different host. It also saves API calls when terminating hosts.

I'm going to build indexes on `{"allocation_id": 1}` and `{"host_tag": 1}` after this is approved to make the queries faster.

### Testing
Tested in staging to verify that:
* Hosts were still given elastic IP addresses, but this time from the `ip_addresses` collection rather than IPAM.
* Hosts unset their IP address when terminated.