### PR TITLE
DEVPROD-16746 add local branch info to patches

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-05-07"
+	ClientVersion = "2025-05-22"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -54,6 +54,9 @@ type githubIntent struct {
 	// to be merged
 	HeadRepoName string `bson:"head_repo_name"`
 
+	// HeadBranch is the branch name that contains the changes for this PR
+	HeadBranch string `bson:"head_branch"`
+
 	// PRNumber is the pull request number in GitHub.
 	PRNumber int `bson:"pr_number"`
 
@@ -166,6 +169,7 @@ func NewGithubIntent(ctx context.Context, msgDeliveryID, patchOwner, calledBy, a
 		BaseRepoName:  pr.Base.Repo.GetFullName(),
 		BaseBranch:    pr.Base.GetRef(),
 		HeadRepoName:  pr.Head.Repo.GetFullName(),
+		HeadBranch:    pr.Head.GetRef(),
 		PRNumber:      pr.GetNumber(),
 		User:          patchOwner,
 		UID:           int(pr.User.GetID()),
@@ -293,6 +297,7 @@ func (g *githubIntent) NewPatch() *Patch {
 			BaseBranch: g.BaseBranch,
 			HeadOwner:  headRepo[0],
 			HeadRepo:   headRepo[1],
+			HeadBranch: g.HeadBranch,
 			HeadHash:   g.HeadHash,
 			BaseHash:   g.BaseHash,
 			MergeBase:  g.MergeBase,

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -103,9 +103,10 @@ type Parameter struct {
 }
 
 type GitMetadata struct {
-	Username   string `bson:"username" json:"username"`
-	Email      string `bson:"email" json:"email"`
-	GitVersion string `bson:"git_version,omitempty" json:"git_version,omitempty"`
+	Username    string `bson:"username" json:"username"`
+	Email       string `bson:"email" json:"email"`
+	GitVersion  string `bson:"git_version,omitempty" json:"git_version,omitempty"`
+	LocalBranch string `bson:"local_branch,omitempty" json:"local_branch,omitempty"`
 }
 
 type LocalModuleInclude struct {

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -861,6 +861,11 @@ func getGitConfigMetadata() (patch.GitMetadata, error) {
 		metadata.GitVersion = version
 	}
 
+	branch, err := gitBranch()
+	if err == nil {
+		metadata.LocalBranch = strings.TrimSpace(branch)
+	}
+
 	return metadata, nil
 }
 

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -471,13 +471,14 @@ func (apiPatch *APIPatch) ToService() (patch.Patch, error) {
 }
 
 type githubPatch struct {
-	PRNumber  int     `json:"pr_number"`
-	BaseOwner *string `json:"base_owner"`
-	BaseRepo  *string `json:"base_repo"`
-	HeadOwner *string `json:"head_owner"`
-	HeadRepo  *string `json:"head_repo"`
-	HeadHash  *string `json:"head_hash"`
-	Author    *string `json:"author"`
+	PRNumber   int     `json:"pr_number"`
+	BaseOwner  *string `json:"base_owner"`
+	BaseRepo   *string `json:"base_repo"`
+	HeadOwner  *string `json:"head_owner"`
+	HeadRepo   *string `json:"head_repo"`
+	HeadBranch *string `json:"head_branch"`
+	HeadHash   *string `json:"head_hash"`
+	Author     *string `json:"author"`
 }
 
 // BuildFromService converts from service level structs to an APIPatch
@@ -487,6 +488,7 @@ func (g *githubPatch) BuildFromService(p thirdparty.GithubPatch) {
 	g.BaseRepo = utility.ToStringPtr(p.BaseRepo)
 	g.HeadOwner = utility.ToStringPtr(p.HeadOwner)
 	g.HeadRepo = utility.ToStringPtr(p.HeadRepo)
+	g.HeadBranch = utility.ToStringPtr(p.HeadBranch)
 	g.HeadHash = utility.ToStringPtr(p.HeadHash)
 	g.Author = utility.ToStringPtr(p.Author)
 }
@@ -499,6 +501,7 @@ func (g *githubPatch) ToService() thirdparty.GithubPatch {
 	res.BaseRepo = utility.FromStringPtr(g.BaseRepo)
 	res.HeadOwner = utility.FromStringPtr(g.HeadOwner)
 	res.HeadRepo = utility.FromStringPtr(g.HeadRepo)
+	res.HeadBranch = utility.FromStringPtr(g.HeadBranch)
 	res.HeadHash = utility.FromStringPtr(g.HeadHash)
 	res.Author = utility.FromStringPtr(g.Author)
 	return res

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -159,6 +159,7 @@ type GithubPatch struct {
 	BaseBranch    string `bson:"base_branch"`
 	HeadOwner     string `bson:"head_owner"`
 	HeadRepo      string `bson:"head_repo"`
+	HeadBranch    string `bson:"head_branch"`
 	HeadHash      string `bson:"head_hash"`
 	BaseHash      string `bson:"base_hash"`
 	Author        string `bson:"author"`

--- a/trigger/payloads_test.go
+++ b/trigger/payloads_test.go
@@ -132,7 +132,7 @@ func (s *payloadSuite) TestEvergreenWebhook() {
 	s.NoError(err)
 	s.Require().NotNil(m)
 
-	s.Len(m.Body, 596)
+	s.Len(m.Body, 615)
 	s.Len(m.Headers, 1)
 }
 


### PR DESCRIPTION
DEVPROD-16746 

### Description
I originally misunderstood this ticket by adding branch_name to the patch (although i think it's fine to have and we don't need to get rid of it, but i can if anyone disagrees). What server leadership wants is to know from what branch a PR or CLI patch was _created from_, so they can start to track how much work is done for each ticket or unit of work.

I will make a DPIPE ticket to expose both of these. 

### Testing
Confirmed that a [CLI patch](https://spruce-staging.corp.mongodb.com/patch/682f94cd7b68bb00078fb961/configure/tasks) has this information under local_branch under git_info: 
<img width="271" alt="image" src="https://github.com/user-attachments/assets/b56f8ec8-bda0-4829-bb72-580cfa3df2fe" />

and that head_branch is set for [PR patches](https://spruce-staging.corp.mongodb.com/version/682f95364aa7b80007950ea9/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) under github_patch_data:
<img width="330" alt="image" src="https://github.com/user-attachments/assets/3d38c7d7-3edd-47fe-8fe6-f1c286eeea81" />

