### PR TITLE
DEVPROD-15741 Don't require edit permissions to view distro

### DIFF
--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -56,6 +56,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	submitPatches := RequiresProjectPermission(evergreen.PermissionPatches, evergreen.PatchSubmit)
 	viewProjectSettings := RequiresProjectPermission(evergreen.PermissionProjectSettings, evergreen.ProjectSettingsView)
 	editProjectSettings := RequiresProjectPermission(evergreen.PermissionProjectSettings, evergreen.ProjectSettingsEdit)
+	viewDistroSettings := RequiresDistroPermission(evergreen.PermissionDistroSettings, evergreen.DistroSettingsView)
 	editDistroSettings := RequiresDistroPermission(evergreen.PermissionDistroSettings, evergreen.DistroSettingsEdit)
 	removeDistroSettings := RequiresDistroPermission(evergreen.PermissionDistroSettings, evergreen.DistroSettingsAdmin)
 	compress := gimlet.WrapperHandlerMiddleware(handlers.CompressHandler)
@@ -138,8 +139,8 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/builds/{build_id}/annotations").Version(2).Get().Wrap(requireUser, viewAnnotations).RouteHandler(makeFetchAnnotationsByBuild())
 	// degraded_mode is used by Kanopy's alertmanager instance, which is only able to perform basic auth for REST, so it does not pass in user info
 	app.AddRoute("/degraded_mode").Version(2).Post().Wrap(requireAlertmanager).RouteHandler(makeSetDegradedMode())
-	app.AddRoute("/distros").Version(2).Get().Wrap(requireUser).RouteHandler(makeDistroRoute())
-	app.AddRoute("/distros/{distro_id}").Version(2).Get().Wrap(requireUser).RouteHandler(makeGetDistroByID())
+	app.AddRoute("/distros").Version(2).Get().Wrap(requireUser, viewDistroSettings).RouteHandler(makeDistroRoute())
+	app.AddRoute("/distros/{distro_id}").Version(2).Get().Wrap(requireUser, viewDistroSettings).RouteHandler(makeGetDistroByID())
 	app.AddRoute("/distros/{distro_id}").Version(2).Patch().Wrap(requireUser, editDistroSettings).RouteHandler(makePatchDistroByID())
 	app.AddRoute("/distros/{distro_id}").Version(2).Delete().Wrap(requireUser, removeDistroSettings).RouteHandler(makeDeleteDistroByID())
 	app.AddRoute("/distros/{distro_id}").Version(2).Put().Wrap(requireUser, createDistro).RouteHandler(makePutDistro())

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -139,7 +139,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	// degraded_mode is used by Kanopy's alertmanager instance, which is only able to perform basic auth for REST, so it does not pass in user info
 	app.AddRoute("/degraded_mode").Version(2).Post().Wrap(requireAlertmanager).RouteHandler(makeSetDegradedMode())
 	app.AddRoute("/distros").Version(2).Get().Wrap(requireUser).RouteHandler(makeDistroRoute())
-	app.AddRoute("/distros/{distro_id}").Version(2).Get().Wrap(requireUser, editDistroSettings).RouteHandler(makeGetDistroByID())
+	app.AddRoute("/distros/{distro_id}").Version(2).Get().Wrap(requireUser).RouteHandler(makeGetDistroByID())
 	app.AddRoute("/distros/{distro_id}").Version(2).Patch().Wrap(requireUser, editDistroSettings).RouteHandler(makePatchDistroByID())
 	app.AddRoute("/distros/{distro_id}").Version(2).Delete().Wrap(requireUser, removeDistroSettings).RouteHandler(makeDeleteDistroByID())
 	app.AddRoute("/distros/{distro_id}").Version(2).Put().Wrap(requireUser, createDistro).RouteHandler(makePutDistro())


### PR DESCRIPTION
DEVPROD-15741

### Description

Remove edit permission for viewing a distro. This matches the current behavior for viewing all distros, so I believe this was an oversight, not a deliberate requirement.

### Testing

N/A

### Documentation

Covered by existing API docs.