### PR TITLE
DEVPROD-20127  Start using the long retention s3 bucket for the specified lists of projects 

### DIFF
--- a/config_bucket.go
+++ b/config_bucket.go
@@ -2,6 +2,7 @@ package evergreen
 
 import (
 	"context"
+	"slices"
 
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
@@ -100,10 +101,8 @@ func (c *BucketsConfig) ValidateAndDefault() error {
 // GetLogBucket returns the appropriate log bucket based on if the project ID
 // is in the LongRetentionProjects list.
 func (c *BucketsConfig) GetLogBucket(projectID string) BucketConfig {
-	for _, project := range c.LongRetentionProjects {
-		if project == projectID {
-			return c.LogBucketLongRetention
-		}
+	if slices.Contains(c.LongRetentionProjects, projectID) {
+		return c.LogBucketLongRetention
 	}
 	return c.LogBucket
 }

--- a/config_bucket.go
+++ b/config_bucket.go
@@ -96,3 +96,14 @@ func (c *BucketsConfig) ValidateAndDefault() error {
 	catcher.Add(c.LogBucketLongRetention.validate())
 	return catcher.Resolve()
 }
+
+// GetLogBucket returns the appropriate log bucket based on if the project ID
+// is in the LongRetentionProjects list.
+func (c *BucketsConfig) GetLogBucket(projectID string) BucketConfig {
+	for _, project := range c.LongRetentionProjects {
+		if project == projectID {
+			return c.LogBucketLongRetention
+		}
+	}
+	return c.LogBucket
+}

--- a/config_test.go
+++ b/config_test.go
@@ -916,6 +916,18 @@ func (s *AdminSuite) TestBucketsConfig() {
 	err = config.ValidateAndDefault()
 	s.NoError(err)
 
+	// Test GetLogBucket method
+	longRetentionBucket := settings.Buckets.GetLogBucket("project1")
+	s.Equal("logs-long-retention", longRetentionBucket.Name)
+	s.Equal(BucketTypeS3, longRetentionBucket.Type)
+
+	longRetentionBucket2 := settings.Buckets.GetLogBucket("project2")
+	s.Equal("logs-long-retention", longRetentionBucket2.Name)
+
+	defaultBucket := settings.Buckets.GetLogBucket("other-project")
+	s.Equal("logs-2", defaultBucket.Name)
+	s.Equal(BucketTypeS3, defaultBucket.Type)
+
 	// Test invalid bucket type
 	config.LogBucketLongRetention.Type = "invalid"
 	err = config.ValidateAndDefault()

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1763,7 +1763,7 @@ func (t *Task) initializeTaskOutputInfo(env evergreen.Environment) (*TaskOutput,
 		return nil, false
 	}
 
-	return InitializeTaskOutput(env), true
+	return InitializeTaskOutput(env, t.Project), true
 }
 
 // GetTaskOutputSafe returns an instantiation of the task output interface and

--- a/model/task/task_output.go
+++ b/model/task/task_output.go
@@ -13,17 +13,18 @@ type TaskOutput struct {
 }
 
 // InitializeTaskOutput initializes the task output for a new task run.
-func InitializeTaskOutput(env evergreen.Environment) *TaskOutput {
+func InitializeTaskOutput(env evergreen.Environment, projectID string) *TaskOutput {
 	settings := env.Settings()
+	logBucket := settings.Buckets.GetLogBucket(projectID)
 
 	return &TaskOutput{
 		TaskLogs: TaskLogOutput{
 			Version:      TestResultServiceEvergreen,
-			BucketConfig: settings.Buckets.LogBucket,
+			BucketConfig: logBucket,
 		},
 		TestLogs: TestLogOutput{
 			Version:      TestResultServiceEvergreen,
-			BucketConfig: settings.Buckets.LogBucket,
+			BucketConfig: logBucket,
 		},
 		TestResults: TestResultOutput{
 			Version:      TestResultServiceEvergreen,


### PR DESCRIPTION
DEVPROD-20127

### Description
This starts using the correct bucket based on the admin list of projects. If a project is in the list, it will use the long retention bucket. 

### Testing
Tested this on staging to make sure that it reads and writes from the correct bucket for [this task.](https://spruce-staging.corp.mongodb.com/task/minna_test_ubuntu2004_validate_commit_message_patch_dc197c1838b80e0d73a2037675b4a33d3b8f7f55_689a324769332e0007afaacf_25_08_11_18_11_29/logs?execution=0). I also added a unit test. 


