### PR TITLE
DEVPROD-20513 Add docs explaining that tasks run by default on the waterfall

### DIFF
--- a/docs/Project-Configuration/Controlling-when-tasks-run.md
+++ b/docs/Project-Configuration/Controlling-when-tasks-run.md
@@ -3,7 +3,7 @@
 By default, the latest commit on the waterfall will be activated each time our activation job is run. (That means if many commits are made in a short period of time,
 only the latest commit will be activated.)
 
-There are multiple ways to control the scheduling of builds/tasks on a project's _waterfall_ page. This means that tasks manually scheduled by a PR or patch will run regardless of cron/batchtime settings.
+By default, every task that is added to at least one build variant's tasks list will run on every commit on the waterfall. However, there are multiple ways to control the scheduling of builds/tasks on a project's _waterfall_ page. This means that tasks manually scheduled by a PR or patch will run regardless of cron/batchtime settings.
 
 In short:
 


### PR DESCRIPTION
DEVPROD-20513

### Description
This came up in a user question so adding it to be more explicit 