### PR TITLE
DEVPROD-17555 Fix race condition with version creation and activation 

### DIFF
--- a/model/version_activation.go
+++ b/model/version_activation.go
@@ -18,11 +18,13 @@ func DoProjectActivation(ctx context.Context, id string, ts time.Time) (bool, er
 	if err != nil {
 		return false, errors.WithStack(err)
 	}
-	if activateVersion == nil {
+	// Skip activation if version is nil or not fully created yet
+	if activateVersion == nil || !activateVersion.CreateComplete {
 		grip.Info(message.Fields{
-			"message":   "no version to activate for repository",
+			"message":   "no complete version to activate for repository",
 			"project":   id,
 			"operation": "project-activation",
+			"complete":  activateVersion != nil && activateVersion.CreateComplete,
 		})
 		return false, nil
 	}

--- a/model/version_activation_test.go
+++ b/model/version_activation_test.go
@@ -1,0 +1,59 @@
+package model
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVersionActivationWithIncompleteVersion(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	ctx := context.Background()
+
+	// Clear the collections before running the test
+	require.NoError(db.ClearCollections(VersionCollection))
+
+	// Create a partially constructed version (simulating version creation in progress)
+	v := &Version{
+		Id:             "test_version",
+		Identifier:     "project",
+		CreateTime:     time.Now().Add(-time.Hour),
+		Requester:      evergreen.RepotrackerVersionRequester,
+		CreateComplete: false,
+		BuildVariants: []VersionBuildStatus{
+			{
+				BuildVariant: "bv1",
+				ActivationStatus: ActivationStatus{
+					Activated:  false,
+					ActivateAt: time.Now().Add(-time.Minute),
+				},
+			},
+		},
+	}
+	require.NoError(v.Insert(ctx))
+
+	// Try to activate the version
+	activated, err := DoProjectActivation(ctx, "project", time.Now())
+	assert.NoError(err)
+	assert.False(activated, "version should not be activated when CreateComplete is false")
+
+	// Complete version creation
+	require.NoError(v.MarkVersionCreationComplete(ctx))
+
+	// Verify the version was also activated when marked as complete
+	v, err = VersionFindOne(ctx, VersionById(v.Id))
+	assert.NoError(err)
+	assert.True(utility.FromBoolPtr(v.Activated))
+
+	// Try to activate again - should be skipped since it's already activated
+	activated, err = DoProjectActivation(ctx, "project", time.Now())
+	assert.NoError(err)
+	assert.False(activated, "version should not be activated when already activated")
+}


### PR DESCRIPTION
DEVPROD-17555 

### Description
A race condition exists where the cron-based activation job might try to activate a version while it's still being created, leading to partial activation. This adds a CreateComplete flag to versions that must be set true before activation is allowed
and modifies DoProjectActivation to skip versions that are not done yet. This also adds an activation check after marking version creation complete to ensure no versions are missed.

### Testing
Added a test 
