### PR TITLE
DEVPROD-7920: store stats on host usage by distro

### DIFF
--- a/model/hoststat/db.go
+++ b/model/hoststat/db.go
@@ -1,0 +1,4 @@
+package hoststat
+
+// Collection stores host usage statistics as time series data.
+const Collection = "hoststats"

--- a/model/hoststat/db.go
+++ b/model/hoststat/db.go
@@ -1,4 +1,4 @@
 package hoststat
 
 // Collection stores host usage statistics as time series data.
-const Collection = "hoststats"
+const Collection = "host_stats"

--- a/model/hoststat/hoststat.go
+++ b/model/hoststat/hoststat.go
@@ -1,0 +1,41 @@
+package hoststat
+
+import (
+	"context"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// HostStat records statistics about host usage by distro.
+type HostStat struct {
+	ID        primitive.ObjectID `bson:"_id"`
+	Timestamp time.Time          `bson:"timestamp"`
+	Metadata  HostStatMetadata   `bson:"metadata"`
+	NumHosts  int                `bson:"num_hosts"`
+}
+
+type HostStatMetadata struct {
+	Distro string `bson:"distro"`
+}
+
+func NewHostStat(distro string, numHosts int) *HostStat {
+	return &HostStat{
+		ID: primitive.NewObjectID(),
+		// kim: NOTE: rounded to the nearest minute to reduce density of data
+		// points. Host allocator runs more than once per minute.
+		Timestamp: time.Now(),
+		Metadata: HostStatMetadata{
+			Distro: distro,
+		},
+		NumHosts: numHosts,
+	}
+}
+
+// kim: NOTE: need to suppress duplicate key errors if the compound
+// index on timestamp requires unique timestamps.
+func (hs *HostStat) Insert(ctx context.Context) error {
+	_, err := evergreen.GetEnvironment().DB().Collection(Collection).InsertOne(ctx, hs)
+	return err
+}

--- a/model/hoststat/hoststat.go
+++ b/model/hoststat/hoststat.go
@@ -27,8 +27,6 @@ func NewHostStat(distroID string, numHosts int) *HostStat {
 	}
 }
 
-// kim: NOTE: need to suppress duplicate key errors if the compound
-// index on timestamp requires unique timestamps.
 func (hs *HostStat) Insert(ctx context.Context) error {
 	_, err := evergreen.GetEnvironment().DB().Collection(Collection).InsertOne(ctx, hs)
 	return err

--- a/model/hoststat/hoststat.go
+++ b/model/hoststat/hoststat.go
@@ -22,10 +22,8 @@ type HostStatMetadata struct {
 
 func NewHostStat(distro string, numHosts int) *HostStat {
 	return &HostStat{
-		ID: primitive.NewObjectID(),
-		// kim: NOTE: rounded to the nearest minute to reduce density of data
-		// points. Host allocator runs more than once per minute.
-		Timestamp: time.Now(),
+		ID:        primitive.NewObjectID(),
+		Timestamp: time.Now().Round(time.Minute),
 		Metadata: HostStatMetadata{
 			Distro: distro,
 		},

--- a/model/hoststat/hoststat.go
+++ b/model/hoststat/hoststat.go
@@ -10,24 +10,20 @@ import (
 
 // HostStat records statistics about host usage by distro.
 type HostStat struct {
-	ID        primitive.ObjectID `bson:"_id"`
-	Timestamp time.Time          `bson:"timestamp"`
-	Metadata  HostStatMetadata   `bson:"metadata"`
-	NumHosts  int                `bson:"num_hosts"`
+	ID        string    `bson:"_id"`
+	DistroID  string    `bson:"distro"`
+	Timestamp time.Time `bson:"timestamp"`
+	NumHosts  int       `bson:"num_hosts"`
 }
 
-type HostStatMetadata struct {
-	Distro string `bson:"distro"`
-}
+const tsFormat = "2006-01-02.15-04-05"
 
-func NewHostStat(distro string, numHosts int) *HostStat {
+func NewHostStat(distroID string, numHosts int) *HostStat {
 	return &HostStat{
-		ID:        primitive.NewObjectID(),
+		ID:        primitive.NewObjectID().Hex(),
 		Timestamp: time.Now().Round(time.Minute),
-		Metadata: HostStatMetadata{
-			Distro: distro,
-		},
-		NumHosts: numHosts,
+		DistroID:  distroID,
+		NumHosts:  numHosts,
 	}
 }
 

--- a/units/host_allocator.go
+++ b/units/host_allocator.go
@@ -419,7 +419,6 @@ func (j *hostAllocatorJob) setTargetAndTerminate(ctx context.Context, numUpHosts
 }
 
 // saveHostStats saves the latest host usage stats for an EC2 distro.
-// kim: TODO: test that this is saved in staging DB.
 func (j *hostAllocatorJob) saveHostStats(ctx context.Context, d *distro.Distro, numUpHosts int) {
 	if !evergreen.IsEc2Provider(d.Provider) {
 		return


### PR DESCRIPTION
DEVPROD-7920

### Description
For auto-tuning distro max hosts, I decided that the best way to do it is to have a job that periodically checks recent host usage by distro and adjust max hosts accordingly. To do that, we need to collect stats on how many hosts a distro uses. This PR collects that data. There's going to be follow-up PRs for adding a distro flag to enable it + actually adjusting distro max hosts.

### Testing
Tested in staging to verify that the job inserts the host usage data as expected.