### PR TITLE
DEVPROD-18267 log if buildvariant activate is set

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -849,6 +849,11 @@ func (g *GeneratedProject) validateNoRedefine(cachedProject projectMaps) error {
 func isNonZeroBV(bv parserBV) bool {
 	// TODO (DEVPROD-723): this omits activate from consideration, but it's
 	// unclear if it's intentional or not.
+	grip.DebugWhen(bv.Activate != nil, message.Fields{
+		"ticket":             "DEVPROD-723",
+		"message":            "activate is not nil",
+		"build_variant_name": bv.Name,
+	})
 	if bv.DisplayName != "" || len(bv.Expansions) > 0 || len(bv.Modules) > 0 ||
 		bv.Disable != nil || len(bv.Tags) > 0 ||
 		bv.BatchTime != nil || bv.Patchable != nil || bv.PatchOnly != nil ||


### PR DESCRIPTION
DEVPROD-18267
### Description
Before merging https://github.com/evergreen-ci/evergreen/pull/9216/files, gut check that generating doesn't depend on this behavior or something, in which case we should maybe just comment why we don't check it here, instead of adding it.