### PR TITLE
DEVPROD-17395 Add a wrapper for kanopy-oidc that selectively displays output

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-04-22"
+	ClientVersion = "2025-05-06"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/client.go
+++ b/operations/client.go
@@ -1,7 +1,12 @@
 package operations
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
+	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
@@ -18,6 +23,52 @@ func Client() cli.Command {
 			getUIUrl(),
 		},
 	}
+}
+
+// RunKanopyOIDCLogin executes the kanopy-oidc login command and captures the JWT token from the output.
+// It also displays output to the user in real-time while ensuring that the JWT token is not printed.
+func RunKanopyOIDCLogin() (string, error) {
+	cmd := exec.Command("kanopy-oidc", "login", "-n", "-f", "device")
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return "", errors.Wrap(err, "creating stdout pipe")
+	}
+
+	cmd.Stderr = os.Stderr // Show stderr output directly to the user
+
+	// Start the command
+	if err := cmd.Start(); err != nil {
+		return "", errors.Wrap(err, "starting kanopy-oidc login")
+	}
+
+	// Process the output - display non-token outputs and capture the token
+	var tokenBuf bytes.Buffer
+	scanner := bufio.NewScanner(stdout)
+
+	for scanner.Scan() {
+		line := scanner.Text()
+
+		// Check if the line contains a JWT (usually starts with "ey")
+		if len(line) > 30 && strings.HasPrefix(line, "ey") {
+			// This is likely the JWT token - capture but don't display
+			tokenBuf.WriteString(line)
+		} else {
+			// This is not a JWT token - display to the user
+			fmt.Println(line)
+		}
+	}
+
+	// Wait for command to complete
+	if err := cmd.Wait(); err != nil {
+		return "", errors.Wrap(err, "waiting for kanopy-oidc login to complete")
+	}
+
+	if tokenBuf.Len() == 0 {
+		return "", errors.New("no token received - ensure kanopy-oidc is installed and configured correctly")
+	}
+
+	return tokenBuf.String(), nil
 }
 
 func getUser() cli.Command {


### PR DESCRIPTION
DEVPROD-17395

### Description
This adds a function that runs kanopy-oidc login in a way that does not require a browser. It ensures that the output from the kanopy-oidc command is displayed to the user in real-time while ensuring that when the kanopy-oidc command prints the JWT token it is captured but not printed. This is important so that we prevent leaking the token every time an evergreen command is run. 

In [DEVPROD-17396](https://jira.mongodb.org/browse/DEVPROD-17396), this will be added to the client so that it's automatically run for every CLI command that needs it. 

### Testing
Tested locally. 

