### PR TITLE
DEVPROD-19659 add build variant path filtering

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -610,6 +610,10 @@ func CreateBuildFromVersionNoInsert(ctx context.Context, creationInfo TaskCreati
 		creationInfo.Version.CreateTime.Format(build.IdTimeLayout))
 
 	activatedTime := utility.ZeroTime
+	// If we're given changed files and they don't match the variants' specified paths (if any), don't activate the build.
+	if !buildVariant.ChangedFilesMatchPaths(creationInfo.ChangedFiles) {
+		creationInfo.ActivateBuild = false
+	}
 	if creationInfo.ActivateBuild {
 		activatedTime = time.Now()
 	}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -707,10 +707,14 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 			DisplayNames:     displayNames,
 			DistroAliases:    distroAliases,
 			TaskCreateTime:   createTime,
-			// When a GitHub PR patch is finalized with the PR alias, all of the
-			// tasks selected by the alias must finish in order for the
-			// build/version to be finished.
-			ActivatedTasksAreEssentialToSucceed: requester == evergreen.GithubPRRequester,
+		}
+		// When a GitHub PR patch is finalized with the PR alias, all of the
+		// tasks selected by the alias must finish in order for the
+		// build/version to be finished, excluding any variants that are
+		// ignored due to files changed.
+		if requester == evergreen.GithubPRRequester {
+			buildCreationArgs.ActivatedTasksAreEssentialToSucceed = true
+			buildCreationArgs.ChangedFiles = p.FilesChanged()
 		}
 		var build *build.Build
 		var tasks task.Tasks

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -684,6 +684,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 
 	buildsToInsert := build.Builds{}
 	tasksToInsert := task.Tasks{}
+	buildsToSendSuccessMessageFor := []string{}
 	for _, vt := range p.VariantsTasks {
 		if _, ok := variantsProcessed[vt.Variant]; ok {
 			continue
@@ -729,6 +730,16 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 				"version": patchVersion.Id,
 			})
 			continue
+		}
+		if !build.Activated {
+			grip.Info(message.Fields{
+				"op":      "skipping deactivated build for patch version",
+				"variant": vt.Variant,
+				"version": patchVersion.Id,
+			})
+			buildsToSendSuccessMessageFor = append(buildsToSendSuccessMessageFor, vt.Variant)
+			continue
+
 		}
 
 		buildsToInsert = append(buildsToInsert, build)

--- a/model/project.go
+++ b/model/project.go
@@ -1787,15 +1787,23 @@ func (p *Project) ResolvePatchVTs(ctx context.Context, patchDoc *patch.Patch, re
 		}
 	}
 	var pairs TaskVariantPairs
-	for _, v := range bvs {
+	for _, bvName := range bvs {
+		//// TODO: One option is to put the skip in here.
+		//bv := p.FindBuildVariant(bvName)
+		//if bv == nil {
+		//	continue
+		//}
+		//if !bv.ChangedFilesMatchPaths(patchDoc.FilesChanged()) {
+		//	continue // but we need this list, so that we know to send a success status
+		//}
 		for _, t := range tasks {
-			if bvt := p.FindTaskForVariant(t, v); bvt != nil {
+			if bvt := p.FindTaskForVariant(t, bvName); bvt != nil {
 				if bvt.IsDisabled() || bvt.SkipOnRequester(requester) {
 					continue
 				}
-				pairs.ExecTasks = append(pairs.ExecTasks, TVPair{Variant: v, TaskName: t})
-			} else if p.GetDisplayTask(v, t) != nil {
-				pairs.DisplayTasks = append(pairs.DisplayTasks, TVPair{Variant: v, TaskName: t})
+				pairs.ExecTasks = append(pairs.ExecTasks, TVPair{Variant: bvName, TaskName: t})
+			} else if p.GetDisplayTask(bvName, t) != nil {
+				pairs.DisplayTasks = append(pairs.DisplayTasks, TVPair{Variant: bvName, TaskName: t})
 			}
 		}
 	}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -341,6 +341,7 @@ type parserBV struct {
 	AllowForGitTag    *bool                     `yaml:"allow_for_git_tag,omitempty" bson:"allow_for_git_tag,omitempty"`
 	GitTagOnly        *bool                     `yaml:"git_tag_only,omitempty" bson:"git_tag_only,omitempty"`
 	AllowedRequesters []evergreen.UserRequester `yaml:"allowed_requesters,omitempty" bson:"allowed_requesters,omitempty"`
+	Paths             parserStringSlice         `yaml:"paths,omitempty" bson:"paths,omitempty"`
 
 	// internal matrix stuff
 	MatrixId  string      `yaml:"matrix_id,omitempty" bson:"matrix_id,omitempty"`
@@ -1210,6 +1211,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 			DeactivatePrevious: pbv.DeactivatePrevious,
 			RunOn:              pbv.RunOn,
 			Tags:               pbv.Tags,
+			Paths:              pbv.Paths,
 		}
 		bv.AllowedRequesters = pbv.AllowedRequesters
 		bv.Tasks, unmatchedSelectors, unmatchedCriteria, errs = evaluateBVTasks(tse, tgse, vse, pbv, tasks)

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -411,6 +411,7 @@ func (pbv *parserBV) canMerge() bool {
 		pbv.AllowForGitTag == nil &&
 		pbv.GitTagOnly == nil &&
 		len(pbv.AllowedRequesters) == 0 &&
+		len(pbv.Paths) == 0 &&
 		pbv.MatrixId == "" &&
 		pbv.MatrixVal == nil &&
 		pbv.Matrix == nil &&

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -919,6 +919,34 @@ tasks:
 	assert.Equal("evergreen", modules[0].Repo)
 }
 
+func TestBuildVariantPaths(t *testing.T) {
+	assert := assert.New(t)
+	yml := `
+buildvariants:
+- name: "v1"
+  paths:
+  - "src/**"
+  - "etc/**"
+  tasks:
+  - name: "t1"
+    create_check_run:
+      path_to_outputs: "path"
+tasks:
+- name: t1
+`
+
+	proj := &Project{}
+	ctx := context.Background()
+	_, err := LoadProjectInto(ctx, []byte(yml), nil, "id", proj)
+	assert.NotNil(proj)
+	assert.NoError(err)
+
+	require.Len(t, proj.BuildVariants, 1)
+	assert.Len(proj.BuildVariants[0].Paths, 2)
+	assert.Equal("src/**", proj.BuildVariants[0].Paths[0])
+	assert.Equal("etc/**", proj.BuildVariants[0].Paths[1])
+}
+
 func TestDisplayTaskParsing(t *testing.T) {
 	assert := assert.New(t)
 	yml := `

--- a/model/task_creation.go
+++ b/model/task_creation.go
@@ -30,6 +30,7 @@ type TaskCreationInfo struct {
 	DistroAliases       distro.AliasLookupTable // Map of distro aliases to names of distros
 	TaskCreateTime      time.Time               // Create time of tasks in the build
 	GithubChecksAliases ProjectAliases          // Project aliases to use to filter tasks to count towards the github checks, if any
+	ChangedFiles        []string                // ChangedFiles is used to determine if the variant should be deactivated based on changed files.
 	// ActivatedTasksAreEssentialToSucceed indicates whether or not all tasks
 	// that are being created and activated immediately are required to finish
 	// in order for the build/version to be finished. Tasks with specific

--- a/model/version.go
+++ b/model/version.go
@@ -356,6 +356,7 @@ type VersionMetadata struct {
 	PeriodicBuildID     string
 	RemotePath          string
 	GitTag              GitTag
+	ChangedFiles        []string
 }
 
 var (

--- a/units/github_status_api.go
+++ b/units/github_status_api.go
@@ -36,6 +36,7 @@ const (
 	PatchingDisabled            = "patching was disabled"
 	mergeQueueDisabled          = "merge queue disabled for project"
 	ignoredFiles                = "all patched files are ignored"
+	ignoredFilesForVariant      = "variant ignored due to path filtering"
 	invalidAlias                = "alias not found"
 	NoTasksOrVariants           = "no tasks/variants were configured"
 	noChildPatchTasksOrVariants = "no tasks/variants were configured for child patch"

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -324,7 +324,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	}
 	// Don't create patches for github PRs if the only changes are in ignored files.
 	if patchDoc.IsGithubPRPatch() && patchedProject.IgnoresAllFiles(patchDoc.FilesChanged()) {
-		j.sendGitHubSuccessMessages(ctx, patchDoc, pref, ignoredFiles)
+		j.sendGitHubSuccessMessages(ctx, patchDoc, pref)
 		return nil
 	}
 

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -352,6 +352,18 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		return errors.Wrap(err, BuildTasksAndVariantsError)
 	}
 
+	ignoredVariants := j.filterOutIgnoredVariants(patchDoc, patchedProject)
+	// If all variants were filtered out, send success messages and don't create the patch.
+	if len(patchDoc.VariantsTasks) == 0 && len(ignoredVariants) > 0 {
+		j.sendGitHubSuccessMessages(ctx, patchDoc, pref)
+		return nil
+	}
+
+	// If some variants were filtered out, send success messages for those variants.
+	if len(ignoredVariants) > 0 {
+		j.sendGitHubSuccessMessageForIgnoredVariants(ctx, patchDoc, ignoredVariants)
+	}
+
 	if (j.intent.ShouldFinalizePatch() || patchDoc.IsMergeQueuePatch()) &&
 		len(patchDoc.VariantsTasks) == 0 {
 		j.gitHubError = NoTasksOrVariants
@@ -1262,9 +1274,27 @@ func (j *patchIntentProcessor) sendGitHubErrorStatus(ctx context.Context, patchD
 	j.AddError(update.Error())
 }
 
+// sendGitHubSuccessMessageForIgnoredVariants sends GitHub success messages for variants that were ignored
+// due to path filtering.
+func (j *patchIntentProcessor) sendGitHubSuccessMessageForIgnoredVariants(ctx context.Context, patchDoc *patch.Patch, ignoredVariants []string) {
+	for _, variant := range ignoredVariants {
+		// Create a context that includes the variant name
+		variantContext := fmt.Sprintf("%s/%s", thirdparty.GithubStatusDefaultContext, variant)
+		update := NewGithubStatusUpdateJobWithSuccessMessage(
+			variantContext,
+			patchDoc.GithubPatchData.BaseOwner,
+			patchDoc.GithubPatchData.BaseRepo,
+			patchDoc.GithubPatchData.HeadHash,
+			ignoredFilesForVariant,
+		)
+		update.Run(ctx)
+		j.AddError(update.Error())
+	}
+}
+
 // sendGitHubSuccessMessages sends a successful status to GitHub with the given message for all
 // Evergreen rules configured for the given project.
-func (j *patchIntentProcessor) sendGitHubSuccessMessages(ctx context.Context, patchDoc *patch.Patch, projectRef *model.ProjectRef, msg string) {
+func (j *patchIntentProcessor) sendGitHubSuccessMessages(ctx context.Context, patchDoc *patch.Patch, projectRef *model.ProjectRef) {
 	rules := j.getEvergreenRulesForStatuses(ctx, patchDoc.GithubPatchData.BaseOwner, projectRef.Repo, projectRef.Branch)
 	for _, rule := range rules {
 		update := NewGithubStatusUpdateJobWithSuccessMessage(
@@ -1272,7 +1302,7 @@ func (j *patchIntentProcessor) sendGitHubSuccessMessages(ctx context.Context, pa
 			patchDoc.GithubPatchData.BaseOwner,
 			patchDoc.GithubPatchData.BaseRepo,
 			patchDoc.GithubPatchData.HeadHash,
-			msg,
+			ignoredFilesForVariant,
 		)
 		update.Run(ctx)
 		j.AddError(update.Error())
@@ -1309,4 +1339,76 @@ func (j *patchIntentProcessor) getEvergreenRulesForStatuses(ctx context.Context,
 	allRules = append(allRules, rulesetRules...)
 
 	return utility.UniqueStrings(allRules)
+}
+
+// filterOutIgnoredVariants checks which variants should be ignored based on their path patterns
+// and the changed files in the patch. It removes ignored variants from all relevant patch fields
+// and returns the list of ignored variant names.
+func (j *patchIntentProcessor) filterOutIgnoredVariants(patchDoc *patch.Patch, patchedProject *model.Project) []string {
+	// Only apply variant filtering for GitHub PR patches
+	if !patchDoc.IsGithubPRPatch() {
+		return nil
+	}
+
+	changedFiles := patchDoc.FilesChanged()
+	if len(changedFiles) == 0 {
+		return nil
+	}
+
+	ignoredVariants := []string{}
+	filteredVariantsTasks := []patch.VariantTasks{}
+	keptVariants := make(map[string]bool)
+
+	// Check each variant in VariantsTasks to see if it should be ignored
+	for _, vt := range patchDoc.VariantsTasks {
+		bv := patchedProject.FindBuildVariant(vt.Variant)
+		if bv == nil {
+			// If we can't find the build variant, keep it (don't ignore)
+			filteredVariantsTasks = append(filteredVariantsTasks, vt)
+			keptVariants[vt.Variant] = true
+			continue
+		}
+
+		// If the variant has path patterns and none of the changed files match, ignore it
+		if len(bv.Paths) > 0 && !bv.ChangedFilesMatchPaths(changedFiles) {
+			ignoredVariants = append(ignoredVariants, vt.Variant)
+		} else {
+			// Keep this variant
+			filteredVariantsTasks = append(filteredVariantsTasks, vt)
+			keptVariants[vt.Variant] = true
+		}
+	}
+
+	// Update the patch document with the filtered variants
+	patchDoc.VariantsTasks = filteredVariantsTasks
+
+	// Update BuildVariants to only include variants that weren't filtered out
+	filteredBuildVariants := []string{}
+	for _, variant := range patchDoc.BuildVariants {
+		if keptVariants[variant] {
+			filteredBuildVariants = append(filteredBuildVariants, variant)
+		}
+	}
+	patchDoc.BuildVariants = filteredBuildVariants
+
+	// Update Tasks to only include tasks that are still used by remaining variants
+	usedTasks := make(map[string]bool)
+	for _, vt := range filteredVariantsTasks {
+		for _, task := range vt.Tasks {
+			usedTasks[task] = true
+		}
+		for _, dt := range vt.DisplayTasks {
+			usedTasks[dt.Name] = true
+		}
+	}
+
+	filteredTasks := []string{}
+	for _, task := range patchDoc.Tasks {
+		if usedTasks[task] {
+			filteredTasks = append(filteredTasks, task)
+		}
+	}
+	patchDoc.Tasks = filteredTasks
+
+	return ignoredVariants
 }

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1793,8 +1793,7 @@ func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 		}
 
 		j := &patchIntentProcessor{}
-		ignoredVariants, err := j.filterOutIgnoredVariants(s.ctx, patchDoc, project)
-		assert.NoError(t, err)
+		ignoredVariants := j.filterOutIgnoredVariants(patchDoc, project)
 		assert.Empty(t, ignoredVariants)
 		assert.Len(t, patchDoc.VariantsTasks, 2)
 		assert.Len(t, patchDoc.BuildVariants, 2)
@@ -1830,8 +1829,7 @@ func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 		}
 
 		j := &patchIntentProcessor{}
-		ignoredVariants, err := j.filterOutIgnoredVariants(s.ctx, patchDoc, project)
-		assert.NoError(t, err)
+		ignoredVariants := j.filterOutIgnoredVariants(patchDoc, project)
 		assert.Empty(t, ignoredVariants)
 		assert.Len(t, patchDoc.VariantsTasks, 1)
 	})
@@ -1876,8 +1874,7 @@ func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 		}
 
 		j := &patchIntentProcessor{}
-		ignoredVariants, err := j.filterOutIgnoredVariants(s.ctx, patchDoc, project)
-		assert.NoError(t, err)
+		ignoredVariants := j.filterOutIgnoredVariants(patchDoc, project)
 		assert.Empty(t, ignoredVariants)
 		assert.Len(t, patchDoc.VariantsTasks, 2)
 		assert.Len(t, patchDoc.BuildVariants, 2)
@@ -1927,8 +1924,7 @@ func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 		}
 
 		j := &patchIntentProcessor{}
-		ignoredVariants, err := j.filterOutIgnoredVariants(s.ctx, patchDoc, project)
-		assert.NoError(t, err)
+		ignoredVariants := j.filterOutIgnoredVariants(patchDoc, project)
 		assert.Equal(t, []string{"frontend", "docs"}, ignoredVariants)
 		assert.Len(t, patchDoc.VariantsTasks, 1)
 		assert.Equal(t, "backend", patchDoc.VariantsTasks[0].Variant)
@@ -1976,8 +1972,7 @@ func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 		}
 
 		j := &patchIntentProcessor{}
-		ignoredVariants, err := j.filterOutIgnoredVariants(s.ctx, patchDoc, project)
-		assert.NoError(t, err)
+		ignoredVariants := j.filterOutIgnoredVariants(patchDoc, project)
 		assert.Equal(t, []string{"frontend", "backend"}, ignoredVariants)
 		assert.Empty(t, patchDoc.VariantsTasks)
 		assert.Empty(t, patchDoc.BuildVariants)
@@ -2028,8 +2023,7 @@ func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 		}
 
 		j := &patchIntentProcessor{}
-		ignoredVariants, err := j.filterOutIgnoredVariants(s.ctx, patchDoc, project)
-		assert.NoError(t, err)
+		ignoredVariants := j.filterOutIgnoredVariants(patchDoc, project)
 		assert.Empty(t, ignoredVariants)
 		assert.Len(t, patchDoc.VariantsTasks, 1)
 		assert.Equal(t, []string{"unit-test", "test-suite"}, patchDoc.Tasks)
@@ -2071,8 +2065,7 @@ func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 		}
 
 		j := &patchIntentProcessor{}
-		ignoredVariants, err := j.filterOutIgnoredVariants(s.ctx, patchDoc, project)
-		assert.NoError(t, err)
+		ignoredVariants := j.filterOutIgnoredVariants(patchDoc, project)
 		assert.Empty(t, ignoredVariants)
 		assert.Len(t, patchDoc.VariantsTasks, 1)
 		assert.Equal(t, []string{"nonexistent"}, patchDoc.BuildVariants)


### PR DESCRIPTION
DEVPROD-19659 
### Description
Adds to PRs and mainline versions. Same behavior as ignored files -- sends statuses for ignored versions for PRs and doesn't create the variants, and just keeps them deactivated for mainline.

<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

### Testing
add a description of how you tested it

### Documentation
Remember to add or edit docs in the docs/ directory if relevant.
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
