### PR TITLE
DEVPROD-22707: Add task activated time to honeycomb

### DIFF
--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -17,6 +17,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/evergreen/util"
+	"github.com/evergreen-ci/utility"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
 )
@@ -291,6 +292,9 @@ func (tc *TaskConfig) TaskAttributeMap() map[string]string {
 	if tc.DisplayTaskInfo != nil {
 		attributes[evergreen.DisplayTaskIDOtelAttribute] = tc.DisplayTaskInfo.ID
 		attributes[evergreen.DisplayTaskNameOtelAttribute] = tc.DisplayTaskInfo.Name
+	}
+	if !utility.IsZeroTime(tc.Task.ActivatedTime) {
+		attributes[evergreen.TaskActivatedTimeOtelAttribute] = tc.Task.ActivatedTime.Format(time.RFC3339)
 	}
 	return attributes
 }

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-09-30a"
+	AgentVersion = "2025-10-02"
 )
 
 const (

--- a/globals.go
+++ b/globals.go
@@ -494,6 +494,7 @@ const (
 	TaskFailingCommandOtelAttribute = "evergreen.task.failing_command"
 	TaskDescriptionOtelAttribute    = "evergreen.task.description"
 	TaskTagsOtelAttribute           = "evergreen.task.tags"
+	TaskActivatedTimeOtelAttribute  = "evergreen.task.activated_time"
 
 	// task otel attributes
 	DisplayTaskIDOtelAttribute   = "evergreen.display_task.id"


### PR DESCRIPTION
DEVPROD-22707

### Description
Save `Task.ActivatedAt` time to a task's Honeycomb trace. Along with the trace's start timestamp and its duration, we can calculate the wait time, run time, and total time taken by a task.

Use RFC3339 format [as expected by Honeycomb](https://docs.honeycomb.io/reference/calculated-field-formula/operators-functions/time/)

<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

### Testing
`evergreen.task.activated_time` is visible in [this](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen-agent/trace/yFCd8j5PTB2?fields[]=s_name&fields[]=s_serviceName&span=6895cd2cdd4c5595) trace from staging