### PR TITLE
DEVPROD-18957: switch ticket number

### DIFF
--- a/scheduler/utilization_based_host_allocator.go
+++ b/scheduler/utilization_based_host_allocator.go
@@ -188,8 +188,8 @@ func evalHostUtilization(ctx context.Context, d distro.Distro, taskGroupData Tas
 
 	// enforce the max hosts cap
 	if isMaxHostsCapacity(maxHosts, containerPool, numNewHosts, len(existingHosts)) {
-		// TODO (DEVPROD-7920): remove log once distro max hosts limitation is
-		// improved.
+		// TODO (DEVPROD-18957): remove log once the distro max host auto-tuning
+		// logic is working effectively.
 		grip.InfoWhen(evergreen.IsEc2Provider(d.Provider) && numNewHosts > 0 && numNewHosts+len(existingHosts) > maxHosts, message.Fields{
 			"message":                     "dynamically allocated distro needs to create more hosts than distro max hosts allows",
 			"target_distro_hosts":         numNewHosts + len(existingHosts),
@@ -199,7 +199,7 @@ func evalHostUtilization(ctx context.Context, d distro.Distro, taskGroupData Tas
 			"max_hosts":                   maxHosts,
 			"distro":                      d.Id,
 			"provider":                    d.Provider,
-			"ticket":                      "DEVPROD-7920",
+			"ticket":                      "DEVPROD-18957",
 		})
 		numNewHosts = maxHosts - len(existingHosts)
 	}


### PR DESCRIPTION
DEVPROD-18957

### Description
The distro auto-tuning logic is enabled, but I'm gonna spend a few weeks keeping an eye on it to see if any issues arise. Going to remove this log once that monitoring period is over, so I switched out the ticket number.