### PR TITLE
DEVPROD-20309 add owner/repo filtering to the /projects route

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1969,12 +1969,10 @@ func FindNonHiddenProjects(ctx context.Context, key string, limit int, sortDir i
 		filter[ProjectRefIdKey] = bson.M{"$gte": key}
 	}
 
-	// Add owner filter if provided
 	if ownerName != "" {
 		filter[ProjectRefOwnerKey] = ownerName
 	}
 
-	// Add repo filter if provided
 	if repoName != "" {
 		filter[ProjectRefRepoKey] = repoName
 	}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1954,7 +1954,8 @@ func UpdateAdminRoles(ctx context.Context, project *ProjectRef, toAdd, toDelete 
 }
 
 // FindNonHiddenProjects returns limit visible project refs starting at project id key in the sortDir direction.
-func FindNonHiddenProjects(ctx context.Context, key string, limit int, sortDir int) ([]ProjectRef, error) {
+// Optionally filters by ownerName and repoName if provided.
+func FindNonHiddenProjects(ctx context.Context, key string, limit int, sortDir int, ownerName, repoName string) ([]ProjectRef, error) {
 	projectRefs := []ProjectRef{}
 	filter := bson.M{
 		ProjectRefHiddenKey: bson.M{"$ne": true},
@@ -1966,6 +1967,16 @@ func FindNonHiddenProjects(ctx context.Context, key string, limit int, sortDir i
 		filter[ProjectRefIdKey] = bson.M{"$lt": key}
 	} else {
 		filter[ProjectRefIdKey] = bson.M{"$gte": key}
+	}
+
+	// Add owner filter if provided
+	if ownerName != "" {
+		filter[ProjectRefOwnerKey] = ownerName
+	}
+
+	// Add repo filter if provided
+	if repoName != "" {
+		filter[ProjectRefRepoKey] = repoName
 	}
 
 	q := db.Query(filter).Sort([]string{sortSpec}).Limit(limit)

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1789,7 +1789,7 @@ func (s *FindProjectsSuite) TestFilterByOwnerName() {
 	// Test filtering by owner "evergreen-ci" - should return projectA and projectB
 	projects, err := FindNonHiddenProjects(s.T().Context(), "", 10, 1, "evergreen-ci", "")
 	s.NoError(err)
-	s.Len(projects, 2)
+	s.Require().Len(projects, 2)
 	// Results should be sorted by ID, so projectA comes first
 	s.Equal("projectA", projects[0].Id)
 	s.Equal("evergreen-ci", projects[0].Owner)
@@ -1801,7 +1801,7 @@ func (s *FindProjectsSuite) TestFilterByRepoName() {
 	// Test filtering by repo "mongo" - should return projectC
 	projects, err := FindNonHiddenProjects(s.T().Context(), "", 10, 1, "", "mongo")
 	s.NoError(err)
-	s.Len(projects, 1)
+	s.Require().Len(projects, 1)
 	s.Equal("projectC", projects[0].Id)
 	s.Equal("mongo", projects[0].Repo)
 }
@@ -1810,7 +1810,7 @@ func (s *FindProjectsSuite) TestFilterByOwnerAndRepo() {
 	// Test filtering by both owner "evergreen-ci" and repo "evergreen" - should return projectB
 	projects, err := FindNonHiddenProjects(s.T().Context(), "", 10, 1, "evergreen-ci", "evergreen")
 	s.NoError(err)
-	s.Len(projects, 1)
+	s.Require().Len(projects, 1)
 	s.Equal("projectB", projects[0].Id)
 	s.Equal("evergreen-ci", projects[0].Owner)
 	s.Equal("evergreen", projects[0].Repo)

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1727,60 +1727,98 @@ func (s *FindProjectsSuite) TearDownSuite() {
 }
 
 func (s *FindProjectsSuite) TestFetchTooManyAsc() {
-	projects, err := FindNonHiddenProjects(s.T().Context(), "", 8, 1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "", 8, 1, "", "")
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 7)
 }
 
 func (s *FindProjectsSuite) TestFetchTooManyDesc() {
-	projects, err := FindNonHiddenProjects(s.T().Context(), "zzz", 8, -1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "zzz", 8, -1, "", "")
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 7)
 }
 
 func (s *FindProjectsSuite) TestFetchExactNumber() {
-	projects, err := FindNonHiddenProjects(s.T().Context(), "", 3, 1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "", 3, 1, "", "")
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 3)
 }
 
 func (s *FindProjectsSuite) TestFetchTooFewAsc() {
-	projects, err := FindNonHiddenProjects(s.T().Context(), "", 2, 1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "", 2, 1, "", "")
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 2)
 }
 
 func (s *FindProjectsSuite) TestFetchTooFewDesc() {
-	projects, err := FindNonHiddenProjects(s.T().Context(), "zzz", 2, -1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "zzz", 2, -1, "", "")
 	s.NoError(err)
 	s.NotNil(projects)
 	s.Len(projects, 2)
 }
 
 func (s *FindProjectsSuite) TestFetchKeyWithinBoundAsc() {
-	projects, err := FindNonHiddenProjects(s.T().Context(), "projectB", 1, 1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "projectB", 1, 1, "", "")
 	s.NoError(err)
 	s.Len(projects, 1)
 }
 
 func (s *FindProjectsSuite) TestFetchKeyWithinBoundDesc() {
-	projects, err := FindNonHiddenProjects(s.T().Context(), "projectD", 1, -1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "projectD", 1, -1, "", "")
 	s.NoError(err)
 	s.Len(projects, 1)
 }
 
 func (s *FindProjectsSuite) TestFetchKeyOutOfBoundAsc() {
-	projects, err := FindNonHiddenProjects(s.T().Context(), "zzz", 1, 1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "zzz", 1, 1, "", "")
 	s.NoError(err)
 	s.Empty(projects)
 }
 
 func (s *FindProjectsSuite) TestFetchKeyOutOfBoundDesc() {
-	projects, err := FindNonHiddenProjects(s.T().Context(), "aaa", 1, -1)
+	projects, err := FindNonHiddenProjects(s.T().Context(), "aaa", 1, -1, "", "")
+	s.NoError(err)
+	s.Empty(projects)
+}
+
+func (s *FindProjectsSuite) TestFilterByOwnerName() {
+	// Test filtering by owner "evergreen-ci" - should return projectA and projectB
+	projects, err := FindNonHiddenProjects(s.T().Context(), "", 10, 1, "evergreen-ci", "")
+	s.NoError(err)
+	s.Len(projects, 2)
+	// Results should be sorted by ID, so projectA comes first
+	s.Equal("projectA", projects[0].Id)
+	s.Equal("evergreen-ci", projects[0].Owner)
+	s.Equal("projectB", projects[1].Id)
+	s.Equal("evergreen-ci", projects[1].Owner)
+}
+
+func (s *FindProjectsSuite) TestFilterByRepoName() {
+	// Test filtering by repo "mongo" - should return projectC
+	projects, err := FindNonHiddenProjects(s.T().Context(), "", 10, 1, "", "mongo")
+	s.NoError(err)
+	s.Len(projects, 1)
+	s.Equal("projectC", projects[0].Id)
+	s.Equal("mongo", projects[0].Repo)
+}
+
+func (s *FindProjectsSuite) TestFilterByOwnerAndRepo() {
+	// Test filtering by both owner "evergreen-ci" and repo "evergreen" - should return projectB
+	projects, err := FindNonHiddenProjects(s.T().Context(), "", 10, 1, "evergreen-ci", "evergreen")
+	s.NoError(err)
+	s.Len(projects, 1)
+	s.Equal("projectB", projects[0].Id)
+	s.Equal("evergreen-ci", projects[0].Owner)
+	s.Equal("evergreen", projects[0].Repo)
+}
+
+func (s *FindProjectsSuite) TestFilterNoMatches() {
+	// Test filtering with non-existent owner/repo combination
+	projects, err := FindNonHiddenProjects(s.T().Context(), "", 10, 1, "nonexistent", "repo")
 	s.NoError(err)
 	s.Empty(projects)
 }


### PR DESCRIPTION
DEVPROD-20309
### Description
add filtering to the projects route to allow this to be used for validating project limits. Kept this a quick-win, just added as params.

### Testing
Added tests, verified this works in local with http://localhost:9090/rest/v2/projects?owner_name=evergreen-ci&repo_name=evergreen

### Documentation
Swaggo updated.
