### PR TITLE
DEVPROD-17165: Added flag to disable and enable new admin settings page

### DIFF
--- a/config_db.go
+++ b/config_db.go
@@ -92,6 +92,7 @@ var (
 	cpuDegradedModeDisabledKey         = bsonutil.MustHaveTag(ServiceFlags{}, "CPUDegradedModeDisabled")
 	elasticIPsDisabledKey              = bsonutil.MustHaveTag(ServiceFlags{}, "ElasticIPsDisabled")
 	releaseModeDisabledKey             = bsonutil.MustHaveTag(ServiceFlags{}, "ReleaseModeDisabled")
+	legacyUIAdminPageDisabledKey       = bsonutil.MustHaveTag(ServiceFlags{}, "LegacyUIAdminPageDisabled")
 
 	// ContainerPoolsConfig keys
 	poolsKey = bsonutil.MustHaveTag(ContainerPoolsConfig{}, "Pools")

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -38,6 +38,7 @@ type ServiceFlags struct {
 	CPUDegradedModeDisabled         bool `bson:"cpu_degraded_mode_disabled" json:"cpu_degraded_mode_disabled"`
 	ElasticIPsDisabled              bool `bson:"elastic_ips_disabled" json:"elastic_ips_disabled"`
 	ReleaseModeDisabled             bool `bson:"release_mode_disabled" json:"release_mode_disabled"`
+	LegacyUIAdminPageDisabled       bool `bson:"legacy_ui_admin_page_disabled" json:"legacy_ui_admin_page_disabled"`
 
 	// Notification Flags
 	EventProcessingDisabled      bool `bson:"event_processing_disabled" json:"event_processing_disabled"`
@@ -92,6 +93,7 @@ func (c *ServiceFlags) Set(ctx context.Context) error {
 			systemFailedTaskRestartDisabledKey: c.SystemFailedTaskRestartDisabled,
 			cpuDegradedModeDisabledKey:         c.CPUDegradedModeDisabled,
 			releaseModeDisabledKey:             c.ReleaseModeDisabled,
+			legacyUIAdminPageDisabledKey:       c.LegacyUIAdminPageDisabled,
 		}}), "updating config section '%s'", c.SectionId(),
 	)
 }

--- a/graphql/schema/types/adminSettings/service_flags.graphql
+++ b/graphql/schema/types/adminSettings/service_flags.graphql
@@ -34,6 +34,7 @@ input ServiceFlagsInput {
   emailNotificationsDisabled: Boolean
   webhookNotificationsDisabled: Boolean
   githubStatusAPIDisabled: Boolean
+  legacyUIAdminPageDisabled: Boolean
 }
 
 type ServiceFlags {
@@ -72,4 +73,5 @@ type ServiceFlags {
   emailNotificationsDisabled: Boolean
   webhookNotificationsDisabled: Boolean
   githubStatusAPIDisabled: Boolean
+  legacyUIAdminPageDisabled: Boolean
 }

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2187,6 +2187,7 @@ type APIServiceFlags struct {
 	DegradedModeDisabled            bool `json:"cpu_degraded_mode_disabled"`
 	ElasticIPsDisabled              bool `json:"elastic_ips_disabled"`
 	ReleaseModeDisabled             bool `json:"release_mode_disabled"`
+	LegacyUIAdminPageDisabled       bool `json:"legacy_ui_admin_page_disabled"`
 
 	// Notifications Flags
 	EventProcessingDisabled      bool `json:"event_processing_disabled"`
@@ -2617,6 +2618,7 @@ func (as *APIServiceFlags) BuildFromService(h any) error {
 		as.DegradedModeDisabled = v.CPUDegradedModeDisabled
 		as.ElasticIPsDisabled = v.ElasticIPsDisabled
 		as.ReleaseModeDisabled = v.ReleaseModeDisabled
+		as.LegacyUIAdminPageDisabled = v.LegacyUIAdminPageDisabled
 	default:
 		return errors.Errorf("programmatic error: expected service flags config but got type %T", h)
 	}
@@ -2661,6 +2663,7 @@ func (as *APIServiceFlags) ToService() (any, error) {
 		CPUDegradedModeDisabled:         as.DegradedModeDisabled,
 		ElasticIPsDisabled:              as.ElasticIPsDisabled,
 		ReleaseModeDisabled:             as.ReleaseModeDisabled,
+		LegacyUIAdminPageDisabled:      as.LegacyUIAdminPageDisabled,
 	}, nil
 }
 

--- a/service/templates/admin.html
+++ b/service/templates/admin.html
@@ -457,6 +457,15 @@ Admin Settings
 												</td>
 											</tr>
 											<tr>
+												<td>Legacy Admin Settings</td>
+												<td colspan="2">
+													<md-radio-group data-ng-model="Settings.service_flags.legacy_ui_admin_page_disabled" layout="row">
+														<md-radio-button data-ng-value="false"></md-radio-button>
+														<md-radio-button data-ng-value="true"></md-radio-button>
+													</md-radio-group>
+												</td>
+											</tr>
+											<tr>
 												<td>&nbsp;</td>
 											</tr>
 											<tr>

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -397,6 +397,7 @@ func MockConfig() *evergreen.Settings {
 			CPUDegradedModeDisabled:         true,
 			ElasticIPsDisabled:              true,
 			ReleaseModeDisabled:             true,
+			LegacyUIAdminPageDisabled: 	     true,
 		},
 		SingleTaskDistro: evergreen.SingleTaskDistroConfig{
 			ProjectTasksPairs: []evergreen.ProjectTasksPair{


### PR DESCRIPTION
[DEVPROD-17165](https://jira.mongodb.org/browse/DEVPROD-17165)

### Description
add service flag to switch between legacy and spruce admin settings pages 

