### PR TITLE
DEVPROD-17417: Add `RebootInstance` method to cloud manager

### DIFF
--- a/cloud/cloud.go
+++ b/cloud/cloud.go
@@ -51,6 +51,9 @@ type Manager interface {
 	// StartInstance starts a stopped instance.
 	StartInstance(context.Context, *host.Host, string) error
 
+	// RebootInstance reboots (stops and restarts) an instance.
+	RebootInstance(ctx context.Context, h *host.Host, user string) error
+
 	// GetDNSName returns the DNS name of a host.
 	GetDNSName(context.Context, *host.Host) (string, error)
 

--- a/cloud/cloud_host.go
+++ b/cloud/cloud_host.go
@@ -46,6 +46,10 @@ func (cloudHost *CloudHost) StartInstance(ctx context.Context, user string) erro
 	return cloudHost.CloudMgr.StartInstance(ctx, cloudHost.Host, user)
 }
 
+func (cloudHost *CloudHost) RebootInstance(ctx context.Context, user string) error {
+	return cloudHost.CloudMgr.RebootInstance(ctx, cloudHost.Host, user)
+}
+
 func (cloudHost *CloudHost) GetInstanceState(ctx context.Context) (CloudInstanceState, error) {
 	return cloudHost.CloudMgr.GetInstanceState(ctx, cloudHost.Host)
 }

--- a/cloud/docker.go
+++ b/cloud/docker.go
@@ -276,6 +276,10 @@ func (m *dockerManager) StartInstance(ctx context.Context, host *host.Host, user
 	return errors.New("StartInstance is not supported for Docker provider")
 }
 
+func (m *dockerManager) RebootInstance(ctx context.Context, host *host.Host, user string) error {
+	return errors.New("RebootInstance is not supported for Docker provider")
+}
+
 // Configure populates a dockerManager by reading relevant settings from the
 // config object.
 func (m *dockerManager) Configure(ctx context.Context, s *evergreen.Settings) error {

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -334,6 +334,11 @@ func (m *ec2FleetManager) StartInstance(context.Context, *host.Host, string) err
 	return errors.New("can't start instances for EC2 fleet provider")
 }
 
+// RebootInstance should do nothing for EC2 Fleet.
+func (m *ec2FleetManager) RebootInstance(ctx context.Context, h *host.Host, user string) error {
+	return errors.New("can't reboot instances for EC2 fleet provider")
+}
+
 // AssociateIP associates the host with its allocated IP address.
 func (m *ec2FleetManager) AssociateIP(ctx context.Context, h *host.Host) error {
 	if h.IPAllocationID == "" {

--- a/cloud/static.go
+++ b/cloud/static.go
@@ -117,6 +117,10 @@ func (staticMgr *staticManager) StartInstance(ctx context.Context, host *host.Ho
 	return errors.New("StartInstance is not supported for static provider")
 }
 
+func (staticMgr *staticManager) RebootInstance(ctx context.Context, host *host.Host, user string) error {
+	return errors.New("RebootInstance is not supported for static provider")
+}
+
 func (staticMgr *staticManager) Configure(ctx context.Context, settings *evergreen.Settings) error {
 	//no-op. maybe will need to load something from settings in the future.
 	return nil


### PR DESCRIPTION
DEVPROD-17417

### Description
Adds `RebootInstance` method to be used with spawn hosts. To keep this PR small, I'm only adding the function definition; next PR will contain amboy job and GraphQL changes.

The only thing I'm unsure about is how this method interacts with sleep schedules. Let me know if I made a mistake somewhere!

<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

### Testing
On staging, I rebooted my host and checked the logs:
<img width="1007" height="183" alt="Screenshot 2025-09-30 at 5 32 13 PM" src="https://github.com/user-attachments/assets/7b3f1818-22ca-4b82-acf2-44d0b74c324e" />

The timestamp of the reboot job matched when I clicked the reboot button.

Chaya also helped me confirm via the events in AWS CloudTrail.
