### PR TITLE
DEVPROD-21706: add method to quarantine a test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -190,7 +190,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation v1.1.1
 	github.com/evergreen-ci/evg-lint v0.0.0-20211115144425-3b19c8e83a57
 	github.com/evergreen-ci/plank v0.0.0-20230207190607-5f47f8a30da1
-	github.com/evergreen-ci/test-selection-client v0.0.0-20250331142509-2af2d0f91c8b
+	github.com/evergreen-ci/test-selection-client v0.0.0-20250909142252-2fdfa736f3ca
 	github.com/fraugster/parquet-go v0.11.0
 	github.com/google/go-github/v70 v70.0.0
 	github.com/gorilla/handlers v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/evergreen-ci/poplar v0.0.0-20250710150300-8483281f1c7d h1:E6ptMvYEC3g
 github.com/evergreen-ci/poplar v0.0.0-20250710150300-8483281f1c7d/go.mod h1:4FYcKrbVgR7DoHpDQEuGYK24X5nmy0UPSR5PD2nUUt0=
 github.com/evergreen-ci/shrub v0.0.0-20250224222152-c8b72a51163b h1:QNI8OFjXDpAys399HGdY4VxsMJqwuPNuauV96k8Ygbs=
 github.com/evergreen-ci/shrub v0.0.0-20250224222152-c8b72a51163b/go.mod h1:XPKWkKSyH41qKMl33gEV9Zq00en3MTZlvyZ5/1MSEek=
-github.com/evergreen-ci/test-selection-client v0.0.0-20250331142509-2af2d0f91c8b h1:u9QPcL6hmnR6tKiJW+Js/bRhFZolDTXPE8MSoqkv1+8=
-github.com/evergreen-ci/test-selection-client v0.0.0-20250331142509-2af2d0f91c8b/go.mod h1:qg5e4Faft68yLXo/dGsCoaGqn4+IqLUtbdy1UM2BbKI=
+github.com/evergreen-ci/test-selection-client v0.0.0-20250909142252-2fdfa736f3ca h1:Anq1OU5tXWAx4zbESnmMhCvH/3w3yXXjLlep3c5KWfQ=
+github.com/evergreen-ci/test-selection-client v0.0.0-20250909142252-2fdfa736f3ca/go.mod h1:0iD20pmczefJcyBCIuYuwfq9J3cqWOM5v61znyqcAwY=
 github.com/evergreen-ci/utility v0.0.0-20230104160902-3f0e05a638bd/go.mod h1:vkCEVgfCMIDajzbG/PHZURszI2Y1SuFqNWX9EUxmLLI=
 github.com/evergreen-ci/utility v0.0.0-20250604173729-c1b32de37d48 h1:xvB8GHNdC6wMsReqxNdmtlA8JU+hanPxHcDZ0wdkTTM=
 github.com/evergreen-ci/utility v0.0.0-20250604173729-c1b32de37d48/go.mod h1:AGAekBl7zMjMvHB6yqkVkE81JuHBxBPaPozF49DsU70=

--- a/rest/data/select.go
+++ b/rest/data/select.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/evergreen-ci/evergreen"
@@ -54,3 +55,14 @@ func SelectTests(ctx context.Context, req model.SelectTestsRequest) ([]string, e
 	return selectedTests, nil
 }
 
+// SetTestQuarantined marks the test as quarantined or unquarantined in the test
+// selection service.
+func SetTestQuarantined(projectID, bvName, taskName string, isQuarantined bool) error {
+	httpClient := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(httpClient)
+	c := newTestSelectionClient(httpClient)
+
+	// kim: TODO: need new TSC version.
+	fmt.Println(c.TestSelectionAPI)
+	return nil
+}

--- a/rest/data/select.go
+++ b/rest/data/select.go
@@ -1,0 +1,56 @@
+package data
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/rest/model"
+	testselection "github.com/evergreen-ci/test-selection-client"
+	"github.com/evergreen-ci/utility"
+	"github.com/pkg/errors"
+)
+
+// newTestSelectionClient constructs a new test selection client using the
+// provided HTTP client.
+func newTestSelectionClient(c *http.Client) *testselection.APIClient {
+	tssBaseURL := evergreen.GetEnvironment().Settings().TestSelection.URL
+	conf := testselection.NewConfiguration()
+	conf.HTTPClient = c
+	conf.Servers = testselection.ServerConfigurations{
+		testselection.ServerConfiguration{
+			URL:         tssBaseURL,
+			Description: "Test selection service",
+		},
+	}
+	return testselection.NewAPIClient(conf)
+}
+
+// SelectTests uses the test selection service to return a filtered set of tests
+// to run based on the provided SelectTestsRequest. It returns the list of
+// selected tests.
+func SelectTests(ctx context.Context, req model.SelectTestsRequest) ([]string, error) {
+	httpClient := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(httpClient)
+
+	c := newTestSelectionClient(httpClient)
+	var strategies []testselection.StrategyEnum
+	for _, s := range req.Strategies {
+		strategies = append(strategies, testselection.StrategyEnum(s))
+	}
+	reqBody := testselection.BodySelectTestsApiTestSelectionSelectTestsProjectIdRequesterBuildVariantNameTaskIdTaskNamePost{
+		TestNames:  req.Tests,
+		Strategies: strategies,
+	}
+	selectedTests, resp, err := c.TestSelectionAPI.SelectTestsApiTestSelectionSelectTestsProjectIdRequesterBuildVariantNameTaskIdTaskNamePost(ctx, req.Project, req.Requester, req.BuildVariant, req.TaskID, req.TaskName).
+		BodySelectTestsApiTestSelectionSelectTestsProjectIdRequesterBuildVariantNameTaskIdTaskNamePost(reqBody).
+		Execute()
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "forwarding request to test selection service")
+	}
+	return selectedTests, nil
+}
+

--- a/rest/model/select.go
+++ b/rest/model/select.go
@@ -1,0 +1,22 @@
+package model
+
+// SelectTestsRequest represents a request to return a filtered set of tests to
+// run. It deliberately includes information that could be looked up in the
+// database in order to bypass database lookups. This allows Evergreen to pass
+// this information directly to the test selector.
+type SelectTestsRequest struct {
+	// Project is the project identifier.
+	Project string `json:"project"`
+	// Requester is the Evergreen requester type.
+	Requester string `json:"requester"`
+	// BuildVariant is the Evergreen build variant.
+	BuildVariant string `json:"build_variant"`
+	// TaskID is the Evergreen task ID.
+	TaskID string `json:"task_id"`
+	// TaskName is the Evergreen task name.
+	TaskName string `json:"task_name"`
+	// Tests is a list of test names.
+	Tests []string `json:"tests"`
+	// Strategies is the optional list of test selection strategies to use.
+	Strategies []string `json:"strategies"`
+}

--- a/rest/route/select.go
+++ b/rest/route/select.go
@@ -7,37 +7,17 @@ import (
 	"net/http"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/rest/data"
+	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/gimlet"
-	testselection "github.com/evergreen-ci/test-selection-client"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 )
 
 type selectTestsHandler struct {
-	selectTests SelectTestsRequest
+	selectTests model.SelectTestsRequest
 	env         evergreen.Environment
-}
-
-// SelectTestsRequest represents a request to return a filtered set of tests to
-// run. It deliberately includes information that could be looked up in the
-// database in order to bypass database lookups. This allows Evergreen to pass
-// this information directly to the test selector.
-type SelectTestsRequest struct {
-	// Project is the project identifier.
-	Project string `json:"project"`
-	// Requester is the Evergreen requester type.
-	Requester string `json:"requester"`
-	// BuildVariant is the Evergreen build variant.
-	BuildVariant string `json:"build_variant"`
-	// TaskID is the Evergreen task ID.
-	TaskID string `json:"task_id"`
-	// TaskName is the Evergreen task name.
-	TaskName string `json:"task_name"`
-	// Tests is a list of test names.
-	Tests []string `json:"tests"`
-	// Strategies is the optional list of test selection strategies to use.
-	Strategies []string `json:"strategies"`
 }
 
 func makeSelectTestsHandler(env evergreen.Environment) gimlet.RouteHandler {
@@ -50,7 +30,7 @@ func makeSelectTestsHandler(env evergreen.Environment) gimlet.RouteHandler {
 //	@Description	Return a subset of tests to run for a given task. This endpoint is not yet ready. Please do not use it.
 //	@Tags			select
 //	@Router			/select/tests [post]
-//	@Param			{object}	body	SelectTestsRequest	true	"Select tests request"
+//	@Param			{object}	body	model.SelectTestsRequest	true	"Select tests request"
 //	@Security		Api-User || Api-Key
 //	@Success		200	{object}	SelectTestsRequest
 func (t *selectTestsHandler) Factory() gimlet.RouteHandler {
@@ -78,40 +58,10 @@ func (t *selectTestsHandler) Parse(ctx context.Context, r *http.Request) error {
 }
 
 func (t *selectTestsHandler) Run(ctx context.Context) gimlet.Responder {
-	tssBaseURL := t.env.Settings().TestSelection.URL
-	if tssBaseURL == "" {
-		return gimlet.NewJSONResponse(t.selectTests)
-	}
-
-	httpClient := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(httpClient)
-	conf := testselection.NewConfiguration()
-	conf.HTTPClient = httpClient
-	conf.Servers = testselection.ServerConfigurations{
-		testselection.ServerConfiguration{
-			URL:         tssBaseURL,
-			Description: "Test selection service",
-		},
-	}
-	c := testselection.NewAPIClient(conf)
-	var strategies []testselection.StrategyEnum
-	for _, s := range t.selectTests.Strategies {
-		strategies = append(strategies, testselection.StrategyEnum(s))
-	}
-	reqBody := testselection.BodySelectTestsApiTestSelectionSelectTestsProjectIdRequesterBuildVariantNameTaskIdTaskNamePost{
-		TestNames:  t.selectTests.Tests,
-		Strategies: strategies,
-	}
-	selectedTests, resp, err := c.TestSelectionAPI.SelectTestsApiTestSelectionSelectTestsProjectIdRequesterBuildVariantNameTaskIdTaskNamePost(ctx, t.selectTests.Project, t.selectTests.Requester, t.selectTests.BuildVariant, t.selectTests.TaskID, t.selectTests.TaskName).
-		BodySelectTestsApiTestSelectionSelectTestsProjectIdRequesterBuildVariantNameTaskIdTaskNamePost(reqBody).
-		Execute()
-	if resp != nil {
-		defer resp.Body.Close()
-	}
+	selectedTests, err := data.SelectTests(ctx, t.selectTests)
 	if err != nil {
-		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "forwarding request to test selection service"))
+		return gimlet.NewJSONInternalErrorResponse(err)
 	}
-
 	rhResp := t.selectTests
 	rhResp.Tests = selectedTests
 	return gimlet.NewJSONResponse(rhResp)


### PR DESCRIPTION
DEVPROD-21706

### Description
* Add method to quarantine a test. It's not used for now, but will be used by the UI.
* Refactor test selection models/logic so it follows the general REST code organization.

### Testing
* Tested in staging to verify that the `/select/tests` route still worked
* Tested in staging by manually calling the quarantine method to verify it returns 200.