### PR TITLE
DEVPROD-13634 Add log when display task id is missing from task struct

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3580,7 +3580,7 @@ func (t *Task) GetDisplayTask(ctx context.Context) (*Task, error) {
 			"message": "missing display task ID",
 			"task_id": t.Id,
 			"dt_id":   dtId,
-			"ticket":  "DEVPROD-13623",
+			"ticket":  "DEVPROD-13634",
 		})
 		// Cache display task ID for future use. If we couldn't find the display task,
 		// we cache the empty string to show that it doesn't exist.

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3576,6 +3576,12 @@ func (t *Task) GetDisplayTask(ctx context.Context) (*Task, error) {
 	}
 
 	if t.DisplayTaskId == nil {
+		grip.Info(message.Fields{
+			"message": "missing display task ID",
+			"task_id": t.Id,
+			"dt_id":   dtId,
+			"ticket":  "DEVPROD-13623",
+		})
 		// Cache display task ID for future use. If we couldn't find the display task,
 		// we cache the empty string to show that it doesn't exist.
 		grip.Error(message.WrapError(t.SetDisplayTaskID(ctx, dtId), message.Fields{


### PR DESCRIPTION
DEVPROD-13634

### Description
In this ticket, I was adding a new display task display name to the task struct. I noticed that we have some logic to backlink the display task id post-creation. This logic was added/intended when tasks that were display tasks could potentially not have the id (4 years ago)

This ticket adds a log were that backlink logic is to confirm my suspicions and I'll revisit the log next week to make sure it isn't hit and then remove the logic.

The reason I'm including this in my ticket, is if we do use it, I should be updating the backlink to include the display task name (and I want to add documentation why we do this backlink here still). I also made [follow up work](https://jira.mongodb.org/browse/DEVPROD-17527) to convert the DisplayTaskId from a pointer to value.
