### PR TITLE
DEVPROD-7920: add distro flag to allow auto-tuning distro max hosts

### DIFF
--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -241,9 +241,12 @@ func (d *Distro) ShellBinary() string {
 }
 
 type HostAllocatorSettings struct {
-	Version                string `bson:"version" json:"version" mapstructure:"version"`
-	MinimumHosts           int    `bson:"minimum_hosts" json:"minimum_hosts" mapstructure:"minimum_hosts"`
-	MaximumHosts           int    `bson:"maximum_hosts" json:"maximum_hosts" mapstructure:"maximum_hosts"`
+	Version      string `bson:"version" json:"version" mapstructure:"version"`
+	MinimumHosts int    `bson:"minimum_hosts" json:"minimum_hosts" mapstructure:"minimum_hosts"`
+	MaximumHosts int    `bson:"maximum_hosts" json:"maximum_hosts" mapstructure:"maximum_hosts"`
+	// AutoTuneMaximumHosts determines if Evergreen is allowed to automatically
+	// tune the distro's maximum hosts.
+	AutoTuneMaximumHosts   bool   `bson:"auto_tune_maximum_hosts" json:"auto_tune_maximum_hosts" mapstructure:"auto_tune_maximum_hosts"`
 	RoundingRule           string `bson:"rounding_rule" json:"rounding_rule" mapstructure:"rounding_rule"`
 	FeedbackRule           string `bson:"feedback_rule" json:"feedback_rule" mapstructure:"feedback_rule"`
 	HostsOverallocatedRule string `bson:"hosts_overallocated_rule" json:"hosts_overallocated_rule" mapstructure:"hosts_overallocated_rule"`
@@ -648,6 +651,7 @@ func (d *Distro) GetResolvedHostAllocatorSettings(s *evergreen.Settings) (HostAl
 		Version:                has.Version,
 		MinimumHosts:           has.MinimumHosts,
 		MaximumHosts:           has.MaximumHosts,
+		AutoTuneMaximumHosts:   has.AutoTuneMaximumHosts,
 		AcceptableHostIdleTime: has.AcceptableHostIdleTime,
 		RoundingRule:           has.RoundingRule,
 		FeedbackRule:           has.FeedbackRule,

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -69,6 +69,7 @@ type APIHostAllocatorSettings struct {
 	Version                *string     `json:"version"`
 	MinimumHosts           int         `json:"minimum_hosts"`
 	MaximumHosts           int         `json:"maximum_hosts"`
+	AutoTuneMaximumHosts   bool        `json:"auto_tune_maximum_hosts"`
 	RoundingRule           *string     `json:"rounding_rule"`
 	FeedbackRule           *string     `json:"feedback_rule"`
 	HostsOverallocatedRule *string     `json:"hosts_overallocated_rule"`
@@ -85,6 +86,7 @@ func (s *APIHostAllocatorSettings) BuildFromService(settings distro.HostAllocato
 	}
 	s.MinimumHosts = settings.MinimumHosts
 	s.MaximumHosts = settings.MaximumHosts
+	s.AutoTuneMaximumHosts = settings.AutoTuneMaximumHosts
 	s.AcceptableHostIdleTime = NewAPIDuration(settings.AcceptableHostIdleTime)
 	s.RoundingRule = utility.ToStringPtr(settings.RoundingRule)
 	s.FeedbackRule = utility.ToStringPtr(settings.FeedbackRule)
@@ -102,6 +104,7 @@ func (s *APIHostAllocatorSettings) ToService() distro.HostAllocatorSettings {
 	}
 	settings.MinimumHosts = s.MinimumHosts
 	settings.MaximumHosts = s.MaximumHosts
+	settings.AutoTuneMaximumHosts = s.AutoTuneMaximumHosts
 	settings.AcceptableHostIdleTime = s.AcceptableHostIdleTime.ToDuration()
 	settings.RoundingRule = utility.FromStringPtr(s.RoundingRule)
 	settings.FeedbackRule = utility.FromStringPtr(s.FeedbackRule)

--- a/rest/model/distro_test.go
+++ b/rest/model/distro_test.go
@@ -34,6 +34,9 @@ func TestDistroBuildFromService(t *testing.T) {
 		Mountpoints:      []string{"/", "/data"},
 		ExecUser:         "exec_user",
 		SingleTaskDistro: true,
+		HostAllocatorSettings: distro.HostAllocatorSettings{
+			AutoTuneMaximumHosts: true,
+		},
 	}
 	apiDistro := &APIDistro{}
 	apiDistro.BuildFromService(d)
@@ -52,6 +55,7 @@ func TestDistroBuildFromService(t *testing.T) {
 	assert.Equal(t, d.Mountpoints, apiDistro.Mountpoints)
 	assert.Equal(t, d.SingleTaskDistro, apiDistro.SingleTaskDistro)
 	assert.Equal(t, d.ExecUser, utility.FromStringPtr(apiDistro.ExecUser))
+	assert.True(t, apiDistro.HostAllocatorSettings.AutoTuneMaximumHosts)
 }
 
 func TestDistroBuildFromServiceDefaults(t *testing.T) {
@@ -102,6 +106,9 @@ func TestDistroToService(t *testing.T) {
 		},
 		Mountpoints: []string{"/", "/data"},
 		ExecUser:    utility.ToStringPtr("exec_user"),
+		HostAllocatorSettings: APIHostAllocatorSettings{
+			AutoTuneMaximumHosts: true,
+		},
 	}
 
 	d := apiDistro.ToService()
@@ -130,6 +137,7 @@ func TestDistroToService(t *testing.T) {
 	assert.Equal(t, utility.FromStringPtr(apiDistro.IcecreamSettings.ConfigPath), d.IceCreamSettings.ConfigPath)
 	assert.Equal(t, apiDistro.Mountpoints, d.Mountpoints)
 	assert.Equal(t, utility.FromStringPtr(apiDistro.ExecUser), d.ExecUser)
+	assert.True(t, d.HostAllocatorSettings.AutoTuneMaximumHosts)
 }
 
 func TestDistroToServiceDefaults(t *testing.T) {

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -191,6 +191,7 @@ func (s *DistroByIDSuite) SetupSuite() {
 				Version:                evergreen.HostAllocatorUtilization,
 				MinimumHosts:           5,
 				MaximumHosts:           10,
+				AutoTuneMaximumHosts:   true,
 				AcceptableHostIdleTime: 10000000000,
 			},
 			FinderSettings: distro.FinderSettings{
@@ -235,6 +236,7 @@ func (s *DistroByIDSuite) TestFindByIdFound() {
 
 	s.Equal(5, d.HostAllocatorSettings.MinimumHosts)
 	s.Equal(10, d.HostAllocatorSettings.MaximumHosts)
+	s.True(d.HostAllocatorSettings.AutoTuneMaximumHosts)
 	s.Equal(restModel.NewAPIDuration(10000000000), d.HostAllocatorSettings.AcceptableHostIdleTime)
 	s.Equal(utility.ToStringPtr(evergreen.PlannerVersionTunable), d.PlannerSettings.Version)
 	s.Equal(restModel.NewAPIDuration(80000000000), d.PlannerSettings.TargetTime)


### PR DESCRIPTION
DEVPROD-7920

### Description
Follow-up to #9125 - some distros can't have their max hosts adjusted (e.g. perf distros) while others can, so I made a flag to choose whether to allow a particular distro to have its max hosts automatically adjusted. The flag is going to be used in a follow-up PR.

I opened a UI ticket (DEVPROD-18438) to add this flag.

### Testing
Updated unit tests.