### PR TITLE
DEVPROD-22453 Remove creationInfo from debug logs

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -583,11 +583,10 @@ func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build
 func CreateBuildFromVersionNoInsert(ctx context.Context, creationInfo TaskCreationInfo) (*build.Build, task.Tasks, error) {
 	// avoid adding all tasks in the case of no tasks matching aliases
 	grip.Debug(message.Fields{
-		"message":      "starting CreateBuildFromVersionNoInsert",
-		"ticket":       "DEVPROD-22453",
-		"runner":       "repotracker",
-		"revision":     creationInfo.Version.Revision,
-		"creationInfo": creationInfo,
+		"message":  "starting CreateBuildFromVersionNoInsert",
+		"ticket":   "DEVPROD-22453",
+		"runner":   "repotracker",
+		"revision": creationInfo.Version.Revision,
 	})
 	if len(creationInfo.Aliases) > 0 && len(creationInfo.TaskNames) == 0 {
 		return nil, nil, nil
@@ -647,11 +646,10 @@ func CreateBuildFromVersionNoInsert(ctx context.Context, creationInfo TaskCreati
 	creationInfo.BuildVariant = buildVariant
 	creationInfo.Build = b
 	grip.Debug(message.Fields{
-		"message":      "starting createTasksForBuild",
-		"ticket":       "DEVPROD-22453",
-		"runner":       "repotracker",
-		"revision":     creationInfo.Version.Revision,
-		"creationInfo": creationInfo,
+		"message":  "starting createTasksForBuild",
+		"ticket":   "DEVPROD-22453",
+		"runner":   "repotracker",
+		"revision": creationInfo.Version.Revision,
 	})
 	tasksForBuild, err := createTasksForBuild(ctx, creationInfo)
 	if err != nil {
@@ -662,7 +660,6 @@ func CreateBuildFromVersionNoInsert(ctx context.Context, creationInfo TaskCreati
 		"ticket":        "DEVPROD-22453",
 		"runner":        "repotracker",
 		"revision":      creationInfo.Version.Revision,
-		"creationInfo":  creationInfo,
 		"tasksForBuild": tasksForBuild,
 	})
 
@@ -686,11 +683,10 @@ func CreateBuildFromVersionNoInsert(ctx context.Context, creationInfo TaskCreati
 		tasks = append(tasks, *taskP)
 	}
 	grip.Debug(message.Fields{
-		"message":      "starting CreateTasksCache",
-		"ticket":       "DEVPROD-22453",
-		"runner":       "repotracker",
-		"revision":     creationInfo.Version.Revision,
-		"creationInfo": creationInfo,
+		"message":  "starting CreateTasksCache",
+		"ticket":   "DEVPROD-22453",
+		"runner":   "repotracker",
+		"revision": creationInfo.Version.Revision,
 	})
 	b.Tasks = CreateTasksCache(tasks)
 	b.Activated = containsActivatedTask
@@ -737,7 +733,14 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 		"ticket":       "DEVPROD-22453",
 		"runner":       "repotracker",
 		"revision":     creationInfo.Version.Revision,
-		"creationInfo": creationInfo,
+		"execTable":    execTable,
+		"displayTable": displayTable,
+	})
+	grip.Debug(message.Fields{
+		"message":  "starting iterating through tasks in createTasksForBuild without taskIDs",
+		"ticket":   "DEVPROD-22453",
+		"runner":   "repotracker",
+		"revision": creationInfo.Version.Revision,
 	})
 	for _, task := range creationInfo.BuildVariant.Tasks {
 		// Verify that the config isn't malformed.
@@ -785,11 +788,10 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 	// create all the actual tasks
 	taskMap := make(map[string]*task.Task)
 	grip.Debug(message.Fields{
-		"message":      "constructing tasks in createTasksForBuild",
-		"ticket":       "DEVPROD-22453",
-		"runner":       "repotracker",
-		"revision":     creationInfo.Version.Revision,
-		"creationInfo": creationInfo,
+		"message":  "constructing tasks in createTasksForBuild",
+		"ticket":   "DEVPROD-22453",
+		"runner":   "repotracker",
+		"revision": creationInfo.Version.Revision,
 	})
 	for _, t := range tasksToCreate {
 		id := execTable.GetId(creationInfo.Build.BuildVariant, t.Name)
@@ -815,11 +817,10 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 	tasks := task.Tasks{}
 	loggedExecutionTaskNotFound := false
 	grip.Debug(message.Fields{
-		"message":      "constructing display tasks in createTasksForBuild",
-		"ticket":       "DEVPROD-22453",
-		"runner":       "repotracker",
-		"revision":     creationInfo.Version.Revision,
-		"creationInfo": creationInfo,
+		"message":  "constructing display tasks in createTasksForBuild",
+		"ticket":   "DEVPROD-22453",
+		"runner":   "repotracker",
+		"revision": creationInfo.Version.Revision,
 	})
 	for _, dt := range creationInfo.BuildVariant.DisplayTasks {
 		id := displayTable.GetId(creationInfo.Build.BuildVariant, dt.Name)
@@ -895,11 +896,10 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 		}
 	}
 	grip.Debug(message.Fields{
-		"message":      "addSingleHostTaskGroupDependencies in createTasksForBuild",
-		"ticket":       "DEVPROD-22453",
-		"runner":       "repotracker",
-		"revision":     creationInfo.Version.Revision,
-		"creationInfo": creationInfo,
+		"message":  "addSingleHostTaskGroupDependencies in createTasksForBuild",
+		"ticket":   "DEVPROD-22453",
+		"runner":   "repotracker",
+		"revision": creationInfo.Version.Revision,
 	})
 	addSingleHostTaskGroupDependencies(taskMap, creationInfo.Project, execTable)
 

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -1138,21 +1138,19 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		}
 
 		grip.Debug(message.Fields{
-			"message":      "creating build",
-			"ticket":       "DEVPROD-22453",
-			"runner":       RunnerName,
-			"revision":     v.Revision,
-			"creationInfo": creationInfo,
+			"message":  "creating build",
+			"ticket":   "DEVPROD-22453",
+			"runner":   RunnerName,
+			"revision": v.Revision,
 		})
 		b, tasks, err := model.CreateBuildFromVersionNoInsert(ctx, creationInfo)
 		grip.Debug(message.Fields{
-			"message":      "created build",
-			"ticket":       "DEVPROD-22453",
-			"runner":       RunnerName,
-			"revision":     v.Revision,
-			"creationInfo": creationInfo,
-			"b":            b,
-			"tasks":        tasks,
+			"message":  "created build",
+			"ticket":   "DEVPROD-22453",
+			"runner":   RunnerName,
+			"revision": v.Revision,
+			"b":        b,
+			"tasks":    tasks,
 		})
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
@@ -1167,13 +1165,12 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		if len(tasks) == 0 {
 			debuggingData[buildvariant.Name] = "no tasks for buildvariant"
 			grip.Debug(message.Fields{
-				"message":      "no tasks",
-				"ticket":       "DEVPROD-22453",
-				"runner":       RunnerName,
-				"revision":     v.Revision,
-				"creationInfo": creationInfo,
-				"b":            b,
-				"tasks":        tasks,
+				"message":  "no tasks",
+				"ticket":   "DEVPROD-22453",
+				"runner":   RunnerName,
+				"revision": v.Revision,
+				"b":        b,
+				"tasks":    tasks,
 			})
 			continue
 		}


### PR DESCRIPTION
DEVPROD-22453

### Description
creationInfo is causing logs to not show up in splunk so removing it to better see where things get stuck.