### PR TITLE
DEVPROD-12889: move test results check into the agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1130,6 +1130,12 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, 
 	if detail.Type != "" {
 		span.SetAttributes(attribute.String(evergreen.TaskFailureTypeOtelAttribute, detail.Type))
 	}
+	if detail.FailingCommand != "" {
+		span.SetAttributes(attribute.String(evergreen.TaskFailingCommandOtelAttribute, detail.FailingCommand))
+	}
+	if detail.Description != "" {
+		span.SetAttributes(attribute.String(evergreen.TaskDescriptionOtelAttribute, detail.Description))
+	}
 
 	return resp, nil
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1125,8 +1125,6 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, 
 	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(attribute.String(evergreen.TaskStatusOtelAttribute, detail.Status))
 	if detail.Status != evergreen.TaskSucceeded {
-		// kim: TODO: verify in staging that task status is set to failure for
-		// test result reasons.
 		span.SetStatus(codes.Error, fmt.Sprintf("failing status '%s'", detail.Status))
 	}
 	if detail.Type != "" {
@@ -1255,7 +1253,6 @@ func setEndTaskFailureDetails(tc *taskContext, detail *apimodels.TaskEndDetail, 
 		} else {
 			detail.FailingCommand = currCmd.FullDisplayName()
 			tc.setFailingCommand(currCmd)
-			fmt.Println("kim: failing command set to:", tc.getFailingCommand().FullDisplayName())
 		}
 		detail.Type = failureType
 		detail.FailureMetadataTags = utility.UniqueStrings(append(tc.getFailingCommand().FailureMetadataTags(), failureMetadataTagsToAdd...))
@@ -1274,8 +1271,6 @@ func setEndTaskFailureDetails(tc *taskContext, detail *apimodels.TaskEndDetail, 
 	}
 }
 
-// kim: TODO: add test for failure setting and priority relative to command
-// failures.
 // updateEndTaskFailureDetailsForTestResults checks and updates the task failure
 // details for missing or failed test results.
 func updateEndTaskFailureDetailsForTestResults(tc *taskContext, detail *apimodels.TaskEndDetail) {
@@ -1286,8 +1281,6 @@ func updateEndTaskFailureDetailsForTestResults(tc *taskContext, detail *apimodel
 		return
 	}
 
-	// kim: TODO: need to check if task has any test results. Possibly can set
-	// in the test results-setting commands.
 	if tc.taskConfig.Task.MustHaveResults && !tc.taskConfig.HasTestResults {
 		tc.logger.Task().Info("Test results are missing and this task must have attached test results. Overall task status changed to FAILED.")
 		detail.Type = evergreen.CommandTypeTest

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1143,6 +1143,7 @@ tasks:
 	s.Equal(evergreen.CommandTypeTest, s.mockCommunicator.EndTaskResult.Detail.Type)
 	s.Equal(evergreen.TaskFailed, s.mockCommunicator.EndTaskResult.Detail.Status)
 	s.Equal(evergreen.TaskDescriptionNoResults, s.mockCommunicator.EndTaskResult.Detail.Description)
+	s.Zero(s.mockCommunicator.EndTaskResult.Detail.FailingCommand)
 
 	s.NoError(s.tc.logger.Close())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
@@ -1174,6 +1175,7 @@ tasks:
 	s.Zero(s.mockCommunicator.EndTaskResult.Detail.Type)
 	s.Equal(evergreen.TaskSucceeded, s.mockCommunicator.EndTaskResult.Detail.Status)
 	s.Zero(s.mockCommunicator.EndTaskResult.Detail.Description)
+	s.Zero(s.mockCommunicator.EndTaskResult.Detail.FailingCommand)
 
 	s.NoError(s.tc.logger.Close())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
@@ -1221,7 +1223,7 @@ tasks:
 	})
 }
 
-func (s *AgentSuite) TestFailureForFailingTestResult() {
+func (s *AgentSuite) TestFailingTestResultFailsTask() {
 	projYml := `
 tasks:
   - name: this_is_a_task_name
@@ -1243,6 +1245,7 @@ tasks:
 	s.Equal(evergreen.CommandTypeTest, s.mockCommunicator.EndTaskResult.Detail.Type)
 	s.Equal(evergreen.TaskFailed, s.mockCommunicator.EndTaskResult.Detail.Status)
 	s.Equal(evergreen.TaskDescriptionResultsFailed, s.mockCommunicator.EndTaskResult.Detail.Description)
+	s.Zero(s.mockCommunicator.EndTaskResult.Detail.FailingCommand)
 
 	s.NoError(s.tc.logger.Close())
 	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1121,6 +1121,173 @@ post:
 	})
 }
 
+func (s *AgentSuite) TestMissingTestResultFailsTask() {
+	projYml := `
+tasks:
+  - name: this_is_a_task_name
+    must_have_test_results: true
+    commands:
+      - command: shell.exec
+        params:
+          script: exit 0
+`
+	s.setupRunTask(projYml)
+	nextTask := &apimodels.NextTaskResponse{
+		TaskId:     s.tc.task.ID,
+		TaskSecret: s.tc.task.Secret,
+	}
+	s.tc.taskConfig.Task.MustHaveResults = true
+	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, false, s.testTmpDirName)
+	s.NoError(err)
+
+	s.Equal(evergreen.CommandTypeTest, s.mockCommunicator.EndTaskResult.Detail.Type)
+	s.Equal(evergreen.TaskFailed, s.mockCommunicator.EndTaskResult.Detail.Status)
+	s.Equal(evergreen.TaskDescriptionNoResults, s.mockCommunicator.EndTaskResult.Detail.Description)
+
+	s.NoError(s.tc.logger.Close())
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
+		"Running task commands",
+		"Running command 'shell.exec' (step 1 of 1)",
+		"Finished command 'shell.exec' (step 1 of 1)",
+		"Test results are missing and this task must have attached test results. Overall task status changed to FAILED.",
+	}, []string{panicLog})
+}
+
+func (s *AgentSuite) TestMissingTestResultDoesNotFailTaskForOptionalTestResults() {
+	projYml := `
+tasks:
+  - name: this_is_a_task_name
+    commands:
+      - command: shell.exec
+        params:
+          script: exit 0
+`
+	s.setupRunTask(projYml)
+	nextTask := &apimodels.NextTaskResponse{
+		TaskId:     s.tc.task.ID,
+		TaskSecret: s.tc.task.Secret,
+	}
+	s.tc.taskConfig.Task.MustHaveResults = false
+	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, false, s.testTmpDirName)
+	s.NoError(err)
+
+	s.Zero(s.mockCommunicator.EndTaskResult.Detail.Type)
+	s.Equal(evergreen.TaskSucceeded, s.mockCommunicator.EndTaskResult.Detail.Status)
+	s.Zero(s.mockCommunicator.EndTaskResult.Detail.Description)
+
+	s.NoError(s.tc.logger.Close())
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
+		"Running task commands",
+		"Running command 'shell.exec' (step 1 of 1)",
+		"Finished command 'shell.exec' (step 1 of 1)",
+	}, []string{
+		panicLog,
+		"Test results are missing and this task must have attached test results. Overall task status changed to FAILED.",
+	})
+}
+
+func (s *AgentSuite) TestFailingCommandIsNotOverwrittenByMissingTestResult() {
+	projYml := `
+tasks:
+  - name: this_is_a_task_name
+    must_have_test_results: true
+    commands:
+      - command: shell.exec
+        params:
+          script: exit 1
+`
+	s.setupRunTask(projYml)
+	nextTask := &apimodels.NextTaskResponse{
+		TaskId:     s.tc.task.ID,
+		TaskSecret: s.tc.task.Secret,
+	}
+	s.tc.taskConfig.Task.MustHaveResults = true
+	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, false, s.testTmpDirName)
+	s.NoError(err)
+
+	s.Equal(evergreen.CommandTypeTest, s.mockCommunicator.EndTaskResult.Detail.Type)
+	s.Equal(evergreen.TaskFailed, s.mockCommunicator.EndTaskResult.Detail.Status)
+	s.Empty(s.mockCommunicator.EndTaskResult.Detail.Description)
+	s.Equal(s.tc.getFailingCommand().FullDisplayName(), s.mockCommunicator.EndTaskResult.Detail.FailingCommand)
+
+	s.NoError(s.tc.logger.Close())
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
+		"Running task commands",
+		"Running command 'shell.exec' (step 1 of 1)",
+		"Finished command 'shell.exec' (step 1 of 1)",
+	}, []string{
+		panicLog,
+		"Test results are missing and this task must have attached test results. Overall task status changed to FAILED.",
+	})
+}
+
+func (s *AgentSuite) TestFailureForFailingTestResult() {
+	projYml := `
+tasks:
+  - name: this_is_a_task_name
+    commands:
+      - command: shell.exec
+        params:
+          script: exit 0
+`
+	s.setupRunTask(projYml)
+	nextTask := &apimodels.NextTaskResponse{
+		TaskId:     s.tc.task.ID,
+		TaskSecret: s.tc.task.Secret,
+	}
+	s.tc.taskConfig.HasTestResults = true
+	s.tc.taskConfig.HasFailingTestResult = true
+	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, false, s.testTmpDirName)
+	s.NoError(err)
+
+	s.Equal(evergreen.CommandTypeTest, s.mockCommunicator.EndTaskResult.Detail.Type)
+	s.Equal(evergreen.TaskFailed, s.mockCommunicator.EndTaskResult.Detail.Status)
+	s.Equal(evergreen.TaskDescriptionResultsFailed, s.mockCommunicator.EndTaskResult.Detail.Description)
+
+	s.NoError(s.tc.logger.Close())
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
+		"Running task commands",
+		"Running command 'shell.exec' (step 1 of 1)",
+		"Finished command 'shell.exec' (step 1 of 1)",
+		"Test results contain at least one failure. Overall task status changed to FAILED.",
+	}, []string{panicLog})
+}
+
+func (s *AgentSuite) TestFailingCommandIsNotOverwrittenByFailingTestResult() {
+	projYml := `
+tasks:
+  - name: this_is_a_task_name
+    commands:
+      - command: shell.exec
+        params:
+          script: exit 1
+`
+	s.setupRunTask(projYml)
+	nextTask := &apimodels.NextTaskResponse{
+		TaskId:     s.tc.task.ID,
+		TaskSecret: s.tc.task.Secret,
+	}
+	s.tc.taskConfig.HasTestResults = true
+	s.tc.taskConfig.HasFailingTestResult = true
+	_, _, err := s.a.runTask(s.ctx, s.tc, nextTask, false, s.testTmpDirName)
+	s.NoError(err)
+
+	s.Equal(evergreen.CommandTypeTest, s.mockCommunicator.EndTaskResult.Detail.Type)
+	s.Equal(evergreen.TaskFailed, s.mockCommunicator.EndTaskResult.Detail.Status)
+	s.Empty(s.mockCommunicator.EndTaskResult.Detail.Description)
+	s.Equal(s.tc.getFailingCommand().FullDisplayName(), s.mockCommunicator.EndTaskResult.Detail.FailingCommand)
+
+	s.NoError(s.tc.logger.Close())
+	checkMockLogs(s.T(), s.mockCommunicator, s.tc.taskConfig.Task.Id, []string{
+		"Running task commands",
+		"Running command 'shell.exec' (step 1 of 1)",
+		"Finished command 'shell.exec' (step 1 of 1)",
+	}, []string{
+		panicLog,
+		"Test results are missing and this task must have attached test results. Overall task status changed to FAILED.",
+	})
+}
+
 func (s *AgentSuite) TestRetryOnFailure() {
 	projYml := `
 tasks:

--- a/agent/command/results_utils.go
+++ b/agent/command/results_utils.go
@@ -84,8 +84,21 @@ func attachTestResults(ctx context.Context, conf *internal.TaskConfig, td client
 		return errors.Wrap(err, "closing test results record")
 	}
 
+	// kim: NOTE: this sets whether the task has at least one failing test
+	// result.
 	if err := comm.SetResultsInfo(ctx, td, testresult.TestResultsServiceCedar, failed); err != nil {
 		return errors.Wrap(err, "setting results info in the task")
+	}
+
+	// kim: NOTE: code can only get here if it has more than one test result
+	// because of sendTestResults check. Therefore, if we get here, we can mark
+	// the task as having test results within the local task config.
+	// Could indirectly check this by looking for CedarTestResultsID.
+	// kim: TODO: test in staging to verify this propagates back when resolving
+	// task end details. I assume it does but should check.
+	conf.HasTestResults = true
+	if failed {
+		conf.HasFailingTestResult = true
 	}
 
 	return nil

--- a/agent/command/results_utils.go
+++ b/agent/command/results_utils.go
@@ -84,18 +84,10 @@ func attachTestResults(ctx context.Context, conf *internal.TaskConfig, td client
 		return errors.Wrap(err, "closing test results record")
 	}
 
-	// kim: NOTE: this sets whether the task has at least one failing test
-	// result.
 	if err := comm.SetResultsInfo(ctx, td, testresult.TestResultsServiceCedar, failed); err != nil {
 		return errors.Wrap(err, "setting results info in the task")
 	}
 
-	// kim: NOTE: code can only get here if it has more than one test result
-	// because of sendTestResults check. Therefore, if we get here, we can mark
-	// the task as having test results within the local task config.
-	// Could indirectly check this by looking for CedarTestResultsID.
-	// kim: TODO: test in staging to verify this propagates back when resolving
-	// task end details. I assume it does but should check.
 	conf.HasTestResults = true
 	if failed {
 		conf.HasFailingTestResult = true

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -64,10 +64,15 @@ type TaskConfig struct {
 	Timeout            Timeout
 	TaskOutput         evergreen.S3Credentials
 	ModulePaths        map[string]string
-	CedarTestResultsID string
-	TaskGroup          *model.TaskGroup
-	CommandCleanups    []CommandCleanup
-	MaxExecTimeoutSecs int
+	// HasTestResults is true if the task has sent at least one test result.
+	HasTestResults bool
+	// HasFailingTestResult is true if the task has sent at least one test
+	// result and at least one of those tests failed.
+	HasFailingTestResult bool
+	CedarTestResultsID   string
+	TaskGroup            *model.TaskGroup
+	CommandCleanups      []CommandCleanup
+	MaxExecTimeoutSecs   int
 
 	// PatchOrVersionDescription holds the description of a patch or
 	// message of a version to be used in the otel attributes.

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-06-10"
+	AgentVersion = "2025-06-11"
 )
 
 const (

--- a/globals.go
+++ b/globals.go
@@ -490,12 +490,14 @@ const (
 
 	OtelAttributeMaxLength = 10000
 	// task otel attributes
-	TaskIDOtelAttribute          = "evergreen.task.id"
-	TaskNameOtelAttribute        = "evergreen.task.name"
-	TaskExecutionOtelAttribute   = "evergreen.task.execution"
-	TaskStatusOtelAttribute      = "evergreen.task.status"
-	TaskFailureTypeOtelAttribute = "evergreen.task.failure_type"
-	TaskTagsOtelAttribute        = "evergreen.task.tags"
+	TaskIDOtelAttribute             = "evergreen.task.id"
+	TaskNameOtelAttribute           = "evergreen.task.name"
+	TaskExecutionOtelAttribute      = "evergreen.task.execution"
+	TaskStatusOtelAttribute         = "evergreen.task.status"
+	TaskFailureTypeOtelAttribute    = "evergreen.task.failure_type"
+	TaskFailingCommandOtelAttribute = "evergreen.task.failing_command"
+	TaskDescriptionOtelAttribute    = "evergreen.task.description"
+	TaskTagsOtelAttribute           = "evergreen.task.tags"
 
 	// task otel attributes
 	DisplayTaskIDOtelAttribute   = "evergreen.display_task.id"

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -807,7 +807,6 @@ func MarkEnd(ctx context.Context, settings *evergreen.Settings, t *task.Task, ca
 			"task_id": t.Id,
 			"host_id": t.HostId,
 		})
-		// kim: TODO: try moving into agent
 		detailsCopy.Type = evergreen.CommandTypeTest
 		detailsCopy.Status = evergreen.TaskFailed
 		detailsCopy.Description = evergreen.TaskDescriptionNoResults

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -776,6 +776,7 @@ func MarkEnd(ctx context.Context, settings *evergreen.Settings, t *task.Task, ca
 
 	detailsCopy := *detail
 	if t.ResultsFailed && detailsCopy.Status != evergreen.TaskFailed {
+		// kim: TODO: try moving into agent
 		detailsCopy.Type = evergreen.CommandTypeTest
 		detailsCopy.Status = evergreen.TaskFailed
 		detailsCopy.Description = evergreen.TaskDescriptionResultsFailed
@@ -789,6 +790,7 @@ func MarkEnd(ctx context.Context, settings *evergreen.Settings, t *task.Task, ca
 		return nil
 	}
 	if detailsCopy.Status == evergreen.TaskSucceeded && t.MustHaveResults && !t.HasResults(ctx) {
+		// kim: TODO: try moving into agent
 		detailsCopy.Type = evergreen.CommandTypeTest
 		detailsCopy.Status = evergreen.TaskFailed
 		detailsCopy.Description = evergreen.TaskDescriptionNoResults

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -776,7 +776,15 @@ func MarkEnd(ctx context.Context, settings *evergreen.Settings, t *task.Task, ca
 
 	detailsCopy := *detail
 	if t.ResultsFailed && detailsCopy.Status != evergreen.TaskFailed {
-		// kim: TODO: try moving into agent
+		// TODO (DEVPROD-12889): remove this log and this logic once it's
+		// confirmed that all agents are on the newer version and the test
+		// results check has been moved.
+		grip.Debug(message.Fields{
+			"message": "overwriting task status to failed in app server due to test results containing failure",
+			"ticket":  "DEVPROD-12889",
+			"task_id": t.Id,
+			"host_id": t.HostId,
+		})
 		detailsCopy.Type = evergreen.CommandTypeTest
 		detailsCopy.Status = evergreen.TaskFailed
 		detailsCopy.Description = evergreen.TaskDescriptionResultsFailed
@@ -790,6 +798,15 @@ func MarkEnd(ctx context.Context, settings *evergreen.Settings, t *task.Task, ca
 		return nil
 	}
 	if detailsCopy.Status == evergreen.TaskSucceeded && t.MustHaveResults && !t.HasResults(ctx) {
+		// TODO (DEVPROD-12889): remove this log and this logic once it's
+		// confirmed that all agents are on the newer version and the test
+		// results check has been moved.
+		grip.Debug(message.Fields{
+			"message": "overwriting task status to failed in app server due to missing test results",
+			"ticket":  "DEVPROD-12889",
+			"task_id": t.Id,
+			"host_id": t.HostId,
+		})
 		// kim: TODO: try moving into agent
 		detailsCopy.Type = evergreen.CommandTypeTest
 		detailsCopy.Status = evergreen.TaskFailed


### PR DESCRIPTION
DEVPROD-12889

### Description
Traces currently don't show any failure when a test fails or no test results are posted (with `must_have_test_results: true`) because [those checks have historically been done in the app server when the task is ending](https://github.com/evergreen-ci/evergreen/blob/8a967916c296fdec9128462aefb6ba65cf646888/model/task_lifecycle.go#L778-L795). I opted to move test results checks into the agent so that the traces can display any test results-related failure.

The agents all have to roll over to the new version before the old checks can be removed. I'll post a follow-up PR once the agents have rolled over.

* Move test results missing/failed checks into the agent.
* Add temporary log to double-check that the app server logic is not used anymore.
* Add failing command and description to OTel traces - this is useful to understand test results-related failures. Currently, Honeycomb traces show a failing span when a command fails so you can deduce what is failing. However in the case of test result checks, there's no specific command that failed, just that a condition needed for the task wasn't met. Adding the failing command and description makes it clearer on the top-level span exactly what caused the task to fail.

### Testing
* Added unit tests.
* Tested in staging to verify that test results missing/failed still behave the same as before. Also verified that traces now are marked red when the test results are missing/failed.