### PR TITLE
DEVPROD-19961: wait longer on associating address

### DIFF
--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -904,7 +904,7 @@ func associateIPAddressForHost(ctx context.Context, c AWSClient, h *host.Host) e
 	ctx, span := tracer.Start(ctx, "associateIPAddressForHost")
 	defer span.End()
 
-	assocAddrOut, err := c.AssociateAddress(ctx, &ec2.AssociateAddressInput{
+	assocAddrOut, err := c.AssociateAddress(ctx, h, &ec2.AssociateAddressInput{
 		InstanceId:   aws.String(h.Id),
 		AllocationId: aws.String(h.IPAllocationID),
 		// Explicitly allowed an elastic IP to be reassociated to a different


### PR DESCRIPTION
DEVPROD-19961

### Description
After we start a host in AWS, we have to associate it with its elastic IP. Unfortunately, this API call to associate the IP address can only succeed when the host is "running" in AWS and it gets rate limited a lot, so we want to avoid calling it unnecessarily before the host is "running".

I looked at some stats and it looks like it typically takes 10-15 seconds from when the host started to actually associating the address. To reduce calls that are going to fail because the host isn't up yet, I adjusted the API call to wait about 10 seconds from the time when the host started.

### Testing
* Tested in staging to verify that it waited before trying to associate the address.
* Will monitor to see if the rate limit issue is reduced after this is deployed.