### PR TITLE
DEVPROD-15265: deduplicate version completion traces and logs

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1774,9 +1774,15 @@ func UpdateVersionAndPatchStatusForBuilds(ctx context.Context, buildIds []string
 		if buildVersion == nil {
 			return errors.Errorf("no version '%s' found", versionId)
 		}
-		newVersionStatus, _, err := updateVersionStatus(ctx, buildVersion)
+		newVersionStatus, versionStatusChanged, err := updateVersionStatus(ctx, buildVersion)
 		if err != nil {
 			return errors.Wrapf(err, "updating version '%s' status", buildVersion.Id)
+		}
+
+		if !versionStatusChanged {
+			// If the version stayed the same, then the patch status has also
+			// stayed the same.
+			continue
 		}
 
 		if evergreen.IsPatchRequester(buildVersion.Requester) {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1723,11 +1723,6 @@ func UpdateBuildAndVersionStatusForTask(ctx context.Context, t *task.Task) error
 				return errors.Wrapf(err, "getting collective status for patch '%s'", p.Id.Hex())
 			}
 			if parentPatch != nil {
-				// kim: NOTE: could have updateVersionStatus make the version
-				// status update atomic and return whether the update actually
-				// changed the version status to a finished state. That would
-				// prevent multiple tasks finishing around the same time from
-				// marking the version finished many times.
 				event.LogVersionChildrenCompletionEvent(ctx, parentPatch.Id.Hex(), versionStatus, parentPatch.Author)
 			} else {
 				event.LogVersionChildrenCompletionEvent(ctx, p.Id.Hex(), versionStatus, p.Author)

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1706,9 +1706,6 @@ func UpdateBuildAndVersionStatusForTask(ctx context.Context, t *task.Task) error
 		if p == nil {
 			return errors.Errorf("no patch found for version '%s'", taskVersion.Id)
 		}
-		// kim: TODO: make UpdatePatchStatus atomically update patch status and
-		// only log events + create version-completion trace if the patch status
-		// was modified in the DB
 		if err = UpdatePatchStatus(ctx, p, newVersionStatus); err != nil {
 			return errors.Wrapf(err, "updating patch '%s' status", p.Id.Hex())
 		}

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1555,12 +1555,14 @@ func TestUpdateVersionStatusForGithubChecks(t *testing.T) {
 }
 
 func TestUpdateVersionStatus(t *testing.T) {
+	colls := []string{task.Collection, build.Collection, VersionCollection, event.EventCollection}
 	type testCase struct {
 		builds []build.Build
 
-		expectedVersionStatus     string
-		expectedVersionAborted    bool
-		expectedVersionActivation bool
+		expectedVersionStatus        string
+		expectedVersionAborted       bool
+		expectedVersionActivation    bool
+		expectedVersionStatusChanged bool
 	}
 
 	for name, test := range map[string]testCase{
@@ -1569,58 +1571,64 @@ func TestUpdateVersionStatus(t *testing.T) {
 				{Status: evergreen.BuildCreated},
 				{Status: evergreen.BuildCreated},
 			},
-			expectedVersionStatus:     evergreen.VersionCreated,
-			expectedVersionAborted:    false,
-			expectedVersionActivation: false,
+			expectedVersionStatus:        evergreen.VersionCreated,
+			expectedVersionStatusChanged: false,
+			expectedVersionAborted:       false,
+			expectedVersionActivation:    false,
 		},
 		"VersionStartedForMixOfSucceededBuildAndBuildWithUnfinishedEssentialTasks": {
 			builds: []build.Build{
 				{Status: evergreen.BuildCreated, Activated: true, HasUnfinishedEssentialTask: true},
 				{Status: evergreen.BuildSucceeded, Activated: true},
 			},
-			expectedVersionStatus:     evergreen.VersionStarted,
-			expectedVersionAborted:    false,
-			expectedVersionActivation: true,
+			expectedVersionStatus:        evergreen.VersionStarted,
+			expectedVersionStatusChanged: true,
+			expectedVersionAborted:       false,
+			expectedVersionActivation:    true,
 		},
 		"VersionStartedForMixOfFailedBuildAndBuildWithUnfinishedEssentialTasks": {
 			builds: []build.Build{
 				{Status: evergreen.BuildCreated, HasUnfinishedEssentialTask: true},
 				{Status: evergreen.BuildFailed, Activated: true},
 			},
-			expectedVersionStatus:     evergreen.VersionFailed,
-			expectedVersionAborted:    false,
-			expectedVersionActivation: true,
+			expectedVersionStatus:        evergreen.VersionFailed,
+			expectedVersionStatusChanged: true,
+			expectedVersionAborted:       false,
+			expectedVersionActivation:    true,
 		},
 		"VersionStartedForMixOfFinishedAndUnfinishedBuilds": {
 			builds: []build.Build{
 				{Status: evergreen.BuildStarted, Activated: true},
 				{Status: evergreen.BuildSucceeded, Activated: true},
 			},
-			expectedVersionStatus:     evergreen.VersionStarted,
-			expectedVersionAborted:    false,
-			expectedVersionActivation: true,
+			expectedVersionStatus:        evergreen.VersionStarted,
+			expectedVersionStatusChanged: true,
+			expectedVersionAborted:       false,
+			expectedVersionActivation:    true,
 		},
 		"VersionAbortedForAbortedBuild": {
 			builds: []build.Build{
 				{Status: evergreen.BuildFailed, Activated: true, Aborted: true},
 				{Status: evergreen.BuildSucceeded, Activated: true},
 			},
-			expectedVersionStatus:     evergreen.VersionFailed,
-			expectedVersionAborted:    true,
-			expectedVersionActivation: true,
+			expectedVersionStatus:        evergreen.VersionFailed,
+			expectedVersionStatusChanged: true,
+			expectedVersionAborted:       true,
+			expectedVersionActivation:    true,
 		},
 		"VersionFinishedForAllFinishedBuilds": {
 			builds: []build.Build{
 				{Status: evergreen.BuildFailed, Activated: true},
 				{Status: evergreen.BuildSucceeded, Activated: true},
 			},
-			expectedVersionStatus:     evergreen.VersionFailed,
-			expectedVersionAborted:    false,
-			expectedVersionActivation: true,
+			expectedVersionStatus:        evergreen.VersionFailed,
+			expectedVersionStatusChanged: true,
+			expectedVersionAborted:       false,
+			expectedVersionActivation:    true,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			require.NoError(t, db.ClearCollections(task.Collection, build.Collection, VersionCollection, event.EventCollection))
+			require.NoError(t, db.ClearCollections(colls...))
 			v := &Version{
 				Id:        primitive.NewObjectID().Hex(),
 				Status:    evergreen.VersionCreated,
@@ -1633,9 +1641,20 @@ func TestUpdateVersionStatus(t *testing.T) {
 				require.NoError(t, b.Insert(t.Context()))
 			}
 
-			status, _, err := updateVersionStatus(t.Context(), v)
+			status, statusChanged, err := updateVersionStatus(t.Context(), v)
 			require.NoError(t, err)
 			assert.Equal(t, test.expectedVersionStatus, status)
+			assert.Equal(t, test.expectedVersionStatusChanged, statusChanged)
+			if statusChanged {
+				events, err := event.FindAllByResourceID(t.Context(), v.Id)
+				require.NoError(t, err)
+				require.Len(t, events, 1)
+				assert.Equal(t, event.VersionStateChange, events[0].EventType, "should log version event if the version status has changed")
+			} else {
+				events, err := event.FindAllByResourceID(t.Context(), v.Id)
+				require.NoError(t, err)
+				assert.Empty(t, events, "should not log any version events if the version status hasn't changed")
+			}
 
 			dbVersion, err := VersionFindOneId(t.Context(), v.Id)
 			require.NoError(t, err)
@@ -1644,6 +1663,36 @@ func TestUpdateVersionStatus(t *testing.T) {
 			assert.Equal(t, test.expectedVersionActivation, utility.FromBoolPtr(dbVersion.Activated))
 		})
 	}
+
+	t.Run("ReturnsStatusNotChangedForMarkingSuccessOnVersionAlreadyMarkedSuccessful", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(colls...))
+		v := &Version{
+			Id:        primitive.NewObjectID().Hex(),
+			Status:    evergreen.VersionSucceeded,
+			Activated: utility.TruePtr(),
+		}
+		require.NoError(t, v.Insert(t.Context()))
+
+		b := build.Build{
+			Id:      "b",
+			Version: v.Id,
+			Status:  evergreen.VersionSucceeded,
+		}
+		require.NoError(t, b.Insert(t.Context()))
+
+		status, statusChanged, err := updateVersionStatus(t.Context(), v)
+		require.NoError(t, err)
+		assert.Equal(t, evergreen.VersionSucceeded, status)
+		assert.False(t, statusChanged, "status was already success so it should not change the status")
+
+		events, err := event.FindAllByResourceID(t.Context(), v.Id)
+		require.NoError(t, err)
+		assert.Empty(t, events, "should not log any version events if the version status hasn't changed")
+
+		dbVersion, err := VersionFindOneId(t.Context(), v.Id)
+		require.NoError(t, err)
+		assert.Equal(t, evergreen.VersionSucceeded, dbVersion.Status)
+	})
 }
 
 func TestUpdateBuildAndVersionStatusForTaskAbort(t *testing.T) {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1543,9 +1543,10 @@ func TestUpdateVersionStatusForGithubChecks(t *testing.T) {
 		Status: evergreen.VersionStarted,
 	}
 	assert.NoError(t, v1.Insert(t.Context()))
-	versionStatus, err := updateVersionStatus(t.Context(), &v1)
+	versionStatus, statusChanged, err := updateVersionStatus(t.Context(), &v1)
 	assert.NoError(t, err)
 	assert.Equal(t, versionStatus, v1.Status) // version status hasn't changed
+	assert.False(t, statusChanged)
 
 	events, err := event.FindAllByResourceID(t.Context(), "v1")
 	assert.NoError(t, err)
@@ -1632,7 +1633,7 @@ func TestUpdateVersionStatus(t *testing.T) {
 				require.NoError(t, b.Insert(t.Context()))
 			}
 
-			status, err := updateVersionStatus(t.Context(), v)
+			status, _, err := updateVersionStatus(t.Context(), v)
 			require.NoError(t, err)
 			assert.Equal(t, test.expectedVersionStatus, status)
 


### PR DESCRIPTION
DEVPROD-15265

### Description
Some versions/patches are completing multiple times without any manual intervention (restart, activated, unscheduled, etc.). In a lot of the cases, it looks like multiple tasks are finishing at around the same time, which is causing multiple tasks to try to update the status to the same (finished) status. I changed the version update so it returns whether it actually changed the version status, which should deduplicate multiple tasks setting the version to the finished status when the updates are happening in parallel.

This only fixes the issue for versions and not patches. Will apply a similar fix for patches in a follow-up PR.

### Testing
Added unit test.
