### PR TITLE
DEVPROD-20862 Don't grip for context cancelled

### DIFF
--- a/config.go
+++ b/config.go
@@ -292,7 +292,9 @@ func getSettings(ctx context.Context, includeOverrides, includeParameterStore bo
 
 		paramCache := map[string]string{}
 		params, err := paramMgr.Get(ctx, collectSecretPaths(settingsValue, settingsType, "")...)
-		if err != nil {
+		if ctx.Err() != nil {
+			return nil, errors.Wrap(ctx.Err(), "context is cancelled, cannot get settings")
+		} else if err != nil {
 			grip.Error(errors.Wrap(err, "getting all admin secrets from parameter store"))
 		} else {
 			for _, param := range params {


### PR DESCRIPTION
DEVPROD-20862

### Description
we shouldn't spam splunk every time there's a context cancellation 