### PR TITLE
DEVPROD-22200: Add type to bucket config

### DIFF
--- a/graphql/schema/types/adminSettings/other.graphql
+++ b/graphql/schema/types/adminSettings/other.graphql
@@ -2,12 +2,14 @@ input BucketConfigInput {
   name: String
   testResultsPrefix: String
   roleARN: String @redactSecrets
+  type: String
 }
 
 type BucketConfig {
   name: String
   testResultsPrefix: String
   roleARN: String @requireAdmin
+  type: String
 }
 
 input BucketsConfigInput {


### PR DESCRIPTION
[DEVPROD-22200](https://jira.mongodb.org/browse/DEVPROD-22200)

### Description
Add the bucket type to the bucket config for admin settings 
