### PR TITLE
DEVPROD-17670 Cap the max priority that can be set in YAML

### DIFF
--- a/docs/Project-Configuration/Task-Priority.md
+++ b/docs/Project-Configuration/Task-Priority.md
@@ -23,6 +23,10 @@ one part of the sum. The default priority is 0. Valid priorities are 0-100 for
 standard users, and higher for project admins. -1 will prevent a task from being
 scheduled, e.g., by stepback.
 
+To enforce responsible use of this feature, task priorities cannot be set above 50 in
+the config YAML. If a value above 50 is used, the task will fall back to 50. Higher priorities
+can be set in important circumstances by admins.
+
 Please be conservative when setting high priorities, as this will deprioritize
 other users' tasks relative to yours. Please stay below 50 if the change is not
 high priority.

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -189,19 +189,6 @@ type displayTask struct {
 func (pt *parserTask) name() string   { return pt.Name }
 func (pt *parserTask) tags() []string { return pt.Tags }
 
-func (pt *parserTask) UnmarshalYAML(unmarshal func(any) error) error {
-	type copyType parserTask
-	var copy copyType
-	if err := unmarshal(&copy); err != nil {
-		return err
-	}
-	if copy.Priority > MaxConfigSetPriority {
-		copy.Priority = MaxConfigSetPriority
-	}
-	*pt = parserTask(copy)
-	return nil
-}
-
 // parserDependency represents the intermediary state for referencing dependencies.
 type parserDependency struct {
 	TaskSelector       taskSelector `yaml:",inline"`
@@ -1483,6 +1470,9 @@ func getParserBuildVariantTaskUnit(name string, pt parserTask, bvt parserBVTaskU
 	res.AllowedRequesters = bvt.AllowedRequesters
 	if res.Priority == 0 {
 		res.Priority = pt.Priority
+	}
+	if res.Priority > MaxConfigSetPriority {
+		res.Priority = MaxConfigSetPriority
 	}
 	if res.Patchable == nil {
 		res.Patchable = pt.Patchable

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -36,6 +36,10 @@ const EmptyConfigurationError = "received empty configuration file"
 // to the place where the parser project is accessed.
 const DefaultParserProjectAccessTimeout = 60 * time.Second
 
+// MaxConfigSetPriority represents the highest value for a task's priority a user can set in theit
+// config YAML.
+const MaxConfigSetPriority = 50
+
 // This file contains the infrastructure for turning a YAML project configuration
 // into a usable Project struct. A basic overview of the project parsing process is:
 //
@@ -184,6 +188,19 @@ type displayTask struct {
 // helper methods for task tag evaluations
 func (pt *parserTask) name() string   { return pt.Name }
 func (pt *parserTask) tags() []string { return pt.Tags }
+
+func (pt *parserTask) UnmarshalYAML(unmarshal func(any) error) error {
+	type copyType parserTask
+	var copy copyType
+	if err := unmarshal(&copy); err != nil {
+		return err
+	}
+	if copy.Priority > MaxConfigSetPriority {
+		copy.Priority = MaxConfigSetPriority
+	}
+	*pt = parserTask(copy)
+	return nil
+}
 
 // parserDependency represents the intermediary state for referencing dependencies.
 type parserDependency struct {

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -665,9 +665,9 @@ func TestParserTaskSelectorEvaluation(t *testing.T) {
 					taskDefs,
 					[]BuildVariantTaskUnit{{Name: "white"}}, nil, nil)
 				parserTaskSelectorTaskEval(tse, tgse,
-					parserBVTaskUnits{{Name: "red", Priority: 500}, {Name: ".secondary"}},
+					parserBVTaskUnits{{Name: "red", Priority: 50}, {Name: ".secondary"}},
 					taskDefs,
-					[]BuildVariantTaskUnit{{Name: "red", Priority: 500}, {Name: "orange"}, {Name: "purple"}, {Name: "green"}}, nil, nil)
+					[]BuildVariantTaskUnit{{Name: "red", Priority: 50}, {Name: "orange"}, {Name: "purple"}, {Name: "green"}}, nil, nil)
 				parserTaskSelectorTaskEval(tse, tgse,
 					parserBVTaskUnits{
 						{Name: "orange", Distros: []string{"d1"}},
@@ -693,13 +693,13 @@ func TestParserTaskSelectorEvaluation(t *testing.T) {
 					}, nil, nil)
 				parserTaskSelectorTaskEval(tse, tgse,
 					parserBVTaskUnits{
-						{Name: "red", Priority: 100},
-						{Name: "!.warm .secondary", Priority: 100}},
+						{Name: "red", Priority: 10},
+						{Name: "!.warm .secondary", Priority: 10}},
 					taskDefs,
 					[]BuildVariantTaskUnit{
-						{Name: "red", Priority: 100},
-						{Name: "purple", Priority: 100},
-						{Name: "green", Priority: 100}}, nil, nil)
+						{Name: "red", Priority: 10},
+						{Name: "purple", Priority: 10},
+						{Name: "green", Priority: 10}}, nil, nil)
 			})
 			Convey("should ignore selectors that do not select any tasks if another does select a task", func() {
 				parserTaskSelectorTaskEval(tse, tgse,

--- a/scripts/setup-credentials.sh
+++ b/scripts/setup-credentials.sh
@@ -1,86 +1,10 @@
 #!/bin/bash
 
-# This script sets up the SETTINGS_OVERRIDE file used as the admin settings when
-# running an integration test that requires secret credentials.
-
-set -o errexit
-
-echo "building creds file!"
-
-cat > creds.yml << EOF
-database:
-  url: "mongodb://localhost:27017"
-  db: "mci"
-  write_concern:
-    wmode: majority
-
-domain_name: "evergreen.local"
-
-configdir: "config_test"
-
-api:
-  url: "http://localhost:9090"
-  github_webhook_secret: "test"
-ui:
-  secret: "secret for UI"
-  defaultproject: "mci"
-  url: "http://localhost:9090"
-
-notify:
-  smtp:
-    from: "mci-notifications+test@mongodb.com"
-    server: "localhost"
-    port: 25
-    admin_email:
-      - "mci@10gen.com"
-
-
-jira:
-  host: "$JIRA_SERVER"
-  personal_access_token: "$JIRA_PERSONAL_ACCESS_TOKEN"
-
-providers:
-  aws:
-    parser_project:
-      bucket: "evergreen-projects-testing"
-      prefix: "$PARSER_PROJECT_S3_PREFIX"
-      generated_json_prefix: $GENERATED_JSON_S3_PREFIX
-    ec2_keys:
-      - region: "us-east-1"
-        key: "$AWS_KEY"
-        secret: "$AWS_SECRET"
-
-runtime_environments:
-  base_url: "$RUNTIME_ENVIRONMENTS_BASE_URL"
-  api_key: "$RUNTIME_ENVIRONMENTS_API_KEY"
-
-auth:
-    naive:
-      users:
-      - username: "mci-nonprod"
-        password: "change me"
-        display_name: "MCI Nonprod"
-    github:
-      app_id: $GITHUB_APP_ID
-      default_owner: "evergreen-ci"
-      default_repo: "evergreen"
-
-github_pr_creator_org: "10gen"
-
-expansions:
-  papertrail_key_id: $PAPERTRAIL_KEY_ID
-  papertrail_secret_key: $PAPERTRAIL_SECRET_KEY
-  aws_key: $AWS_ACCESS_KEY_ID
-  aws_secret: $AWS_SECRET_ACCESS_KEY
-  aws_token: $AWS_SESSION_TOKEN
-  bucket: evergreen-integration-testing
-  # Do not edit below this line
-  github_app_key: |
-EOF
-
-# Write the GitHub app key to a file for easier formatting
-echo "$GITHUB_APP_KEY" > app_key.txt
-# Linux and MacOS friendly command to add 4 spaces to the start of each line
-sed -i'' -e 's/^/    /' app_key.txt
-# Append the formatted GitHub app key to the creds.yml file
-cat app_key.txt >> creds.yml
+(
+    for cluster in "staging" "prod"; do
+        export KUBECONFIG=~/.kube/config.$cluster
+        kanopy-oidc kube setup $cluster > ~/.kube/config.$cluster
+        kanopy-oidc kube login
+        kubectl config set-context $(kubectl config current-context) --namespace=devprod-evergreen
+    done
+)

--- a/scripts/setup-credentials.sh
+++ b/scripts/setup-credentials.sh
@@ -1,10 +1,86 @@
 #!/bin/bash
 
-(
-    for cluster in "staging" "prod"; do
-        export KUBECONFIG=~/.kube/config.$cluster
-        kanopy-oidc kube setup $cluster > ~/.kube/config.$cluster
-        kanopy-oidc kube login
-        kubectl config set-context $(kubectl config current-context) --namespace=devprod-evergreen
-    done
-)
+# This script sets up the SETTINGS_OVERRIDE file used as the admin settings when
+# running an integration test that requires secret credentials.
+
+set -o errexit
+
+echo "building creds file!"
+
+cat > creds.yml << EOF
+database:
+  url: "mongodb://localhost:27017"
+  db: "mci"
+  write_concern:
+    wmode: majority
+
+domain_name: "evergreen.local"
+
+configdir: "config_test"
+
+api:
+  url: "http://localhost:9090"
+  github_webhook_secret: "test"
+ui:
+  secret: "secret for UI"
+  defaultproject: "mci"
+  url: "http://localhost:9090"
+
+notify:
+  smtp:
+    from: "mci-notifications+test@mongodb.com"
+    server: "localhost"
+    port: 25
+    admin_email:
+      - "mci@10gen.com"
+
+
+jira:
+  host: "$JIRA_SERVER"
+  personal_access_token: "$JIRA_PERSONAL_ACCESS_TOKEN"
+
+providers:
+  aws:
+    parser_project:
+      bucket: "evergreen-projects-testing"
+      prefix: "$PARSER_PROJECT_S3_PREFIX"
+      generated_json_prefix: $GENERATED_JSON_S3_PREFIX
+    ec2_keys:
+      - region: "us-east-1"
+        key: "$AWS_KEY"
+        secret: "$AWS_SECRET"
+
+runtime_environments:
+  base_url: "$RUNTIME_ENVIRONMENTS_BASE_URL"
+  api_key: "$RUNTIME_ENVIRONMENTS_API_KEY"
+
+auth:
+    naive:
+      users:
+      - username: "mci-nonprod"
+        password: "change me"
+        display_name: "MCI Nonprod"
+    github:
+      app_id: $GITHUB_APP_ID
+      default_owner: "evergreen-ci"
+      default_repo: "evergreen"
+
+github_pr_creator_org: "10gen"
+
+expansions:
+  papertrail_key_id: $PAPERTRAIL_KEY_ID
+  papertrail_secret_key: $PAPERTRAIL_SECRET_KEY
+  aws_key: $AWS_ACCESS_KEY_ID
+  aws_secret: $AWS_SECRET_ACCESS_KEY
+  aws_token: $AWS_SESSION_TOKEN
+  bucket: evergreen-integration-testing
+  # Do not edit below this line
+  github_app_key: |
+EOF
+
+# Write the GitHub app key to a file for easier formatting
+echo "$GITHUB_APP_KEY" > app_key.txt
+# Linux and MacOS friendly command to add 4 spaces to the start of each line
+sed -i'' -e 's/^/    /' app_key.txt
+# Append the formatted GitHub app key to the creds.yml file
+cat app_key.txt >> creds.yml

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -2280,7 +2280,7 @@ func checkTasks(project *model.Project) ValidationErrors {
 				},
 			)
 		}
-		if task.Priority >= model.MaxConfigSetPriority {
+		if task.Priority > model.MaxConfigSetPriority {
 			errs = append(errs,
 				ValidationError{
 					Message: fmt.Sprintf("task '%s' has been set at or above %d priority, in YAML, will default priority to %d",

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -2280,7 +2280,7 @@ func checkTasks(project *model.Project) ValidationErrors {
 				},
 			)
 		}
-		if task.Priority >= 50 {
+		if task.Priority >= model.MaxConfigSetPriority {
 			errs = append(errs,
 				ValidationError{
 					Message: fmt.Sprintf("task '%s' has been set at or above %d priority, in YAML, will default priority to %d",

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1472,6 +1472,21 @@ func checkBVBatchTimes(buildVariant *model.BuildVariant) ValidationErrors {
 	return errs
 }
 
+func checkBVTaskPriority(buildVariant *model.BuildVariant) ValidationErrors {
+	errs := ValidationErrors{}
+	for _, t := range buildVariant.Tasks {
+		if t.Priority > model.MaxConfigSetPriority {
+			errs = append(errs,
+				ValidationError{
+					Message: fmt.Sprintf("task '%s' has been set at or above %d priority, in YAML, will default priority to %d",
+						t.Name, model.MaxConfigSetPriority, model.MaxConfigSetPriority),
+					Level: Warning,
+				})
+		}
+	}
+	return errs
+}
+
 func validateDisplayTaskNames(project *model.Project) ValidationErrors {
 	errs := ValidationErrors{}
 
@@ -2355,6 +2370,7 @@ func checkBuildVariants(project *model.Project) ValidationErrors {
 
 		errs = append(errs, checkBVNames(&buildVariant)...)
 		errs = append(errs, checkBVBatchTimes(&buildVariant)...)
+		errs = append(errs, checkBVTaskPriority(&buildVariant)...)
 	}
 
 	for k, v := range displayNames {

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -2280,6 +2280,15 @@ func checkTasks(project *model.Project) ValidationErrors {
 				},
 			)
 		}
+		if task.Priority >= 50 {
+			errs = append(errs,
+				ValidationError{
+					Message: fmt.Sprintf("task '%s' has been set at or above %d priority, in YAML, will default priority to %d",
+						task.Name, model.MaxConfigSetPriority, model.MaxConfigSetPriority),
+					Level: Warning,
+				},
+			)
+		}
 		if project.ExecTimeoutSecs == 0 && task.ExecTimeoutSecs == 0 && !execTimeoutWarningAdded {
 			errs = append(errs,
 				ValidationError{


### PR DESCRIPTION
DEVPROD-17670

### Description
People have been abusing this feature by setting 100k+ priority, so enforcing a maximum level of 50 when set via config. Implemented a silent fallback so as not to break anyone's build who is currently doing this.

### Testing
Tested in staging.
### Documentation
Updated docs. Will also send out some comms on approval.