### PR TITLE
DEVPROD-7920: log stats about distro max hosts

### DIFF
--- a/scheduler/utilization_based_host_allocator.go
+++ b/scheduler/utilization_based_host_allocator.go
@@ -188,6 +188,19 @@ func evalHostUtilization(ctx context.Context, d distro.Distro, taskGroupData Tas
 
 	// enforce the max hosts cap
 	if isMaxHostsCapacity(maxHosts, containerPool, numNewHosts, len(existingHosts)) {
+		// TODO (DEVPROD-7920): remove log once distro max hosts limitation is
+		// improved.
+		grip.InfoWhen(evergreen.IsEc2Provider(d.Provider) && numNewHosts > 0 && numNewHosts+len(existingHosts) > maxHosts, message.Fields{
+			"message":                     "dynamically allocated distro needs to create more hosts than distro max hosts allows",
+			"target_distro_hosts":         numNewHosts + len(existingHosts),
+			"target_distro_hosts_deficit": numNewHosts + len(existingHosts) - maxHosts,
+			"target_num_new_hosts":        numNewHosts,
+			"num_existing_hosts":          len(existingHosts),
+			"max_hosts":                   maxHosts,
+			"distro":                      d.Id,
+			"provider":                    d.Provider,
+			"ticket":                      "DEVPROD-7920",
+		})
 		numNewHosts = maxHosts - len(existingHosts)
 	}
 


### PR DESCRIPTION
DEVPROD-7920

### Description
Add info about how much the host allocator wants to create hosts above the distro max hosts limit. This will be important to figure out how to change distro max hosts so we don't have to always automatically bump it higher.

### Testing
N/A
