### PR TITLE
DEVPROD-20298 Add cost data to the distro struct

### DIFF
--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -46,6 +46,11 @@ var (
 	// ImageID is not equivalent to AMI. It is the identifier of the base image for the distro.
 	ImageIDKey          = bsonutil.MustHaveTag(Distro{}, "ImageID")
 	SingleTaskDistroKey = bsonutil.MustHaveTag(Distro{}, "SingleTaskDistro")
+	CostDataKey         = bsonutil.MustHaveTag(Distro{}, "CostData")
+
+	// bson fields for the CostData struct
+	CostDataOnDemandRateKey    = bsonutil.MustHaveTag(CostData{}, "OnDemandRate")
+	CostDataSavingsPlanRateKey = bsonutil.MustHaveTag(CostData{}, "SavingsPlanRate")
 
 	hostAllocatorMaxHostsKey         = bsonutil.MustHaveTag(HostAllocatorSettings{}, "MaximumHosts")
 	hostAllocatorAutoTuneMaxHostsKey = bsonutil.MustHaveTag(HostAllocatorSettings{}, "AutoTuneMaximumHosts")

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -66,6 +66,9 @@ type Distro struct {
 
 	// ExecUser is the user to run shell.exec and subprocess.exec processes as. If unset, processes are run as the regular distro User.
 	ExecUser string `bson:"exec_user,omitempty" json:"exec_user,omitempty" mapstructure:"exec_user,omitempty"`
+
+	// Cost data for pricing calculations
+	CostData CostData `bson:"cost_data,omitempty" json:"cost_data,omitempty" mapstructure:"cost_data,omitempty"`
 }
 
 // DistroData is the same as a distro, with the only difference being that all
@@ -969,4 +972,10 @@ func (d *Distro) SetMaxHosts(ctx context.Context, newMaxHosts int) error {
 	d.HostAllocatorSettings.MaximumHosts = newMaxHosts
 
 	return nil
+}
+
+// CostData represents cost information for a distro
+type CostData struct {
+	OnDemandRate    float64 `bson:"on_demand_rate,omitempty" json:"on_demand_rate,omitempty" mapstructure:"on_demand_rate,omitempty"`
+	SavingsPlanRate float64 `bson:"savings_plan_rate,omitempty" json:"savings_plan_rate,omitempty" mapstructure:"savings_plan_rate,omitempty"`
 }

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -711,3 +711,34 @@ func TestGetImageIDFromDistro(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "ubuntu1804", found)
 }
+
+func TestCostData(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	assert.NoError(t, db.Clear(Collection))
+
+	// Test distro with cost data
+	d := &Distro{
+		Id: "cost-test-distro",
+		CostData: CostData{
+			OnDemandRate:    0.25,
+			SavingsPlanRate: 0.15,
+		},
+	}
+	assert.NoError(t, d.Insert(ctx))
+
+	found, err := FindOneId(ctx, d.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, 0.25, found.CostData.OnDemandRate)
+	assert.Equal(t, 0.15, found.CostData.SavingsPlanRate)
+
+	// Test without cost data (should default to zero values)
+	d2 := &Distro{Id: "cost-test-distro-2"}
+	assert.NoError(t, d2.Insert(ctx))
+
+	found2, err := FindOneId(ctx, d2.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, 0.0, found2.CostData.OnDemandRate)
+	assert.Equal(t, 0.0, found2.CostData.SavingsPlanRate)
+}

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -334,6 +334,23 @@ func (s *APIIceCreamSettings) ToService() distro.IceCreamSettings {
 	}
 }
 
+type APICostData struct {
+	OnDemandRate    float64 `json:"on_demand_rate"`
+	SavingsPlanRate float64 `json:"savings_plan_rate"`
+}
+
+func (s *APICostData) BuildFromService(settings distro.CostData) {
+	s.OnDemandRate = settings.OnDemandRate
+	s.SavingsPlanRate = settings.SavingsPlanRate
+}
+
+func (s *APICostData) ToService() distro.CostData {
+	return distro.CostData{
+		OnDemandRate:    s.OnDemandRate,
+		SavingsPlanRate: s.SavingsPlanRate,
+	}
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 //
 // APIDistro is the model to be returned by the API whenever distros are fetched
@@ -373,6 +390,7 @@ type APIDistro struct {
 	SingleTaskDistro      bool                     `json:"single_task_distro"`
 	ImageID               *string                  `json:"image_id"`
 	ExecUser              *string                  `json:"exec_user"`
+	CostData              APICostData              `json:"cost_data"`
 }
 
 // BuildFromService converts from service level distro.Distro to an APIDistro
@@ -439,6 +457,10 @@ func (apiDistro *APIDistro) BuildFromService(d distro.Distro) {
 	bootstrapSettings := APIBootstrapSettings{}
 	bootstrapSettings.BuildFromService(d.BootstrapSettings)
 	apiDistro.BootstrapSettings = bootstrapSettings
+
+	costData := APICostData{}
+	costData.BuildFromService(d.CostData)
+	apiDistro.CostData = costData
 }
 
 // ToService returns a service layer distro using the data from APIDistro
@@ -484,6 +506,7 @@ func (apiDistro *APIDistro) ToService() *distro.Distro {
 
 	d.IsVirtualWorkstation = apiDistro.IsVirtualWorkstation
 	d.IsCluster = apiDistro.IsCluster
+	d.CostData = apiDistro.CostData.ToService()
 
 	return &d
 }

--- a/rest/route/distro_test.go
+++ b/rest/route/distro_test.go
@@ -1520,3 +1520,21 @@ func (s *distroCopySuite) TestRunInvalidCopyNonexistentID() {
 	err := (resp.Data()).(gimlet.ErrorResponse)
 	s.Equal("distro 'nonexistent' not found", err.Message)
 }
+
+func (s *DistroPatchSetupByIDSuite) TestRunValidCostData() {
+	ctx := context.Background()
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "me"})
+	json := []byte(`{"cost_data": {"on_demand_rate": 0.25, "savings_plan_rate": 0.15}}`)
+	h := s.rm.(*distroIDPatchHandler)
+	h.distroID = "fedora8"
+	h.body = json
+
+	resp := s.rm.Run(ctx)
+	s.NotNil(resp.Data())
+	s.Equal(http.StatusOK, resp.Status())
+
+	apiDistro, ok := (resp.Data()).(*restModel.APIDistro)
+	s.Require().True(ok)
+	s.Equal(0.25, apiDistro.CostData.OnDemandRate)
+	s.Equal(0.15, apiDistro.CostData.SavingsPlanRate)
+}


### PR DESCRIPTION
DEVPROD-20298

### Description
This will allow us to calculate costs based on task runtime and the distro rates 

### Testing
Added tests 