### PR TITLE
DEVPROD-17531 Document extract_to for s3.get requires a tarball

### DIFF
--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1325,7 +1325,7 @@ Parameters:
     This is the recommended way to authenticate with AWS.
 -   `local_file`: the local file to save, do not use with `extract_to`
 -   `extract_to`: the local directory to extract to, do not use with
-    `local_file`
+    `local_file`. This requires the remote file to be a tarball (eg. `.tgz`)
 -   `remote_file`: the S3 path to get the file from
 -   `bucket`: the S3 bucket to use.
 -   `region`: AWS region of the bucket, defaults to us-east-1.


### PR DESCRIPTION
DEVPROD-17531

### Description
This adds some documentation to `extract_to` that it should be a [tarball](https://github.com/ZackarySantana/evergreen/blob/be9059b07ab966be7db3822e6781ab521d48e7db/agent/command/s3_get.go#L67)

### Testing
add a description of how you tested it

### Documentation
Remember to add or edit docs in the docs/ directory if relevant.
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
