### PR TITLE
DEVPROD-15640: Remove integration test configuration in GraphQL tests

### DIFF
--- a/graphql/integration_atomic_test_util.go
+++ b/graphql/integration_atomic_test_util.go
@@ -34,7 +34,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/log"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
@@ -592,7 +591,6 @@ func directorySpecificTestSetup(t *testing.T, state AtomicGraphQLState) {
 		"mutation/spawnVolume":          {spawnTestHostAndVolume, addSubnets},
 		"mutation/updateVolume":         {spawnTestHostAndVolume},
 		"mutation/schedulePatch":        {persistTestSettings},
-		"mutation/saveDistro":           {configureImageVisibilityAPI},
 	}
 	if m[state.Directory] != nil {
 		for _, exec := range m[state.Directory] {
@@ -612,12 +610,6 @@ func directorySpecificTestCleanup(t *testing.T, directory string) {
 			exec(t)
 		}
 	}
-}
-
-func configureImageVisibilityAPI(t *testing.T) {
-	testConfig := testutil.TestConfig()
-	testutil.ConfigureIntegrationTest(t, testConfig)
-	require.NoError(t, testConfig.RuntimeEnvironments.Set(t.Context()))
 }
 
 func spawnTestHostAndVolume(t *testing.T) {

--- a/graphql/tests/mutation/saveDistro/queries/save.graphql
+++ b/graphql/tests/mutation/saveDistro/queries/save.graphql
@@ -3,7 +3,7 @@ mutation {
     opts: {
       distro: {
         name: "rhel71-power8-large"
-        imageId: "rhel71-ppc"
+        imageId: ""
         adminOnly: true
         aliases: ["new-alias"]
         arch: LINUX_PPC_64_BIT
@@ -106,7 +106,6 @@ mutation {
       aliases
       disableShallowClone
       isCluster
-      imageId
       name
       note
       warningNote

--- a/graphql/tests/mutation/saveDistro/results.json
+++ b/graphql/tests/mutation/saveDistro/results.json
@@ -10,7 +10,6 @@
               "aliases": ["new-alias"],
               "disableShallowClone": true,
               "isCluster": true,
-              "imageId": "rhel71-ppc",
               "name": "rhel71-power8-large",
               "note": "This is an updated note",
               "warningNote": "This is a warning",


### PR DESCRIPTION
DEVPROD-15640

### Description
I don't know why this doesn't work for deploys but I just deleted it 

### Testing
* Deployed on staging
