### PR TITLE
DEVPROD-11204 Return error when tasks exceed maximum exec timelimit

### DIFF
--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1142,8 +1142,7 @@ func validateTimeoutLimits(_ context.Context, settings *evergreen.Settings, proj
 			if task.ExecTimeoutSecs > settings.TaskLimits.MaxExecTimeoutSecs {
 				errs = append(errs, ValidationError{
 					Message: fmt.Sprintf("task '%s' exec timeout (%d) is too high and will be set to maximum limit (%d)", task.Name, task.ExecTimeoutSecs, settings.TaskLimits.MaxExecTimeoutSecs),
-					// TODO DEVPROD-11204: Update to Error once the exec timeout limit can be enforced
-					Level: Warning,
+					Level:   Error,
 				})
 			}
 		}

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -1758,7 +1758,7 @@ func TestValidateTimeoutLimits(t *testing.T) {
 		}
 		errs := validateTimeoutLimits(ctx, settings, project, &model.ProjectRef{}, false)
 		require.Len(t, errs, 1)
-		assert.Equal(t, Warning, errs[0].Level)
+		assert.Equal(t, Error, errs[0].Level)
 		assert.Contains(t, "task 'task' exec timeout (10) is too high and will be set to maximum limit (1)", errs[0].Message)
 	})
 	t.Run("SucceedsWithNoMaxTimeoutLimit", func(t *testing.T) {


### PR DESCRIPTION
DEVPROD-11204

### Description
previously this error was a warning because there were teams that relied on this not erroring 
this should be okay now that teams don't rely on this behavior anymore

### Testing
fixed unit test