### PR TITLE
DEVPROD-20580: support returning module revisions from last-revision

### DIFF
--- a/operations/last_revision.go
+++ b/operations/last_revision.go
@@ -30,7 +30,7 @@ func LastRevision() cli.Command {
 	)
 	return cli.Command{
 		Name:  "last-revision",
-		Usage: "return the latest revision for a version that matches a set of criteria",
+		Usage: "return the latest revision for a version that matches a set of criteria, along with its modules",
 		Flags: addProjectFlag(
 			cli.StringSliceFlag{
 				Name:  joinFlagNames(regexpVariantsFlagName, "rv"),

--- a/operations/last_revision.go
+++ b/operations/last_revision.go
@@ -124,7 +124,6 @@ func LastRevision() cli.Command {
 	}
 }
 
-// kim: TODO: test module printing with/without JSON in staging.
 func printLastRevision(v *model.APIVersion, modules []model.APIManifestModule, jsonOutput bool) error {
 	versionID := utility.FromStringPtr(v.Id)
 	revision := utility.FromStringPtr(v.Revision)
@@ -165,7 +164,7 @@ func printLastRevision(v *model.APIVersion, modules []model.APIManifestModule, j
 	if len(modules) > 0 {
 		fmt.Println("Modules:")
 		for _, m := range modules {
-			fmt.Printf("\t- %s: %s\n", utility.FromStringPtr(m.Name), utility.FromStringPtr(m.Revision))
+			fmt.Printf("- name: %s\n  revision: %s\n", utility.FromStringPtr(m.Name), utility.FromStringPtr(m.Revision))
 		}
 	}
 	return nil

--- a/operations/model.go
+++ b/operations/model.go
@@ -256,8 +256,7 @@ func (s *ClientSettings) getApiServerHost(useCorp bool) string {
 func printUserMessages(ctx context.Context, c client.Communicator, checkForUpdate bool) {
 	banner, err := c.GetBannerMessage(ctx)
 	if err != nil {
-		grip.Debug(err)
-
+		grip.Debug(errors.Wrap(err, "getting banner messages"))
 	} else if len(banner) > 0 {
 		grip.Noticef("Banner: %s", banner)
 	}

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -105,6 +105,8 @@ type Communicator interface {
 
 	// GetManifestByTask returns the manifest corresponding to the given task
 	GetManifestByTask(ctx context.Context, taskId string) (*manifest.Manifest, error)
+	// GetManifestForVersion returns the manifest for a given version ID.
+	GetManifestForVersion(ctx context.Context, versionID string) (*restmodel.APIManifest, error)
 
 	// GetRecentVersionsForProject returns the most recent versions for a
 	// project.

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -1526,7 +1526,7 @@ func (c *communicatorImpl) GetManifestForVersion(ctx context.Context, versionID 
 
 	manifestResp := restmodel.APIManifest{}
 	if err = utility.ReadJSON(resp.Body, &manifestResp); err != nil {
-		return nil, errors.Wrap(err, "reading response body")
+		return nil, errors.Wrap(err, "reading manifest response body")
 	}
 	return &manifestResp, nil
 }

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -1500,6 +1500,37 @@ func (c *communicatorImpl) GetRawPatchWithModules(ctx context.Context, patchId s
 	return &rp, nil
 }
 
+func (c *communicatorImpl) GetManifestForVersion(ctx context.Context, versionID string) (*restmodel.APIManifest, error) {
+	info := requestInfo{
+		method: http.MethodGet,
+		path:   fmt.Sprintf("versions/%s/manifest", versionID),
+	}
+	resp, err := c.request(ctx, info, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "sending request to get version manifest")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, util.RespError(resp, AuthError)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		// Manifests are optional for versions that don't use modules, so the
+		// route can return 404 if the version does not exist or if the version
+		// has no manifest.
+		return nil, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, util.RespError(resp, "getting version manifest")
+	}
+
+	manifestResp := restmodel.APIManifest{}
+	if err = utility.ReadJSON(resp.Body, &manifestResp); err != nil {
+		return nil, errors.Wrap(err, "reading response body")
+	}
+	return &manifestResp, nil
+}
+
 func (c *communicatorImpl) GetTaskLogs(ctx context.Context, opts GetTaskLogsOptions) (io.ReadCloser, error) {
 	var params []string
 	if opts.Execution != nil {

--- a/rest/model/manifest.go
+++ b/rest/model/manifest.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"github.com/evergreen-ci/evergreen/model/manifest"
+	"github.com/evergreen-ci/utility"
+)
+
+type APIManifest struct {
+	Id          *string             `json:"id"`
+	Revision    *string             `json:"revision"`
+	ProjectName *string             `json:"project"`
+	Branch      *string             `json:"branch"`
+	Modules     []APIManifestModule `json:"modules"`
+}
+
+func (m *APIManifest) BuildFromService(mfst *manifest.Manifest) {
+	m.Id = utility.ToStringPtr(mfst.Id)
+	m.Revision = utility.ToStringPtr(mfst.Revision)
+	m.ProjectName = utility.ToStringPtr(mfst.ProjectName)
+	m.Branch = utility.ToStringPtr(mfst.Branch)
+	for modName, mod := range mfst.Modules {
+		apiMod := APIManifestModule{}
+		apiMod.BuildFromService(modName, mod)
+		m.Modules = append(m.Modules, apiMod)
+	}
+}
+
+type APIManifestModule struct {
+	Name     *string `json:"name"`
+	Owner    *string `json:"owner"`
+	Repo     *string `json:"repo"`
+	Branch   *string `json:"branch"`
+	Revision *string `json:"revision"`
+	URL      *string `json:"url"`
+}
+
+func (m *APIManifestModule) BuildFromService(modName string, mod *manifest.Module) {
+	m.Name = utility.ToStringPtr(modName)
+	m.Branch = utility.ToStringPtr(mod.Branch)
+	m.Repo = utility.ToStringPtr(mod.Repo)
+	m.Revision = utility.ToStringPtr(mod.Revision)
+	m.Owner = utility.ToStringPtr(mod.Owner)
+	m.URL = utility.ToStringPtr(mod.URL)
+}

--- a/rest/model/manifest.go
+++ b/rest/model/manifest.go
@@ -10,6 +10,7 @@ type APIManifest struct {
 	Revision    *string             `json:"revision"`
 	ProjectName *string             `json:"project"`
 	Branch      *string             `json:"branch"`
+	IsBase      bool                `json:"is_base"`
 	Modules     []APIManifestModule `json:"modules"`
 }
 
@@ -18,6 +19,7 @@ func (m *APIManifest) BuildFromService(mfst *manifest.Manifest) {
 	m.Revision = utility.ToStringPtr(mfst.Revision)
 	m.ProjectName = utility.ToStringPtr(mfst.ProjectName)
 	m.Branch = utility.ToStringPtr(mfst.Branch)
+	m.IsBase = mfst.IsBase
 	for modName, mod := range mfst.Modules {
 		apiMod := APIManifestModule{}
 		apiMod.BuildFromService(modName, mod)

--- a/rest/model/manifest_test.go
+++ b/rest/model/manifest_test.go
@@ -15,6 +15,7 @@ func TestBuildFromService(t *testing.T) {
 		Revision:    "1234567890abcdef",
 		ProjectName: "test-project",
 		Branch:      "main",
+		IsBase:      true,
 		Modules: map[string]*manifest.Module{
 			"module1": {
 				Branch:   "main",
@@ -32,6 +33,7 @@ func TestBuildFromService(t *testing.T) {
 	assert.Equal(t, mfst.Revision, utility.FromStringPtr(apiManifest.Revision))
 	assert.Equal(t, mfst.ProjectName, utility.FromStringPtr(apiManifest.ProjectName))
 	assert.Equal(t, mfst.Branch, utility.FromStringPtr(apiManifest.Branch))
+	assert.Equal(t, mfst.IsBase, apiManifest.IsBase)
 	require.Len(t, apiManifest.Modules, 1)
 	expectedModule := mfst.Modules["module1"]
 	assert.Equal(t, "module1", utility.FromStringPtr(apiManifest.Modules[0].Name))

--- a/rest/model/manifest_test.go
+++ b/rest/model/manifest_test.go
@@ -1,0 +1,43 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/evergreen-ci/evergreen/model/manifest"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildFromService(t *testing.T) {
+	mfst := &manifest.Manifest{
+		Id:          "test-manifest",
+		Revision:    "1234567890abcdef",
+		ProjectName: "test-project",
+		Branch:      "main",
+		Modules: map[string]*manifest.Module{
+			"module1": {
+				Branch:   "main",
+				Owner:    "owner",
+				Repo:     "repo",
+				Revision: "abcdef1234567890",
+				URL:      "url",
+			},
+		},
+	}
+	apiManifest := &APIManifest{}
+	apiManifest.BuildFromService(mfst)
+
+	assert.Equal(t, mfst.Id, utility.FromStringPtr(apiManifest.Id))
+	assert.Equal(t, mfst.Revision, utility.FromStringPtr(apiManifest.Revision))
+	assert.Equal(t, mfst.ProjectName, utility.FromStringPtr(apiManifest.ProjectName))
+	assert.Equal(t, mfst.Branch, utility.FromStringPtr(apiManifest.Branch))
+	require.Len(t, apiManifest.Modules, 1)
+	expectedModule := mfst.Modules["module1"]
+	assert.Equal(t, "module1", utility.FromStringPtr(apiManifest.Modules[0].Name))
+	assert.Equal(t, expectedModule.Branch, utility.FromStringPtr(apiManifest.Modules[0].Branch))
+	assert.Equal(t, expectedModule.Owner, utility.FromStringPtr(apiManifest.Modules[0].Owner))
+	assert.Equal(t, expectedModule.Repo, utility.FromStringPtr(apiManifest.Modules[0].Repo))
+	assert.Equal(t, expectedModule.Revision, utility.FromStringPtr(apiManifest.Modules[0].Revision))
+	assert.Equal(t, expectedModule.URL, utility.FromStringPtr(apiManifest.Modules[0].URL))
+}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -255,6 +255,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/versions/{version_id}/builds").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetVersionBuilds(env))
 	app.AddRoute("/versions/{version_id}/restart").Version(2).Post().Wrap(requireUser, editTasks).RouteHandler(makeRestartVersion())
 	app.AddRoute("/versions/{version_id}/annotations").Version(2).Get().Wrap(requireUser, viewAnnotations).RouteHandler(makeFetchAnnotationsByVersion())
+	app.AddRoute("/versions/{version_id}/manifest").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetVersionManifest())
 
 	// Add an options method to every GET, POST request to handle pre-flight Options requests.
 	// These requests must not check for credentials and just validate whether a route exists

--- a/rest/route/version.go
+++ b/rest/route/version.go
@@ -357,9 +357,9 @@ func makeGetVersionManifest() gimlet.RouteHandler {
 
 // Factory creates an instance of the handler.
 //
-//	@Summary		Fetch module manifest by version ID
-//	@Description	Fetches the module manifest by its version ID
-//	@Tags			versions
+//	@Summary		Fetch manifest by version ID
+//	@Description	Fetches the manifest by its version ID
+//	@Tags			manifests
 //	@Router			/versions/{version_id}/manifest [get]
 //	@Security		Api-User || Api-Key
 //	@Param			version_id	path		string	true	"version ID"

--- a/rest/route/version_test.go
+++ b/rest/route/version_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/mock"
 	serviceModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/manifest"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/model"
@@ -56,7 +57,7 @@ func (s *VersionSuite) SetupSuite() {
 	branch = "branch"
 	project = "project"
 
-	s.NoError(db.ClearCollections(task.Collection, serviceModel.VersionCollection, build.Collection))
+	s.NoError(db.ClearCollections(task.Collection, serviceModel.VersionCollection, build.Collection, manifest.Collection))
 	s.bv = append(s.bv, "buildvariant1", "buildvariant2")
 	s.bi = append(s.bi, "buildId1", "buildId2")
 	s.btc = [][]build.TaskCache{
@@ -290,4 +291,59 @@ func (s *VersionSuite) TestRestartVersion() {
 	v, err := serviceModel.VersionFindOneId(s.ctx, "versionId")
 	s.NoError(err)
 	s.Equal(evergreen.VersionStarted, v.Status)
+}
+
+func (s *VersionSuite) TestGetManifestForVersion() {
+	mfst := manifest.Manifest{
+		Id:          versionId,
+		Revision:    revision,
+		ProjectName: project,
+		Branch:      branch,
+		Modules: map[string]*manifest.Module{
+			"module1": {
+				Branch:   "module1_branch",
+				Repo:     "module1_repo",
+				Revision: "module1_revision",
+				Owner:    "module1_owner",
+				URL:      "module1_url",
+			},
+		},
+	}
+	exists, err := mfst.TryInsert(s.ctx)
+	s.Require().NoError(err)
+	s.False(exists)
+
+	ctx := gimlet.AttachUser(s.ctx, &user.DBUser{Id: "caller1"})
+
+	handler := &versionManifestGetHandler{versionId: "versionId"}
+
+	res := handler.Run(ctx)
+	s.NotNil(res)
+	s.Equal(http.StatusOK, res.Status())
+
+	apiMfst, ok := res.Data().(*model.APIManifest)
+	s.Require().True(ok)
+	s.Equal(versionId, utility.FromStringPtr(apiMfst.Id))
+	s.Equal(revision, utility.FromStringPtr(apiMfst.Revision))
+	s.Equal(project, utility.FromStringPtr(apiMfst.ProjectName))
+	s.Equal(branch, utility.FromStringPtr(apiMfst.Branch))
+	s.NotEmpty(apiMfst.Modules)
+	s.Len(apiMfst.Modules, 1)
+	expectedModule := mfst.Modules["module1"]
+	s.Equal("module1", utility.FromStringPtr(apiMfst.Modules[0].Name))
+	s.Equal(expectedModule.Branch, utility.FromStringPtr(apiMfst.Modules[0].Branch))
+	s.Equal(expectedModule.Repo, utility.FromStringPtr(apiMfst.Modules[0].Repo))
+	s.Equal(expectedModule.Revision, utility.FromStringPtr(apiMfst.Modules[0].Revision))
+	s.Equal(expectedModule.Owner, utility.FromStringPtr(apiMfst.Modules[0].Owner))
+	s.Equal(expectedModule.URL, utility.FromStringPtr(apiMfst.Modules[0].URL))
+}
+
+func (s *VersionSuite) TestGetManifestForVersionErrorsForNonexistentVersion() {
+	ctx := gimlet.AttachUser(s.ctx, &user.DBUser{Id: "caller1"})
+
+	handler := &versionManifestGetHandler{versionId: "nonexistent"}
+
+	res := handler.Run(ctx)
+	s.NotNil(res)
+	s.Equal(http.StatusNotFound, res.Status())
 }


### PR DESCRIPTION
DEVPROD-20580

### Description
Update the last-revision command to output the version revision and the revisions of all of its modules. There's no REST route that currently lets you get the version manifest (except a legacy REST route, which would actually be slightly difficult to incorporate), so I made a REST v2 route for it.

* Create REST route for getting a manifest by version ID.
* Print revisions for modules if the version found by last-revision has a manifest.

### Testing
* Added unit tests for route.
* Tested in staging to verify that it returned module revisions if the matching version had modules, otherwise the output is unchanged for versions without modules.

### Documentation
* Updated CLI doc usage text.
* Updated REST v2 docs for new route.