### PR TITLE
DEVPROD-17893 remove incorrect hint from taskstats 

### DIFF
--- a/model/taskstats/db.go
+++ b/model/taskstats/db.go
@@ -57,9 +57,6 @@ const (
 	nsInASecond                = time.Second / time.Nanosecond
 )
 
-// StatsPipelineIndex is the branch_1_finish_time_1 index.
-var StatsPipelineIndex = bson.D{{Key: "branch", Value: 1}, {Key: "finish_time", Value: 1}}
-
 var (
 	// '$' references to the BSON fields of tasks.
 	taskIdKeyRef           = "$" + task.IdKey
@@ -572,11 +569,11 @@ func (pf PaginationField) GetNextExpression() bson.M {
 // Internal helpers for writing documents, running aggregations //
 //////////////////////////////////////////////////////////////////
 
-// aggregateIntoCollectionWithHint runs an aggregation pipeline on a collection and bulk upserts all the documents
+// aggregateIntoCollection runs an aggregation pipeline on a collection and bulk upserts all the documents
 // into the target collection, using the given hint.
-func aggregateIntoCollectionWithHint(ctx context.Context, collection string, pipeline []bson.M, hint bson.D, outputCollection string) error {
+func aggregateIntoCollection(ctx context.Context, collection string, pipeline []bson.M, outputCollection string) error {
 	env := evergreen.GetEnvironment()
-	opts := options.Aggregate().SetAllowDiskUse(true).SetHint(hint)
+	opts := options.Aggregate().SetAllowDiskUse(true)
 	cursor, err := env.DB().Collection(collection, options.Collection().SetReadPreference(readpref.SecondaryPreferred())).Aggregate(ctx, pipeline, opts)
 	if err != nil {
 		return errors.Wrap(err, "running aggregation")

--- a/model/taskstats/stats.go
+++ b/model/taskstats/stats.go
@@ -121,8 +121,7 @@ func GenerateStats(ctx context.Context, opts GenerateStatsOptions) error {
 	})
 	start := utility.GetUTCDay(opts.Date)
 	end := start.Add(24 * time.Hour)
-	if err := aggregateIntoCollectionWithHint(ctx, task.Collection, statsPipeline(opts.ProjectID, opts.Requester, start, end, opts.Tasks),
-		StatsPipelineIndex, DailyTaskStatsCollection); err != nil {
+	if err := aggregateIntoCollection(ctx, task.Collection, statsPipeline(opts.ProjectID, opts.Requester, start, end, opts.Tasks), DailyTaskStatsCollection); err != nil {
 		return errors.Wrap(err, "aggregating daily task stats")
 	}
 

--- a/model/taskstats/stats_test.go
+++ b/model/taskstats/stats_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/mongo"
 )
 
 var baseTime = time.Date(2018, 7, 15, 16, 45, 0, 0, time.UTC)
@@ -42,8 +41,6 @@ func (s *statsSuite) SetupTest() {
 	for _, coll := range collectionsToClear {
 		s.NoError(db.Clear(coll))
 	}
-	s.NoError(db.EnsureIndex(task.Collection, mongo.IndexModel{Keys: StatsPipelineIndex}), "problem setting up index")
-
 }
 
 func (s *statsSuite) TestStatsStatus() {

--- a/units/cache_historical_task_data_test.go
+++ b/units/cache_historical_task_data_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"go.mongodb.org/mongo-driver/mongo"
-
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -254,7 +252,6 @@ func TestCacheHistoricalTaskDataJob(t *testing.T) {
 			tctx := testutil.TestSpan(ctx, t)
 
 			require.NoError(t, db.ClearCollections(task.Collection, taskstats.DailyTaskStatsCollection, taskstats.DailyStatsStatusCollection))
-			require.NoError(t, db.EnsureIndex(task.Collection, mongo.IndexModel{Keys: taskstats.StatsPipelineIndex}))
 			if test.pre != nil {
 				test.pre(tctx, t)
 			}


### PR DESCRIPTION
DEVPROD-17893
### Description

I put this hint for the generate pipeline and not the find pipeline so it _severely_ slowed it down, since it's not the right index. That being said, find has been going fine and I think doesn't need this index, so I'd like just take it out to give us time to catch up this weekend.