### PR TITLE
DEVPROD-21298 Add disk usage/available/utilization metrics to honeycomb

### DIFF
--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-08-21"
+	AgentVersion = "2025-08-26"
 )
 
 const (


### PR DESCRIPTION
[DEVPROD-21298](https://jira.mongodb.org/browse/DEVPROD-21298)

### Description
This adds some more disk metrics to honeycomb!

### Testing
Deploy to staging, run a [task](https://spruce-staging.corp.mongodb.com/task/zackary_bisect_pass_passtest_patch_faa32cbeb73b5b0b298aa5b1155e85d0621722b2_68add30c5117dd0007e275ab_25_08_26_15_30_31/logs?execution=0), got these [system metrics](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/zZ8G2rQ5e4K?expd_asc=true&expd_col=_hny.ts&expd_fwd=false&expd_id=pd1KgfNzTXF&expd_page=25&tab=explore).

<img width="767" height="754" alt="Screenshot 2025-08-26 at 11 52 14 AM" src="https://github.com/user-attachments/assets/1e21c290-e875-4560-a3de-75e62cac557c" />
