### PR TITLE
DEVPROD-11839 Use userID when restarting tasks via API

### DIFF
--- a/rest/route/task_restart.go
+++ b/rest/route/task_restart.go
@@ -63,7 +63,7 @@ func (trh *taskRestartHandler) Parse(ctx context.Context, r *http.Request) error
 	}
 	trh.taskId = projCtx.Task.Id
 	u := MustHaveUser(ctx)
-	trh.username = u.DisplayName()
+	trh.username = u.Username()
 
 	b, err := io.ReadAll(r.Body)
 	if err != nil {


### PR DESCRIPTION
DEVPROD-11839

### Description
Tasks using this route would end up having their `activated_by` field set to the user's display name rather than ID, and a surprising amount of human users use this route (300k / month).
### Testing
Existing tests