### PR TITLE
DEVPROD-19659: Add more unit tests for path filtering

### DIFF
--- a/model/project_test.go
+++ b/model/project_test.go
@@ -2786,5 +2786,20 @@ func (s *projectSuite) TestBuildVariantPathsMatchAny() {
 			files = []string{"evergreen.yml"}
 			So(bv.ChangedFilesMatchPaths(files), ShouldBeTrue)
 		})
+		Convey("if a parent directory is ignored, but child is not-ignored, file should be fetched", func() {
+			bv := &BuildVariant{Paths: []string{"!server/**", "server/conf/**"}}
+			files = []string{"server/conf/conf-test-e2e.properties"}
+			So(bv.ChangedFilesMatchPaths(files), ShouldBeTrue)
+		})
+		Convey("if a parent directory is enabled, child directory is ignored, file in the child directory should be ignored", func() {
+			bv := &BuildVariant{Paths: []string{"server/**", "!server/conf/**"}}
+			files = []string{"server/conf/conf-test-e2e.properties"}
+			So(bv.ChangedFilesMatchPaths(files), ShouldBeFalse)
+		})
+		Convey("if a parent directory is enabled, child is ignored, file in the child directory should be ignored", func() {
+			bv := &BuildVariant{Paths: []string{"server/**", "!server/conf/**", "server/conf/conf-test*.properties"}}
+			files = []string{"server/conf/conf-test-e2e.properties"}
+			So(bv.ChangedFilesMatchPaths(files), ShouldBeTrue)
+		})
 	})
 }

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -2786,17 +2786,17 @@ func (s *projectSuite) TestBuildVariantPathsMatchAny() {
 			files = []string{"evergreen.yml"}
 			So(bv.ChangedFilesMatchPaths(files), ShouldBeTrue)
 		})
-		Convey("if a parent directory is ignored, but child is not-ignored, file should be fetched", func() {
+		Convey("if a parent directory is ignored and child directory is not-ignored, file should be fetched", func() {
 			bv := &BuildVariant{Paths: []string{"!server/**", "server/conf/**"}}
 			files = []string{"server/conf/conf-test-e2e.properties"}
 			So(bv.ChangedFilesMatchPaths(files), ShouldBeTrue)
 		})
-		Convey("if a parent directory is enabled, child directory is ignored, file in the child directory should be ignored", func() {
+		Convey("if a parent directory is enabled and child directory is ignored, file in the child directory should be ignored", func() {
 			bv := &BuildVariant{Paths: []string{"server/**", "!server/conf/**"}}
 			files = []string{"server/conf/conf-test-e2e.properties"}
 			So(bv.ChangedFilesMatchPaths(files), ShouldBeFalse)
 		})
-		Convey("if a parent directory is enabled, child is ignored, file in the child directory should be ignored", func() {
+		Convey("if a parent directory is enabled and file is un-ignored, file should be fetched", func() {
 			bv := &BuildVariant{Paths: []string{"server/**", "!server/conf/**", "server/conf/conf-test*.properties"}}
 			files = []string{"server/conf/conf-test-e2e.properties"}
 			So(bv.ChangedFilesMatchPaths(files), ShouldBeTrue)


### PR DESCRIPTION

### Description
This pull request adds new test cases to the `TestBuildVariantPathsMatchAny` function in `model/project_test.go` to improve coverage of path matching logic, especially around combinations of ignored and included directories and files.

### Testing

Path matching test improvements:

* Added a test to ensure that if a parent directory is ignored but a child directory is specifically included, files in the child directory are matched.
* Added a test to verify that if a parent directory is included but a child directory is ignored, files in the child directory are not matched.
* Added a test to confirm that if a parent directory is included, a child directory is ignored, but a specific file in the child directory is re-included, that file is matched.



### Documentation
Remember to add or edit docs in the docs/ directory if relevant.
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
