### PR TITLE
DEVPROD-17798 remove unpopulated builds field from version rest route

### DIFF
--- a/rest/model/version.go
+++ b/rest/model/version.go
@@ -38,7 +38,6 @@ type APIVersion struct {
 	Parameters []APIParameter `json:"parameters"`
 	// List of documents of the associated build variant and the build id
 	BuildVariantStatus []buildDetail `json:"build_variants_status"`
-	Builds             []APIBuild    `json:"builds,omitempty"`
 	// Version created by one of "patch_request", "github_pull_request",
 	// "gitter_request" (caused by git commit, aka the repotracker requester),
 	// "trigger_request" (Project Trigger versions) , "github_merge_request" (GitHub merge queue), "ad_hoc" (periodic builds)
@@ -93,11 +92,6 @@ func (apiVersion *APIVersion) BuildFromService(ctx context.Context, v model.Vers
 			BuildId:      utility.ToStringPtr(t.BuildId),
 		}
 		apiVersion.BuildVariantStatus = append(apiVersion.BuildVariantStatus, bd)
-	}
-	for _, bv := range v.Builds {
-		apiBuild := APIBuild{}
-		apiBuild.BuildFromService(ctx, bv, nil)
-		apiVersion.Builds = append(apiVersion.Builds, apiBuild)
 	}
 
 	for _, param := range v.Parameters {


### PR DESCRIPTION
DEVPROD-17798
### Description
Confirmed that we don't populate this, or use it anywhere. 

### Documentation
Remember to add or edit docs in the docs/ directory if relevant.
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
