### PR TITLE
DEVPROD-15330 Handle empty vars in swaggo file

### DIFF
--- a/scripts/prepare-swagger-push.sh
+++ b/scripts/prepare-swagger-push.sh
@@ -30,12 +30,20 @@ if [[ "${environment}" == "staging" ]]; then
     host_url="evergreen-staging.corp.mongodb.com"
 fi
 
-version_number=1
+version_number=0
+old_sum=""
 
 # Check if the old sum file exists and read values if it does.
 if [[ -f "${SWAGGER_OLD_SUM_FILE}" ]]; then
-    read old_sum old_version_number < "${SWAGGER_OLD_SUM_FILE}"
-    version_number="${old_version_number}"
+    # Try to read the values, but handle the case where the file is empty or malformed
+    if read old_sum old_version_number < "${SWAGGER_OLD_SUM_FILE}" 2>/dev/null && [[ -n "${old_sum}" ]] && [[ -n "${old_version_number}" ]]; then
+        version_number="${old_version_number}"
+        echo "Found existing version: ${old_version_number} with sum: ${old_sum}"
+    else
+        echo "Warning: ${SWAGGER_OLD_SUM_FILE} exists but is empty or malformed. Using default version number."
+    fi
+else
+    echo "No existing sum file found. Using default version number."
 fi
 
 # Use a temp copy to avoid modifying the original file.


### PR DESCRIPTION
DEVPROD-15330

### Description

It looks like Evergreen creates an empty file when s3.get fails https://github.com/evergreen-ci/evergreen/blob/d03d37ed2d43602506e276059634c580f3d5e46e/agent/command/s3_get.go#L317. I opened https://jira.mongodb.org/browse/DEVPROD-18161 for this.

### Testing

I tested the script change locally, but this is difficult to test without a commit. I set the xtrace in to investigate further if needed.

### Documentation

N/A
