### PR TITLE
DEVPROD-13915 Fix json output for patch-file command

### DIFF
--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-05-30"
+	ClientVersion = "2025-06-02"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -382,6 +382,7 @@ func PatchFile() cli.Command {
 		),
 		Before: mergeBeforeFuncs(
 			autoUpdateCLI,
+			setPlainLogger,
 			mutuallyExclusiveArgs(false, patchDescriptionFlagName, autoDescriptionFlag),
 			mutuallyExclusiveArgs(false, diffPathFlagName, diffPatchIdFlagName),
 			mutuallyExclusiveArgs(false, allowEmptyFlagName, diffPatchIdFlagName),
@@ -398,12 +399,21 @@ func PatchFile() cli.Command {
 				}
 			}
 			confPath := c.Parent().String(confFlagName)
+			outputJSON := c.Bool(jsonFlagName)
+			if outputJSON {
+				// If outputting the patch data as JSON, suppress any non-error
+				// logs since the logs won't be in JSON format. Errors should
+				// still appear so users can diagnose issues.
+				l := grip.GetSender().Level()
+				l.Threshold = level.Error
+				grip.Error(errors.Wrap(grip.SetLevel(l), "increasing log level to suppress non-errors for JSON output"))
+			}
 			params := &patchParams{
 				Project:          c.String(projectFlagName),
 				Variants:         utility.SplitCommas(c.StringSlice(variantsFlagName)),
 				Tasks:            utility.SplitCommas(c.StringSlice(tasksFlagName)),
 				Alias:            c.String(patchAliasFlagName),
-				SkipConfirm:      c.Bool(skipConfirmFlagName),
+				SkipConfirm:      c.Bool(skipConfirmFlagName) || outputJSON,
 				Description:      c.String(patchDescriptionFlagName),
 				AutoDescription:  c.Bool(autoDescriptionFlag),
 				ShowSummary:      c.Bool(patchVerboseFlagName),
@@ -431,7 +441,7 @@ func PatchFile() cli.Command {
 				return errors.Wrap(err, "loading configuration")
 			}
 
-			comm, err := conf.setupRestCommunicator(ctx, true)
+			comm, err := conf.setupRestCommunicator(ctx, !outputJSON)
 			if err != nil {
 				return errors.Wrap(err, "setting up REST communicator")
 			}
@@ -511,7 +521,7 @@ func PatchFile() cli.Command {
 			outputParams := outputPatchParams{
 				patches:    []patch.Patch{*newPatch},
 				uiHost:     conf.UIServerHost,
-				outputJSON: c.Bool(jsonFlagName),
+				outputJSON: outputJSON,
 			}
 
 			return params.displayPatch(ctx, ac, outputParams)


### PR DESCRIPTION
DEVPROD-13915

### Description
This re-applies #8769

### Testing
I compiled it locally and ran against prod. I added a top-level grip.Infof and it was ignored when outputting

Output (After the first "FInished Building Evergreen", I did not use `--json`):
<img width="454" alt="Screenshot 2025-06-02 at 4 26 33 PM" src="https://github.com/user-attachments/assets/54cf28bc-019a-44c5-8c01-185d46fc800c" />

Code:
<img width="976" alt="Screenshot 2025-06-02 at 4 26 59 PM" src="https://github.com/user-attachments/assets/0e301605-e43d-401b-8d45-115e35ee55d9" />
