### PR TITLE
DEVPROD-19992, DEVPROD-19999: set up basic last-revision command

### DIFF
--- a/cmd/evergreen/evergreen.go
+++ b/cmd/evergreen/evergreen.go
@@ -55,6 +55,7 @@ func buildApp() *cli.App {
 		operations.Validate(),
 		operations.List(),
 		operations.LastGreen(),
+		operations.LastRevision(),
 		operations.Subscriptions(),
 		operations.Client(),
 

--- a/config.go
+++ b/config.go
@@ -31,7 +31,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-07-16c"
+	ClientVersion = "2025-07-29"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -135,6 +135,13 @@ func addVariantsFlag(flags ...cli.Flag) []cli.Flag {
 	})
 }
 
+func addVariantsRegexpFlag(flags ...cli.Flag) []cli.Flag {
+	return append(flags, cli.StringSliceFlag{
+		Name:  joinFlagNames(regexVariantsFlagName, "rv"),
+		Usage: "regexps for build variant names",
+	})
+}
+
 func addPatchIDFlag(flags ...cli.Flag) []cli.Flag {
 	return append(flags, cli.StringFlag{
 		Name:  joinFlagNames(patchIDFlagName, "id", "i"),

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -135,13 +135,6 @@ func addVariantsFlag(flags ...cli.Flag) []cli.Flag {
 	})
 }
 
-func addVariantsRegexpFlag(flags ...cli.Flag) []cli.Flag {
-	return append(flags, cli.StringSliceFlag{
-		Name:  joinFlagNames(regexVariantsFlagName, "rv"),
-		Usage: "regexps for build variant names",
-	})
-}
-
 func addPatchIDFlag(flags ...cli.Flag) []cli.Flag {
 	return append(flags, cli.StringFlag{
 		Name:  joinFlagNames(patchIDFlagName, "id", "i"),

--- a/operations/last_revision.go
+++ b/operations/last_revision.go
@@ -2,11 +2,16 @@ package operations
 
 import (
 	"context"
+	"fmt"
 	"regexp"
+	"sync"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/rest/client"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -18,18 +23,18 @@ func LastRevision() cli.Command {
 		Name:   "last-revision",
 		Usage:  "return the latest revision that shouldApply a set of criteria",
 		Flags:  addProjectFlag(addVariantsRegexpFlag()...),
-		Before: mergeBeforeFuncs(autoUpdateCLI, requireVariantsFlag),
+		Before: mergeBeforeFuncs(autoUpdateCLI, setPlainLogger, requireVariantsFlag),
 		Action: func(c *cli.Context) error {
 			confPath := c.Parent().String(confFlagName)
 			criteria, err := newLastRevisionCriteria(c.String(projectFlagName), c.StringSlice(variantsFlagName))
 			if err != nil {
 				return errors.Wrap(err, "building last revision options")
 			}
+
+			grip.Debugf("Criteria: %s\n", criteria.String())
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
-
-			// kim: TODO: get version and builds, then make a skeleton similar
-			// to what git-co-evg-base does.
 
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
@@ -48,33 +53,12 @@ func LastRevision() cli.Command {
 				return errors.Wrap(err, "getting latest versions for project")
 			}
 
-			// GET /versions/{version_id}/builds
-			// kim: TODO: figure out if latestVersions is ordered most to least
-			// recent.
-			for _, v := range latestVersions {
-				builds, err := client.GetBuildsForVersion(ctx, utility.FromStringPtr(v.Id))
-				if err != nil {
-					return errors.Wrapf(err, "getting builds for version '%s'", utility.FromStringPtr(v.Id))
-				}
-				// kim: TODO: eventually make goroutines to parallel check all
-				// the builds.
-				for _, b := range builds {
-					if !criteria.shouldApply(utility.FromStringPtr(b.BuildVariant)) {
-						continue
-					}
-
-					tasks, err := client.GetTasksForBuild(ctx, utility.FromStringPtr(b.Id))
-					if err != nil {
-						return errors.Wrapf(err, "getting tasks for build '%s'", utility.FromStringPtr(b.Id))
-					}
-
-					buildInfo := newLastRevisionBuildInfo(b, tasks)
-					if !criteria.check(buildInfo) {
-						continue
-					}
-					// kim: TODO: handle the builds that do match somehow
-				}
+			revisionInfo, err := findLatestMatchingRevision(ctx, client, latestVersions, *criteria)
+			if err != nil {
+				return errors.Wrap(err, "finding latest matching revision")
 			}
+
+			grip.Infof("Latest revision that matches criteria: %s\n", revisionInfo.revision)
 
 			return nil
 		},
@@ -107,7 +91,6 @@ func (i *lastRevisionBuildInfo) successProportion() float64 {
 	return float64(i.numSuccessfulTasks) / float64(i.numTasks)
 }
 
-// kim: TODO: use once flags are set up.
 // lastRevisionCriteria defines the user criteria for selecting a suitable last
 // revision.
 type lastRevisionCriteria struct {
@@ -137,6 +120,14 @@ func newLastRevisionCriteria(project string, bvRegexpsAsStr []string) (*lastRevi
 	}, nil
 }
 
+func (c *lastRevisionCriteria) String() string {
+	bvRegexps := make([]string, 0, len(c.buildVariantRegexp))
+	for _, re := range c.buildVariantRegexp {
+		bvRegexps = append(bvRegexps, re.String())
+	}
+	return fmt.Sprintf("Project: %s\nBuild Variant Regexps: %v\nMin Success Proportion: %f", c.project, bvRegexps, c.minSuccessProportion)
+}
+
 // shouldApply returns whether the criteria applies to this build variant.
 func (c *lastRevisionCriteria) shouldApply(bv string) bool {
 	for _, bvRegexp := range c.buildVariantRegexp {
@@ -155,8 +146,106 @@ func (c *lastRevisionCriteria) check(info lastRevisionBuildInfo) bool {
 	}
 
 	if info.successProportion() < c.minSuccessProportion {
+		grip.Debug(message.Fields{
+			"message":                "build does not meet minimum success proportion",
+			"build_variant":          info.buildVariant,
+			"min_success_proportion": c.minSuccessProportion,
+			"success_proportion":     info.successProportion(),
+		})
 		return false
 	}
 
 	return true
+}
+
+type lastRevisionInfo struct {
+	// revision is the latest revision that matches the criteria.
+	revision string
+}
+
+func findLatestMatchingRevision(ctx context.Context, c client.Communicator, latestVersions []model.APIVersion, criteria lastRevisionCriteria) (*lastRevisionInfo, error) {
+	// GET /versions/{version_id}/builds
+	// kim: TODO: figure out if latestVersions is ordered most to least
+	// recent.
+	for _, v := range latestVersions {
+		builds, err := c.GetBuildsForVersion(ctx, utility.FromStringPtr(v.Id))
+		if err != nil {
+			return nil, errors.Wrapf(err, "getting builds for version '%s'", utility.FromStringPtr(v.Id))
+		}
+		// kim: TODO: eventually make goroutines to parallel check all
+		// the builds.
+
+		type buildResult struct {
+			passesCriteria bool
+			err            error
+		}
+
+		buildResults := make(chan buildResult, len(builds))
+		wg := sync.WaitGroup{}
+		for _, b := range builds {
+			if !criteria.shouldApply(utility.FromStringPtr(b.BuildVariant)) {
+				continue
+			}
+
+			grip.Debug(message.Fields{
+				"message":       "checking build for last revision criteria",
+				"build_id":      b.Id,
+				"build_variant": b.BuildVariant,
+				"version":       b.Version,
+			})
+
+			wg.Add(1)
+
+			go func() {
+				defer wg.Done()
+
+				res := buildResult{}
+				res.passesCriteria, res.err = checkBuildMatchesCriteria(ctx, c, b, criteria)
+				select {
+				case <-ctx.Done():
+				case buildResults <- res:
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		catcher := grip.NewBasicCatcher()
+		allBuildsPassedCriteria := true
+		for res := range buildResults {
+			if res.err != nil {
+				catcher.Add(errors.Wrapf(res.err, "checking build '%s' for last revision criteria", utility.FromStringPtr(v.Id)))
+			}
+			if !res.passesCriteria {
+				allBuildsPassedCriteria = false
+			}
+		}
+		if catcher.HasErrors() {
+			return nil, catcher.Resolve()
+		}
+		if !allBuildsPassedCriteria {
+			continue
+		}
+
+		return &lastRevisionInfo{
+			revision: utility.FromStringPtr(v.Revision),
+		}, nil
+	}
+
+	return nil, errors.New("no matching revision found")
+}
+
+func checkBuildMatchesCriteria(ctx context.Context, c client.Communicator, b model.APIBuild, criteria lastRevisionCriteria) (passesCriteria bool, err error) {
+	if !criteria.shouldApply(utility.FromStringPtr(b.BuildVariant)) {
+		return false, nil // criteria does not apply to this build variant
+	}
+
+	tasks, err := c.GetTasksForBuild(ctx, utility.FromStringPtr(b.Id))
+	if err != nil {
+		return false, errors.Wrapf(err, "getting tasks for build '%s'", utility.FromStringPtr(b.Id))
+	}
+
+	buildInfo := newLastRevisionBuildInfo(b, tasks)
+
+	return criteria.check(buildInfo), nil
 }

--- a/operations/last_revision.go
+++ b/operations/last_revision.go
@@ -1,0 +1,162 @@
+package operations
+
+import (
+	"context"
+	"regexp"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/utility"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+const defaultLastRevisionLookbackLimit = 50
+
+func LastRevision() cli.Command {
+	return cli.Command{
+		Name:   "last-revision",
+		Usage:  "return the latest revision that shouldApply a set of criteria",
+		Flags:  addProjectFlag(addVariantsRegexpFlag()...),
+		Before: mergeBeforeFuncs(autoUpdateCLI, requireVariantsFlag),
+		Action: func(c *cli.Context) error {
+			confPath := c.Parent().String(confFlagName)
+			criteria, err := newLastRevisionCriteria(c.String(projectFlagName), c.StringSlice(variantsFlagName))
+			if err != nil {
+				return errors.Wrap(err, "building last revision options")
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			// kim: TODO: get version and builds, then make a skeleton similar
+			// to what git-co-evg-base does.
+
+			conf, err := NewClientSettings(confPath)
+			if err != nil {
+				return errors.Wrap(err, "loading configuration")
+			}
+
+			client, err := conf.setupRestCommunicator(ctx, true)
+			if err != nil {
+				return errors.Wrap(err, "setting up REST communicator")
+			}
+			defer client.Close()
+
+			// GET /projects/{project_id}/versions
+			latestVersions, err := client.GetRecentVersionsForProject(ctx, c.String(projectFlagName), evergreen.RepotrackerVersionRequester, defaultLastRevisionLookbackLimit)
+			if err != nil {
+				return errors.Wrap(err, "getting latest versions for project")
+			}
+
+			// GET /versions/{version_id}/builds
+			// kim: TODO: figure out if latestVersions is ordered most to least
+			// recent.
+			for _, v := range latestVersions {
+				builds, err := client.GetBuildsForVersion(ctx, utility.FromStringPtr(v.Id))
+				if err != nil {
+					return errors.Wrapf(err, "getting builds for version '%s'", utility.FromStringPtr(v.Id))
+				}
+				// kim: TODO: eventually make goroutines to parallel check all
+				// the builds.
+				for _, b := range builds {
+					if !criteria.shouldApply(utility.FromStringPtr(b.BuildVariant)) {
+						continue
+					}
+
+					tasks, err := client.GetTasksForBuild(ctx, utility.FromStringPtr(b.Id))
+					if err != nil {
+						return errors.Wrapf(err, "getting tasks for build '%s'", utility.FromStringPtr(b.Id))
+					}
+
+					buildInfo := newLastRevisionBuildInfo(b, tasks)
+					if !criteria.check(buildInfo) {
+						continue
+					}
+					// kim: TODO: handle the builds that do match somehow
+				}
+			}
+
+			return nil
+		},
+	}
+}
+
+// lastRevisionBuildInfo includes information needed to determine if a build
+// passes a set of criteria.
+type lastRevisionBuildInfo struct {
+	buildVariant       string
+	numTasks           int
+	numSuccessfulTasks int
+}
+
+func newLastRevisionBuildInfo(b model.APIBuild, buildTasks []model.APITask) lastRevisionBuildInfo {
+	numSuccessfulTasks := 0
+	for _, t := range buildTasks {
+		if utility.FromStringPtr(t.Status) == evergreen.TaskSucceeded {
+			numSuccessfulTasks++
+		}
+	}
+	return lastRevisionBuildInfo{
+		buildVariant:       utility.FromStringPtr(b.BuildVariant),
+		numTasks:           len(buildTasks),
+		numSuccessfulTasks: numSuccessfulTasks,
+	}
+}
+
+func (i *lastRevisionBuildInfo) successProportion() float64 {
+	return float64(i.numSuccessfulTasks) / float64(i.numTasks)
+}
+
+// kim: TODO: use once flags are set up.
+// lastRevisionCriteria defines the user criteria for selecting a suitable last
+// revision.
+type lastRevisionCriteria struct {
+	// project is the project ID or identifier.
+	project string
+	// buildVariantRegexp is a list of regular expressions of build variant
+	// names. This determines which particular build variants the criteria
+	// should apply to.
+	buildVariantRegexp []regexp.Regexp
+	// minSuccessProportion is a criterion for the minimum proportion of tasks
+	// in the build that must succeed.
+	minSuccessProportion float64
+}
+
+func newLastRevisionCriteria(project string, bvRegexpsAsStr []string) (*lastRevisionCriteria, error) {
+	bvRegexps := make([]regexp.Regexp, 0, len(bvRegexpsAsStr))
+	for _, bvRegexpStr := range bvRegexpsAsStr {
+		bvRegexp, err := regexp.Compile(bvRegexpStr)
+		if err != nil {
+			return nil, errors.Wrap(err, "compiling build variant regexp")
+		}
+		bvRegexps = append(bvRegexps, *bvRegexp)
+	}
+	return &lastRevisionCriteria{
+		project:            project,
+		buildVariantRegexp: bvRegexps,
+	}, nil
+}
+
+// shouldApply returns whether the criteria applies to this build variant.
+func (c *lastRevisionCriteria) shouldApply(bv string) bool {
+	for _, bvRegexp := range c.buildVariantRegexp {
+		if bvRegexp.MatchString(bv) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *lastRevisionCriteria) check(info lastRevisionBuildInfo) bool {
+	if !c.shouldApply(info.buildVariant) {
+		// The criteria does not apply to this build variant, so it
+		// automatically passes checks.
+		return true
+	}
+
+	if info.successProportion() < c.minSuccessProportion {
+		return false
+	}
+
+	return true
+}

--- a/operations/last_revision_test.go
+++ b/operations/last_revision_test.go
@@ -1,0 +1,159 @@
+package operations
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/rest/client"
+	"github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLastRevisionCheckBuilds(t *testing.T) {
+	for tName, tCase := range map[string]func(t *testing.T, c *client.Mock){
+		"PassesCriteriaWithBuildSuccessRateAboveThreshold": func(t *testing.T, c *client.Mock) {
+			builds := []model.APIBuild{
+				{
+					Id:           utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+				},
+			}
+			c.GetTasksForBuildResult = []model.APITask{
+				{
+					Id:           utility.ToStringPtr("t1"),
+					BuildId:      utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+					Status:       utility.ToStringPtr(evergreen.TaskSucceeded),
+				},
+				{
+					Id:           utility.ToStringPtr("t2"),
+					BuildId:      utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+					Status:       utility.ToStringPtr(evergreen.TaskSucceeded),
+				},
+			}
+
+			criteria := lastRevisionCriteria{
+				project:              "test_project",
+				buildVariantRegexp:   []regexp.Regexp{*regexp.MustCompile("bv1")},
+				minSuccessProportion: 0.5,
+			}
+
+			passesCriteria, err := checkBuildsPassCriteria(t.Context(), c, builds, criteria)
+			require.NoError(t, err)
+			assert.True(t, passesCriteria)
+		},
+		"DoesNotPassCriteriaWithBuildSuccessRateBelowThreshold": func(t *testing.T, c *client.Mock) {
+			builds := []model.APIBuild{
+				{
+					Id:           utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+				},
+			}
+			c.GetTasksForBuildResult = []model.APITask{
+				{
+					Id:           utility.ToStringPtr("t1"),
+					BuildId:      utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+					Status:       utility.ToStringPtr(evergreen.TaskFailed),
+				},
+				{
+					Id:           utility.ToStringPtr("t2"),
+					BuildId:      utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+					Status:       utility.ToStringPtr(evergreen.TaskSucceeded),
+				},
+			}
+
+			criteria := lastRevisionCriteria{
+				project:              "test_project",
+				buildVariantRegexp:   []regexp.Regexp{*regexp.MustCompile("bv1")},
+				minSuccessProportion: 1,
+			}
+
+			passesCriteria, err := checkBuildsPassCriteria(t.Context(), c, builds, criteria)
+			require.NoError(t, err)
+			assert.False(t, passesCriteria)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			tCase(t, &client.Mock{})
+		})
+	}
+}
+
+func TestLastRevisionCheckVersions(t *testing.T) {
+	for tName, tCase := range map[string]func(t *testing.T, c *client.Mock){
+		"PassesCriteriaWithBuildSuccessRateAboveThreshold": func(t *testing.T, c *client.Mock) {
+			builds := []model.APIBuild{
+				{
+					Id:           utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+				},
+			}
+			c.GetTasksForBuildResult = []model.APITask{
+				{
+					Id:           utility.ToStringPtr("t1"),
+					BuildId:      utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+					Status:       utility.ToStringPtr(evergreen.TaskSucceeded),
+				},
+				{
+					Id:           utility.ToStringPtr("t2"),
+					BuildId:      utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+					Status:       utility.ToStringPtr(evergreen.TaskSucceeded),
+				},
+			}
+
+			criteria := lastRevisionCriteria{
+				project:              "test_project",
+				buildVariantRegexp:   []regexp.Regexp{*regexp.MustCompile("bv1")},
+				minSuccessProportion: 0.5,
+			}
+
+			passesCriteria, err := checkBuildsPassCriteria(t.Context(), c, builds, criteria)
+			require.NoError(t, err)
+			assert.True(t, passesCriteria)
+		},
+		"DoesNotPassCriteriaWithBuildSuccessRateBelowThreshold": func(t *testing.T, c *client.Mock) {
+			builds := []model.APIBuild{
+				{
+					Id:           utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+				},
+			}
+			c.GetTasksForBuildResult = []model.APITask{
+				{
+					Id:           utility.ToStringPtr("t1"),
+					BuildId:      utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+					Status:       utility.ToStringPtr(evergreen.TaskFailed),
+				},
+				{
+					Id:           utility.ToStringPtr("t2"),
+					BuildId:      utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+					Status:       utility.ToStringPtr(evergreen.TaskSucceeded),
+				},
+			}
+
+			criteria := lastRevisionCriteria{
+				project:              "test_project",
+				buildVariantRegexp:   []regexp.Regexp{*regexp.MustCompile("bv1")},
+				minSuccessProportion: 1,
+			}
+
+			passesCriteria, err := checkBuildsPassCriteria(t.Context(), c, builds, criteria)
+			require.NoError(t, err)
+			assert.False(t, passesCriteria)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			tCase(t, &client.Mock{})
+		})
+	}
+}

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -106,7 +106,14 @@ type Communicator interface {
 	// GetManifestByTask returns the manifest corresponding to the given task
 	GetManifestByTask(ctx context.Context, taskId string) (*manifest.Manifest, error)
 
-	GetRecentVersionsForProject(ctx context.Context, projectID, requester string) ([]restmodel.APIVersion, error)
+	// GetRecentVersionsForProject returns the most recent versions for a
+	// project.
+	GetRecentVersionsForProject(ctx context.Context, projectID, requester string, limit int) ([]restmodel.APIVersion, error)
+
+	// GetBuildsForVersion gets all builds for a version.
+	GetBuildsForVersion(ctx context.Context, versionID string) ([]restmodel.APIBuild, error)
+	// GetTasksForBuild gets all tasks in a build.
+	GetTasksForBuild(ctx context.Context, buildID string) ([]restmodel.APITask, error)
 
 	// GetClientURLs returns the all URLs that can be used to request the
 	// Evergreen binary for a given distro.

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -1248,15 +1248,25 @@ func (c *communicatorImpl) GetHostProcessOutput(ctx context.Context, hostProcess
 	return result, nil
 }
 
-func (c *communicatorImpl) GetRecentVersionsForProject(ctx context.Context, projectID, requester string) ([]model.APIVersion, error) {
+func (c *communicatorImpl) GetRecentVersionsForProject(ctx context.Context, projectID, requester string, limit int) ([]model.APIVersion, error) {
 	info := requestInfo{
 		method: http.MethodGet,
-		path:   fmt.Sprintf("projects/%s/versions?requester=%s", projectID, requester),
+		path:   fmt.Sprintf("projects/%s/versions", projectID),
+	}
+	queryParams := []string{}
+	if requester != "" {
+		queryParams = append(queryParams, fmt.Sprintf("requester=%s", requester))
+	}
+	if limit > 0 {
+		queryParams = append(queryParams, fmt.Sprintf("limit=%d", limit))
+	}
+	if len(queryParams) > 0 {
+		info.path = info.path + "?" + strings.Join(queryParams, "&")
 	}
 
 	resp, err := c.request(ctx, info, nil)
 	if err != nil {
-		return nil, errors.Wrapf(err, "sending request to get versions for project '%s' and requester '%s'", projectID, requester)
+		return nil, errors.Wrapf(err, "sending request to get versions for project '%s'", projectID)
 	}
 	defer resp.Body.Close()
 
@@ -1264,7 +1274,7 @@ func (c *communicatorImpl) GetRecentVersionsForProject(ctx context.Context, proj
 		return nil, util.RespError(resp, AuthError)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, util.RespErrorf(resp, "getting versions for project '%s' and requester '%s'", projectID, requester)
+		return nil, util.RespErrorf(resp, "getting versions for project '%s'", projectID)
 	}
 
 	getVersionsResp := []model.APIVersion{}
@@ -1273,6 +1283,60 @@ func (c *communicatorImpl) GetRecentVersionsForProject(ctx context.Context, proj
 	}
 
 	return getVersionsResp, nil
+}
+
+func (c *communicatorImpl) GetBuildsForVersion(ctx context.Context, versionID string) ([]restmodel.APIBuild, error) {
+	info := requestInfo{
+		method: http.MethodGet,
+		path:   fmt.Sprintf("versions/%s/builds", versionID),
+	}
+
+	resp, err := c.request(ctx, info, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "sending request to get builds for version '%s'", versionID)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, util.RespError(resp, AuthError)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, util.RespErrorf(resp, "getting builds for version '%s'", versionID)
+	}
+
+	getBuildsResp := []model.APIBuild{}
+	if err = utility.ReadJSON(resp.Body, &getBuildsResp); err != nil {
+		return nil, errors.Wrap(err, "reading JSON response body")
+	}
+
+	return getBuildsResp, nil
+}
+
+func (c *communicatorImpl) GetTasksForBuild(ctx context.Context, buildID string) ([]restmodel.APITask, error) {
+	info := requestInfo{
+		method: http.MethodGet,
+		path:   fmt.Sprintf("builds/%s/tasks", buildID),
+	}
+
+	resp, err := c.request(ctx, info, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "sending request to get tasks for build '%s'", buildID)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, util.RespError(resp, AuthError)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, util.RespErrorf(resp, "getting tasks for build '%s'", buildID)
+	}
+
+	getTasksResp := []model.APITask{}
+	if err = utility.ReadJSON(resp.Body, &getTasksResp); err != nil {
+		return nil, errors.Wrap(err, "reading JSON response body")
+	}
+
+	return getTasksResp, nil
 }
 
 func (c *communicatorImpl) GetDistroByName(ctx context.Context, id string) (*restmodel.APIDistro, error) {

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -267,6 +267,14 @@ func (c *Mock) GetRecentVersionsForProject(context.Context, string, string) ([]r
 	return nil, nil
 }
 
+func (c *Mock) GetBuildsForVersion(ctx context.Context, versionID string) ([]restmodel.APIBuild, error) {
+	return nil, nil
+}
+
+func (c *Mock) GetTasksForBuild(ctx context.Context, buildID string) ([]restmodel.APITask, error) {
+	return nil, nil
+}
+
 func (c *Mock) GetDistroByName(context.Context, string) (*model.APIDistro, error) {
 	return nil, nil
 }

--- a/rest/client/mock.go
+++ b/rest/client/mock.go
@@ -31,6 +31,10 @@ type Mock struct {
 	GetSubscriptionsFail bool
 	MockServiceFlags     *model.APIServiceFlags
 	MockServiceFlagErr   error
+
+	GetRecentVersionsResult   []restmodel.APIVersion
+	GetBuildsForVersionResult []restmodel.APIBuild
+	GetTasksForBuildResult    []restmodel.APITask
 }
 
 func (c *Mock) Close() {}
@@ -263,15 +267,24 @@ func (c *Mock) GetMatchingHosts(context.Context, time.Time, time.Time, string, b
 	return nil, nil
 }
 
-func (c *Mock) GetRecentVersionsForProject(context.Context, string, string) ([]restmodel.APIVersion, error) {
+func (c *Mock) GetRecentVersionsForProject(ctx context.Context, project, branch string, limit int) ([]restmodel.APIVersion, error) {
+	if c.GetRecentVersionsResult != nil {
+		return c.GetRecentVersionsResult, nil
+	}
 	return nil, nil
 }
 
 func (c *Mock) GetBuildsForVersion(ctx context.Context, versionID string) ([]restmodel.APIBuild, error) {
+	if c.GetBuildsForVersionResult != nil {
+		return c.GetBuildsForVersionResult, nil
+	}
 	return nil, nil
 }
 
 func (c *Mock) GetTasksForBuild(ctx context.Context, buildID string) ([]restmodel.APITask, error) {
+	if c.GetTasksForBuildResult != nil {
+		return c.GetTasksForBuildResult, nil
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION
DEVPROD-19992
DEVPROD-19999

### Description
The S&amp;I team wants the main functionality of [the git-co-evg-base CLI](https://github.com/evergreen-ci/git-co-evg-base) to be absorbed into the Evergreen CLI so they can deprecate the tool. Info on how it's used is [here](https://evergreen-ci.github.io/git-co-evg-base/concepts/criteria/).

I decided that the existing `evergreen last-green` command was too limited/specific to be able to handle all the functionality that git-co-evg-base has, so I made a separate `evergreen last-revision` command to generalize/extend it. Most of this change is to port over `evergreen last-green`'s functionality into the new command in a way that's more extensible (like [how git-co-evg-base does it](https://github.com/evergreen-ci/git-co-evg-base/blob/da1912185c0d974aaf690fcc19a76b2f929b05f5/src/goodbase/services/search_service.py#L35)) so we can add more of the git-co-evg-base functionality in later PRs.

I'm also aware that `evergreen last-green` is probably more performant than this command, but in exchange, it's difficult to extend because a lot of criteria that git-co-evg-base supports would be extremely difficult to add to a query (e.g. only find builds with specific passing tasks, treat known failures as successes).

* Add last-revision command.
* Support passing in a build variant regexp + the minimum proportion of the tasks that have to succeed.

### Testing
* Added unit tests.
* Tested manually with evergreen and mongodb-mongo-master to verify that it appeared to return recent and correct revisions with minimum build variant passing thresholds. For example, `evergreen last-revision -p evergreen --regex-variants '^ubuntu2204$' --min-success 1` returned the latest revision where all the ubuntu2204 tasks passed in Evergreen's self-tests.

### Documentation
Documentation is in the CLI.
