### PR TITLE
DEVPROD-18860 Fallback Submitter on papertrail trace command

### DIFF
--- a/agent/command/papertrail_trace.go
+++ b/agent/command/papertrail_trace.go
@@ -17,6 +17,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	unknownSubmitter = "unknown"
+)
+
 type papertrailTrace struct {
 	Address   string   `mapstructure:"address" plugin:"expand"`
 	KeyID     string   `mapstructure:"key_id" plugin:"expand"`
@@ -61,7 +65,7 @@ func (t *papertrailTrace) Execute(ctx context.Context,
 		}
 
 		if args.Submitter == "" {
-			args.Submitter = "Unknown"
+			args.Submitter = unknownSubmitter
 		}
 
 		if err := pclient.Trace(ctx, args); err != nil {

--- a/agent/command/papertrail_trace.go
+++ b/agent/command/papertrail_trace.go
@@ -60,6 +60,10 @@ func (t *papertrailTrace) Execute(ctx context.Context,
 			Submitter: task.ActivatedBy,
 		}
 
+		if args.Submitter == "" {
+			args.Submitter = "Unknown"
+		}
+
 		if err := pclient.Trace(ctx, args); err != nil {
 			return errors.Wrap(err, "running trace")
 		}

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-07-21"
+	AgentVersion = "2025-07-28"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-18860

### Description
The papertrail service expects something in the submitter field, this ensures it fallsback to something always.
<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->