### PR TITLE
DEVPROD-20862 Use context without cancel for parameter store

### DIFF
--- a/config.go
+++ b/config.go
@@ -334,11 +334,13 @@ func readAdminSecrets(ctx context.Context, paramMgr *parameterstore.ParameterMan
 			if secretTag := field.Tag.Get("secret"); secretTag == "true" {
 				// If the field is a string, store in parameter manager and update struct with path.
 				if fieldValue.Kind() == reflect.String {
+					// Use a detached context to avoid context cancellation as this
+					// is a critical operation.
 					// We don't defer the cancel() and instead cancel it immediately
 					// after the parameter store read to avoid context leaks.
 					// This is because the recursive calls can create many contexts,
 					// and we want to ensure they are all cleaned up properly.
-					paramCtx, cancel := context.WithTimeout(ctx, parameterStoreTimeout)
+					paramCtx, cancel := context.WithTimeout(context.Background(), parameterStoreTimeout)
 					param, err := paramMgr.Get(paramCtx, fieldPath)
 					cancel()
 					if err != nil {
@@ -353,11 +355,13 @@ func readAdminSecrets(ctx context.Context, paramMgr *parameterstore.ParameterMan
 					newMap := reflect.MakeMap(fieldValue.Type())
 					for _, key := range fieldValue.MapKeys() {
 						mapFieldPath := fmt.Sprintf("%s/%s", fieldPath, key.String())
+						// Use a detached context to avoid context cancellation as this
+						// is a critical operation.
 						// We don't defer the cancel() and instead cancel it immediately
 						// after the parameter store read to avoid context leaks.
 						// This is because the recursive calls can create many contexts,
 						// and we want to ensure they are all cleaned up properly.
-						paramCtx, cancel := context.WithTimeout(ctx, parameterStoreTimeout)
+						paramCtx, cancel := context.WithTimeout(context.Background(), parameterStoreTimeout)
 						param, err := paramMgr.Get(paramCtx, mapFieldPath)
 						cancel()
 						if err != nil {

--- a/config.go
+++ b/config.go
@@ -340,7 +340,7 @@ func readAdminSecrets(ctx context.Context, paramMgr *parameterstore.ParameterMan
 					// after the parameter store read to avoid context leaks.
 					// This is because the recursive calls can create many contexts,
 					// and we want to ensure they are all cleaned up properly.
-					paramCtx, cancel := context.WithTimeout(context.Background(), parameterStoreTimeout)
+					paramCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), parameterStoreTimeout)
 					param, err := paramMgr.Get(paramCtx, fieldPath)
 					cancel()
 					if err != nil {
@@ -361,7 +361,7 @@ func readAdminSecrets(ctx context.Context, paramMgr *parameterstore.ParameterMan
 						// after the parameter store read to avoid context leaks.
 						// This is because the recursive calls can create many contexts,
 						// and we want to ensure they are all cleaned up properly.
-						paramCtx, cancel := context.WithTimeout(context.Background(), parameterStoreTimeout)
+						paramCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), parameterStoreTimeout)
 						param, err := paramMgr.Get(paramCtx, mapFieldPath)
 						cancel()
 						if err != nil {


### PR DESCRIPTION
DEVPROD-20862

### Description
the last PR for canceling the context manually did reduce the rate of these errors but I want to further reduce them
Context without Cancel is a new feature in go 1.21 where cancelling the parent context won't cancel the child one. 