### PR TITLE
DEVPROD-18277 Handle parsing start_at with or without quotes

### DIFF
--- a/rest/route/patch.go
+++ b/rest/route/patch.go
@@ -365,12 +365,13 @@ func (p *patchesByProjectHandler) Parse(ctx context.Context, r *http.Request) er
 	vals := r.URL.Query()
 
 	var err error
-	if vals.Get("start_at") == "" {
+	start_at := vals.Get("start_at")
+	if start_at == "" {
 		p.key = time.Now()
 	} else {
-		p.key, err = time.ParseInLocation(model.APITimeFormat, vals.Get("start_at"), time.FixedZone("", 0))
+		p.key, err = model.ParseTime(start_at)
 		if err != nil {
-			return errors.Wrapf(err, "parsing 'start at' time %s", p.key)
+			return errors.Wrapf(err, "parsing start_at '%s'", start_at)
 		}
 	}
 

--- a/rest/route/patch.go
+++ b/rest/route/patch.go
@@ -365,13 +365,13 @@ func (p *patchesByProjectHandler) Parse(ctx context.Context, r *http.Request) er
 	vals := r.URL.Query()
 
 	var err error
-	start_at := vals.Get("start_at")
-	if start_at == "" {
+	startAt := vals.Get("start_at")
+	if startAt == "" {
 		p.key = time.Now()
 	} else {
-		p.key, err = model.ParseTime(start_at)
+		p.key, err = model.ParseTime(startAt)
 		if err != nil {
-			return errors.Wrapf(err, "parsing start_at '%s'", start_at)
+			return errors.Wrapf(err, "parsing start_at '%s'", startAt)
 		}
 	}
 

--- a/rest/route/patch_test.go
+++ b/rest/route/patch_test.go
@@ -219,6 +219,35 @@ func (s *PatchesByProjectSuite) TestInvalidTimesAsKeyShouldError() {
 	}
 }
 
+func (s *PatchesByProjectSuite) TestValidTimesAsKeyShouldNotError() {
+	// Time format: APITimeFormat = "\"2006-01-02T15:04:05.000Z\""
+	inputs := []string{
+		"2023-10-01T12:30:45.000Z", // valid time
+		"2000-01-01T00:00:00.000Z", // start of the 21st century
+		"2050-12-31T23:59:59.999Z", // end-of-year edge case
+
+		// Edge cases for formatting
+		"2023-01-01T00:00:00.000Z", // start of a day
+		"2023-05-01T15:04:05.123Z", // random valid timestamp
+		"2023-10-01T00:00:00.000Z", // midnight edge case
+	}
+
+	for _, i := range inputs {
+		s.Run("Time: "+i, func() {
+			req, err := http.NewRequest(http.MethodGet, "https://example.net/foo/?limit=10&start_at="+i, nil)
+			s.Require().NoError(err)
+			err = s.route.Parse(context.Background(), req)
+			s.NoError(err)
+		})
+		s.Run("Time wrapped in quotes: "+i, func() {
+			req, err := http.NewRequest(http.MethodGet, "https://example.net/foo/?limit=10&start_at=\""+i+"\"", nil)
+			s.Require().NoError(err)
+			err = s.route.Parse(context.Background(), req)
+			s.NoError(err)
+		})
+	}
+}
+
 func (s *PatchesByProjectSuite) TestEmptyTimeShouldSetNow() {
 	req, err := http.NewRequest(http.MethodGet, "https://example.net/foo/?limit=10", nil)
 	s.Require().NoError(err)

--- a/rest/route/patch_test.go
+++ b/rest/route/patch_test.go
@@ -220,7 +220,6 @@ func (s *PatchesByProjectSuite) TestInvalidTimesAsKeyShouldError() {
 }
 
 func (s *PatchesByProjectSuite) TestValidTimesAsKeyShouldNotError() {
-	// Time format: APITimeFormat = "\"2006-01-02T15:04:05.000Z\""
 	inputs := []string{
 		"2023-10-01T12:30:45.000Z", // valid time
 		"2000-01-01T00:00:00.000Z", // start of the 21st century
@@ -233,13 +232,13 @@ func (s *PatchesByProjectSuite) TestValidTimesAsKeyShouldNotError() {
 	}
 
 	for _, i := range inputs {
-		s.Run("Time: "+i, func() {
+		s.Run("Time:"+i, func() {
 			req, err := http.NewRequest(http.MethodGet, "https://example.net/foo/?limit=10&start_at="+i, nil)
 			s.Require().NoError(err)
 			err = s.route.Parse(context.Background(), req)
 			s.NoError(err)
 		})
-		s.Run("Time wrapped in quotes: "+i, func() {
+		s.Run("TimeWrappedInQuotes:"+i, func() {
 			req, err := http.NewRequest(http.MethodGet, "https://example.net/foo/?limit=10&start_at=\""+i+"\"", nil)
 			s.Require().NoError(err)
 			err = s.route.Parse(context.Background(), req)


### PR DESCRIPTION
DEVPROD-18277

### Description
The type of time format we use for `start_at` is a bit weird, it **requires** quotes. We have a helper func to account for this for user-inputted values, but we don't use it for `start_at`.

### Testing
I added new unit tests to make sure it works with and without quotes. I ran the new tests without the changes, and they fail.