### PR TITLE
DEVPROD-17022: fix flaky repotracker test

### DIFF
--- a/repotracker/github_poller_test.go
+++ b/repotracker/github_poller_test.go
@@ -48,7 +48,7 @@ func getDistantEVGRevision() (string, error) {
 	buf := &bufCloser{&bytes.Buffer{}}
 	bufErr := &bufCloser{&bytes.Buffer{}}
 
-	cmd := jasper.NewCommand().Add([]string{"git", "rev-list", "--reverse", "--max-count=1", "HEAD~100"}).Directory(cwd).
+	cmd := jasper.NewCommand().Add([]string{"git", "rev-list", "--reverse", "--max-count=1", "HEAD~50"}).Directory(cwd).
 		SetOutputWriter(buf).SetErrorWriter(bufErr)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
@@ -63,7 +63,6 @@ func getDistantEVGRevision() (string, error) {
 }
 
 func resetProjectRefs() {
-	// TODO: should use an evergreen-owned repo for the integration tests.
 	projectRef = &model.ProjectRef{
 		Id:          "mci-test",
 		DisplayName: "MCI Test",

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -600,24 +600,9 @@ tasks:
   - <<: *run-go-test-suite-with-mongodb-useast
     tags: ["db", "test"]
     name: test-graphql
-  - name: test-repotracker
+  - <<: *run-go-test-suite-with-mongodb
+    name: test-repotracker
     tags: ["db", "test"]
-    commands:
-      - command: github.generate_token
-        params:
-          expansion_name: github_token
-          permissions:
-            contents: read
-      - command: git.get_project
-        type: setup
-        params:
-          directory: evergreen
-          token: ${github_token}
-          shallow_clone: true
-      - func: setup-credentials
-      - func: setup-mongodb
-      - func: run-make
-        vars: { target: "test-repotracker" }
   - name: verify-swaggo-fmt
     tags: ["linter"]
     commands:

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -613,8 +613,7 @@ tasks:
         params:
           directory: evergreen
           token: ${github_token}
-          # The test-repotracker relies on HEAD~100
-          clone_depth: 110
+          shallow_clone: true
       - func: setup-credentials
       - func: setup-mongodb
       - func: run-make


### PR DESCRIPTION
DEVPROD-17022

### Description
I can't actually ascertain the exact reason why this test fails, but I believe it has something to do with the shallow cloning change in #8894. The test needs to find 100 commits before the HEAD of main in the PR task, so the task clones to a depth of 110. Unfortunately, it seems like [it still fails sometimes](https://evergreen.mongodb.com/task_log_raw/evergreen_ubuntu2204_test_repotracker_patch_76628279d06a1f2af9599e2f5760277243decaec_6806659ce99fff00076c6b0c_25_04_21_15_34_52/0?type=T), and the error message suggests that it failed because it couldn't find the 100th commit before HEAD due to the clone depth.

This test doesn't actually need to search 100 revisions back, it just needs to search more than a few commits into the past to prove the function can find older revisions. Because of that, I reduced the search to 50 commits back, which is well within the 100 commit limit when using shallow cloning.

### Testing
Ran the test 30 times in manual patches and didn't see any flakes.