### PR TITLE
DEVPROD-19993: support JSON output for last-revision

### DIFF
--- a/operations/last_revision.go
+++ b/operations/last_revision.go
@@ -106,37 +106,33 @@ func LastRevision() cli.Command {
 				return errors.New("no matching version found")
 			}
 
-			printLastRevisionResult(conf, matchingVersion, jsonOutput)
+			printLastRevision(matchingVersion, jsonOutput)
 
 			return nil
 		},
 	}
 }
 
-// kim: TODO: manually test JSON output
-func printLastRevisionResult(conf *ClientSettings, v *model.APIVersion, jsonOutput bool) error {
+func printLastRevision(v *model.APIVersion, jsonOutput bool) error {
 	versionID := utility.FromStringPtr(v.Id)
 	revision := utility.FromStringPtr(v.Revision)
-	versionURL := fmt.Sprintf("%s/%s/%s", conf.UIServerHost, "version", versionID)
 
 	if jsonOutput {
 		output, err := json.MarshalIndent(struct {
-			VersionID  string `json:"version_id"`
-			VersionURL string `json:"version_url"`
-			Revision   string `json:"revision"`
+			VersionID string `json:"version_id"`
+			Revision  string `json:"revision"`
 		}{
-			VersionID:  versionID,
-			Revision:   revision,
-			VersionURL: versionURL,
+			VersionID: versionID,
+			Revision:  revision,
 		}, "", "\t")
 		if err != nil {
-			return errors.Wrap(err, "marshaling output to JSON")
+			return errors.Wrap(err, "marshalling output to JSON")
 		}
 		fmt.Println(string(output))
 		return nil
 	}
 
-	fmt.Printf("Latest version that matches criteria: %s\nRevision: %s\nVersion URL: %s\n", utility.FromStringPtr(v.Id), utility.FromStringPtr(v.Revision), versionURL)
+	fmt.Printf("Latest version that matches criteria: %s\nRevision: %s\n", utility.FromStringPtr(v.Id), utility.FromStringPtr(v.Revision))
 	return nil
 
 }


### PR DESCRIPTION
DEVPROD-19993

### Description
git-co-evg-base supports functionality to actually perform git operations. Based on [the original ticket](https://jira.mongodb.org/browse/DEVPROD-15858), I don't think we actually need to have the Evergreen CLI do the git operations on behalf of the user, but should make it possible/easy to output a result that users can script around (e.g. parsing it using `jq` and then using command substitution to git checkout the revision it found). To support scripting workflows, I added support for JSON output (which silences other CLI messages like auto-upgrading messages and admin banners).

### Testing
Manually tested the CLI to verify that it outputted JSON output and did not show any additional output such as banners.

### Documentation
Added usage docs to the CLI.
