### PR TITLE
DEVPROD-22277 Fix nil pointer exception in CLI communicator's Validate func

### DIFF
--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -1672,7 +1672,9 @@ func (c *communicatorImpl) Validate(ctx context.Context, data []byte, quiet bool
 		ProjectID:   projectID,
 	}
 	resp, err := c.retryRequest(ctx, info, body)
-	defer resp.Body.Close()
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 
 	// we want to ignore the error if it's a 400, since that is expected when validation fails
 	if err != nil && err.Error() != server400 {


### PR DESCRIPTION
DEVPROD-22277

### Description
This fixes a nil pointer exception in the CLI communicator.
<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->
