### PR TITLE
DEVPROD-18083: fix flaky patch configure test

### DIFF
--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -1099,6 +1099,10 @@ func TestConfigurePatch(t *testing.T) {
 					},
 				},
 			}
+			varTasksMap := map[string]patch.VariantTasks{}
+			for _, vt := range req.VariantsTasks {
+				varTasksMap[vt.Variant] = vt
+			}
 			_, err := ConfigurePatch(ctx, &evergreen.Settings{}, p, v, pRef, req)
 			assert.NoError(t, err)
 
@@ -1106,9 +1110,12 @@ func TestConfigurePatch(t *testing.T) {
 			assert.NoError(t, err)
 			require.NotNil(t, p)
 			assert.Len(t, dbPatch.VariantsTasks, len(req.VariantsTasks))
-			for i := range dbPatch.VariantsTasks {
-				assert.Equal(t, p.VariantsTasks[i].Variant, req.VariantsTasks[i].Variant)
-				assert.ElementsMatch(t, p.VariantsTasks[i].Tasks, req.VariantsTasks[i].Tasks)
+			for _, vt := range dbPatch.VariantsTasks {
+				expectedVarTasks, ok := varTasksMap[vt.Variant]
+				if !assert.True(t, ok, "expected variant tasks not found for variant '%s'", vt.Variant) {
+					continue
+				}
+				assert.ElementsMatch(t, expectedVarTasks.Tasks, vt.Tasks)
 			}
 			assert.True(t, p.Activated)
 			assert.True(t, p.IsReconfigured)


### PR DESCRIPTION
DEVPROD-18083

### Description
Noticed the new test coverage I added for configuring patches in #9053 is flaky because it assumes the order of variant/tasks in the patch doc will match the original input. It actually looks like the configured patch stores the new variant/tasks in a randomized order, so I made the test not dependent on the original request and resulting patch having the same order of elements.

### Testing
Ran the test locally 50 times to verify it doesn't flake anymore.