### PR TITLE
DEVPROD-17803 Fix task group task drawdown logic

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -680,8 +680,12 @@ func (h *Host) IdleTime() time.Duration {
 		return 0
 	}
 
-	// If the host is currently tearing down a task group, it is not idle.
+	// If the host is currently tearing down a task group, it is only considered idle
+	// if the teardown time has exceeded the maximum allowed time.
 	if h.IsTearingDown() {
+		if h.TeardownTimeExceededMax() {
+			return time.Since(h.TaskGroupTeardownStartTime)
+		}
 		return 0
 	}
 

--- a/units/host_drawdown.go
+++ b/units/host_drawdown.go
@@ -117,7 +117,7 @@ func (j *hostDrawdownJob) checkAndDecommission(ctx context.Context, h *host.Host
 	}
 
 	// Don't drawdown hosts that are currently in the middle of tearing down a task group.
-	if h.IsTearingDown() && h.TeardownTimeExceededMax() {
+	if h.IsTearingDown() && !h.TeardownTimeExceededMax() {
 		return nil
 	}
 

--- a/units/host_drawdown.go
+++ b/units/host_drawdown.go
@@ -19,9 +19,8 @@ const (
 	hostDrawdownJobName = "host-drawdown"
 
 	// if we need to drawdown hosts, we want to catch as many hosts as we can that are between jobs
-	idleTimeDrawdownCutoff               = 5 * time.Second
-	idleTaskGroupDrawdownCutoff          = 10 * time.Minute
-	idleTransitioningTasksDrawdownCutoff = 30 * time.Second
+	idleTimeDrawdownCutoff      = 5 * time.Second
+	idleTaskGroupDrawdownCutoff = 10 * time.Minute
 )
 
 func init() {
@@ -136,8 +135,6 @@ func (j *hostDrawdownJob) checkAndDecommission(ctx context.Context, h *host.Host
 	idleThreshold := idleTimeDrawdownCutoff
 	if h.RunningTaskGroup != "" {
 		idleThreshold = idleTaskGroupDrawdownCutoff
-	} else if h.IsTransitioningTasks {
-		idleThreshold = idleTransitioningTasksDrawdownCutoff
 	}
 
 	if idleTime > idleThreshold {

--- a/units/host_drawdown.go
+++ b/units/host_drawdown.go
@@ -19,8 +19,9 @@ const (
 	hostDrawdownJobName = "host-drawdown"
 
 	// if we need to drawdown hosts, we want to catch as many hosts as we can that are between jobs
-	idleTimeDrawdownCutoff      = 5 * time.Second
-	idleTaskGroupDrawdownCutoff = 10 * time.Minute
+	idleTimeDrawdownCutoff               = 5 * time.Second
+	idleTaskGroupDrawdownCutoff          = 10 * time.Minute
+	idleTransitioningTasksDrawdownCutoff = 30 * time.Second
 )
 
 func init() {
@@ -135,6 +136,8 @@ func (j *hostDrawdownJob) checkAndDecommission(ctx context.Context, h *host.Host
 	idleThreshold := idleTimeDrawdownCutoff
 	if h.RunningTaskGroup != "" {
 		idleThreshold = idleTaskGroupDrawdownCutoff
+	} else if h.IsTransitioningTasks {
+		idleThreshold = idleTransitioningTasksDrawdownCutoff
 	}
 
 	if idleTime > idleThreshold {

--- a/units/host_drawdown_test.go
+++ b/units/host_drawdown_test.go
@@ -114,7 +114,7 @@ func TestHostDrawdown(t *testing.T) {
 				RunningTask:      "dummy_task_name1",
 			}
 			host2 := host.Host{
-				Id:           "ih2",
+				Id:           "h2",
 				Distro:       d,
 				Provider:     evergreen.ProviderNameMock,
 				CreationTime: time.Now().Add(-30 * time.Minute),
@@ -148,7 +148,7 @@ func TestHostDrawdown(t *testing.T) {
 		},
 		"IgnoresHostRunningTask": func(ctx context.Context, t *testing.T, env *mock.Environment, d distro.Distro) {
 			host1 := host.Host{
-				Id:           "uuh1",
+				Id:           "h1",
 				Distro:       d,
 				Provider:     evergreen.ProviderNameMock,
 				CreationTime: time.Now().Add(-30 * time.Minute),
@@ -172,7 +172,7 @@ func TestHostDrawdown(t *testing.T) {
 		},
 		"IgnoresHostThatRecentlyRanTaskGroup": func(ctx context.Context, t *testing.T, env *mock.Environment, d distro.Distro) {
 			host1 := host.Host{
-				Id:                    "yyh1",
+				Id:                    "h1",
 				Distro:                d,
 				Provider:              evergreen.ProviderNameMock,
 				CreationTime:          time.Now().Add(-30 * time.Minute),
@@ -201,7 +201,7 @@ func TestHostDrawdown(t *testing.T) {
 		"DecommissionsIdleMultiHostTaskGroupHost": func(ctx context.Context, t *testing.T, env *mock.Environment, d distro.Distro) {
 
 			host1 := host.Host{
-				Id:                    "tth1",
+				Id:                    "h1",
 				Distro:                d,
 				Provider:              evergreen.ProviderNameMock,
 				CreationTime:          time.Now().Add(-30 * time.Minute),


### PR DESCRIPTION
DEVPROD-17803 
### Description
We want to not drawdown if the host is currently tearing down a task and it has not yet exceeded the max time. 