### PR TITLE
DEVPROD-12099 Refactor patches page query to properly use index

### DIFF
--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -186,17 +186,6 @@ func ByPatchNameStatusesMergeQueuePaginated(ctx context.Context, opts ByPatchNam
 	pipeline := []bson.M{}
 	match := bson.M{}
 
-	if len(opts.Requesters) > 0 || utility.FromBoolPtr(opts.OnlyMergeQueue) {
-		requesterMatch := bson.M{"$in": opts.Requesters}
-		// Conditionally add the merge queue requester filter if the user is explicitly filtering on it.
-		// This is only used on the project patches page when we want to conditionally only show merge queue patches.
-		if utility.FromBoolPtr(opts.OnlyMergeQueue) {
-			requesterMatch = bson.M{"$eq": evergreen.GithubMergeRequester}
-		}
-		pipeline = append(pipeline, bson.M{"$addFields": bson.M{"requester": requesterExpression}})
-		match["requester"] = requesterMatch
-	}
-
 	if !utility.FromBoolTPtr(opts.IncludeHidden) {
 		match[HiddenKey] = bson.M{"$ne": true}
 	}
@@ -223,6 +212,20 @@ func ByPatchNameStatusesMergeQueuePaginated(ctx context.Context, opts ByPatchNam
 	}
 	// paginatePipeline will be used for the results
 	paginatePipeline := append(pipeline, sort)
+
+	if len(opts.Requesters) > 0 || utility.FromBoolPtr(opts.OnlyMergeQueue) {
+		matchRequesterStage := bson.M{}
+		requesterMatch := bson.M{"$in": opts.Requesters}
+		// Conditionally add the merge queue requester filter if the user is explicitly filtering on it.
+		// This is only used on the project patches page when we want to conditionally only show merge queue patches.
+		if utility.FromBoolPtr(opts.OnlyMergeQueue) {
+			requesterMatch = bson.M{"$eq": evergreen.GithubMergeRequester}
+		}
+		pipeline = append(pipeline, bson.M{"$addFields": bson.M{"requester": requesterExpression}})
+		matchRequesterStage["requester"] = requesterMatch
+		pipeline = append(pipeline, bson.M{"$match": matchRequesterStage})
+	}
+
 	if opts.Page > 0 {
 		skipStage := bson.M{
 			"$skip": opts.Page * opts.Limit,

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -215,7 +215,13 @@ func ByPatchNameStatusesMergeQueuePaginated(ctx context.Context, opts ByPatchNam
 
 	if len(opts.Requesters) > 0 || utility.FromBoolPtr(opts.OnlyMergeQueue) {
 		matchRequesterStage := bson.M{}
-		requesterMatch := bson.M{"$in": opts.Requesters}
+		validatedRequesters := []string{}
+		for _, requester := range opts.Requesters {
+			if evergreen.IsPatchRequester(requester) {
+				validatedRequesters = append(validatedRequesters, requester)
+			}
+		}
+		requesterMatch := bson.M{"$in": validatedRequesters}
 		// Conditionally add the merge queue requester filter if the user is explicitly filtering on it.
 		// This is only used on the project patches page when we want to conditionally only show merge queue patches.
 		if utility.FromBoolPtr(opts.OnlyMergeQueue) {


### PR DESCRIPTION
DEVPROD-12099

### Description
Refactors the query used by the patches page to first leverage the `branch_1_create_time_1_alias_1` index before applying the `requester` filter. The `requester` field is not stored directly on patch documents—it is computed dynamically. Previously, the query used `addFields` to compute `requester`, followed by a `$match` on `requester` and other fields. This resulted in a full collection scan, since none of the filtering could benefit from indexing. With this change, we first reduce the dataset by filtering on indexed fields, and only then apply additional filtering on the dynamically computed `requester`, if it was requested by the user.

<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

### Testing
Before:
https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/spruce/result/sK46TGDkjQQ/trace/5ef5erRBVGC?fields%5B%5D=s_name&fields%5B%5D=s_serviceName&span=83f2e25e201bb677
5+ minutes with no result
After:
<img width="1333" alt="image" src="https://github.com/user-attachments/assets/44fbb41a-b7cd-466f-ac95-9e62f8042c3d" />
300 ms with a result on the same query

