### PR TITLE
DEVPROD-21623 Add back empty banner theme

### DIFF
--- a/config.go
+++ b/config.go
@@ -810,7 +810,8 @@ func (s *DBSettings) mongoOptions(url string) *options.ClientOptions {
 	return opts
 }
 
-// supported banner themes in Evergreen
+// Supported banner themes in Evergreen.
+// Empty is a valid banner theme that should not be deleted.
 type BannerTheme string
 
 const (
@@ -818,6 +819,7 @@ const (
 	Information  BannerTheme = "INFORMATION"
 	Warning      BannerTheme = "WARNING"
 	Important    BannerTheme = "IMPORTANT"
+	Empty        BannerTheme = ""
 )
 
 func IsValidBannerTheme(input string) (bool, BannerTheme) {


### PR DESCRIPTION
DEVPROD-21623

### Description
this was causing some apis to fail because they expect empty banner to be valid
