### PR TITLE
DEVPROD-22725: move test_selection.get logs to task logs

### DIFF
--- a/agent/command/test_selection_get.go
+++ b/agent/command/test_selection_get.go
@@ -132,7 +132,7 @@ func (c *testSelectionGet) Execute(ctx context.Context, comm client.Communicator
 	trace.SpanFromContext(ctx).SetAttributes(attribute.Bool(testSelectionEnabledAttribute, enabled))
 	trace.SpanFromContext(ctx).SetAttributes(attribute.StringSlice(testSelectionInputTestsAttribute, c.Tests))
 	if !enabled {
-		logger.Execution().Info("Test selection is not allowed/enabled, writing empty test list")
+		logger.Task().Info("Test selection is not allowed/enabled, writing empty test list")
 		return c.writeTestList([]string{})
 	}
 
@@ -143,7 +143,7 @@ func (c *testSelectionGet) Execute(ctx context.Context, comm client.Communicator
 		// Random float in [0.0, 1.0) will always have a
 		// usage_rate percentage chance of no-oping.
 		if rng.Float64() < c.rate {
-			logger.Execution().Infof("Skipping test selection based on usage rate '%s'", c.UsageRate)
+			logger.Task().Infof("Skipping test selection based on usage rate '%s'", c.UsageRate)
 			return c.writeTestList([]string{})
 		}
 		trace.SpanFromContext(ctx).SetAttributes(attribute.Float64(testSelectionUsageRateAttribute, c.rate))

--- a/config.go
+++ b/config.go
@@ -36,7 +36,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2025-10-03"
+	AgentVersion = "2025-10-03a"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-22725

### Description
Move logs for `test_selection.get` from execution to task logs. This is more convenient for users because task logs are meant for info relevant to what the task commands do.

### Testing
Tested in staging to verify the logs were moved to task logs.