### PR TITLE
DEVPROD-20862 Cache Admin Secrets

### DIFF
--- a/config.go
+++ b/config.go
@@ -282,6 +282,10 @@ func getSettings(ctx context.Context, includeOverrides, includeParameterStore bo
 	if !baseConfig.ServiceFlags.AdminParameterStoreDisabled && includeParameterStore {
 		paramConfig := baseConfig
 		paramMgr := GetEnvironment().ParameterManager()
+		if paramMgr == nil {
+			grip.Errorf("parameter manager is nil, cannot read admin secrets from parameter store")
+			return baseConfig, nil
+		}
 		settingsValue := reflect.ValueOf(paramConfig).Elem()
 		settingsType := reflect.TypeOf(*paramConfig)
 		adminCatcher := grip.NewBasicCatcher()

--- a/config_test.go
+++ b/config_test.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/evergreen-ci/evergreen/cloud/parameterstore"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip/send"
 	"github.com/stretchr/testify/assert"
@@ -80,17 +79,8 @@ func TestAdminSuite(t *testing.T) {
 	}
 
 	originalEnv := GetEnvironment()
-	pm, err := parameterstore.NewParameterManager(ctx, parameterstore.ParameterManagerOptions{
-		PathPrefix:     "prefix",
-		CachingEnabled: true,
-		DB:             originalEnv.DB(),
-	})
+	originalSettings, err := NewSettings(configFile)
 	require.NoError(t, err)
-	originalEnv.SetParameterManager(pm)
-
-	originalSettings, err := GetConfig(ctx)
-	require.NoError(t, err)
-
 	env, err := NewEnvironment(ctx, configFile, "", "", nil, noop.NewTracerProvider())
 	require.NoError(t, err)
 


### PR DESCRIPTION
DEVPROD-20862

### Description
this does 1 batch call to parameter store to cache all the information before trying to calll them all individually to trying to reduce db load


### Testing
existing tests pass
admin settings saves and load properly on staging with no occasional errors on splunk