### PR TITLE
DEVPROD-17893 remove sort for task stats and decrease window size if behind

### DIFF
--- a/model/taskstats/db.go
+++ b/model/taskstats/db.go
@@ -241,10 +241,6 @@ func statsToUpdatePipeline(projectID string, requester []string, start, end time
 			statsToUpdateDayKey:       bson.M{"$dateFromString": bson.M{"dateString": "$_id." + statsToUpdateDayKey, "format": "%Y-%m-%d"}},
 			statsToUpdateTasksKey:     1,
 		}},
-		{"$sort": bson.D{
-			{Key: statsToUpdateDayKey, Value: 1},
-			{Key: statsToUpdateRequesterKey, Value: 1},
-		}},
 	}
 }
 

--- a/model/taskstats/stats_test.go
+++ b/model/taskstats/stats_test.go
@@ -10,6 +10,7 @@ import (
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -164,6 +165,32 @@ func (s *statsSuite) TestGenerateStats() {
 	s.WithinDuration(time.Now(), doc.LastUpdate, time.Minute)
 }
 
+func TestGetUpdateWindow(t *testing.T) {
+	startTime := time.Now()
+
+	t.Run("Within24HourWindow", func(t *testing.T) {
+		processedTasksUntil := startTime.Add(-12 * time.Hour)
+		status := StatsStatus{ProcessedTasksUntil: processedTasksUntil}
+		start, end := status.GetUpdateWindow()
+		assert.WithinDuration(t, processedTasksUntil, start, time.Minute)
+		assert.WithinDuration(t, time.Now(), end, time.Minute)
+	})
+	t.Run("2DayWindowShouldBeCapped", func(t *testing.T) {
+		processedTasksUntil := startTime.Add(-2 * 24 * time.Hour)
+		status := StatsStatus{ProcessedTasksUntil: processedTasksUntil}
+		start, end := status.GetUpdateWindow()
+		assert.WithinDuration(t, processedTasksUntil, start, time.Minute)
+		assert.WithinDuration(t, processedTasksUntil.Add(24*time.Hour), end, time.Minute)
+	})
+	t.Run("4DayWindowShouldBeCapped", func(t *testing.T) {
+		processedTasksUntil := startTime.Add(-4 * 24 * time.Hour)
+		status := StatsStatus{ProcessedTasksUntil: processedTasksUntil}
+		start, end := status.GetUpdateWindow()
+		assert.WithinDuration(t, processedTasksUntil, start, time.Minute)
+		assert.WithinDuration(t, processedTasksUntil.Add(12*time.Hour), end, time.Minute)
+	})
+}
+
 func (s *statsSuite) TestFindStatsToUpdate() {
 	// Insert task docs.
 	s.initTasksToUpdate()
@@ -191,10 +218,20 @@ func (s *statsSuite) TestFindStatsToUpdate() {
 	s.Require().NoError(err)
 	s.Require().Len(statsList, 2)
 
-	// The results are sorted so we know the order.
-	s.Equal("r1", statsList[0].Requester)
-	s.Equal(utility.GetUTCDay(commit1), statsList[0].Day)
-	s.Equal([]string{"task1"}, statsList[0].Tasks)
+	// The results are not sorted so we can't make any assumptions about the order.
+	for _, stats := range statsList {
+		if stats.Requester == "r1" {
+			s.Equal(utility.GetUTCDay(commit1), stats.Day)
+			s.Equal([]string{"task1"}, stats.Tasks)
+		} else if stats.Requester == "r2" {
+			s.Equal(utility.GetUTCDay(commit2), stats.Day)
+			s.Require().Len(stats.Tasks, 2)
+			s.Contains(stats.Tasks, "task2")
+			s.Contains(stats.Tasks, "task2bis")
+		} else {
+			s.Fail("Unexpected requester")
+		}
+	}
 
 	// Find stats for p5 for a period around finish1
 	start = finish1.Add(-1 * time.Hour)
@@ -202,15 +239,21 @@ func (s *statsSuite) TestFindStatsToUpdate() {
 	statsList, err = FindStatsToUpdate(s.T().Context(), FindStatsToUpdateOptions{ProjectID: "p5", Requesters: nil, Start: start, End: end})
 	s.Require().NoError(err)
 	s.Require().Len(statsList, 2)
-	// The results are sorted so we know the order
-	s.Equal("r1", statsList[0].Requester)
-	s.Equal(utility.GetUTCDay(commit1), statsList[0].Day)
-	s.Equal([]string{"task1"}, statsList[0].Tasks)
-	s.Equal("r2", statsList[1].Requester)
-	s.Equal(utility.GetUTCDay(commit2), statsList[1].Day)
-	s.Require().Len(statsList[1].Tasks, 2)
-	s.Contains(statsList[1].Tasks, "task2")
-	s.Contains(statsList[1].Tasks, "task2bis")
+
+	// The results are not sorted so we can't make any assumptions about the order.
+	for _, stats := range statsList {
+		if stats.Requester == "r1" {
+			s.Equal(utility.GetUTCDay(commit1), stats.Day)
+			s.Equal([]string{"task1"}, stats.Tasks)
+		} else if stats.Requester == "r2" {
+			s.Equal(utility.GetUTCDay(commit2), stats.Day)
+			s.Require().Len(stats.Tasks, 2)
+			s.Contains(stats.Tasks, "task2")
+			s.Contains(stats.Tasks, "task2bis")
+		} else {
+			s.Fail("Unexpected requester")
+		}
+	}
 }
 
 /////////////////////////////////////////


### PR DESCRIPTION
[DEVPROD-17893](https://jira.mongodb.org/browse/DEVPROD-17893)

### Description
It looks like nightly hasn't updated in the last month. Made the following changes:
* Removed the sort at the end of the aggregation; this seems to exist only for testing. We run every 12 hours so we should still eventually catch up.
* Reduced the window to 12 hours if we're really behind, since maybe 24 hours isn't enough of a reduction.

Rejected Ideas:
* We discussed increasing the timeout (5 minutes) but this appears to be a global (and reasonable)[ timeout.](https://github.com/evergreen-ci/evergreen/blob/40efdf5bfbbe6ec26ff5fe31524620e4c432c22d/config.go#L42)
* Considered an index [for the aggregation](https://github.com/evergreen-ci/evergreen/blob/5992dbbd475da444b1f0b91e6c7bba03d18d241c/model/taskstats/stats.go#L162), but there's already an index on finish_time and project, so adding one that also includes requester might help but seems like not the main problem? That'd probably be my next step if this isn't sufficient though. I'm guessing there's just really too many tasks to process. 


### Testing
Added a unit test.
