### PR TITLE
DEVPROD-20229: Add weightedio disk stat in linux machines to honeycomb

### DIFF
--- a/agent/otel.go
+++ b/agent/otel.go
@@ -237,7 +237,7 @@ func addMemoryMetrics(meter metric.Meter) error {
 func isWeightedIOSupported() bool {
 	switch runtime.GOOS {
 	case "linux":
-		return true // Linux(since Linux 2.5.69) supports WeightedIO in /proc/diskstats
+		return true // Linux(since 2.5.69) supports WeightedIO in /proc/diskstats
 	default:
 		return false // Windows and macOS typically don't provide this metric
 	}


### PR DESCRIPTION
DEVPROD-20229

### Description
Having weightedIO will help us in getting a better sense of the true time spent waiting on EBS i/o operations. This in turn would help us in understanding if a task is potentially io bound. 

### Testing
add a description of how you tested it

### Documentation
Remember to add or edit docs in the docs/ directory if relevant.
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
