### PR TITLE
DEVPROD-17396 Generate a jwt token and send it along with the request 

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-05-06"
+	ClientVersion = "2025-05-07"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/globals.go
+++ b/globals.go
@@ -564,6 +564,7 @@ const (
 	ContentLengthHeader = "Content-Length"
 	APIUserHeader       = "Api-User"
 	APIKeyHeader        = "Api-Key"
+	KanopyTokenHeader   = "X-Kanopy-Authorization"
 	EnvironmentHeader   = "X-Evergreen-Environment"
 )
 

--- a/operations/client.go
+++ b/operations/client.go
@@ -25,9 +25,9 @@ func Client() cli.Command {
 	}
 }
 
-// RunKanopyOIDCLogin executes the kanopy-oidc login command and captures the JWT token from the output.
+// runKanopyOIDCLogin executes the kanopy-oidc login command and captures the JWT token from the output.
 // It also displays output to the user in real-time while ensuring that the JWT token is not printed.
-func RunKanopyOIDCLogin() (string, error) {
+func runKanopyOIDCLogin() (string, error) {
 	cmd := exec.Command("kanopy-oidc", "login", "-n", "-f", "device")
 
 	stdout, err := cmd.StdoutPipe()

--- a/operations/model.go
+++ b/operations/model.go
@@ -183,6 +183,7 @@ func (s *ClientSettings) shouldGenerateJWT(ctx context.Context, c client.Communi
 	}
 
 	flags, err := c.GetServiceFlags(ctx)
+	//todo: remove in DEVPROD-17618
 	if flags == nil {
 		return false
 	}

--- a/operations/model.go
+++ b/operations/model.go
@@ -183,7 +183,9 @@ func (s *ClientSettings) shouldGenerateJWT(ctx context.Context, c client.Communi
 	}
 
 	flags, err := c.GetServiceFlags(ctx)
-	grip.Infof("flags: %s, error: %s", flags, err.Error())
+	if flags == nil {
+		return false
+	}
 
 	// if we get an unauthorized error when trying to get the flags, we can assume
 	// that the static api keys are no longer accepted and we should get a JWT token

--- a/operations/model.go
+++ b/operations/model.go
@@ -161,8 +161,8 @@ func (s *ClientSettings) setupRestCommunicator(ctx context.Context, printMessage
 	}
 
 	if s.shouldGenerateJWT(ctx, c) {
-		grip.Info("We will attempt to generate a JWT token, to opt out of this, set 'do_not_run_kanopy_oidc' to true in your config file")
-		if s.JWT, err = RunKanopyOIDCLogin(); err != nil {
+		grip.Info("Evergreen CLI will attempt to generate a JWT token, to opt out of this, set 'do_not_run_kanopy_oidc' to true in your config file")
+		if s.JWT, err = runKanopyOIDCLogin(); err != nil {
 			grip.Warningf("Failed to get JWT token: %s", err)
 			return c, err
 		}
@@ -178,17 +178,20 @@ func (s *ClientSettings) shouldGenerateJWT(ctx context.Context, c client.Communi
 	}
 
 	if s.APIKey == "" {
-		grip.Info("No API key found, attempting to use a JWT token.")
+		grip.Info("No API key found in local Evergreen YAML, attempting to use a JWT token.")
 		return true
 	}
 
 	flags, err := c.GetServiceFlags(ctx)
+	grip.Infof("flags: %s, error: %s", flags, err.Error())
+
 	// if we get an unauthorized error when trying to get the flags, we can assume
 	// that the static api keys are no longer accepted and we should get a JWT token
 	if err != nil && isUnauthorized(err) {
 		return true
 	}
 
+	// todo: add an isServiceUser check
 	if err == nil && !flags.JWTTokenForCLIDisabled {
 		return true
 	}

--- a/operations/model_test.go
+++ b/operations/model_test.go
@@ -1,7 +1,6 @@
 package operations
 
 import (
-	"context"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -251,8 +250,6 @@ func TestLoadWorkingChangesFromFile(t *testing.T) {
 }
 
 func TestShouldGenerateJWT(t *testing.T) {
-	ctx := context.Background()
-
 	tests := []struct {
 		name           string
 		settings       *ClientSettings
@@ -294,7 +291,7 @@ func TestShouldGenerateJWT(t *testing.T) {
 				},
 				MockServiceFlagErr: test.flagsErr,
 			}
-			result := test.settings.shouldGenerateJWT(ctx, mock)
+			result := test.settings.shouldGenerateJWT(t.Context(), mock)
 			assert.Equal(t, test.expectedResult, result)
 		})
 	}

--- a/operations/model_test.go
+++ b/operations/model_test.go
@@ -277,17 +277,11 @@ func TestShouldGenerateJWT(t *testing.T) {
 			expectedResult: true,
 		},
 		{
-			name:     "StaticAPIKeysDisabled",
+			name:     "JWTTokenForCLIDisabled",
 			settings: &ClientSettings{APIKey: "key"},
 			serviceFlags: evergreen.ServiceFlags{
-				StaticAPIKeysDisabled: true,
+				JWTTokenForCLIDisabled: true,
 			},
-			expectedResult: true,
-		},
-		{
-			name:           "ValidAPIKey",
-			settings:       &ClientSettings{APIKey: "key"},
-			serviceFlags:   evergreen.ServiceFlags{},
 			expectedResult: false,
 		},
 	}
@@ -296,7 +290,7 @@ func TestShouldGenerateJWT(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			mock := &client.Mock{
 				MockServiceFlags: &restmodel.APIServiceFlags{
-					StaticAPIKeysDisabled: test.serviceFlags.StaticAPIKeysDisabled,
+					JWTTokenForCLIDisabled: test.serviceFlags.JWTTokenForCLIDisabled,
 				},
 				MockServiceFlagErr: test.flagsErr,
 			}

--- a/rest/client/client.go
+++ b/rest/client/client.go
@@ -27,6 +27,7 @@ type communicatorImpl struct {
 	// these fields have setters
 	apiUser string
 	apiKey  string
+	jwt     string
 
 	hostID     string
 	hostSecret string
@@ -86,6 +87,11 @@ func (c *communicatorImpl) SetAPIUser(apiUser string) {
 // SetAPIKey sets the API key.
 func (c *communicatorImpl) SetAPIKey(apiKey string) {
 	c.apiKey = apiKey
+}
+
+// SetJWT sets the JWT for authentication.
+func (c *communicatorImpl) SetJWT(jwt string) {
+	c.jwt = jwt
 }
 
 // SetHostID sets the host ID for authentication using host credentials instead

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -27,6 +27,7 @@ type Communicator interface {
 	// Client authentication methods (for users)
 	SetAPIUser(string)
 	SetAPIKey(string)
+	SetJWT(string)
 	// Client authentication methods (for hosts)
 	SetHostID(string)
 	SetHostSecret(string)

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -596,23 +596,7 @@ func (c *communicatorImpl) SetServiceFlags(ctx context.Context, f *model.APIServ
 }
 
 func (c *communicatorImpl) GetServiceFlags(ctx context.Context) (*model.APIServiceFlags, error) {
-	info := requestInfo{
-		method: http.MethodGet,
-		path:   "admin",
-	}
-
-	resp, err := c.request(ctx, info, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "sending request to get service flags")
-	}
-	defer resp.Body.Close()
-
-	settings := model.APIAdminSettings{}
-	if err = utility.ReadJSON(resp.Body, &settings); err != nil {
-		return nil, errors.Wrap(err, "reading JSON response body")
-	}
-
-	return settings.ServiceFlags, nil
+	return nil, nil
 }
 
 func (c *communicatorImpl) RestartRecentTasks(ctx context.Context, startAt, endAt time.Time) error {

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -596,6 +596,7 @@ func (c *communicatorImpl) SetServiceFlags(ctx context.Context, f *model.APIServ
 }
 
 func (c *communicatorImpl) GetServiceFlags(ctx context.Context) (*model.APIServiceFlags, error) {
+	// todo: implement in DEVPROD-17618
 	return nil, nil
 }
 

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -1436,6 +1436,9 @@ func (c *communicatorImpl) GetTaskLogs(ctx context.Context, opts GetTaskLogsOpti
 	header := make(http.Header)
 	header.Add(evergreen.APIUserHeader, c.apiUser)
 	header.Add(evergreen.APIKeyHeader, c.apiKey)
+	if c.jwt != "" {
+		header.Add(evergreen.KanopyTokenHeader, "Bearer "+c.jwt)
+	}
 	return utility.NewPaginatedReadCloser(ctx, c.httpClient, resp, header), nil
 }
 
@@ -1488,6 +1491,9 @@ func (c *communicatorImpl) GetTestLogs(ctx context.Context, opts GetTestLogsOpti
 	header := make(http.Header)
 	header.Add(evergreen.APIUserHeader, c.apiUser)
 	header.Add(evergreen.APIKeyHeader, c.apiKey)
+	if c.jwt != "" {
+		header.Add(evergreen.KanopyTokenHeader, "Bearer "+c.jwt)
+	}
 	return utility.NewPaginatedReadCloser(ctx, c.httpClient, resp, header), nil
 }
 

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -144,7 +144,7 @@ func (c *Mock) SetServiceFlags(ctx context.Context, f *model.APIServiceFlags) er
 
 func (c *Mock) GetServiceFlags(ctx context.Context) (*model.APIServiceFlags, error) {
 	if c.MockServiceFlagErr != nil {
-		return nil, c.MockServiceFlagErr
+		return c.MockServiceFlags, c.MockServiceFlagErr
 	}
 	return c.MockServiceFlags, nil
 }

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -29,6 +29,8 @@ type Mock struct {
 
 	// mock behavior
 	GetSubscriptionsFail bool
+	MockServiceFlags     *model.APIServiceFlags
+	MockServiceFlagErr   error
 }
 
 func (c *Mock) Close() {}
@@ -137,9 +139,16 @@ func (c *Mock) GetHosts(ctx context.Context, data model.APIHostParams) ([]*model
 func (c *Mock) SetBannerMessage(ctx context.Context, m string, t evergreen.BannerTheme) error {
 	return nil
 }
-func (c *Mock) GetBannerMessage(ctx context.Context) (string, error)                  { return "", nil }
-func (c *Mock) SetServiceFlags(ctx context.Context, f *model.APIServiceFlags) error   { return nil }
-func (c *Mock) GetServiceFlags(ctx context.Context) (*model.APIServiceFlags, error)   { return nil, nil }
+func (c *Mock) GetBannerMessage(ctx context.Context) (string, error)                { return "", nil }
+func (c *Mock) SetServiceFlags(ctx context.Context, f *model.APIServiceFlags) error { return nil }
+
+func (c *Mock) GetServiceFlags(ctx context.Context) (*model.APIServiceFlags, error) {
+	if c.MockServiceFlagErr != nil {
+		return nil, c.MockServiceFlagErr
+	}
+	return c.MockServiceFlags, nil
+}
+
 func (c *Mock) RestartRecentTasks(ctx context.Context, starAt, endAt time.Time) error { return nil }
 func (c *Mock) GetSettings(ctx context.Context) (*evergreen.Settings, error)          { return nil, nil }
 func (c *Mock) UpdateSettings(ctx context.Context, update *model.APIAdminSettings) (*model.APIAdminSettings, error) {

--- a/rest/client/request.go
+++ b/rest/client/request.go
@@ -49,10 +49,12 @@ func (c *communicatorImpl) newRequest(method, path string, data any) (*http.Requ
 
 	if c.apiUser != "" {
 		r.Header.Add(evergreen.APIUserHeader, c.apiUser)
-	}
-	if c.apiUser != "" {
 		r.Header.Add(evergreen.APIKeyHeader, c.apiKey)
 	}
+	if c.jwt != "" {
+		r.Header.Add(evergreen.KanopyTokenHeader, "Bearer "+c.jwt)
+	}
+
 	if c.hostID != "" && c.hostSecret != "" {
 		r.Header.Add(evergreen.HostHeader, c.hostID)
 		r.Header.Add(evergreen.HostSecretHeader, c.hostSecret)


### PR DESCRIPTION
DEVPROD-17396

### Description

- Generate a JWT token if the service flag is on, if the user doesn't have an api key or if we get an unauthorized error when trying to retrieve the service flags.  
- Give users the option to opt out. This can be helpful if users want more time to get set up after we flip the flag. 
- If we have a token, send that along with requests (not yet implemented for the legacy client). 

### Testing
Added tests and also tested this against the corp secure staging endpoint with `volume list` and no api key saved to my local evergreen file. 

I will make sure the use jwt tokens flag is disabled on prod before merging this. 
