### PR TITLE
DEVPROD-7920: log distro auto tune debug info

### DIFF
--- a/units/distro_auto_tune.go
+++ b/units/distro_auto_tune.go
@@ -86,15 +86,21 @@ func (j *distroAutoTuneJob) Run(ctx context.Context) {
 	}
 
 	summary := j.summarizeStatsUsage(stats)
+	grip.Debug(message.Fields{
+		"message": "distro host usage stats",
+		"distro":  j.DistroID,
+		"summary": summary,
+		"job":     j.ID(),
+	})
 
 	// Avoid tuning rarely-used distros because they may not have enough data to
 	// make a reasonable decision about the distro's host usage.
 	const minFractionOfTimeUsingHostsToAutoTune = 0.01
-	if summary.fractionOfTimeUsingHosts < minFractionOfTimeUsingHostsToAutoTune {
+	if summary.FractionOfTimeUsingHosts < minFractionOfTimeUsingHostsToAutoTune {
 		grip.Info(message.Fields{
 			"message":                      "skipping auto-tuning maximum hosts for rarely-used distro",
 			"distro":                       j.DistroID,
-			"fraction_of_time_using_hosts": summary.fractionOfTimeUsingHosts,
+			"fraction_of_time_using_hosts": summary.FractionOfTimeUsingHosts,
 			"job":                          j.ID(),
 		})
 		return
@@ -108,14 +114,14 @@ func (j *distroAutoTuneJob) Run(ctx context.Context) {
 		maxFractionalHostIncrease        = 0.25
 	)
 	newMaxHosts := j.distro.HostAllocatorSettings.MaximumHosts
-	if summary.fractionOfMaxHostsUsed < thresholdFractionToDecreaseHosts {
+	if summary.FractionOfMaxHostsUsed < thresholdFractionToDecreaseHosts {
 		// Decrease max hosts due to low usage based on percentage of distro
 		// max hosts utilized.
-		fractionToDecrease := min(thresholdFractionToDecreaseHosts-summary.fractionOfMaxHostsUsed, maxFractionalHostDecrease)
+		fractionToDecrease := min(thresholdFractionToDecreaseHosts-summary.FractionOfMaxHostsUsed, maxFractionalHostDecrease)
 		newMaxHosts = int(float64(j.distro.HostAllocatorSettings.MaximumHosts) * (1 - fractionToDecrease))
-	} else if summary.fractionOfTimeAtMaxHosts >= thresholdFractionToIncreaseHosts {
+	} else if summary.FractionOfTimeAtMaxHosts >= thresholdFractionToIncreaseHosts {
 		// Increase max hosts based on % of times distro max hosts was hit.
-		fractionToIncrease := min(summary.fractionOfTimeAtMaxHosts, maxFractionalHostIncrease)
+		fractionToIncrease := min(summary.FractionOfTimeAtMaxHosts, maxFractionalHostIncrease)
 		newMaxHosts = int(float64(j.distro.HostAllocatorSettings.MaximumHosts) * (1 + fractionToIncrease))
 	}
 
@@ -137,7 +143,7 @@ func (j *distroAutoTuneJob) Run(ctx context.Context) {
 		grip.Info(message.Fields{
 			"message":                      "did not change maximum hosts during auto-tuning",
 			"distro":                       j.DistroID,
-			"fraction_of_time_using_hosts": summary.fractionOfTimeUsingHosts,
+			"fraction_of_time_using_hosts": summary.FractionOfTimeUsingHosts,
 			"job":                          j.ID(),
 		})
 		return
@@ -170,15 +176,15 @@ func (j *distroAutoTuneJob) populate(ctx context.Context) error {
 }
 
 type hostStatsSummary struct {
-	// fractionOfTimeAtMaxHosts is the fraction of time that the distro was at
+	// FractionOfTimeAtMaxHosts is the fraction of time that the distro was at
 	// or above max hosts.
-	fractionOfTimeAtMaxHosts float64
-	// fractionOfMaxHostsUsed is the maximum number of hosts used as a fraction
+	FractionOfTimeAtMaxHosts float64 `json:"fraction_of_time_at_max_hosts"`
+	// FractionOfMaxHostsUsed is the maximum number of hosts used as a fraction
 	// of distro max hosts.
-	fractionOfMaxHostsUsed float64
-	// fractionOfTimeUsingHosts is the fraction of time that the distro used any
+	FractionOfMaxHostsUsed float64 `json:"fraction_of_max_hosts_used"`
+	// FractionOfTimeUsingHosts is the fraction of time that the distro used any
 	// non-zero number of hosts.
-	fractionOfTimeUsingHosts float64
+	FractionOfTimeUsingHosts float64 `json:"fraction_of_time_using_hosts"`
 }
 
 func (j *distroAutoTuneJob) summarizeStatsUsage(stats []hoststat.HostStat) hostStatsSummary {
@@ -197,9 +203,9 @@ func (j *distroAutoTuneJob) summarizeStatsUsage(stats []hoststat.HostStat) hostS
 		}
 		maxHostsUsed = max(maxHostsUsed, stat.NumHosts)
 	}
-	summary.fractionOfTimeUsingHosts = float64(numTimesHostsUsed) / float64(len(stats))
-	summary.fractionOfTimeAtMaxHosts = float64(numTimesMaxHostsHit) / float64(len(stats))
-	summary.fractionOfMaxHostsUsed = float64(maxHostsUsed) / float64(j.distro.HostAllocatorSettings.MaximumHosts)
+	summary.FractionOfTimeUsingHosts = float64(numTimesHostsUsed) / float64(len(stats))
+	summary.FractionOfTimeAtMaxHosts = float64(numTimesMaxHostsHit) / float64(len(stats))
+	summary.FractionOfMaxHostsUsed = float64(maxHostsUsed) / float64(j.distro.HostAllocatorSettings.MaximumHosts)
 	return summary
 }
 


### PR DESCRIPTION
DEVPROD-7920

### Description
Add logging so we can debug the distro auto-tuning if needed. I assume the numbers/general heuristics that I used for auto-tuning distro max hosts will probably will have to be tweaked eventually. This log helps figure out what the host stats looks like for that distro, so it's easier to see what data made it choose to increase/decrease/not change distro max hosts.

### Testing
Checked the logged looked as expected in staging.