### PR TITLE
DEVPROD-17116 add idle time override to release mode

### DIFF
--- a/config_release_mode.go
+++ b/config_release_mode.go
@@ -11,6 +11,7 @@ import (
 type ReleaseModeConfig struct {
 	DistroMaxHostsFactor      float64 `bson:"distro_max_hosts_factor" json:"distro_max_hosts_factor" yaml:"distro_max_hosts_factor"`
 	TargetTimeSecondsOverride int     `bson:"target_time_seconds_override" json:"target_time_seconds_override" yaml:"target_time_seconds_override"`
+	IdleTimeSecondsOverride   int     `bson:"idle_time_seconds_override" json:"idle_time_seconds_override" yaml:"idle_time_seconds_override"`
 }
 
 func (c *ReleaseModeConfig) SectionId() string { return "release_mode" }
@@ -24,6 +25,7 @@ func (c *ReleaseModeConfig) Set(ctx context.Context) error {
 		"$set": bson.M{
 			"distro_max_hosts_factor":      c.DistroMaxHostsFactor,
 			"target_time_seconds_override": c.TargetTimeSecondsOverride,
+			"idle_time_seconds_override":   c.IdleTimeSecondsOverride,
 		}}), "updating config section '%s'", c.SectionId(),
 	)
 }
@@ -31,6 +33,9 @@ func (c *ReleaseModeConfig) Set(ctx context.Context) error {
 func (c *ReleaseModeConfig) ValidateAndDefault() error {
 	if c.TargetTimeSecondsOverride < 0 {
 		return errors.Errorf("target time seconds override cannot be negative")
+	}
+	if c.IdleTimeSecondsOverride < 0 {
+		return errors.Errorf("idle time seconds override cannot be negative")
 	}
 	if c.DistroMaxHostsFactor < 0 {
 		return errors.Errorf("distro max hosts factor cannot be negative")

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -671,13 +671,13 @@ func (d *Distro) GetResolvedHostAllocatorSettings(s *evergreen.Settings) (HostAl
 		resolved.MaximumHosts = int(math.Ceil(float64(resolved.MaximumHosts) * s.ReleaseMode.DistroMaxHostsFactor))
 	}
 
-	if resolved.AcceptableHostIdleTime == 0 {
-		resolved.AcceptableHostIdleTime = time.Duration(config.AcceptableHostIdleTimeSeconds) * time.Second
-	}
 	// If enabled, release mode takes precedent over both distro and admin value.
 	if !s.ServiceFlags.ReleaseModeDisabled && s.ReleaseMode.IdleTimeSecondsOverride > 0 {
 		resolved.AcceptableHostIdleTime = time.Duration(s.ReleaseMode.IdleTimeSecondsOverride) * time.Second
+	} else if resolved.AcceptableHostIdleTime == 0 { // Fallback to admin value if not set at the distro level.
+		resolved.AcceptableHostIdleTime = time.Duration(config.AcceptableHostIdleTimeSeconds) * time.Second
 	}
+
 	if resolved.RoundingRule == evergreen.HostAllocatorRoundDefault {
 		resolved.RoundingRule = config.HostAllocatorRoundingRule
 	}
@@ -733,13 +733,14 @@ func (d *Distro) GetResolvedPlannerSettings(s *evergreen.Settings) (PlannerSetti
 	if !utility.StringSliceContains(evergreen.ValidTaskPlannerVersions, resolved.Version) {
 		catcher.Errorf("'%s' is not a valid planner version", resolved.Version)
 	}
-	if resolved.TargetTime == 0 {
-		resolved.TargetTime = time.Duration(config.TargetTimeSeconds) * time.Second
-	}
+
 	// If enabled, release mode takes precedent over both distro and admin value.
 	if !s.ServiceFlags.ReleaseModeDisabled && s.ReleaseMode.TargetTimeSecondsOverride > 0 {
 		resolved.TargetTime = time.Duration(s.ReleaseMode.TargetTimeSecondsOverride) * time.Second
+	} else if resolved.TargetTime == 0 { // Fallback to the admin value if not set at the distro level.
+		resolved.TargetTime = time.Duration(config.TargetTimeSeconds) * time.Second
 	}
+
 	if resolved.GroupVersions == nil {
 		resolved.GroupVersions = &config.GroupVersions
 	}

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -674,6 +674,10 @@ func (d *Distro) GetResolvedHostAllocatorSettings(s *evergreen.Settings) (HostAl
 	if resolved.AcceptableHostIdleTime == 0 {
 		resolved.AcceptableHostIdleTime = time.Duration(config.AcceptableHostIdleTimeSeconds) * time.Second
 	}
+	// If enabled, release mode takes precedent over both distro and admin value.
+	if !s.ServiceFlags.ReleaseModeDisabled && s.ReleaseMode.IdleTimeSecondsOverride > 0 {
+		resolved.AcceptableHostIdleTime = time.Duration(s.ReleaseMode.IdleTimeSecondsOverride) * time.Second
+	}
 	if resolved.RoundingRule == evergreen.HostAllocatorRoundDefault {
 		resolved.RoundingRule = config.HostAllocatorRoundingRule
 	}

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -339,7 +339,8 @@ func TestGetResolvedHostAllocatorSettings(t *testing.T) {
 		ExpectedRuntimeFactor:         7,
 	}
 	releaseModeConfig := evergreen.ReleaseModeConfig{
-		DistroMaxHostsFactor: 2.0,
+		DistroMaxHostsFactor:    2.0,
+		IdleTimeSecondsOverride: 300,
 	}
 	serviceFlags := evergreen.ServiceFlags{
 		ReleaseModeDisabled: true,
@@ -380,6 +381,7 @@ func TestGetResolvedHostAllocatorSettings(t *testing.T) {
 
 	// Factor in release mode when enabled.
 	assert.Equal(t, 20, resolved1.MaximumHosts)
+	assert.Equal(t, time.Duration(300)*time.Second, resolved1.AcceptableHostIdleTime)
 }
 
 func TestGetResolvedPlannerSettings(t *testing.T) {

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2043,6 +2043,7 @@ func (a *APIRepoTrackerConfig) ToService() (any, error) {
 type APIReleaseModeConfig struct {
 	DistroMaxHostsFactor      float64 `json:"distro_max_hosts_factor"`
 	TargetTimeSecondsOverride int     `json:"target_time_seconds_override"`
+	IdleTimeSecondsOverride   int     `json:"idle_time_seconds_override"`
 }
 
 func (a *APIReleaseModeConfig) BuildFromService(h any) error {
@@ -2050,6 +2051,7 @@ func (a *APIReleaseModeConfig) BuildFromService(h any) error {
 	case evergreen.ReleaseModeConfig:
 		a.DistroMaxHostsFactor = v.DistroMaxHostsFactor
 		a.TargetTimeSecondsOverride = v.TargetTimeSecondsOverride
+		a.IdleTimeSecondsOverride = v.IdleTimeSecondsOverride
 	default:
 		return errors.Errorf("programmatic error: expected ReleaseModeConfig but got type %T", h)
 	}
@@ -2060,6 +2062,7 @@ func (a *APIReleaseModeConfig) ToService() (any, error) {
 	return evergreen.ReleaseModeConfig{
 		DistroMaxHostsFactor:      a.DistroMaxHostsFactor,
 		TargetTimeSecondsOverride: a.TargetTimeSecondsOverride,
+		IdleTimeSecondsOverride:   a.IdleTimeSecondsOverride,
 	}, nil
 }
 

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -594,7 +594,7 @@ Admin Settings
 										</md-input-container>
 									</md-card-content>
 								</md-card>
-								<md-card flex=50 id="release-mode" style="height:240px">
+								<md-card flex=50 id="release-mode" style="height:300px">
 									<md-card-title>
 										<md-card-title-text>
 											<span>Release Mode Settings</span>
@@ -610,6 +610,11 @@ Admin Settings
 											<label>Target Time Seconds Override</label>
 											<div class="muted small">Override for the target time to clear a task from the queue (ignored if 0).</div>
 											<input type="number" ng-model="Settings.release_mode.target_time_seconds_override">
+										</md-input-container>
+										<md-input-container class="control" style="width:45%;">
+											<label>Idle Time Seconds Override</label>
+											<div class="muted small">Override for the acceptable host idle time (ignored if 0).</div>
+											<input type="number" ng-model="Settings.release_mode.idle_time_seconds_override">
 										</md-input-container>
 									</md-card-content>
 								</md-card>
@@ -2697,7 +2702,7 @@ Admin Settings
 													<md-input-container class="control" flex=25>
 														<input class="control" type="text" ng-model="new_owner_repo.owner" placeholder="Owner Name">
 													</md-input-container>
-	
+
 													<md-input-container class="control" flex=50>
 														<input class="control" type="text" ng-model="new_owner_repo.repo" placeholder="Repo Name">
 													</md-input-container>

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -366,6 +366,7 @@ func MockConfig() *evergreen.Settings {
 		ReleaseMode: evergreen.ReleaseModeConfig{
 			DistroMaxHostsFactor:      2.0,
 			TargetTimeSecondsOverride: 60,
+			IdleTimeSecondsOverride:   120,
 		},
 		Scheduler: evergreen.SchedulerConfig{
 			TaskFinder: "legacy",


### PR DESCRIPTION
DEVPROD-17116 
### Description
Added idle time override to release mode. 

### Testing
Added a unit test and ensured this worked locally. 

### Documentation
Will add some process docs now that release mode is complete, and loop in Aldo and Mohamed.
