### PR TITLE
DEVPROD-21515: add test selection enabled flag for task

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -352,6 +352,10 @@ type Task struct {
 	// CachedProjectStorageMethod is a cached value how the parser project for this task's version was
 	// stored at the time this task was created. If this is empty, the default storage method is StorageMethodDB.
 	CachedProjectStorageMethod evergreen.ParserProjectStorageMethod `bson:"cached_project_storage_method" json:"cached_project_storage_method,omitempty"`
+
+	// TestSelectionEnabled indicates whether test selection is enabled for this
+	// task.
+	TestSelectionEnabled bool `bson:"test_selection_enabled" json:"test_selection_enabled"`
 }
 
 // GeneratedJSONFiles represent files used by a task for generate.tasks to update the project YAML.


### PR DESCRIPTION
DEVPROD-21515

### Description
* Add field (which isn't set/used yet, but will unblock other app/UI tickets) which marks if a task has test selection enabled.
* Created [DPIPE ticket](https://jira.mongodb.org/browse/DPIPE-8705) for the new task field.

### Testing
N/A
