### PR TITLE
DEVPROD-16202 Remove cedar from Evergreen agent

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -254,21 +254,6 @@ func (a *Agent) loop(ctx context.Context) error {
 			grip.Info("Agent loop canceled.")
 			return nil
 		case <-timer.C:
-			// Check the cedar GRPC connection so we can fail early
-			// and avoid task system failures.
-			err := utility.Retry(ctx, func() (bool, error) {
-				_, err := a.comm.GetCedarGRPCConn(ctx)
-				return true, err
-			}, utility.RetryOptions{MaxAttempts: 5, MaxDelay: globals.MinAgentSleepInterval})
-			if err != nil {
-				if ctx.Err() != nil {
-					// We don't want to return an error if
-					// the agent loop is canceled.
-					return nil
-				}
-				return errors.Wrap(err, "connecting to Cedar")
-			}
-
 			var previousTaskGroup string
 			if tc.taskConfig != nil && tc.taskConfig.TaskGroup != nil {
 				previousTaskGroup = tc.taskConfig.TaskGroup.Name

--- a/agent/command/perf_send.go
+++ b/agent/command/perf_send.go
@@ -67,15 +67,15 @@ func (c *perfSend) Execute(ctx context.Context, comm client.Communicator, logger
 	}
 	c.addEvgData(report, conf)
 
-	cedarConfig, err := comm.GetCedarConfig(ctx)
+	perfURL, err := comm.GetPerfMonitoringURL(ctx)
 	if err != nil {
-		return errors.Wrap(err, "getting Cedar config for performance results")
+		return errors.Wrap(err, "getting performance URL")
 	}
 	opts := rpc.UploadReportOptions{
 		Report: report,
-		SPSURL: cedarConfig.SPSURL,
+		SPSURL: perfURL,
 	}
-	return errors.Wrap(rpc.UploadReport(ctx, opts), "uploading report to Cedar")
+	return errors.Wrap(rpc.UploadReport(ctx, opts), "uploading report")
 }
 
 func (c *perfSend) addEvgData(report *poplar.Report, conf *internal.TaskConfig) {

--- a/agent/command/results_utils.go
+++ b/agent/command/results_utils.go
@@ -14,7 +14,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/testlog"
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/pail"
-	"github.com/evergreen-ci/timber/testresults"
 	"github.com/evergreen-ci/utility"
 	goparquet "github.com/fraugster/parquet-go"
 	"github.com/fraugster/parquet-go/floor"
@@ -31,7 +30,7 @@ func sendTestResults(ctx context.Context, comm client.Communicator, logger clien
 	td := client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}
 
 	if err := attachTestResults(ctx, conf, td, comm, results); err != nil {
-		return errors.Wrap(err, "sending test results to Cedar")
+		return errors.Wrap(err, "sending test results")
 	}
 
 	logger.Task().Info("Successfully attached results.")
@@ -63,22 +62,13 @@ func sendTestLogsAndResults(ctx context.Context, comm client.Communicator, logge
 }
 
 func attachTestResults(ctx context.Context, conf *internal.TaskConfig, td client.TaskData, comm client.Communicator, results []testresult.TestResult) error {
-	var failed bool
-	var err error
 	output, ok := conf.Task.GetTaskOutputSafe()
-	// Version 0 denotes that the task will use cedar's test result service,
-	// whereas other version numbers indicate that the task uses evergreen's
-	// test result service.
-	if !ok || output.TestResults.Version == 0 {
-		failed, err = uploadTestResultsCedar(ctx, comm, conf, results)
-		if err != nil {
-			return errors.Wrap(err, "attaching test results to Cedar")
-		}
-	} else {
-		failed, err = uploadTestResults(ctx, comm, conf, results, td, output)
-		if err != nil {
-			return errors.Wrap(err, "attaching test results")
-		}
+	if !ok {
+		return errors.New("cannot attach test results without a task output")
+	}
+	failed, err := uploadTestResults(ctx, comm, conf, results, td, output)
+	if err != nil {
+		return errors.Wrap(err, "attaching test results")
 	}
 	conf.HasTestResults = true
 	if err := comm.SetResultsInfo(ctx, td, failed); err != nil {
@@ -88,34 +78,6 @@ func attachTestResults(ctx context.Context, conf *internal.TaskConfig, td client
 		conf.HasFailingTestResult = true
 	}
 	return nil
-}
-
-func uploadTestResultsCedar(ctx context.Context, comm client.Communicator, conf *internal.TaskConfig, results []testresult.TestResult) (bool, error) {
-	conn, err := comm.GetCedarGRPCConn(ctx)
-	if err != nil {
-		return false, errors.Wrap(err, "getting Cedar connection")
-	}
-	client, err := testresults.NewClientWithExistingConnection(ctx, conn)
-	if err != nil {
-		return false, errors.Wrap(err, "creating test results client")
-	}
-
-	if conf.CedarTestResultsID == "" {
-		conf.CedarTestResultsID, err = client.CreateRecord(ctx, makeCedarTestResultsRecord(conf, conf.DisplayTaskInfo))
-		if err != nil {
-			return false, errors.Wrap(err, "creating test results record")
-		}
-	}
-
-	cedarResults, failed := makeCedarTestResults(conf.CedarTestResultsID, &conf.Task, results)
-	if err = client.AddResults(ctx, cedarResults); err != nil {
-		return false, errors.Wrap(err, "adding test results")
-	}
-
-	if err = client.CloseRecord(ctx, conf.CedarTestResultsID); err != nil {
-		return false, errors.Wrap(err, "closing test results record")
-	}
-	return failed, nil
 }
 
 func uploadTestResults(ctx context.Context, comm client.Communicator, conf *internal.TaskConfig, results []testresult.TestResult, td client.TaskData, output *task.TaskOutput) (bool, error) {
@@ -157,63 +119,6 @@ func uploadTestResults(ctx context.Context, comm client.Communicator, conf *inte
 		return false, errors.Wrap(err, "sending test results")
 	}
 	return tr.Stats.FailedCount > 0, nil
-}
-
-func makeCedarTestResultsRecord(conf *internal.TaskConfig, displayTaskInfo *apimodels.DisplayTaskInfo) testresults.CreateOptions {
-	return testresults.CreateOptions{
-		Project:         conf.Task.Project,
-		Version:         conf.Task.Version,
-		Variant:         conf.Task.BuildVariant,
-		TaskID:          conf.Task.Id,
-		TaskName:        conf.Task.DisplayName,
-		DisplayTaskID:   displayTaskInfo.ID,
-		DisplayTaskName: displayTaskInfo.Name,
-		Execution:       int32(conf.Task.Execution),
-		RequestType:     conf.Task.Requester,
-		Mainline:        !conf.Task.IsPatchRequest(),
-	}
-}
-
-func makeCedarTestResults(id string, t *task.Task, results []testresult.TestResult) (testresults.Results, bool) {
-	rs := testresults.Results{ID: id}
-	failed := false
-	for _, r := range results {
-		if r.DisplayTestName == "" {
-			r.DisplayTestName = r.TestName
-		}
-		var logInfo *testresults.LogInfo
-		if r.LogInfo != nil {
-			logInfo = &testresults.LogInfo{
-				LogName:       r.LogInfo.LogName,
-				LineNum:       r.LogInfo.LineNum,
-				RenderingType: r.LogInfo.RenderingType,
-				Version:       r.LogInfo.Version,
-			}
-			for _, logName := range r.LogInfo.LogsToMerge {
-				logInfo.LogsToMerge = append(logInfo.LogsToMerge, *logName)
-			}
-		}
-
-		rs.Results = append(rs.Results, testresults.Result{
-			TestName:        utility.RandomString(),
-			DisplayTestName: r.DisplayTestName,
-			Status:          r.Status,
-			LogInfo:         logInfo,
-			GroupID:         r.GroupID,
-			LogURL:          r.LogURL,
-			RawLogURL:       r.RawLogURL,
-			LineNum:         int32(r.LineNum),
-			TaskCreated:     t.CreateTime,
-			TestStarted:     r.TestStartTime,
-			TestEnded:       r.TestEndTime,
-		})
-
-		if r.Status == evergreen.TestFailedStatus {
-			failed = true
-		}
-	}
-
-	return rs, failed
 }
 
 func uploadParquet(ctx context.Context, credentials evergreen.S3Credentials, output task.TaskOutput, results *testresult.ParquetTestResults, key string) error {

--- a/agent/command/results_utils_test.go
+++ b/agent/command/results_utils_test.go
@@ -15,18 +15,14 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	resultTestutil "github.com/evergreen-ci/evergreen/model/testresult/testutil"
-	serviceutil "github.com/evergreen-ci/evergreen/service/testutil"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/pail"
-	timberutil "github.com/evergreen-ci/timber/testutil"
 	"github.com/evergreen-ci/utility"
 	goparquet "github.com/fraugster/parquet-go"
 	"github.com/fraugster/parquet-go/floor"
 	"github.com/mongodb/grip/sometimes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestSendTestResults(t *testing.T) {
@@ -82,127 +78,12 @@ func TestSendTestResults(t *testing.T) {
 			Name: "display_task_name",
 		},
 	}
-	td := client.TaskData{ID: conf.Task.Id, Secret: conf.Task.Secret}
 	comm := client.NewMock("url")
-	displayTaskInfo, err := comm.GetDisplayTaskInfoFromExecution(ctx, td)
-	require.NoError(t, err)
 	logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
 	require.NoError(t, err)
 	defer func() {
 		assert.NoError(t, logger.Close())
 	}()
-
-	t.Run("ToCedar", func(t *testing.T) {
-		checkRecord := func(t *testing.T, srv *timberutil.MockTestResultsServer) {
-			require.NotZero(t, srv.Create)
-			assert.Equal(t, conf.Task.Id, srv.Create.TaskId)
-			assert.Equal(t, conf.Task.Project, srv.Create.Project)
-			assert.Equal(t, conf.Task.BuildVariant, srv.Create.Variant)
-			assert.Equal(t, conf.Task.Version, srv.Create.Version)
-			assert.EqualValues(t, conf.Task.Execution, srv.Create.Execution)
-			assert.Equal(t, conf.Task.Requester, srv.Create.RequestType)
-			assert.Equal(t, conf.Task.DisplayName, srv.Create.TaskName)
-			assert.Equal(t, displayTaskInfo.ID, srv.Create.DisplayTaskId)
-			assert.Equal(t, displayTaskInfo.Name, srv.Create.DisplayTaskName)
-			assert.False(t, srv.Create.Mainline)
-		}
-		checkResults := func(t *testing.T, srv *timberutil.MockTestResultsServer) {
-			require.Len(t, srv.Results, 1)
-			for id, res := range srv.Results {
-				assert.NotEmpty(t, id)
-				require.Len(t, res, 1)
-				require.Len(t, res[0].Results, 1)
-				assert.NotEmpty(t, res[0].Results[0].TestName)
-				assert.NotEqual(t, results[0].TestName, res[0].Results[0].TestName)
-				if results[0].DisplayTestName != "" {
-					assert.Equal(t, results[0].DisplayTestName, res[0].Results[0].DisplayTestName)
-				} else {
-					assert.Equal(t, results[0].TestName, res[0].Results[0].DisplayTestName)
-				}
-				assert.Equal(t, results[0].Status, res[0].Results[0].Status)
-				assert.Equal(t, results[0].LogInfo.LogName, res[0].Results[0].LogInfo.LogName)
-				require.Len(t, res[0].Results[0].LogInfo.LogsToMerge, len(results[0].LogInfo.LogsToMerge))
-				for i, logName := range results[0].LogInfo.LogsToMerge {
-					assert.Equal(t, *logName, res[0].Results[0].LogInfo.LogsToMerge[i])
-				}
-				assert.Equal(t, results[0].LogInfo.LineNum, res[0].Results[0].LogInfo.LineNum)
-				assert.Equal(t, results[0].LogInfo.RenderingType, res[0].Results[0].LogInfo.RenderingType)
-				assert.Equal(t, results[0].LogInfo.Version, res[0].Results[0].LogInfo.Version)
-				assert.Equal(t, results[0].TestStartTime, res[0].Results[0].TestStartTime.AsTime())
-				assert.Equal(t, results[0].TestEndTime, res[0].Results[0].TestEndTime.AsTime())
-
-				// Legacy test log fields.
-				assert.Equal(t, results[0].GroupID, res[0].Results[0].GroupId)
-				assert.Empty(t, res[0].Results[0].LogTestName)
-				assert.Equal(t, results[0].LogURL, res[0].Results[0].LogUrl)
-				assert.Equal(t, results[0].RawLogURL, res[0].Results[0].RawLogUrl)
-				assert.EqualValues(t, results[0].LineNum, res[0].Results[0].LineNum)
-			}
-		}
-
-		for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, srv *timberutil.MockTestResultsServer, comm *client.Mock){
-			"Succeeds": func(ctx context.Context, t *testing.T, srv *timberutil.MockTestResultsServer, comm *client.Mock) {
-				t.Run("PassingResults", func(t *testing.T) {
-					require.NoError(t, sendTestResults(ctx, comm, logger, conf, results))
-
-					assert.Equal(t, srv.Close.TestResultsRecordId, conf.CedarTestResultsID)
-					checkRecord(t, srv)
-					checkResults(t, srv)
-					assert.NotZero(t, srv.Close.TestResultsRecordId)
-					assert.False(t, comm.ResultsFailed)
-				})
-				t.Run("FailingResults", func(t *testing.T) {
-					results[0].Status = evergreen.TestFailedStatus
-					require.NoError(t, sendTestResults(ctx, comm, logger, conf, results))
-
-					assert.True(t, comm.ResultsFailed)
-					results[0].Status = "pass"
-				})
-			},
-			"SucceedsNoDisplayTestName": func(ctx context.Context, t *testing.T, srv *timberutil.MockTestResultsServer, comm *client.Mock) {
-				displayTestName := results[0].DisplayTestName
-				results[0].DisplayTestName = ""
-				require.NoError(t, sendTestResults(ctx, comm, logger, conf, results))
-
-				assert.Equal(t, srv.Close.TestResultsRecordId, conf.CedarTestResultsID)
-				checkRecord(t, srv)
-				checkResults(t, srv)
-				assert.NotZero(t, srv.Close.TestResultsRecordId)
-				assert.False(t, comm.ResultsFailed)
-				results[0].DisplayTestName = displayTestName
-			},
-			"FailsIfCreatingRecordFails": func(ctx context.Context, t *testing.T, srv *timberutil.MockTestResultsServer, comm *client.Mock) {
-				srv.CreateErr = true
-
-				require.Error(t, sendTestResults(ctx, comm, logger, conf, results))
-				assert.Empty(t, srv.Results)
-				assert.Zero(t, srv.Close)
-			},
-			"FailsIfAddingResultsFails": func(ctx context.Context, t *testing.T, srv *timberutil.MockTestResultsServer, comm *client.Mock) {
-				srv.AddErr = true
-
-				require.Error(t, sendTestResults(ctx, comm, logger, conf, results))
-				checkRecord(t, srv)
-				assert.Empty(t, srv.Results)
-				assert.Zero(t, srv.Close)
-			},
-			"FailsIfClosingRecordFails": func(ctx context.Context, t *testing.T, srv *timberutil.MockTestResultsServer, comm *client.Mock) {
-				srv.CloseErr = true
-
-				require.Error(t, sendTestResults(ctx, comm, logger, conf, results))
-				checkRecord(t, srv)
-				checkResults(t, srv)
-				assert.Zero(t, srv.Close)
-			},
-		} {
-			t.Run(testName, func(t *testing.T) {
-				conf.CedarTestResultsID = ""
-				srv := setupCedarServer(ctx, t, comm)
-				comm.ResultsFailed = false
-				testCase(ctx, t, srv.TestResults, comm)
-			})
-		}
-	})
 
 	conf.Task.TaskOutputInfo = &task.TaskOutput{
 		TestResults: task.TestResultOutput{
@@ -247,16 +128,6 @@ func TestSendTestResults(t *testing.T) {
 			})
 		}
 	})
-}
-
-func setupCedarServer(ctx context.Context, t *testing.T, comm *client.Mock) *timberutil.MockCedarServer {
-	srv, err := timberutil.NewMockCedarServer(ctx, serviceutil.NextPort())
-	require.NoError(t, err)
-
-	conn, err := grpc.DialContext(ctx, srv.Address(), grpc.WithTransportCredentials(insecure.NewCredentials()))
-	require.NoError(t, err)
-	comm.CedarGRPCConn = conn
-	return srv
 }
 
 func getTestResults() *testresult.DbTaskTestResults {

--- a/agent/command/results_utils_test.go
+++ b/agent/command/results_utils_test.go
@@ -87,7 +87,7 @@ func TestSendTestResults(t *testing.T) {
 
 	conf.Task.TaskOutputInfo = &task.TaskOutput{
 		TestResults: task.TestResultOutput{
-			Version: 1,
+			Version: task.TestResultServiceEvergreen,
 			BucketConfig: evergreen.BucketConfig{
 				Type:              evergreen.BucketTypeLocal,
 				TestResultsPrefix: "test-results",

--- a/agent/command/results_xunit_parser.go
+++ b/agent/command/results_xunit_parser.go
@@ -146,7 +146,7 @@ func (tc testCase) toModelTestResultAndLog(conf *internal.TaskConfig, logger cli
 	}
 
 	if log != nil {
-		// When sending test logs to Cedar we need to use a
+		// When sending test logs we need to use a
 		// unique string since there may be duplicate file
 		// names if there are duplicate test names.
 		log.Name = utility.RandomString()

--- a/agent/command/results_xunit_test.go
+++ b/agent/command/results_xunit_test.go
@@ -165,10 +165,10 @@ func TestXUnitParseAndUpload(t *testing.T) {
 		WorkDir:         filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "xunit"),
 		NewExpansions:   &util.DynamicExpansions{},
 	}
-	conf.Task.TaskOutputInfo.TestResults.Version = 2
+	conf.Task.TaskOutputInfo.TestResults.Version = task.TestResultServiceLocal
 
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, conf *internal.TaskConfig, logger client.LoggerProducer){
-		"GlobMatchesAsteriskAndSendsToCedar": func(ctx context.Context, t *testing.T, conf *internal.TaskConfig, logger client.LoggerProducer) {
+		"GlobMatchesAsteriskAndSendsTestResults": func(ctx context.Context, t *testing.T, conf *internal.TaskConfig, logger client.LoggerProducer) {
 			xr := xunitResults{
 				Files: []string{"*"},
 			}
@@ -190,7 +190,7 @@ func TestXUnitParseAndUpload(t *testing.T) {
 				}
 			}
 		},
-		"GlobMatchesAbsolutePathContainingWorkDirPrefixAndSendsToCedar": func(ctx context.Context, t *testing.T, conf *internal.TaskConfig, logger client.LoggerProducer) {
+		"GlobMatchesAbsolutePathContainingWorkDirPrefixAndSendsTestResults": func(ctx context.Context, t *testing.T, conf *internal.TaskConfig, logger client.LoggerProducer) {
 			xr := xunitResults{
 				Files: []string{filepath.Join(conf.WorkDir, "junit*.xml")},
 			}
@@ -201,7 +201,7 @@ func TestXUnitParseAndUpload(t *testing.T) {
 			require.NoError(t, err)
 			assert.Len(t, dbResults.Results, 1)
 		},
-		"GlobMatchesRelativePathAndSendsToCedar": func(ctx context.Context, t *testing.T, conf *internal.TaskConfig, logger client.LoggerProducer) {
+		"GlobMatchesRelativePathAndSendsTestResults": func(ctx context.Context, t *testing.T, conf *internal.TaskConfig, logger client.LoggerProducer) {
 			xr := xunitResults{
 				Files: []string{filepath.Join(conf.WorkDir, "*")},
 			}

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -18,7 +18,6 @@ import (
 	restmodel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/google/go-github/v70/github"
 	"github.com/mongodb/grip"
-	"google.golang.org/grpc"
 )
 
 type Communicator interface {
@@ -73,11 +72,8 @@ type SharedCommunicator interface {
 	// project variables, project private variables, and version parameters are
 	// included, but not project parameters.
 	GetExpansionsAndVars(context.Context, TaskData) (*apimodels.ExpansionsAndVars, error)
-	// GetCedarConfig returns the Cedar service configuration.
-	GetCedarConfig(context.Context) (*apimodels.CedarConfig, error)
-	// GetCedarGRPCConn returns the client connection to cedar if it exists, or
-	// creates it if it doesn't exist.
-	GetCedarGRPCConn(context.Context) (*grpc.ClientConn, error)
+	// GetPerfMonitoringURL returns the Performance monitoring URL configuration.
+	GetPerfMonitoringURL(context.Context) (string, error)
 	// SetResultsInfo sets the test results information in the task.
 	SetResultsInfo(context.Context, TaskData, bool) error
 

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -29,7 +29,6 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/send"
 	"github.com/pkg/errors"
-	"google.golang.org/grpc"
 )
 
 // Mock mocks the Communicator for testing.
@@ -72,8 +71,6 @@ type Mock struct {
 	AssumeRoleResponse                   *apimodels.AWSCredentials
 	S3Response                           *apimodels.AWSCredentials
 	SendTaskDetailsShouldFail            bool
-
-	CedarGRPCConn *grpc.ClientConn
 
 	AttachedFiles    map[string][]*artifact.File
 	LogID            string
@@ -321,22 +318,9 @@ func (c *Mock) GetNextTask(ctx context.Context, details *apimodels.GetNextTaskDe
 	}, nil
 }
 
-// GetCedarConfig returns a mock Cedar service configuration.
-func (c *Mock) GetCedarConfig(ctx context.Context) (*apimodels.CedarConfig, error) {
-	return &apimodels.CedarConfig{
-		BaseURL:  "base_url",
-		RPCPort:  "1000",
-		Username: "user",
-		APIKey:   "api_key",
-	}, nil
-}
-
-// GetCedarGRPCConn returns gRPC connection if it is set.
-func (c *Mock) GetCedarGRPCConn(ctx context.Context) (*grpc.ClientConn, error) {
-	if c.CedarGRPCConn == nil {
-		return nil, nil
-	}
-	return c.CedarGRPCConn, nil
+// GetPerfMonitoringURL returns a mock performance URL.
+func (c *Mock) GetPerfMonitoringURL(ctx context.Context) (string, error) {
+	return "http://myurl.mongodb.com", nil
 }
 
 // GetLoggerProducer constructs a single channel log producer.

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -77,6 +77,8 @@ type Mock struct {
 	LocalTestResults []testresult.TestResult
 	HasTestResults   bool
 	ResultsFailed    bool
+	TestResultStats  testresult.TaskTestResultsStats
+	FailedTestSample []string
 	TestLogs         []*testlog.TestLog
 	TestLogCount     int
 
@@ -470,7 +472,11 @@ func (c *Mock) SendTestLog(ctx context.Context, td TaskData, log *testlog.TestLo
 
 // SendTestResults appends test results to the local list of test results.
 func (c *Mock) SendTestResults(ctx context.Context, td TaskData, tr *testresult.DbTaskTestResults) error {
-	c.ResultsFailed = tr != nil && tr.Stats.FailedCount > 0
+	if tr != nil {
+		c.ResultsFailed = tr.Stats.FailedCount > 0
+		c.TestResultStats = tr.Stats
+		c.FailedTestSample = tr.FailedTestsSample
+	}
 	return nil
 }
 

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -69,7 +69,6 @@ type TaskConfig struct {
 	// HasFailingTestResult is true if the task has sent at least one test
 	// result and at least one of those tests failed.
 	HasFailingTestResult bool
-	CedarTestResultsID   string
 	TaskGroup            *model.TaskGroup
 	CommandCleanups      []CommandCleanup
 	MaxExecTimeoutSecs   int

--- a/agent/internal/testutil/task_output.go
+++ b/agent/internal/testutil/task_output.go
@@ -24,7 +24,7 @@ func InitializeTaskOutput(t *testing.T) *task.TaskOutput {
 			},
 		},
 		TestResults: task.TestResultOutput{
-			Version: 1,
+			Version: task.TestResultServiceEvergreen,
 			BucketConfig: evergreen.BucketConfig{
 				Name: t.TempDir(),
 				Type: evergreen.BucketTypeLocal,

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -10,7 +10,6 @@ import (
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/evergreen-ci/evergreen/agent/internal/redactor"
 	"github.com/evergreen-ci/evergreen/model"
-	"github.com/evergreen-ci/pail"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/send"

--- a/agent/logging.go
+++ b/agent/logging.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/evergreen-ci/evergreen/agent/internal/redactor"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/pail"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/send"

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-07-01"
+	AgentVersion = "2025-07-02"
 )
 
 const (
@@ -92,6 +92,7 @@ type Settings struct {
 	Notify              NotifyConfig              `yaml:"notify" bson:"notify" json:"notify" id:"notify"`
 	Overrides           OverridesConfig           `yaml:"overrides" bson:"overrides" json:"overrides" id:"overrides"`
 	ParameterStore      ParameterStoreConfig      `yaml:"parameter_store" bson:"parameter_store" json:"parameter_store" id:"parameter_store"`
+	PerfMonitoringURL   string                    `yaml:"perf_monitoring_url" bson:"perf_monitoring_url" json:"perf_monitoring_url" id:"perf_monitoring_url"`
 	Plugins             PluginConfig              `yaml:"plugins" bson:"plugins" json:"plugins"`
 	PluginsNew          util.KeyValuePairSlice    `yaml:"plugins_new" bson:"plugins_new" json:"plugins_new"`
 	PodLifecycle        PodLifecycleConfig        `yaml:"pod_lifecycle" bson:"pod_lifecycle" json:"pod_lifecycle" id:"pod_lifecycle"`

--- a/config.go
+++ b/config.go
@@ -92,7 +92,7 @@ type Settings struct {
 	Notify              NotifyConfig              `yaml:"notify" bson:"notify" json:"notify" id:"notify"`
 	Overrides           OverridesConfig           `yaml:"overrides" bson:"overrides" json:"overrides" id:"overrides"`
 	ParameterStore      ParameterStoreConfig      `yaml:"parameter_store" bson:"parameter_store" json:"parameter_store" id:"parameter_store"`
-	PerfMonitoringURL   string                    `yaml:"perf_monitoring_url" bson:"perf_monitoring_url" json:"perf_monitoring_url" id:"perf_monitoring_url"`
+	PerfMonitoringURL   string                    `yaml:"perf_monitoring_url" bson:"perf_monitoring_url" json:"perf_monitoring_url"`
 	Plugins             PluginConfig              `yaml:"plugins" bson:"plugins" json:"plugins"`
 	PluginsNew          util.KeyValuePairSlice    `yaml:"plugins_new" bson:"plugins_new" json:"plugins_new"`
 	PodLifecycle        PodLifecycleConfig        `yaml:"pod_lifecycle" bson:"pod_lifecycle" json:"pod_lifecycle" id:"pod_lifecycle"`
@@ -142,6 +142,7 @@ func (c *Settings) Set(ctx context.Context) error {
 			disabledGQLQueriesKey:  c.DisabledGQLQueries,
 			kanopySSHKeyPathKey:    c.KanopySSHKeyPath,
 			logPathKey:             c.LogPath,
+			perfMonitoringURLKey:   c.PerfMonitoringURL,
 			pprofPortKey:           c.PprofPort,
 			pluginsKey:             c.Plugins,
 			pluginsNewKey:          c.PluginsNew,

--- a/config_db.go
+++ b/config_db.go
@@ -47,6 +47,7 @@ var (
 	loggerConfigKey        = bsonutil.MustHaveTag(Settings{}, "LoggerConfig")
 	logPathKey             = bsonutil.MustHaveTag(Settings{}, "LogPath")
 	pprofPortKey           = bsonutil.MustHaveTag(Settings{}, "PprofPort")
+	perfMonitoringURLKey   = bsonutil.MustHaveTag(Settings{}, "PerfMonitoringURL")
 	githubPRCreatorOrgKey  = bsonutil.MustHaveTag(Settings{}, "GithubPRCreatorOrg")
 	githubOrgsKey          = bsonutil.MustHaveTag(Settings{}, "GithubOrgs")
 	githubWebhookSecretKey = bsonutil.MustHaveTag(Settings{}, "GithubWebhookSecret")

--- a/config_test/evg_settings.yml
+++ b/config_test/evg_settings.yml
@@ -9,6 +9,8 @@ cedar:
   db_url: "mongodb://localhost:27017"
   db_name: "mci_test"
 
+perf_monitoring_url: "https://performance-monitoring-local.corp.mongodb.com"
+
 buckets:
   log_bucket:
     name: "logs"

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/evergreen-ci/certdepot v0.0.0-20250313151408-76b756321eda
 	github.com/evergreen-ci/cocoa v0.0.0-20250225172339-717c91acad92
 	github.com/evergreen-ci/gimlet v0.0.0-20250610151514-2545690ba23c
-	github.com/evergreen-ci/juniper v0.0.0-20230901183147-c805ea7351aa
+	github.com/evergreen-ci/juniper v0.0.0-20230901183147-c805ea7351aa // indirect
 	github.com/evergreen-ci/pail v0.0.0-20250501154731-3b1a60d7772f
 	github.com/evergreen-ci/poplar v0.0.0-20250313160224-22f0e4e98238
 	github.com/evergreen-ci/shrub v0.0.0-20250224222152-c8b72a51163b

--- a/model/task/evergreen_service_test.go
+++ b/model/task/evergreen_service_test.go
@@ -25,7 +25,7 @@ func init() { testutil.Setup() }
 
 var output = TaskOutput{
 	TestResults: TestResultOutput{
-		Version: 1,
+		Version: TestResultServiceEvergreen,
 		BucketConfig: evergreen.BucketConfig{
 			Type:              evergreen.BucketTypeLocal,
 			TestResultsPrefix: "test-results",
@@ -35,7 +35,7 @@ var output = TaskOutput{
 
 var outputCedar = TaskOutput{
 	TestResults: TestResultOutput{
-		Version: 0,
+		Version: TestResultServiceCedar,
 	},
 }
 

--- a/model/task/local_service_test.go
+++ b/model/task/local_service_test.go
@@ -16,7 +16,7 @@ import (
 
 var localOutput = TaskOutput{
 	TestResults: TestResultOutput{
-		Version: 2,
+		Version: TestResultServiceLocal,
 		BucketConfig: evergreen.BucketConfig{
 			Type:              evergreen.BucketTypeLocal,
 			TestResultsPrefix: "test-results",

--- a/model/task/task_output.go
+++ b/model/task/task_output.go
@@ -18,15 +18,15 @@ func InitializeTaskOutput(env evergreen.Environment) *TaskOutput {
 
 	return &TaskOutput{
 		TaskLogs: TaskLogOutput{
-			Version:      1,
+			Version:      TestResultServiceEvergreen,
 			BucketConfig: settings.Buckets.LogBucket,
 		},
 		TestLogs: TestLogOutput{
-			Version:      1,
+			Version:      TestResultServiceEvergreen,
 			BucketConfig: settings.Buckets.LogBucket,
 		},
 		TestResults: TestResultOutput{
-			Version:      1,
+			Version:      TestResultServiceEvergreen,
 			BucketConfig: settings.Buckets.TestResultsBucket,
 		},
 	}

--- a/model/task/test_result.go
+++ b/model/task/test_result.go
@@ -24,6 +24,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	TestResultServiceCedar     = 0
+	TestResultServiceEvergreen = 1
+	TestResultServiceLocal     = 2
+)
+
 var ParquetTestResultsSchemaDef *parquetschema.SchemaDefinition
 
 func init() {

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -85,6 +85,7 @@ type APIAdminSettings struct {
 	Notify              *APINotifyConfig              `json:"notify,omitempty"`
 	Overrides           *APIOverridesConfig           `json:"overrides,omitempty"`
 	ParameterStore      *APIParameterStoreConfig      `json:"parameter_store,omitempty"`
+	PerfMonitoringURL   *string                       `json:"perf_monitoring_url"`
 	Plugins             map[string]map[string]any     `json:"plugins,omitempty"`
 	PodLifecycle        *APIPodLifecycleConfig        `json:"pod_lifecycle,omitempty"`
 	PprofPort           *string                       `json:"pprof_port,omitempty"`
@@ -145,6 +146,7 @@ func (as *APIAdminSettings) BuildFromService(h any) error {
 		as.DomainName = utility.ToStringPtr(v.DomainName)
 		as.GithubPRCreatorOrg = &v.GithubPRCreatorOrg
 		as.LogPath = &v.LogPath
+		as.PerfMonitoringURL = &v.PerfMonitoringURL
 		as.Plugins = v.Plugins
 		as.PprofPort = &v.PprofPort
 		as.Expansions = v.Expansions
@@ -246,6 +248,9 @@ func (as *APIAdminSettings) ToService() (any, error) {
 	}
 	if as.PprofPort != nil {
 		settings.PprofPort = *as.PprofPort
+	}
+	if as.PerfMonitoringURL != nil {
+		settings.PerfMonitoringURL = *as.PerfMonitoringURL
 	}
 
 	apiModelReflect := reflect.ValueOf(*as)

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -64,6 +64,29 @@ func (h *agentCedarConfig) Run(ctx context.Context) gimlet.Responder {
 	})
 }
 
+// GET /rest/v2/agent/perf_monitoring_url
+type agentPerfURL struct {
+	perfURL string
+}
+
+func makeGetPerfURL(perfURL string) *agentPerfURL {
+	return &agentPerfURL{
+		perfURL: perfURL,
+	}
+}
+
+func (h *agentPerfURL) Factory() gimlet.RouteHandler {
+	return &agentPerfURL{
+		perfURL: h.perfURL,
+	}
+}
+
+func (*agentPerfURL) Parse(_ context.Context, _ *http.Request) error { return nil }
+
+func (h *agentPerfURL) Run(ctx context.Context) gimlet.Responder {
+	return gimlet.NewTextResponse(h.perfURL)
+}
+
 // GET /rest/v2/agent/setup
 type agentSetup struct {
 	settings *evergreen.Settings

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -67,6 +67,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 
 	// Agent protocol routes
 	app.AddRoute("/agent/cedar_config").Version(2).Get().Wrap(requirePodOrHost).RouteHandler(makeAgentCedarConfig(settings.Cedar))
+	app.AddRoute("/agent/perf_monitoring_url").Version(2).Get().Wrap(requirePodOrHost).RouteHandler(makeGetPerfURL(settings.PerfMonitoringURL))
 	app.AddRoute("/agent/setup").Version(2).Get().Wrap(requirePodOrHost).RouteHandler(makeAgentSetup(settings))
 	app.AddRoute("/distros/{distro_id}/ami").Version(2).Get().Wrap(requireTask).RouteHandler(makeGetDistroAMI())
 	app.AddRoute("/distros/{distro_id}/client_urls").Version(2).Get().Wrap(requireHost).RouteHandler(makeGetDistroClientURLs(env))

--- a/service/rest_task_test.go
+++ b/service/rest_task_test.go
@@ -65,7 +65,7 @@ func insertTaskForTesting(ctx context.Context, env evergreen.Environment, taskId
 		ExpectedDuration: 99 * time.Millisecond,
 		TaskOutputInfo: &task.TaskOutput{
 			TestResults: task.TestResultOutput{
-				Version: 1,
+				Version: task.TestResultServiceEvergreen,
 				BucketConfig: evergreen.BucketConfig{
 					Type:              evergreen.BucketTypeLocal,
 					TestResultsPrefix: "test-results",
@@ -365,7 +365,7 @@ func TestGetTaskStatus(t *testing.T) {
 			ResultsService: task.TestResultsServiceEvergreen,
 			TaskOutputInfo: &task.TaskOutput{
 				TestResults: task.TestResultOutput{
-					Version: 1,
+					Version: task.TestResultServiceEvergreen,
 					BucketConfig: evergreen.BucketConfig{
 						Type:              evergreen.BucketTypeLocal,
 						TestResultsPrefix: "test-results",

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -198,12 +198,6 @@ func MockConfig() *evergreen.Settings {
 				Secret: "aws_secret",
 			},
 		},
-		Cedar: evergreen.CedarConfig{
-			BaseURL: "url.com",
-			RPCPort: "7070",
-			User:    "cedar-user",
-			APIKey:  "cedar-key",
-		},
 		ConfigDir: "cfg_dir",
 		ContainerPools: evergreen.ContainerPoolsConfig{
 			Pools: []evergreen.ContainerPool{

--- a/trigger/task_test.go
+++ b/trigger/task_test.go
@@ -34,7 +34,7 @@ import (
 
 var output = task.TaskOutput{
 	TestResults: task.TestResultOutput{
-		Version: 1,
+		Version: task.TestResultServiceEvergreen,
 		BucketConfig: evergreen.BucketConfig{
 			Type:              evergreen.BucketTypeLocal,
 			TestResultsPrefix: "test-results",
@@ -217,7 +217,7 @@ func (s *taskSuite) SetupTest() {
 		FinishTime:          startTime.Add(20 * time.Minute),
 		RevisionOrderNumber: 1,
 		Requester:           evergreen.RepotrackerVersionRequester,
-		TaskOutputInfo:      &task.TaskOutput{TestResults: task.TestResultOutput{Version: 1}},
+		TaskOutputInfo:      &task.TaskOutput{TestResults: task.TestResultOutput{Version: task.TestResultServiceEvergreen}},
 	}
 	s.NoError(s.task.Insert(s.ctx))
 


### PR DESCRIPTION
DEVPROD-16202

### Description
Removes cedar from the agent. A follow up PR will be made to remove cedar-specific agent routes post deploy.

### Testing
Existing tests
