### PR TITLE
DEVPROD-18209 Document s3.put can be used to debug generate.tasks

### DIFF
--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -562,7 +562,7 @@ Notes:
     to no-op rather than generate duplicate configuration.
 -   The command does not give any feedback (via logs or the UI) what
     tasks were generated so using [s3.put](#s3put) after the command to upload
-    the JSON file used in recommended for debuggability.
+    the JSON file used is recommended for debuggability.
 
 ``` yaml
 - command: generate.tasks

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -569,6 +569,20 @@ Notes:
   params:
     files:
       - example.json
+
+# Example s3.put command to upload the JSON file used to generate tasks
+- command: s3.put
+  params:
+    role_arn: ${role_arn}
+    local_file: example.json
+    remote_file: mongodb-mongo-master/${build_variant}/${revision}/generate_tasks/example.json
+    bucket: mciuploads
+    region: us-east-1
+    permissions: private
+    visibility: signed
+    content_type: application/json
+    display_name: Generate Tasks example.json JSON
+
 ```
 
 Parameters:

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -562,7 +562,7 @@ Notes:
     to no-op rather than generate duplicate configuration.
 -   The command does not give any feedback (via logs or the UI) what
     tasks were generated so using [s3.put](#s3put) to upload the JSON file used
-    in the `generate.tasks` command is recommended.
+    in recommended for debuggability.
 
 ``` yaml
 - command: generate.tasks

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -560,6 +560,9 @@ Notes:
 -   generate.tasks is idempotent across task restarts. In other words, once
     generate.tasks succeeds once, later task restarts will cause generate.tasks
     to no-op rather than generate duplicate configuration.
+-   The command does not give any feedback (via logs or the UI) what
+    tasks were generated so using [s3.put](#s3put) to upload the JSON file used
+    in the `generate.tasks` command is recommended.
 
 ``` yaml
 - command: generate.tasks

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -561,8 +561,8 @@ Notes:
     generate.tasks succeeds once, later task restarts will cause generate.tasks
     to no-op rather than generate duplicate configuration.
 -   The command does not give any feedback (via logs or the UI) what
-    tasks were generated so using [s3.put](#s3put) to upload the JSON file used
-    in recommended for debuggability.
+    tasks were generated so using [s3.put](#s3put) after the command to upload
+    the JSON file used in recommended for debuggability.
 
 ``` yaml
 - command: generate.tasks


### PR DESCRIPTION
DEVPROD-18209

### Description
Users wanted some feedback (UI or logs) from generate.tasks about what it generated. This could already be done using `s3.put`
