### PR TITLE
DEVPROD-18860 Use git tag requester as activator when none is found

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1207,6 +1207,10 @@ func createOneTask(ctx context.Context, id string, creationInfo TaskCreationInfo
 		t.ActivatedBy = evergreen.StepbackTaskActivator
 	}
 
+	if t.ActivatedBy == "" && creationInfo.Version.TriggeredByGitTag.Tag != "" {
+		t.ActivatedBy = evergreen.GitTagRequester
+	}
+
 	if buildVarTask.IsPartOfGroup {
 		tg := creationInfo.Project.FindTaskGroup(buildVarTask.GroupName)
 		if tg == nil {


### PR DESCRIPTION
DEVPROD-18860

### Description
This adds the git tag requester as the activator when none is found.

<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->
