### PR TITLE
DEVPROD-17978 Add extra parquet tags for test result log info

### DIFF
--- a/config_db.go
+++ b/config_db.go
@@ -83,7 +83,6 @@ var (
 	hostAllocatorDisabledKey           = bsonutil.MustHaveTag(ServiceFlags{}, "HostAllocatorDisabled")
 	podAllocatorDisabledKey            = bsonutil.MustHaveTag(ServiceFlags{}, "PodAllocatorDisabled")
 	backgroundReauthDisabledKey        = bsonutil.MustHaveTag(ServiceFlags{}, "BackgroundReauthDisabled")
-	backgroundCleanupDisabledKey       = bsonutil.MustHaveTag(ServiceFlags{}, "BackgroundCleanupDisabled")
 	cloudCleanupDisabledKey            = bsonutil.MustHaveTag(ServiceFlags{}, "CloudCleanupDisabled")
 	unrecognizedPodCleanupDisabledKey  = bsonutil.MustHaveTag(ServiceFlags{}, "UnrecognizedPodCleanupDisabled")
 	sleepScheduleDisabledKey           = bsonutil.MustHaveTag(ServiceFlags{}, "SleepScheduleDisabled")

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -30,7 +30,6 @@ type ServiceFlags struct {
 	PodAllocatorDisabled            bool `bson:"pod_allocator_disabled" json:"pod_allocator_disabled"`
 	UnrecognizedPodCleanupDisabled  bool `bson:"unrecognized_pod_cleanup_disabled" json:"unrecognized_pod_cleanup_disabled"`
 	BackgroundReauthDisabled        bool `bson:"background_reauth_disabled" json:"background_reauth_disabled"`
-	BackgroundCleanupDisabled       bool `bson:"background_cleanup_disabled" json:"background_cleanup_disabled"`
 	CloudCleanupDisabled            bool `bson:"cloud_cleanup_disabled" json:"cloud_cleanup_disabled"`
 	SleepScheduleDisabled           bool `bson:"sleep_schedule_disabled" json:"sleep_schedule_disabled"`
 	StaticAPIKeysDisabled           bool `bson:"static_api_keys_disabled" json:"static_api_keys_disabled"`
@@ -84,7 +83,6 @@ func (c *ServiceFlags) Set(ctx context.Context) error {
 			taskReliabilityDisabledKey:         c.TaskReliabilityDisabled,
 			hostAllocatorDisabledKey:           c.HostAllocatorDisabled,
 			podAllocatorDisabledKey:            c.PodAllocatorDisabled,
-			backgroundCleanupDisabledKey:       c.BackgroundCleanupDisabled,
 			backgroundReauthDisabledKey:        c.BackgroundReauthDisabled,
 			cloudCleanupDisabledKey:            c.CloudCleanupDisabled,
 			unrecognizedPodCleanupDisabledKey:  c.UnrecognizedPodCleanupDisabled,

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1270,7 +1270,6 @@ type ComplexityRoot struct {
 		AdminParameterStoreDisabled     func(childComplexity int) int
 		AgentStartDisabled              func(childComplexity int) int
 		AlertsDisabled                  func(childComplexity int) int
-		BackgroundCleanupDisabled       func(childComplexity int) int
 		BackgroundReauthDisabled        func(childComplexity int) int
 		BackgroundStatsDisabled         func(childComplexity int) int
 		CLIUpdatesDisabled              func(childComplexity int) int
@@ -8201,13 +8200,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.ServiceFlags.AlertsDisabled(childComplexity), true
-
-	case "ServiceFlags.backgroundCleanupDisabled":
-		if e.complexity.ServiceFlags.BackgroundCleanupDisabled == nil {
-			break
-		}
-
-		return e.complexity.ServiceFlags.BackgroundCleanupDisabled(childComplexity), true
 
 	case "ServiceFlags.backgroundReauthDisabled":
 		if e.complexity.ServiceFlags.BackgroundReauthDisabled == nil {
@@ -17852,8 +17844,6 @@ func (ec *executionContext) fieldContext_AdminSettings_serviceFlags(_ context.Co
 				return ec.fieldContext_ServiceFlags_unrecognizedPodCleanupDisabled(ctx, field)
 			case "backgroundReauthDisabled":
 				return ec.fieldContext_ServiceFlags_backgroundReauthDisabled(ctx, field)
-			case "backgroundCleanupDisabled":
-				return ec.fieldContext_ServiceFlags_backgroundCleanupDisabled(ctx, field)
 			case "cloudCleanupDisabled":
 				return ec.fieldContext_ServiceFlags_cloudCleanupDisabled(ctx, field)
 			case "sleepScheduleDisabled":
@@ -59760,50 +59750,6 @@ func (ec *executionContext) fieldContext_ServiceFlags_backgroundReauthDisabled(_
 	return fc, nil
 }
 
-func (ec *executionContext) _ServiceFlags_backgroundCleanupDisabled(ctx context.Context, field graphql.CollectedField, obj *model.APIServiceFlags) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_ServiceFlags_backgroundCleanupDisabled(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.BackgroundCleanupDisabled, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(bool)
-	fc.Result = res
-	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_ServiceFlags_backgroundCleanupDisabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "ServiceFlags",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _ServiceFlags_cloudCleanupDisabled(ctx context.Context, field graphql.CollectedField, obj *model.APIServiceFlags) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ServiceFlags_cloudCleanupDisabled(ctx, field)
 	if err != nil {
@@ -86372,7 +86318,7 @@ func (ec *executionContext) unmarshalInputServiceFlagsInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"taskDispatchDisabled", "hostInitDisabled", "podInitDisabled", "largeParserProjectsDisabled", "monitorDisabled", "alertsDisabled", "agentStartDisabled", "repotrackerDisabled", "schedulerDisabled", "checkBlockedTasksDisabled", "githubPRTestingDisabled", "cliUpdatesDisabled", "backgroundStatsDisabled", "taskLoggingDisabled", "cacheStatsJobDisabled", "cacheStatsEndpointDisabled", "taskReliabilityDisabled", "hostAllocatorDisabled", "podAllocatorDisabled", "unrecognizedPodCleanupDisabled", "backgroundReauthDisabled", "backgroundCleanupDisabled", "cloudCleanupDisabled", "sleepScheduleDisabled", "staticAPIKeysDisabled", "jwtTokenForCLIDisabled", "systemFailedTaskRestartDisabled", "degradedModeDisabled", "elasticIPsDisabled", "releaseModeDisabled", "adminParameterStoreDisabled", "eventProcessingDisabled", "jiraNotificationsDisabled", "slackNotificationsDisabled", "emailNotificationsDisabled", "webhookNotificationsDisabled", "githubStatusAPIDisabled"}
+	fieldsInOrder := [...]string{"taskDispatchDisabled", "hostInitDisabled", "podInitDisabled", "largeParserProjectsDisabled", "monitorDisabled", "alertsDisabled", "agentStartDisabled", "repotrackerDisabled", "schedulerDisabled", "checkBlockedTasksDisabled", "githubPRTestingDisabled", "cliUpdatesDisabled", "backgroundStatsDisabled", "taskLoggingDisabled", "cacheStatsJobDisabled", "cacheStatsEndpointDisabled", "taskReliabilityDisabled", "hostAllocatorDisabled", "podAllocatorDisabled", "unrecognizedPodCleanupDisabled", "backgroundReauthDisabled", "cloudCleanupDisabled", "sleepScheduleDisabled", "staticAPIKeysDisabled", "jwtTokenForCLIDisabled", "systemFailedTaskRestartDisabled", "degradedModeDisabled", "elasticIPsDisabled", "releaseModeDisabled", "adminParameterStoreDisabled", "eventProcessingDisabled", "jiraNotificationsDisabled", "slackNotificationsDisabled", "emailNotificationsDisabled", "webhookNotificationsDisabled", "githubStatusAPIDisabled"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -86526,13 +86472,6 @@ func (ec *executionContext) unmarshalInputServiceFlagsInput(ctx context.Context,
 				return it, err
 			}
 			it.BackgroundReauthDisabled = data
-		case "backgroundCleanupDisabled":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("backgroundCleanupDisabled"))
-			data, err := ec.unmarshalNBoolean2bool(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.BackgroundCleanupDisabled = data
 		case "cloudCleanupDisabled":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("cloudCleanupDisabled"))
 			data, err := ec.unmarshalNBoolean2bool(ctx, v)
@@ -98997,11 +98936,6 @@ func (ec *executionContext) _ServiceFlags(ctx context.Context, sel ast.Selection
 			}
 		case "backgroundReauthDisabled":
 			out.Values[i] = ec._ServiceFlags_backgroundReauthDisabled(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "backgroundCleanupDisabled":
-			out.Values[i] = ec._ServiceFlags_backgroundCleanupDisabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/graphql/schema/types/config.graphql
+++ b/graphql/schema/types/config.graphql
@@ -193,7 +193,6 @@ input ServiceFlagsInput {
   podAllocatorDisabled: Boolean!
   unrecognizedPodCleanupDisabled: Boolean!
   backgroundReauthDisabled: Boolean!
-  backgroundCleanupDisabled: Boolean!
   cloudCleanupDisabled: Boolean!
   sleepScheduleDisabled: Boolean!
   staticAPIKeysDisabled: Boolean!
@@ -233,7 +232,6 @@ type ServiceFlags {
   podAllocatorDisabled: Boolean!
   unrecognizedPodCleanupDisabled: Boolean!
   backgroundReauthDisabled: Boolean!
-  backgroundCleanupDisabled: Boolean!
   cloudCleanupDisabled: Boolean!
   sleepScheduleDisabled: Boolean!
   staticAPIKeysDisabled: Boolean!

--- a/graphql/tests/mutation/saveAdminSettings/queries/service_flags.graphql
+++ b/graphql/tests/mutation/saveAdminSettings/queries/service_flags.graphql
@@ -5,7 +5,6 @@ mutation {
         adminParameterStoreDisabled: true
         agentStartDisabled: true
         alertsDisabled: true
-        backgroundCleanupDisabled: true
         backgroundReauthDisabled: true
         backgroundStatsDisabled: true
         cacheStatsEndpointDisabled: true
@@ -46,7 +45,6 @@ mutation {
       adminParameterStoreDisabled
       agentStartDisabled
       alertsDisabled
-      backgroundCleanupDisabled
       backgroundReauthDisabled
       backgroundStatsDisabled
       cacheStatsEndpointDisabled

--- a/graphql/tests/mutation/saveAdminSettings/results.json
+++ b/graphql/tests/mutation/saveAdminSettings/results.json
@@ -20,7 +20,6 @@
               "adminParameterStoreDisabled": true,
               "agentStartDisabled": true,
               "alertsDisabled": true,
-              "backgroundCleanupDisabled": true,
               "backgroundReauthDisabled": true,
               "backgroundStatsDisabled": true,
               "cacheStatsEndpointDisabled": true,

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2128,7 +2128,6 @@ type APIServiceFlags struct {
 	PodAllocatorDisabled            bool `json:"pod_allocator_disabled"`
 	UnrecognizedPodCleanupDisabled  bool `json:"unrecognized_pod_cleanup_disabled"`
 	BackgroundReauthDisabled        bool `json:"background_reauth_disabled"`
-	BackgroundCleanupDisabled       bool `json:"background_cleanup_disabled"`
 	CloudCleanupDisabled            bool `json:"cloud_cleanup_disabled"`
 	SleepScheduleDisabled           bool `json:"sleep_schedule_disabled"`
 	StaticAPIKeysDisabled           bool `json:"static_api_keys_disabled"`
@@ -2559,7 +2558,6 @@ func (as *APIServiceFlags) BuildFromService(h any) error {
 		as.HostAllocatorDisabled = v.HostAllocatorDisabled
 		as.PodAllocatorDisabled = v.PodAllocatorDisabled
 		as.UnrecognizedPodCleanupDisabled = v.UnrecognizedPodCleanupDisabled
-		as.BackgroundCleanupDisabled = v.BackgroundCleanupDisabled
 		as.BackgroundReauthDisabled = v.BackgroundReauthDisabled
 		as.CloudCleanupDisabled = v.CloudCleanupDisabled
 		as.SleepScheduleDisabled = v.SleepScheduleDisabled
@@ -2605,7 +2603,6 @@ func (as *APIServiceFlags) ToService() (any, error) {
 		HostAllocatorDisabled:           as.HostAllocatorDisabled,
 		PodAllocatorDisabled:            as.PodAllocatorDisabled,
 		UnrecognizedPodCleanupDisabled:  as.UnrecognizedPodCleanupDisabled,
-		BackgroundCleanupDisabled:       as.BackgroundCleanupDisabled,
 		BackgroundReauthDisabled:        as.BackgroundReauthDisabled,
 		CloudCleanupDisabled:            as.CloudCleanupDisabled,
 		SleepScheduleDisabled:           as.SleepScheduleDisabled,

--- a/rest/model/test.go
+++ b/rest/model/test.go
@@ -76,8 +76,14 @@ func (at *APITest) BuildFromService(st any) error {
 		}
 		if v.LogInfo != nil {
 			at.Logs.RenderingType = v.LogInfo.RenderingType
+			if at.Logs.RenderingType == nil {
+				at.Logs.RenderingType = v.LogInfo.RenderingTypeCedar
+			}
 			at.Logs.Version = v.LogInfo.Version
 			at.Logs.LineNum = int(v.LogInfo.LineNum)
+			if at.Logs.LineNum == 0 {
+				at.Logs.LineNum = int(v.LogInfo.LineNumCedar)
+			}
 		}
 	case string:
 		at.TaskID = utility.ToStringPtr(v)


### PR DESCRIPTION
DEVPROD-17978

### Description
Extra tags with old parquet tags need to be added to the test results log info struct. They will be treated as deprecated fields used for tasks that wrote test results through Cedar. These tasks wrote using custom parquet tags that included underscores.

Conversely, tasks that wrote test results directly to Evergreen will use the tags above that don't contain any underscores, since when the evergreen test result service launched the fields defaulted to tag names with no underscores because of how the parquet-go library automatically resolves tag names. Both fields are required to support backwards compatability.

### Testing
Tested the spruce links to test logs work for tasks before and after the cedar shutdown.
