### PR TITLE
DEVPROD-21525 Update docs around kanopy-oidc being installed on spawn hosts

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -21,8 +21,6 @@ Please use `evergreen get-update` to upgrade your Evergreen CLI if you don't hav
 
 ### Install kanopy-oidc
 
-_Note: This will already be configured for you on all spawn hosts except Windows hosts. Please see [DEVPROD-18592](https://jira.mongodb.org/browse/DEVPROD-18592) for updates. If you are using a Windows spawn host, please opt out by setting 'do_not_run_kanopy_oidc' to true in your evergreen config file (~/.evergreen.yml) until further notice._
-
 - [Download](https://github.com/kanopy-platform/kanopy-oidc/releases/) the latest release for your laptop’s OS/architecture. If you already have Kanopy-OIDC installed, make sure you’re running version 0.5.0 or later.
 - untar the release tarball
 - put the kanopy-oidc binary on your PATH


### PR DESCRIPTION
DEVPROD-21525

### Description
Removes the mention of it because it's no longer true. 