### PR TITLE
DEVPROD-18856: Create patches for github automatic_base_change_succeeded events

### DIFF
--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -33,6 +33,7 @@ const (
 	githubActionOpened          = "opened"
 	githubActionSynchronize     = "synchronize"
 	githubActionReopened        = "reopened"
+	githubActionAutoBaseChange  = "automatic_base_change_succeeded"
 	githubActionChecksRequested = "checks_requested"
 	githubActionRerequested     = "rerequested"
 
@@ -176,7 +177,7 @@ func (gh *githubHookApi) Run(_ context.Context) gimlet.Responder {
 
 		action := utility.FromStringPtr(event.Action)
 		if action == githubActionOpened || action == githubActionSynchronize ||
-			action == githubActionReopened {
+			action == githubActionReopened || action == githubActionAutoBaseChange {
 			grip.Info(message.Fields{
 				"source":    "GitHub hook",
 				"msg_id":    gh.msgID,

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -182,6 +182,7 @@ func (gh *githubHookApi) Run(_ context.Context) gimlet.Responder {
 				"source":    "GitHub hook",
 				"msg_id":    gh.msgID,
 				"event":     gh.eventType,
+				"action":    action,
 				"repo":      *event.PullRequest.Base.Repo.FullName,
 				"ref":       *event.PullRequest.Base.Ref,
 				"pr_number": *event.PullRequest.Number,


### PR DESCRIPTION
DEVPROD-18856: Create patches for github automatic_base_change_succeeded events

### Description
When a PR has a base branch of another branch, and that target branch is merged into main, github sends an `automatic_base_change_succeeded` event which should be sufficient notice to start a new patch

This is my first PR against evergreen. Wanted to sanity check this is a reasonable path before I write test

### Testing
add a description of how you tested it

### Documentation
Remember to add or edit docs in the docs/ directory if relevant.
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
