### PR TITLE
DEVPROD-3168: increase timeout for GitHub webhook requests

### DIFF
--- a/rest/data/otel.go
+++ b/rest/data/otel.go
@@ -1,0 +1,12 @@
+package data
+
+import (
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen"
+	"go.opentelemetry.io/otel"
+)
+
+var packageName = fmt.Sprintf("%s%s", evergreen.PackageName, "/rest/data")
+
+var tracer = otel.GetTracerProvider().Tracer(packageName)

--- a/rest/data/repotracker.go
+++ b/rest/data/repotracker.go
@@ -25,6 +25,9 @@ const branchRefPrefix = "refs/heads/"
 // TriggerRepotracker creates an amboy job to get the commits from a
 // Github Push Event
 func TriggerRepotracker(ctx context.Context, q amboy.Queue, msgID string, event *github.PushEvent) error {
+	ctx, span := tracer.Start(ctx, "trigger-repotracker")
+	defer span.End()
+
 	branch, err := validatePushEvent(event)
 	if err != nil {
 		grip.Error(message.WrapError(err, message.Fields{

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -857,6 +857,9 @@ func (gh *githubHookApi) overrideOtherPRs(ctx context.Context, pr *github.PullRe
 
 // handleGitTag adds the tag to the version it was pushed to, and triggers a new version if applicable
 func (gh *githubHookApi) handleGitTag(ctx context.Context, event *github.PushEvent) error {
+	ctx, span := tracer.Start(ctx, "handle-git-tag")
+	defer span.End()
+
 	if err := validatePushTagEvent(event); err != nil {
 		grip.Debug(message.WrapError(err, message.Fields{
 			"source":  "GitHub hook",


### PR DESCRIPTION
DEVPROD-3168

### Description
Creating git tag versions for server releases is currently hitting a context deadline exceeded error. Since the request can run for one minute, it's possible that handling the git tag from a server release is particularly slow, so increasing the timeout may alleviate the issue. I also thought tracing would help here because if it errors, we can tell how long the operation took.

* Increase timeout for GitHub webhook requests.
* Add OTel tracing for git tags.

### Testing
No real way to test this since most webhook operations complete within the 1 minute timeout, but we can ask the server release team to trigger another git tag to see if it hits the timeout again/view the trace info.

### Documentation
N/A