### PR TITLE
[Idea] Implement MCP server for Evergreen patch/task helpers

### DIFF
--- a/cmd/evergreen/evergreen.go
+++ b/cmd/evergreen/evergreen.go
@@ -58,10 +58,13 @@ func buildApp() *cli.App {
 		operations.LastRevision(),
 		operations.Subscriptions(),
 		operations.Client(),
+		operations.MCPServer(),
+		operations.MCPServerSDK(),
 
 		// Patch creation and management commands (top-level)
 		operations.Patch(),
 		operations.PatchFile(),
+		operations.PatchFailedLogs(),
 		operations.PatchList(),
 		operations.PatchSetModule(),
 		operations.PatchRemoveModule(),

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -490,6 +490,43 @@ The "url" keys in each list item should contain the appropriate URL to the binar
 
 ### Notifications
 
+
+### MCP Server
+
+Expose Evergreen helpers over the Model Context Protocol (MCP) via stdio.
+
+Usage:
+
+```bash
+# Start server on stdio (reads newline-delimited JSON-RPC 2.0 requests from stdin)
+evergreen mcp-server --stdio
+
+# With explicit patch context and tail limit for convenience methods
+printf '%s\n' '{ "jsonrpc": "2.0", "id": 1, "method": "detectPatchId", "params": {} }' | evergreen mcp-server --stdio
+```
+
+Methods:
+- detectPatchId(params: { project?: string, patchId?: string }) -> { patchId, reason }
+- listPatchTasks(params: { patchId?: string, failedOnly?: bool }) -> TaskSummary[]
+- getTaskLogs(params: { taskId: string, execution?: number, type?: string, tail?: number }) -> { content: string }
+- fetchFailedLogsForPatch(params: { patchId?: string, tail?: number }) -> { logs: Record<taskId,string> }
+
+Notes:
+- The server uses your CLI config for authentication (see --conf flag).
+- TCP transport via --port is reserved for future use.
+
+#### Patch Failed Logs
+
+Fetch logs for failed tasks in a given patch ID.
+
+```bash
+evergreen patch-failed-logs --patch <patch_id> --tail 200
+```
+
+- Uses the same authentication and server configuration as other commands.
+- Output is printed to stdout with simple headings per task.
+
+
 The Evergreen CLI has the ability to send slack and email notifications for scripting. These use Evergreen's account, so be cautious about rate limits or being marked as a spammer.
 
 ```bash

--- a/docs/mcp-augment-setup.md
+++ b/docs/mcp-augment-setup.md
@@ -1,0 +1,199 @@
+# Using Evergreen MCP Server with Augment
+
+This guide shows how to set up and test the Evergreen MCP (Model Context Protocol) server with Augment for intelligent patch and task introspection.
+
+## Prerequisites
+
+- Evergreen CLI built with MCP server support
+- Augment installed and configured
+- Evergreen credentials configured in `~/.evergreen.yml`
+- Network access to your Evergreen instance
+
+## 1. Build and Test the MCP Server
+
+First, build the Evergreen CLI with MCP support:
+
+```bash
+cd /Users/w.trocki/Projects/evergreen
+go build -o ./bin/evergreen ./cmd/evergreen
+```
+
+This creates `bin/evergreen` with the MCP server command:
+- `mcp-server-sdk` - Uses official MCP Go SDK
+
+Test that the MCP server starts correctly:
+
+```bash
+./bin/evergreen mcp-server-sdk --help
+```
+
+Run the smoke test to validate basic functionality:
+
+```bash
+./test_mcp_server.sh
+```
+
+## 2. Configure Augment MCP Integration
+
+Add the Evergreen MCP server to your Augment configuration. The exact location depends on your Augment setup, but typically you'll add this to your MCP servers configuration:
+
+```json
+{
+  "mcpServers": {
+    "evergreen": {
+      "command": "/Users/w.trocki/Projects/evergreen/bin/evergreen",
+      "args": ["mcp-server-sdk", "--stdio"],
+      "description": "Evergreen patch and task introspection"
+    }
+  }
+}
+```
+
+**Alternative configuration formats:**
+
+For Augment desktop app, you might need to add this in the MCP settings UI:
+- **Server Name:** `evergreen`
+- **Command:** `/Users/w.trocki/Projects/evergreen/bin/evergreen`
+- **Arguments:** `["mcp-server-sdk", "--stdio"]`
+
+## 3. Available MCP Methods
+
+The Evergreen MCP server exposes these methods:
+
+### `detectPatchId`
+Automatically detect the current patch ID using precedence:
+1. Explicit patch parameter
+2. `EVG_PATCH_ID` environment variable
+3. Most recent patch (optionally filtered by project)
+
+### `listPatchTasks`
+List tasks for a patch, with optional filtering for failed tasks only.
+
+### `getTaskLogs`
+Retrieve logs for a specific task with configurable tail limit and log type.
+
+### `fetchFailedLogsForPatch`
+Fetch logs for all failed tasks in a patch with bounded concurrency.
+
+## 4. Testing with Augment
+
+Once configured, you can ask Augment natural language questions:
+
+### Patch Detection
+```
+"Can you detect my current Evergreen patch ID?"
+"What's my latest patch for the mongodb project?"
+```
+
+### Task Listing
+```
+"Show me all failed tasks in my current patch"
+"List all tasks in patch 507f1f77bcf86cd799439011"
+"What tasks are failing in my latest patch?"
+```
+
+### Log Retrieval
+```
+"Get the logs for task ID 507f1f77bcf86cd799439012"
+"Show me the last 50 lines of logs for the failing compile task"
+"Fetch logs for all failed tasks in my current patch"
+```
+
+### Analysis and Debugging
+```
+"Analyze the failed tasks in my patch and summarize the errors"
+"What are the common failure patterns in my patch?"
+"Help me debug the test failures in my latest patch"
+```
+
+## 5. Manual Testing (Before Augment Integration)
+
+Test the MCP server manually to ensure it's working:
+
+```bash
+# Start the server
+./bin/evergreen mcp-server-sdk --stdio
+
+# In another terminal, send test requests:
+
+# Initialize and detect patch ID
+printf '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}\n{"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "detectPatchId", "arguments": {}}}\n' | ./bin/evergreen mcp-server-sdk --stdio
+
+# List failed tasks
+printf '{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"protocolVersion": "2024-11-05", "capabilities": {}, "clientInfo": {"name": "test-client", "version": "1.0.0"}}}\n{"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": "listPatchTasks", "arguments": {"failedOnly": true}}}\n' | ./bin/evergreen mcp-server-sdk --stdio
+```
+
+## 6. Environment Configuration
+
+### Automatic Patch Detection
+
+Set the `EVG_PATCH_ID` environment variable for automatic patch detection:
+
+```bash
+export EVG_PATCH_ID="your-patch-id-here"
+./bin/evergreen mcp-server-sdk --stdio
+```
+
+### Project-Specific Detection
+
+Use the `--project` flag to filter patches by project:
+
+```bash
+./bin/evergreen mcp-server-sdk --stdio --project mongodb
+```
+
+### Custom Patch Limits
+
+Control how many recent patches to consider:
+
+```bash
+./bin/evergreen mcp-server-sdk --stdio --max-patches 20
+```
+
+## 7. Troubleshooting
+
+### Common Issues
+
+**Authentication errors:**
+- Ensure `~/.evergreen.yml` is properly configured
+- Check that your API key is valid and not expired
+
+**No patches found:**
+- Verify you have recent patches in your account
+- Try specifying a project with `--project` flag
+- Check that you're authenticated to the correct Evergreen instance
+
+**Connection timeouts:**
+- Verify network connectivity to your Evergreen instance
+- Check firewall settings
+
+### Debug Mode
+
+For verbose logging, you can modify the MCP server startup to include debug output:
+
+```bash
+GRIP_LEVEL=debug ./bin/evergreen mcp-server --stdio
+```
+
+## 8. Non-MCP Alternative
+
+If you prefer direct CLI usage without MCP:
+
+```bash
+# Get failed logs for a specific patch
+./bin/evergreen patch-failed-logs --patch 507f1f77bcf86cd799439011 --tail 200
+
+# Use with automatic patch detection
+EVG_PATCH_ID=507f1f77bcf86cd799439011 ./bin/evergreen patch-failed-logs --tail 100
+```
+
+## Next Steps
+
+Once you have the MCP server working with Augment:
+
+1. **Create workflows** for common debugging tasks
+2. **Set up aliases** for frequently used patch IDs
+3. **Integrate with CI/CD** by setting `EVG_PATCH_ID` in your build environment
+4. **Extend functionality** by contributing additional MCP methods
+
+The MCP integration enables powerful AI-assisted debugging and analysis of your Evergreen patches and tasks!

--- a/go.mod
+++ b/go.mod
@@ -195,6 +195,7 @@ require (
 	github.com/fraugster/parquet-go v0.11.0
 	github.com/google/go-github/v70 v70.0.0
 	github.com/gorilla/handlers v1.5.2
+	github.com/modelcontextprotocol/go-sdk v0.2.0
 	github.com/mongodb/jasper v0.0.0-20250304205544-71af207b4383
 	github.com/shirou/gopsutil/v3 v3.24.5
 	go.uber.org/automaxprocs v1.6.0
@@ -207,6 +208,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sns v1.34.7 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.mongodb.org/mongo-driver/v2 v2.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -464,6 +464,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
 github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
+github.com/modelcontextprotocol/go-sdk v0.2.0 h1:PESNYOmyM1c369tRkzXLY5hHrazj8x9CY1Xu0fLCryM=
+github.com/modelcontextprotocol/go-sdk v0.2.0/go.mod h1:0sL9zUKKs2FTTkeCCVnKqbLJTw5TScefPAzojjU459E=
 github.com/mongodb/amboy v0.0.0-20250313150805-ef0cd9968322 h1:1xqCqYPM+8syjjL9puyOaDQMntws7COPovUluWuh0YA=
 github.com/mongodb/amboy v0.0.0-20250313150805-ef0cd9968322/go.mod h1:bUrCbClVqpWfIWSkhs6PCwd0qYVjZn+/y+sZTkl4Fos=
 github.com/mongodb/anser v0.0.0-20250324144457-fcc2c57eee09 h1:6keoRkoEcOX/3Wlxtni/eto9JD6f8dcYJjdlI+JL/Is=
@@ -627,6 +629,8 @@ github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMx
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=

--- a/operations/mcp_basic_test.go
+++ b/operations/mcp_basic_test.go
@@ -1,0 +1,88 @@
+package operations
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// Basic test for JSON-RPC parsing and unknown method handling
+// This test is in a separate file to avoid init() conflicts with cli_integration_test.go
+func TestMCPBasicFunctionality(t *testing.T) {
+	server := &mcpServer{}
+	var in bytes.Buffer
+	var out bytes.Buffer
+
+	// Write a malformed line
+	in.WriteString("not-json\n")
+	// Write an unknown method
+	req := rpcRequest{JSONRPC: "2.0", ID: json.RawMessage("1"), Method: "nope"}
+	b, _ := json.Marshal(req)
+	in.WriteString(string(b) + "\n")
+
+	err := server.runStdio(context.Background(), &in, &out)
+	if err != nil {
+		t.Fatalf("runStdio failed: %v", err)
+	}
+
+	// Ensure there is at least one response written
+	if out.Len() == 0 {
+		t.Fatalf("expected some output from server")
+	}
+
+	// Check that we got error responses
+	scanner := bufio.NewScanner(&out)
+	responses := 0
+	for scanner.Scan() {
+		var resp rpcResponse
+		err := json.Unmarshal(scanner.Bytes(), &resp)
+		if err != nil {
+			t.Fatalf("failed to unmarshal response: %v", err)
+		}
+		if resp.Error == nil {
+			t.Errorf("expected error response, got: %+v", resp)
+		}
+		responses++
+	}
+	if responses != 2 {
+		t.Errorf("expected 2 responses, got %d", responses)
+	}
+}
+
+func TestMCPDispatchBasics(t *testing.T) {
+	server := &mcpServer{}
+
+	t.Run("InvalidJSONRPCVersion", func(t *testing.T) {
+		req := &rpcRequest{
+			JSONRPC: "1.0",
+			ID:      json.RawMessage("5"),
+			Method:  "detectPatchId",
+		}
+
+		resp := server.dispatch(context.Background(), req)
+		if resp.Error == nil {
+			t.Errorf("expected error for invalid JSON-RPC version")
+		}
+		if resp.Error.Code != -32600 {
+			t.Errorf("expected error code -32600, got %d", resp.Error.Code)
+		}
+	})
+
+	t.Run("UnknownMethod", func(t *testing.T) {
+		req := &rpcRequest{
+			JSONRPC: "2.0",
+			ID:      json.RawMessage("6"),
+			Method:  "unknownMethod",
+		}
+
+		resp := server.dispatch(context.Background(), req)
+		if resp.Error == nil {
+			t.Errorf("expected error for unknown method")
+		}
+		if resp.Error.Code != -32601 {
+			t.Errorf("expected error code -32601, got %d", resp.Error.Code)
+		}
+	})
+}

--- a/operations/mcp_server.go
+++ b/operations/mcp_server.go
@@ -1,0 +1,404 @@
+package operations
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/evergreen-ci/evergreen"
+	restclient "github.com/evergreen-ci/evergreen/rest/client"
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
+	perrors "github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+// CLI flags specific to MCP server
+const (
+	mcpStdioFlagName   = "stdio"
+	mcpPortFlagName    = "port"
+	mcpPatchFlagName   = "patch"
+	mcpProjectFlagName = "project"
+	mcpMaxPatchesFlag  = "max-patches"
+)
+
+// TaskSummary represents a light view of a task for MCP responses
+type TaskSummary struct {
+	ID        string `json:"id"`
+	Display   string `json:"display_name"`
+	Status    string `json:"status"`
+	Variant   string `json:"variant"`
+	Execution int    `json:"execution"`
+}
+
+// MCPServer returns the CLI command definition for the Model Context Protocol server
+func MCPServer() cli.Command {
+	flags := []cli.Flag{
+		cli.BoolFlag{
+			Name:  mcpStdioFlagName,
+			Usage: "run MCP server over stdio (JSON-RPC 2.0, newline-delimited)",
+		},
+		cli.IntFlag{
+			Name:  mcpPortFlagName,
+			Usage: "run MCP server listening on TCP port (not yet implemented)",
+			Value: 0,
+		},
+		cli.StringFlag{
+			Name:  mcpPatchFlagName,
+			Usage: "explicit patch ID to use in server session",
+		},
+		cli.StringFlag{
+			Name:  mcpProjectFlagName,
+			Usage: "project identifier to narrow patch detection",
+		},
+		cli.IntFlag{
+			Name:  mcpMaxPatchesFlag,
+			Usage: "max recent patches to consider in detection heuristic",
+			Value: 10,
+		},
+	}
+
+	return cli.Command{
+		Name:  "mcp-server",
+		Usage: "expose Evergreen patch/task helpers over the Model Context Protocol",
+		Flags: flags,
+		Action: func(c *cli.Context) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			conf, err := NewClientSettings(c.GlobalString(confFlagName))
+			if err != nil {
+				return perrors.Wrap(err, "loading configuration")
+			}
+
+			rest, err := conf.setupRestCommunicator(ctx, false)
+			if err != nil {
+				return perrors.Wrap(err, "setting up REST communicator")
+			}
+			defer rest.Close()
+
+			ac, rc, err := conf.getLegacyClients()
+			if err != nil {
+				return perrors.Wrap(err, "setting up legacy Evergreen client")
+			}
+
+			server := &mcpServer{
+				conf:        conf,
+				rest:        rest,
+				ac:          ac,
+				rc:          rc,
+				patchHint:   c.String(mcpPatchFlagName),
+				projectHint: c.String(mcpProjectFlagName),
+				maxPatches:  c.Int(mcpMaxPatchesFlag),
+			}
+
+			if c.Bool(mcpStdioFlagName) || c.Int(mcpPortFlagName) == 0 {
+				grip.Notice("Starting MCP server on stdio (JSON-RPC 2.0, newline-delimited)")
+				return server.runStdio(ctx, os.Stdin, os.Stdout)
+			}
+			return errors.New("TCP transport not yet implemented; use --stdio")
+		},
+	}
+}
+
+type mcpServer struct {
+	conf        *ClientSettings
+	rest        restclient.Communicator
+	ac          *legacyClient
+	rc          *legacyClient
+	patchHint   string
+	projectHint string
+	maxPatches  int
+}
+
+// JSON-RPC structures
+
+type rpcRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  any             `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+type rpcError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+func (s *mcpServer) runStdio(ctx context.Context, in io.Reader, out io.Writer) error {
+	scanner := bufio.NewScanner(in)
+	// Increase the buffer to accommodate larger requests
+	buf := make([]byte, 0, 1024*64)
+	scanner.Buffer(buf, 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		// ignore empty lines
+		if len(strings.TrimSpace(string(line))) == 0 {
+			continue
+		}
+		var req rpcRequest
+		if err := json.Unmarshal(line, &req); err != nil {
+			writeRPC(out, rpcResponse{JSONRPC: "2.0", ID: nullID(), Error: &rpcError{Code: -32700, Message: "parse error", Data: err.Error()}})
+			continue
+		}
+		resp := s.dispatch(ctx, &req)
+		writeRPC(out, resp)
+	}
+	return scanner.Err()
+}
+
+func nullID() json.RawMessage { return json.RawMessage("null") }
+
+func writeRPC(w io.Writer, resp rpcResponse) {
+	enc := json.NewEncoder(w)
+	_ = enc.Encode(resp)
+}
+
+func (s *mcpServer) dispatch(ctx context.Context, req *rpcRequest) rpcResponse {
+	if req.JSONRPC != "2.0" {
+		return rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: -32600, Message: "invalid request: jsonrpc must be '2.0'"}}
+	}
+	switch req.Method {
+	case "detectPatchId":
+		var p struct {
+			Project string `json:"project"`
+			Branch  string `json:"branch"`
+			PatchId string `json:"patchId"`
+		}
+		_ = json.Unmarshal(req.Params, &p)
+		patchID, reason, err := s.detectPatchID(ctx, detectOpts{PatchFlag: p.PatchId, Project: p.Project, MaxPatches: s.maxPatches})
+		if err != nil {
+			return rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: -32000, Message: "detectPatchId error", Data: err.Error()}}
+		}
+		return rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: map[string]any{"patchId": patchID, "reason": reason}}
+
+	case "listPatchTasks":
+		var p struct {
+			PatchId    string `json:"patchId"`
+			FailedOnly bool   `json:"failedOnly"`
+		}
+		_ = json.Unmarshal(req.Params, &p)
+		if p.PatchId == "" {
+			var err error
+			p.PatchId, _, err = s.detectPatchID(ctx, detectOpts{PatchFlag: s.patchHint, Project: s.projectHint, MaxPatches: s.maxPatches})
+			if err != nil {
+				return rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: -32000, Message: "could not resolve patch id", Data: err.Error()}}
+			}
+		}
+		tasks, err := s.listTasksForPatch(ctx, p.PatchId, p.FailedOnly)
+		if err != nil {
+			return rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: -32000, Message: "listPatchTasks error", Data: err.Error()}}
+		}
+		return rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: tasks}
+
+	case "getTaskLogs":
+		var p struct {
+			TaskId    string `json:"taskId"`
+			Execution *int   `json:"execution"`
+			Type      string `json:"type"`
+			Tail      int    `json:"tail"`
+		}
+		_ = json.Unmarshal(req.Params, &p)
+		content, err := s.getTaskLogs(ctx, p.TaskId, p.Execution, p.Type, p.Tail)
+		if err != nil {
+			return rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: -32000, Message: "getTaskLogs error", Data: err.Error()}}
+		}
+		return rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: map[string]any{"content": content}}
+
+	case "fetchFailedLogsForPatch":
+		var p struct {
+			PatchId string `json:"patchId"`
+			Tail    int    `json:"tail"`
+		}
+		_ = json.Unmarshal(req.Params, &p)
+		patchID := p.PatchId
+		if patchID == "" {
+			var reason string
+			var err error
+			patchID, reason, err = s.detectPatchID(ctx, detectOpts{PatchFlag: s.patchHint, Project: s.projectHint, MaxPatches: s.maxPatches})
+			if err != nil {
+				return rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: -32000, Message: "could not resolve patch id", Data: err.Error()}}
+			}
+			_ = reason // not currently returned here
+		}
+		failedTasks, err := s.listTasksForPatch(ctx, patchID, true)
+		if err != nil {
+			return rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: -32000, Message: "listing failed tasks", Data: err.Error()}}
+		}
+		// Fetch logs concurrently with a bound.
+		logs := make(map[string]string)
+		type item struct {
+			id   string
+			exec int
+		}
+		jobs := make(chan item)
+		wg := sync.WaitGroup{}
+		mu := sync.Mutex{}
+		workers := 4
+		for i := 0; i < workers; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for it := range jobs {
+					content, err := s.getTaskLogs(ctx, it.id, utility.ToIntPtr(it.exec), "all_logs", p.Tail)
+					mu.Lock()
+					if err != nil {
+						logs[it.id] = fmt.Sprintf("error: %v", err)
+					} else {
+						logs[it.id] = content
+					}
+					mu.Unlock()
+				}
+			}()
+		}
+		for _, t := range failedTasks {
+			jobs <- item{id: t.ID, exec: t.Execution}
+		}
+		close(jobs)
+		wg.Wait()
+		return rpcResponse{JSONRPC: "2.0", ID: req.ID, Result: map[string]any{"logs": logs}}
+	default:
+		return rpcResponse{JSONRPC: "2.0", ID: req.ID, Error: &rpcError{Code: -32601, Message: "method not found"}}
+	}
+}
+
+// Helper: detectPatchID
+
+type detectOpts struct {
+	PatchFlag  string
+	Project    string
+	MaxPatches int
+}
+
+func (s *mcpServer) detectPatchID(ctx context.Context, opts detectOpts) (string, string, error) {
+	if opts.PatchFlag != "" {
+		return opts.PatchFlag, "provided by flag", nil
+	}
+	if env := strings.TrimSpace(os.Getenv("EVG_PATCH_ID")); env != "" {
+		return env, "from EVG_PATCH_ID", nil
+	}
+	maxN := opts.MaxPatches
+	if maxN <= 0 {
+		maxN = 10
+	}
+	patches, err := s.ac.GetPatches(maxN)
+	if err != nil {
+		return "", "", err
+	}
+	if len(patches) == 0 {
+		return "", "", errors.New("no recent patches found")
+	}
+	if opts.Project != "" {
+		for _, p := range patches {
+			if p.Project == opts.Project {
+				return p.Id.Hex(), "recent patch for project", nil
+			}
+		}
+	}
+	// default to most recent
+	return patches[0].Id.Hex(), "most recent patch", nil
+}
+
+// Helper: list tasks for a patch version, optionally filter by failed-only
+func (s *mcpServer) listTasksForPatch(ctx context.Context, patchID string, failedOnly bool) ([]TaskSummary, error) {
+	if patchID == "" {
+		return nil, errors.New("patch id must be provided")
+	}
+	// Use legacy client to get patch with Version
+	restPatch, err := s.ac.GetRestPatch(patchID)
+	if err != nil {
+		return nil, perrors.Wrap(err, "getting patch")
+	}
+	versionID := restPatch.Version
+	if versionID == "" {
+		return nil, errors.New("patch has no version id (not finalized?)")
+	}
+	builds, err := s.rest.GetBuildsForVersion(ctx, versionID)
+	if err != nil {
+		return nil, perrors.Wrap(err, "listing builds for version")
+	}
+	out := []TaskSummary{}
+	for _, b := range builds {
+		buildID := utility.FromStringPtr(b.Id)
+		if buildID == "" {
+			continue
+		}
+		tasks, err := s.rest.GetTasksForBuild(ctx, buildID)
+		if err != nil {
+			return nil, perrors.Wrapf(err, "listing tasks for build %s", buildID)
+		}
+		for _, t := range tasks {
+			status := utility.FromStringPtr(t.Status)
+			if failedOnly && status != evergreen.TaskFailed {
+				continue
+			}
+			out = append(out, TaskSummary{
+				ID:        utility.FromStringPtr(t.Id),
+				Display:   utility.FromStringPtr(t.DisplayName),
+				Status:    status,
+				Variant:   utility.FromStringPtr(t.BuildVariant),
+				Execution: t.Execution,
+			})
+		}
+	}
+	return out, nil
+}
+
+// Helper: get task logs content as a string
+func (s *mcpServer) getTaskLogs(ctx context.Context, taskID string, execution *int, logType string, tail int) (string, error) {
+	if taskID == "" {
+		return "", errors.New("taskId is required")
+	}
+	if logType == "" {
+		logType = "all_logs"
+	}
+	r, err := s.rest.GetTaskLogs(ctx, restclient.GetTaskLogsOptions{
+		TaskID:        taskID,
+		Execution:     execution,
+		Type:          logType,
+		TailLimit:     tail,
+		PrintTime:     false,
+		PrintPriority: false,
+		Paginate:      false,
+	})
+	if err != nil {
+		return "", err
+	}
+	defer r.Close()
+	var b strings.Builder
+	if _, err := io.Copy(&b, r); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+// Utility to convert possibly numeric JSON id to a string for logging (not used in payloads but handy for debug)
+func idToString(id json.RawMessage) string {
+	if len(id) == 0 || string(id) == "null" {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(id, &s); err == nil {
+		return s
+	}
+	var n int64
+	if err := json.Unmarshal(id, &n); err == nil {
+		return strconv.FormatInt(n, 10)
+	}
+	return string(id)
+}

--- a/operations/mcp_server_sdk.go
+++ b/operations/mcp_server_sdk.go
@@ -1,0 +1,409 @@
+package operations
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/evergreen-ci/evergreen"
+	restclient "github.com/evergreen-ci/evergreen/rest/client"
+	"github.com/evergreen-ci/utility"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/mongodb/grip"
+	perrors "github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+// MCPServerSDK returns the CLI command definition for the Model Context Protocol server using the official SDK
+func MCPServerSDK() cli.Command {
+	flags := []cli.Flag{
+		cli.BoolFlag{
+			Name:  mcpStdioFlagName,
+			Usage: "run MCP server over stdio (JSON-RPC 2.0, newline-delimited)",
+		},
+		cli.IntFlag{
+			Name:  mcpPortFlagName,
+			Usage: "run MCP server listening on TCP port (not yet implemented)",
+			Value: 0,
+		},
+		cli.StringFlag{
+			Name:  mcpPatchFlagName,
+			Usage: "explicit patch ID to use in server session",
+		},
+		cli.StringFlag{
+			Name:  mcpProjectFlagName,
+			Usage: "project identifier to narrow patch detection",
+		},
+		cli.IntFlag{
+			Name:  mcpMaxPatchesFlag,
+			Usage: "max recent patches to consider in detection heuristic",
+			Value: 10,
+		},
+	}
+
+	return cli.Command{
+		Name:  "mcp-server-sdk",
+		Usage: "expose Evergreen patch/task helpers over the Model Context Protocol using official SDK",
+		Flags: flags,
+		Action: func(c *cli.Context) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			conf, err := NewClientSettings(c.GlobalString(confFlagName))
+			if err != nil {
+				return perrors.Wrap(err, "loading configuration")
+			}
+
+			rest, err := conf.setupRestCommunicator(ctx, false)
+			if err != nil {
+				return perrors.Wrap(err, "setting up REST communicator")
+			}
+			defer rest.Close()
+
+			ac, rc, err := conf.getLegacyClients()
+			if err != nil {
+				return perrors.Wrap(err, "setting up legacy Evergreen client")
+			}
+
+			// Create the MCP server using the official SDK
+			server := mcp.NewServer(&mcp.Implementation{
+				Name:    "evergreen-mcp-server",
+				Version: "1.0.0",
+			}, nil)
+
+			// Create our Evergreen service wrapper
+			evgService := &evergreenService{
+				conf:        conf,
+				rest:        rest,
+				ac:          ac,
+				rc:          rc,
+				patchHint:   c.String(mcpPatchFlagName),
+				projectHint: c.String(mcpProjectFlagName),
+				maxPatches:  c.Int(mcpMaxPatchesFlag),
+			}
+
+			// Register tools
+			if err := registerEvergreenTools(server, evgService); err != nil {
+				return perrors.Wrap(err, "registering MCP tools")
+			}
+
+			if c.Bool(mcpStdioFlagName) || c.Int(mcpPortFlagName) == 0 {
+				grip.Notice("Starting MCP server using official SDK on stdio")
+				transport := mcp.NewStdioTransport()
+				return server.Run(ctx, transport)
+			}
+			return errors.New("TCP transport not yet implemented; use --stdio")
+		},
+	}
+}
+
+// evergreenService wraps the Evergreen clients and configuration
+type evergreenService struct {
+	conf        *ClientSettings
+	rest        restclient.Communicator
+	ac          *legacyClient
+	rc          *legacyClient
+	patchHint   string
+	projectHint string
+	maxPatches  int
+}
+
+// Tool argument types for type safety
+type DetectPatchIdArgs struct {
+	Project string `json:"project,omitempty"`
+	Branch  string `json:"branch,omitempty"`
+	PatchId string `json:"patchId,omitempty"`
+}
+
+type ListPatchTasksArgs struct {
+	PatchId    string `json:"patchId,omitempty"`
+	FailedOnly bool   `json:"failedOnly,omitempty"`
+}
+
+type GetTaskLogsArgs struct {
+	TaskId    string `json:"taskId"`
+	Execution *int   `json:"execution,omitempty"`
+	Type      string `json:"type,omitempty"`
+	Tail      int    `json:"tail,omitempty"`
+}
+
+type FetchFailedLogsForPatchArgs struct {
+	PatchId string `json:"patchId,omitempty"`
+	Tail    int    `json:"tail,omitempty"`
+}
+
+// registerEvergreenTools registers all the Evergreen MCP tools
+func registerEvergreenTools(server *mcp.Server, evg *evergreenService) error {
+	// Register detectPatchId tool
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "detectPatchId",
+		Description: "Automatically detect the current patch ID using precedence: explicit patch parameter, EVG_PATCH_ID environment variable, or most recent patch",
+	}, func(ctx context.Context, session *mcp.ServerSession, params *mcp.CallToolParamsFor[DetectPatchIdArgs]) (*mcp.CallToolResultFor[any], error) {
+		patchID, reason, err := evg.detectPatchID(ctx, detectOpts{
+			PatchFlag:  params.Arguments.PatchId,
+			Project:    params.Arguments.Project,
+			MaxPatches: evg.maxPatches,
+		})
+		if err != nil {
+			return &mcp.CallToolResultFor[any]{
+				IsError: true,
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error detecting patch ID: %v", err)}},
+			}, nil
+		}
+
+		result := map[string]any{
+			"patchId": patchID,
+			"reason":  reason,
+		}
+		return &mcp.CallToolResultFor[any]{
+			Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Detected patch ID: %s (reason: %s)", patchID, reason)}},
+			Meta:    result,
+		}, nil
+	})
+
+	// Register listPatchTasks tool
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "listPatchTasks",
+		Description: "List tasks for a patch, with optional filtering for failed tasks only",
+	}, func(ctx context.Context, session *mcp.ServerSession, params *mcp.CallToolParamsFor[ListPatchTasksArgs]) (*mcp.CallToolResultFor[any], error) {
+		patchID := params.Arguments.PatchId
+		if patchID == "" {
+			var err error
+			patchID, _, err = evg.detectPatchID(ctx, detectOpts{
+				PatchFlag:  evg.patchHint,
+				Project:    evg.projectHint,
+				MaxPatches: evg.maxPatches,
+			})
+			if err != nil {
+				return &mcp.CallToolResultFor[any]{
+					IsError: true,
+					Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Could not resolve patch ID: %v", err)}},
+				}, nil
+			}
+		}
+
+		tasks, err := evg.listTasksForPatch(ctx, patchID, params.Arguments.FailedOnly)
+		if err != nil {
+			return &mcp.CallToolResultFor[any]{
+				IsError: true,
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error listing tasks: %v", err)}},
+			}, nil
+		}
+
+		var content strings.Builder
+		content.WriteString(fmt.Sprintf("Found %d tasks for patch %s:\n", len(tasks), patchID))
+		for _, task := range tasks {
+			content.WriteString(fmt.Sprintf("- %s (%s) - %s on %s\n", task.Display, task.ID, task.Status, task.Variant))
+		}
+
+		return &mcp.CallToolResultFor[any]{
+			Content: []mcp.Content{&mcp.TextContent{Text: content.String()}},
+			Meta:    map[string]any{"tasks": tasks, "patchId": patchID},
+		}, nil
+	})
+
+	// Register getTaskLogs tool
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "getTaskLogs",
+		Description: "Get logs for a specific task",
+	}, func(ctx context.Context, session *mcp.ServerSession, params *mcp.CallToolParamsFor[GetTaskLogsArgs]) (*mcp.CallToolResultFor[any], error) {
+		content, err := evg.getTaskLogs(ctx, params.Arguments.TaskId, params.Arguments.Execution, params.Arguments.Type, params.Arguments.Tail)
+		if err != nil {
+			return &mcp.CallToolResultFor[any]{
+				IsError: true,
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error getting task logs: %v", err)}},
+			}, nil
+		}
+
+		return &mcp.CallToolResultFor[any]{
+			Content: []mcp.Content{&mcp.TextContent{Text: content}},
+			Meta:    map[string]any{"taskId": params.Arguments.TaskId, "logLength": len(content)},
+		}, nil
+	})
+
+	// Register fetchFailedLogsForPatch tool
+	mcp.AddTool(server, &mcp.Tool{
+		Name:        "fetchFailedLogsForPatch",
+		Description: "Fetch logs for all failed tasks in a patch",
+	}, func(ctx context.Context, session *mcp.ServerSession, params *mcp.CallToolParamsFor[FetchFailedLogsForPatchArgs]) (*mcp.CallToolResultFor[any], error) {
+		patchID := params.Arguments.PatchId
+		if patchID == "" {
+			var err error
+			patchID, _, err = evg.detectPatchID(ctx, detectOpts{
+				PatchFlag:  evg.patchHint,
+				Project:    evg.projectHint,
+				MaxPatches: evg.maxPatches,
+			})
+			if err != nil {
+				return &mcp.CallToolResultFor[any]{
+					IsError: true,
+					Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Could not resolve patch ID: %v", err)}},
+				}, nil
+			}
+		}
+
+		failedTasks, err := evg.listTasksForPatch(ctx, patchID, true)
+		if err != nil {
+			return &mcp.CallToolResultFor[any]{
+				IsError: true,
+				Content: []mcp.Content{&mcp.TextContent{Text: fmt.Sprintf("Error listing failed tasks: %v", err)}},
+			}, nil
+		}
+
+		// Fetch logs concurrently with a bound
+		logs := make(map[string]string)
+		type item struct {
+			id   string
+			exec int
+		}
+		jobs := make(chan item, len(failedTasks))
+		wg := sync.WaitGroup{}
+		mu := sync.Mutex{}
+		workers := 4
+
+		for i := 0; i < workers; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for it := range jobs {
+					content, err := evg.getTaskLogs(ctx, it.id, utility.ToIntPtr(it.exec), "all_logs", params.Arguments.Tail)
+					mu.Lock()
+					if err != nil {
+						logs[it.id] = fmt.Sprintf("error: %v", err)
+					} else {
+						logs[it.id] = content
+					}
+					mu.Unlock()
+				}
+			}()
+		}
+
+		for _, t := range failedTasks {
+			jobs <- item{id: t.ID, exec: t.Execution}
+		}
+		close(jobs)
+		wg.Wait()
+
+		var content strings.Builder
+		content.WriteString(fmt.Sprintf("Fetched logs for %d failed tasks in patch %s:\n\n", len(logs), patchID))
+		for taskID, logContent := range logs {
+			content.WriteString(fmt.Sprintf("=== Task %s ===\n%s\n\n", taskID, logContent))
+		}
+
+		return &mcp.CallToolResultFor[any]{
+			Content: []mcp.Content{&mcp.TextContent{Text: content.String()}},
+			Meta:    map[string]any{"logs": logs, "patchId": patchID, "taskCount": len(logs)},
+		}, nil
+	})
+
+	return nil
+}
+
+// Helper methods - reusing the same logic from the original implementation
+
+// detectPatchID detects the patch ID using the same logic as the original implementation
+func (evg *evergreenService) detectPatchID(ctx context.Context, opts detectOpts) (string, string, error) {
+	if opts.PatchFlag != "" {
+		return opts.PatchFlag, "provided by flag", nil
+	}
+	if env := strings.TrimSpace(os.Getenv("EVG_PATCH_ID")); env != "" {
+		return env, "from EVG_PATCH_ID", nil
+	}
+	maxN := opts.MaxPatches
+	if maxN <= 0 {
+		maxN = 10
+	}
+	patches, err := evg.ac.GetPatches(maxN)
+	if err != nil {
+		return "", "", err
+	}
+	if len(patches) == 0 {
+		return "", "", errors.New("no recent patches found")
+	}
+	if opts.Project != "" {
+		for _, p := range patches {
+			if p.Project == opts.Project {
+				return p.Id.Hex(), "recent patch for project", nil
+			}
+		}
+	}
+	// default to most recent
+	return patches[0].Id.Hex(), "most recent patch", nil
+}
+
+// listTasksForPatch lists tasks for a patch version, optionally filtering by failed-only
+func (evg *evergreenService) listTasksForPatch(ctx context.Context, patchID string, failedOnly bool) ([]TaskSummary, error) {
+	if patchID == "" {
+		return nil, errors.New("patch id must be provided")
+	}
+	// Use legacy client to get patch with Version
+	restPatch, err := evg.ac.GetRestPatch(patchID)
+	if err != nil {
+		return nil, perrors.Wrap(err, "getting patch")
+	}
+	versionID := restPatch.Version
+	if versionID == "" {
+		return nil, errors.New("patch has no version id (not finalized?)")
+	}
+	builds, err := evg.rest.GetBuildsForVersion(ctx, versionID)
+	if err != nil {
+		return nil, perrors.Wrap(err, "listing builds for version")
+	}
+	out := []TaskSummary{}
+	for _, b := range builds {
+		buildID := utility.FromStringPtr(b.Id)
+		if buildID == "" {
+			continue
+		}
+		tasks, err := evg.rest.GetTasksForBuild(ctx, buildID)
+		if err != nil {
+			return nil, perrors.Wrapf(err, "listing tasks for build %s", buildID)
+		}
+		for _, t := range tasks {
+			status := utility.FromStringPtr(t.Status)
+			if failedOnly && status != evergreen.TaskFailed {
+				continue
+			}
+			out = append(out, TaskSummary{
+				ID:        utility.FromStringPtr(t.Id),
+				Display:   utility.FromStringPtr(t.DisplayName),
+				Status:    status,
+				Variant:   utility.FromStringPtr(t.BuildVariant),
+				Execution: t.Execution,
+			})
+		}
+	}
+	return out, nil
+}
+
+// getTaskLogs gets task logs content as a string
+func (evg *evergreenService) getTaskLogs(ctx context.Context, taskID string, execution *int, logType string, tail int) (string, error) {
+	if taskID == "" {
+		return "", errors.New("taskId is required")
+	}
+	if logType == "" {
+		logType = "all_logs"
+	}
+	r, err := evg.rest.GetTaskLogs(ctx, restclient.GetTaskLogsOptions{
+		TaskID:        taskID,
+		Execution:     execution,
+		Type:          logType,
+		TailLimit:     tail,
+		PrintTime:     false,
+		PrintPriority: false,
+		Paginate:      false,
+	})
+	if err != nil {
+		return "", err
+	}
+	defer r.Close()
+	var b strings.Builder
+	if _, err := io.Copy(&b, r); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}

--- a/operations/patch_failed_logs.go
+++ b/operations/patch_failed_logs.go
@@ -1,0 +1,79 @@
+package operations
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/evergreen-ci/utility"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+// PatchFailedLogs is a convenience CLI to fetch logs for failed tasks in a patch.
+func PatchFailedLogs() cli.Command {
+	const (
+		tailFlagName = "tail"
+	)
+
+	return cli.Command{
+		Name:  "patch-failed-logs",
+		Usage: "fetch logs for all failed tasks in a patch",
+		Flags: mergeFlagSlices(
+			addPatchIDFlag(
+				cli.IntFlag{
+					Name:  tailFlagName,
+					Usage: "tail limit (number of lines) for logs per task",
+					Value: 200,
+				},
+			),
+		),
+		Before: requirePatchIDFlag,
+		Action: func(c *cli.Context) error {
+			confPath := c.Parent().String(confFlagName)
+			patchID := c.String(patchIDFlagName)
+			tail := c.Int(tailFlagName)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			conf, err := NewClientSettings(confPath)
+			if err != nil {
+				return errors.Wrap(err, "loading configuration")
+			}
+
+			rest, err := conf.setupRestCommunicator(ctx, false)
+			if err != nil {
+				return errors.Wrap(err, "setting up REST communicator")
+			}
+			defer rest.Close()
+
+			ac, _, err := conf.getLegacyClients()
+			if err != nil {
+				return errors.Wrap(err, "setting up legacy Evergreen client")
+			}
+
+			server := &mcpServer{conf: conf, rest: rest, ac: ac}
+
+			failedTasks, err := server.listTasksForPatch(ctx, patchID, true)
+			if err != nil {
+				return errors.Wrap(err, "listing failed tasks")
+			}
+
+			for _, t := range failedTasks {
+				content, err := server.getTaskLogs(ctx, t.ID, utility.ToIntPtr(t.Execution), "all_logs", tail)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "# %s (exec %d) ERROR: %v\n", t.ID, t.Execution, err)
+					continue
+				}
+				fmt.Printf("# %s (%s on %s)\n", t.Display, t.Status, t.Variant)
+				io.Copy(os.Stdout, strings.NewReader(content))
+				fmt.Println()
+			}
+
+			return nil
+		},
+	}
+}

--- a/test_mcp_server.sh
+++ b/test_mcp_server.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Simple smoke test for the MCP server
+# This script tests the basic JSON-RPC functionality without requiring real Evergreen credentials
+
+set -e
+
+echo "Testing MCP server smoke test..."
+
+# Build the CLI if not already built
+if [ ! -f "./bin/evergreen" ]; then
+    echo "Building evergreen CLI..."
+    go build -o ./bin/evergreen ./cmd/evergreen
+fi
+
+# Test 1: Unknown method should return method not found error
+echo "Test 1: Testing unknown method..."
+response=$(echo '{"jsonrpc":"2.0","id":1,"method":"unknownMethod","params":{}}' | timeout 5s ./bin/evergreen mcp-server --stdio 2>/dev/null || true)
+echo "Response: $response"
+
+if echo "$response" | grep -q '"error"' && echo "$response" | grep -q '"method not found"'; then
+    echo "✓ Test 1 passed: Unknown method correctly returns error"
+else
+    echo "✗ Test 1 failed: Expected method not found error"
+    exit 1
+fi
+
+# Test 2: Invalid JSON-RPC version should return error
+echo -e "\nTest 2: Testing invalid JSON-RPC version..."
+response=$(echo '{"jsonrpc":"1.0","id":2,"method":"detectPatchId","params":{}}' | timeout 5s ./bin/evergreen mcp-server --stdio 2>/dev/null || true)
+echo "Response: $response"
+
+if echo "$response" | grep -q '"error"' && echo "$response" | grep -q "jsonrpc must be"; then
+    echo "✓ Test 2 passed: Invalid JSON-RPC version correctly returns error"
+else
+    echo "✗ Test 2 failed: Expected JSON-RPC version error"
+    exit 1
+fi
+
+# Test 3: Malformed JSON should return parse error
+echo -e "\nTest 3: Testing malformed JSON..."
+response=$(echo 'not-valid-json' | timeout 5s ./bin/evergreen mcp-server --stdio 2>/dev/null || true)
+echo "Response: $response"
+
+if echo "$response" | grep -q '"error"' && echo "$response" | grep -q "parse error"; then
+    echo "✓ Test 3 passed: Malformed JSON correctly returns parse error"
+else
+    echo "✗ Test 3 failed: Expected parse error"
+    exit 1
+fi
+
+# Test 4: Valid method structure (will fail due to no credentials, but should parse correctly)
+echo -e "\nTest 4: Testing valid method structure..."
+response=$(echo '{"jsonrpc":"2.0","id":4,"method":"detectPatchId","params":{}}' | timeout 5s ./bin/evergreen mcp-server --stdio 2>/dev/null || true)
+echo "Response: $response"
+
+# This should either succeed or fail with a configuration/authentication error, not a parse/method error
+if echo "$response" | grep -q '"jsonrpc":"2.0"' && echo "$response" | grep -q '"id":4'; then
+    echo "✓ Test 4 passed: Valid method structure correctly parsed"
+else
+    echo "✗ Test 4 failed: Expected valid JSON-RPC response structure"
+    exit 1
+fi
+
+echo -e "\n✓ All smoke tests passed!"
+echo "The MCP server correctly handles JSON-RPC protocol basics."
+echo ""
+echo "To test with real Evergreen credentials:"
+echo "1. Set up your ~/.evergreen.yml configuration"
+echo "2. Run: echo '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"detectPatchId\",\"params\":{}}' | ./bin/evergreen mcp-server --stdio"
+echo "3. Run: ./bin/evergreen patch-failed-logs --patch <your-patch-id>"


### PR DESCRIPTION
## Goal

Created MCP server for evergreen embeeded into CLI command.
Add a new top-level command for MCP in CLI:
- `evergreen mcp-server [--stdio | --port <num>] [--patch <patch-id>] [--project <id>] [--max-patches <n>]`

PR created for prototyping and demo purposes. 
I do not intend to merge it in the current state.

## Tasks

- Add new 'mcp-server' command exposing JSON-RPC 2.0 over stdio
- Implement 4 MCP methods: detectPatchId, listPatchTasks, getTaskLogs, fetchFailedLogsForPatch
- Add convenience CLI command 'patch-failed-logs' for direct log fetching
- Support patch detection via flag, EVG_PATCH_ID env var, or recent patches

## AI use cases

MCP running in system can be automatically detected by chat bots like Claude sonet or GitHub copilot or Augment

1. Running using MCP (globally configured MCP server)
<img width="652" height="758" alt="Screenshot 2025-08-10 at 15 13 28" src="https://github.com/user-attachments/assets/cf46f058-0144-489b-bd79-1178893bf542" />

2. AI IDE running cli command directly based on prompts
<img width="506" height="582" alt="Screenshot 2025-08-10 at 15 14 33" src="https://github.com/user-attachments/assets/568aaedb-c9bb-4836-9cbe-324d06c82dc0" />

## Using Evergreen MCP Server 

This guide shows how to set up and test the Evergreen MCP (Model Context Protocol) server with AI IDE (augment/copilot) for intelligent patch and task introspection.

### Build and Test the MCP Server 

First, build the Evergreen CLI with MCP support (this PR)

```bash
go build -o ./bin/evergreen ./cmd/evergreen
```

Test that the MCP server command exist

```bash
./bin/evergreen mcp-server --help
```

## 2. Configure Augment MCP Integration

Add the Evergreen MCP server to your mcp configuration. 
```json
{
  "mcpServers": {
    "evergreen": {
      "command": "/Users/w.trocki/Projects/evergreen/bin/evergreen",
      "args": ["mcp-server", "--stdio"],
      "description": "Evergreen patch and task introspection"
    }
  }
}
```


 