### PR TITLE
DEVPROD-15757: support local modules for evergreen evaluate

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -234,7 +234,7 @@ Note: `set-module` must be run before finalizing the patch.
 ##### Validating changes to config files
 
 When editing yaml project files, you can verify that the file will work correctly after committing by checking it with the "validate" command.
-To validate local changes within modules, use the ``local_modules`` flag to list out module name and path pairs.
+To validate local changes within [included module files](Project-Configuration/Project-Configuration-Files#include), use the ``local_modules`` flag to list out module name and path pairs.
 
 Note: Must include a local path for includes that use a module.
 
@@ -253,7 +253,7 @@ The validation step will check for
 Note: validation is server-side and requires a valid evergreen configuration file (by default located at ~/.evergreen.yml). If the configuration file exists but is not valid (malformed, references invalid hosts, invalid api key, etc.) the `evergreen validate` command [will exit with code 0, indicating success, even when the project file is invalid](https://jira.mongodb.org/browse/EVG-6417). The validation is likely not performed at all in this scenario. To check whether a project file is valid, verify that the process exited with code 0 and produced the output "\<project file path\> is valid".
 
 Additionally, the `evaluate` command can be used to locally expand task tags and return a fully evaluated version of a project file.
-(Note that this command doesn't support evaluating included files from modules.)
+To evaluate local changes within [included module files](Project-Configuration/Project-Configuration-Files#include), use the ``local_modules`` flag to list out module name and path pairs.
 
 ```
 evergreen evaluate <path-to-yaml-project-file>

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -328,7 +328,7 @@ Evergreen.
 
 Configuration files listed in `include` will be merged with the main
 project configuration file. All top-level configuration files can define
-includes. This will accept a list of filenames and module names. If the
+includes. This will accept a list of filenames and [module names](#modules). If the
 include isn't given, we will only use the main project configuration
 file.
 

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -243,7 +243,9 @@ func (pd *parserDependency) UnmarshalYAML(unmarshal func(any) error) error {
 
 type parserInclude struct {
 	FileName string `yaml:"filename,omitempty" bson:"filename,omitempty"`
-	Module   string `yaml:"module,omitempty" bson:"module,omitempty"`
+	// kim; NOTE: this is used to determine includes coming from modules instead
+	// of the project itself.
+	Module string `yaml:"module,omitempty" bson:"module,omitempty"`
 }
 
 // TaskSelector handles the selection of specific task/variant combinations

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -243,13 +243,11 @@ func (pd *parserDependency) UnmarshalYAML(unmarshal func(any) error) error {
 
 type parserInclude struct {
 	FileName string `yaml:"filename,omitempty" bson:"filename,omitempty"`
-	// kim; NOTE: this is used to determine includes coming from modules instead
-	// of the project itself.
-	Module string `yaml:"module,omitempty" bson:"module,omitempty"`
+	Module   string `yaml:"module,omitempty" bson:"module,omitempty"`
 }
 
 // TaskSelector handles the selection of specific task/variant combinations
-// in the context of dependencies. //TODO no export?
+// in the context of dependencies.
 type taskSelector struct {
 	Name    string           `yaml:"name,omitempty"`
 	Variant *variantSelector `yaml:"variant,omitempty" bson:"variant,omitempty"`

--- a/operations/evaluate.go
+++ b/operations/evaluate.go
@@ -35,6 +35,10 @@ func Evaluate() cli.Command {
 				Name:  diffableFlagName,
 				Usage: "show the project configuration in an ordered, diff-friendly format",
 			},
+			cli.StringSliceFlag{
+				Name:  joinFlagNames(localModulesFlagName, "lm"),
+				Usage: "specify local modules for included files as MODULE_NAME=PATH pairs",
+			},
 		),
 		Before: mergeBeforeFuncs(requirePathFlag),
 		Action: func(c *cli.Context) error {
@@ -42,6 +46,11 @@ func Evaluate() cli.Command {
 			showTasks := c.Bool(taskFlagName)
 			showVariants := c.Bool(variantsFlagName)
 			diffable := c.Bool(diffableFlagName)
+			localModulePaths := c.StringSlice(localModulesFlagName)
+			localModuleMap, err := getLocalModulesFromInput(localModulePaths)
+			if err != nil {
+				return err
+			}
 
 			configBytes, err := os.ReadFile(path)
 			if err != nil {
@@ -51,6 +60,7 @@ func Evaluate() cli.Command {
 			p := &model.Project{}
 			ctx := context.Background()
 			opts := &model.GetProjectOpts{
+				LocalModules: localModuleMap,
 				ReadFileFrom: model.ReadFromLocal,
 			}
 			_, err = model.LoadProjectInto(ctx, configBytes, opts, "", p)


### PR DESCRIPTION
DEVPROD-15757

### Description
Add support for local modules to `evergreen evaluate` so if a project YAML is including files from a module, the user can get the evaluated YAML including the files from modules by passing in the paths to their locally-cloned git repos.

From [the original ticket that introduced local modules to `evergreen validate`](https://jira.mongodb.org/browse/EVG-15295), it seems like local modules were requested as part of the project and there's no particular reason that `evergreen evaluate` couldn't also support it. I suspect it might have just been a feature oversight since `evergreen validate` is used more widely.

### Testing
* Ran `evergreen evaluate etc/system_perf.yml` in the mongo repo. Pre-change and post-change, it returns an error as expected (because the file includes files from modules).
* Ran `evergreen evaluate -lm <MY_LOCAL_PATH_TO_DSI> etc/system_perf.yml` and it successfully found the local modules using the local file path. Outputted YAML contained the configuration from the module included files.

### Documentation
* Updated documentation to say local modules are supported for `evergreen evaluate`.
* Added a few links to make it a little clearer that local modules are to support module included files.