### PR TITLE
DEVPROD-18424: add retries to Docker image pull

### DIFF
--- a/cloud/docker_integration_test.go
+++ b/cloud/docker_integration_test.go
@@ -61,7 +61,7 @@ func (s *DockerIntegrationSuite) TestImagePull() {
 	}, utility.RetryOptions{
 		MaxAttempts: 10,
 		MinDelay:    time.Second,
-		MaxDelay:    10 * time.Minute,
+		MaxDelay:    30 * time.Second,
 	})
 	s.NoError(err)
 

--- a/thirdparty/docker/docker_cleanup_test.go
+++ b/thirdparty/docker/docker_cleanup_test.go
@@ -130,7 +130,7 @@ func TestCleanup(t *testing.T) {
 		}, utility.RetryOptions{
 			MaxAttempts: 10,
 			MinDelay:    time.Second,
-			MaxDelay:    10 * time.Minute,
+			MaxDelay:    30 * time.Second,
 		}))
 
 		t.Run(name, test)


### PR DESCRIPTION
DEVPROD-18424

### Description
Add retries (like what's done in the cloud package tests) when pulling the image in the Docker cleanup test. In addition, it seems like `ImagePull` can both return no error and also fail to pull the image if the rate limit is exceeded, so I expanded the retry logic to also double-check that the image exists.

* Add retries to Docker image pull for rate limit.
* Fix weird usage of context in the test cases.

### Testing
Ran test-thirdparty-docker in a bunch of patches and it passes consistently.