### PR TITLE
DEVPROD-17544 Fix client mock

### DIFF
--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -11,6 +12,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/manifest"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	restmodel "github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/evergreen/validator"
 	"github.com/evergreen-ci/utility"
 	"github.com/pkg/errors"
 )
@@ -70,7 +72,7 @@ func (*Mock) TerminateSpawnHost(ctx context.Context, hostID string) error {
 	return errors.New("(*Mock) TerminateSpawnHost is not implemented")
 }
 
-func (*Mock) StopSpawnHost(context.Context, string, string, bool) error {
+func (*Mock) StopSpawnHost(ctx context.Context, hostID string, subscriptionType string, shouldKeepOff, wait bool) error {
 	return errors.New("(*Mock) StopSpawnHost is not implemented")
 }
 
@@ -82,8 +84,8 @@ func (*Mock) ChangeSpawnHostPassword(context.Context, string, string) error {
 	return errors.New("(*Mock) ChangeSpawnHostPassword is not implemented")
 }
 
-func (*Mock) FindHostByIpAddress(context.Context, string) error {
-	return errors.New("(*Mock) FindHostByIpAddress is not implemented")
+func (*Mock) FindHostByIpAddress(ctx context.Context, ip string) (*model.APIHost, error) {
+	return nil, errors.New("(*Mock) FindHostByIpAddress is not implemented")
 }
 
 func (*Mock) ExtendSpawnHostExpiration(context.Context, string, int) error {
@@ -183,7 +185,7 @@ func (c *Mock) DeletePublicKey(ctx context.Context, keyName string) error {
 	return errors.New("(c *Mock) DeletePublicKey not implemented")
 }
 
-func (c *Mock) ListAliases(ctx context.Context, keyName string) ([]serviceModel.ProjectAlias, error) {
+func (c *Mock) ListAliases(ctx context.Context, project string, includeProjectConfig bool) ([]serviceModel.ProjectAlias, error) {
 	return nil, errors.New("(c *Mock) ListAliases not implemented")
 }
 
@@ -274,13 +276,13 @@ func (c *Mock) GetClientURLs(context.Context, string) ([]string, error) {
 	return []string{"https://example.com"}, nil
 }
 
-func (c *Mock) PostHostIsUp(ctx context.Context, hostID, hostSecret, instanceID string) (*restmodel.APIHost, error) {
+func (c *Mock) PostHostIsUp(ctx context.Context, ec2InstanceID, hostname string) (*restmodel.APIHost, error) {
 	return &restmodel.APIHost{
 		Id: utility.ToStringPtr("mock_host_id"),
 	}, nil
 }
 
-func (c *Mock) GetHostProvisioningOptions(ctx context.Context, hostID, hostSecret string) (*restmodel.APIHostProvisioningOptions, error) {
+func (c *Mock) GetHostProvisioningOptions(ctx context.Context) (*restmodel.APIHostProvisioningOptions, error) {
 	return &restmodel.APIHostProvisioningOptions{
 		Content: "echo hello world",
 	}, nil
@@ -289,3 +291,33 @@ func (c *Mock) GetHostProvisioningOptions(ctx context.Context, hostID, hostSecre
 func (c *Mock) GetRawPatchWithModules(context.Context, string) (*restmodel.APIRawPatch, error) {
 	return nil, nil
 }
+
+func (c *Mock) GetEstimatedGeneratedTasks(ctx context.Context, patchId string, tvPairs []serviceModel.TVPair) (int, error) {
+	return 0, nil
+}
+
+func (c *Mock) GetTaskLogs(ctx context.Context, opts GetTaskLogsOptions) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (c *Mock) GetTestLogs(ctx context.Context, opts GetTestLogsOptions) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (c *Mock) GetUiV2URL(ctx context.Context) (string, error) {
+	return "https://example.com", nil
+}
+
+func (c *Mock) Validate(ctx context.Context, data []byte, quiet bool, projectID string) (validator.ValidationErrors, error) {
+	return nil, nil
+}
+
+func (c *Mock) RevokeGitHubDynamicAccessTokens(ctx context.Context, taskId string, tokens []string) error {
+	return nil
+}
+
+func (c *Mock) SetHostID(hostID string) {}
+
+func (c *Mock) SetHostSecret(hostSecret string) {}
+
+func (c *Mock) SetJWT(jwt string) {}


### PR DESCRIPTION
DEVPROD-17544

### Description
The rest client mock was out of date and many methods were missing or inaccurate. This cleans it up to bring it back to a usable state. 

This does not impact any current tests as it's not currently used anywhere. I'm preparing it ahead of adding new functionality to the CLI that I will need the mock for. 
