### PR TITLE
DEVPROD-19717 Allow private and admin vars to be copied correctly

### DIFF
--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -579,30 +579,31 @@ func (projectVars *ProjectVars) FindAndModify(ctx context.Context, varsToDelete 
 		update["$unset"] = unsetUpdate
 	}
 
-	// check original project vars and see if privatevarsmap and adminonlyvasmap are null
-	// if it is, update them to be empty maps
-	initializeUpdate := bson.M{}
-	originalProjectVars, err := FindOneProjectVars(ctx, projectVars.Id)
-	if err != nil {
-		return nil, errors.Wrapf(err, "finding original project vars for project '%s'", projectVars.Id)
-	}
-	if originalProjectVars == nil {
-		return nil, errors.Errorf("project vars for project '%s' not found", projectVars.Id)
-	}
-	if originalProjectVars.PrivateVars == nil {
-		initializeUpdate[privateVarsMapKey] = bson.M{}
-	}
-	if originalProjectVars.AdminOnlyVars == nil {
-		initializeUpdate[adminOnlyVarsMapKey] = bson.M{}
-	}
-	if len(initializeUpdate) > 0 {
-		err := db.UpdateContext(ctx,
-			ProjectVarsCollection,
-			bson.M{projectVarIdKey: projectVars.Id},
-			bson.M{"$set": initializeUpdate},
-		)
+	if len(projectVars.PrivateVars) != 0 && len(projectVars.AdminOnlyVars) != 0 {
+		// Initialize the private and admin-only vars maps if they don't exist.
+		initializeUpdate := bson.M{}
+		originalProjectVars, err := FindOneProjectVars(ctx, projectVars.Id)
 		if err != nil {
-			return nil, errors.Wrap(err, "initializing private and admin-only vars in DB")
+			return nil, errors.Wrapf(err, "finding original project vars for project '%s'", projectVars.Id)
+		}
+		if originalProjectVars == nil {
+			return nil, errors.Errorf("project vars for project '%s' not found", projectVars.Id)
+		}
+		if originalProjectVars.PrivateVars == nil {
+			initializeUpdate[privateVarsMapKey] = bson.M{}
+		}
+		if originalProjectVars.AdminOnlyVars == nil {
+			initializeUpdate[adminOnlyVarsMapKey] = bson.M{}
+		}
+		if len(initializeUpdate) > 0 {
+			err := db.UpdateContext(ctx,
+				ProjectVarsCollection,
+				bson.M{projectVarIdKey: projectVars.Id},
+				bson.M{"$set": initializeUpdate},
+			)
+			if err != nil {
+				return nil, errors.Wrap(err, "initializing private and admin-only vars in DB")
+			}
 		}
 	}
 

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -579,6 +579,33 @@ func (projectVars *ProjectVars) FindAndModify(ctx context.Context, varsToDelete 
 		update["$unset"] = unsetUpdate
 	}
 
+	// check original project vars and see if privatevarsmap and adminonlyvasmap are null
+	// if it is, update them to be empty maps
+	initializeUpdate := bson.M{}
+	originalProjectVars, err := FindOneProjectVars(ctx, projectVars.Id)
+	if err != nil {
+		return nil, errors.Wrapf(err, "finding original project vars for project '%s'", projectVars.Id)
+	}
+	if originalProjectVars == nil {
+		return nil, errors.Errorf("project vars for project '%s' not found", projectVars.Id)
+	}
+	if originalProjectVars.PrivateVars == nil {
+		initializeUpdate[privateVarsMapKey] = bson.M{}
+	}
+	if originalProjectVars.AdminOnlyVars == nil {
+		initializeUpdate[adminOnlyVarsMapKey] = bson.M{}
+	}
+	if len(initializeUpdate) > 0 {
+		err := db.UpdateContext(ctx,
+			ProjectVarsCollection,
+			bson.M{projectVarIdKey: projectVars.Id},
+			bson.M{"$set": initializeUpdate},
+		)
+		if err != nil {
+			return nil, errors.Wrap(err, "initializing private and admin-only vars in DB")
+		}
+	}
+
 	change, err := db.FindAndModify(ctx,
 		ProjectVarsCollection,
 		bson.M{projectVarIdKey: projectVars.Id},

--- a/rest/route/project_copy_test.go
+++ b/rest/route/project_copy_test.go
@@ -232,6 +232,7 @@ func (s *copyVariablesSuite) TestCopyAllVariables() {
 		DryRun:         true,
 		IncludePrivate: true,
 	}
+	// Explicitly don't set private and admin-only variables for testing.
 	newProjectVar := &model.ProjectVars{
 		Id:   "projectB",
 		Vars: map[string]string{"banana": "yellow"},

--- a/rest/route/project_copy_test.go
+++ b/rest/route/project_copy_test.go
@@ -178,19 +178,20 @@ func (s *copyVariablesSuite) SetupTest() {
 	}}
 	s.NoError(repoRef.Replace(s.ctx))
 	projectVar1 := &model.ProjectVars{
-		Id:          "projectA",
-		Vars:        map[string]string{"apple": "red", "hello": "world"},
-		PrivateVars: map[string]bool{"hello": true},
+		Id:            "projectA",
+		Vars:          map[string]string{"apple": "red", "hello": "world"},
+		PrivateVars:   map[string]bool{"hello": true},
+		AdminOnlyVars: map[string]bool{"hello": true},
 	}
 	projectVar2 := &model.ProjectVars{
-		Id:          "projectB",
-		Vars:        map[string]string{"banana": "yellow", "apple": "green", "hello": "its me"},
-		PrivateVars: map[string]bool{},
+		Id:   "projectB",
+		Vars: map[string]string{"banana": "yellow", "apple": "green", "hello": "its me"},
+		// PrivateVars: map[string]bool{},
 	}
 	projectVar3 := model.ProjectVars{
-		Id:          "repoRef",
-		Vars:        map[string]string{"chicago": "cubs"},
-		PrivateVars: map[string]bool{},
+		Id:   "repoRef",
+		Vars: map[string]string{"chicago": "cubs"},
+		// PrivateVars: map[string]bool{},
 	}
 
 	s.NoError(projectVar1.Insert(s.T().Context()))
@@ -232,9 +233,8 @@ func (s *copyVariablesSuite) TestCopyAllVariables() {
 		IncludePrivate: true,
 	}
 	newProjectVar := &model.ProjectVars{
-		Id:          "projectB",
-		Vars:        map[string]string{"banana": "yellow"},
-		PrivateVars: map[string]bool{},
+		Id:   "projectB",
+		Vars: map[string]string{"banana": "yellow"},
 	}
 	_, err := newProjectVar.Upsert(s.ctx)
 	s.NoError(err)

--- a/rest/route/project_copy_test.go
+++ b/rest/route/project_copy_test.go
@@ -184,14 +184,14 @@ func (s *copyVariablesSuite) SetupTest() {
 		AdminOnlyVars: map[string]bool{"hello": true},
 	}
 	projectVar2 := &model.ProjectVars{
-		Id:   "projectB",
-		Vars: map[string]string{"banana": "yellow", "apple": "green", "hello": "its me"},
-		// PrivateVars: map[string]bool{},
+		Id:          "projectB",
+		Vars:        map[string]string{"banana": "yellow", "apple": "green", "hello": "its me"},
+		PrivateVars: map[string]bool{},
 	}
 	projectVar3 := model.ProjectVars{
-		Id:   "repoRef",
-		Vars: map[string]string{"chicago": "cubs"},
-		// PrivateVars: map[string]bool{},
+		Id:          "repoRef",
+		Vars:        map[string]string{"chicago": "cubs"},
+		PrivateVars: map[string]bool{},
 	}
 
 	s.NoError(projectVar1.Insert(s.T().Context()))


### PR DESCRIPTION
DEVPROD-19717

### Description
copy var routes were erroring because it was trying to add to a null object 
this initializes them if we are making edits to the null maps 


### Testing
unit testing