### PR TITLE
DEVPROD-19402 Add required expansions for expansion resolutions

### DIFF
--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -722,7 +722,7 @@ command: shell.exec
     script: |
       if [ ${has_pyyaml_installed|false} = false ]; then
         echo "Using python version ${python_version!|3.8}"
-      ...
+        ...
 ```
 
 Likewise, the default argument of an expansion can be an expansion

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -705,21 +705,24 @@ expansion whose value uses another expansion.
 
 ```yaml
 command: s3.get
-   params:
-     aws_key: ${aws_key}
-     aws_secret: ${aws_secret}
+  params:
+    aws_key: ${aws_key}
+    aws_secret: ${aws_secret}
 ```
 
-Expansions can also take default arguments, in the form of
-`${key_name|default}`.
+Expansions can be provided a default when the expansion is undefined,
+in the form of `${key_name|default}`. To provide a default
+when the expansion is either undefined or defined but empty,
+use the form `${key_name!|default}`.
 
 ```yaml
 command: shell.exec
-   params:
-     working_dir: src
-     script: |
-       if [ ${has_pyyaml_installed|false} = false ]; then
-       ...
+  params:
+    working_dir: src
+    script: |
+      if [ ${has_pyyaml_installed|false} = false ]; then
+        echo "Using python version ${python_version!|3.8}"
+      ...
 ```
 
 Likewise, the default argument of an expansion can be an expansion
@@ -728,9 +731,10 @@ expansion value of the default value, rather than the hard coded string.
 
 ```yaml
 command: shell.exec
-   params:
+  params:
     script: |
       VERSION=${use_version|*use_version_default} ./foo.sh
+      YAML=${yaml_file!|*yaml_file_default} ./bar.sh
 ```
 
 If an expansion is used in your project file, but is unset, it will be
@@ -743,10 +747,10 @@ Expansions are also case-sensitive.
 
 ```yaml
 command: shell.exec
-   params:
-      working_dir: src
-     script: |
-       echo ${HelloWorld}
+  params:
+    working_dir: src
+    script: |
+      echo ${HelloWorld}
 ```
 
 #### Usage

--- a/util/expansion.go
+++ b/util/expansion.go
@@ -99,9 +99,19 @@ func (exp *Expansions) ExpandString(toExpand string) (string, error) {
 				match = match[0:idx]
 			}
 
+			// determine if the expansion is required to have a value
+			var requireVal bool
+			if secondaryValue != "" && strings.HasSuffix(match, "!") {
+				requireVal = true
+				match = match[:len(match)-1]
+			}
+
 			// return the specified expansion, if it is present.
 			if exp.Exists(match) {
-				return []byte(exp.Get(match))
+				expVal := exp.Get(match)
+				if !requireVal || (requireVal && expVal != "") {
+					return []byte(expVal)
+				}
 			}
 
 			// look for an expansion in the secondary value


### PR DESCRIPTION
DEVPROD-19402

### Description
This PR introduces a new expansion resolution capability, to provide a default when the expansion is _either_ undefined **or** an empty string.

The rewritten test file showcases this really well, but a TLDR is this allows prepending a `!` to allow a check for the expansion to not be empty.

### Testing
Unit tests

I did a grep of all configs to make sure no one is using a variable or expansion ending in `!`, as this would break it. I did `\$\{.*\|.*\}` as an initial grep to get all the expansion usage (17k results). I then did `\$\{.*!\|.*\}` which adds `!` right before `|` this returned 0 results
