### PR TITLE
DEVPROD-5810: upgrade Grip

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mongodb/amboy v0.0.0-20250313150805-ef0cd9968322
 	github.com/mongodb/anser v0.0.0-20250324144457-fcc2c57eee09
-	github.com/mongodb/grip v0.0.0-20250410161241-7cb1e90e324d
+	github.com/mongodb/grip v0.0.0-20250605170751-42f96c9d4abf
 	github.com/pkg/errors v0.9.1
 	github.com/ravilushqa/otelgqlgen v0.17.0
 	github.com/robbiet480/go.sns v0.0.0-20210223081447-c7c9eb6836cb

--- a/go.sum
+++ b/go.sum
@@ -458,8 +458,8 @@ github.com/mongodb/ftdc v0.0.0-20220401165013-13e4af55e809 h1:CQVEigRr2M/OFIPn+w
 github.com/mongodb/ftdc v0.0.0-20220401165013-13e4af55e809/go.mod h1:zz0HHFUU4/TOxl9TW4P9t3y3Ivx+sTWS2nwnhuYYRdw=
 github.com/mongodb/grip v0.0.0-20211018154934-e661a71929d5/go.mod h1:g0r93iHSTLD50bDT7vNj+z+Y3nKz9o/tQXtB9esq2tk=
 github.com/mongodb/grip v0.0.0-20220401165023-6a1d9bb90c21/go.mod h1:QfF6CwbaTQx1Kgww77c6ROPBFN+JCiU2qBnk2SjKHyU=
-github.com/mongodb/grip v0.0.0-20250410161241-7cb1e90e324d h1:ZPsQ9C3XiObSazV23vWlBeKFv01JwJkFN5Wzhs1QHnQ=
-github.com/mongodb/grip v0.0.0-20250410161241-7cb1e90e324d/go.mod h1:y3Icl6CvpvcfvRBVfzYQlpuplQ5KDHOlS/vq5rpaf8s=
+github.com/mongodb/grip v0.0.0-20250605170751-42f96c9d4abf h1:siGjCM/VepnLyajHGXHJkHnrn66jEv03ZisZ5kLB/oA=
+github.com/mongodb/grip v0.0.0-20250605170751-42f96c9d4abf/go.mod h1:y3Icl6CvpvcfvRBVfzYQlpuplQ5KDHOlS/vq5rpaf8s=
 github.com/mongodb/jasper v0.0.0-20250304205544-71af207b4383 h1:bSik9Vq7CmNuDo7ajEIDFiprrOyyzK4LyoV2+QFzY4E=
 github.com/mongodb/jasper v0.0.0-20250304205544-71af207b4383/go.mod h1:5XXow1Gps0T9x31n412o7X79JVkG8dC39fG4iVJ3MY8=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=


### PR DESCRIPTION
DEVPROD-5810

### Description
Upgrade Grip for https://github.com/mongodb/grip/commit/42f96c9d4abf5ccf9807521386f1b634872fe898.

### Testing
Compiles and existing tests pass.