### PR TITLE
DEVPROD-17412 Check if user has submit patch auth for child patches

### DIFF
--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -3,6 +3,7 @@ package units
 import (
 	"context"
 	"fmt"
+	"github.com/evergreen-ci/gimlet"
 	"regexp"
 	"strings"
 	"time"
@@ -406,7 +407,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 		}
 	}
 
-	if err = ProcessTriggerAliases(ctx, patchDoc, pref, j.env, patchDoc.Triggers.Aliases); err != nil {
+	if err = processTriggerAliases(ctx, patchDoc, pref, j.env, patchDoc.Triggers.Aliases); err != nil {
 		if strings.Contains(err.Error(), noChildPatchTasksOrVariants) {
 			j.gitHubError = noChildPatchTasksOrVariants
 		}
@@ -745,7 +746,7 @@ func (j *patchIntentProcessor) setToPreviousPatchDefinition(ctx context.Context,
 	return nil
 }
 
-func ProcessTriggerAliases(ctx context.Context, p *patch.Patch, projectRef *model.ProjectRef, env evergreen.Environment, aliasNames []string) error {
+func processTriggerAliases(ctx context.Context, p *patch.Patch, projectRef *model.ProjectRef, env evergreen.Environment, aliasNames []string) error {
 	if len(aliasNames) == 0 {
 		return nil
 	}
@@ -756,6 +757,16 @@ func ProcessTriggerAliases(ctx context.Context, p *patch.Patch, projectRef *mode
 		parentAsModule     string
 		downstreamRevision string
 	}
+
+	var u *user.DBUser
+	var err error
+	if p.Author != "" {
+		u, err = user.FindOneByIdContext(ctx, p.Author)
+		if err != nil {
+			return errors.Wrap(err, "getting user")
+		}
+	}
+
 	aliasGroups := make(map[aliasGroup][]patch.PatchTriggerDefinition)
 	for _, aliasName := range aliasNames {
 		alias, found := projectRef.GetPatchTriggerAlias(aliasName)
@@ -763,6 +774,16 @@ func ProcessTriggerAliases(ctx context.Context, p *patch.Patch, projectRef *mode
 			return errors.Errorf("patch trigger alias '%s' is not defined", aliasName)
 		}
 		// group patches on project, status, parentAsModule, and revision
+		opts := gimlet.PermissionOpts{
+			Resource:      alias.ChildProject,
+			ResourceType:  evergreen.ProjectResourceType,
+			Permission:    evergreen.PermissionPatches,
+			RequiredLevel: evergreen.PatchSubmit.Value,
+		}
+		if u != nil && !u.HasPermission(opts) {
+			return errors.Errorf("user is not authorized to submit patches on child project '%s'", alias.ChildProject)
+		}
+
 		group := aliasGroup{
 			project:            alias.ChildProject,
 			status:             alias.Status,

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -3,7 +3,6 @@ package units
 import (
 	"context"
 	"fmt"
-	"github.com/evergreen-ci/gimlet"
 	"regexp"
 	"strings"
 	"time"
@@ -18,6 +17,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/evergreen/validator"
+	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/job"

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/evergreen/util"
+	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/google/go-github/v70/github"
 	"github.com/mongodb/amboy/registry"
@@ -1577,6 +1578,24 @@ index ca20f6c..224168e 100644
 }
 
 func (s *PatchIntentUnitsSuite) TestProcessTriggerAliases() {
+	roleManager := s.env.RoleManager()
+	childProjScope := gimlet.Scope{
+		ID:        "childProjScope",
+		Type:      evergreen.ProjectResourceType,
+		Resources: []string{"childProj"},
+	}
+	s.Require().NoError(roleManager.AddScope(childProjScope))
+
+	childProjRole := gimlet.Role{
+		ID:          "childProj_patcher",
+		Scope:       childProjScope.ID,
+		Permissions: gimlet.Permissions{evergreen.PermissionPatches: evergreen.PatchSubmit.Value},
+	}
+	s.Require().NoError(roleManager.UpdateRole(childProjRole))
+
+	githubUser := &user.DBUser{Id: evergreen.GithubPatchUser}
+	s.Require().NoError(githubUser.AddRole(s.ctx, childProjRole.ID))
+
 	latestVersion := model.Version{
 		Id:         "childProj-some-version",
 		Identifier: "childProj",
@@ -1646,6 +1665,24 @@ tasks:
 }
 
 func (s *PatchIntentUnitsSuite) TestTriggerAliasWithDownstreamRevision() {
+	roleManager := s.env.RoleManager()
+	childProjScope := gimlet.Scope{
+		ID:        "childProjScope2",
+		Type:      evergreen.ProjectResourceType,
+		Resources: []string{"childProj"},
+	}
+	s.Require().NoError(roleManager.AddScope(childProjScope))
+
+	childProjRole := gimlet.Role{
+		ID:          "childProj_patcher2",
+		Scope:       childProjScope.ID,
+		Permissions: gimlet.Permissions{evergreen.PermissionPatches: evergreen.PatchSubmit.Value},
+	}
+	s.Require().NoError(roleManager.UpdateRole(childProjRole))
+
+	githubUser := &user.DBUser{Id: evergreen.GithubPatchUser}
+	s.Require().NoError(githubUser.AddRole(s.ctx, childProjRole.ID))
+
 	specificRevision := model.Version{
 		Id:         "childProj-some-version",
 		Identifier: "childProj",
@@ -1713,6 +1750,24 @@ tasks:
 }
 
 func (s *PatchIntentUnitsSuite) TestProcessTriggerAliasesWithAliasThatDoesNotMatchAnyVariantTasks() {
+	roleManager := s.env.RoleManager()
+	childProjScope := gimlet.Scope{
+		ID:        "childProjScope3",
+		Type:      evergreen.ProjectResourceType,
+		Resources: []string{"childProj"},
+	}
+	s.Require().NoError(roleManager.AddScope(childProjScope))
+
+	childProjRole := gimlet.Role{
+		ID:          "childProj_patcher3",
+		Scope:       childProjScope.ID,
+		Permissions: gimlet.Permissions{evergreen.PermissionPatches: evergreen.PatchSubmit.Value},
+	}
+	s.Require().NoError(roleManager.UpdateRole(childProjRole))
+
+	githubUser := &user.DBUser{Id: evergreen.GithubPatchUser}
+	s.Require().NoError(githubUser.AddRole(s.ctx, childProjRole.ID))
+
 	p := &patch.Patch{
 		Id:      mgobson.NewObjectId(),
 		Project: s.project,

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1628,7 +1628,7 @@ tasks:
 	s.NoError(err)
 
 	s.Empty(p.Triggers.ChildPatches)
-	s.NoError(ProcessTriggerAliases(s.ctx, p, projectRef, s.env, []string{"patch-alias"}))
+	s.NoError(processTriggerAliases(s.ctx, p, projectRef, s.env, []string{"patch-alias"}))
 
 	dbPatch, err := patch.FindOneId(s.ctx, p.Id.Hex())
 	s.NoError(err)
@@ -1695,7 +1695,7 @@ tasks:
 	s.Require().Len(projectRef.PatchTriggerAliases, 1)
 	projectRef.PatchTriggerAliases[0].DownstreamRevision = "abc"
 
-	s.NoError(ProcessTriggerAliases(s.ctx, p, projectRef, s.env, []string{"patch-alias"}))
+	s.NoError(processTriggerAliases(s.ctx, p, projectRef, s.env, []string{"patch-alias"}))
 
 	dbPatch, err := patch.FindOneId(s.ctx, p.Id.Hex())
 	s.NoError(err)
@@ -1755,7 +1755,7 @@ tasks:
 	s.NoError(err)
 
 	s.Empty(p.Triggers.ChildPatches)
-	s.Error(ProcessTriggerAliases(s.ctx, p, projectRef, s.env, []string{"patch-alias"}), "should error if no tasks/variants match")
+	s.Error(processTriggerAliases(s.ctx, p, projectRef, s.env, []string{"patch-alias"}), "should error if no tasks/variants match")
 	s.Len(p.Triggers.ChildPatches, 1)
 
 	dbPatch, err := patch.FindOneId(s.ctx, p.Id.Hex())

--- a/units/schedule_patch.go
+++ b/units/schedule_patch.go
@@ -44,7 +44,7 @@ func SchedulePatch(ctx context.Context, env evergreen.Environment, patchId strin
 	newCxt := context.WithoutCancel(ctx)
 	// Process additional patch trigger aliases added via UI.
 	// Child patches created with the CLI --trigger-alias flag go through a separate flow, so ensure that new child patches are also created before the parent is finalized.
-	if err := ProcessTriggerAliases(ctx, p, projectRef, env, patchUpdateReq.PatchTriggerAliases); err != nil {
+	if err := processTriggerAliases(ctx, p, projectRef, env, patchUpdateReq.PatchTriggerAliases); err != nil {
 		return http.StatusInternalServerError, errors.Wrap(err, "processing patch trigger aliases")
 	}
 	if len(patchUpdateReq.PatchTriggerAliases) > 0 {


### PR DESCRIPTION
DEVPROD-17412

### Description
Right now, a user can bypass the submit patches permission for a project by specifying it as a child patch on another project. This PR introduces a permission check to fix this security issue.

### Testing
Unit tests and tested in staging.
