### PR TITLE
DEVPROD-20206: add detailed documentation for last-revision

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -436,8 +436,9 @@ The list command can take an optional `-f/--file` argument for specifying a loca
 
 ### Last Revision
 
-The command `evergreen last-revision` can help you find the most recent suitable base commit to patch against based on
-task statuses. You can define your own custom search criteria when looking for a suitable recent commit.
+The command `evergreen last-revision` can help you find a suitable recent base commit that matches some user-customized
+search criteria. This can be used to find a base commit for patching. Much of the functionality of this command is based
+on the [git-co-evg-base CLI tool](https://github.com/evergreen-ci/git-co-evg-base).
 
 To use it, specify the project you wish to query, the set of build variants to verify, and [criteria](#criteria)
 defining what you need from a suitable commit.
@@ -445,24 +446,25 @@ defining what you need from a suitable commit.
 #### Criteria
 
 To begin searching for a suitable base commit, you must specify the build variants that you'd like to check to see if a
-commit is suitable to use. The build variants can be specified using a regular expression on build variant name, or
-build variant display name. The build variant flags can be specified multiple times to match different build variants,
-and last-revision will search all matching build variants.
+commit is suitable to use. The build variants can be specified using a regular expression on build variant name
+(`--regex-variants`, or `--rv`), or build variant display name (`--regex-display-variants`). The build variant flags can
+be specified multiple times to include more build variants, and last-revision will verify the criteria for all matching
+build variants.
 
 For example:
 
 ```sh
 # Verify build variants by name (flag can also be shortened to --rv)
-evergreen last-revision -p mongodb-mongo-master --regex-variants "<build_variant_name>" 
+evergreen last-revision -p mongodb-mongo-master --regex-variants "<build_variant_name>"
 # Multiple build variants can be checked simultaneously
-evergreen last-revision -p mongodb-mongo-master --regex-variants "build-variant-1" --regex-variants "build-variant-2" 
+evergreen last-revision -p mongodb-mongo-master --regex-variants "build-variant-1" --regex-variants "build-variant-2"
 
 # Verify build variants by display name
 evergreen last-revision -p mongodb-mongo-master --regex-display-variants "<build_variant_display_name>"
 ```
 
-Once you've chosen suitable build variants, you must decide what criteria to filter for within those build variants when
-deciding what's a suitable base commit (see below for available options).
+Once you've chosen suitable build variants, you must decide what criteria to filter for within those build variants to
+determine what's a suitable base commit (see below for available options).
 
 ##### Successful Tasks
 
@@ -515,20 +517,21 @@ evergreen last-revision -p mongodb-mongo-master --rv '.*-required$' --min-finish
 
 ##### Ignoring Known Issues
 
-Some users may prefer to ignore known issues when searching for a good base commit. To treat known issues as if they
-were successful, you can set the `--known-failures-are-success` flag.
+Some users may prefer to ignore known issues when searching for a base commit. To treat known issues as if they were
+successful, you can set the `--known-issues-are-success` flag.
 
 #### Saving Criteria
 
-Instead of typing out the criteria on every single search, criteria can be grouped and saved under a given name and
-referenced in later searches.
+Instead of typing out the criteria on every single search, criteria can be saved under a more user-friendly name to be
+reused in later searches.
 
 To save a set of criteria, specify the criteria you'd like to save and `--save <name>`. If `--save` is given, the
-last-revision command will be saved to your personal Evergreen YAML file and will not run the search.
+last-revision command criteria will be saved to your personal Evergreen YAML file and will not run the search.
 
 If `--save` is run on a name that's already saved, there are two possible outcomes:
 
-1. If the build variants match the previously specified build variants, the command will overwrite the previous criteria.
+1. If the build variants exactly match the previously specified build variants, the command will overwrite the previous
+   criteria.
 2. If the build variants do not match any previous specified build variants, then the criteria will be added along with
    the existing criteria. This allows you to specify different criteria for different build variants.
 
@@ -548,7 +551,8 @@ evergreen last-revision --rv '.*windows.*' --successful-tasks compile_dist_test 
 
 ##### Reusing Criteria
 
-Once criteria has been [saved](#saving-criteria), you can use the `--reuse <name>` option to perform a search with it. The option takes the name of the saved criteria as an argument:
+Once criteria has been [saved](#saving-criteria), you can use the `--reuse <name>` option to perform a search with it.
+The option takes the name of the saved criteria group as an argument.
 
 To reuse the previously saved `required` criteria:
 
@@ -557,7 +561,7 @@ evergreen last-revision -p mongodb-mongo-master --reuse required
 ```
 
 ##### Listing Criteria
-To output the names and criteria for all saved criteria groups, you can use the `--list` option:
+To print out the names and criteria for all saved criteria groups, you can use the `--list` option:
 
 ```sh
 evergreen last-revision --list
@@ -571,12 +575,11 @@ and change the timeout using the `--timeout` flag.
 
 #### Configuring Output Logs
 
-By default, last-revision will only show the final output revision found (if any) along with any module revisions (if
-the version uses modules). Specify `--json` to print the output in JSON format.
+By default, last-revision will only output the final commit found (if any) along with any module revisions (if the
+version uses modules). Specify `--json` to print the output in JSON format.
 
 You can use `evergreen --level=debug last-revision` if you'd like to see more verbose output from last-revision showing
 the result of each revision that the command searches through.
-
 
 ### Last Green
 
@@ -587,7 +590,7 @@ The command `evergreen last-green` can help you find an entirely successful comm
 To use it, specify the project you wish to query along with the set of variants to verify as passing.
 
 ```bash
-    evergreen last-green -p <project_id> -v <variant1> -v <variant2> -v <variant...>
+evergreen last-green -p <project_id> -v <variant1> -v <variant2> -v <variant...>
 ```
 
 A run might look something like


### PR DESCRIPTION
DEVPROD-20206

### Description
Add more detailed documentation about how to use the `evergreen last-revision` command. [The git-co-evg-base docs](https://evergreen-ci.github.io/git-co-evg-base/concepts/criteria/) are already quite good, so I largely lifted up that documentation and tweaked it a bit.
