### PR TITLE
DEVPROD-17313: clean up stray elastic IPs

### DIFF
--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -955,7 +955,7 @@ func (c *awsClientImpl) AllocateAddress(ctx context.Context, input *ec2.Allocate
 					grip.Debug(message.WrapError(apiErr, msg))
 				}
 				errMsg := err.Error()
-				if strings.Contains(errMsg, EC2InsufficientAddressCapacity) || strings.Contains(errMsg, EC2AddressLimitExceeded) {
+				if strings.Contains(errMsg, EC2InsufficientAddressCapacity) || strings.Contains(errMsg, EC2AddressLimitExceeded) || strings.Contains(errMsg, ec2InsufficientFreeAddresses) {
 					return false, err
 				}
 				return true, err

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -377,7 +377,6 @@ func (m *ec2FleetManager) CleanupIP(ctx context.Context, h *host.Host) error {
 	return releaseIPAddressForHost(ctx, h)
 }
 
-// kim: TODO: test cloud cleanup job for this.
 func (m *ec2FleetManager) Cleanup(ctx context.Context) error {
 	if err := m.setupClient(ctx); err != nil {
 		return errors.Wrap(err, "creating client")

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -46,6 +46,9 @@ const (
 	// ec2ResourceAlreadyAssociated means an elastic IP is already associated
 	// with another resource.
 	ec2ResourceAlreadyAssociated = "Resource.AlreadyAssociated"
+	// ec2InsufficientFreeAddresses	means that there are no IP addresses
+	// remaining in an IPAM pool to allocate (not documented in AWS).
+	ec2InsufficientFreeAddresses = "InsufficientFreeAddressesInPool"
 
 	r53InvalidInput       = "InvalidInput"
 	r53InvalidChangeBatch = "InvalidChangeBatch"

--- a/model/host/ip_address.go
+++ b/model/host/ip_address.go
@@ -94,7 +94,6 @@ func FindIPAddressByAllocationID(ctx context.Context, allocationID string) (*IPA
 
 // FindStaleIPAddresses finds all IP addresses that are currently assigned to
 // some host but whose host is already terminated.
-// kim: TODO: test manually in MDB.
 func FindStaleIPAddresses(ctx context.Context) ([]IPAddress, error) {
 	ipAddrs := []IPAddress{}
 	const hostKey = "host"

--- a/model/host/ip_address.go
+++ b/model/host/ip_address.go
@@ -65,6 +65,20 @@ func (a *IPAddress) UnsetHostTag(ctx context.Context) error {
 	return nil
 }
 
+// IPAddressUnsetHostTags unsets the host tag for many IP addresses by ID.
+func IPAddressUnsetHostTags(ctx context.Context, ids ...string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+
+	_, err := db.UpdateAllContext(ctx, IPAddressCollection, bson.M{
+		ipAddressIDKey: bson.M{"$in": ids},
+	}, bson.M{
+		"$unset": bson.M{ipAddressHostTagKey: 1},
+	})
+	return err
+}
+
 // FindIPAddressByAllocationID finds an IP address by the IP address's
 // allocation ID.
 func FindIPAddressByAllocationID(ctx context.Context, allocationID string) (*IPAddress, error) {


### PR DESCRIPTION
DEVPROD-17313

### Description
Follow-up to #9010 - task hosts can now use elastic IPs from the `ip_addresses` collection, but the host lifecycle still can't guarantee that it'll unset the host from the IP address doc when terminating the host. We need to unset the host so that the IP address can be reused. I added a background check to ensure that if the host is already marked terminated, it doesn't need the IP address anymore, so we can safely free the IP address so it can be used by a new host.

* Clean up stray IP addresses that are still associated with a host that no longer needs it.
* Handle an extra error message from `AllocateAddress` that I noticed in prod, which is logged when the IPAM pool has no available free IP addresses.

### Testing
Tested in staging to confirm that it cleaned up IP addresses that were either associated with a nonexistent host or were still associated with a host that was already terminated.