### PR TITLE
DEVPROD-20862 Use context with no cancel

### DIFF
--- a/config.go
+++ b/config.go
@@ -356,7 +356,7 @@ func readAdminSecrets(ctx context.Context, paramMgr *parameterstore.ParameterMan
 						// after the parameter store read to avoid context leaks.
 						// This is because the recursive calls can create many contexts,
 						// and we want to ensure they are all cleaned up properly.
-						paramCtx, cancel := context.WithTimeout(ctx, parameterStoreTimeout)
+						paramCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), parameterStoreTimeout)
 						param, err := paramMgr.Get(paramCtx, fieldPath)
 						cancel()
 						if err != nil {
@@ -380,7 +380,7 @@ func readAdminSecrets(ctx context.Context, paramMgr *parameterstore.ParameterMan
 							// after the parameter store read to avoid context leaks.
 							// This is because the recursive calls can create many contexts,
 							// and we want to ensure they are all cleaned up properly.
-							paramCtx, cancel := context.WithTimeout(ctx, parameterStoreTimeout)
+							paramCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), parameterStoreTimeout)
 							param, err := paramMgr.Get(paramCtx, mapFieldPath)
 							cancel()
 							if err != nil {


### PR DESCRIPTION
DEVPROD-20862

### Description
there seems to be workflows in evergreen that involve cancelling the context of getting the settings very often
this cannot be mitigated in anyway to in order to have the parameter store functions not error mid way through, we should use the withoutcancel context. 

this withoutcancel context will only affect the scope of the parameter store gets and won't change anything else 
if the parent does intentionally cancel, the parameter store function will still complete but that should not negatively affect the performance too much as most things are cached