### PR TITLE
DEVPROD-16863 Expose ProviderAccount field via graphql api

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -21093,14 +21093,11 @@ func (ec *executionContext) _Distro_providerAccount(ctx context.Context, field g
 		return graphql.Null
 	}
 	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
 		return graphql.Null
 	}
 	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Distro_providerAccount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -77845,7 +77842,7 @@ func (ec *executionContext) unmarshalInputDistroInput(ctx context.Context, obj a
 			}
 		case "providerAccount":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("providerAccount"))
-			data, err := ec.unmarshalNString2ᚖstring(ctx, v)
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -84102,9 +84099,6 @@ func (ec *executionContext) _Distro(ctx context.Context, sel ast.SelectionSet, o
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "providerAccount":
 			out.Values[i] = ec._Distro_providerAccount(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "providerSettingsList":
 			field := field
 

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -276,6 +276,7 @@ type ComplexityRoot struct {
 		Note                  func(childComplexity int) int
 		PlannerSettings       func(childComplexity int) int
 		Provider              func(childComplexity int) int
+		ProviderAccount       func(childComplexity int) int
 		ProviderSettingsList  func(childComplexity int) int
 		SSHOptions            func(childComplexity int) int
 		Setup                 func(childComplexity int) int
@@ -1788,6 +1789,7 @@ type DistroResolver interface {
 	Arch(ctx context.Context, obj *model.APIDistro) (Arch, error)
 
 	Provider(ctx context.Context, obj *model.APIDistro) (Provider, error)
+
 	ProviderSettingsList(ctx context.Context, obj *model.APIDistro) ([]map[string]any, error)
 }
 type FinderSettingsResolver interface {
@@ -2146,6 +2148,7 @@ type DistroInputResolver interface {
 	Arch(ctx context.Context, obj *model.APIDistro, data Arch) error
 
 	Provider(ctx context.Context, obj *model.APIDistro, data Provider) error
+
 	ProviderSettingsList(ctx context.Context, obj *model.APIDistro, data []map[string]any) error
 }
 type FinderSettingsInputResolver interface {
@@ -2902,6 +2905,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Distro.Provider(childComplexity), true
+
+	case "Distro.providerAccount":
+		if e.complexity.Distro.ProviderAccount == nil {
+			break
+		}
+
+		return e.complexity.Distro.ProviderAccount(childComplexity), true
 
 	case "Distro.providerSettingsList":
 		if e.complexity.Distro.ProviderSettingsList == nil {
@@ -21062,6 +21072,50 @@ func (ec *executionContext) fieldContext_Distro_provider(_ context.Context, fiel
 	return fc, nil
 }
 
+func (ec *executionContext) _Distro_providerAccount(ctx context.Context, field graphql.CollectedField, obj *model.APIDistro) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Distro_providerAccount(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ProviderAccount, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Distro_providerAccount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Distro",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Distro_providerSettingsList(ctx context.Context, field graphql.CollectedField, obj *model.APIDistro) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Distro_providerSettingsList(ctx, field)
 	if err != nil {
@@ -28624,6 +28678,8 @@ func (ec *executionContext) fieldContext_Image_distros(_ context.Context, field 
 				return ec.fieldContext_Distro_plannerSettings(ctx, field)
 			case "provider":
 				return ec.fieldContext_Distro_provider(ctx, field)
+			case "providerAccount":
+				return ec.fieldContext_Distro_providerAccount(ctx, field)
 			case "providerSettingsList":
 				return ec.fieldContext_Distro_providerSettingsList(ctx, field)
 			case "setup":
@@ -49320,6 +49376,8 @@ func (ec *executionContext) fieldContext_Query_distro(ctx context.Context, field
 				return ec.fieldContext_Distro_plannerSettings(ctx, field)
 			case "provider":
 				return ec.fieldContext_Distro_provider(ctx, field)
+			case "providerAccount":
+				return ec.fieldContext_Distro_providerAccount(ctx, field)
 			case "providerSettingsList":
 				return ec.fieldContext_Distro_providerSettingsList(ctx, field)
 			case "setup":
@@ -49504,6 +49562,8 @@ func (ec *executionContext) fieldContext_Query_distros(ctx context.Context, fiel
 				return ec.fieldContext_Distro_plannerSettings(ctx, field)
 			case "provider":
 				return ec.fieldContext_Distro_provider(ctx, field)
+			case "providerAccount":
+				return ec.fieldContext_Distro_providerAccount(ctx, field)
 			case "providerSettingsList":
 				return ec.fieldContext_Distro_providerSettingsList(ctx, field)
 			case "setup":
@@ -55418,6 +55478,8 @@ func (ec *executionContext) fieldContext_SaveDistroPayload_distro(_ context.Cont
 				return ec.fieldContext_Distro_plannerSettings(ctx, field)
 			case "provider":
 				return ec.fieldContext_Distro_provider(ctx, field)
+			case "providerAccount":
+				return ec.fieldContext_Distro_providerAccount(ctx, field)
 			case "providerSettingsList":
 				return ec.fieldContext_Distro_providerSettingsList(ctx, field)
 			case "setup":
@@ -77587,7 +77649,7 @@ func (ec *executionContext) unmarshalInputDistroInput(ctx context.Context, obj a
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"adminOnly", "aliases", "arch", "authorizedKeysFile", "bootstrapSettings", "containerPool", "disabled", "disableShallowClone", "dispatcherSettings", "execUser", "expansions", "finderSettings", "homeVolumeSettings", "hostAllocatorSettings", "iceCreamSettings", "imageId", "isCluster", "isVirtualWorkStation", "mountpoints", "name", "note", "plannerSettings", "provider", "providerSettingsList", "setup", "setupAsSudo", "singleTaskDistro", "sshOptions", "user", "userSpawnAllowed", "validProjects", "warningNote", "workDir"}
+	fieldsInOrder := [...]string{"adminOnly", "aliases", "arch", "authorizedKeysFile", "bootstrapSettings", "containerPool", "disabled", "disableShallowClone", "dispatcherSettings", "execUser", "expansions", "finderSettings", "homeVolumeSettings", "hostAllocatorSettings", "iceCreamSettings", "imageId", "isCluster", "isVirtualWorkStation", "mountpoints", "name", "note", "plannerSettings", "provider", "providerAccount", "providerSettingsList", "setup", "setupAsSudo", "singleTaskDistro", "sshOptions", "user", "userSpawnAllowed", "validProjects", "warningNote", "workDir"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -77781,6 +77843,13 @@ func (ec *executionContext) unmarshalInputDistroInput(ctx context.Context, obj a
 			if err = ec.resolvers.DistroInput().Provider(ctx, &it, data); err != nil {
 				return it, err
 			}
+		case "providerAccount":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("providerAccount"))
+			data, err := ec.unmarshalNString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ProviderAccount = data
 		case "providerSettingsList":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("providerSettingsList"))
 			data, err := ec.unmarshalNMap2ᚕmapᚄ(ctx, v)
@@ -84031,6 +84100,11 @@ func (ec *executionContext) _Distro(ctx context.Context, sel ast.SelectionSet, o
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "providerAccount":
+			out.Values[i] = ec._Distro_providerAccount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "providerSettingsList":
 			field := field
 

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -21093,11 +21093,14 @@ func (ec *executionContext) _Distro_providerAccount(ctx context.Context, field g
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
 	res := resTmp.(*string)
 	fc.Result = res
-	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalNString2ᚖstring(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Distro_providerAccount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -84099,6 +84102,9 @@ func (ec *executionContext) _Distro(ctx context.Context, sel ast.SelectionSet, o
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "providerAccount":
 			out.Values[i] = ec._Distro_providerAccount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "providerSettingsList":
 			field := field
 

--- a/graphql/schema/types/distro.graphql
+++ b/graphql/schema/types/distro.graphql
@@ -138,7 +138,7 @@ input DistroInput {
   note: String!
   plannerSettings: PlannerSettingsInput!
   provider: Provider!
-  providerAccount: String!
+  providerAccount: String
   providerSettingsList: [Map!]!
   setup: String!
   setupAsSudo: Boolean!
@@ -292,7 +292,7 @@ type Distro {
   note: String!
   plannerSettings: PlannerSettings!
   provider: Provider!
-  providerAccount: String!
+  providerAccount: String
   providerSettingsList: [Map!]!
   setup: String!
   setupAsSudo: Boolean!

--- a/graphql/schema/types/distro.graphql
+++ b/graphql/schema/types/distro.graphql
@@ -292,7 +292,7 @@ type Distro {
   note: String!
   plannerSettings: PlannerSettings!
   provider: Provider!
-  providerAccount: String
+  providerAccount: String!
   providerSettingsList: [Map!]!
   setup: String!
   setupAsSudo: Boolean!

--- a/graphql/schema/types/distro.graphql
+++ b/graphql/schema/types/distro.graphql
@@ -138,6 +138,7 @@ input DistroInput {
   note: String!
   plannerSettings: PlannerSettingsInput!
   provider: Provider!
+  providerAccount: String!
   providerSettingsList: [Map!]!
   setup: String!
   setupAsSudo: Boolean!
@@ -291,6 +292,7 @@ type Distro {
   note: String!
   plannerSettings: PlannerSettings!
   provider: Provider!
+  providerAccount: String!
   providerSettingsList: [Map!]!
   setup: String!
   setupAsSudo: Boolean!

--- a/graphql/tests/mutation/saveDistro/data.json
+++ b/graphql/tests/mutation/saveDistro/data.json
@@ -2,11 +2,16 @@
   "distro": [
     {
       "_id": "rhel71-power8-large",
-      "aliases": ["rhel71-power8", "rhel71-power8-build"],
+      "aliases": [
+        "rhel71-power8",
+        "rhel71-power8-build"
+      ],
       "arch": "linux_ppc64le",
       "disabled": false,
       "work_dir": "/data/mci",
-      "mountpoints": ["/"],
+      "mountpoints": [
+        "/"
+      ],
       "provider": "static",
       "provider_settings": [
         {
@@ -20,6 +25,7 @@
           ]
         }
       ],
+      "provider_account": "aws",
       "user": "mci-exec",
       "bootstrap_settings": {
         "method": "legacy-ssh",
@@ -106,13 +112,20 @@
     {
       "_id": "host_1",
       "container_images": null,
-      "creation_time": { "$date": "2018-09-19T13:32:26.568Z" },
+      "creation_time": {
+        "$date": "2018-09-19T13:32:26.568Z"
+      },
       "distro": {
         "_id": "rhel71-power8-large",
-        "aliases": ["rhel71-power8", "rhel71-power8-build"],
+        "aliases": [
+          "rhel71-power8",
+          "rhel71-power8-build"
+        ],
         "arch": "linux_ppc64le",
         "work_dir": "/data/mci",
-        "mountpoints": ["/"],
+        "mountpoints": [
+          "/"
+        ],
         "provider": "static",
         "provider_settings": [
           {
@@ -126,6 +139,7 @@
             ]
           }
         ],
+        "provider_account": "",
         "user": "mci-exec",
         "bootstrap_settings": {
           "method": "legacy-ssh",
@@ -161,32 +175,54 @@
             "value": "kill -- -$(ps opgid= %v)"
           }
         ],
-        "finder_settings": { "version": "legacy" },
+        "finder_settings": {
+          "version": "legacy"
+        },
         "planner_settings": {
           "version": "tunable",
-          "target_time": { "$numberLong": "0" },
+          "target_time": {
+            "$numberLong": "0"
+          },
           "group_versions": false,
-          "patch_zipper_factor": { "$numberLong": "0" },
-          "patch_time_in_queue_factor": { "$numberLong": "0" },
-          "commit_queue_factor": { "$numberLong": "0" },
-          "mainline_time_in_queue_factor": { "$numberLong": "0" },
-          "expected_runtime_factor": { "$numberLong": "0" }
+          "patch_zipper_factor": {
+            "$numberLong": "0"
+          },
+          "patch_time_in_queue_factor": {
+            "$numberLong": "0"
+          },
+          "commit_queue_factor": {
+            "$numberLong": "0"
+          },
+          "mainline_time_in_queue_factor": {
+            "$numberLong": "0"
+          },
+          "expected_runtime_factor": {
+            "$numberLong": "0"
+          }
         },
-        "dispatcher_settings": { "version": "revised-with-dependencies" },
+        "dispatcher_settings": {
+          "version": "revised-with-dependencies"
+        },
         "host_allocator_settings": {
           "version": "utilization",
           "minimum_hosts": 0,
           "maximum_hosts": 0,
-          "acceptable_host_idle_time": { "$numberLong": "0" }
+          "acceptable_host_idle_time": {
+            "$numberLong": "0"
+          }
         },
         "disable_shallow_clone": false,
         "note": "",
         "is_virtual_workstation": false,
         "is_cluster": false,
-        "home_volume_settings": { "format_command": "" },
+        "home_volume_settings": {
+          "format_command": ""
+        },
         "icecream_settings": {}
       },
-      "expiration_time": { "$date": "0001-01-01T00:00:00Z" },
+      "expiration_time": {
+        "$date": "0001-01-01T00:00:00Z"
+      },
       "has_containers": false,
       "host_id": "rhel71-ppc-1.pic.build.10gen.cc",
       "host_type": "static",
@@ -195,7 +231,9 @@
       "project": "",
       "provision_options": null,
       "provisioned": true,
-      "start_time": { "$date": "0001-01-01T00:00:00Z" },
+      "start_time": {
+        "$date": "0001-01-01T00:00:00Z"
+      },
       "started_by": "mci",
       "status": "running",
       "tag": "",
@@ -204,13 +242,20 @@
     {
       "_id": "host_2",
       "container_images": null,
-      "creation_time": { "$date": "2018-09-19T13:32:26.568Z" },
+      "creation_time": {
+        "$date": "2018-09-19T13:32:26.568Z"
+      },
       "distro": {
         "_id": "rhel71-power8-large",
-        "aliases": ["rhel71-power8", "rhel71-power8-build"],
+        "aliases": [
+          "rhel71-power8",
+          "rhel71-power8-build"
+        ],
         "arch": "linux_ppc64le",
         "work_dir": "/data/mci",
-        "mountpoints": ["/"],
+        "mountpoints": [
+          "/"
+        ],
         "provider": "static",
         "provider_settings": [
           {
@@ -224,6 +269,7 @@
             ]
           }
         ],
+        "provider_account": "",
         "user": "mci-exec",
         "bootstrap_settings": {
           "method": "legacy-ssh",
@@ -259,32 +305,54 @@
             "value": "kill -- -$(ps opgid= %v)"
           }
         ],
-        "finder_settings": { "version": "legacy" },
+        "finder_settings": {
+          "version": "legacy"
+        },
         "planner_settings": {
           "version": "tunable",
-          "target_time": { "$numberLong": "0" },
+          "target_time": {
+            "$numberLong": "0"
+          },
           "group_versions": false,
-          "patch_zipper_factor": { "$numberLong": "0" },
-          "patch_time_in_queue_factor": { "$numberLong": "0" },
-          "commit_queue_factor": { "$numberLong": "0" },
-          "mainline_time_in_queue_factor": { "$numberLong": "0" },
-          "expected_runtime_factor": { "$numberLong": "0" }
+          "patch_zipper_factor": {
+            "$numberLong": "0"
+          },
+          "patch_time_in_queue_factor": {
+            "$numberLong": "0"
+          },
+          "commit_queue_factor": {
+            "$numberLong": "0"
+          },
+          "mainline_time_in_queue_factor": {
+            "$numberLong": "0"
+          },
+          "expected_runtime_factor": {
+            "$numberLong": "0"
+          }
         },
-        "dispatcher_settings": { "version": "revised-with-dependencies" },
+        "dispatcher_settings": {
+          "version": "revised-with-dependencies"
+        },
         "host_allocator_settings": {
           "version": "utilization",
           "minimum_hosts": 0,
           "maximum_hosts": 0,
-          "acceptable_host_idle_time": { "$numberLong": "0" }
+          "acceptable_host_idle_time": {
+            "$numberLong": "0"
+          }
         },
         "disable_shallow_clone": false,
         "note": "",
         "is_virtual_workstation": false,
         "is_cluster": false,
-        "home_volume_settings": { "format_command": "" },
+        "home_volume_settings": {
+          "format_command": ""
+        },
         "icecream_settings": {}
       },
-      "expiration_time": { "$date": "0001-01-01T00:00:00Z" },
+      "expiration_time": {
+        "$date": "0001-01-01T00:00:00Z"
+      },
       "has_containers": false,
       "host_id": "rhel71-ppc-1.pic.build.10gen.cc",
       "host_type": "static",
@@ -293,7 +361,9 @@
       "project": "",
       "provision_options": null,
       "provisioned": true,
-      "start_time": { "$date": "0001-01-01T00:00:00Z" },
+      "start_time": {
+        "$date": "0001-01-01T00:00:00Z"
+      },
       "started_by": "mci",
       "status": "running",
       "tag": "",

--- a/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/insufficient_permissions.graphql
@@ -30,6 +30,7 @@ mutation {
             security_group_ids: ["2"]
           }
         ]
+        providerAccount: "aws"
         user: "mci-exec"
         bootstrapSettings: {
           clientDir: "/home/mci-exec/evergreen_provisioning"

--- a/graphql/tests/mutation/saveDistro/queries/save.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/save.graphql
@@ -13,6 +13,7 @@ mutation {
         workDir: "/data/mci"
         mountpoints: ["/"]
         provider: EC2_ON_DEMAND
+        providerAccount: "aws"
         providerSettingsList: [
           {
             ami: "who-ami"

--- a/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/validation_error.graphql
@@ -30,6 +30,7 @@ mutation {
             security_group_ids: ["2"]
           }
         ]
+        providerAccount: "aws"
         user: "mci-exec"
         bootstrapSettings: {
           clientDir: "/home/mci-exec/evergreen_provisioning"

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -342,6 +342,7 @@ type APIDistro struct {
 	UserSpawnAllowed      bool                     `json:"user_spawn_allowed"`
 	Provider              *string                  `json:"provider"`
 	ProviderSettingsList  []*birch.Document        `json:"provider_settings" swaggertype:"object"`
+	ProviderAccount       *string                  `json:"provider_account"`
 	Arch                  *string                  `json:"arch"`
 	WorkDir               *string                  `json:"work_dir"`
 	SetupAsSudo           bool                     `json:"setup_as_sudo"`
@@ -379,6 +380,7 @@ func (apiDistro *APIDistro) BuildFromService(d distro.Distro) {
 	apiDistro.UserSpawnAllowed = d.SpawnAllowed
 	apiDistro.Provider = utility.ToStringPtr(d.Provider)
 	apiDistro.ProviderSettingsList = d.ProviderSettingsList
+	apiDistro.ProviderAccount = utility.ToStringPtr(d.ProviderAccount)
 	apiDistro.Arch = utility.ToStringPtr(d.Arch)
 	apiDistro.WorkDir = utility.ToStringPtr(d.WorkDir)
 	apiDistro.SetupAsSudo = d.SetupAsSudo
@@ -446,6 +448,7 @@ func (apiDistro *APIDistro) ToService() *distro.Distro {
 	d.WorkDir = utility.FromStringPtr(apiDistro.WorkDir)
 	d.Provider = utility.FromStringPtr(apiDistro.Provider)
 	d.ProviderSettingsList = apiDistro.ProviderSettingsList
+	d.ProviderAccount = utility.FromStringPtr(apiDistro.ProviderAccount)
 	d.SetupAsSudo = apiDistro.SetupAsSudo
 	d.Setup = utility.FromStringPtr(apiDistro.Setup)
 	d.User = utility.FromStringPtr(apiDistro.User)


### PR DESCRIPTION
DEVPROD-16863

### Description
Expose the provideraccount field to the graphql api so we can use expose it on the UI.

<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

### Testing
add a description of how you tested it

### Documentation
Remember to add or edit docs in the docs/ directory if relevant.
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
