### PR TITLE
DEVPROD-19924 Add child patches to merge queue

### DIFF
--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -189,7 +189,6 @@ type GithubPullRequestSubscriber struct {
 	PRNumber int    `bson:"pr_number"`
 	Ref      string `bson:"ref"`
 	ChildId  string `bson:"child"`
-	Type     string `bson:"type"`
 }
 
 func (s *GithubPullRequestSubscriber) String() string {
@@ -207,13 +206,14 @@ func (s *GithubCheckSubscriber) String() string {
 }
 
 type GithubMergeSubscriber struct {
-	Owner string `bson:"owner"`
-	Repo  string `bson:"repo"`
-	Ref   string `bson:"ref"`
+	Owner   string `bson:"owner"`
+	Repo    string `bson:"repo"`
+	Ref     string `bson:"ref"`
+	ChildId string `bson:"child"`
 }
 
 func (s *GithubMergeSubscriber) String() string {
-	return fmt.Sprintf("%s-%s-%s", s.Owner, s.Repo, s.Ref)
+	return fmt.Sprintf("%s-%s-%s-%s", s.Owner, s.Repo, s.Ref, s.ChildId)
 }
 
 type ChildPatchSubscriber struct {

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -507,7 +507,7 @@ func (j *patchIntentProcessor) createGitHubSubscriptions(ctx context.Context, p 
 	buildSub := event.NewExpiringBuildOutcomeSubscriptionByVersion(j.PatchID.Hex(), ghSub)
 	catcher.Wrap(buildSub.Upsert(ctx), "inserting build subscription for GitHub PR")
 	if p.IsParent() {
-		// add a subscription on each child patch to report it's status to github when it's done.
+		// add a subscription on each child patch to report its status to github when it's done.
 		for _, childPatch := range p.Triggers.ChildPatches {
 			childGhStatusSub := event.NewGithubStatusAPISubscriber(event.GithubPullRequestSubscriber{
 				Owner:    p.GithubPatchData.BaseOwner,
@@ -538,7 +538,7 @@ func (j *patchIntentProcessor) createGitHubMergeSubscription(ctx context.Context
 	catcher.Wrap(buildSub.Upsert(ctx), "inserting build subscription for GitHub merge queue")
 
 	if p.IsParent() {
-		// add a subscription on each child patch to report it's status to github when it's done.
+		// add a subscription on each child patch to report its status to github when it's done.
 		for _, childPatch := range p.Triggers.ChildPatches {
 			childGhStatusSub := event.NewGithubMergeAPISubscriber(event.GithubMergeSubscriber{
 				Owner:   p.GithubPatchData.BaseOwner,


### PR DESCRIPTION
DEVPROD-19924

### Description
This adds child patches to merge queue. This isn't feature-complete, and users aren't able to add these via the UI yet. As well, tests will be added in [DEVPROD-19925](https://jira.mongodb.org/browse/DEVPROD-19925).
<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

### Testing
Manual testing on staging.

I deployed these changes, added the mq patch alias to my project config, and it successfully created the child patch and waited for it to complete before actually passing the merge queue. [This was the patch](https://spruce-staging.corp.mongodb.com/version/68a609446e362d000774a91a/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) for reference.

### Documentation
Documentation will also be done in a future ticket when this feature is exposed to users.
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
