### PR TITLE
DEVPROD-17555 Fix builds not activating when now is within 5 minutes of the previous version's activate_at

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2552,9 +2552,10 @@ func (p *ProjectRef) CheckAndUpdateAutoRestartLimit(ctx context.Context, maxDail
 
 // isActiveCronTimeRange checks that the proposed cron should activate now or
 // has already activated very recently.
+const CronActiveRange = 5 * time.Minute
+
 func (p *ProjectRef) isActiveCronTimeRange(proposedCron time.Time, now time.Time) bool {
-	const cronActiveRange = 5 * time.Minute
-	return !proposedCron.Before(now.Add(-cronActiveRange))
+	return !proposedCron.Before(now.Add(-CronActiveRange))
 }
 
 // isValidBVCron checks is a build variant cron is valid.

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2550,10 +2550,10 @@ func (p *ProjectRef) CheckAndUpdateAutoRestartLimit(ctx context.Context, maxDail
 	return errors.Wrap(db.UpdateContext(ctx, ProjectRefCollection, bson.M{ProjectRefIdKey: p.Id}, update), "updating project's auto-restart limit")
 }
 
-// isActiveCronTimeRange checks that the proposed cron should activate now or
-// has already activated very recently.
 const CronActiveRange = 5 * time.Minute
 
+// isActiveCronTimeRange checks that the proposed cron should activate now or
+// has already activated very recently.
 func (p *ProjectRef) isActiveCronTimeRange(proposedCron time.Time, now time.Time) bool {
 	return !proposedCron.Before(now.Add(-CronActiveRange))
 }

--- a/model/version_activation_test.go
+++ b/model/version_activation_test.go
@@ -1,0 +1,96 @@
+package model
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type VersionActivationSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func TestVersionActivationSuite(t *testing.T) {
+	suite.Run(t, new(VersionActivationSuite))
+}
+
+func (s *VersionActivationSuite) SetupTest() {
+	s.ctx = context.Background()
+	require.NoError(s.T(), db.ClearCollections(VersionCollection))
+}
+
+func (s *VersionActivationSuite) TestDoProjectActivationWithBuffer() {
+	t := s.T()
+	require := require.New(t)
+
+	projectID := "test-project"
+	now := time.Now()
+
+	// Create versions at different times
+	versions := []Version{
+		{
+			Id:                  "version-1",
+			Requester:           evergreen.RepotrackerVersionRequester,
+			Identifier:          projectID,
+			CreateTime:          now.Add(-15 * time.Minute),
+			Ignored:             false,
+			RevisionOrderNumber: 1,
+		},
+		{
+			Id:                  "version-2",
+			Requester:           evergreen.RepotrackerVersionRequester,
+			Identifier:          projectID,
+			CreateTime:          now.Add(-6 * time.Minute),
+			Ignored:             false,
+			RevisionOrderNumber: 2,
+			BuildVariants: []VersionBuildStatus{
+				{
+					BuildVariant: "bv",
+					ActivationStatus: ActivationStatus{
+						Activated:  false,
+						ActivateAt: now.Add(-7 * time.Minute),
+					},
+				},
+			},
+		},
+		{
+			Id:                  "version-3",
+			Requester:           evergreen.RepotrackerVersionRequester,
+			Identifier:          projectID,
+			CreateTime:          now.Add(-4 * time.Minute), // within buffer
+			Ignored:             false,
+			RevisionOrderNumber: 3,
+		},
+		{
+			Id:                  "version-4",
+			Requester:           evergreen.RepotrackerVersionRequester,
+			Identifier:          projectID,
+			CreateTime:          now.Add(-1 * time.Minute), // within buffer
+			Ignored:             false,
+			RevisionOrderNumber: 4,
+		},
+	}
+
+	// Insert versions
+	for _, v := range versions {
+		require.NoError(v.Insert(s.ctx))
+	}
+
+	// Test activation
+	activated, err := DoProjectActivation(s.ctx, projectID, now.Add(-CronActiveRange))
+	require.NoError(err)
+	require.True(activated)
+
+	// Verify that we got the correct version (version-2)
+	// This version should be selected because it's the most recent one outside the 5-minute buffer
+	activatedVersion, err := VersionFindOne(s.ctx, VersionByMostRecentNonIgnored(projectID, now.Add(-CronActiveRange)))
+	require.NoError(err)
+	require.NotNil(activatedVersion)
+	require.Equal("version-2", activatedVersion.Id)
+}

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -184,10 +184,8 @@ func (repoTracker *RepoTracker) FetchRevisions(ctx context.Context) error {
 			return errors.WithStack(err)
 		}
 	}
-	// Fetch the most recent, non-ignored version (before the given time, but allowing for a 5 minute buffer).
-	// Do not use a version that is in the active cron range because those will be ignored when the one before
-	// it has an activate_at that is within the cron range.
-	ok, err := model.DoProjectActivation(ctx, projectRef.Id, time.Now().Add(-model.CronActiveRange))
+
+	ok, err := model.DoProjectActivation(ctx, projectRef.Id, time.Now())
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":            "problem activating recent commit for project",

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -184,7 +184,10 @@ func (repoTracker *RepoTracker) FetchRevisions(ctx context.Context) error {
 			return errors.WithStack(err)
 		}
 	}
-	ok, err := model.DoProjectActivation(ctx, projectRef.Id, time.Now())
+	// Fetch the most recent, non-ignored version (before the given time, but allowing for a 5 minute buffer).
+	// Do not use a version that is in the active cron range because those will be ignored when the one before
+	// it has an activate_at that is within the cron range.
+	ok, err := model.DoProjectActivation(ctx, projectRef.Id, time.Now().Add(-model.CronActiveRange))
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{
 			"message":            "problem activating recent commit for project",

--- a/units/version_activation_catchup.go
+++ b/units/version_activation_catchup.go
@@ -87,7 +87,10 @@ func (j *versionActivationCatchup) Run(ctx context.Context) {
 		if !ref.Enabled {
 			continue
 		}
-		ok, err := repotracker.ActivateBuildsForProject(ctx, ref, ts)
+
+		// Do not use a version that is in the active cron range because those will be ignored when the one before
+		// it has an activate_at that is within the cron range.
+		ok, err := repotracker.ActivateBuildsForProject(ctx, ref, ts.Add(-model.CronActiveRange))
 		j.AddError(errors.Wrapf(err, "activating builds for project '%s'", ref.Id))
 		if ok {
 			projectsActivated = append(projectsActivated, ref.Identifier)


### PR DESCRIPTION
DEVPROD-17555

### Description
A user ran into an issue where a nightly build with a "0 0 * * *" wasn't activated as expected. After some investigation we discovered that the reason why that happened is because when we looked at the most recent version at midnight, it was set to activate midnight of the next day rather than that current midnight. The reason why that was set to the next midnight is because that version was created at 11:59, and 11:59 is within the 5 minute cron range window of the previous version that is already set to activate at midnight. This part is correct and we need to do that to avoid a race where two builds are activated instead of one. However, in this situation, at midnight when we pull the version to activate, we should consider this buffer and ignore any versions that came in in the last five minutes so that we don't end up not activating anything in this case. This PR does that. 

### Testing
Added a version activation test (we didn't have one yet) and a project ref test that checks that activate_at is set to the next midnight when there's already a version with activate_at in the buffer time. 


