### PR TITLE
DEVPROD-19101: ignore single task distros for auto-tuning

### DIFF
--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -227,6 +227,7 @@ func FindByCanAutoTune(ctx context.Context) ([]Distro, error) {
 	q := bson.M{
 		DisabledKey:         bson.M{"$ne": true},
 		ProviderKey:         bson.M{"$in": []string{evergreen.ProviderNameEc2Fleet, evergreen.ProviderNameEc2OnDemand}},
+		SingleTaskDistroKey: false,
 		autoTuneMaxHostsKey: true,
 	}
 	return Find(ctx, q)

--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -227,7 +227,7 @@ func FindByCanAutoTune(ctx context.Context) ([]Distro, error) {
 	q := bson.M{
 		DisabledKey:         bson.M{"$ne": true},
 		ProviderKey:         bson.M{"$in": []string{evergreen.ProviderNameEc2Fleet, evergreen.ProviderNameEc2OnDemand}},
-		SingleTaskDistroKey: false,
+		SingleTaskDistroKey: bson.M{"$ne": true},
 		autoTuneMaxHostsKey: true,
 	}
 	return Find(ctx, q)

--- a/units/distro_auto_tune.go
+++ b/units/distro_auto_tune.go
@@ -68,9 +68,10 @@ func (j *distroAutoTuneJob) Run(ctx context.Context) {
 		return
 	}
 
-	if !evergreen.IsEc2Provider(j.distro.Provider) || !j.distro.HostAllocatorSettings.AutoTuneMaximumHosts {
+	if !evergreen.IsEc2Provider(j.distro.Provider) || !j.distro.HostAllocatorSettings.AutoTuneMaximumHosts || j.distro.SingleTaskDistro {
 		// Only auto-tune maximum hosts for dynamically-allocated distros that
-		// have auto-tuning enabled.
+		// have auto-tuning enabled. Skip single task distros since they have
+		// niche usage and are therefore difficult to tune accurately.
 		return
 	}
 

--- a/units/distro_auto_tune_test.go
+++ b/units/distro_auto_tune_test.go
@@ -116,7 +116,21 @@ func TestDistroAutoTuneJob(t *testing.T) {
 			dbDistro, err := distro.FindOneId(t.Context(), j.distro.Id)
 			require.NoError(t, err)
 			require.NotZero(t, dbDistro)
-			assert.Equal(t, originalMaxHosts, dbDistro.HostAllocatorSettings.MaximumHosts, "max hosts should not change for non-EC2 distro")
+			assert.Equal(t, originalMaxHosts, dbDistro.HostAllocatorSettings.MaximumHosts, "max hosts should not change if auto-tuning disabled")
+		},
+		"NoopsForSingleTaskDistro": func(t *testing.T, env *mock.Environment, j *distroAutoTuneJob) {
+			j.distro.SingleTaskDistro = true
+			require.NoError(t, j.distro.Insert(t.Context()))
+
+			originalMaxHosts := j.distro.HostAllocatorSettings.MaximumHosts
+			addDistroHostStats(t, j.distro.Id, slices.Repeat([]int{j.distro.HostAllocatorSettings.MaximumHosts}, 10)...)
+			j.Run(t.Context())
+			require.NoError(t, j.Error())
+
+			dbDistro, err := distro.FindOneId(t.Context(), j.distro.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbDistro)
+			assert.Equal(t, originalMaxHosts, dbDistro.HostAllocatorSettings.MaximumHosts, "max hosts should not change for single task distro")
 		},
 		"NoopsForNoHostStats": func(t *testing.T, env *mock.Environment, j *distroAutoTuneJob) {
 			originalMaxHosts := j.distro.HostAllocatorSettings.MaximumHosts


### PR DESCRIPTION
DEVPROD-19101

### Description
Distro auto-tuning works best on distros that are regularly used so that they have more predictable patterns of usage. Single host distros aren't regularly used since they're only for releases, so the auto-tuning won't be able to adjust distro max hosts very accurately. Because they're so niche, I don't think it makes sense to let them be auto-tuned.

* Do not allow auto-tuning for single task distros.

### Testing
Added unit test.