### PR TITLE
DEVPROD-17670 Cap max priority set in YAML

### DIFF
--- a/docs/Project-Configuration/Task-Priority.md
+++ b/docs/Project-Configuration/Task-Priority.md
@@ -23,6 +23,10 @@ one part of the sum. The default priority is 0. Valid priorities are 0-100 for
 standard users, and higher for project admins. -1 will prevent a task from being
 scheduled, e.g., by stepback.
 
+To enforce responsible use of this feature, task priorities cannot be set above 50 in
+the config YAML. If a value above 50 is used, the task will fall back to 50. Higher priorities
+can be set in important circumstances by admins.
+
 Please be conservative when setting high priorities, as this will deprioritize
 other users' tasks relative to yours. Please stay below 50 if the change is not
 high priority.

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -36,6 +36,10 @@ const EmptyConfigurationError = "received empty configuration file"
 // to the place where the parser project is accessed.
 const DefaultParserProjectAccessTimeout = 60 * time.Second
 
+// MaxConfigSetPriority represents the highest value for a task's priority a user can set in theit
+// config YAML.
+const MaxConfigSetPriority = 50
+
 // This file contains the infrastructure for turning a YAML project configuration
 // into a usable Project struct. A basic overview of the project parsing process is:
 //
@@ -1469,6 +1473,9 @@ func getParserBuildVariantTaskUnit(name string, pt parserTask, bvt parserBVTaskU
 	res.AllowedRequesters = bvt.AllowedRequesters
 	if res.Priority == 0 {
 		res.Priority = pt.Priority
+	}
+	if res.Priority > MaxConfigSetPriority {
+		res.Priority = MaxConfigSetPriority
 	}
 	if res.Patchable == nil {
 		res.Patchable = pt.Patchable

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -665,9 +665,9 @@ func TestParserTaskSelectorEvaluation(t *testing.T) {
 					taskDefs,
 					[]BuildVariantTaskUnit{{Name: "white"}}, nil, nil)
 				parserTaskSelectorTaskEval(tse, tgse,
-					parserBVTaskUnits{{Name: "red", Priority: 500}, {Name: ".secondary"}},
+					parserBVTaskUnits{{Name: "red", Priority: 50}, {Name: ".secondary"}},
 					taskDefs,
-					[]BuildVariantTaskUnit{{Name: "red", Priority: 500}, {Name: "orange"}, {Name: "purple"}, {Name: "green"}}, nil, nil)
+					[]BuildVariantTaskUnit{{Name: "red", Priority: 50}, {Name: "orange"}, {Name: "purple"}, {Name: "green"}}, nil, nil)
 				parserTaskSelectorTaskEval(tse, tgse,
 					parserBVTaskUnits{
 						{Name: "orange", Distros: []string{"d1"}},
@@ -693,13 +693,13 @@ func TestParserTaskSelectorEvaluation(t *testing.T) {
 					}, nil, nil)
 				parserTaskSelectorTaskEval(tse, tgse,
 					parserBVTaskUnits{
-						{Name: "red", Priority: 100},
-						{Name: "!.warm .secondary", Priority: 100}},
+						{Name: "red", Priority: 10},
+						{Name: "!.warm .secondary", Priority: 10}},
 					taskDefs,
 					[]BuildVariantTaskUnit{
-						{Name: "red", Priority: 100},
-						{Name: "purple", Priority: 100},
-						{Name: "green", Priority: 100}}, nil, nil)
+						{Name: "red", Priority: 10},
+						{Name: "purple", Priority: 10},
+						{Name: "green", Priority: 10}}, nil, nil)
 			})
 			Convey("should ignore selectors that do not select any tasks if another does select a task", func() {
 				parserTaskSelectorTaskEval(tse, tgse,

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1472,6 +1472,21 @@ func checkBVBatchTimes(buildVariant *model.BuildVariant) ValidationErrors {
 	return errs
 }
 
+func checkBVTaskPriority(buildVariant *model.BuildVariant) ValidationErrors {
+	errs := ValidationErrors{}
+	for _, t := range buildVariant.Tasks {
+		if t.Priority > model.MaxConfigSetPriority {
+			errs = append(errs,
+				ValidationError{
+					Message: fmt.Sprintf("task '%s' has been set at or above %d priority, in YAML, will default priority to %d",
+						t.Name, model.MaxConfigSetPriority, model.MaxConfigSetPriority),
+					Level: Warning,
+				})
+		}
+	}
+	return errs
+}
+
 func validateDisplayTaskNames(project *model.Project) ValidationErrors {
 	errs := ValidationErrors{}
 
@@ -2280,6 +2295,15 @@ func checkTasks(project *model.Project) ValidationErrors {
 				},
 			)
 		}
+		if task.Priority > model.MaxConfigSetPriority {
+			errs = append(errs,
+				ValidationError{
+					Message: fmt.Sprintf("task '%s' has been set at or above %d priority, in YAML, will default priority to %d",
+						task.Name, model.MaxConfigSetPriority, model.MaxConfigSetPriority),
+					Level: Warning,
+				},
+			)
+		}
 		if project.ExecTimeoutSecs == 0 && task.ExecTimeoutSecs == 0 && !execTimeoutWarningAdded {
 			errs = append(errs,
 				ValidationError{
@@ -2346,6 +2370,7 @@ func checkBuildVariants(project *model.Project) ValidationErrors {
 
 		errs = append(errs, checkBVNames(&buildVariant)...)
 		errs = append(errs, checkBVBatchTimes(&buildVariant)...)
+		errs = append(errs, checkBVTaskPriority(&buildVariant)...)
 	}
 
 	for k, v := range displayNames {

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1472,6 +1472,21 @@ func checkBVBatchTimes(buildVariant *model.BuildVariant) ValidationErrors {
 	return errs
 }
 
+func checkBVTaskPriority(buildVariant *model.BuildVariant) ValidationErrors {
+	errs := ValidationErrors{}
+	for _, t := range buildVariant.Tasks {
+		if t.Priority > model.MaxConfigSetPriority {
+			errs = append(errs,
+				ValidationError{
+					Message: fmt.Sprintf("task '%s' has been set at or above %d priority, in YAML, will default priority to %d",
+						t.Name, model.MaxConfigSetPriority, model.MaxConfigSetPriority),
+					Level: Notice,
+				})
+		}
+	}
+	return errs
+}
+
 func validateDisplayTaskNames(project *model.Project) ValidationErrors {
 	errs := ValidationErrors{}
 
@@ -2280,6 +2295,15 @@ func checkTasks(project *model.Project) ValidationErrors {
 				},
 			)
 		}
+		if task.Priority > model.MaxConfigSetPriority {
+			errs = append(errs,
+				ValidationError{
+					Message: fmt.Sprintf("task '%s' has been set at or above %d priority, in YAML, will default priority to %d",
+						task.Name, model.MaxConfigSetPriority, model.MaxConfigSetPriority),
+					Level: Notice,
+				},
+			)
+		}
 		if project.ExecTimeoutSecs == 0 && task.ExecTimeoutSecs == 0 && !execTimeoutWarningAdded {
 			errs = append(errs,
 				ValidationError{
@@ -2346,6 +2370,7 @@ func checkBuildVariants(project *model.Project) ValidationErrors {
 
 		errs = append(errs, checkBVNames(&buildVariant)...)
 		errs = append(errs, checkBVBatchTimes(&buildVariant)...)
+		errs = append(errs, checkBVTaskPriority(&buildVariant)...)
 	}
 
 	for k, v := range displayNames {

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1478,7 +1478,7 @@ func checkBVTaskPriority(buildVariant *model.BuildVariant) ValidationErrors {
 		if t.Priority > model.MaxConfigSetPriority {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("task '%s' has been set at or above %d priority, in YAML, will default priority to %d",
+					Message: fmt.Sprintf("task '%s' has been set above %d priority, in YAML, will default priority to %d",
 						t.Name, model.MaxConfigSetPriority, model.MaxConfigSetPriority),
 					Level: Notice,
 				})

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -2298,7 +2298,7 @@ func checkTasks(project *model.Project) ValidationErrors {
 		if task.Priority > model.MaxConfigSetPriority {
 			errs = append(errs,
 				ValidationError{
-					Message: fmt.Sprintf("task '%s' has been set at or above %d priority, in YAML, will default priority to %d",
+					Message: fmt.Sprintf("task '%s' has been set above %d priority, in YAML, will default priority to %d",
 						task.Name, model.MaxConfigSetPriority, model.MaxConfigSetPriority),
 					Level: Notice,
 				},

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1472,21 +1472,6 @@ func checkBVBatchTimes(buildVariant *model.BuildVariant) ValidationErrors {
 	return errs
 }
 
-func checkBVTaskPriority(buildVariant *model.BuildVariant) ValidationErrors {
-	errs := ValidationErrors{}
-	for _, t := range buildVariant.Tasks {
-		if t.Priority > model.MaxConfigSetPriority {
-			errs = append(errs,
-				ValidationError{
-					Message: fmt.Sprintf("task '%s' has been set at or above %d priority, in YAML, will default priority to %d",
-						t.Name, model.MaxConfigSetPriority, model.MaxConfigSetPriority),
-					Level: Warning,
-				})
-		}
-	}
-	return errs
-}
-
 func validateDisplayTaskNames(project *model.Project) ValidationErrors {
 	errs := ValidationErrors{}
 
@@ -2295,15 +2280,6 @@ func checkTasks(project *model.Project) ValidationErrors {
 				},
 			)
 		}
-		if task.Priority > model.MaxConfigSetPriority {
-			errs = append(errs,
-				ValidationError{
-					Message: fmt.Sprintf("task '%s' has been set at or above %d priority, in YAML, will default priority to %d",
-						task.Name, model.MaxConfigSetPriority, model.MaxConfigSetPriority),
-					Level: Warning,
-				},
-			)
-		}
 		if project.ExecTimeoutSecs == 0 && task.ExecTimeoutSecs == 0 && !execTimeoutWarningAdded {
 			errs = append(errs,
 				ValidationError{
@@ -2370,7 +2346,6 @@ func checkBuildVariants(project *model.Project) ValidationErrors {
 
 		errs = append(errs, checkBVNames(&buildVariant)...)
 		errs = append(errs, checkBVBatchTimes(&buildVariant)...)
-		errs = append(errs, checkBVTaskPriority(&buildVariant)...)
 	}
 
 	for k, v := range displayNames {


### PR DESCRIPTION
DEVPROD-17670

### Description
Caps YAML priority at 50 to prevent users from setting it to 10k+.

Prior validation warnings were set at the warning level with the intent to not break user builds. However there are users with large YAML priorities that also are set to fail on any warnings, so using warning level validations was breaking. This is the same PR with the validation level downgraded to `notice`

### Testing
Tested in staging. Will be sending out the following email to devprod-announce so please LGTM this as part of review too:
```
[Evergreen] New restrictions on setting task priority via the project yaml

Hi all,
The priority setting in project YAML is now capped at 50. Any values above 50 will be automatically adjusted down to this new maximum. 

This change has been done to ensure responsible use of the priority feature and ensures fair task queue ordering across all projects.

If tasks need to urgently have their priority set above 50, please contact a project admin who will be able to set values above 50 in the UI.

Thank you,
Malik Hadjri
```

### Documentation
Added documentation