### PR TITLE
DEVPROD-13634 Add display task's display name to execution task otel traces

### DIFF
--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -259,6 +259,9 @@ func (tc *TaskConfig) TaskAttributeMap() map[string]string {
 		evergreen.DistroIDOtelAttribute:           tc.Task.DistroId,
 		evergreen.VersionDescriptionOtelAttribute: tc.PatchOrVersionDescription,
 	}
+	if tc.Task.DisplayTask != nil && tc.Task.DisplayTask.DisplayName != "" {
+		attributes[evergreen.TaskDisplayTaskNameOtelAttribute] = tc.Task.DisplayTask.DisplayName
+	}
 	if tc.GithubPatchData.PRNumber != 0 {
 		attributes[evergreen.VersionPRNumOtelAttribute] = strconv.Itoa(tc.GithubPatchData.PRNumber)
 	}

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -259,8 +259,8 @@ func (tc *TaskConfig) TaskAttributeMap() map[string]string {
 		evergreen.DistroIDOtelAttribute:           tc.Task.DistroId,
 		evergreen.VersionDescriptionOtelAttribute: tc.PatchOrVersionDescription,
 	}
-	if tc.Task.DisplayTask != nil && tc.Task.DisplayTask.DisplayName != "" {
-		attributes[evergreen.TaskDisplayTaskNameOtelAttribute] = tc.Task.DisplayTask.DisplayName
+	if tc.Task.DisplayTaskDisplayName != nil && *tc.Task.DisplayTaskDisplayName != "" {
+		attributes[evergreen.TaskDisplayTaskNameOtelAttribute] = *tc.Task.DisplayTaskDisplayName
 	}
 	if tc.GithubPatchData.PRNumber != 0 {
 		attributes[evergreen.VersionPRNumOtelAttribute] = strconv.Itoa(tc.GithubPatchData.PRNumber)

--- a/globals.go
+++ b/globals.go
@@ -492,7 +492,7 @@ const (
 	// task otel attributes
 	TaskIDOtelAttribute              = "evergreen.task.id"
 	TaskNameOtelAttribute            = "evergreen.task.name"
-	TaskDisplayTaskNameOtelAttribute = "evergreen.task.display_task_name"
+	TaskDisplayTaskNameOtelAttribute = "evergreen.task.display_task.name"
 	TaskExecutionOtelAttribute       = "evergreen.task.execution"
 	TaskStatusOtelAttribute          = "evergreen.task.status"
 	TaskFailureTypeOtelAttribute     = "evergreen.task.failure_type"

--- a/globals.go
+++ b/globals.go
@@ -490,12 +490,13 @@ const (
 
 	OtelAttributeMaxLength = 10000
 	// task otel attributes
-	TaskIDOtelAttribute          = "evergreen.task.id"
-	TaskNameOtelAttribute        = "evergreen.task.name"
-	TaskExecutionOtelAttribute   = "evergreen.task.execution"
-	TaskStatusOtelAttribute      = "evergreen.task.status"
-	TaskFailureTypeOtelAttribute = "evergreen.task.failure_type"
-	TaskTagsOtelAttribute        = "evergreen.task.tags"
+	TaskIDOtelAttribute              = "evergreen.task.id"
+	TaskNameOtelAttribute            = "evergreen.task.name"
+	TaskDisplayTaskNameOtelAttribute = "evergreen.task.display_task_name"
+	TaskExecutionOtelAttribute       = "evergreen.task.execution"
+	TaskStatusOtelAttribute          = "evergreen.task.status"
+	TaskFailureTypeOtelAttribute     = "evergreen.task.failure_type"
+	TaskTagsOtelAttribute            = "evergreen.task.tags"
 
 	// version otel attributes
 	VersionIDOtelAttribute               = "evergreen.version.id"

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -807,7 +807,7 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 		}
 
 		// update existing exec tasks
-		grip.Error(message.WrapError(task.AddDisplayTaskIdToExecTasks(ctx, id, execTasksThatNeedParentId), message.Fields{
+		grip.Error(message.WrapError(task.AddDisplayTaskInfoToExecTasks(ctx, id, dt.Name, execTasksThatNeedParentId), message.Fields{
 			"message":              "problem adding display task ID to exec tasks",
 			"exec_tasks_to_update": execTasksThatNeedParentId,
 			"display_task_id":      id,

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -91,6 +91,7 @@ var (
 	ExecutionTasksKey              = bsonutil.MustHaveTag(Task{}, "ExecutionTasks")
 	DisplayOnlyKey                 = bsonutil.MustHaveTag(Task{}, "DisplayOnly")
 	DisplayTaskIdKey               = bsonutil.MustHaveTag(Task{}, "DisplayTaskId")
+	DisplayTaskDisplayNameKey      = bsonutil.MustHaveTag(Task{}, "DisplayTaskDisplayName")
 	ParentPatchIDKey               = bsonutil.MustHaveTag(Task{}, "ParentPatchID")
 	TaskGroupKey                   = bsonutil.MustHaveTag(Task{}, "TaskGroup")
 	TaskGroupMaxHostsKey           = bsonutil.MustHaveTag(Task{}, "TaskGroupMaxHosts")

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -281,6 +281,8 @@ type Task struct {
 	// DisplayTaskId is set to the display task ID if the task is an execution task, the empty string if it's not an execution task,
 	// and is nil if we haven't yet checked whether or not this task has a display task.
 	DisplayTaskId *string `bson:"display_task_id,omitempty" json:"display_task_id,omitempty"`
+	//DisplayTaskDisplayName is the name of the display task that this task is part of, if any.
+	DisplayTaskDisplayName *string `bson:"display_task_display_name,omitempty" json:"display_task_display_name,omitempty"`
 
 	// GenerateTask indicates that the task generates other tasks, which the
 	// scheduler will use to prioritize this task. This will not be set for
@@ -4061,7 +4063,7 @@ func (t *Task) SetNumDependents(ctx context.Context) error {
 	}, update)
 }
 
-func AddDisplayTaskIdToExecTasks(ctx context.Context, displayTaskId string, execTasksToUpdate []string) error {
+func AddDisplayTaskInfoToExecTasks(ctx context.Context, displayTaskId, displayTaskDisplayName string, execTasksToUpdate []string) error {
 	if len(execTasksToUpdate) == 0 {
 		return nil
 	}
@@ -4069,7 +4071,8 @@ func AddDisplayTaskIdToExecTasks(ctx context.Context, displayTaskId string, exec
 		IdKey: bson.M{"$in": execTasksToUpdate},
 	},
 		bson.M{"$set": bson.M{
-			DisplayTaskIdKey: displayTaskId,
+			DisplayTaskIdKey:          displayTaskId,
+			DisplayTaskDisplayNameKey: displayTaskDisplayName,
 		}},
 	)
 	return err

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -3854,20 +3854,23 @@ func TestAddDisplayTaskIdToExecTasks(t *testing.T) {
 	assert.NoError(t, t2.Insert(t.Context()))
 	assert.NoError(t, t3.Insert(t.Context()))
 
-	assert.NoError(t, AddDisplayTaskIdToExecTasks(ctx, "dt", []string{t1.Id, t2.Id}))
+	assert.NoError(t, AddDisplayTaskInfoToExecTasks(ctx, "dt", "dtDisplayName", []string{t1.Id, t2.Id}))
 
 	var err error
 	t1, err = FindOneId(ctx, t1.Id)
 	assert.NoError(t, err)
 	assert.Equal(t, "dt", utility.FromStringPtr(t1.DisplayTaskId))
+	assert.Equal(t, "dtDisplayName", utility.FromStringPtr(t1.DisplayTaskDisplayName))
 
 	t2, err = FindOneId(ctx, t2.Id)
 	assert.NoError(t, err)
 	assert.Equal(t, "dt", utility.FromStringPtr(t2.DisplayTaskId))
+	assert.Equal(t, "dtDisplayName", utility.FromStringPtr(t2.DisplayTaskDisplayName))
 
 	t3, err = FindOneId(ctx, t3.Id)
 	assert.NoError(t, err)
 	assert.NotEqual(t, "dt", utility.FromStringPtr(t3.DisplayTaskId))
+	assert.NotEqual(t, "dtDisplayName", utility.FromStringPtr(t3.DisplayTaskDisplayName))
 }
 
 func TestAddExecTasksToDisplayTask(t *testing.T) {


### PR DESCRIPTION
DEVPROD-13634

### Description
User's wanted a way to get the display task name inside the otel attribute, since there hasn't been much asks for display task attributes in otel, I cached it inside the task document so we don't have to add another lookup.

I'm not sure if I like this cache style more or adding another db call, lmk what you think!

### Testing
Unit tests

### Documentation
If we do go the cache route like I've done, I need to communicate the added field to analytics/data team