### PR TITLE
DEVPROD-10172 Log when a pr is not attached to a project ref with testing enabled

### DIFF
--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -720,12 +720,12 @@ func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequ
 	}
 	if projectRef == nil {
 		grip.Info(message.Fields{
-			"message":     "skipping CI on PR due to no project ref with PR testing found",
-			"org":         pr.Base.Repo.Owner.GetLogin(),
-			"repo":        pr.Base.Repo.GetName(),
-			"github_user": pr.Base.User.GetLogin(),
-			"ref":         pr.Head.GetRef(),
-			"pr_num":      pr.GetNumber(),
+			"message": "skipping CI on PR due to no project ref with PR testing found",
+			"owner":   pr.Base.User.GetLogin(),
+			"repo":    pr.Base.Repo.GetName(),
+			"org":     pr.Base.Repo.Owner.GetLogin(),
+			"ref":     pr.Head.GetRef(),
+			"pr_num":  pr.GetNumber(),
 		})
 		return nil
 	}

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -722,8 +722,8 @@ func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequ
 		grip.Info(message.Fields{
 			"message": "skipping CI on PR due to no project ref with PR testing found",
 			"owner":   pr.Base.User.GetLogin(),
-			"repo":    pr.Base.Repo.GetName(),
 			"org":     pr.Base.Repo.Owner.GetLogin(),
+			"repo":    pr.Base.Repo.GetName(),
 			"ref":     pr.Head.GetRef(),
 			"pr_num":  pr.GetNumber(),
 		})
@@ -752,13 +752,13 @@ func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequ
 		}
 		if strings.Contains(title, label) || strings.Contains(limitedDesc, label) {
 			grip.Info(message.Fields{
-				"message":     "skipping CI on PR due to skip label in title/description",
-				"org":         pr.Base.Repo.Owner.GetLogin(),
-				"repo":        pr.Base.Repo.GetName(),
-				"github_user": pr.Base.User.GetLogin(),
-				"ref":         pr.Head.GetRef(),
-				"pr_num":      pr.GetNumber(),
-				"label":       label,
+				"message": "skipping CI on PR due to skip label in title/description",
+				"owner":   pr.Base.User.GetLogin(),
+				"org":     pr.Base.Repo.Owner.GetLogin(),
+				"repo":    pr.Base.Repo.GetName(),
+				"ref":     pr.Head.GetRef(),
+				"pr_num":  pr.GetNumber(),
+				"label":   label,
 			})
 			return nil
 		}

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -722,7 +722,6 @@ func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequ
 		grip.Info(message.Fields{
 			"message": "skipping CI on PR due to no project ref with PR testing found",
 			"owner":   pr.Base.User.GetLogin(),
-			"org":     pr.Base.Repo.Owner.GetLogin(),
 			"repo":    pr.Base.Repo.GetName(),
 			"ref":     pr.Head.GetRef(),
 			"pr_num":  pr.GetNumber(),
@@ -754,7 +753,6 @@ func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequ
 			grip.Info(message.Fields{
 				"message": "skipping CI on PR due to skip label in title/description",
 				"owner":   pr.Base.User.GetLogin(),
-				"org":     pr.Base.Repo.Owner.GetLogin(),
 				"repo":    pr.Base.Repo.GetName(),
 				"ref":     pr.Head.GetRef(),
 				"pr_num":  pr.GetNumber(),

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -719,6 +719,13 @@ func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequ
 		return errors.Wrap(err, "finding project ref for patch")
 	}
 	if projectRef == nil {
+		grip.Info(message.Fields{
+			"message": "skipping CI on PR due to no project ref with PR testing found",
+			"owner":   pr.Base.User.GetLogin(),
+			"repo":    pr.Base.Repo.GetName(),
+			"ref":     pr.Head.GetRef(),
+			"pr_num":  pr.GetNumber(),
+		})
 		return nil
 	}
 

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -720,11 +720,12 @@ func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequ
 	}
 	if projectRef == nil {
 		grip.Info(message.Fields{
-			"message": "skipping CI on PR due to no project ref with PR testing found",
-			"owner":   pr.Base.User.GetLogin(),
-			"repo":    pr.Base.Repo.GetName(),
-			"ref":     pr.Head.GetRef(),
-			"pr_num":  pr.GetNumber(),
+			"message":     "skipping CI on PR due to no project ref with PR testing found",
+			"org":         pr.Base.Repo.Owner.GetLogin(),
+			"repo":        pr.Base.Repo.GetName(),
+			"github_user": pr.Base.User.GetLogin(),
+			"ref":         pr.Head.GetRef(),
+			"pr_num":      pr.GetNumber(),
 		})
 		return nil
 	}

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -752,12 +752,13 @@ func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequ
 		}
 		if strings.Contains(title, label) || strings.Contains(limitedDesc, label) {
 			grip.Info(message.Fields{
-				"message": "skipping CI on PR due to skip label in title/description",
-				"owner":   pr.Base.User.GetLogin(),
-				"repo":    pr.Base.Repo.GetName(),
-				"ref":     pr.Head.GetRef(),
-				"pr_num":  pr.GetNumber(),
-				"label":   label,
+				"message":     "skipping CI on PR due to skip label in title/description",
+				"org":         pr.Base.Repo.Owner.GetLogin(),
+				"repo":        pr.Base.Repo.GetName(),
+				"github_user": pr.Base.User.GetLogin(),
+				"ref":         pr.Head.GetRef(),
+				"pr_num":      pr.GetNumber(),
+				"label":       label,
 			})
 			return nil
 		}


### PR DESCRIPTION
DEVPROD-10172

### Description
This adds a log when we no-op for a PR when there isn't a project ref with testing enabled found.