### PR TITLE
DEVPROD-21479 Redact Github Webhook Secret

### DIFF
--- a/config.go
+++ b/config.go
@@ -82,7 +82,7 @@ type Settings struct {
 	GithubPRCreatorOrg  string                  `yaml:"github_pr_creator_org" bson:"github_pr_creator_org" json:"github_pr_creator_org"`
 	GitHubCheckRun      GitHubCheckRunConfig    `yaml:"github_check_run" bson:"github_check_run" json:"github_check_run" id:"github_check_run"`
 	GithubOrgs          []string                `yaml:"github_orgs" bson:"github_orgs" json:"github_orgs"`
-	GithubWebhookSecret string                  `yaml:"github_webhook_secret" bson:"github_webhook_secret" json:"github_webhook_secret"`
+	GithubWebhookSecret string                  `yaml:"github_webhook_secret" bson:"github_webhook_secret" json:"github_webhook_secret" secret:"true"`
 	DisabledGQLQueries  []string                `yaml:"disabled_gql_queries" bson:"disabled_gql_queries" json:"disabled_gql_queries"`
 	HostInit            HostInitConfig          `yaml:"hostinit" bson:"hostinit" json:"hostinit" id:"hostinit"`
 	HostJasper          HostJasperConfig        `yaml:"host_jasper" bson:"host_jasper" json:"host_jasper" id:"host_jasper"`


### PR DESCRIPTION
DEVPROD-21479

### Description
github webhook secret should be considered a secret 
also updated on events DB to be redacted



### Testing
<img width="448" height="55" alt="image" src="https://github.com/user-attachments/assets/d730aa6e-0ad2-4eee-9221-6cdb2c17bb91" />

updated in DB on staging

