### PR TITLE
DEVPROD-18478 Surface inactive tasks consistently across graphql resolvers

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1661,7 +1661,7 @@ type ComplexityRoot struct {
 		Revision                 func(childComplexity int) int
 		StartTime                func(childComplexity int) int
 		Status                   func(childComplexity int) int
-		TaskCount                func(childComplexity int, includeNeverActivatedTasks *bool) int
+		TaskCount                func(childComplexity int, options *TaskCountOptions) int
 		TaskStatusStats          func(childComplexity int, options BuildVariantOptions) int
 		TaskStatuses             func(childComplexity int) int
 		Tasks                    func(childComplexity int, options TaskFilterOptions) int
@@ -2128,7 +2128,7 @@ type VersionResolver interface {
 	ProjectMetadata(ctx context.Context, obj *model.APIVersion) (*model.APIProjectRef, error)
 
 	Status(ctx context.Context, obj *model.APIVersion) (string, error)
-	TaskCount(ctx context.Context, obj *model.APIVersion, includeNeverActivatedTasks *bool) (*int, error)
+	TaskCount(ctx context.Context, obj *model.APIVersion, options *TaskCountOptions) (*int, error)
 	Tasks(ctx context.Context, obj *model.APIVersion, options TaskFilterOptions) (*VersionTasks, error)
 	TaskStatuses(ctx context.Context, obj *model.APIVersion) ([]string, error)
 	TaskStatusStats(ctx context.Context, obj *model.APIVersion, options BuildVariantOptions) (*task.TaskStats, error)
@@ -10060,7 +10060,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.complexity.Version.TaskCount(childComplexity, args["includeNeverActivatedTasks"].(*bool)), true
+		return e.complexity.Version.TaskCount(childComplexity, args["options"].(*TaskCountOptions)), true
 
 	case "Version.taskStatusStats":
 		if e.complexity.Version.TaskStatusStats == nil {
@@ -10604,6 +10604,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputSubscriberInput,
 		ec.unmarshalInputSubscriptionInput,
 		ec.unmarshalInputTaskAnnotationSettingsInput,
+		ec.unmarshalInputTaskCountOptions,
 		ec.unmarshalInputTaskFilterOptions,
 		ec.unmarshalInputTaskHistoryOpts,
 		ec.unmarshalInputTaskSpecifierInput,
@@ -16378,28 +16379,28 @@ func (ec *executionContext) field_Version_buildVariants_argsOptions(
 func (ec *executionContext) field_Version_taskCount_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
-	arg0, err := ec.field_Version_taskCount_argsIncludeNeverActivatedTasks(ctx, rawArgs)
+	arg0, err := ec.field_Version_taskCount_argsOptions(ctx, rawArgs)
 	if err != nil {
 		return nil, err
 	}
-	args["includeNeverActivatedTasks"] = arg0
+	args["options"] = arg0
 	return args, nil
 }
-func (ec *executionContext) field_Version_taskCount_argsIncludeNeverActivatedTasks(
+func (ec *executionContext) field_Version_taskCount_argsOptions(
 	ctx context.Context,
 	rawArgs map[string]any,
-) (*bool, error) {
-	if _, ok := rawArgs["includeNeverActivatedTasks"]; !ok {
-		var zeroVal *bool
+) (*TaskCountOptions, error) {
+	if _, ok := rawArgs["options"]; !ok {
+		var zeroVal *TaskCountOptions
 		return zeroVal, nil
 	}
 
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("includeNeverActivatedTasks"))
-	if tmp, ok := rawArgs["includeNeverActivatedTasks"]; ok {
-		return ec.unmarshalOBoolean2ᚖbool(ctx, tmp)
+	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("options"))
+	if tmp, ok := rawArgs["options"]; ok {
+		return ec.unmarshalOTaskCountOptions2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskCountOptions(ctx, tmp)
 	}
 
-	var zeroVal *bool
+	var zeroVal *TaskCountOptions
 	return zeroVal, nil
 }
 
@@ -71579,7 +71580,7 @@ func (ec *executionContext) _Version_taskCount(ctx context.Context, field graphq
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Version().TaskCount(rctx, obj, fc.Args["includeNeverActivatedTasks"].(*bool))
+		return ec.resolvers.Version().TaskCount(rctx, obj, fc.Args["options"].(*TaskCountOptions))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -81627,6 +81628,33 @@ func (ec *executionContext) unmarshalInputTaskAnnotationSettingsInput(ctx contex
 				return it, err
 			}
 			it.FileTicketWebhook = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputTaskCountOptions(ctx context.Context, obj any) (TaskCountOptions, error) {
+	var it TaskCountOptions
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"includeNeverActivatedTasks"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "includeNeverActivatedTasks":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("includeNeverActivatedTasks"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IncludeNeverActivatedTasks = data
 		}
 	}
 
@@ -106893,6 +106921,14 @@ func (ec *executionContext) marshalOTask2ᚖgithubᚗcomᚋevergreenᚑciᚋever
 func (ec *executionContext) unmarshalOTaskAnnotationSettingsInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITaskAnnotationSettings(ctx context.Context, v any) (model.APITaskAnnotationSettings, error) {
 	res, err := ec.unmarshalInputTaskAnnotationSettingsInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalOTaskCountOptions2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskCountOptions(ctx context.Context, v any) (*TaskCountOptions, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputTaskCountOptions(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) marshalOTaskEndDetail2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐApiTaskEndDetail(ctx context.Context, sel ast.SelectionSet, v model.ApiTaskEndDetail) graphql.Marshaler {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -40,10 +40,11 @@ type BuildBaron struct {
 // BuildVariantOptions is an input to the mainlineCommits query.
 // It stores values for statuses, tasks, and variants which are used to filter for matching versions.
 type BuildVariantOptions struct {
-	IncludeBaseTasks *bool    `json:"includeBaseTasks,omitempty"`
-	Statuses         []string `json:"statuses,omitempty"`
-	Tasks            []string `json:"tasks,omitempty"`
-	Variants         []string `json:"variants,omitempty"`
+	IncludeBaseTasks           *bool    `json:"includeBaseTasks,omitempty"`
+	IncludeNeverActivatedTasks *bool    `json:"includeNeverActivatedTasks,omitempty"`
+	Statuses                   []string `json:"statuses,omitempty"`
+	Tasks                      []string `json:"tasks,omitempty"`
+	Variants                   []string `json:"variants,omitempty"`
 }
 
 // CreateDistroInput is the input to the createDistro mutation.

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -471,6 +471,11 @@ type Subscriber struct {
 	WebhookSubscriber     *model.APIWebhookSubscriber     `json:"webhookSubscriber,omitempty"`
 }
 
+// TaskCountOptions defines the parameters that are used when counting tasks from a Version.
+type TaskCountOptions struct {
+	IncludeNeverActivatedTasks *bool `json:"includeNeverActivatedTasks,omitempty"`
+}
+
 // TaskFiles is the return value for the taskFiles query.
 // Some tasks generate files which are represented by this type.
 type TaskFiles struct {

--- a/graphql/schema/types/mainline_commits.graphql
+++ b/graphql/schema/types/mainline_commits.graphql
@@ -5,6 +5,7 @@ It stores values for statuses, tasks, and variants which are used to filter for 
 """
 input BuildVariantOptions {
   includeBaseTasks: Boolean
+  includeNeverActivatedTasks: Boolean
   statuses: [String!]
   tasks: [String!]
   variants: [String!]

--- a/graphql/schema/types/version.graphql
+++ b/graphql/schema/types/version.graphql
@@ -23,6 +23,13 @@ input TaskFilterOptions {
 }
 
 """
+TaskCountOptions defines the parameters that are used when counting tasks from a Version.
+"""
+input TaskCountOptions {
+  includeNeverActivatedTasks: Boolean
+}
+
+"""
 SortOrder[] is an input value for version.tasks. It is used to define whether to sort by ASC/DEC for a given sort key.
 """
 input SortOrder {
@@ -67,7 +74,7 @@ type Version {
   revision: String!
   startTime: Time
   status: String!
-  taskCount(includeNeverActivatedTasks: Boolean): Int
+  taskCount(options: TaskCountOptions): Int
   tasks(options: TaskFilterOptions!): VersionTasks!
   taskStatuses: [String!]!
   taskStatusStats(options: BuildVariantOptions!): TaskStats

--- a/graphql/schema/types/version.graphql
+++ b/graphql/schema/types/version.graphql
@@ -67,7 +67,7 @@ type Version {
   revision: String!
   startTime: Time
   status: String!
-  taskCount: Int
+  taskCount(includeNeverActivatedTasks: Boolean): Int
   tasks(options: TaskFilterOptions!): VersionTasks!
   taskStatuses: [String!]!
   taskStatusStats(options: BuildVariantOptions!): TaskStats

--- a/graphql/tests/version/taskCount/data.json
+++ b/graphql/tests/version/taskCount/data.json
@@ -1,0 +1,115 @@
+{
+  "versions": [
+    {
+      "_id": "mainline_commit",
+      "create_time": {
+        "$date": "2025-02-21T15:13:48.801Z"
+      },
+      "start_time": {
+        "$date": "2025-02-21T15:15:38.261Z"
+      },
+      "finish_time": {
+        "$date": "2025-02-21T15:29:54.869Z"
+      },
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "author": "mohamed.khelif",
+      "author_email": "",
+      "status": "failed",
+      "identifier": "spruce",
+      "r": "gitter_request",
+      "activated": true
+    },
+    {
+        "_id": "patch",
+        "create_time": {
+            "$date": "2025-02-21T15:13:48.801Z"
+        },
+        "start_time": {
+            "$date": "2025-02-21T15:15:38.261Z"
+        },
+        "finish_time": {
+            "$date": "2025-02-21T15:29:54.869Z"
+        },
+        "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+        "author": "mohamed.khelif",
+        "author_email": "",
+        "status": "failed",
+        "identifier": "spruce",
+        "r": "github_pull_request",
+        "activated": false
+    }
+  ],
+  "tasks": [
+    {
+      "_id": "1_mainline_commit_activated",
+      "version": "mainline_commit",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "ubuntu1604",
+      "build_variant_display_name": "Ubuntu 16.04",
+      "display_name": "test-thirdparty-docker",
+      "r": "github_pull_request",
+      "status": "success",
+      "branch": "evergreen",
+      "build_id": "evergreen_ubuntu1604_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
+      "display_task_id": "",
+      "activated": true,
+      "activated_time": {
+        "$date": "2025-02-21T15:15:38.261Z"
+      }
+    },
+    {
+      "_id": "2_mainline_commit_never_activated",
+      "version": "mainline_commit",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "ubuntu1604",
+      "build_variant_display_name": "Ubuntu 16.04",
+      "display_name": "test-cloud",
+      "r": "github_pull_request",
+      "status": "failed",
+      "build_id": "evergreen_ubuntu1604_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
+      "display_task_id": "",
+      "activated": false,
+      "activated_time": {
+        "$date": "1970-01-01T00:00:00.000Z"
+      }
+    },
+    {
+      "_id": "3_patch_activated",
+      "version": "patch",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "lint",
+      "build_variant_display_name": "Lint",
+      "display_name": "generate-lint",
+      "r": "github_pull_request",
+      "status": "success",
+      "build_id": "evergreen_lint_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
+      "display_task_id": "",
+      "activated": true,
+      "activated_time": {
+        "$date": "2025-02-21T15:15:38.261Z"
+      }
+    },
+    {
+      "_id": "4_patch_never_activated",
+      "version": "patch",
+      "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
+      "build_variant": "lint",
+      "build_variant_display_name": "Lint",
+      "display_name": "lint-service",
+      "r": "github_pull_request",
+      "status": "failed",
+      "build_id": "evergreen_lint_patch_5e823e1f28baeaa22ae00823d83e03082cd148ab_5e4ff3abe3c3317e352062e4_20_02_21_15_13_48",
+      "display_task_id": "",
+      "activated": false,
+      "activated_time": {
+        "$date": "1970-01-01T00:00:00.000Z"
+      }
+    }
+  ],
+  "project_ref": [
+    {
+      "_id": "spruce",
+      "identifier": "spruce"
+    }
+  ]
+}

--- a/graphql/tests/version/taskCount/queries/task_count_default.graphql
+++ b/graphql/tests/version/taskCount/queries/task_count_default.graphql
@@ -1,0 +1,8 @@
+{
+  taskCountMainlineCommit: version(versionId: "mainline_commit") {
+    taskCount
+  }
+  taskCountPatch: version(versionId: "patch") {
+    taskCount
+  }
+}

--- a/graphql/tests/version/taskCount/queries/task_count_include_never_activated_tasks_false.graphql
+++ b/graphql/tests/version/taskCount/queries/task_count_include_never_activated_tasks_false.graphql
@@ -2,9 +2,9 @@
   taskCountIncludeNeverActivatedTasksFalseMainlineCommit: version(
     versionId: "mainline_commit"
   ) {
-    taskCount(includeNeverActivatedTasks: false)
+    taskCount(options: { includeNeverActivatedTasks: false })
   }
   taskCountIncludeNeverActivatedTasksFalsePatch: version(versionId: "patch") {
-    taskCount(includeNeverActivatedTasks: false)
+    taskCount(options: { includeNeverActivatedTasks: false })
   }
 }

--- a/graphql/tests/version/taskCount/queries/task_count_include_never_activated_tasks_false.graphql
+++ b/graphql/tests/version/taskCount/queries/task_count_include_never_activated_tasks_false.graphql
@@ -1,0 +1,10 @@
+{
+  taskCountIncludeNeverActivatedTasksFalseMainlineCommit: version(
+    versionId: "mainline_commit"
+  ) {
+    taskCount(includeNeverActivatedTasks: false)
+  }
+  taskCountIncludeNeverActivatedTasksFalsePatch: version(versionId: "patch") {
+    taskCount(includeNeverActivatedTasks: false)
+  }
+}

--- a/graphql/tests/version/taskCount/queries/task_count_include_never_activated_tasks_true.graphql
+++ b/graphql/tests/version/taskCount/queries/task_count_include_never_activated_tasks_true.graphql
@@ -1,0 +1,10 @@
+{
+  taskCountIncludeNeverActivatedTasksTrueMainlineCommit: version(
+    versionId: "mainline_commit"
+  ) {
+    taskCount(includeNeverActivatedTasks: true)
+  }
+  taskCountIncludeNeverActivatedTasksTruePatch: version(versionId: "patch") {
+    taskCount(includeNeverActivatedTasks: true)
+  }
+}

--- a/graphql/tests/version/taskCount/queries/task_count_include_never_activated_tasks_true.graphql
+++ b/graphql/tests/version/taskCount/queries/task_count_include_never_activated_tasks_true.graphql
@@ -2,9 +2,9 @@
   taskCountIncludeNeverActivatedTasksTrueMainlineCommit: version(
     versionId: "mainline_commit"
   ) {
-    taskCount(includeNeverActivatedTasks: true)
+    taskCount(options: { includeNeverActivatedTasks: true })
   }
   taskCountIncludeNeverActivatedTasksTruePatch: version(versionId: "patch") {
-    taskCount(includeNeverActivatedTasks: true)
+    taskCount(options: { includeNeverActivatedTasks: true })
   }
 }

--- a/graphql/tests/version/taskCount/results.json
+++ b/graphql/tests/version/taskCount/results.json
@@ -1,0 +1,43 @@
+{
+    "tests": [
+        {
+            "query_file": "task_count_default.graphql",
+            "result": {
+                "data": {
+                    "taskCountMainlineCommit": {
+                            "taskCount": 2
+                    },
+                    "taskCountPatch": {
+                            "taskCount": 1
+                    }
+                }
+            }
+        },
+        {
+            "query_file": "task_count_include_never_activated_tasks_true.graphql",
+            "result": {
+                "data": {
+                    "taskCountIncludeNeverActivatedTasksTrueMainlineCommit": {
+                            "taskCount": 2
+                    },
+                    "taskCountIncludeNeverActivatedTasksTruePatch": {
+                            "taskCount": 2
+                    }
+                }
+            }
+        },
+        {
+            "query_file": "task_count_include_never_activated_tasks_false.graphql",
+            "result": {
+                "data": {
+                    "taskCountIncludeNeverActivatedTasksFalseMainlineCommit": {
+                            "taskCount": 1
+                    },
+                    "taskCountIncludeNeverActivatedTasksFalsePatch": {
+                            "taskCount": 1
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -342,6 +342,10 @@ func generateBuildVariants(ctx context.Context, versionId string, buildVariantOp
 			baseVersionID = baseVersion.Id
 		}
 	}
+	includeNeverActivatedTasks := buildVariantOpts.IncludeNeverActivatedTasks
+	if includeNeverActivatedTasks == nil {
+		includeNeverActivatedTasks = utility.ToBoolPtr(false)
+	}
 	opts := task.GetTasksByVersionOptions{
 		Statuses:      getValidTaskStatusesFilter(buildVariantOpts.Statuses),
 		Variants:      buildVariantOpts.Variants,
@@ -349,7 +353,7 @@ func generateBuildVariants(ctx context.Context, versionId string, buildVariantOp
 		Sorts:         defaultSort,
 		BaseVersionID: baseVersionID,
 		// Do not fetch inactive tasks for patches. This is because the UI does not display inactive tasks for patches.
-		IncludeNeverActivatedTasks: !evergreen.IsPatchRequester(requester),
+		IncludeNeverActivatedTasks: *includeNeverActivatedTasks || !evergreen.IsPatchRequester(requester),
 	}
 
 	tasks, _, err := task.GetTasksByVersion(ctx, versionId, opts)

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -277,11 +277,12 @@ func (r *versionResolver) Status(ctx context.Context, obj *restModel.APIVersion)
 }
 
 // TaskCount is the resolver for the taskCount field.
-func (r *versionResolver) TaskCount(ctx context.Context, obj *restModel.APIVersion, includeNeverActivatedTasks *bool) (*int, error) {
+func (r *versionResolver) TaskCount(ctx context.Context, obj *restModel.APIVersion, options *TaskCountOptions) (*int, error) {
 	versionID := utility.FromStringPtr(obj.Id)
 	// if includeNeverActivatedTasks is nil, we default to using the value of the requester
-	if includeNeverActivatedTasks == nil {
-		includeNeverActivatedTasks = utility.ToBoolPtr(!obj.IsPatchRequester())
+	includeNeverActivatedTasks := utility.ToBoolPtr(!obj.IsPatchRequester())
+	if options != nil && options.IncludeNeverActivatedTasks != nil {
+		includeNeverActivatedTasks = options.IncludeNeverActivatedTasks
 	}
 	taskCount, err := task.Count(ctx, db.Query(task.DisplayTasksByVersion(versionID, utility.FromBoolPtr(includeNeverActivatedTasks))))
 	if err != nil {

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -77,11 +77,15 @@ func (r *versionResolver) BuildVariants(ctx context.Context, obj *restModel.APIV
 
 // BuildVariantStats is the resolver for the buildVariantStats field.
 func (r *versionResolver) BuildVariantStats(ctx context.Context, obj *restModel.APIVersion, options BuildVariantOptions) ([]*task.GroupedTaskStatusCount, error) {
+	includeNeverActivatedTasks := options.IncludeNeverActivatedTasks
+	if includeNeverActivatedTasks == nil {
+		includeNeverActivatedTasks = utility.ToBoolPtr(false)
+	}
 	opts := task.GetTasksByVersionOptions{
 		TaskNames:                  options.Tasks,
 		Variants:                   options.Variants,
 		Statuses:                   options.Statuses,
-		IncludeNeverActivatedTasks: !obj.IsPatchRequester(),
+		IncludeNeverActivatedTasks: *includeNeverActivatedTasks || !obj.IsPatchRequester(),
 	}
 	versionID := utility.FromStringPtr(obj.Id)
 	stats, err := task.GetGroupedTaskStatsByVersion(ctx, versionID, opts)
@@ -273,9 +277,13 @@ func (r *versionResolver) Status(ctx context.Context, obj *restModel.APIVersion)
 }
 
 // TaskCount is the resolver for the taskCount field.
-func (r *versionResolver) TaskCount(ctx context.Context, obj *restModel.APIVersion) (*int, error) {
+func (r *versionResolver) TaskCount(ctx context.Context, obj *restModel.APIVersion, includeNeverActivatedTasks *bool) (*int, error) {
 	versionID := utility.FromStringPtr(obj.Id)
-	taskCount, err := task.Count(ctx, db.Query(task.DisplayTasksByVersion(versionID, !obj.IsPatchRequester())))
+	// if includeNeverActivatedTasks is nil, we default to using the value of the requester
+	if includeNeverActivatedTasks == nil {
+		includeNeverActivatedTasks = utility.ToBoolPtr(!obj.IsPatchRequester())
+	}
+	taskCount, err := task.Count(ctx, db.Query(task.DisplayTasksByVersion(versionID, utility.FromBoolPtr(includeNeverActivatedTasks))))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting task count for version '%s': %s", versionID, err.Error()))
 	}
@@ -285,6 +293,10 @@ func (r *versionResolver) TaskCount(ctx context.Context, obj *restModel.APIVersi
 // Tasks is the resolver for the tasks field.
 func (r *versionResolver) Tasks(ctx context.Context, obj *restModel.APIVersion, options TaskFilterOptions) (*VersionTasks, error) {
 	versionID := utility.FromStringPtr(obj.Id)
+	includeNeverActivatedTasks := options.IncludeNeverActivatedTasks
+	if includeNeverActivatedTasks == nil {
+		includeNeverActivatedTasks = utility.ToBoolPtr(false)
+	}
 	pageParam := 0
 	if options.Page != nil {
 		pageParam = *options.Page
@@ -345,7 +357,7 @@ func (r *versionResolver) Tasks(ctx context.Context, obj *restModel.APIVersion, 
 		Limit:        limitParam,
 		Sorts:        taskSorts,
 		// If the version is a patch, we want to exclude inactive tasks by default.
-		IncludeNeverActivatedTasks: !evergreen.IsPatchRequester(utility.FromStringPtr(obj.Requester)) || utility.FromBoolPtr(options.IncludeNeverActivatedTasks),
+		IncludeNeverActivatedTasks: *includeNeverActivatedTasks || !evergreen.IsPatchRequester(utility.FromStringPtr(obj.Requester)),
 		BaseVersionID:              baseVersionID,
 	}
 	tasks, count, err := task.GetTasksByVersion(ctx, versionID, opts)
@@ -381,13 +393,17 @@ func (r *versionResolver) TaskStatuses(ctx context.Context, obj *restModel.APIVe
 
 // TaskStatusStats is the resolver for the taskStatusStats field.
 func (r *versionResolver) TaskStatusStats(ctx context.Context, obj *restModel.APIVersion, options BuildVariantOptions) (*task.TaskStats, error) {
+	includeNeverActivatedTasks := options.IncludeNeverActivatedTasks
+	if includeNeverActivatedTasks == nil {
+		includeNeverActivatedTasks = utility.ToBoolPtr(false)
+	}
 	opts := task.GetTasksByVersionOptions{
 		IncludeExecutionTasks: false,
 		TaskNames:             options.Tasks,
 		Variants:              options.Variants,
 		Statuses:              getValidTaskStatusesFilter(options.Statuses),
 		// If the version is a patch, we don't want to include its never activated tasks.
-		IncludeNeverActivatedTasks: !obj.IsPatchRequester(),
+		IncludeNeverActivatedTasks: *includeNeverActivatedTasks || !obj.IsPatchRequester(),
 	}
 
 	versionID := utility.FromStringPtr(obj.Id)


### PR DESCRIPTION
DEVPROD-18478 

### Description
Usually whether we surface an inactive task depends on the versions requester. This PR updates it so it can be toggleable by a query parameter. This also extends other related fields so they return the same set of tasks and counts.


<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

### Testing
Before:
<img width="1234" alt="image" src="https://github.com/user-attachments/assets/86000701-e40d-42f1-8b26-5ff544b19229" />
After:
<img width="1247" alt="image" src="https://github.com/user-attachments/assets/5447bb89-d8d0-432a-9b31-5970ebf4a82d" />


### Documentation
Remember to add or edit docs in the docs/ directory if relevant.
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
