### PR TITLE
DEVPROD-17996 Add a set-jwt method to evergreen cli

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-05-29"
+	ClientVersion = "2025-05-30"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/client.go
+++ b/operations/client.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -156,8 +155,8 @@ func getJWTFromKanopy() cli.Command {
 	}
 }
 
-// Setting the kanopy token in the Evergreen config file is helpful for services that already 
-// set up to read auth information from he Evergreen config file. 
+// Setting the kanopy token in the Evergreen config file is helpful for services that already
+// set up to read auth information from he Evergreen config file.
 func setJWTInConfig() cli.Command {
 	return cli.Command{
 		Name:    "set-jwt",

--- a/operations/client.go
+++ b/operations/client.go
@@ -156,7 +156,7 @@ func getJWTFromKanopy() cli.Command {
 }
 
 // Setting the kanopy token in the Evergreen config file is helpful for services that already
-// set up to read auth information from he Evergreen config file.
+// set up to read auth information from the Evergreen config file.
 func setJWTInConfig() cli.Command {
 	return cli.Command{
 		Name:    "set-jwt",

--- a/operations/client.go
+++ b/operations/client.go
@@ -156,6 +156,8 @@ func getJWTFromKanopy() cli.Command {
 	}
 }
 
+// Setting the kanopy token in the Evergreen config file is helpful for services that already 
+// set up to read auth information from he Evergreen config file. 
 func setJWTInConfig() cli.Command {
 	return cli.Command{
 		Name:    "set-jwt",
@@ -179,7 +181,7 @@ func setJWTInConfig() cli.Command {
 			conf.JWT = jwt
 
 			if err := conf.Write(""); err != nil {
-				grip.Warning(message.WrapError(err, "failed to set a jwt token "))
+				return errors.Wrap(err, "failed to set a jwt token ")
 			}
 
 			grip.Info("The jwt token was set.")


### PR DESCRIPTION
DEVPROD-17996

### Description
There are other cli tools that rely on the auth in the .evergreen.yml file for evergreen authentication. Without being able to rely on the config file for auth, each cli tool will separately have to implement the kanopy-oidc flow adding a lot of overhead. With this, they can instead use evergreen to set it in the config file and then read it from there. 

If you'd like to discuss my security reasoning around this, please dm me. 

### Testing
Testing locally

### Documentation 
Documentation will be added in a follow up PR after https://github.com/evergreen-ci/evergreen/pull/9065 is merged. 