### PR TITLE
DEVPROD-20997 Allow expansions for s3.put permissions parameter

### DIFF
--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -220,8 +220,8 @@ func (s3pc *s3put) validate() error {
 
 	catcher.Wrapf(validateS3BucketName(s3pc.Bucket), "invalid bucket name '%s'", s3pc.Bucket)
 
-	// make sure the s3 permissions are valid
-	if !validS3Permissions(s3pc.Permissions) {
+	// Check that the permissions are expanded and not invalid.
+	if !util.IsExpandable(s3pc.Permissions) && !validS3Permissions(s3pc.Permissions) {
 		catcher.Errorf("invalid permissions '%s'", s3pc.Permissions)
 	}
 

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -197,6 +197,22 @@ func TestS3PutValidateParams(t *testing.T) {
 				So(err.Error(), ShouldContainSubstring, "invalid permissions")
 			})
 
+			Convey("an expansion s3 permission should pass", func() {
+
+				params := map[string]any{
+					"aws_key":      "key",
+					"aws_secret":   "secret",
+					"local_file":   "local",
+					"remote_file":  "remote",
+					"bucket":       "bck",
+					"permissions":  "${test|private}",
+					"content_type": "application/x-tar",
+					"display_name": "test_file",
+				}
+				err := cmd.ParseParams(params)
+				require.NoError(t, err)
+			})
+
 			Convey("a missing content type should cause an error", func() {
 
 				params := map[string]any{

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-08-11"
+	AgentVersion = "2025-08-18"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-20997

### Description
To improve flexibility with security of s3.put, this allows expansions in the permissions parameter.

### Testing
Deployed to staging, before deploying I get:
```
creating cli patch: Unexpected reply from server (500 Internal Server Error): 400 (Bad Request): error processing patch: invalid patched project config: invalid patched config syntax: post section in 's3.put' command: parsing parameters for command 's3.put' ('Upload smoke test's app server logs to S3') (step 2 of 3): invalid permissions '${some_exp|private}'
```

After deploying, the same config works