### PR TITLE
DEVPROD-18621 Add better validation error for missing command and function

### DIFF
--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1506,7 +1506,7 @@ func validateCommands(section string, taskName string, project *model.Project, c
 			hasFuncOrCommand = false
 			errs = append(errs, ValidationError{
 				Level:   Error,
-				Message: fmt.Sprintf("must specify either command or function %s", formattedTaskMsg),
+				Message: fmt.Sprintf("must specify either command or function%s", formattedTaskMsg),
 			})
 		}
 		if cmd.Function != "" && cmd.Command != "" {

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -3684,6 +3684,25 @@ tasks:
 			So(len(validationErrs.AtLevel(Error)), ShouldEqual, 1)
 			So(validationErrs.AtLevel(Error)[0].Message, ShouldContainSubstring, "params cannot be nil")
 		})
+		Convey("an error should be thrown if a command has no command or function name", func() {
+			exampleYml := `
+tasks:
+- name: example_task
+  commands:
+  - params:
+      script: echo test
+`
+			proj := model.Project{}
+			ctx := context.Background()
+			pp, err := model.LoadProjectInto(ctx, []byte(exampleYml), nil, "example_project", &proj)
+			So(pp, ShouldNotBeNil)
+			So(proj, ShouldNotBeNil)
+			So(err, ShouldBeNil)
+			validationErrs := validatePluginCommands(&proj)
+			So(validationErrs, ShouldNotResemble, ValidationErrors{})
+			So(len(validationErrs.AtLevel(Error)), ShouldEqual, 1)
+			So(validationErrs.AtLevel(Error)[0].Message, ShouldContainSubstring, "must specify either command or function for task 'example_task'")
+		})
 		Convey("an error should return if a shell.exec command is missing a script", func() {
 			project := &model.Project{
 				Functions: map[string]*model.YAMLCommandSet{


### PR DESCRIPTION
DEVPROD-18621

### Description
Detects if a command has no command name or function name, and if so, returns a specific validation error to fix that rather than trying to render the command which would definitely fail.

### Testing
Tested in staging & unit test.