### PR TITLE
DEVPROD-21088 Allow s3.put visibility parameter to be expanded

### DIFF
--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -214,7 +214,7 @@ func (s3pc *s3put) validate() error {
 		catcher.New("visibility: signed should not be combined with permissions: public-read or permissions: public-read-write")
 	}
 
-	if !utility.StringSliceContains(artifact.ValidVisibilities, s3pc.Visibility) {
+	if !util.IsExpandable(s3pc.Visibility) && !utility.StringSliceContains(artifact.ValidVisibilities, s3pc.Visibility) {
 		catcher.Errorf("invalid visibility setting '%s', allowed visibilities are: %s", s3pc.Visibility, artifact.ValidVisibilities)
 	}
 

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -213,6 +213,23 @@ func TestS3PutValidateParams(t *testing.T) {
 				require.NoError(t, err)
 			})
 
+			Convey("an expansion s3 visibility should pass", func() {
+
+				params := map[string]any{
+					"aws_key":      "key",
+					"aws_secret":   "secret",
+					"local_file":   "local",
+					"remote_file":  "remote",
+					"bucket":       "bck",
+					"permissions":  "permissions",
+					"visibility":   "${visibility|signed}",
+					"content_type": "application/x-tar",
+					"display_name": "test_file",
+				}
+				err := cmd.ParseParams(params)
+				require.NoError(t, err)
+			})
+
 			Convey("a missing content type should cause an error", func() {
 
 				params := map[string]any{


### PR DESCRIPTION
DEVPROD-21088

### Description
Although it has `plugin: expand`, we check against a static list of things. We first have to check if it is not expandable before we check for it. If it's expandable, it means we are in the `Parse` step rather than `Execute` (where expansions have been applied).
<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

### Testing
Add unit test