### PR TITLE
DEVPROD-20001: add option to reuse criteria in last-revision

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-08-19"
+	ClientVersion = "2025-08-21"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/last_revision.go
+++ b/operations/last_revision.go
@@ -79,11 +79,11 @@ func LastRevision() cli.Command {
 			},
 			cli.StringFlag{
 				Name:  saveFlagName,
-				Usage: "instead of searching for a revision, save the last revision criteria for reuse with the given name. If a set of criteria already exists for the same build variant name/display name regexps, the old criteria will be overwritten.",
+				Usage: "instead of searching for a revision, save the last revision criteria for reuse with the given group name. If a set of criteria already exists in the group for the same build variant name/display name regexps, the old criteria will be overwritten.",
 			},
 			cli.StringFlag{
 				Name:  reuseFlagName,
-				Usage: "reuse a set of last revision criteria by name",
+				Usage: "reuse a set of last revision criteria by group name",
 			},
 		),
 		Before: mergeBeforeFuncs(setPlainLogger,
@@ -137,7 +137,7 @@ func LastRevision() cli.Command {
 				}
 				if reuseCriteria && (len(c.StringSlice(regexpVariantsFlagName)) > 0 || len(c.StringSlice(regexpVariantsDisplayNameFlagName)) > 0 ||
 					c.Float64(minSuccessProportionFlagName) > 0 || c.Float64(minFinishedProportionFlagName) > 0 || len(c.StringSlice(successfulTasks)) > 0) {
-					return errors.New("cannot both reuse criteria and also specify specify other criteria")
+					return errors.New("cannot both reuse criteria and also specify other criteria")
 				}
 				return nil
 			},
@@ -195,7 +195,6 @@ func LastRevision() cli.Command {
 
 			var allCriteria []lastRevisionCriteria
 			if reuseCriteriaName != "" {
-				// kim: TODO: manually test reusing criteria
 				allCriteria, err = getLastRevisionCriteria(conf, reuseCriteriaName, projectID, knownIssuesAreSuccess)
 				if err != nil {
 					return errors.Wrapf(err, "getting last revision criteria with name '%s'", reuseCriteriaName)

--- a/operations/last_revision.go
+++ b/operations/last_revision.go
@@ -96,12 +96,7 @@ func LastRevision() cli.Command {
 				return autoUpdateCLI(c)
 			},
 			requireProjectFlag,
-			func(c *cli.Context) error {
-				if c.String(reuseFlagName) == "" && len(c.StringSlice(regexpVariantsFlagName)) == 0 && len(c.StringSlice(regexpVariantsDisplayNameFlagName)) == 0 {
-					return errors.New("must specify at least one build variant name or display name regexp")
-				}
-				return nil
-			},
+			requireAtLeastOneFlag(reuseFlagName, regexpVariantsFlagName, regexpVariantsDisplayNameFlagName),
 			func(c *cli.Context) error {
 				if c.Float64(minSuccessProportionFlagName) < 0 || c.Float64(minSuccessProportionFlagName) > 1 {
 					return errors.New("minimum success proportion must be between 0 and 1 inclusive")
@@ -123,18 +118,10 @@ func LastRevision() cli.Command {
 				}
 				return nil
 			},
-			func(c *cli.Context) error {
-				if c.String(reuseFlagName) == "" && c.Float64(minSuccessProportionFlagName) == 0 && c.Float64(minFinishedProportionFlagName) == 0 && len(c.StringSlice(successfulTasks)) == 0 {
-					return errors.New("must specify at least one criteria (minimum success proportion, minimum finished proportion, or required successful tasks) or set of criteria to reuse")
-				}
-				return nil
-			},
+			requireAtLeastOneFlag(reuseFlagName, minSuccessProportionFlagName, minFinishedProportionFlagName, successfulTasks),
+			mutuallyExclusiveArgs(false, reuseFlagName, saveFlagName),
 			func(c *cli.Context) error {
 				reuseCriteria := c.String(reuseFlagName) != ""
-				saveCriteria := c.String(saveFlagName) != ""
-				if reuseCriteria && saveCriteria {
-					return errors.New("cannot both reuse and save criteria")
-				}
 				if reuseCriteria && (len(c.StringSlice(regexpVariantsFlagName)) > 0 || len(c.StringSlice(regexpVariantsDisplayNameFlagName)) > 0 ||
 					c.Float64(minSuccessProportionFlagName) > 0 || c.Float64(minFinishedProportionFlagName) > 0 || len(c.StringSlice(successfulTasks)) > 0) {
 					return errors.New("cannot both reuse criteria and also specify other criteria")

--- a/operations/last_revision_test.go
+++ b/operations/last_revision_test.go
@@ -549,7 +549,7 @@ func TestLastRevisionCriteriaReuse(t *testing.T) {
 	}
 	t.Run("ReturnsExistingCriteriaGroup", func(t *testing.T) {
 		allCriteria, err := getLastRevisionCriteria(conf, "group1", "project", true)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		require.Len(t, allCriteria, 2)
 		for _, c := range allCriteria {
 			assert.Equal(t, "project", c.project)

--- a/operations/last_revision_test.go
+++ b/operations/last_revision_test.go
@@ -527,3 +527,49 @@ func TestLastRevisionCheckVersions(t *testing.T) {
 		})
 	}
 }
+
+func TestLastRevisionCriteriaReuse(t *testing.T) {
+	criteria1 := reusableLastRevisionCriteria{
+		BVRegexps:             []string{"bv1"},
+		MinSuccessProportion:  0.5,
+		MinFinishedProportion: 0.9,
+		SuccessfulTasks:       []string{"task1", "task2"},
+	}
+	criteria2 := reusableLastRevisionCriteria{
+		BVDisplayRegexps: []string{"Build Variant 2"},
+		SuccessfulTasks:  []string{"task3"},
+	}
+	conf := &ClientSettings{
+		LastRevisionCriteriaGroups: []lastRevisionCriteriaGroup{
+			{
+				Name:     "group1",
+				Criteria: []reusableLastRevisionCriteria{criteria1, criteria2},
+			},
+		},
+	}
+	t.Run("ReturnsExistingCriteriaGroup", func(t *testing.T) {
+		allCriteria, err := getLastRevisionCriteria(conf, "group1", "project", true)
+		assert.NoError(t, err)
+		require.Len(t, allCriteria, 2)
+		for _, c := range allCriteria {
+			assert.Equal(t, "project", c.project)
+			assert.True(t, c.knownIssuesAreSuccess)
+		}
+
+		assert.Len(t, allCriteria[0].buildVariantRegexps, len(criteria1.BVRegexps))
+		assert.Len(t, allCriteria[0].buildVariantDisplayNameRegexps, len(criteria1.BVDisplayRegexps))
+		assert.Equal(t, criteria1.MinSuccessProportion, allCriteria[0].minSuccessProportion)
+		assert.Equal(t, criteria1.MinFinishedProportion, allCriteria[0].minFinishedProportion)
+		assert.Len(t, allCriteria[0].successfulTasks, len(criteria1.SuccessfulTasks))
+
+		assert.Len(t, allCriteria[1].buildVariantRegexps, len(criteria2.BVRegexps))
+		assert.Len(t, allCriteria[1].buildVariantDisplayNameRegexps, len(criteria2.BVDisplayRegexps))
+		assert.Zero(t, allCriteria[1].minSuccessProportion, criteria2.MinSuccessProportion)
+		assert.Zero(t, allCriteria[1].minFinishedProportion, criteria2.MinFinishedProportion)
+		assert.Len(t, allCriteria[1].successfulTasks, len(criteria2.SuccessfulTasks))
+	})
+	t.Run("ErrorsForNonexistentCriteriaGroup", func(t *testing.T) {
+		_, err := getLastRevisionCriteria(conf, "nonexistent", "project", true)
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
DEVPROD-20001

### Description
Follow-up to #9313 - the CLI can save last-revision criteria to the user's personal Evergreen YAML config, so this adds support to reuse that saved criteria when running the last-revision command.

### Testing
* Added unit test for finding criteria to reuse from config.
* Manually tested to verify that it could load last-revision criteria from the config file and checked all criteria to pass.

### Documentation
Updated CLI usage docs.
