### PR TITLE
DEVPROD-22453 Increase task ID log verbosity

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -881,6 +881,12 @@ func NewTaskIdConfigForRepotrackerVersion(ctx context.Context, p *Project, v *Ve
 		} else if v.Requester == evergreen.GitTagRequester {
 			rev = fmt.Sprintf("%s_%s", sourceRev, v.TriggeredByGitTag.Tag)
 		}
+		grip.Debug(message.Fields{
+			"message":  "starting bv iteration",
+			"ticket":   "DEVPROD-22453",
+			"revision": v.Revision,
+			"bvTasks":  bv.Tasks,
+		})
 		for _, t := range bv.Tasks {
 			// omit tasks excluded from the version
 			if t.IsDisabled() || t.SkipOnRequester(v.Requester) {
@@ -893,6 +899,12 @@ func NewTaskIdConfigForRepotrackerVersion(ctx context.Context, p *Project, v *Ve
 					}
 					taskId := generateId(groupTask, projectIdentifier, &bv, rev, v)
 					execTable[TVPair{bv.Name, groupTask}] = util.CleanName(taskId)
+					grip.Debug(message.Fields{
+						"message":  "added ID",
+						"ticket":   "DEVPROD-22453",
+						"revision": v.Revision,
+						"id":       util.CleanName(taskId),
+					})
 				}
 			} else {
 				if isCreatingSubsetOfTasks && !utility.StringSliceContains(taskNamesInBV, t.Name) {
@@ -901,7 +913,14 @@ func NewTaskIdConfigForRepotrackerVersion(ctx context.Context, p *Project, v *Ve
 				// create a unique Id for each task
 				taskId := generateId(t.Name, projectIdentifier, &bv, rev, v)
 				execTable[TVPair{bv.Name, t.Name}] = util.CleanName(taskId)
+				grip.Debug(message.Fields{
+					"message":  "added ID",
+					"ticket":   "DEVPROD-22453",
+					"revision": v.Revision,
+					"id":       util.CleanName(taskId),
+				})
 			}
+
 		}
 
 		for _, dt := range bv.DisplayTasks {

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -941,7 +941,76 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		}))
 	}
 
+	grip.Debug(message.Fields{
+		"message":       "preparing NewTaskIdConfigForRepotrackerVersion",
+		"ticket":        "DEVPROD-22453",
+		"runner":        RunnerName,
+		"revision":      v.Revision,
+		"pairsToCreate": pairsToCreate,
+	})
+	grip.Debug(message.Fields{
+		"message":  "preparing NewTaskIdConfigForRepotrackerVersion",
+		"ticket":   "DEVPROD-22453",
+		"runner":   RunnerName,
+		"revision": v.Revision,
+		"v":        v,
+	})
+	grip.Debug(message.Fields{
+		"message":             "preparing NewTaskIdConfigForRepotrackerVersion",
+		"ticket":              "DEVPROD-22453",
+		"runner":              RunnerName,
+		"revision":            v.Revision,
+		"projectInfo.Project": projectInfo.Project,
+	})
 	taskIds := model.NewTaskIdConfigForRepotrackerVersion(ctx, projectInfo.Project, v, pairsToCreate, sourceRev, metadata.TriggerDefinitionID)
+	grip.Debug(message.Fields{
+		"message":        "computed taskIds",
+		"ticket":         "DEVPROD-22453",
+		"runner":         RunnerName,
+		"revision":       v.Revision,
+		"execIds":        len(taskIds.ExecutionTasks.GetIdsForAllTasks()),
+		"displayTaskIds": len(taskIds.DisplayTasks.GetIdsForAllTasks()),
+	})
+	grip.Debug(message.Fields{
+		"message":            "computed taskIds",
+		"ticket":             "DEVPROD-22453",
+		"runner":             RunnerName,
+		"revision":           v.Revision,
+		"execIdsFull":        taskIds.ExecutionTasks.GetIdsForAllTasks(),
+		"displayTaskIdsFull": taskIds.DisplayTasks.GetIdsForAllTasks(),
+	})
+	grip.Debug(message.Fields{
+		"message":  "full taskIds",
+		"ticket":   "DEVPROD-22453",
+		"runner":   RunnerName,
+		"revision": v.Revision,
+		"taskIds":  taskIds,
+	})
+	numPrints := 0
+	if len(taskIds.ExecutionTasks.GetIdsForAllTasks()) > 0 {
+		for tvPair, name := range taskIds.ExecutionTasks {
+			if numPrints > 5 {
+				break
+			}
+			grip.Debug(message.Fields{
+				"message":  "individual taskIds",
+				"ticket":   "DEVPROD-22453",
+				"runner":   RunnerName,
+				"revision": v.Revision,
+				"name":     name,
+				"tvPair":   tvPair,
+			})
+			grip.Debug(message.Fields{
+				"message":   "individual taskIds length",
+				"ticket":    "DEVPROD-22453",
+				"runner":    RunnerName,
+				"revision":  v.Revision,
+				"nameLen":   len(name),
+				"tvPairLen": len(tvPair.TaskName) + len(tvPair.Variant),
+			})
+			numPrints++
+		}
+	}
 
 	grip.Debug(message.Fields{
 		"message":  "constructing variants",

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -964,7 +964,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 	})
 	taskIds := model.NewTaskIdConfigForRepotrackerVersion(ctx, projectInfo.Project, v, pairsToCreate, sourceRev, metadata.TriggerDefinitionID)
 	grip.Debug(message.Fields{
-		"message":        "computed taskIds",
+		"message":        "computed taskIds length",
 		"ticket":         "DEVPROD-22453",
 		"runner":         RunnerName,
 		"revision":       v.Revision,


### PR DESCRIPTION
DEVPROD-22453

### Description
Add more log verbosity because the taskIds field is not logging in splunk and is a potential culprit.