### PR TITLE
DEVPROD-20399 Remove check on receiver for degraded webhook

### DIFF
--- a/rest/route/degraded_mode.go
+++ b/rest/route/degraded_mode.go
@@ -14,15 +14,13 @@ import (
 )
 
 const firingStatus = "firing"
-const evergreenWebhook = "webhook-devprod-evergreen"
 
 func makeSetDegradedMode() gimlet.RouteHandler {
 	return &degradedModeHandler{}
 }
 
 type degradedModeHandler struct {
-	Receiver string `json:"receiver"`
-	Status   string `json:"status"`
+	Status string `json:"status"`
 }
 
 func (h *degradedModeHandler) Factory() gimlet.RouteHandler {
@@ -33,7 +31,7 @@ func (h *degradedModeHandler) Parse(ctx context.Context, r *http.Request) error 
 	if err := gimlet.GetJSON(r.Body, h); err != nil {
 		return errors.Wrap(err, "parsing request")
 	}
-	if h.Status != firingStatus || h.Receiver != evergreenWebhook {
+	if h.Status != firingStatus {
 		return gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
 			Message:    "alert is in incorrect state to trigger degraded mode",


### PR DESCRIPTION
DEVPROD-20399

### Description
During the migration of this ticket (using self-service webhooks in kanopy), the receiver name is now changed. According to the kanopy team, it's an 'implementation detail' on how it's constructed. I don't think we should check on this, as it sounds prone to change from now on if they change how it's constructed (which would result in degraded mode not being that resilient) 

### Testing
Deployed to staging
