### PR TITLE
DEVPROD-21708: Add failed tasks log bucket field

### DIFF
--- a/graphql/schema/types/adminSettings/other.graphql
+++ b/graphql/schema/types/adminSettings/other.graphql
@@ -13,6 +13,7 @@ type BucketConfig {
 input BucketsConfigInput {
   logBucket: BucketConfigInput
   logBucketLongRetention: BucketConfigInput
+  logBucketFailedTasks: BucketConfigInput
   longRetentionProjects: [String!]
   testResultsBucket: BucketConfigInput
   internalBuckets: [String!]
@@ -22,6 +23,7 @@ input BucketsConfigInput {
 type BucketsConfig {
   logBucket: BucketConfig
   logBucketLongRetention: BucketConfig
+  logBucketFailedTasks: BucketConfig
   longRetentionProjects: [String!]
   testResultsBucket: BucketConfig
   internalBuckets: [String!]


### PR DESCRIPTION
[DEVPROD-21708](https://jira.mongodb.org/browse/DEVPROD-21708)

### Description

Adds the failed tasks log bucket name as a field for admin graph ql 
