### PR TITLE
DEVPROD-19997: add option to configure timeout for last-revision

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-08-13"
+	ClientVersion = "2025-08-15"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).


### PR DESCRIPTION
DEVPROD-19997

### Description
* Add option for maximum timeout on last-revision before giving up.
* Slightly refactor the CLI input validation checks so they're in the CLI before funcs.

### Testing
* Tested manually to verify that it respected the timeout.
* Tested input validations manually.

### Documentation
Updated CLI usage docs.
