### PR TITLE
DEVPROD-10172 Wrap error when verifying pull request event before aborting

### DIFF
--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -180,7 +180,7 @@ func FindPatchesByUser(ctx context.Context, user string, ts time.Time, limit int
 func AbortPatchesFromPullRequest(ctx context.Context, event *github.PullRequestEvent) error {
 	owner, repo, err := verifyPullRequestEventForAbort(event)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "verifying pull request event for abort")
 	}
 
 	if err = model.AbortPatchesWithGithubPatchData(ctx, event.PullRequest.GetClosedAt().Time, true, "", owner, repo, *event.Number); err != nil {


### PR DESCRIPTION
DEVPROD-10172

### Description
Wrapping this error will help with tracing when it does get returned.