### PR TITLE
DEVPROD-18267 consider the activate field to determine if bv is non-zero

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -847,10 +847,8 @@ func (g *GeneratedProject) validateNoRedefine(cachedProject projectMaps) error {
 }
 
 func isNonZeroBV(bv parserBV) bool {
-	// TODO (DEVPROD-723): this omits activate from consideration, but it's
-	// unclear if it's intentional or not.
 	if bv.DisplayName != "" || len(bv.Expansions) > 0 || len(bv.Modules) > 0 ||
-		bv.Disable != nil || len(bv.Tags) > 0 ||
+		bv.Disable != nil || len(bv.Tags) > 0 || bv.Activate != nil ||
 		bv.BatchTime != nil || bv.Patchable != nil || bv.PatchOnly != nil ||
 		bv.AllowForGitTag != nil || bv.GitTagOnly != nil || len(bv.AllowedRequesters) > 0 ||
 		bv.Stepback != nil || bv.DeactivatePrevious != nil || len(bv.RunOn) > 0 {


### PR DESCRIPTION
DEVPROD-18267

### Description
This helper is used to make sure that the only thing being added to a build variant (when processing includes) is new tasks. I think it's an oversight that `activate` isn't included here. 

### Testing
Ran evergreen validate on all configs to ensure we didn't hit a new error here.

### Documentation
Remember to add or edit docs in the docs/ directory if relevant.
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
