### PR TITLE
DEVPROD-16201 Omit base tasks in Cedar request if base tasks wrote from Evergreen

### DIFF
--- a/model/task/test_result.go
+++ b/model/task/test_result.go
@@ -74,6 +74,8 @@ func getMergedTaskTestResults(ctx context.Context, env evergreen.Environment, ta
 	var baseTasks []Task
 	if output.TestResults.Version == 0 && getOpts != nil {
 		baseTasks = getOpts.BaseTasks
+		// If base tasks are newer than the actual tasks and used the Evergreen test result service,
+		// we need to remove those base tasks from the cedar request and fetch them in a separate request.
 		if len(baseTasks) > 0 {
 			baseTaskOutput, baseTaskOk := baseTasks[0].GetTaskOutputSafe()
 			if baseTaskOk && baseTaskOutput.TestResults.Version == 1 {

--- a/model/task/test_result.go
+++ b/model/task/test_result.go
@@ -74,6 +74,12 @@ func getMergedTaskTestResults(ctx context.Context, env evergreen.Environment, ta
 	var baseTasks []Task
 	if output.TestResults.Version == 0 && getOpts != nil {
 		baseTasks = getOpts.BaseTasks
+		if len(baseTasks) > 0 {
+			baseTaskOutput, baseTaskOk := baseTasks[0].GetTaskOutputSafe()
+			if baseTaskOk && baseTaskOutput.TestResults.Version == 1 {
+				baseTasks = nil
+			}
+		}
 	}
 	allTestResults, err := svc.GetTaskTestResults(ctx, tasks, baseTasks)
 	if err != nil {


### PR DESCRIPTION
DEVPROD-16201

### Description
The request to get test results from cedar automatically includes the "base tasks" (the most recent mainline tasks) in the payload.

It could be possible to have a less common case where the base tasks are actually _newer_ than the actual tasks and ran post-deploy of switching new tasks to the Evergreen test result service, the request to Cedar will not be able to retrieve test results for those base tasks. This PR fixes this

### Testing
Repro in staging and confirmed it went away.
