### PR TITLE
DEVPROD-13597: add Honeycomb tracing when a patch is reconfigured

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -511,6 +511,9 @@ const (
 	VersionPRNumOtelAttribute            = "evergreen.version.pr_num"
 	VersionDescriptionOtelAttribute      = "evergreen.version.description"
 
+	// patch otel attributes
+	PatchIsReconfiguredOtelAttribute = "evergreen.patch.is_reconfigured"
+
 	// build otel attributes
 	BuildIDOtelAttribute   = "evergreen.build.id"
 	BuildNameOtelAttribute = "evergreen.build.name"

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -42,6 +42,7 @@ var (
 	PatchesKey              = bsonutil.MustHaveTag(Patch{}, "Patches")
 	ParametersKey           = bsonutil.MustHaveTag(Patch{}, "Parameters")
 	ActivatedKey            = bsonutil.MustHaveTag(Patch{}, "Activated")
+	IsReconfiguredKey       = bsonutil.MustHaveTag(Patch{}, "IsReconfigured")
 	ProjectStorageMethodKey = bsonutil.MustHaveTag(Patch{}, "ProjectStorageMethod")
 	PatchedProjectConfigKey = bsonutil.MustHaveTag(Patch{}, "PatchedProjectConfig")
 	AliasKey                = bsonutil.MustHaveTag(Patch{}, "Alias")

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -143,6 +143,9 @@ type Patch struct {
 	Activated bool `bson:"activated"`
 	// IsReconfigured indicates whether this patch was finalized with an initial
 	// set of tasks, then later reconfigured to add more tasks to run.
+	// This doesn't take into account if existing tasks were
+	// scheduled/unscheduled, it's only considered reconfigured if new tasks
+	// were created after the patch was finalized.
 	IsReconfigured bool `bson:"is_reconfigured,omitempty"`
 	// Project contains the project ID for the patch. The bson tag here is `branch` due to legacy usage.
 	Project string `bson:"branch"`

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -102,11 +102,11 @@ func addNewTasksAndBuildsForPatch(ctx context.Context, p *patch.Patch, creationI
 	err = activateExistingInactiveTasks(ctx, creationInfo, existingBuilds, caller)
 	totalActivatedTasks := len(activatedTasks) + len(activatedTasksInExistingBuilds) + len(activatedDeps) + len(activatedDepsInExistingBuilds)
 	if totalActivatedTasks > 0 {
-		// It's necessary to check if tasks were actually scheduled because it's
-		// valid for a user to use the reconfigure page to modify a patch but it
-		// doesn't change the patch's tasks at all (e.g. if they just updated
-		// the patch description). A patch is only considered reconfigured if
-		// new tasks were added.
+		// It's necessary to check if new tasks were actually created because
+		// it's valid for a user to reconfigure a patch without changing the
+		// patch's tasks at all (e.g. if they just updated the patch
+		// description). A patch is only considered reconfigured if new tasks
+		// were added.
 		if err := p.SetIsReconfigured(ctx, true); err != nil {
 			return errors.Wrap(err, "marking patch as reconfigured")
 		}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -182,8 +182,6 @@ func ConfigurePatch(ctx context.Context, settings *evergreen.Settings, p *patch.
 				ActivationInfo: specificActivationInfo{},
 				GeneratedBy:    "",
 			}
-			// kim: NOTE: this looks like where patches get new tasks get added
-			// after patch creation.
 			err = addNewTasksAndBuildsForPatch(ctx, p, creationInfo, patchUpdateReq.Caller)
 			if err != nil {
 				return http.StatusInternalServerError, errors.Wrapf(err, "creating new tasks/builds for version '%s'", version.Id)


### PR DESCRIPTION
DEVPROD-13597

### Description
Add a patch field to indicate whether a patch was reconfigured after it was finalized. This is so that users can see if a patch was reconfigured in the version-completion traces for their stats. I narrowly defined reconfiguring as _adding new tasks_ because the reconfigure page can do a bunch of other things like set the patch description or re-schedule existing tasks.

* Add new patch field which is set if the patch is finalized with an initial set of tasks, then the patch is later reconfigured to add more tasks.
    * Filed [DPIPE-8270](https://jira.mongodb.org/browse/DPIPE-8270) for the new patch field.
* Add Honeycomb attribute to version-completion span for whether the patch was reconfigured.

### Testing
* Tested in staging to verify that the field was set if I reconfigured the patch and added new tasks. Did not set the field if I just re-scheduled an existing task or updated the patch description.
* Added unit test.

### Documentation
N/A
