### PR TITLE
DOCS: DEVPROD-18242 Update assume_role docs with project ID

### DIFF
--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -382,7 +382,10 @@ Parameters:
 
 The call to AssumeRole includes an external ID formatted as
 `<project_id>-<requester>`. This cannot be modified by the user.
-The list of requesters can be found [here](../Reference/Glossary.md#requesters).
+
+- An Evergreen project's ID can be found on its General Settings page.
+- The list of requesters can be found [here](../Reference/Glossary.md#requesters).
+
 The originating role is: 
 `arn:aws:iam::<evergreen_account_id>:role/evergreen.role.production`
 and your role should only trust that exact role. You should add an


### PR DESCRIPTION
Supports DEVPROD-18242

### Description
Update docs for `assume_roles` command to indicate that project ID is now visible on a project's settings page. Also update the formatting a bit.

### Documentation
[Pine patch](https://spruce.mongodb.com/version/6852cc3b4989a5000773f405/downstream-projects?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)
