### PR TITLE
DEVPROD-19994: support option for required successful tasks

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-07-29"
+	ClientVersion = "2025-08-04"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/last_revision.go
+++ b/operations/last_revision.go
@@ -34,7 +34,6 @@ func LastRevision() cli.Command {
 			cli.Float64Flag{
 				Name:  joinFlagNames(minSuccessProportionFlagName),
 				Usage: "minimum proportion of successful tasks (between 0 and 1 inclusive) in a build for it to be considered a match",
-				Value: 1,
 			},
 			cli.StringSliceFlag{
 				Name:  joinFlagNames(successfulTasks, "t"),

--- a/operations/last_revision.go
+++ b/operations/last_revision.go
@@ -201,9 +201,6 @@ func (c *lastRevisionCriteria) check(info lastRevisionBuildInfo) bool {
 		return false
 	}
 
-	// kim; TODO: add tests for successful tasks criteria
-	// kim: TODO: test that nonexistent tasks always pass this check since
-	// they're not in the version.
 	allTasksSet := make(map[string]model.APITask, len(info.allTasks))
 	for _, t := range info.allTasks {
 		allTasksSet[utility.FromStringPtr(t.DisplayName)] = t

--- a/operations/last_revision.go
+++ b/operations/last_revision.go
@@ -52,18 +52,19 @@ func LastRevision() cli.Command {
 			regexpBVs := c.StringSlice(regexpVariantsFlagName)
 			minSuccessProp := c.Float64(minSuccessProportionFlagName)
 			successfulTasks := c.StringSlice(successfulTasks)
+
 			criteria, err := newLastRevisionCriteria(projectID, regexpBVs, minSuccessProp, successfulTasks)
 			if err != nil {
 				return errors.Wrap(err, "building last revision options")
 			}
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
 			conf, err := NewClientSettings(confPath)
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			client, err := conf.setupRestCommunicator(ctx, true)
 			if err != nil {
@@ -151,6 +152,9 @@ func newLastRevisionCriteria(project string, bvRegexpsAsStr []string, minSuccess
 	}
 	if minSuccessProportion < 0 || minSuccessProportion > 1 {
 		return nil, errors.New("minimum success proportion must be between 0 and 1 inclusive")
+	}
+	if project == "" {
+		return nil, errors.New("must specify a project")
 	}
 
 	bvRegexps := make([]regexp.Regexp, 0, len(bvRegexpsAsStr))

--- a/operations/last_revision.go
+++ b/operations/last_revision.go
@@ -38,7 +38,7 @@ func LastRevision() cli.Command {
 			},
 			cli.StringSliceFlag{
 				Name:  joinFlagNames(successfulTasks, "t"),
-				Usage: "names of tasks that, if present in the builds under consideration, must have succeeded",
+				Usage: "names of tasks that, if present in the builds, must have succeeded",
 			},
 		),
 		Before: mergeBeforeFuncs(autoUpdateCLI, setPlainLogger, func(c *cli.Context) error {

--- a/operations/last_revision.go
+++ b/operations/last_revision.go
@@ -21,6 +21,7 @@ func LastRevision() cli.Command {
 	const (
 		regexpVariantsFlagName       = "regex-variants"
 		minSuccessProportionFlagName = "min-success"
+		successfulTasks              = "successful-tasks"
 	)
 	return cli.Command{
 		Name:  "last-revision",
@@ -28,12 +29,18 @@ func LastRevision() cli.Command {
 		Flags: addProjectFlag(
 			cli.StringSliceFlag{
 				Name:  joinFlagNames(regexpVariantsFlagName, "rv"),
-				Usage: "regexps for build variant names",
-			}, cli.Float64Flag{
+				Usage: "regexps for build variant names to check",
+			},
+			cli.Float64Flag{
 				Name:  joinFlagNames(minSuccessProportionFlagName),
 				Usage: "minimum proportion of successful tasks (between 0 and 1 inclusive) in a build for it to be considered a match",
 				Value: 1,
-			}),
+			},
+			cli.StringSliceFlag{
+				Name:  joinFlagNames(successfulTasks, "t"),
+				Usage: "names of tasks that, if present in the builds under consideration, must have succeeded",
+			},
+		),
 		Before: mergeBeforeFuncs(autoUpdateCLI, setPlainLogger, func(c *cli.Context) error {
 			if len(c.StringSlice(regexpVariantsFlagName)) == 0 {
 				return errors.New("must specify at least one build variant regexp")
@@ -42,7 +49,11 @@ func LastRevision() cli.Command {
 		}),
 		Action: func(c *cli.Context) error {
 			confPath := c.Parent().String(confFlagName)
-			criteria, err := newLastRevisionCriteria(c.String(projectFlagName), c.StringSlice(regexpVariantsFlagName), c.Float64(minSuccessProportionFlagName))
+			projectID := c.String(projectFlagName)
+			regexpBVs := c.StringSlice(regexpVariantsFlagName)
+			minSuccessProp := c.Float64(minSuccessProportionFlagName)
+			successfulTasks := c.StringSlice(successfulTasks)
+			criteria, err := newLastRevisionCriteria(projectID, regexpBVs, minSuccessProp, successfulTasks)
 			if err != nil {
 				return errors.Wrap(err, "building last revision options")
 			}
@@ -90,8 +101,8 @@ type lastRevisionBuildInfo struct {
 	versionID string
 	// buildVariant is the name of the build variant for this build.
 	buildVariant string
-	// numTasks is the total number of tasks in the build.
-	numTasks int
+	// allTasks is the set of all tasks in the build.
+	allTasks []model.APITask
 	// numSuccessfulTasks is the number of tasks in the build that succeeded.
 	numSuccessfulTasks int
 }
@@ -107,7 +118,7 @@ func newLastRevisionBuildInfo(b model.APIBuild, buildTasks []model.APITask) last
 		buildID:            utility.FromStringPtr(b.Id),
 		buildVariant:       utility.FromStringPtr(b.BuildVariant),
 		versionID:          utility.FromStringPtr(b.Version),
-		numTasks:           len(buildTasks),
+		allTasks:           buildTasks,
 		numSuccessfulTasks: numSuccessfulTasks,
 	}
 }
@@ -115,7 +126,7 @@ func newLastRevisionBuildInfo(b model.APIBuild, buildTasks []model.APITask) last
 // successProportion calculates the proportion of successful tasks out of all
 // the tasks in the build.
 func (i *lastRevisionBuildInfo) successProportion() float64 {
-	return float64(i.numSuccessfulTasks) / float64(i.numTasks)
+	return float64(i.numSuccessfulTasks) / float64(len(i.allTasks))
 }
 
 // lastRevisionCriteria defines the user criteria for selecting a suitable last
@@ -130,9 +141,12 @@ type lastRevisionCriteria struct {
 	// minSuccessProportion is a criterion for the minimum proportion of tasks
 	// in a matching build that must succeed.
 	minSuccessProportion float64
+	// successfulTasks is a criterion for the list of task names that must have
+	// succeeded in the build.
+	successfulTasks []string
 }
 
-func newLastRevisionCriteria(project string, bvRegexpsAsStr []string, minSuccessProportion float64) (*lastRevisionCriteria, error) {
+func newLastRevisionCriteria(project string, bvRegexpsAsStr []string, minSuccessProportion float64, successfulTasks []string) (*lastRevisionCriteria, error) {
 	if len(bvRegexpsAsStr) == 0 {
 		return nil, errors.New("must specify at least one build variant regexp for criteria")
 	}
@@ -151,6 +165,7 @@ func newLastRevisionCriteria(project string, bvRegexpsAsStr []string, minSuccess
 
 	return &lastRevisionCriteria{
 		project:              project,
+		successfulTasks:      successfulTasks,
 		buildVariantRegexp:   bvRegexps,
 		minSuccessProportion: minSuccessProportion,
 	}, nil
@@ -185,6 +200,33 @@ func (c *lastRevisionCriteria) check(info lastRevisionBuildInfo) bool {
 			"success_proportion":     info.successProportion(),
 		})
 		return false
+	}
+
+	// kim; TODO: add tests for successful tasks criteria
+	// kim: TODO: test that nonexistent tasks always pass this check since
+	// they're not in the version.
+	allTasksSet := make(map[string]model.APITask, len(info.allTasks))
+	for _, t := range info.allTasks {
+		allTasksSet[utility.FromStringPtr(t.DisplayName)] = t
+	}
+	for _, taskName := range c.successfulTasks {
+		tsk, ok := allTasksSet[taskName]
+		if !ok {
+			// The task does not run in this build, so the criteria does not
+			// apply.
+			continue
+		}
+		if status := utility.FromStringPtr(tsk.Status); status != evergreen.TaskSucceeded {
+			grip.Debug(message.Fields{
+				"message":                  "build has required task but it was not successful",
+				"version_id":               info.versionID,
+				"build_id":                 info.buildID,
+				"build_variant":            info.buildVariant,
+				"required_successful_task": taskName,
+				"task_status":              status,
+			})
+			return false
+		}
 	}
 
 	return true

--- a/operations/last_revision_test.go
+++ b/operations/last_revision_test.go
@@ -101,6 +101,83 @@ func TestLastRevisionCheckBuilds(t *testing.T) {
 			require.NoError(t, err)
 			assert.True(t, passesCriteria)
 		},
+		"PassesCriteriaWithRequiredSuccessfulTaskInBuild": func(t *testing.T, c *client.Mock) {
+			builds := []model.APIBuild{
+				{
+					Id:           utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+				},
+			}
+			c.GetTasksForBuildResult = []model.APITask{
+				{
+					Id:           utility.ToStringPtr("t1"),
+					DisplayName:  utility.ToStringPtr("Task 1"),
+					BuildId:      utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+					Status:       utility.ToStringPtr(evergreen.TaskSucceeded),
+				},
+			}
+			criteria := lastRevisionCriteria{
+				project:            "test_project",
+				buildVariantRegexp: []regexp.Regexp{*regexp.MustCompile("bv1")},
+				successfulTasks:    []string{"Task 1"},
+			}
+
+			passesCriteria, err := checkBuildsPassCriteria(t.Context(), c, builds, criteria)
+			require.NoError(t, err)
+			assert.True(t, passesCriteria)
+		},
+		"PassesCriteriaWithRequiredSuccessfulTaskNotInBuild": func(t *testing.T, c *client.Mock) {
+			builds := []model.APIBuild{
+				{
+					Id:           utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+				},
+			}
+			c.GetTasksForBuildResult = []model.APITask{
+				{
+					Id:           utility.ToStringPtr("t1"),
+					BuildId:      utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+					Status:       utility.ToStringPtr(evergreen.TaskSucceeded),
+				},
+			}
+			criteria := lastRevisionCriteria{
+				project:            "test_project",
+				buildVariantRegexp: []regexp.Regexp{*regexp.MustCompile("bv1")},
+				successfulTasks:    []string{"nonexistent"},
+			}
+
+			passesCriteria, err := checkBuildsPassCriteria(t.Context(), c, builds, criteria)
+			require.NoError(t, err)
+			assert.True(t, passesCriteria)
+		},
+		"DoesNotPassCriteriaWithRequiredSuccessfulTaskFailingInBuild": func(t *testing.T, c *client.Mock) {
+			builds := []model.APIBuild{
+				{
+					Id:           utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+				},
+			}
+			c.GetTasksForBuildResult = []model.APITask{
+				{
+					Id:           utility.ToStringPtr("t1"),
+					DisplayName:  utility.ToStringPtr("Task 1"),
+					BuildId:      utility.ToStringPtr("b1"),
+					BuildVariant: utility.ToStringPtr("bv1"),
+					Status:       utility.ToStringPtr(evergreen.TaskFailed),
+				},
+			}
+			criteria := lastRevisionCriteria{
+				project:            "test_project",
+				buildVariantRegexp: []regexp.Regexp{*regexp.MustCompile("bv1")},
+				successfulTasks:    []string{"Task 1"},
+			}
+
+			passesCriteria, err := checkBuildsPassCriteria(t.Context(), c, builds, criteria)
+			require.NoError(t, err)
+			assert.False(t, passesCriteria)
+		},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			tCase(t, &client.Mock{})


### PR DESCRIPTION
DEVPROD-19994

### Description
git-co-evg-base allows you to find a commit version where, if a task appears in the build variants the user is interested in, that task must succeed. This is for people who want to avoid picking revisions that have a particular failing task.

* Add option to require specific task names to succeed.
* Add check to ensure a project is given.

### Testing
* Added unit tests.
* Tested manually to verify that `evergreen last-revision --rv <bv_regexp> --successful-tasks <task_name>` returned projects

### Documentation
Added documentation to the CLI.