### PR TITLE
fix: version typo for otel attribute

### DIFF
--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -235,7 +235,7 @@ func NewTaskConfig(opts TaskConfigOptions) (*TaskConfig, error) {
 		taskConfig.GithubPatchData = opts.Patch.GithubPatchData
 		taskConfig.GithubMergeData = opts.Patch.GithubMergeData
 		taskConfig.PatchOrVersionDescription = opts.Patch.Description
-	} else if opts.Patch != nil {
+	} else if opts.Version != nil {
 		taskConfig.PatchOrVersionDescription = opts.Version.Message
 	}
 


### PR DESCRIPTION
### Description
I noticed a doubled if condition that stopped reporting an otel attribute for users:

It was introduced [here](https://github.com/evergreen-ci/evergreen/pull/8788/files#diff-48f1ebe9d546f0e438a5d95b0d9c62328bc8586c35f7c241d538883ae4648b1eR237).
