### PR TITLE
DEVPROD-20809 Change where the task log bucket is read from

### DIFF
--- a/model/task/task_log.go
+++ b/model/task/task_log.go
@@ -130,20 +130,13 @@ func getTaskLogs(ctx context.Context, task Task, getOpts TaskLogGetOptions) (log
 		return nil, err
 	}
 
-	// If the project is in the long retention list, override the bucket config
-	env := evergreen.GetEnvironment()
-	var taskLogOutput TaskLogOutput
+	// Get the appropriate bucket config for this project
+	bucketConfig := getBucketConfigForProject(task.Project, output.TaskLogs.BucketConfig)
 
-	if env != nil && env.Settings() != nil && slices.Contains(env.Settings().Buckets.LongRetentionProjects, task.Project) {
-		// Project is in long retention list, use current long retention bucket
-		taskLogOutput = TaskLogOutput{
-			Version:        output.TaskLogs.Version,
-			BucketConfig:   env.Settings().Buckets.LogBucketLongRetention,
-			AWSCredentials: output.TaskLogs.AWSCredentials,
-		}
-	} else {
-		// Project is not in long retention list, use original bucket config
-		taskLogOutput = output.TaskLogs
+	taskLogOutput := TaskLogOutput{
+		Version:        output.TaskLogs.Version,
+		BucketConfig:   bucketConfig,
+		AWSCredentials: output.TaskLogs.AWSCredentials,
 	}
 
 	svc, err := getLogService(ctx, taskLogOutput)
@@ -185,4 +178,16 @@ func getLogService(ctx context.Context, o TaskLogOutput) (log.LogService, error)
 	}
 
 	return log.NewLogServiceV0(b), nil
+}
+
+// getBucketConfigForProject returns the appropriate bucket config for a project,
+// using long retention bucket if the project is in the long retention list.
+func getBucketConfigForProject(project string, originalBucketConfig evergreen.BucketConfig) evergreen.BucketConfig {
+	env := evergreen.GetEnvironment()
+	if env != nil && env.Settings() != nil && slices.Contains(env.Settings().Buckets.LongRetentionProjects, project) {
+		// Project is in long retention list, use current long retention bucket
+		return env.Settings().Buckets.LogBucketLongRetention
+	}
+	// Project is not in long retention list, use original bucket config
+	return originalBucketConfig
 }

--- a/model/task/task_log.go
+++ b/model/task/task_log.go
@@ -131,14 +131,14 @@ func getTaskLogs(ctx context.Context, task Task, getOpts TaskLogGetOptions) (log
 	}
 
 	// If the project is in the long retention list, override the bucket config
-	settings := evergreen.GetEnvironment().Settings()
+	env := evergreen.GetEnvironment()
 	var taskLogOutput TaskLogOutput
 
-	if settings != nil && slices.Contains(settings.Buckets.LongRetentionProjects, task.Project) {
+	if env != nil && env.Settings() != nil && slices.Contains(env.Settings().Buckets.LongRetentionProjects, task.Project) {
 		// Project is in long retention list, use current long retention bucket
 		taskLogOutput = TaskLogOutput{
 			Version:        output.TaskLogs.Version,
-			BucketConfig:   settings.Buckets.LogBucketLongRetention,
+			BucketConfig:   env.Settings().Buckets.LogBucketLongRetention,
 			AWSCredentials: output.TaskLogs.AWSCredentials,
 		}
 	} else {

--- a/model/task/test_log.go
+++ b/model/task/test_log.go
@@ -77,14 +77,14 @@ func getTestLogs(ctx context.Context, task Task, getOpts TestLogGetOptions) (log
 	}
 
 	// If the project is in the long retention list, override the bucket config
-	settings := evergreen.GetEnvironment().Settings()
+	env := evergreen.GetEnvironment()
 	var testLogOutput TestLogOutput
 
-	if settings != nil && slices.Contains(settings.Buckets.LongRetentionProjects, task.Project) {
+	if env != nil && env.Settings() != nil && slices.Contains(env.Settings().Buckets.LongRetentionProjects, task.Project) {
 		// Project is in long retention list, use current long retention bucket
 		testLogOutput = TestLogOutput{
 			Version:        output.TestLogs.Version,
-			BucketConfig:   settings.Buckets.LogBucketLongRetention,
+			BucketConfig:   env.Settings().Buckets.LogBucketLongRetention,
 			AWSCredentials: output.TestLogs.AWSCredentials,
 		}
 	} else {


### PR DESCRIPTION
DEVPROD-20809

### Description
We recently moved some projects over to the long retention bucket. The files are already copied over and we plan to change the default bucket to a shorter retention. However, the existing logs still have the old bucket stored in their metadata. This adds a workaround for it that we can delete after one year from today. 

### Testing
I tested this on staging with [this task.](https://spruce-staging.corp.mongodb.com/task/minna_test_ubuntu2004_validate_commit_message_patch_dc197c1838b80e0d73a2037675b4a33d3b8f7f55_689aa9a5ef8f1d0007608cc5_25_08_12_02_40_54/logs?execution=0). The task has the old default bucket saved in task output. I deleted the logs from that bucket and they are now only in the long retention bucket. If I try to load the logs, it shows "no logs found". With these changes, the logs load (on both parsley and html). 
