### PR TITLE
DEVPROD-17532 Fix error message for link name in tarball extraction for s3.get

### DIFF
--- a/agent/command/archive_util.go
+++ b/agent/command/archive_util.go
@@ -186,7 +186,7 @@ tarReaderLoop:
 		}
 		if linkname != "" {
 			if err := validateRelativePath(linkname, rootPath); err != nil {
-				return errors.Wrapf(err, "artifact path link name '%s' should be relative to the root path", name)
+				return errors.Wrapf(err, "artifact path link name '%s' should be relative to the root path", linkname)
 			}
 		}
 


### PR DESCRIPTION
DEVPROD-17532

### Description
This fixes an error message in tarball extraction for s3.get.