### PR TITLE
DEVPROD-18957: make distro max host decreases more conservative

### DIFF
--- a/units/distro_auto_tune.go
+++ b/units/distro_auto_tune.go
@@ -87,10 +87,11 @@ func (j *distroAutoTuneJob) Run(ctx context.Context) {
 
 	summary := j.summarizeStatsUsage(stats)
 	grip.Debug(message.Fields{
-		"message": "distro host usage stats",
-		"distro":  j.DistroID,
-		"summary": summary,
-		"job":     j.ID(),
+		"message":          "distro host usage stats",
+		"distro":           j.DistroID,
+		"distro_max_hosts": j.distro.HostAllocatorSettings.MaximumHosts,
+		"summary":          summary,
+		"job":              j.ID(),
 	})
 
 	// Avoid tuning rarely-used distros because they may not have enough data to


### PR DESCRIPTION
DEVPROD-18957

### Description
After observing how distros have been adjusted, it's clear that a ton of distros have a max host limit way higher than their actual regular usage (e.g. there are distros with 3k+ max hosts but have used at most a few hundred hosts in the past week). With the current way, it would decrease max hosts for these distros a lot because they're effectively little-used. My main concern with the current way it decreases max hosts is that some of these distros with extremely low usage _are_ utilized very little on a day-to-day basis but could become extremely busy sometimes (e.g. if an old server branch that uses an old distro has to backport many commits). Decreasing max hosts is not as critical as increasing it, so I made it much more conservative about decreasing max hosts.

* Only decrease distro max hosts if the distro has used less than 10% of its max hosts limit in the past week.

### Testing
Existing tests pass.
