### PR TITLE
DEVPROD-687 Otel attribute for git.get_project's parameter is_oauth

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -55,6 +55,7 @@ var (
 	cloneModuleAttribute  = fmt.Sprintf("%s.clone_module", gitGetProjectAttribute)
 	cloneMethodAttribute  = fmt.Sprintf("%s.clone_method", gitGetProjectAttribute)
 	cloneAttemptAttribute = fmt.Sprintf("%s.attempt", gitGetProjectAttribute)
+	cloneIsOauthAttribute = fmt.Sprintf("%s.is_oauth", gitGetProjectAttribute)
 
 	// validCloneMethods includes all recognized clone methods.
 	validCloneMethods = []string{
@@ -460,6 +461,7 @@ func (c *gitFetchProject) fetchSource(ctx context.Context, logger client.LoggerP
 			attribute.String(cloneBranchAttribute, opts.branch),
 			attribute.String(cloneMethodAttribute, opts.method),
 			attribute.Int(cloneAttemptAttribute, attempt),
+			attribute.Bool(cloneIsOauthAttribute, c.IsOauth),
 		))
 		defer span.End()
 
@@ -640,6 +642,7 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 			attribute.String(cloneBranchAttribute, opts.branch),
 			attribute.String(cloneMethodAttribute, opts.method),
 			attribute.Int(cloneAttemptAttribute, attempt),
+			attribute.Bool(cloneIsOauthAttribute, c.IsOauth),
 		))
 		defer span.End()
 


### PR DESCRIPTION
DEVPROD-687

### Description
Although it looks like no one is using this via all-configs, I'm still hesitant to remove it because someone might be using it via a generated yaml. This will allow me to verify if anyone's using it before removing it.

<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->
