### PR TITLE
DEVPROD-17408 Add documentation for static credentials deprecation

### DIFF
--- a/docs/API/REST-V1-Usage.md
+++ b/docs/API/REST-V1-Usage.md
@@ -1,20 +1,32 @@
 # Legacy API
+
 ----------
 
 *Note*: For the REST v2 API documentation, please see [REST V2 Usage](REST-V2-Usage).
 
-## A note on authentication
-
+## Authentication
 The V2 REST routes will return a 404 if no authentication headers are sent, or if the user is invalid.
 
-The simplest way to do this is to use your `user` and `api_key` fields from the Settings page.
+### Personal Access Tokens
+*Note*: This is only available for human users, [service users](../Project-Configuration/Project-and-Distro-Settings#service-users),  should use [Static API Keys](#static-api-keys).
+
+Fore instructions, please see [here](https://wiki.corp.mongodb.com/spaces/DBDEVPROD/pages/384992097/Kanopy+Auth+On+Evergreen#KanopyAuthOnEvergreen-RESTAPI(V1andV2)).
+
+### Static API Keys
+
+*Note*: This will soon be deprecated for human users (everyone except [service users](../Project-Configuration/Project-and-Distro-Settings#service-users)), who should use [personal access tokens instead](#personal-access-tokens).
+
+Use the `user` and `api_key` fields from the Settings page.
 Authenticated REST access requires setting two headers, `Api-User` and `Api-Key`.
 
-### Example
+Static api keys can only be used when authenticating for evergreen.mongodb.com, it cannot be used with evergreen.corp.mongodb.com.
 
+#### Example
 ```bash
-    curl -H Api-User:my.name -H Api-Key:21312mykey12312 https://evergreen.example.com/rest/v1/projects/my_private_project
+    curl -H Api-User:my.name -H Api-Key:21312mykey12312 https://evergreen.mongodb.com/rest/v1/projects/my_private_project
 ```
+
+
 ## Retrieve a list of active project IDs
 
     GET /rest/v1/projects

--- a/docs/API/REST-V2-Usage.mdx
+++ b/docs/API/REST-V2-Usage.mdx
@@ -9,6 +9,8 @@ example, to [get a single task](#tag/tasks/paths/~1tasks~1{task_id}/get), make a
 
 ## General Functionality
 
+Please see [A note on authentication](REST-V1-Usage#a-note-on-authentication) for authentication instructions.
+
 ### Errors
 
 When an error is encountered during a request, the API returns a JSON

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -7,9 +7,38 @@ Downloading the Command Line Tool
 --
 
 Go to your [evergreen user settings page](https://spruce.mongodb.com/preferences) and follow the steps there.
-Copy and paste the text in the configuration panel on the settings page into a file in your *home directory* called `.evergreen.yml`, which will contain the authentication information needed for the client to access the server.
+Copy and paste the text in the configuration panel on the settings page into a file in your *home directory* called `.evergreen.yml`, which will contain the information needed for the client to access the server.
 
 On macOS, the evergreen binary is currently not notarized. To allow running it, go to System Preferences, then Security and Privacy. You should be able to make an exception for it in the "General" tab.
+
+Authentication
+--
+[Service users](../Project-Configuration/Project-and-Distro-Settings#service-users) do not need any further authentication as they can rely on the api key in the `.evergreen.yml` file. 
+
+API Keys will soon be deprecated for human users. The following will need to be done to authenticate when using the CLI. 
+
+### Install kanopy-oidc
+  
+  *Note: This will already be configured for you when using a spawn host.*
+  
+  - [Download](https://github.com/kanopy-platform/kanopy-oidc/releases/) the latest release for your laptop’s OS/architecture. If you already have Kanopy-OIDC installed, make sure you’re running version 0.5.0 or later.
+  - untar the release tarball
+  - put the kanopy-oidc binary on your PATH
+  - `sudo mv ~/Downloads/kanopy-oidc-*/bin/kanopy-oidc-* /usr/local/bin/kanopy-oidc`
+  - Create the kanopy-oidc configuration file by Copy/Pasting from [here](https://kanopy.corp.mongodb.com/docs/configuration/kubeconfig/#configure-kanopy-oidc) to ~/.kanopy/config.yaml.
+  - run `kanopy-oidc version` to verify installation
+
+### Authenticate when prompted
+  > **This is coming soon. Please follow [DEVPROD-4160](https://jira.mongodb.org/browse/DEVPROD-4160) for updates. To test this before it is released, delete or comment out the `api_key` from your evergreen authentication file (~/.evergreen.yml).**
+
+  *Note: If you are not prompted, please update your Evergreen CLI using evergreen get-update --install to ensure you have the latest release.*
+  
+  - Any Evergreen CLI commands that talk to evergreen will attempt to generate a token for you using kanopy-oidc behind the scenes. It will then use that instead of the api token saved in your evergreen config file (~/.evergreen.yml).
+   - If you do not have kanopy-oidc installed properly, this will fail.
+   - It will print a url for you to use to authenticate. Open the link in your laptop's browser and authenticate. 
+   - If you need some more time and would like to opt out of the CLI attempting to generate and use a token, you can do that by setting do_not_run_kanopy_oidc to true in your evergreen config file (~/.evergreen.yml).
+   - To test if you are all effectively communicating with Evergreen via a personal access token, you can comment out or delete the api key from your evergreen config file (~/.evergreen.yml) and try running a command, for example, evergreen list --projects.
+
 
 Basic Patch Usage
 --

--- a/docs/FAQ/Dynamic-Github-Tokens-FAQ.md
+++ b/docs/FAQ/Dynamic-Github-Tokens-FAQ.md
@@ -1,18 +1,4 @@
-# FAQ
-
-Additional FAQ can be found [here](https://wiki.corp.mongodb.com/questions/topics/82870324/evergreen?&filter=recent).
-
-This FAQ is in progress. If there is anything you'd like to see added, please reach out in #ask-devprod-evergreen.
-
-##### What is the difference between cron, batchtime, and periodic build?
-
-The main difference is that cron and batchtime are tied to activating builds for existing commits and periodic builds creates new builds on a schedule regardless of commit activity. For more on their differences and examples, see [controlling when tasks run](Project-Configuration/Controlling-when-tasks-run).
-
-##### Why am I seeing a 'fatal: ...no merge base' error?
-
-This is most likely because your repo was cloned with a specified depth and the merge base was outside the range of the depth. To fix this, rebase your HEAD to the latest master. If this happens often, we recommend increasing the clone depth in your project's [`git.get_project`](Project-Configuration/Project-Commands#gitget_project) to a more suitable depth.  
-
-#### Dynamic Github Access Tokens
+# Dynamic Github Access Tokens FAQ
 
 ##### Which permissions should the github app have?
 

--- a/docs/FAQ/General-FAQ.md
+++ b/docs/FAQ/General-FAQ.md
@@ -1,0 +1,9 @@
+# General FAQ
+
+##### What is the difference between cron, batchtime, and periodic build?
+
+The main difference is that cron and batchtime are tied to activating builds for existing commits and periodic builds creates new builds on a schedule regardless of commit activity. For more on their differences and examples, see [controlling when tasks run](Project-Configuration/Controlling-when-tasks-run).
+
+##### Why am I seeing a 'fatal: ...no merge base' error?
+
+This is most likely because your repo was cloned with a specified depth and the merge base was outside the range of the depth. To fix this, rebase your HEAD to the latest master. If this happens often, we recommend increasing the clone depth in your project's [`git.get_project`](Project-Configuration/Project-Commands#gitget_project) to a more suitable depth.  

--- a/docs/FAQ/README.md
+++ b/docs/FAQ/README.md
@@ -1,0 +1,3 @@
+# FAQ
+
+Additional FAQ can be found [here](https://wiki.corp.mongodb.com/questions/topics/82870324/evergreen?&filter=recent).

--- a/docs/FAQ/Static-Token-Deprecation-FAQ.md
+++ b/docs/FAQ/Static-Token-Deprecation-FAQ.md
@@ -1,0 +1,35 @@
+# Static Token Deprecation FAQ
+
+## What is being deprecated?
+
+We will transition over to using personal access tokens for all human users instead of the static api keys we have been using and downloading from [preferences/cli](https://spruce.mongodb.com/preferences/cli) until now.
+
+
+## What does this affect?
+
+- **UI**: No Changes
+  - You will be able to continue using the Evergreen and Spruce UI without any changes.
+- **CLI**: Action Needed 
+  - Until now, you were able to use a static API key saved to a `~/.evergreen.yml` file. This will no longer be accepted after the transition. Please see [here](../CLI.md#authentication).
+- **REST API**: Action Needed for Scripting with Human Users
+  - **Using the REST API in the browser**: Not affected.
+  - **Using the REST API with a service user**: Not affected (e.g., calling it with a service user in scripts that run in Evergreen tasks).
+  - **Using the REST API with a human user**: Affected. Please see [here](../API/REST-V1-Usage#authentication).
+
+
+## I am using a static Evergreen API key in an Evergreen task, will this continue to work?
+
+If the API key belongs to a [service user](../Project-Configuration/Project-and-Distro-Settings#service-users) it will continue to work as expected. If it belongs to a human user, please reach out to the evergreen team to have a service user created for you. 
+
+
+## Will spawn hosts be affected?
+
+Yes, to use the evergreen CLI on a spawn host, you will need to copy/paste the link provided into your laptop's browser when prompted. You will not need to do any other additional setup. 
+
+## How often will I be asked to click on a link to authenticate?
+
+Please see [here](https://kanopy.corp.mongodb.com/docs/corpsecure/auth_flow/#refresh-token).
+
+## Why am I being asked to copy and paste a link instead of the link being opened in a browser automatically?
+
+We implemented it this way so that it is compatible with spawn hosts. 


### PR DESCRIPTION
DEVPROD-17408

### Description
I originally planned to break this up more, but that would make linking complicated, so I decided to put it all into one big PR. 

I broke up the FAQ into a few different documents, but most of it is just being moved. I'lll comment on those docs to make reviewing easier, because they can be skipped as there are no changes to the content. 

The feature flag will need to be flipped before we attempt to generate tokens in the CLI. However, I don't want to start doing that before sending an email so that users are don't get confused when they are all of a sudden prompted to click a link to authenticate. I need to link this documentation in that email, so we have a bit of a chicken and egg problem. There therefore might be a small window of time in which a user finds this documentation on their own before the feature flag is on, leading to some confusion. However, I don't think that is very likely so I think that level of risk is okay. 
