### PR TITLE
DEVPROD-18232 Log redacted secret changes to event log

### DIFF
--- a/config.go
+++ b/config.go
@@ -761,7 +761,8 @@ func StoreAdminSecrets(ctx context.Context, paramMgr *parameterstore.ParameterMa
 					if err != nil {
 						catcher.Wrapf(err, "Failed to store secret field '%s' in parameter store", fieldPath)
 					}
-					fieldValue.SetString(RedactedValue)
+					redactedValue := fmt.Sprintf("REDACTED:%s", util.GetSHA256Hash(secretValue)[:6])
+					fieldValue.SetString(redactedValue)
 					// if the field is a map[string]string, store each key-value pair individually
 				} else if fieldValue.Kind() == reflect.Map && fieldValue.Type().Key().Kind() == reflect.String && fieldValue.Type().Elem().Kind() == reflect.String {
 					// Create a new map to store the paths
@@ -775,7 +776,8 @@ func StoreAdminSecrets(ctx context.Context, paramMgr *parameterstore.ParameterMa
 							catcher.Wrapf(err, "Failed to store secret map field '%s' in parameter store", mapFieldPath)
 							continue
 						}
-						newMap.SetMapIndex(key, reflect.ValueOf(RedactedValue))
+						redactedValue := fmt.Sprintf("REDACTED:%s", util.GetSHA256Hash(secretValue)[:6])
+						newMap.SetMapIndex(key, reflect.ValueOf(redactedValue))
 					}
 					fieldValue.Set(newMap)
 				}

--- a/rest/data/admin_test.go
+++ b/rest/data/admin_test.go
@@ -260,7 +260,7 @@ func (s *AdminDataSuite) TestSetAndGetSettings() {
 		case *evergreen.CloudProviders:
 			foundProvidersEvent = true
 			s.Require().NotEmpty(v.AWS.EC2Keys)
-			s.Equal(evergreen.RedactedValue, v.AWS.EC2Keys[0].Key)
+			s.Equal("REDACTED:40aedb", v.AWS.EC2Keys[0].Key)
 		case *evergreen.UIConfig:
 			foundUiEvent = true
 			s.Equal(testSettings.Ui.Url, v.Url)

--- a/testutil/testing.go
+++ b/testutil/testing.go
@@ -70,8 +70,6 @@ func ConfigureIntegrationTest(t *testing.T, testSettings *evergreen.Settings) {
 	err = testSettings.Set(context.Background())
 	require.NoError(t, err, "Error updating admin settings in DB")
 
-	// err = evergreen.UpdateConfig(context.Background(), testSettings)
-	// require.NoError(t, err, "Error updating settings in DB")
 	catcher := grip.NewBasicCatcher()
 	evergreen.StoreAdminSecrets(context.Background(),
 		evergreen.GetEnvironment().ParameterManager(),


### PR DESCRIPTION
DEVPROD-18232

### Description
With the previous change, we wouldn't log any secret changes because in the DB we would be changing them from REDACTED to REDACTED but now we add a little hash value so we will log them while still being redacted 

### Testing
staging