### PR TITLE
DEVPROD-22453 Include SHTG dependencies when checking for cycles

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -520,7 +520,7 @@ func addTasksToGraph(tasks TVPairSet, graph task.DependencyGraph, p *Project, ta
 		}
 	}
 
-	for _, dep := range dependenciesForTaskUnit(bvts) {
+	for _, dep := range dependenciesForTaskUnit(bvts, p) {
 		dep.From.ID = taskIDs.ExecutionTasks.GetId(dep.From.Variant, dep.From.Name)
 		dep.To.ID = taskIDs.ExecutionTasks.GetId(dep.To.Variant, dep.To.Name)
 		graph.AddEdge(dep.From, dep.To, dep.Status)

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -29,9 +29,6 @@ const (
 	AllStatuses     = "*"
 )
 
-const ShaToDebug = "4460599de82c3f131f9f20db585846d8b188260d"
-const ProjectToDebug = "68a607d7b02fbf0007b810ba"
-
 type RestartOptions struct {
 	DryRun    bool      `bson:"dry_run" json:"dry_run"`
 	StartTime time.Time `bson:"start_time" json:"start_time"`
@@ -585,12 +582,6 @@ func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build
 // is responsible for inserting the created build and task documents
 func CreateBuildFromVersionNoInsert(ctx context.Context, creationInfo TaskCreationInfo) (*build.Build, task.Tasks, error) {
 	// avoid adding all tasks in the case of no tasks matching aliases
-	grip.Debug(message.Fields{
-		"message":  "starting CreateBuildFromVersionNoInsert",
-		"ticket":   "DEVPROD-22453",
-		"runner":   "repotracker",
-		"revision": creationInfo.Version.Revision,
-	})
 	if len(creationInfo.Aliases) > 0 && len(creationInfo.TaskNames) == 0 {
 		return nil, nil, nil
 	}
@@ -648,23 +639,10 @@ func CreateBuildFromVersionNoInsert(ctx context.Context, creationInfo TaskCreati
 	// create all the necessary tasks for the build
 	creationInfo.BuildVariant = buildVariant
 	creationInfo.Build = b
-	grip.DebugWhen(creationInfo.Version.Revision == ShaToDebug, message.Fields{
-		"message":  "starting createTasksForBuild",
-		"ticket":   "DEVPROD-22453",
-		"runner":   "repotracker",
-		"revision": creationInfo.Version.Revision,
-	})
 	tasksForBuild, err := createTasksForBuild(ctx, creationInfo)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "creating tasks for build '%s'", b.Id)
 	}
-	grip.DebugWhen(creationInfo.Version.Revision == ShaToDebug, message.Fields{
-		"message":       "finished createTasksForBuild",
-		"ticket":        "DEVPROD-22453",
-		"runner":        "repotracker",
-		"revision":      creationInfo.Version.Revision,
-		"tasksForBuild": tasksForBuild,
-	})
 
 	// create task caches for all of the tasks, and place them into the build
 	tasks := []task.Task{}
@@ -685,27 +663,7 @@ func CreateBuildFromVersionNoInsert(ctx context.Context, creationInfo TaskCreati
 		}
 		tasks = append(tasks, *taskP)
 	}
-	grip.DebugWhen(creationInfo.Version.Revision == ShaToDebug, message.Fields{
-		"message":  "starting CreateTasksCache",
-		"ticket":   "DEVPROD-22453",
-		"runner":   "repotracker",
-		"revision": creationInfo.Version.Revision,
-	})
 	b.Tasks = CreateTasksCache(tasks)
-	grip.DebugWhen(creationInfo.Version.Revision == ShaToDebug, message.Fields{
-		"message":       "finished CreateTasksCache",
-		"ticket":        "DEVPROD-22453",
-		"runner":        "repotracker",
-		"revision":      creationInfo.Version.Revision,
-		"tasks":         len(b.Tasks),
-		"tasksForBuild": len(tasksForBuild),
-	})
-	grip.DebugWhen(creationInfo.Version.Revision == ShaToDebug, message.Fields{
-		"message":  "finished CreateTasksCache",
-		"ticket":   "DEVPROD-22453",
-		"runner":   "repotracker",
-		"revision": creationInfo.Version.Revision,
-	})
 	b.Activated = containsActivatedTask
 	b.HasUnfinishedEssentialTask = hasUnfinishedEssentialTask
 	return b, tasksForBuild, nil
@@ -745,20 +703,6 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 		tgMap[tg.Name] = tg
 	}
 
-	grip.DebugWhen(creationInfo.Version.Revision == ShaToDebug, message.Fields{
-		"message":      "starting iterating through tasks in createTasksForBuild",
-		"ticket":       "DEVPROD-22453",
-		"runner":       "repotracker",
-		"revision":     creationInfo.Version.Revision,
-		"execTable":    execTable,
-		"displayTable": displayTable,
-	})
-	grip.DebugWhen(creationInfo.Version.Revision == ShaToDebug, message.Fields{
-		"message":  "starting iterating through tasks in createTasksForBuild without taskIDs",
-		"ticket":   "DEVPROD-22453",
-		"runner":   "repotracker",
-		"revision": creationInfo.Version.Revision,
-	})
 	for _, task := range creationInfo.BuildVariant.Tasks {
 		// Verify that the config isn't malformed.
 		if task.Name != "" && !task.IsGroup {
@@ -804,12 +748,6 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 
 	// create all the actual tasks
 	taskMap := make(map[string]*task.Task)
-	grip.DebugWhen(creationInfo.Version.Revision == ShaToDebug, message.Fields{
-		"message":  "constructing tasks in createTasksForBuild",
-		"ticket":   "DEVPROD-22453",
-		"runner":   "repotracker",
-		"revision": creationInfo.Version.Revision,
-	})
 	for _, t := range tasksToCreate {
 		id := execTable.GetId(creationInfo.Build.BuildVariant, t.Name)
 		newTask, err := createOneTask(ctx, id, creationInfo, t)
@@ -833,12 +771,6 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 	// Create and update display tasks
 	tasks := task.Tasks{}
 	loggedExecutionTaskNotFound := false
-	grip.DebugWhen(creationInfo.Version.Revision == ShaToDebug, message.Fields{
-		"message":  "constructing display tasks in createTasksForBuild",
-		"ticket":   "DEVPROD-22453",
-		"runner":   "repotracker",
-		"revision": creationInfo.Version.Revision,
-	})
 	for _, dt := range creationInfo.BuildVariant.DisplayTasks {
 		id := displayTable.GetId(creationInfo.Build.BuildVariant, dt.Name)
 		if id == "" {
@@ -912,12 +844,6 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 			tasks = append(tasks, newDisplayTask)
 		}
 	}
-	grip.DebugWhen(creationInfo.Version.Revision == ShaToDebug, message.Fields{
-		"message":  "addSingleHostTaskGroupDependencies in createTasksForBuild",
-		"ticket":   "DEVPROD-22453",
-		"runner":   "repotracker",
-		"revision": creationInfo.Version.Revision,
-	})
 	addSingleHostTaskGroupDependencies(taskMap, creationInfo.Project, execTable)
 
 	for _, t := range taskMap {

--- a/model/project.go
+++ b/model/project.go
@@ -881,12 +881,6 @@ func NewTaskIdConfigForRepotrackerVersion(ctx context.Context, p *Project, v *Ve
 		} else if v.Requester == evergreen.GitTagRequester {
 			rev = fmt.Sprintf("%s_%s", sourceRev, v.TriggeredByGitTag.Tag)
 		}
-		grip.Debug(message.Fields{
-			"message":  "starting bv iteration",
-			"ticket":   "DEVPROD-22453",
-			"revision": v.Revision,
-			"bvTasks":  bv.Tasks,
-		})
 		for _, t := range bv.Tasks {
 			// omit tasks excluded from the version
 			if t.IsDisabled() || t.SkipOnRequester(v.Requester) {
@@ -899,12 +893,6 @@ func NewTaskIdConfigForRepotrackerVersion(ctx context.Context, p *Project, v *Ve
 					}
 					taskId := generateId(groupTask, projectIdentifier, &bv, rev, v)
 					execTable[TVPair{bv.Name, groupTask}] = util.CleanName(taskId)
-					grip.Debug(message.Fields{
-						"message":  "added ID",
-						"ticket":   "DEVPROD-22453",
-						"revision": v.Revision,
-						"id":       util.CleanName(taskId),
-					})
 				}
 			} else {
 				if isCreatingSubsetOfTasks && !utility.StringSliceContains(taskNamesInBV, t.Name) {
@@ -913,12 +901,6 @@ func NewTaskIdConfigForRepotrackerVersion(ctx context.Context, p *Project, v *Ve
 				// create a unique Id for each task
 				taskId := generateId(t.Name, projectIdentifier, &bv, rev, v)
 				execTable[TVPair{bv.Name, t.Name}] = util.CleanName(taskId)
-				grip.Debug(message.Fields{
-					"message":  "added ID",
-					"ticket":   "DEVPROD-22453",
-					"revision": v.Revision,
-					"id":       util.CleanName(taskId),
-				})
 			}
 
 		}

--- a/model/project.go
+++ b/model/project.go
@@ -2113,6 +2113,8 @@ func dependenciesForTaskUnit(taskUnits []BuildVariantTaskUnit, p *Project) []tas
 			if tg == nil || tg.MaxHosts > 1 {
 				continue
 			}
+			// Single host task groups are a special case of dependencies because they implicitly form a linear
+			// dependency chain on the prior task group tasks
 			for i := len(tg.Tasks) - 1; i >= 0; i-- {
 				// Check the task display names since no display name will appear twice
 				// within the same task group

--- a/model/project.go
+++ b/model/project.go
@@ -2116,8 +2116,8 @@ func dependenciesForTaskUnit(taskUnits []BuildVariantTaskUnit, p *Project) []tas
 			for i := len(tg.Tasks) - 1; i >= 0; i-- {
 				// Check the task display names since no display name will appear twice
 				// within the same task group
-				if dependentTask.Name == tg.Tasks[i] && i < len(tg.Tasks)-1 {
-					dependentTask.DependsOn = append(dependentTask.DependsOn, TaskUnitDependency{Name: tg.Tasks[i+1], Variant: dependentTask.Variant})
+				if dependentTask.Name == tg.Tasks[i] && i > 0 {
+					dependentTask.DependsOn = append(dependentTask.DependsOn, TaskUnitDependency{Name: tg.Tasks[i-1], Variant: dependentTask.Variant})
 				}
 			}
 		}

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -2576,7 +2576,7 @@ func TestDependenciesForTaskUnit(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			dependencies := dependenciesForTaskUnit(testCase.taskUnits)
+			dependencies := dependenciesForTaskUnit(testCase.taskUnits, &Project{})
 			assert.Len(t, dependencies, len(testCase.expectedDependencies))
 			for _, expectedDep := range testCase.expectedDependencies {
 				assert.Contains(t, dependencies, expectedDep)

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -248,14 +248,6 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 			continue
 		}
 
-		grip.DebugWhen(ref.Id == model.ProjectToDebug, message.Fields{
-			"message":            "getting project config",
-			"ticket":             "DEVPROD-22453",
-			"runner":             RunnerName,
-			"project":            ref.Id,
-			"project_identifier": ref.Identifier,
-			"revision":           revision,
-		})
 		var versionErrs *VersionErrors
 		pInfo, err := repoTracker.GetProjectConfig(ctx, revision)
 		if err != nil {
@@ -314,14 +306,6 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 		var ignore bool
 		var filenames []string
 
-		grip.DebugWhen(ref.Id == model.ProjectToDebug, message.Fields{
-			"message":            "getting changed files",
-			"ticket":             "DEVPROD-22453",
-			"runner":             RunnerName,
-			"project":            ref.Id,
-			"project_identifier": ref.Identifier,
-			"revision":           revision,
-		})
 		// Always get changed files for build variant filtering
 		filenames, err = repoTracker.GetChangedFiles(ctx, revision)
 		if err != nil {
@@ -348,24 +332,8 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 			IntermediateProject: pInfo.IntermediateProject,
 			Config:              pInfo.Config,
 		}
-		grip.DebugWhen(ref.Id == model.ProjectToDebug, message.Fields{
-			"message":            "starting version creation",
-			"ticket":             "DEVPROD-22453",
-			"runner":             RunnerName,
-			"project":            ref.Id,
-			"project_identifier": ref.Identifier,
-			"revision":           revision,
-		})
 		v, err := CreateVersionFromConfig(ctx, projectInfo, metadata, ignore, versionErrs)
 		if err != nil {
-			grip.DebugWhen(ref.Id == model.ProjectToDebug, message.Fields{
-				"message":            "finished1 version creation",
-				"ticket":             "DEVPROD-22453",
-				"runner":             RunnerName,
-				"project":            ref.Id,
-				"project_identifier": ref.Identifier,
-				"revision":           revision,
-			})
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":            "error creating version",
 				"runner":             RunnerName,
@@ -378,14 +346,6 @@ func (repoTracker *RepoTracker) StoreRevisions(ctx context.Context, revisions []
 			// in a half-broken state.
 			continue
 		}
-		grip.DebugWhen(ref.Id == model.ProjectToDebug, message.Fields{
-			"message":            "finished2 version creation",
-			"ticket":             "DEVPROD-22453",
-			"runner":             RunnerName,
-			"project":            ref.Id,
-			"project_identifier": ref.Identifier,
-			"revision":           revision,
-		})
 		if err = AddBuildBreakSubscriptions(ctx, v, ref); err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":            "error creating build break subscriptions",
@@ -647,12 +607,6 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 	}
 
 	// create a version document
-	grip.DebugWhen(metadata.Revision.Revision == model.ShaToDebug, message.Fields{
-		"message":  "creating shell version",
-		"ticket":   "DEVPROD-22453",
-		"runner":   RunnerName,
-		"revision": metadata.Revision,
-	})
 	v, err := ShellVersionFromRevision(ctx, projectInfo.Ref, metadata)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create shell version")
@@ -728,12 +682,6 @@ func CreateVersionFromConfig(ctx context.Context, projectInfo *model.ProjectInfo
 		}
 	}
 
-	grip.DebugWhen(metadata.Revision.Revision == model.ShaToDebug, message.Fields{
-		"message":  "creating version items",
-		"ticket":   "DEVPROD-22453",
-		"runner":   RunnerName,
-		"revision": metadata.Revision,
-	})
 	return v, errors.Wrap(createVersionItems(ctx, v, metadata, projectInfo, aliases), "error creating version items")
 }
 
@@ -898,7 +846,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 				var match bool
 				name, tags, ok := projectInfo.Project.GetTaskNameAndTags(t)
 				if !ok {
-					grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
+					grip.Debug(message.Fields{
 						"message": "task doesn't exist in project",
 						"project": projectInfo.Project.Identifier,
 						"task":    t,
@@ -941,83 +889,8 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		}))
 	}
 
-	grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-		"message":       "preparing NewTaskIdConfigForRepotrackerVersion",
-		"ticket":        "DEVPROD-22453",
-		"runner":        RunnerName,
-		"revision":      v.Revision,
-		"pairsToCreate": pairsToCreate,
-	})
-	grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-		"message":  "preparing NewTaskIdConfigForRepotrackerVersion",
-		"ticket":   "DEVPROD-22453",
-		"runner":   RunnerName,
-		"revision": v.Revision,
-		"v":        v,
-	})
-	grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-		"message":             "preparing NewTaskIdConfigForRepotrackerVersion",
-		"ticket":              "DEVPROD-22453",
-		"runner":              RunnerName,
-		"revision":            v.Revision,
-		"projectInfo.Project": projectInfo.Project,
-	})
 	taskIds := model.NewTaskIdConfigForRepotrackerVersion(ctx, projectInfo.Project, v, pairsToCreate, sourceRev, metadata.TriggerDefinitionID)
-	grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-		"message":        "computed taskIds length",
-		"ticket":         "DEVPROD-22453",
-		"runner":         RunnerName,
-		"revision":       v.Revision,
-		"execIds":        len(taskIds.ExecutionTasks.GetIdsForAllTasks()),
-		"displayTaskIds": len(taskIds.DisplayTasks.GetIdsForAllTasks()),
-	})
-	grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-		"message":            "computed taskIds",
-		"ticket":             "DEVPROD-22453",
-		"runner":             RunnerName,
-		"revision":           v.Revision,
-		"execIdsFull":        taskIds.ExecutionTasks.GetIdsForAllTasks(),
-		"displayTaskIdsFull": taskIds.DisplayTasks.GetIdsForAllTasks(),
-	})
-	grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-		"message":  "full taskIds",
-		"ticket":   "DEVPROD-22453",
-		"runner":   RunnerName,
-		"revision": v.Revision,
-		"taskIds":  taskIds,
-	})
-	numPrints := 0
-	if len(taskIds.ExecutionTasks.GetIdsForAllTasks()) > 0 {
-		for tvPair, name := range taskIds.ExecutionTasks {
-			if numPrints > 5 {
-				break
-			}
-			grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-				"message":  "individual taskIds",
-				"ticket":   "DEVPROD-22453",
-				"runner":   RunnerName,
-				"revision": v.Revision,
-				"name":     name,
-				"tvPair":   tvPair,
-			})
-			grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-				"message":   "individual taskIds length",
-				"ticket":    "DEVPROD-22453",
-				"runner":    RunnerName,
-				"revision":  v.Revision,
-				"nameLen":   len(name),
-				"tvPairLen": len(tvPair.TaskName) + len(tvPair.Variant),
-			})
-			numPrints++
-		}
-	}
 
-	grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-		"message":  "constructing variants",
-		"ticket":   "DEVPROD-22453",
-		"runner":   RunnerName,
-		"revision": v.Revision,
-	})
 	for _, buildvariant := range projectInfo.Project.BuildVariants {
 		taskNames := pairsToCreate.TaskNames(buildvariant.Name)
 		var aliasesMatchingVariant model.ProjectAliases
@@ -1029,97 +902,6 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			"version":            v.Id,
 			"variant":            buildvariant.Name,
 		}))
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":      "Project",
-			"ticket":       "DEVPROD-22453",
-			"runner":       RunnerName,
-			"revision":     v.Revision,
-			"creationInfo": projectInfo.Project,
-		})
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":      "ProjectRef",
-			"ticket":       "DEVPROD-22453",
-			"runner":       RunnerName,
-			"revision":     v.Revision,
-			"creationInfo": projectInfo.Ref,
-		})
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":      "Version",
-			"ticket":       "DEVPROD-22453",
-			"runner":       RunnerName,
-			"revision":     v.Revision,
-			"creationInfo": v,
-		})
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":      "TaskIDs",
-			"ticket":       "DEVPROD-22453",
-			"runner":       RunnerName,
-			"revision":     v.Revision,
-			"creationInfo": taskIds,
-		})
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":      "TaskNames",
-			"ticket":       "DEVPROD-22453",
-			"runner":       RunnerName,
-			"revision":     v.Revision,
-			"creationInfo": taskNames,
-		})
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":      "BuildVariantName",
-			"ticket":       "DEVPROD-22453",
-			"runner":       RunnerName,
-			"revision":     v.Revision,
-			"creationInfo": buildvariant.Name,
-		})
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":      "ActivateBuild",
-			"ticket":       "DEVPROD-22453",
-			"runner":       RunnerName,
-			"revision":     v.Revision,
-			"creationInfo": utility.FromBoolPtr(v.Activated),
-		})
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":      "SourceRev",
-			"ticket":       "DEVPROD-22453",
-			"runner":       RunnerName,
-			"revision":     v.Revision,
-			"creationInfo": sourceRev,
-		})
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":      "DefinitionID",
-			"ticket":       "DEVPROD-22453",
-			"runner":       RunnerName,
-			"revision":     v.Revision,
-			"creationInfo": metadata.TriggerDefinitionID,
-		})
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":      "Aliases",
-			"ticket":       "DEVPROD-22453",
-			"runner":       RunnerName,
-			"revision":     v.Revision,
-			"creationInfo": aliases,
-		})
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":      "DistroAliases",
-			"ticket":       "DEVPROD-22453",
-			"runner":       RunnerName,
-			"revision":     v.Revision,
-			"creationInfo": distroAliases,
-		})
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":      "TaskCreateTime",
-			"ticket":       "DEVPROD-22453",
-			"runner":       RunnerName,
-			"revision":     v.Revision,
-			"creationInfo": v.CreateTime,
-		})
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":      "GithubChecksAliases",
-			"ticket":       "DEVPROD-22453",
-			"runner":       RunnerName,
-			"revision":     v.Revision,
-			"creationInfo": aliasesMatchingVariant,
-		})
 
 		creationInfo := model.TaskCreationInfo{
 			Project:             projectInfo.Project,
@@ -1137,34 +919,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			GithubChecksAliases: aliasesMatchingVariant,
 		}
 
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":  "creating build",
-			"ticket":   "DEVPROD-22453",
-			"runner":   RunnerName,
-			"revision": v.Revision,
-		})
 		b, tasks, err := model.CreateBuildFromVersionNoInsert(ctx, creationInfo)
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":  "created build without data",
-			"ticket":   "DEVPROD-22453",
-			"runner":   RunnerName,
-			"revision": v.Revision,
-		})
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":  "created build inspecting length",
-			"ticket":   "DEVPROD-22453",
-			"runner":   RunnerName,
-			"revision": v.Revision,
-			"tasks":    len(tasks),
-		})
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":  "created build",
-			"ticket":   "DEVPROD-22453",
-			"runner":   RunnerName,
-			"revision": v.Revision,
-			"b":        b,
-			"tasks":    tasks,
-		})
 		if err != nil {
 			grip.Error(message.WrapError(err, message.Fields{
 				"message":            "error creating build",
@@ -1177,22 +932,8 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 		}
 		if len(tasks) == 0 {
 			debuggingData[buildvariant.Name] = "no tasks for buildvariant"
-			grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-				"message":  "no tasks",
-				"ticket":   "DEVPROD-22453",
-				"runner":   RunnerName,
-				"revision": v.Revision,
-				"b":        b,
-				"tasks":    tasks,
-			})
 			continue
 		}
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":  "creating buildsToCreate and tasksToCreate",
-			"ticket":   "DEVPROD-22453",
-			"runner":   RunnerName,
-			"revision": v.Revision,
-		})
 		buildsToCreate = append(buildsToCreate, *b)
 		taskNameToId := map[string]string{}
 		for _, t := range tasks {
@@ -1200,37 +941,13 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			tasksToCreate = append(tasksToCreate, t)
 		}
 
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":  "ChangedFilesMatchPaths",
-			"ticket":   "DEVPROD-22453",
-			"runner":   RunnerName,
-			"revision": v.Revision,
-		})
 		// Determine if this build variant should be ignored due to path filtering.
 		ignoreBuildVariant := !buildvariant.ChangedFilesMatchPaths(metadata.ChangedFiles)
 
 		activateVariantAt := time.Now()
 		taskStatuses := []model.BatchTimeTaskStatus{}
-		grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-			"message":  "Considering batchtime",
-			"ticket":   "DEVPROD-22453",
-			"runner":   RunnerName,
-			"revision": v.Revision,
-		})
 		if evergreen.ShouldConsiderBatchtime(v.Requester) && !ignoreBuildVariant {
-			grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-				"message":  "Checking batchtime",
-				"ticket":   "DEVPROD-22453",
-				"runner":   RunnerName,
-				"revision": v.Revision,
-			})
 			activateVariantAt, err = projectInfo.Ref.GetActivationTimeForVariant(ctx, &buildvariant, v.CreateTime, time.Now())
-			grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-				"message":  "Finished checking batchtime",
-				"ticket":   "DEVPROD-22453",
-				"runner":   RunnerName,
-				"revision": v.Revision,
-			})
 			batchTimeCatcher.Add(errors.Wrapf(err, "unable to get activation time for variant '%s'", buildvariant.Name))
 			// add only tasks that require activation times
 			for _, bvt := range buildvariant.Tasks {
@@ -1238,19 +955,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 				if !ok || !bvt.HasSpecificActivation() {
 					continue
 				}
-				grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-					"message":  "Checking batchtime for task",
-					"ticket":   "DEVPROD-22453",
-					"runner":   RunnerName,
-					"revision": v.Revision,
-				})
 				activateTaskAt, err := projectInfo.Ref.GetActivationTimeForTask(ctx, &bvt, v.CreateTime, time.Now())
-				grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-					"message":  "Finished checking batchtime for task",
-					"ticket":   "DEVPROD-22453",
-					"runner":   RunnerName,
-					"revision": v.Revision,
-				})
 				batchTimeCatcher.Add(errors.Wrapf(err, "unable to get activation time for task '%s' (variant '%s')", bvt.Name, buildvariant.Name))
 
 				taskStatuses = append(taskStatuses,
@@ -1278,12 +983,6 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			},
 		})
 	}
-	grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-		"message":  "SetNumDependents",
-		"ticket":   "DEVPROD-22453",
-		"runner":   RunnerName,
-		"revision": v.Revision,
-	})
 	// We must set the NumDependents field for tasks prior to inserting them in the DB.
 	model.SetNumDependents(tasksToCreate)
 
@@ -1314,24 +1013,12 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 
 	env := evergreen.GetEnvironment()
 
-	grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-		"message":  "upserting PP",
-		"ticket":   "DEVPROD-22453",
-		"runner":   RunnerName,
-		"revision": v.Revision,
-	})
 	ppStorageMethod, err := model.ParserProjectUpsertOneWithS3Fallback(ctx, env.Settings(), evergreen.ProjectStorageMethodDB, projectInfo.IntermediateProject)
 	if err != nil {
 		return errors.Wrapf(err, "upserting parser project '%s' for version '%s'", projectInfo.IntermediateProject.Id, v.Id)
 	}
 	v.ProjectStorageMethod = ppStorageMethod
 
-	grip.DebugWhen(v.Revision == model.ShaToDebug, message.Fields{
-		"message":  "defining transaction",
-		"ticket":   "DEVPROD-22453",
-		"runner":   RunnerName,
-		"revision": v.Revision,
-	})
 	txFunc := func(sessCtx mongo.SessionContext) error {
 		err := sessCtx.StartTransaction()
 		if err != nil {
@@ -1422,12 +1109,6 @@ func transactionWithRetries(ctx context.Context, versionId string, sessionFunc f
 	const minBackoffInterval = 1 * time.Second
 	const maxBackoffInterval = 60 * time.Second
 
-	grip.DebugWhen(strings.Contains(versionId, model.ShaToDebug), message.Fields{
-		"message":  "starting transaction",
-		"ticket":   "DEVPROD-22453",
-		"runner":   RunnerName,
-		"revision": versionId,
-	})
 	client := evergreen.GetEnvironment().Client()
 	errs := grip.NewBasicCatcher()
 	interval := backoff.Backoff{
@@ -1436,13 +1117,6 @@ func transactionWithRetries(ctx context.Context, versionId string, sessionFunc f
 		Factor: 2,
 	}
 	for i := 0; i < retryCount; i++ {
-		grip.DebugWhen(strings.Contains(versionId, model.ShaToDebug), message.Fields{
-			"message":     "retrying transaction",
-			"ticket":      "DEVPROD-22453",
-			"runner":      RunnerName,
-			"revision":    versionId,
-			"retry_count": i,
-		})
 		err := client.UseSession(ctx, sessionFunc)
 		if err == nil {
 			return nil


### PR DESCRIPTION
DEVPROD-22453

### Description
After a very deep dive and scattering gazillions of debug logs across prod....

[Here](https://github.com/mongodb/ai-assistant/blob/cfd3d50f0a910cb1caa8c2b6b498e6c44ccb03e1/.evg.yml) is the user's problematic YAML.

`DeployTaskGroup` is a single host task group which automatically computes dependencies in a linear direction. so lint-kube-ci -> test-all -> build-push is the dependency chain that gets computed since that's the order they were defined in

Separately, the `lint-kube-ci` is defined to depend on `test-all`. So now we have a cyclical dependency where `lint-kube-ci` and `test-all` depend on each other. We typically try to catch cyclical dependency errors in validation but this special case was missed, which is a bug.

This explains the OOM issues the evergreen app has been facing as well as why this project's repotracker has been completely blocked. When evergreen tries to build this invalid config it gets caught in an infinite loop evaluating the dependency tree and eventually the pod crashes with no helpful error message anywhere.

### Solution
Include SHTG dependencies when checking for cycles during validation

### Testing
Tested in staging
