### PR TITLE
DEVPROD-7920: implement distro auto-tune job

### DIFF
--- a/docs/decisions/2025-06-23_auto_tune_distro_max_hosts.md
+++ b/docs/decisions/2025-06-23_auto_tune_distro_max_hosts.md
@@ -1,0 +1,32 @@
+# 2025-06-23 Auto-Tuning Distro Max Hosts
+
+* status: proposed
+* date: 2025-06-23
+* authors: Kim Tao
+
+## Context and Problem Statement
+Each distro has a cap on the maximum number of hosts it can create to run tasks. There's two major reasons for this. The
+first is that some distros have to artificially keep the parallelization of tasks low (e.g. external non-Evergreen
+infrastructure that can only handle so many tasks running at once). The second reason is that limiting a distro's hosts
+is a safety guard to prevent any single distro from allocating too many hosts. The safety is important because that
+Evergreen has (and will continue to have for the foreseeable future) a global limitation on the number of EC2 hosts it
+can have running at any given time. However, even though this cap has its uses, it has also been somewhat inconvenient
+because it has to be manually adjusted whenever a distro's usage changes. Distro max hosts isn't adjusted that
+frequently, so it can cause long queue times unnecessarily if a distro has a max host limit that's far below what the
+distro's tasks need to run quickly.
+
+## Considered Options
+One alternative that was considered was to make distro max hosts optional and allow those distros to scale up or down as
+much as needed. Most distros are fairly low-usage with only a handful that are popular enough to potentially be a
+concern for load, so it would reduce some burden from adjusting smaller distros. However, even then, having a cap on
+distro max hosts could be useful just to prevent obvious over-usage. It would also not eliminate the problem entirely
+because many of the more popular distros could benefit from being adjusted occasionally to allow more hosts and those do
+have a concern that they could starve other distros of hosts during periods of very high load.
+
+## Decision Outcome
+The decision was to add a job that would incrementally increase/decrease a distro's max hosts according to that distro's
+recent host usage. Keeping distro max hosts has the benefit of maintaining a cap on a distro to avoid starving other
+distros. It also means a distro can more frequently adjust to actual distro usage since it runs as an automated
+background process, which is an improvement over the purely human-driven process to manually adjust distro max hosts.
+
+## More Information

--- a/model/hoststat/db.go
+++ b/model/hoststat/db.go
@@ -1,4 +1,39 @@
 package hoststat
 
+import (
+	"context"
+	"time"
+
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/db/mgo/bson"
+	"github.com/mongodb/anser/bsonutil"
+)
+
+var (
+	distroIDKey  = bsonutil.MustHaveTag(HostStat{}, "DistroID")
+	timestampKey = bsonutil.MustHaveTag(HostStat{}, "Timestamp")
+)
+
 // Collection stores host usage statistics as time series data.
 const Collection = "host_stats"
+
+// Find finds all host stats that match the given query.
+func Find(ctx context.Context, q db.Q) ([]HostStat, error) {
+	stats := []HostStat{}
+	err := db.FindAllQ(ctx, Collection, q, &stats)
+	if err != nil {
+		return nil, err
+	}
+	return stats, nil
+}
+
+// FindByDistroSince finds all host stats for a given distro since the start
+// timestamp.
+// kim: TODO: add unit test
+func FindByDistroSince(ctx context.Context, distroID string, startAt time.Time) ([]HostStat, error) {
+	q := db.Query(bson.M{
+		distroIDKey:  distroID,
+		timestampKey: bson.M{"$gte": startAt},
+	})
+	return Find(ctx, q)
+}

--- a/model/hoststat/db.go
+++ b/model/hoststat/db.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	distroIDKey  = bsonutil.MustHaveTag(HostStat{}, "DistroID")
+	distroKey    = bsonutil.MustHaveTag(HostStat{}, "Distro")
 	timestampKey = bsonutil.MustHaveTag(HostStat{}, "Timestamp")
 )
 
@@ -31,7 +31,7 @@ func Find(ctx context.Context, q db.Q) ([]HostStat, error) {
 // timestamp.
 func FindByDistroSince(ctx context.Context, distroID string, startAt time.Time) ([]HostStat, error) {
 	q := db.Query(bson.M{
-		distroIDKey:  distroID,
+		distroKey:    distroID,
 		timestampKey: bson.M{"$gte": startAt},
 	})
 	return Find(ctx, q)

--- a/model/hoststat/db.go
+++ b/model/hoststat/db.go
@@ -29,7 +29,6 @@ func Find(ctx context.Context, q db.Q) ([]HostStat, error) {
 
 // FindByDistroSince finds all host stats for a given distro since the start
 // timestamp.
-// kim: TODO: add unit test
 func FindByDistroSince(ctx context.Context, distroID string, startAt time.Time) ([]HostStat, error) {
 	q := db.Query(bson.M{
 		distroIDKey:  distroID,

--- a/model/hoststat/db_test.go
+++ b/model/hoststat/db_test.go
@@ -1,0 +1,56 @@
+package hoststat
+
+import (
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	testutil.Setup()
+}
+
+func TestFindByDistroSince(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(Collection))
+	}()
+	for tName, tCase := range map[string]func(t *testing.T){
+		"ReturnsOnlyThoseMatchingDistro": func(t *testing.T) {
+			stat1 := NewHostStat("distro1", 100)
+			stat1.Timestamp = utility.BSONTime(stat1.Timestamp)
+			require.NoError(t, stat1.Insert(t.Context()))
+			stat2 := NewHostStat("distro2", 200)
+			stat2.Timestamp = utility.BSONTime(stat2.Timestamp)
+			require.NoError(t, stat2.Insert(t.Context()))
+
+			dbStats, err := FindByDistroSince(t.Context(), "distro1", stat1.Timestamp.Add(-time.Hour))
+			require.NoError(t, err)
+			require.Len(t, dbStats, 1)
+			assert.Equal(t, *stat1, dbStats[0])
+		},
+		"ReturnsOnlyThoseInTimeRange": func(t *testing.T) {
+			stat1 := NewHostStat("distro1", 100)
+			stat1.Timestamp = utility.BSONTime(stat1.Timestamp)
+			require.NoError(t, stat1.Insert(t.Context()))
+			stat2 := NewHostStat("distro1", 200)
+			stat2.Timestamp = utility.BSONTime(time.Now().Add(-100 * utility.Day))
+			require.NoError(t, stat2.Insert(t.Context()))
+
+			dbStats, err := FindByDistroSince(t.Context(), "distro1", stat1.Timestamp.Add(-time.Hour))
+			require.NoError(t, err)
+			require.Len(t, dbStats, 1)
+			assert.Equal(t, *stat1, dbStats[0])
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(Collection))
+
+			tCase(t)
+		})
+	}
+}

--- a/model/hoststat/hoststat.go
+++ b/model/hoststat/hoststat.go
@@ -11,7 +11,7 @@ import (
 // HostStat records statistics about host usage by distro.
 type HostStat struct {
 	ID        string    `bson:"_id"`
-	DistroID  string    `bson:"distro"`
+	Distro    string    `bson:"distro"`
 	Timestamp time.Time `bson:"timestamp"`
 	NumHosts  int       `bson:"num_hosts"`
 }
@@ -20,7 +20,7 @@ func NewHostStat(distroID string, numHosts int) *HostStat {
 	return &HostStat{
 		ID:        primitive.NewObjectID().Hex(),
 		Timestamp: time.Now().Round(time.Minute),
-		DistroID:  distroID,
+		Distro:    distroID,
 		NumHosts:  numHosts,
 	}
 }

--- a/units/crons.go
+++ b/units/crons.go
@@ -1204,7 +1204,6 @@ func populateIPAddressAllocatorJobs(env evergreen.Environment) amboy.QueueOperat
 	}
 }
 
-// kim: TODO: test in staging that the jobs are enqueued to run once per day.
 func PopulateDistroAutoTuneJobs() amboy.QueueOperation {
 	return func(ctx context.Context, queue amboy.Queue) error {
 		distrosToAutoTune, err := distro.FindByNeedsAutoTune(ctx)
@@ -1213,7 +1212,6 @@ func PopulateDistroAutoTuneJobs() amboy.QueueOperation {
 		}
 		catcher := grip.NewBasicCatcher()
 		for _, d := range distrosToAutoTune {
-			// kim: TODO: ensure this only runs once per day.
 			ts := utility.RoundPartOfDay(0).Format(TSFormat)
 			if err := amboy.EnqueueUniqueJob(ctx, queue, NewDistroAutoTuneJob(d.Id, ts)); err != nil {
 				catcher.Wrapf(err, "enqueueing auto-tune job for distro '%s'", d.Id)

--- a/units/crons_remote_hour.go
+++ b/units/crons_remote_hour.go
@@ -55,6 +55,7 @@ func (j *cronsRemoteHourJob) Run(ctx context.Context) {
 		PopulateDuplicateTaskCheckJobs(),
 		PopulatePodResourceCleanupJobs(),
 		PopulateUnexpirableSpawnHostStatsJob(),
+		PopulateDistroAutoTuneJobs(),
 	}
 
 	queue := j.env.RemoteQueue()

--- a/units/distro_autotune.go
+++ b/units/distro_autotune.go
@@ -1,0 +1,52 @@
+package units
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+)
+
+const distroAutoTuneJobName = "distro-auto-tune"
+
+func init() {
+	registry.AddJobType(distroAutoTuneJobName, func() amboy.Job {
+		return makeDistroAutoTuneJob()
+	})
+}
+
+type distroAutoTuneJob struct {
+	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
+	DistroID string `bson:"distro_id" json:"distro_id" yaml:"distro_id"`
+}
+
+func makeDistroAutoTuneJob() *distroAutoTuneJob {
+	j := &distroAutoTuneJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    distroAutoTuneJobName,
+				Version: 0,
+			},
+		},
+	}
+	return j
+}
+
+// NewDistroAutoTuneJob returns a job to automatically adjust a distro's maximum
+// hosts.
+func NewDistroAutoTuneJob(distroID, ts string) amboy.Job {
+	j := makeDistroAutoTuneJob()
+	j.SetID(fmt.Sprintf("%s.%s.%s", distroAutoTuneJobName, distroID, ts))
+	j.SetScopes([]string{fmt.Sprintf("%s.%s", distroAutoTuneJobName, distroID)})
+	j.SetEnqueueAllScopes(true)
+	j.DistroID = distroID
+	return j
+}
+
+// kim: TODO: implement
+func (j *distroAutoTuneJob) Run(ctx context.Context) {
+	defer j.MarkComplete()
+
+}

--- a/units/distro_autotune.go
+++ b/units/distro_autotune.go
@@ -3,10 +3,15 @@ package units
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/hoststat"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
+	"github.com/pkg/errors"
 )
 
 const distroAutoTuneJobName = "distro-auto-tune"
@@ -20,6 +25,7 @@ func init() {
 type distroAutoTuneJob struct {
 	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
 	DistroID string `bson:"distro_id" json:"distro_id" yaml:"distro_id"`
+	distro   distro.Distro
 }
 
 func makeDistroAutoTuneJob() *distroAutoTuneJob {
@@ -49,4 +55,34 @@ func NewDistroAutoTuneJob(distroID, ts string) amboy.Job {
 func (j *distroAutoTuneJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 
+	if err := j.populate(ctx); err != nil {
+		j.AddError(errors.Wrapf(err, "populating job for distro '%s'", j.DistroID))
+		return
+	}
+
+	// kim: TODO: needs distro feature flag merged.
+	if !j.distro.HostAllocatorSettings.AutoTuneMaximumHosts {
+		return
+	}
+
+	const recentStatsWindow = 7 * utility.Day
+	stats, err := hoststat.FindByDistroSince(ctx, j.DistroID, time.Now().Add(-recentStatsWindow))
+	if err != nil {
+		j.AddError(errors.Wrapf(err, "getting host stats for distro '%s'", j.DistroID))
+		return
+	}
+
+	// kim: TODO: use stats to decide whether to adjust up/down.
+	fmt.Println(stats)
+}
+
+func (j *distroAutoTuneJob) populate(ctx context.Context) error {
+	d, err := distro.FindOneId(j.DistroID)
+	if err != nil {
+		return errors.Wrapf(err, "finding distro '%s'", j.DistroID)
+	}
+	if d == nil {
+		return errors.Errorf("distro '%s' not found", j.DistroID)
+	}
+	j.distro = d
 }

--- a/units/distro_autotune.go
+++ b/units/distro_autotune.go
@@ -50,6 +50,7 @@ func makeDistroAutoTuneJob() *distroAutoTuneJob {
 
 // NewDistroAutoTuneJob returns a job to automatically adjust a distro's maximum
 // hosts.
+// kim: TODO: test job in staging
 func NewDistroAutoTuneJob(distroID, ts string) amboy.Job {
 	j := makeDistroAutoTuneJob()
 	j.SetID(fmt.Sprintf("%s.%s.%s", distroAutoTuneJobName, distroID, ts))

--- a/units/distro_autotune.go
+++ b/units/distro_autotune.go
@@ -59,7 +59,6 @@ func NewDistroAutoTuneJob(distroID, ts string) amboy.Job {
 	return j
 }
 
-// kim: TODO: implement
 func (j *distroAutoTuneJob) Run(ctx context.Context) {
 	defer j.MarkComplete()
 

--- a/units/distro_autotune_test.go
+++ b/units/distro_autotune_test.go
@@ -1,0 +1,198 @@
+package units
+
+import (
+	"math/rand/v2"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/mock"
+	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/event"
+	"github.com/evergreen-ci/evergreen/model/hoststat"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDistroAutoTuneJob(t *testing.T) {
+	colls := []string{distro.Collection, hoststat.Collection, event.EventCollection}
+	defer func() {
+		assert.NoError(t, db.ClearCollections(colls...))
+	}()
+
+	addDistroHostStats := func(t *testing.T, distroID string, numHosts ...int) {
+		for _, num := range numHosts {
+			stat := hoststat.NewHostStat(distroID, num)
+			numMinsPerDay := 60 * 24
+			stat.Timestamp = time.Now().Add(time.Duration(rand.IntN(numMinsPerDay)) * time.Minute)
+			require.NoError(t, stat.Insert(t.Context()))
+		}
+	}
+
+	for tName, tCase := range map[string]func(t *testing.T, env *mock.Environment, j *distroAutoTuneJob){
+		"IncreasesMaxHostsWhenHittingMaxHostsFrequently": func(t *testing.T, env *mock.Environment, j *distroAutoTuneJob) {
+			originalMaxHosts := j.distro.HostAllocatorSettings.MaximumHosts
+			require.NoError(t, j.distro.Insert(t.Context()))
+
+			addDistroHostStats(t, j.distro.Id, slices.Repeat([]int{j.distro.HostAllocatorSettings.MaximumHosts}, 10)...)
+			j.Run(t.Context())
+			assert.NoError(t, j.Error())
+
+			dbDistro, err := distro.FindOneId(t.Context(), j.distro.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbDistro)
+			assert.Greater(t, dbDistro.HostAllocatorSettings.MaximumHosts, originalMaxHosts, "max hosts should be increased due to hitting max hosts frequently")
+
+			events, err := event.FindAllByResourceID(t.Context(), j.distro.Id)
+			require.NoError(t, err)
+			require.Len(t, events, 1)
+			assert.Equal(t, event.ResourceTypeDistro, events[0].ResourceType)
+			assert.Equal(t, event.EventDistroModified, events[0].EventType)
+		},
+		"DecreasesMaxHostsWhenMaxHostUtilizationIsVeryLow": func(t *testing.T, env *mock.Environment, j *distroAutoTuneJob) {
+			originalMaxHosts := j.distro.HostAllocatorSettings.MaximumHosts
+			require.NoError(t, j.distro.Insert(t.Context()))
+
+			addDistroHostStats(t, j.distro.Id, slices.Repeat([]int{1}, 10)...)
+			j.Run(t.Context())
+			assert.NoError(t, j.Error())
+
+			dbDistro, err := distro.FindOneId(t.Context(), j.distro.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbDistro)
+			assert.Less(t, dbDistro.HostAllocatorSettings.MaximumHosts, originalMaxHosts, "max hosts should be decreased due to using very few hosts")
+
+			events, err := event.FindAllByResourceID(t.Context(), j.distro.Id)
+			require.NoError(t, err)
+			require.Len(t, events, 1)
+			assert.Equal(t, event.ResourceTypeDistro, events[0].ResourceType)
+			assert.Equal(t, event.EventDistroModified, events[0].EventType)
+		},
+		"NoopsForNonEC2Distro": func(t *testing.T, env *mock.Environment, j *distroAutoTuneJob) {
+			originalMaxHosts := j.distro.HostAllocatorSettings.MaximumHosts
+			j.distro.Provider = evergreen.ProviderNameStatic
+			require.NoError(t, j.distro.Insert(t.Context()))
+
+			addDistroHostStats(t, j.distro.Id, slices.Repeat([]int{j.distro.HostAllocatorSettings.MaximumHosts}, 10)...)
+			j.Run(t.Context())
+			assert.NoError(t, j.Error())
+
+			dbDistro, err := distro.FindOneId(t.Context(), j.distro.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbDistro)
+			assert.Equal(t, originalMaxHosts, dbDistro.HostAllocatorSettings.MaximumHosts, "max hosts should not change for non-EC2 distro")
+		},
+		"NoopsIfDistroAutoTuningDisabled": func(t *testing.T, env *mock.Environment, j *distroAutoTuneJob) {
+			j.distro.HostAllocatorSettings.AutoTuneMaximumHosts = false
+			require.NoError(t, j.distro.Insert(t.Context()))
+
+			originalMaxHosts := j.distro.HostAllocatorSettings.MaximumHosts
+			addDistroHostStats(t, j.distro.Id, slices.Repeat([]int{j.distro.HostAllocatorSettings.MaximumHosts}, 10)...)
+			j.Run(t.Context())
+			assert.NoError(t, j.Error())
+
+			dbDistro, err := distro.FindOneId(t.Context(), j.distro.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbDistro)
+			assert.Equal(t, originalMaxHosts, dbDistro.HostAllocatorSettings.MaximumHosts, "max hosts should not change for non-EC2 distro")
+		},
+		"NoopsForNoHostStats": func(t *testing.T, env *mock.Environment, j *distroAutoTuneJob) {
+			originalMaxHosts := j.distro.HostAllocatorSettings.MaximumHosts
+			require.NoError(t, j.distro.Insert(t.Context()))
+
+			j.Run(t.Context())
+			assert.NoError(t, j.Error())
+
+			dbDistro, err := distro.FindOneId(t.Context(), j.distro.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbDistro)
+			assert.Equal(t, originalMaxHosts, dbDistro.HostAllocatorSettings.MaximumHosts, "max hosts should not change if there's no host data")
+		},
+		"NoopsForExtremelyLowAmountOfTimeUsingHosts": func(t *testing.T, env *mock.Environment, j *distroAutoTuneJob) {
+			originalMaxHosts := j.distro.HostAllocatorSettings.MaximumHosts
+			require.NoError(t, j.distro.Insert(t.Context()))
+
+			addDistroHostStats(t, j.distro.Id, slices.Repeat([]int{0}, 200)...)
+			addDistroHostStats(t, j.distro.Id, slices.Repeat([]int{1}, 1)...)
+			j.Run(t.Context())
+			assert.NoError(t, j.Error())
+
+			dbDistro, err := distro.FindOneId(t.Context(), j.distro.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbDistro)
+			assert.Equal(t, originalMaxHosts, dbDistro.HostAllocatorSettings.MaximumHosts, "max hosts should not change if the distro is rarely used")
+		},
+		"CannotDecreaseMaxHostsBelowMinHosts": func(t *testing.T, env *mock.Environment, j *distroAutoTuneJob) {
+			j.distro.HostAllocatorSettings.MinimumHosts = j.distro.HostAllocatorSettings.MaximumHosts - 1
+			require.NoError(t, j.distro.Insert(t.Context()))
+
+			addDistroHostStats(t, j.distro.Id, slices.Repeat([]int{1}, 10)...)
+			j.Run(t.Context())
+			assert.NoError(t, j.Error())
+
+			dbDistro, err := distro.FindOneId(t.Context(), j.distro.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbDistro)
+			assert.Equal(t, j.distro.HostAllocatorSettings.MinimumHosts, dbDistro.HostAllocatorSettings.MaximumHosts, "max hosts should be decreased due to using very few hosts but not go below min hosts")
+
+			events, err := event.FindAllByResourceID(t.Context(), j.distro.Id)
+			require.NoError(t, err)
+			require.Len(t, events, 1)
+			assert.Equal(t, event.ResourceTypeDistro, events[0].ResourceType)
+			assert.Equal(t, event.EventDistroModified, events[0].EventType)
+		},
+		"DoesNotChangeMaxHostsIfMaxHostsIsOccasionallyHit": func(t *testing.T, env *mock.Environment, j *distroAutoTuneJob) {
+			originalMaxHosts := j.distro.HostAllocatorSettings.MaximumHosts
+			require.NoError(t, j.distro.Insert(t.Context()))
+
+			addDistroHostStats(t, j.distro.Id, slices.Repeat([]int{j.distro.HostAllocatorSettings.MaximumHosts / 2}, 100)...)
+			addDistroHostStats(t, j.distro.Id, slices.Repeat([]int{j.distro.HostAllocatorSettings.MaximumHosts}, 1)...)
+			j.Run(t.Context())
+			assert.NoError(t, j.Error())
+
+			dbDistro, err := distro.FindOneId(t.Context(), j.distro.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbDistro)
+			assert.Equal(t, originalMaxHosts, dbDistro.HostAllocatorSettings.MaximumHosts, "max hosts should not be changed if it occasionally hits max hosts")
+		},
+		"DoesNotChangeMaxHostsIfMaxHostsIsOccasionallyAlmostHIt": func(t *testing.T, env *mock.Environment, j *distroAutoTuneJob) {
+			originalMaxHosts := j.distro.HostAllocatorSettings.MaximumHosts
+			require.NoError(t, j.distro.Insert(t.Context()))
+
+			addDistroHostStats(t, j.distro.Id, slices.Repeat([]int{j.distro.HostAllocatorSettings.MaximumHosts / 2}, 100)...)
+			addDistroHostStats(t, j.distro.Id, slices.Repeat([]int{j.distro.HostAllocatorSettings.MaximumHosts - 1}, 1)...)
+			j.Run(t.Context())
+			assert.NoError(t, j.Error())
+
+			dbDistro, err := distro.FindOneId(t.Context(), j.distro.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbDistro)
+			assert.Equal(t, originalMaxHosts, dbDistro.HostAllocatorSettings.MaximumHosts, "max hosts should not be changed if it occasionally is close to hitting max hosts")
+		},
+		// "": func(t *testing.T, env *mock.Environment, j *distroAutoTuneJob) {},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(colls...))
+			env := &mock.Environment{}
+			require.NoError(t, env.Configure(t.Context()))
+			env.EvergreenSettings.HostInit.MaxTotalDynamicHosts = 10000
+
+			d := &distro.Distro{
+				Id:       "d",
+				Provider: evergreen.ProviderNameEc2Fleet,
+				HostAllocatorSettings: distro.HostAllocatorSettings{
+					MaximumHosts:         100,
+					AutoTuneMaximumHosts: true,
+				},
+			}
+
+			j := makeDistroAutoTuneJob()
+			j.settings = env.Settings()
+			j.distro = d
+			j.DistroID = d.Id
+			tCase(t, env, j)
+		})
+	}
+}

--- a/units/distro_autotune_test.go
+++ b/units/distro_autotune_test.go
@@ -110,7 +110,7 @@ func TestDistroAutoTuneJob(t *testing.T) {
 			require.NotZero(t, dbDistro)
 			assert.Equal(t, originalMaxHosts, dbDistro.HostAllocatorSettings.MaximumHosts, "max hosts should not change if there's no host data")
 		},
-		"NoopsForExtremelyLowAmountOfTimeUsingHosts": func(t *testing.T, env *mock.Environment, j *distroAutoTuneJob) {
+		"DoesNotChangeMaxHostsForExtremelyLowAmountOfTimeUsingHosts": func(t *testing.T, env *mock.Environment, j *distroAutoTuneJob) {
 			originalMaxHosts := j.distro.HostAllocatorSettings.MaximumHosts
 			require.NoError(t, j.distro.Insert(t.Context()))
 

--- a/units/distro_autotune_test.go
+++ b/units/distro_autotune_test.go
@@ -191,7 +191,6 @@ func TestDistroAutoTuneJob(t *testing.T) {
 			require.NotZero(t, dbDistro)
 			assert.Equal(t, originalMaxHosts, dbDistro.HostAllocatorSettings.MaximumHosts, "max hosts should not be changed if it occasionally is close to hitting max hosts")
 		},
-		// "": func(t *testing.T, env *mock.Environment, j *distroAutoTuneJob) {},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			require.NoError(t, db.ClearCollections(colls...))


### PR DESCRIPTION
DEVPROD-7920

### Description
If a distro allows auto-tuning in its host allocator settings, this new job will run to adjust distro max hosts up/down according to usage.

The algorithm is very loosely based on how we already decide to adjust distro max hosts, which is based on how often the distro hits max hosts. I'm also aware that the algorithm is kind of just magic percentages and numbers moving up and down relative to distro max hosts, but I think that's okay because the adjustments are pretty conservative to start off (it increases/decreases max hosts much slowly than we tend to do in our manual adjustments). We can always adjust it later on after we see how well it does and fix up any weaknesses in it later.

* Implement daily job to auto-tune max hosts for distros that have it enabled.
* Write ADR for auto-tuning distro max hosts.

### Testing
* Added unit tests.
* Tested in staging to verify the job runs daily and reduced max hosts in a distro due to very low host usage.
