### PR TITLE
DEVPROD-13311: do not run env var process cleanup test on MacOS

### DIFF
--- a/agent/util/subtree_linux_test.go
+++ b/agent/util/subtree_linux_test.go
@@ -1,0 +1,66 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/mongodb/grip"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPIDsToKill(t *testing.T) {
+	const timeoutSecs = 10
+	ctx := t.Context()
+
+	agentPID, ok := os.LookupEnv(MarkerAgentPID)
+	if ok {
+		// For CI testing, temporarily simulate this process as running outside
+		// of the agent so that getPIDsToKill performs its special checks for
+		// agent-external processes.
+		os.Unsetenv(MarkerAgentPID)
+		defer os.Setenv(MarkerAgentPID, agentPID)
+	}
+
+	inEvergreenCmd := exec.CommandContext(ctx, "sleep", strconv.Itoa(timeoutSecs))
+	inEvergreenCmd.Env = append(inEvergreenCmd.Env, fmt.Sprintf("%s=true", MarkerInEvergreen))
+	require.NoError(t, inEvergreenCmd.Start())
+	inEvergreenPID := inEvergreenCmd.Process.Pid
+
+	fullSleepPath, err := exec.LookPath("sleep")
+	require.NoError(t, err)
+
+	inWorkingDirCmd := exec.CommandContext(ctx, fullSleepPath, strconv.Itoa(timeoutSecs))
+	require.NoError(t, inWorkingDirCmd.Start())
+	inWorkingDirPID := inWorkingDirCmd.Process.Pid
+
+	assert.Eventually(t, func() bool {
+		// Since the processes run in the background, we have to poll them until
+		// they actually start, at which point they should appear in the listed
+		// PIDs.
+		pids, err := getPIDsToKill(ctx, "", filepath.Dir(fullSleepPath), grip.GetDefaultJournaler())
+		require.NoError(t, err)
+
+		var (
+			foundInEvergreenPID  bool
+			foundInWorkingDirPID bool
+		)
+		for _, pid := range pids {
+			if pid == inEvergreenPID {
+				foundInEvergreenPID = true
+			}
+			if pid == inWorkingDirPID {
+				foundInWorkingDirPID = true
+			}
+			if foundInEvergreenPID && foundInWorkingDirPID {
+				break
+			}
+		}
+		return foundInEvergreenPID && foundInWorkingDirPID
+	}, timeoutSecs*time.Second, 100*time.Millisecond, "in Evergreen process (pid %d) and in working directory process (pid %d) both should have eventually appeared in the listed PID")
+}

--- a/agent/util/subtree_unix_test.go
+++ b/agent/util/subtree_unix_test.go
@@ -5,11 +5,7 @@ package util
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
-	"strconv"
 	"testing"
 	"time"
 
@@ -18,58 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestGetPIDsToKill(t *testing.T) {
-	const timeoutSecs = 10
-	ctx, cancel := context.WithTimeout(context.Background(), timeoutSecs*time.Second)
-	defer cancel()
-
-	agentPID, ok := os.LookupEnv(MarkerAgentPID)
-	if ok {
-		// For CI testing, temporarily simulate this process as running outside
-		// of the agent so that getPIDsToKill performs its special checks for
-		// agent-external processes.
-		os.Unsetenv(MarkerAgentPID)
-		defer os.Setenv(MarkerAgentPID, agentPID)
-	}
-
-	inEvergreenCmd := exec.CommandContext(ctx, "sleep", strconv.Itoa(timeoutSecs))
-	inEvergreenCmd.Env = append(inEvergreenCmd.Env, fmt.Sprintf("%s=true", MarkerInEvergreen))
-	require.NoError(t, inEvergreenCmd.Start())
-	inEvergreenPID := inEvergreenCmd.Process.Pid
-
-	fullSleepPath, err := exec.LookPath("sleep")
-	require.NoError(t, err)
-
-	inWorkingDirCmd := exec.CommandContext(ctx, fullSleepPath, strconv.Itoa(timeoutSecs))
-	require.NoError(t, inWorkingDirCmd.Start())
-	inWorkingDirPID := inWorkingDirCmd.Process.Pid
-
-	assert.Eventually(t, func() bool {
-		// Since the processes run in the background, we have to poll them until
-		// they actually start, at which point they should appear in the listed
-		// PIDs.
-		pids, err := getPIDsToKill(ctx, "", filepath.Dir(fullSleepPath), grip.GetDefaultJournaler())
-		require.NoError(t, err)
-
-		var (
-			foundInEvergreenPID  bool
-			foundInWorkingDirPID bool
-		)
-		for _, pid := range pids {
-			if pid == inEvergreenPID {
-				foundInEvergreenPID = true
-			}
-			if pid == inWorkingDirPID {
-				foundInWorkingDirPID = true
-			}
-			if foundInEvergreenPID && foundInWorkingDirPID {
-				break
-			}
-		}
-		return foundInEvergreenPID && foundInWorkingDirPID
-	}, timeoutSecs*time.Second, 100*time.Millisecond, "in Evergreen process (pid %d) and in working directory process (pid %d) both should have eventually appeared in the listed PID")
-}
 
 func TestKillSpawnedProcs(t *testing.T) {
 	for testName, test := range map[string]func(ctx context.Context, t *testing.T){

--- a/config_cloud.go
+++ b/config_cloud.go
@@ -84,7 +84,7 @@ type AWSConfig struct {
 
 	// IPAMPoolID is the ID for the IP address management (IPAM) pool in AWS.
 	IPAMPoolID string `bson:"ipam_pool_id" json:"ipam_pool_id" yaml:"ipam_pool_id"`
-	// ElasticIPUsageRatio is the probability (out of 1) of a host that has
+	// ElasticIPUsageRate is the probability (out of 1) of a host that has
 	// elastic IPs enabled being assigned an elastic IP address.
 	ElasticIPUsageRate float64 `bson:"elastic_ip_usage_rate" json:"elastic_ip_usage_rate" yaml:"elastic_ip_usage_rate"`
 }


### PR DESCRIPTION
DEVPROD-13311

### Description
This test will never pass on MacOS because the more recent MacOS hosts don't support Evergreen's current process cleanup method. For MacOS/Linux, Evergreen looks for special env vars to find child processes' PIDs and cleaning them up. Since MacOS changed what processes are visible via `ps`, MacOS process cleanup doesn't really work anymore and needs to be implemented differently. More context is in DEVPROD-6539.

This env var-detecting logic will need to be replaced in DEVPROD-10457 with a different process sandboxing methodology, so this test is not useful for MacOS anymore.

### Testing
Ran MacOS tests and it no longer runs this test.
