### PR TITLE
DEVPROD-16645: do not delete repo admin permissions via route

### DIFF
--- a/model/repo_ref.go
+++ b/model/repo_ref.go
@@ -3,6 +3,7 @@ package model
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -244,4 +245,9 @@ func GetRepoAdminScope(repoId string) string {
 // GetRepoAdminRole returns the repo admin role ID for the given repo.
 func GetRepoAdminRole(repoId string) string {
 	return fmt.Sprintf("admin_repo_%s", repoId)
+}
+
+// IsAdminRepoRole returns whether or not the role ID is for an admin repo role.
+func IsAdminRepoRole(roleID string) bool {
+	return strings.HasPrefix(roleID, "admin_repo_")
 }

--- a/rest/route/user.go
+++ b/rest/route/user.go
@@ -321,32 +321,16 @@ func (h *userPermissionsDeleteHandler) Run(ctx context.Context) gimlet.Responder
 		return gimlet.NewJSONResponse(struct{}{})
 	}
 
-	// kim: NOTE: this finds all project/repo refs that have this resource ID.
-	// Repo scopes are special in that they count as "projects" from the
-	// perspective of the permissions system but repo refs are different from
-	// regular project refs because their scopes always include the child
-	// project refs (so that repo admins get permissions to all the child
-	// project refs). Therefore, they're included in this query.
 	rolesForResource, err := h.rm.FilterForResource(rolesToCheck, h.resourceId, h.resourceType)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "filtering user roles for resource '%s'", h.resourceId))
 	}
-	// kim: NOTE: the bug here is that it filters by resource ID and type but
-	// doesn't consider that repo admins are controlled separately from MANA. If
-	// a project ref and repo ref are using the same GitHub owner/repo and MANA
-	// wants to delete the project ref permissions, it can also end up deleting
-	// the repo ref permissions. Since the admin list is the authoritative
-	// source of repo ref permissions and not MANA, this route should ignore
-	// roles for repo refs.
 	rolesToRemove := []string{}
 	for _, r := range rolesForResource {
 		rolesToRemove = append(rolesToRemove, r.ID)
 	}
 
-	// kim: NOTE: the loss of repo admin permissions appears to be caused by
-	// this route based on yuan.fang example of the bug logging this line. They
-	// stay on the admin list though since the repo ref isn't updated here.
-	grip.InfoWhen(len(rolesToRemove) > 0, message.Fields{
+	grip.Info(message.Fields{
 		"removed_roles": rolesToRemove,
 		"user":          u.Id,
 		"resource_type": h.resourceType,


### PR DESCRIPTION
DEVPROD-16645

### Description
This fixes a bug where MANA could accidentally delete repo admin permissions via the `DELETE /rest/v2/users/{user_id}/permissions` route. Repo admins are maintained by the repo admin list because MANA doesn't support repo refs, but branch projects are maintained by MANA. When MANA ran the route, it would try removing roles related to a branch project, but the route would also delete any roles for the parent repo ref as well. Since repo admins are maintained by the admin list, MANA should not be modifying them in the route. To actually remove repo admin permissions, a user needs to remove themselves from the repo admin list.

* Fix delete user permissions route so it never deletes repo admin permissions.

#### Post-Deploy Fixes

This doesn't retroactively fix users who have already lost their repo admin permissions, so after this is deployed, I'm going to separately run a script to re-add permissions to users who lost it due to this bug.

### Testing
* Tested in staging to verify that:
    * Pre-change, if I removed my own branch project admin permissions via the route, I lost repo admin role.
    * Post-change, if I removed my own branch project admin permissions via the route, I still keep my repo admin role.
* Added unit test.
