### PR TITLE
DEVPROD-18695: retry agent requests on invalid body

### DIFF
--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -26,7 +26,6 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/logging"
-	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/send"
 	"github.com/pkg/errors"
 )
@@ -758,10 +757,6 @@ func (c *baseCommunicator) GetDistroByName(ctx context.Context, id string) (*res
 
 // StartTask marks the task as started, and sends traceId and diskDevices to be stored with the task.
 func (c *baseCommunicator) StartTask(ctx context.Context, taskData TaskData, traceID string, diskDevices []string) error {
-	grip.Info(message.Fields{
-		"message": "started StartTask",
-		"task_id": taskData.ID,
-	})
 	taskStartRequest := &apimodels.TaskStartRequest{
 		TraceID:     traceID,
 		DiskDevices: diskDevices,
@@ -776,10 +771,6 @@ func (c *baseCommunicator) StartTask(ctx context.Context, taskData TaskData, tra
 		return util.RespError(resp, errors.Wrap(err, "starting task").Error())
 	}
 	defer resp.Body.Close()
-	grip.Info(message.Fields{
-		"message": "finished StartTask",
-		"task_id": taskData.ID,
-	})
 	return nil
 }
 

--- a/agent/internal/client/base_client.go
+++ b/agent/internal/client/base_client.go
@@ -234,9 +234,8 @@ func (c *baseCommunicator) GetDistroAMI(ctx context.Context, distro, region stri
 
 func (c *baseCommunicator) GetProject(ctx context.Context, taskData TaskData) (*model.Project, error) {
 	info := requestInfo{
-		method:             http.MethodGet,
-		taskData:           &taskData,
-		retryOnInvalidBody: true, // This route has returned an invalid body for older distros. See DEVPROD-7885.
+		method:   http.MethodGet,
+		taskData: &taskData,
 	}
 	info.setTaskPathSuffix("parser_project")
 	resp, err := c.retryRequest(ctx, info, nil)

--- a/agent/internal/client/request.go
+++ b/agent/internal/client/request.go
@@ -23,8 +23,7 @@ type requestInfo struct {
 	path     string
 	taskData *TaskData
 
-	retryOnInvalidBody bool
-	retryOn413         bool
+	retryOn413 bool
 }
 
 func (c *baseCommunicator) newRequest(method, path, taskID, taskSecret string, data any) (*http.Request, error) {
@@ -145,8 +144,9 @@ func (c *baseCommunicator) retryRequest(ctx context.Context, info requestInfo, d
 	r.Header.Add(evergreen.ContentLengthHeader, strconv.Itoa(len(out)))
 
 	opts := utility.RetryRequestOptions{
-		RetryOptions:       c.retry,
-		RetryOnInvalidBody: info.retryOnInvalidBody,
+		RetryOptions: c.retry,
+		// Routes have returned an invalid body for some distros. See DEVPROD-7885.
+		RetryOnInvalidBody: true,
 		RetryOn413:         info.retryOn413,
 	}
 	resp, err := utility.RetryRequest(ctx, r, opts)


### PR DESCRIPTION
DEVPROD-18695

### Description
This is pretty much the same issue as DEVPROD-7885 - some distros occasionally fail to read the response body, which can result in random task failures due to a failed network request. Since any request could fail from this and make the task fail, I just made all routes retry if they get an unexpected EOF while reading the body.