### PR TITLE
DEVPROD-17893 remove one-day update from task stats

### DIFF
--- a/model/taskstats/stats.go
+++ b/model/taskstats/stats.go
@@ -84,7 +84,7 @@ func UpdateStatsStatus(ctx context.Context, projectID string, lastJobRun, proces
 
 // GetUpdateWindow returns the start and end of the time window for the stats.
 // This size of this window is capped at 12 hours to prevent
-// long-running jobs and overwhelming the database and ensure we aren't failing due to high load.
+// long-running jobs, overwhelming the database, and avoid excessive load.
 func (status *StatsStatus) GetUpdateWindow() (time.Time, time.Time) {
 	start := status.ProcessedTasksUntil
 	end := time.Now()

--- a/model/taskstats/stats.go
+++ b/model/taskstats/stats.go
@@ -83,18 +83,15 @@ func UpdateStatsStatus(ctx context.Context, projectID string, lastJobRun, proces
 }
 
 // GetUpdateWindow returns the start and end of the time window for the stats.
-// This size of this window is capped at 24 hours to prevent
-// long-running jobs and overwhelming the database, or 12 hours if we're
-// more than 3 days behind, as we may be repeatedly failing due to high load.
+// This size of this window is capped at 12 hours to prevent
+// long-running jobs and overwhelming the database and ensure we aren't failing due to high load.
 func (status *StatsStatus) GetUpdateWindow() (time.Time, time.Time) {
 	start := status.ProcessedTasksUntil
 	end := time.Now()
 
 	windowSize := end.Sub(start)
-	if windowSize > 72*time.Hour {
+	if windowSize >= 12*time.Hour {
 		end = start.Add(12 * time.Hour)
-	} else if windowSize > 24*time.Hour {
-		end = start.Add(24 * time.Hour)
 	}
 	return start, end
 }

--- a/model/taskstats/stats.go
+++ b/model/taskstats/stats.go
@@ -90,8 +90,9 @@ func (status *StatsStatus) GetUpdateWindow() (time.Time, time.Time) {
 	end := time.Now()
 
 	windowSize := end.Sub(start)
-	if windowSize >= 12*time.Hour {
-		end = start.Add(12 * time.Hour)
+	cutoffDuration := 12 * time.Hour
+	if windowSize >= cutoffDuration {
+		end = start.Add(cutoffDuration)
 	}
 	return start, end
 }

--- a/model/taskstats/stats_test.go
+++ b/model/taskstats/stats_test.go
@@ -171,22 +171,22 @@ func (s *statsSuite) TestGenerateStats() {
 func TestGetUpdateWindow(t *testing.T) {
 	startTime := time.Now()
 
-	t.Run("Within24HourWindow", func(t *testing.T) {
-		processedTasksUntil := startTime.Add(-12 * time.Hour)
+	t.Run("Within12HourWindow", func(t *testing.T) {
+		processedTasksUntil := startTime.Add(-10 * time.Hour)
 		status := StatsStatus{ProcessedTasksUntil: processedTasksUntil}
 		start, end := status.GetUpdateWindow()
 		assert.WithinDuration(t, processedTasksUntil, start, time.Minute)
 		assert.WithinDuration(t, time.Now(), end, time.Minute)
 	})
-	t.Run("2DayWindowShouldBeCapped", func(t *testing.T) {
-		processedTasksUntil := startTime.Add(-2 * 24 * time.Hour)
+	t.Run("24HourWindowShouldBeCapped", func(t *testing.T) {
+		processedTasksUntil := startTime.Add(-24 * time.Hour)
 		status := StatsStatus{ProcessedTasksUntil: processedTasksUntil}
 		start, end := status.GetUpdateWindow()
 		assert.WithinDuration(t, processedTasksUntil, start, time.Minute)
-		assert.WithinDuration(t, processedTasksUntil.Add(24*time.Hour), end, time.Minute)
+		assert.WithinDuration(t, processedTasksUntil.Add(12*time.Hour), end, time.Minute)
 	})
-	t.Run("4DayWindowShouldBeCapped", func(t *testing.T) {
-		processedTasksUntil := startTime.Add(-4 * 24 * time.Hour)
+	t.Run("2DayWindowShouldBeCapped", func(t *testing.T) {
+		processedTasksUntil := startTime.Add(-2 * 24 * time.Hour)
 		status := StatsStatus{ProcessedTasksUntil: processedTasksUntil}
 		start, end := status.GetUpdateWindow()
 		assert.WithinDuration(t, processedTasksUntil, start, time.Minute)


### PR DESCRIPTION
DEVPROD-17893
### Description
We caught up on task-stats and then began failing again once we got to the 24 hour amount of updating; I think we'll keep failing until we get three days out and start doing 12 hour updates again. Given this, I propose we just switch to 12 hour updates completely, since it hasn't been an issue. 

### Testing
Fixed tests. 
