### PR TITLE
DEVPROD-22498: determine if test selection enabled for tasks

### DIFF
--- a/model/generate.go
+++ b/model/generate.go
@@ -351,27 +351,6 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 				return errors.Wrap(err, "making test selection params for task creation")
 			}
 			creationInfo.TestSelection = *tsParams
-			// kim: TODO: remove
-			// testSelectionIncludeBVs, err := toRegexps(patchDoc.RegexTestSelectionBuildVariants)
-			// if err != nil {
-			//     return errors.Wrap(err, "compiling test selection build variant regexes")
-			// }
-			// testSelectionExcludeBVs, err := toRegexps(patchDoc.RegexTestSelectionExcludedBuildVariants)
-			// if err != nil {
-			//     return errors.Wrap(err, "compiling test selection excluded build variant regexes")
-			// }
-			// testSelectionIncludeTasks, err := toRegexps(patchDoc.RegexTestSelectionTasks)
-			// if err != nil {
-			//     return errors.Wrap(err, "compiling test selection task regexes")
-			// }
-			// testSelectionExcludeTasks, err := toRegexps(patchDoc.RegexTestSelectionExcludedTasks)
-			// if err != nil {
-			//     return errors.Wrap(err, "compiling test selection excluded task regexes")
-			// }
-			// creationInfo.TestSelectionIncludeBVs = testSelectionIncludeBVs
-			// creationInfo.TestSelectionExcludeBVs = testSelectionExcludeBVs
-			// creationInfo.TestSelectionIncludeTasks = testSelectionIncludeTasks
-			// creationInfo.TestSelectionExcludeTasks = testSelectionExcludeTasks
 		}
 	}
 

--- a/model/generate.go
+++ b/model/generate.go
@@ -350,7 +350,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 			if err != nil {
 				return errors.Wrap(err, "making test selection params for task creation")
 			}
-			creationInfo.TestSelection = *tsParams
+			creationInfo.TestSelectionParams = *tsParams
 		}
 	}
 

--- a/model/generate.go
+++ b/model/generate.go
@@ -346,26 +346,32 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 			return errors.Wrapf(err, "finding patch '%s'", v.Id)
 		}
 		if patchDoc != nil {
-			testSelectionIncludeBVs, err := toRegexps(patchDoc.RegexTestSelectionBuildVariants)
+			tsParams, err := newTestSelectionParams(patchDoc)
 			if err != nil {
-				return errors.Wrap(err, "compiling test selection build variant regexes")
+				return errors.Wrap(err, "making test selection params for task creation")
 			}
-			testSelectionExcludeBVs, err := toRegexps(patchDoc.RegexTestSelectionExcludedBuildVariants)
-			if err != nil {
-				return errors.Wrap(err, "compiling test selection excluded build variant regexes")
-			}
-			testSelectionIncludeTasks, err := toRegexps(patchDoc.RegexTestSelectionTasks)
-			if err != nil {
-				return errors.Wrap(err, "compiling test selection task regexes")
-			}
-			testSelectionExcludeTasks, err := toRegexps(patchDoc.RegexTestSelectionExcludedTasks)
-			if err != nil {
-				return errors.Wrap(err, "compiling test selection excluded task regexes")
-			}
-			creationInfo.TestSelectionIncludeBVs = testSelectionIncludeBVs
-			creationInfo.TestSelectionExcludeBVs = testSelectionExcludeBVs
-			creationInfo.TestSelectionIncludeTasks = testSelectionIncludeTasks
-			creationInfo.TestSelectionExcludeTasks = testSelectionExcludeTasks
+			creationInfo.TestSelection = *tsParams
+			// kim: TODO: remove
+			// testSelectionIncludeBVs, err := toRegexps(patchDoc.RegexTestSelectionBuildVariants)
+			// if err != nil {
+			//     return errors.Wrap(err, "compiling test selection build variant regexes")
+			// }
+			// testSelectionExcludeBVs, err := toRegexps(patchDoc.RegexTestSelectionExcludedBuildVariants)
+			// if err != nil {
+			//     return errors.Wrap(err, "compiling test selection excluded build variant regexes")
+			// }
+			// testSelectionIncludeTasks, err := toRegexps(patchDoc.RegexTestSelectionTasks)
+			// if err != nil {
+			//     return errors.Wrap(err, "compiling test selection task regexes")
+			// }
+			// testSelectionExcludeTasks, err := toRegexps(patchDoc.RegexTestSelectionExcludedTasks)
+			// if err != nil {
+			//     return errors.Wrap(err, "compiling test selection excluded task regexes")
+			// }
+			// creationInfo.TestSelectionIncludeBVs = testSelectionIncludeBVs
+			// creationInfo.TestSelectionExcludeBVs = testSelectionExcludeBVs
+			// creationInfo.TestSelectionIncludeTasks = testSelectionIncludeTasks
+			// creationInfo.TestSelectionExcludeTasks = testSelectionExcludeTasks
 		}
 	}
 

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1645,12 +1645,6 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 			TaskCreateTime:                      createTime,
 			ActivatedTasksAreEssentialToSucceed: creationInfo.ActivatedTasksAreEssentialToSucceed,
 			TestSelection:                       tsParams,
-			// kim: TODO: remove
-			// TestSelectionIncludeBVs:             creationInfo.TestSelectionIncludeBVs,
-			// TestSelectionExcludeBVs:             creationInfo.TestSelectionExcludeBVs,
-			// TestSelectionIncludeTasks:           creationInfo.TestSelectionIncludeTasks,
-			// TestSelectionExcludeTasks:           creationInfo.TestSelectionExcludeTasks,
-			// CanBuildVariantEnableTestSelection:  canBuildVariantEnableTestSelection(pair.Variant, creationInfo),
 		}
 
 		grip.Info(message.Fields{

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1524,6 +1524,11 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 			continue
 		}
 		variantsProcessed[pair.Variant] = true
+		// kim: TODO: check if variant should enable test selection for its
+		// tasks. If just variants specified and no tasks, whole variants are
+		// included/excluded. If variants and tasks are both specified, specific tasks
+		// within that variant are included/excluded. If variants not specified
+		// at all, fall back to checking project default enabled/disabled.
 		// Extract the unique set of task names for the variant we're about to create
 		taskNames := creationInfo.Pairs.ExecTasks.TaskNames(pair.Variant)
 		displayNames := creationInfo.Pairs.DisplayTasks.TaskNames(pair.Variant)

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -855,9 +855,6 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 	// not existing tasks. If a task already existed and is now being regrouped
 	// under a new display task, its test selection state will not be
 	// re-evaluated to avoid changing the behavior of the task.
-	// kim: NOTE: should test this carefully with display tasks. It should check
-	// test selection enabled for new tasks, and correctly handle whether it's
-	// grouped under a new or already-existing display task.
 	setTestSelectionEnabledForTasks(taskMap, displayTaskIDsToNames, creationInfo)
 
 	for _, t := range taskMap {
@@ -1234,10 +1231,6 @@ func createOneTask(ctx context.Context, id string, creationInfo TaskCreationInfo
 		tg.InjectInfo(t)
 	}
 
-	// kim: NOTE: can't decide if test selection is enabled here because of
-	// display tasks. If display tasks count towards matching include/exclude
-	// regexps, then we need to wait until the display tasks are created.
-
 	return t, nil
 }
 
@@ -1612,7 +1605,6 @@ func canBuildVariantEnableTestSelection(bvName string, creationInfo TaskCreation
 // do not exist yet out of the set of pairs. No tasks are added for builds which already exist
 // (see AddNewTasksForPatch). New builds/tasks are activated depending on their batchtime.
 // Returns task IDs for activated tasks and for activated dependencies.
-// kim: TODO: add tests to ensure test selection enable is set correctly.
 func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBuilds []build.Build) ([]string, []string, error) {
 	ctx, span := tracer.Start(ctx, "add-new-builds")
 	defer span.End()
@@ -1643,13 +1635,6 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 			continue
 		}
 		variantsProcessed[pair.Variant] = true
-		// kim: NOTE: If just variants specified and no tasks, whole variants
-		// are included/excluded. If variants and tasks are both specified,
-		// specific tasks within that variant are included/excluded. If variants
-		// not specified at all, fall back to checking project default
-		// enabled/disabled. Need to be careful to make sure
-		// include/exclude/default is handled properly.
-
 		// Extract the unique set of task names for the variant we're about to create
 		taskNames := creationInfo.Pairs.ExecTasks.TaskNames(pair.Variant)
 		displayNames := creationInfo.Pairs.DisplayTasks.TaskNames(pair.Variant)
@@ -1788,7 +1773,6 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 // Given a version and set of variant/task pairs, creates any tasks that don't exist yet,
 // within the set of already existing builds. Returns task IDs for activated
 // tasks and task IDs for activated dependencies.
-// kim: TODO: add tests to ensure test selection enable is set correctly.
 func addNewTasksToExistingBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBuilds []build.Build, caller string) ([]string, []string, error) {
 	ctx, span := tracer.Start(ctx, "add-new-tasks")
 	defer span.End()

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -855,7 +855,9 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 	// not existing tasks. If a task already existed and is now being regrouped
 	// under a new display task, its test selection state will not be
 	// re-evaluated to avoid changing the behavior of the task.
-	setTestSelectionEnabledForTasks(taskMap, displayTaskIDsToNames, creationInfo)
+	if err := setTestSelectionEnabledForTasks(taskMap, displayTaskIDsToNames, creationInfo); err != nil {
+		return nil, errors.Wrap(err, "setting test selection enabled for newly-created tasks")
+	}
 
 	for _, t := range taskMap {
 		tasks = append(tasks, t)

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1643,11 +1643,10 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 			continue
 		}
 		variantsProcessed[pair.Variant] = true
-		// kim: TODO: check if variant should enable test selection for its
-		// tasks. If just variants specified and no tasks, whole variants are
-		// included/excluded. If variants and tasks are both specified, specific
-		// tasks within that variant are included/excluded. If variants not
-		// specified at all, fall back to checking project default
+		// kim: NOTE: If just variants specified and no tasks, whole variants
+		// are included/excluded. If variants and tasks are both specified,
+		// specific tasks within that variant are included/excluded. If variants
+		// not specified at all, fall back to checking project default
 		// enabled/disabled. Need to be careful to make sure
 		// include/exclude/default is handled properly.
 
@@ -1668,6 +1667,10 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 			GeneratedBy:                         creationInfo.GeneratedBy,
 			TaskCreateTime:                      createTime,
 			ActivatedTasksAreEssentialToSucceed: creationInfo.ActivatedTasksAreEssentialToSucceed,
+			TestSelectionIncludeBVs:             creationInfo.TestSelectionIncludeBVs,
+			TestSelectionExcludeBVs:             creationInfo.TestSelectionExcludeBVs,
+			TestSelectionIncludeTasks:           creationInfo.TestSelectionIncludeTasks,
+			TestSelectionExcludeTasks:           creationInfo.TestSelectionExcludeTasks,
 			CanBuildVariantEnableTestSelection:  canBuildVariantEnableTestSelection(pair.Variant, creationInfo),
 		}
 

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -3121,11 +3121,6 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 					regexp.MustCompile("bv2"),
 				},
 			},
-			// kim: TODO: remove
-			// TestSelectionIncludeBVs: []*regexp.Regexp{
-			//     regexp.MustCompile("bv1"),
-			//     regexp.MustCompile("bv2"),
-			// },
 		}
 		assert.True(t, canBuildVariantEnableTestSelection("bv2", creationInfo))
 	})
@@ -3143,12 +3138,6 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 				},
 				IncludeTasks: []*regexp.Regexp{regexp.MustCompile("t1")},
 			},
-			// kim: TODO: remove
-			// TestSelectionIncludeBVs: []*regexp.Regexp{
-			//     regexp.MustCompile("bv1"),
-			//     regexp.MustCompile("bv2"),
-			// },
-			// TestSelectionIncludeTasks: []*regexp.Regexp{regexp.MustCompile("t1")},
 		}
 		assert.True(t, canBuildVariantEnableTestSelection("bv2", creationInfo))
 	})
@@ -3166,12 +3155,6 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 				},
 				ExcludeBuildVariants: []*regexp.Regexp{regexp.MustCompile("bv1")},
 			},
-			// kim: TODO: remove
-			// TestSelectionIncludeBVs: []*regexp.Regexp{
-			//     regexp.MustCompile("bv1"),
-			//     regexp.MustCompile("bv2"),
-			// },
-			// TestSelectionExcludeBVs: []*regexp.Regexp{regexp.MustCompile("bv1")},
 		}
 		assert.True(t, canBuildVariantEnableTestSelection("bv2", creationInfo))
 	})
@@ -3186,8 +3169,6 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 			TestSelection: TestSelectionParams{
 				ExcludeBuildVariants: []*regexp.Regexp{regexp.MustCompile("bv2")},
 			},
-			// kim: TODO: remove
-			// TestSelectionExcludeBVs: []*regexp.Regexp{regexp.MustCompile("bv2")},
 		}
 		assert.False(t, canBuildVariantEnableTestSelection("bv2", creationInfo))
 	})
@@ -3205,12 +3186,6 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 				},
 				ExcludeBuildVariants: []*regexp.Regexp{regexp.MustCompile("bv2")},
 			},
-			// kim: TODO: remove
-			// TestSelectionIncludeBVs: []*regexp.Regexp{
-			//     regexp.MustCompile("bv1"),
-			//     regexp.MustCompile("bv2"),
-			// },
-			// TestSelectionExcludeBVs: []*regexp.Regexp{regexp.MustCompile("bv2")},
 		}
 		assert.False(t, canBuildVariantEnableTestSelection("bv2", creationInfo))
 	})
@@ -3224,8 +3199,6 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 			TestSelection: TestSelectionParams{
 				IncludeTasks: []*regexp.Regexp{regexp.MustCompile("t1")},
 			},
-			// kim: TODO: remove
-			// TestSelectionIncludeTasks: []*regexp.Regexp{regexp.MustCompile("t1")},
 		}
 		// This includes tasks that match the pattern t1 across all build
 		// variants, so the build variant can enable test selection if such a
@@ -3242,8 +3215,6 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 			TestSelection: TestSelectionParams{
 				IncludeBuildVariants: []*regexp.Regexp{regexp.MustCompile("bv1")},
 			},
-			// kim: TODO: remove
-			// TestSelectionIncludeBVs: []*regexp.Regexp{regexp.MustCompile("bv1")},
 		}
 		assert.False(t, canBuildVariantEnableTestSelection("bv3", creationInfo))
 	})
@@ -3258,8 +3229,6 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 			TestSelection: TestSelectionParams{
 				IncludeBuildVariants: []*regexp.Regexp{regexp.MustCompile("bv1")},
 			},
-			// kim: TODO: remove
-			// TestSelectionIncludeBVs: []*regexp.Regexp{regexp.MustCompile("bv1")},
 		}
 		assert.False(t, canBuildVariantEnableTestSelection("bv2", creationInfo))
 	})
@@ -3290,8 +3259,6 @@ func TestIsTestSelectionEnabledForTask(t *testing.T) {
 	for tName, tCase := range map[string]func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo){
 		"ReturnsTrueIfTaskIncludedInTestSelection": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
 			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
-			// kim: TODO: remove
-			// creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.True(t, isTestSelectionEnabled)
@@ -3299,8 +3266,6 @@ func TestIsTestSelectionEnabledForTask(t *testing.T) {
 		"ReturnsTrueIfParentDisplayTaskIncludedInTestSelection": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
 			tsk.DisplayTaskId = utility.ToStringPtr("display_task_id1")
 			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("dt1")}
-			// kim: TODO: remove
-			// creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("dt1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.True(t, isTestSelectionEnabled)
@@ -3308,16 +3273,12 @@ func TestIsTestSelectionEnabledForTask(t *testing.T) {
 		"ReturnsTrueIfTaskGroupIsIncludedInTestSelection": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
 			tsk.TaskGroup = "tg1"
 			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("tg1")}
-			// kim: TODO: remove
-			// creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("tg1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.True(t, isTestSelectionEnabled)
 		},
 		"ReturnsFalseIfTaskIsNotIncludedInTestSelection": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
 			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t2")}
-			// kim: TODO: remove
-			// creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("t2")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.False(t, isTestSelectionEnabled)
@@ -3326,9 +3287,6 @@ func TestIsTestSelectionEnabledForTask(t *testing.T) {
 			tsk.DisplayTaskId = utility.ToStringPtr("display_task_id1")
 			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
 			creationInfo.TestSelection.ExcludeTasks = []*regexp.Regexp{regexp.MustCompile("dt1")}
-			// kim: TODO: remove
-			// creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
-			// creationInfo.TestSelectionExcludeTasks = []*regexp.Regexp{regexp.MustCompile("dt1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.False(t, isTestSelectionEnabled)
@@ -3337,25 +3295,18 @@ func TestIsTestSelectionEnabledForTask(t *testing.T) {
 			tsk.TaskGroup = "tg1"
 			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
 			creationInfo.TestSelection.ExcludeTasks = []*regexp.Regexp{regexp.MustCompile("tg1")}
-			// kim: TODO: remove
-			// creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
-			// creationInfo.TestSelectionExcludeTasks = []*regexp.Regexp{regexp.MustCompile("tg1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.False(t, isTestSelectionEnabled)
 		},
 		"ReturnsFalseIfTaskIsExcluded": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
 			creationInfo.TestSelection.ExcludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
-			// kim: TODO: remove
-			// creationInfo.TestSelectionExcludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.False(t, isTestSelectionEnabled)
 		},
 		"ReturnsTrueIfVariantCanEnableTestSelectionAndTaskIsNotExcluded": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
 			creationInfo.TestSelection.ExcludeTasks = []*regexp.Regexp{regexp.MustCompile("t2")}
-			// kim: TODO: remove
-			// creationInfo.TestSelectionExcludeTasks = []*regexp.Regexp{regexp.MustCompile("t2")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.True(t, isTestSelectionEnabled)

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -3115,10 +3115,17 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 					Allowed: utility.TruePtr(),
 				},
 			},
-			TestSelectionIncludeBVs: []*regexp.Regexp{
-				regexp.MustCompile("bv1"),
-				regexp.MustCompile("bv2"),
+			TestSelection: TestSelectionParams{
+				IncludeBuildVariants: []*regexp.Regexp{
+					regexp.MustCompile("bv1"),
+					regexp.MustCompile("bv2"),
+				},
 			},
+			// kim: TODO: remove
+			// TestSelectionIncludeBVs: []*regexp.Regexp{
+			//     regexp.MustCompile("bv1"),
+			//     regexp.MustCompile("bv2"),
+			// },
 		}
 		assert.True(t, canBuildVariantEnableTestSelection("bv2", creationInfo))
 	})
@@ -3129,11 +3136,19 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 					Allowed: utility.TruePtr(),
 				},
 			},
-			TestSelectionIncludeBVs: []*regexp.Regexp{
-				regexp.MustCompile("bv1"),
-				regexp.MustCompile("bv2"),
+			TestSelection: TestSelectionParams{
+				IncludeBuildVariants: []*regexp.Regexp{
+					regexp.MustCompile("bv1"),
+					regexp.MustCompile("bv2"),
+				},
+				IncludeTasks: []*regexp.Regexp{regexp.MustCompile("t1")},
 			},
-			TestSelectionIncludeTasks: []*regexp.Regexp{regexp.MustCompile("t1")},
+			// kim: TODO: remove
+			// TestSelectionIncludeBVs: []*regexp.Regexp{
+			//     regexp.MustCompile("bv1"),
+			//     regexp.MustCompile("bv2"),
+			// },
+			// TestSelectionIncludeTasks: []*regexp.Regexp{regexp.MustCompile("t1")},
 		}
 		assert.True(t, canBuildVariantEnableTestSelection("bv2", creationInfo))
 	})
@@ -3144,11 +3159,19 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 					Allowed: utility.TruePtr(),
 				},
 			},
-			TestSelectionIncludeBVs: []*regexp.Regexp{
-				regexp.MustCompile("bv1"),
-				regexp.MustCompile("bv2"),
+			TestSelection: TestSelectionParams{
+				IncludeBuildVariants: []*regexp.Regexp{
+					regexp.MustCompile("bv1"),
+					regexp.MustCompile("bv2"),
+				},
+				ExcludeBuildVariants: []*regexp.Regexp{regexp.MustCompile("bv1")},
 			},
-			TestSelectionExcludeBVs: []*regexp.Regexp{regexp.MustCompile("bv1")},
+			// kim: TODO: remove
+			// TestSelectionIncludeBVs: []*regexp.Regexp{
+			//     regexp.MustCompile("bv1"),
+			//     regexp.MustCompile("bv2"),
+			// },
+			// TestSelectionExcludeBVs: []*regexp.Regexp{regexp.MustCompile("bv1")},
 		}
 		assert.True(t, canBuildVariantEnableTestSelection("bv2", creationInfo))
 	})
@@ -3160,7 +3183,11 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 					DefaultEnabled: utility.TruePtr(),
 				},
 			},
-			TestSelectionExcludeBVs: []*regexp.Regexp{regexp.MustCompile("bv2")},
+			TestSelection: TestSelectionParams{
+				ExcludeBuildVariants: []*regexp.Regexp{regexp.MustCompile("bv2")},
+			},
+			// kim: TODO: remove
+			// TestSelectionExcludeBVs: []*regexp.Regexp{regexp.MustCompile("bv2")},
 		}
 		assert.False(t, canBuildVariantEnableTestSelection("bv2", creationInfo))
 	})
@@ -3171,11 +3198,19 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 					Allowed: utility.TruePtr(),
 				},
 			},
-			TestSelectionIncludeBVs: []*regexp.Regexp{
-				regexp.MustCompile("bv1"),
-				regexp.MustCompile("bv2"),
+			TestSelection: TestSelectionParams{
+				IncludeBuildVariants: []*regexp.Regexp{
+					regexp.MustCompile("bv1"),
+					regexp.MustCompile("bv2"),
+				},
+				ExcludeBuildVariants: []*regexp.Regexp{regexp.MustCompile("bv2")},
 			},
-			TestSelectionExcludeBVs: []*regexp.Regexp{regexp.MustCompile("bv2")},
+			// kim: TODO: remove
+			// TestSelectionIncludeBVs: []*regexp.Regexp{
+			//     regexp.MustCompile("bv1"),
+			//     regexp.MustCompile("bv2"),
+			// },
+			// TestSelectionExcludeBVs: []*regexp.Regexp{regexp.MustCompile("bv2")},
 		}
 		assert.False(t, canBuildVariantEnableTestSelection("bv2", creationInfo))
 	})
@@ -3186,7 +3221,11 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 					Allowed: utility.TruePtr(),
 				},
 			},
-			TestSelectionIncludeTasks: []*regexp.Regexp{regexp.MustCompile("t1")},
+			TestSelection: TestSelectionParams{
+				IncludeTasks: []*regexp.Regexp{regexp.MustCompile("t1")},
+			},
+			// kim: TODO: remove
+			// TestSelectionIncludeTasks: []*regexp.Regexp{regexp.MustCompile("t1")},
 		}
 		// This includes tasks that match the pattern t1 across all build
 		// variants, so the build variant can enable test selection if such a
@@ -3200,7 +3239,11 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 					Allowed: utility.TruePtr(),
 				},
 			},
-			TestSelectionIncludeBVs: []*regexp.Regexp{regexp.MustCompile("bv1")},
+			TestSelection: TestSelectionParams{
+				IncludeBuildVariants: []*regexp.Regexp{regexp.MustCompile("bv1")},
+			},
+			// kim: TODO: remove
+			// TestSelectionIncludeBVs: []*regexp.Regexp{regexp.MustCompile("bv1")},
 		}
 		assert.False(t, canBuildVariantEnableTestSelection("bv3", creationInfo))
 	})
@@ -3212,7 +3255,11 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 					DefaultEnabled: utility.TruePtr(),
 				},
 			},
-			TestSelectionIncludeBVs: []*regexp.Regexp{regexp.MustCompile("bv1")},
+			TestSelection: TestSelectionParams{
+				IncludeBuildVariants: []*regexp.Regexp{regexp.MustCompile("bv1")},
+			},
+			// kim: TODO: remove
+			// TestSelectionIncludeBVs: []*regexp.Regexp{regexp.MustCompile("bv1")},
 		}
 		assert.False(t, canBuildVariantEnableTestSelection("bv2", creationInfo))
 	})
@@ -3242,61 +3289,80 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 func TestIsTestSelectionEnabledForTask(t *testing.T) {
 	for tName, tCase := range map[string]func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo){
 		"ReturnsTrueIfTaskIncludedInTestSelection": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
-			creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
+			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
+			// kim: TODO: remove
+			// creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.True(t, isTestSelectionEnabled)
 		},
 		"ReturnsTrueIfParentDisplayTaskIncludedInTestSelection": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
 			tsk.DisplayTaskId = utility.ToStringPtr("display_task_id1")
-			creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("dt1")}
+			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("dt1")}
+			// kim: TODO: remove
+			// creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("dt1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.True(t, isTestSelectionEnabled)
 		},
 		"ReturnsTrueIfTaskGroupIsIncludedInTestSelection": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
 			tsk.TaskGroup = "tg1"
-			creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("tg1")}
+			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("tg1")}
+			// kim: TODO: remove
+			// creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("tg1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.True(t, isTestSelectionEnabled)
 		},
 		"ReturnsFalseIfTaskIsNotIncludedInTestSelection": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
-			creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("t2")}
+			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t2")}
+			// kim: TODO: remove
+			// creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("t2")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.False(t, isTestSelectionEnabled)
 		},
 		"ReturnsFalseIfTaskIsIncludedByNameButDisplayTaskIsExcluded": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
 			tsk.DisplayTaskId = utility.ToStringPtr("display_task_id1")
-			creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
-			creationInfo.TestSelectionExcludeTasks = []*regexp.Regexp{regexp.MustCompile("dt1")}
+			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
+			creationInfo.TestSelection.ExcludeTasks = []*regexp.Regexp{regexp.MustCompile("dt1")}
+			// kim: TODO: remove
+			// creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
+			// creationInfo.TestSelectionExcludeTasks = []*regexp.Regexp{regexp.MustCompile("dt1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.False(t, isTestSelectionEnabled)
 		},
 		"ReturnsFalseIfTaskIsIncludedByNameButTaskGroupIsExcluded": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
 			tsk.TaskGroup = "tg1"
-			creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
-			creationInfo.TestSelectionExcludeTasks = []*regexp.Regexp{regexp.MustCompile("tg1")}
+			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
+			creationInfo.TestSelection.ExcludeTasks = []*regexp.Regexp{regexp.MustCompile("tg1")}
+			// kim: TODO: remove
+			// creationInfo.TestSelectionIncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
+			// creationInfo.TestSelectionExcludeTasks = []*regexp.Regexp{regexp.MustCompile("tg1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.False(t, isTestSelectionEnabled)
 		},
 		"ReturnsFalseIfTaskIsExcluded": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
-			creationInfo.TestSelectionExcludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
+			creationInfo.TestSelection.ExcludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
+			// kim: TODO: remove
+			// creationInfo.TestSelectionExcludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.False(t, isTestSelectionEnabled)
 		},
 		"ReturnsTrueIfVariantCanEnableTestSelectionAndTaskIsNotExcluded": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
-			creationInfo.TestSelectionExcludeTasks = []*regexp.Regexp{regexp.MustCompile("t2")}
+			creationInfo.TestSelection.ExcludeTasks = []*regexp.Regexp{regexp.MustCompile("t2")}
+			// kim: TODO: remove
+			// creationInfo.TestSelectionExcludeTasks = []*regexp.Regexp{regexp.MustCompile("t2")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.True(t, isTestSelectionEnabled)
 		},
 		"ReturnsFalseIfBVCannotEnableTestSelection": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
-			creationInfo.CanBuildVariantEnableTestSelection = false
+			creationInfo.TestSelection.CanBuildVariantEnableTestSelection = false
+			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.False(t, isTestSelectionEnabled)
@@ -3309,7 +3375,9 @@ func TestIsTestSelectionEnabledForTask(t *testing.T) {
 			}
 			displayTasks := map[string]string{"display_task_id1": "dt1"}
 			creationInfo := TaskCreationInfo{
-				CanBuildVariantEnableTestSelection: true,
+				TestSelection: TestSelectionParams{
+					CanBuildVariantEnableTestSelection: true,
+				},
 			}
 			tCase(t, tsk, displayTasks, creationInfo)
 		})

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -3115,7 +3115,7 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 					Allowed: utility.TruePtr(),
 				},
 			},
-			TestSelection: TestSelectionParams{
+			TestSelectionParams: TestSelectionParams{
 				IncludeBuildVariants: []*regexp.Regexp{
 					regexp.MustCompile("bv1"),
 					regexp.MustCompile("bv2"),
@@ -3131,7 +3131,7 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 					Allowed: utility.TruePtr(),
 				},
 			},
-			TestSelection: TestSelectionParams{
+			TestSelectionParams: TestSelectionParams{
 				IncludeBuildVariants: []*regexp.Regexp{
 					regexp.MustCompile("bv1"),
 					regexp.MustCompile("bv2"),
@@ -3148,7 +3148,7 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 					Allowed: utility.TruePtr(),
 				},
 			},
-			TestSelection: TestSelectionParams{
+			TestSelectionParams: TestSelectionParams{
 				IncludeBuildVariants: []*regexp.Regexp{
 					regexp.MustCompile("bv1"),
 					regexp.MustCompile("bv2"),
@@ -3166,7 +3166,7 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 					DefaultEnabled: utility.TruePtr(),
 				},
 			},
-			TestSelection: TestSelectionParams{
+			TestSelectionParams: TestSelectionParams{
 				ExcludeBuildVariants: []*regexp.Regexp{regexp.MustCompile("bv2")},
 			},
 		}
@@ -3179,7 +3179,7 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 					Allowed: utility.TruePtr(),
 				},
 			},
-			TestSelection: TestSelectionParams{
+			TestSelectionParams: TestSelectionParams{
 				IncludeBuildVariants: []*regexp.Regexp{
 					regexp.MustCompile("bv1"),
 					regexp.MustCompile("bv2"),
@@ -3196,7 +3196,7 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 					Allowed: utility.TruePtr(),
 				},
 			},
-			TestSelection: TestSelectionParams{
+			TestSelectionParams: TestSelectionParams{
 				IncludeTasks: []*regexp.Regexp{regexp.MustCompile("t1")},
 			},
 		}
@@ -3212,7 +3212,7 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 					Allowed: utility.TruePtr(),
 				},
 			},
-			TestSelection: TestSelectionParams{
+			TestSelectionParams: TestSelectionParams{
 				IncludeBuildVariants: []*regexp.Regexp{regexp.MustCompile("bv1")},
 			},
 		}
@@ -3226,7 +3226,7 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 					DefaultEnabled: utility.TruePtr(),
 				},
 			},
-			TestSelection: TestSelectionParams{
+			TestSelectionParams: TestSelectionParams{
 				IncludeBuildVariants: []*regexp.Regexp{regexp.MustCompile("bv1")},
 			},
 		}
@@ -3258,62 +3258,62 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 func TestIsTestSelectionEnabledForTask(t *testing.T) {
 	for tName, tCase := range map[string]func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo){
 		"ReturnsTrueIfTaskIncludedInTestSelection": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
-			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
+			creationInfo.TestSelectionParams.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.True(t, isTestSelectionEnabled)
 		},
 		"ReturnsTrueIfParentDisplayTaskIncludedInTestSelection": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
 			tsk.DisplayTaskId = utility.ToStringPtr("display_task_id1")
-			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("dt1")}
+			creationInfo.TestSelectionParams.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("dt1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.True(t, isTestSelectionEnabled)
 		},
 		"ReturnsTrueIfTaskGroupIsIncludedInTestSelection": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
 			tsk.TaskGroup = "tg1"
-			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("tg1")}
+			creationInfo.TestSelectionParams.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("tg1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.True(t, isTestSelectionEnabled)
 		},
 		"ReturnsFalseIfTaskIsNotIncludedInTestSelection": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
-			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t2")}
+			creationInfo.TestSelectionParams.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t2")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.False(t, isTestSelectionEnabled)
 		},
 		"ReturnsFalseIfTaskIsIncludedByNameButDisplayTaskIsExcluded": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
 			tsk.DisplayTaskId = utility.ToStringPtr("display_task_id1")
-			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
-			creationInfo.TestSelection.ExcludeTasks = []*regexp.Regexp{regexp.MustCompile("dt1")}
+			creationInfo.TestSelectionParams.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
+			creationInfo.TestSelectionParams.ExcludeTasks = []*regexp.Regexp{regexp.MustCompile("dt1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.False(t, isTestSelectionEnabled)
 		},
 		"ReturnsFalseIfTaskIsIncludedByNameButTaskGroupIsExcluded": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
 			tsk.TaskGroup = "tg1"
-			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
-			creationInfo.TestSelection.ExcludeTasks = []*regexp.Regexp{regexp.MustCompile("tg1")}
+			creationInfo.TestSelectionParams.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
+			creationInfo.TestSelectionParams.ExcludeTasks = []*regexp.Regexp{regexp.MustCompile("tg1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.False(t, isTestSelectionEnabled)
 		},
 		"ReturnsFalseIfTaskIsExcluded": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
-			creationInfo.TestSelection.ExcludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
+			creationInfo.TestSelectionParams.ExcludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.False(t, isTestSelectionEnabled)
 		},
 		"ReturnsTrueIfVariantCanEnableTestSelectionAndTaskIsNotExcluded": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
-			creationInfo.TestSelection.ExcludeTasks = []*regexp.Regexp{regexp.MustCompile("t2")}
+			creationInfo.TestSelectionParams.ExcludeTasks = []*regexp.Regexp{regexp.MustCompile("t2")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.True(t, isTestSelectionEnabled)
 		},
 		"ReturnsFalseIfBVCannotEnableTestSelection": func(t *testing.T, tsk *task.Task, displayTasks map[string]string, creationInfo TaskCreationInfo) {
-			creationInfo.TestSelection.CanBuildVariantEnableTestSelection = false
-			creationInfo.TestSelection.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
+			creationInfo.TestSelectionParams.CanBuildVariantEnableTestSelection = false
+			creationInfo.TestSelectionParams.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("t1")}
 			isTestSelectionEnabled, err := isTestSelectionEnabledForTask(tsk, displayTasks, creationInfo)
 			assert.NoError(t, err)
 			assert.False(t, isTestSelectionEnabled)
@@ -3326,7 +3326,7 @@ func TestIsTestSelectionEnabledForTask(t *testing.T) {
 			}
 			displayTasks := map[string]string{"display_task_id1": "dt1"}
 			creationInfo := TaskCreationInfo{
-				TestSelection: TestSelectionParams{
+				TestSelectionParams: TestSelectionParams{
 					CanBuildVariantEnableTestSelection: true,
 				},
 			}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -173,23 +173,6 @@ func ConfigurePatch(ctx context.Context, settings *evergreen.Settings, p *patch.
 		}
 
 		if len(patchVariantTasks) > 0 {
-			// kim: TODO: remove
-			// testSelectionIncludeBVs, err := toRegexps(p.RegexTestSelectionBuildVariants)
-			// if err != nil {
-			//     return http.StatusInternalServerError, errors.Wrap(err, "compiling test selection build variant regexes")
-			// }
-			// testSelectionExcludeBVs, err := toRegexps(p.RegexTestSelectionExcludedBuildVariants)
-			// if err != nil {
-			//     return http.StatusInternalServerError, errors.Wrap(err, "compiling test selection excluded build variant regexes")
-			// }
-			// testSelectionIncludeTasks, err := toRegexps(p.RegexTestSelectionTasks)
-			// if err != nil {
-			//     return http.StatusInternalServerError, errors.Wrap(err, "compiling test selection task regexes")
-			// }
-			// testSelectionExcludeTasks, err := toRegexps(p.RegexTestSelectionExcludedTasks)
-			// if err != nil {
-			//     return http.StatusInternalServerError, errors.Wrap(err, "compiling test selection excluded task regexes")
-			// }
 			tsParams, err := newTestSelectionParams(p)
 			if err != nil {
 				return http.StatusInternalServerError, errors.Wrap(err, "making test selection parameters for task creation")
@@ -203,11 +186,6 @@ func ConfigurePatch(ctx context.Context, settings *evergreen.Settings, p *patch.
 				ActivationInfo: specificActivationInfo{},
 				GeneratedBy:    "",
 				TestSelection:  *tsParams,
-				// kim: TODO: remove
-				// TestSelectionIncludeBVs:   testSelectionIncludeBVs,
-				// TestSelectionExcludeBVs:   testSelectionExcludeBVs,
-				// TestSelectionIncludeTasks: testSelectionIncludeTasks,
-				// TestSelectionExcludeTasks: testSelectionExcludeTasks,
 			}
 			err = addNewTasksAndBuildsForPatch(ctx, p, creationInfo, patchUpdateReq.Caller)
 			if err != nil {
@@ -699,24 +677,6 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 	}
 	variantsProcessed := map[string]bool{}
 
-	// kim: TODO: remove
-	// testSelectionIncludeBVs, err := toRegexps(p.RegexTestSelectionBuildVariants)
-	// if err != nil {
-	//     return nil, errors.Wrap(err, "compiling test selection build variant regexes")
-	// }
-	// testSelectionExcludeBVs, err := toRegexps(p.RegexTestSelectionExcludedBuildVariants)
-	// if err != nil {
-	//     return nil, errors.Wrap(err, "compiling test selection excluded build variant regexes")
-	// }
-	// testSelectionIncludeTasks, err := toRegexps(p.RegexTestSelectionTasks)
-	// if err != nil {
-	//     return nil, errors.Wrap(err, "compiling test selection task regexes")
-	// }
-	// testSelectionExcludeTasks, err := toRegexps(p.RegexTestSelectionExcludedTasks)
-	// if err != nil {
-	//     return nil, errors.Wrap(err, "compiling test selection excluded task regexes")
-	// }
-
 	tsParams, err := newTestSelectionParams(p)
 	if err != nil {
 		return nil, errors.Wrap(err, "making test selection parameters for task creation")
@@ -727,11 +687,6 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 		Project:       project,
 		ProjectRef:    projectRef,
 		TestSelection: *tsParams,
-		// kim: TODO: remove
-		// TestSelectionIncludeBVs:   testSelectionIncludeBVs,
-		// TestSelectionExcludeBVs:   testSelectionExcludeBVs,
-		// TestSelectionIncludeTasks: testSelectionIncludeTasks,
-		// TestSelectionExcludeTasks: testSelectionExcludeTasks,
 	}
 	createTime, err := getTaskCreateTime(ctx, creationInfo)
 	if err != nil {
@@ -770,14 +725,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 			// build/version to be finished.
 			ActivatedTasksAreEssentialToSucceed: requester == evergreen.GithubPRRequester,
 			TestSelection:                       tsParams,
-			// kim: TODO: remove
-			// TestSelectionIncludeBVs:             creationInfo.TestSelectionIncludeBVs,
-			// TestSelectionExcludeBVs:             creationInfo.TestSelectionExcludeBVs,
-			// TestSelectionIncludeTasks:           creationInfo.TestSelectionIncludeTasks,
-			// TestSelectionExcludeTasks:           creationInfo.TestSelectionExcludeTasks,
 		}
-		// kim: TODO: remove
-		// buildCreationArgs.CanBuildVariantEnableTestSelection = canBuildVariantEnableTestSelection(vt.Variant, buildCreationArgs)
 		var build *build.Build
 		var tasks task.Tasks
 		build, tasks, err = CreateBuildFromVersionNoInsert(ctx, buildCreationArgs)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -173,34 +173,41 @@ func ConfigurePatch(ctx context.Context, settings *evergreen.Settings, p *patch.
 		}
 
 		if len(patchVariantTasks) > 0 {
-			testSelectionIncludeBVs, err := toRegexps(p.RegexTestSelectionBuildVariants)
+			// kim: TODO: remove
+			// testSelectionIncludeBVs, err := toRegexps(p.RegexTestSelectionBuildVariants)
+			// if err != nil {
+			//     return http.StatusInternalServerError, errors.Wrap(err, "compiling test selection build variant regexes")
+			// }
+			// testSelectionExcludeBVs, err := toRegexps(p.RegexTestSelectionExcludedBuildVariants)
+			// if err != nil {
+			//     return http.StatusInternalServerError, errors.Wrap(err, "compiling test selection excluded build variant regexes")
+			// }
+			// testSelectionIncludeTasks, err := toRegexps(p.RegexTestSelectionTasks)
+			// if err != nil {
+			//     return http.StatusInternalServerError, errors.Wrap(err, "compiling test selection task regexes")
+			// }
+			// testSelectionExcludeTasks, err := toRegexps(p.RegexTestSelectionExcludedTasks)
+			// if err != nil {
+			//     return http.StatusInternalServerError, errors.Wrap(err, "compiling test selection excluded task regexes")
+			// }
+			tsParams, err := newTestSelectionParams(p)
 			if err != nil {
-				return http.StatusInternalServerError, errors.Wrap(err, "compiling test selection build variant regexes")
-			}
-			testSelectionExcludeBVs, err := toRegexps(p.RegexTestSelectionExcludedBuildVariants)
-			if err != nil {
-				return http.StatusInternalServerError, errors.Wrap(err, "compiling test selection excluded build variant regexes")
-			}
-			testSelectionIncludeTasks, err := toRegexps(p.RegexTestSelectionTasks)
-			if err != nil {
-				return http.StatusInternalServerError, errors.Wrap(err, "compiling test selection task regexes")
-			}
-			testSelectionExcludeTasks, err := toRegexps(p.RegexTestSelectionExcludedTasks)
-			if err != nil {
-				return http.StatusInternalServerError, errors.Wrap(err, "compiling test selection excluded task regexes")
+				return http.StatusInternalServerError, errors.Wrap(err, "making test selection parameters for task creation")
 			}
 			// Add new tasks to existing builds, if necessary
 			creationInfo := TaskCreationInfo{
-				Project:                   project,
-				ProjectRef:                proj,
-				Version:                   version,
-				Pairs:                     tasks,
-				ActivationInfo:            specificActivationInfo{},
-				GeneratedBy:               "",
-				TestSelectionIncludeBVs:   testSelectionIncludeBVs,
-				TestSelectionExcludeBVs:   testSelectionExcludeBVs,
-				TestSelectionIncludeTasks: testSelectionIncludeTasks,
-				TestSelectionExcludeTasks: testSelectionExcludeTasks,
+				Project:        project,
+				ProjectRef:     proj,
+				Version:        version,
+				Pairs:          tasks,
+				ActivationInfo: specificActivationInfo{},
+				GeneratedBy:    "",
+				TestSelection:  *tsParams,
+				// kim: TODO: remove
+				// TestSelectionIncludeBVs:   testSelectionIncludeBVs,
+				// TestSelectionExcludeBVs:   testSelectionExcludeBVs,
+				// TestSelectionIncludeTasks: testSelectionIncludeTasks,
+				// TestSelectionExcludeTasks: testSelectionExcludeTasks,
 			}
 			err = addNewTasksAndBuildsForPatch(ctx, p, creationInfo, patchUpdateReq.Caller)
 			if err != nil {
@@ -692,31 +699,39 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 	}
 	variantsProcessed := map[string]bool{}
 
-	testSelectionIncludeBVs, err := toRegexps(p.RegexTestSelectionBuildVariants)
+	// kim: TODO: remove
+	// testSelectionIncludeBVs, err := toRegexps(p.RegexTestSelectionBuildVariants)
+	// if err != nil {
+	//     return nil, errors.Wrap(err, "compiling test selection build variant regexes")
+	// }
+	// testSelectionExcludeBVs, err := toRegexps(p.RegexTestSelectionExcludedBuildVariants)
+	// if err != nil {
+	//     return nil, errors.Wrap(err, "compiling test selection excluded build variant regexes")
+	// }
+	// testSelectionIncludeTasks, err := toRegexps(p.RegexTestSelectionTasks)
+	// if err != nil {
+	//     return nil, errors.Wrap(err, "compiling test selection task regexes")
+	// }
+	// testSelectionExcludeTasks, err := toRegexps(p.RegexTestSelectionExcludedTasks)
+	// if err != nil {
+	//     return nil, errors.Wrap(err, "compiling test selection excluded task regexes")
+	// }
+
+	tsParams, err := newTestSelectionParams(p)
 	if err != nil {
-		return nil, errors.Wrap(err, "compiling test selection build variant regexes")
-	}
-	testSelectionExcludeBVs, err := toRegexps(p.RegexTestSelectionExcludedBuildVariants)
-	if err != nil {
-		return nil, errors.Wrap(err, "compiling test selection excluded build variant regexes")
-	}
-	testSelectionIncludeTasks, err := toRegexps(p.RegexTestSelectionTasks)
-	if err != nil {
-		return nil, errors.Wrap(err, "compiling test selection task regexes")
-	}
-	testSelectionExcludeTasks, err := toRegexps(p.RegexTestSelectionExcludedTasks)
-	if err != nil {
-		return nil, errors.Wrap(err, "compiling test selection excluded task regexes")
+		return nil, errors.Wrap(err, "making test selection parameters for task creation")
 	}
 
 	creationInfo := TaskCreationInfo{
-		Version:                   patchVersion,
-		Project:                   project,
-		ProjectRef:                projectRef,
-		TestSelectionIncludeBVs:   testSelectionIncludeBVs,
-		TestSelectionExcludeBVs:   testSelectionExcludeBVs,
-		TestSelectionIncludeTasks: testSelectionIncludeTasks,
-		TestSelectionExcludeTasks: testSelectionExcludeTasks,
+		Version:       patchVersion,
+		Project:       project,
+		ProjectRef:    projectRef,
+		TestSelection: *tsParams,
+		// kim: TODO: remove
+		// TestSelectionIncludeBVs:   testSelectionIncludeBVs,
+		// TestSelectionExcludeBVs:   testSelectionExcludeBVs,
+		// TestSelectionIncludeTasks: testSelectionIncludeTasks,
+		// TestSelectionExcludeTasks: testSelectionExcludeTasks,
 	}
 	createTime, err := getTaskCreateTime(ctx, creationInfo)
 	if err != nil {
@@ -737,6 +752,8 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 		}
 		taskNames := tasks.ExecTasks.TaskNames(vt.Variant)
 
+		tsParams := creationInfo.TestSelection
+		tsParams.CanBuildVariantEnableTestSelection = canBuildVariantEnableTestSelection(vt.Variant, creationInfo)
 		buildCreationArgs := TaskCreationInfo{
 			Project:          creationInfo.Project,
 			ProjectRef:       creationInfo.ProjectRef,
@@ -752,12 +769,15 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 			// tasks selected by the alias must finish in order for the
 			// build/version to be finished.
 			ActivatedTasksAreEssentialToSucceed: requester == evergreen.GithubPRRequester,
-			TestSelectionIncludeBVs:             creationInfo.TestSelectionIncludeBVs,
-			TestSelectionExcludeBVs:             creationInfo.TestSelectionExcludeBVs,
-			TestSelectionIncludeTasks:           creationInfo.TestSelectionIncludeTasks,
-			TestSelectionExcludeTasks:           creationInfo.TestSelectionExcludeTasks,
+			TestSelection:                       tsParams,
+			// kim: TODO: remove
+			// TestSelectionIncludeBVs:             creationInfo.TestSelectionIncludeBVs,
+			// TestSelectionExcludeBVs:             creationInfo.TestSelectionExcludeBVs,
+			// TestSelectionIncludeTasks:           creationInfo.TestSelectionIncludeTasks,
+			// TestSelectionExcludeTasks:           creationInfo.TestSelectionExcludeTasks,
 		}
-		buildCreationArgs.CanBuildVariantEnableTestSelection = canBuildVariantEnableTestSelection(vt.Variant, buildCreationArgs)
+		// kim: TODO: remove
+		// buildCreationArgs.CanBuildVariantEnableTestSelection = canBuildVariantEnableTestSelection(vt.Variant, buildCreationArgs)
 		var build *build.Build
 		var tasks task.Tasks
 		build, tasks, err = CreateBuildFromVersionNoInsert(ctx, buildCreationArgs)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -179,13 +179,13 @@ func ConfigurePatch(ctx context.Context, settings *evergreen.Settings, p *patch.
 			}
 			// Add new tasks to existing builds, if necessary
 			creationInfo := TaskCreationInfo{
-				Project:        project,
-				ProjectRef:     proj,
-				Version:        version,
-				Pairs:          tasks,
-				ActivationInfo: specificActivationInfo{},
-				GeneratedBy:    "",
-				TestSelection:  *tsParams,
+				Project:             project,
+				ProjectRef:          proj,
+				Version:             version,
+				Pairs:               tasks,
+				ActivationInfo:      specificActivationInfo{},
+				GeneratedBy:         "",
+				TestSelectionParams: *tsParams,
 			}
 			err = addNewTasksAndBuildsForPatch(ctx, p, creationInfo, patchUpdateReq.Caller)
 			if err != nil {
@@ -683,10 +683,10 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 	}
 
 	creationInfo := TaskCreationInfo{
-		Version:       patchVersion,
-		Project:       project,
-		ProjectRef:    projectRef,
-		TestSelection: *tsParams,
+		Version:             patchVersion,
+		Project:             project,
+		ProjectRef:          projectRef,
+		TestSelectionParams: *tsParams,
 	}
 	createTime, err := getTaskCreateTime(ctx, creationInfo)
 	if err != nil {
@@ -707,7 +707,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 		}
 		taskNames := tasks.ExecTasks.TaskNames(vt.Variant)
 
-		tsParams := creationInfo.TestSelection
+		tsParams := creationInfo.TestSelectionParams
 		tsParams.CanBuildVariantEnableTestSelection = canBuildVariantEnableTestSelection(vt.Variant, creationInfo)
 		buildCreationArgs := TaskCreationInfo{
 			Project:          creationInfo.Project,
@@ -724,7 +724,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 			// tasks selected by the alias must finish in order for the
 			// build/version to be finished.
 			ActivatedTasksAreEssentialToSucceed: requester == evergreen.GithubPRRequester,
-			TestSelection:                       tsParams,
+			TestSelectionParams:                 tsParams,
 		}
 		var build *build.Build
 		var tasks task.Tasks

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -843,7 +843,7 @@ func TestAddNewPatch(t *testing.T) {
 		Pairs:          tasks,
 		ActivationInfo: specificActivationInfo{},
 		GeneratedBy:    "",
-		TestSelection: TestSelectionParams{
+		TestSelectionParams: TestSelectionParams{
 			IncludeBuildVariants: []*regexp.Regexp{regexp.MustCompile("variant")},
 			IncludeTasks:         []*regexp.Regexp{regexp.MustCompile("task1")},
 		},

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -632,6 +632,10 @@ func (p *ProjectRef) AliasesNeeded() bool {
 	return p.IsGithubChecksEnabled() || p.IsGitTagVersionsEnabled() || p.IsGithubChecksEnabled() || p.IsPRTestingEnabled()
 }
 
+func (p *ProjectRef) IsTestSelectionDefaultEnabled() bool {
+	return utility.FromBoolPtr(p.TestSelection.DefaultEnabled)
+}
+
 const (
 	ProjectRefCollection     = "project_ref"
 	ProjectTriggerLevelTask  = "task"

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -632,6 +632,10 @@ func (p *ProjectRef) AliasesNeeded() bool {
 	return p.IsGithubChecksEnabled() || p.IsGitTagVersionsEnabled() || p.IsGithubChecksEnabled() || p.IsPRTestingEnabled()
 }
 
+func (p *ProjectRef) IsTestSelectionAllowed() bool {
+	return utility.FromBoolPtr(p.TestSelection.Allowed)
+}
+
 func (p *ProjectRef) IsTestSelectionDefaultEnabled() bool {
 	return utility.FromBoolPtr(p.TestSelection.DefaultEnabled)
 }

--- a/model/task_creation.go
+++ b/model/task_creation.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/evergreen-ci/evergreen/model/build"
 	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/pkg/errors"
 )
 
 // TaskCreationInfo contains the needed parameters to construct new builds and tasks for a given version.
@@ -36,11 +38,52 @@ type TaskCreationInfo struct {
 	// in order for the build/version to be finished. Tasks with specific
 	// activation conditions (e.g. cron, activate) are not considered essential.
 	ActivatedTasksAreEssentialToSucceed bool
-	// kim: TODO: move test selection fields into its own struct since it's
-	// getting out of hand
+	TestSelection                       TestSelectionParams // Task creation parameters for test selection
+}
+
+// TestSelectionParams contains parameters for enabling test selection on tasks
+// in a build variant.
+type TestSelectionParams struct {
 	CanBuildVariantEnableTestSelection bool             // Whether or not any of the tasks in the build variant can use test selection.
-	TestSelectionIncludeBVs            []*regexp.Regexp // Regexes for build variants to include when enabling test selection.
-	TestSelectionExcludeBVs            []*regexp.Regexp // Regexes for build variants to exclude when enabling test selection.
-	TestSelectionIncludeTasks          []*regexp.Regexp // Regexes for tasks to include when enabling test selection.
-	TestSelectionExcludeTasks          []*regexp.Regexp // Regexes for tasks to exclude when enabling test selection.
+	IncludeBuildVariants               []*regexp.Regexp // Regexes for build variants to include when enabling test selection.
+	ExcludeBuildVariants               []*regexp.Regexp // Regexes for build variants to exclude when enabling test selection.
+	IncludeTasks                       []*regexp.Regexp // Regexes for tasks to include when enabling test selection.
+	ExcludeTasks                       []*regexp.Regexp // Regexes for tasks to exclude when enabling test selection.
+}
+
+func newTestSelectionParams(p *patch.Patch) (*TestSelectionParams, error) {
+	testSelectionIncludeBVs, err := toRegexps(p.RegexTestSelectionBuildVariants)
+	if err != nil {
+		return nil, errors.Wrap(err, "compiling test selection build variant regexes")
+	}
+	testSelectionExcludeBVs, err := toRegexps(p.RegexTestSelectionExcludedBuildVariants)
+	if err != nil {
+		return nil, errors.Wrap(err, "compiling test selection excluded build variant regexes")
+	}
+	testSelectionIncludeTasks, err := toRegexps(p.RegexTestSelectionTasks)
+	if err != nil {
+		return nil, errors.Wrap(err, "compiling test selection task regexes")
+	}
+	testSelectionExcludeTasks, err := toRegexps(p.RegexTestSelectionExcludedTasks)
+	if err != nil {
+		return nil, errors.Wrap(err, "compiling test selection excluded task regexes")
+	}
+	return &TestSelectionParams{
+		IncludeBuildVariants: testSelectionIncludeBVs,
+		ExcludeBuildVariants: testSelectionExcludeBVs,
+		IncludeTasks:         testSelectionIncludeTasks,
+		ExcludeTasks:         testSelectionExcludeTasks,
+	}, nil
+}
+
+func toRegexps(strs []string) ([]*regexp.Regexp, error) {
+	regexps := make([]*regexp.Regexp, 0, len(strs))
+	for _, s := range strs {
+		re, err := regexp.Compile(s)
+		if err != nil {
+			return nil, errors.Wrapf(err, "compiling regexp '%s'", s)
+		}
+		regexps = append(regexps, re)
+	}
+	return regexps, nil
 }

--- a/model/task_creation.go
+++ b/model/task_creation.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"regexp"
 	"time"
 
 	"github.com/evergreen-ci/evergreen/model/build"
@@ -35,4 +36,9 @@ type TaskCreationInfo struct {
 	// in order for the build/version to be finished. Tasks with specific
 	// activation conditions (e.g. cron, activate) are not considered essential.
 	ActivatedTasksAreEssentialToSucceed bool
+	CanBuildVariantEnableTestSelection  bool
+	TestSelectionIncludeBVs             []*regexp.Regexp
+	TestSelectionExcludeBVs             []*regexp.Regexp
+	TestSelectionIncludeTasks           []*regexp.Regexp
+	TestSelectionExcludeTasks           []*regexp.Regexp
 }

--- a/model/task_creation.go
+++ b/model/task_creation.go
@@ -38,7 +38,7 @@ type TaskCreationInfo struct {
 	// in order for the build/version to be finished. Tasks with specific
 	// activation conditions (e.g. cron, activate) are not considered essential.
 	ActivatedTasksAreEssentialToSucceed bool
-	TestSelection                       TestSelectionParams // Task creation parameters for test selection
+	TestSelectionParams                 TestSelectionParams // Task creation parameters for test selection
 }
 
 // TestSelectionParams contains parameters for enabling test selection on tasks

--- a/model/task_creation.go
+++ b/model/task_creation.go
@@ -52,27 +52,27 @@ type TestSelectionParams struct {
 }
 
 func newTestSelectionParams(p *patch.Patch) (*TestSelectionParams, error) {
-	testSelectionIncludeBVs, err := toRegexps(p.RegexTestSelectionBuildVariants)
+	includeBVs, err := toRegexps(p.RegexTestSelectionBuildVariants)
 	if err != nil {
 		return nil, errors.Wrap(err, "compiling test selection build variant regexes")
 	}
-	testSelectionExcludeBVs, err := toRegexps(p.RegexTestSelectionExcludedBuildVariants)
+	excludeBVs, err := toRegexps(p.RegexTestSelectionExcludedBuildVariants)
 	if err != nil {
 		return nil, errors.Wrap(err, "compiling test selection excluded build variant regexes")
 	}
-	testSelectionIncludeTasks, err := toRegexps(p.RegexTestSelectionTasks)
+	includeTasks, err := toRegexps(p.RegexTestSelectionTasks)
 	if err != nil {
 		return nil, errors.Wrap(err, "compiling test selection task regexes")
 	}
-	testSelectionExcludeTasks, err := toRegexps(p.RegexTestSelectionExcludedTasks)
+	excludeTasks, err := toRegexps(p.RegexTestSelectionExcludedTasks)
 	if err != nil {
 		return nil, errors.Wrap(err, "compiling test selection excluded task regexes")
 	}
 	return &TestSelectionParams{
-		IncludeBuildVariants: testSelectionIncludeBVs,
-		ExcludeBuildVariants: testSelectionExcludeBVs,
-		IncludeTasks:         testSelectionIncludeTasks,
-		ExcludeTasks:         testSelectionExcludeTasks,
+		IncludeBuildVariants: includeBVs,
+		ExcludeBuildVariants: excludeBVs,
+		IncludeTasks:         includeTasks,
+		ExcludeTasks:         excludeTasks,
 	}, nil
 }
 

--- a/model/task_creation.go
+++ b/model/task_creation.go
@@ -36,9 +36,9 @@ type TaskCreationInfo struct {
 	// in order for the build/version to be finished. Tasks with specific
 	// activation conditions (e.g. cron, activate) are not considered essential.
 	ActivatedTasksAreEssentialToSucceed bool
-	CanBuildVariantEnableTestSelection  bool
-	TestSelectionIncludeBVs             []*regexp.Regexp
-	TestSelectionExcludeBVs             []*regexp.Regexp
-	TestSelectionIncludeTasks           []*regexp.Regexp
-	TestSelectionExcludeTasks           []*regexp.Regexp
+	CanBuildVariantEnableTestSelection  bool             // Whether or not any of the tasks in the build variant can use test selection.
+	TestSelectionIncludeBVs             []*regexp.Regexp // Regexes for build variants to include when enabling test selection.
+	TestSelectionExcludeBVs             []*regexp.Regexp // Regexes for build variants to exclude when enabling test selection.
+	TestSelectionIncludeTasks           []*regexp.Regexp // Regexes for tasks to include when enabling test selection.
+	TestSelectionExcludeTasks           []*regexp.Regexp // Regexes for tasks to exclude when enabling test selection.
 }

--- a/model/task_creation.go
+++ b/model/task_creation.go
@@ -36,9 +36,11 @@ type TaskCreationInfo struct {
 	// in order for the build/version to be finished. Tasks with specific
 	// activation conditions (e.g. cron, activate) are not considered essential.
 	ActivatedTasksAreEssentialToSucceed bool
-	CanBuildVariantEnableTestSelection  bool             // Whether or not any of the tasks in the build variant can use test selection.
-	TestSelectionIncludeBVs             []*regexp.Regexp // Regexes for build variants to include when enabling test selection.
-	TestSelectionExcludeBVs             []*regexp.Regexp // Regexes for build variants to exclude when enabling test selection.
-	TestSelectionIncludeTasks           []*regexp.Regexp // Regexes for tasks to include when enabling test selection.
-	TestSelectionExcludeTasks           []*regexp.Regexp // Regexes for tasks to exclude when enabling test selection.
+	// kim: TODO: move test selection fields into its own struct since it's
+	// getting out of hand
+	CanBuildVariantEnableTestSelection bool             // Whether or not any of the tasks in the build variant can use test selection.
+	TestSelectionIncludeBVs            []*regexp.Regexp // Regexes for build variants to include when enabling test selection.
+	TestSelectionExcludeBVs            []*regexp.Regexp // Regexes for build variants to exclude when enabling test selection.
+	TestSelectionIncludeTasks          []*regexp.Regexp // Regexes for tasks to include when enabling test selection.
+	TestSelectionExcludeTasks          []*regexp.Regexp // Regexes for tasks to exclude when enabling test selection.
 }


### PR DESCRIPTION
DEVPROD-22498

### Description
Follow-up to #9413, which added the CLI options so users could pick BVs/tasks on which to use test selection in CLI patches. This adds the logic so that given the user's regex variants/tasks where they'd like to enable test selection, Evergreen will create tasks with the `TestSelectionEnabled` bool set. That allows the task to use the `test_selection.get` project command. If the patch is reconfigured or tasks are generated, the new tasks are evaluated to determine which ones have test selection enabled.

### Testing
* Added unit tests.
* Tested in staging for:
    * Task names, display task names, and task group names can match.
    * User can specify just variants (i.e. use test selection in all tasks in the variant) or just tasks to match (i.e. match a task in any variant).
    * Generated tasks can match.
    * Reconfiguring a patch can create new tasks with test selection enabled.
    * It's valid to specify just build variants or just tasks in the CLI.
