### PR TITLE
DEVPROD-21468 create an api endpoint to change the url for a task artifact

### DIFF
--- a/model/artifact/db.go
+++ b/model/artifact/db.go
@@ -125,3 +125,20 @@ func FindAll(ctx context.Context, query db.Q) ([]Entry, error) {
 	err := db.FindAllQ(ctx, Collection, query, &entries)
 	return entries, err
 }
+
+// UpdateFileLink updates the link for a single artifact file matching task ID, execution,
+// file name, and current link. Returns db.ErrNotFound if no file matched.
+func UpdateFileLink(ctx context.Context, taskID string, execution int, fileName, currentLink, newLink string) error {
+	filter := bson.M{
+		TaskIdKey:    taskID,
+		ExecutionKey: execution,
+		FilesKey: bson.M{"$elemMatch": bson.M{
+			NameKey: fileName,
+			LinkKey: currentLink,
+		}},
+	}
+	update := bson.M{"$set": bson.M{
+		bsonutil.GetDottedKeyName(FilesKey, "$", LinkKey): newLink,
+	}}
+	return db.UpdateContext(ctx, Collection, filter, update)
+}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -225,6 +225,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/subscriptions").Version(2).Post().Wrap(requireUser).RouteHandler(makeSetSubscription())
 	app.AddRoute("/tasks/{task_id}").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetTaskRoute(parsleyURL, opts.URL))
 	app.AddRoute("/tasks/{task_id}").Version(2).Patch().Wrap(requireUser, addProject, editTasks).RouteHandler(makeModifyTaskRoute())
+	app.AddRoute("/tasks/{task_id}/artifacts/url").Version(2).Patch().Wrap(requireUser, requireProjectAdmin, editTasks).RouteHandler(makeUpdateArtifactURLRoute())
 	app.AddRoute("/tasks/{task_id}/annotations").Version(2).Get().Wrap(requireUser, viewAnnotations).RouteHandler(makeFetchAnnotationsByTask())
 	app.AddRoute("/tasks/{task_id}/annotation").Version(2).Put().Wrap(requireUser, editAnnotations).RouteHandler(makePutAnnotationsByTask())
 	app.AddRoute("/tasks/{task_id}/annotation").Version(2).Patch().Wrap(requireUser, editAnnotations).RouteHandler(makePatchAnnotationsByTask())

--- a/rest/route/task_test.go
+++ b/rest/route/task_test.go
@@ -1,7 +1,9 @@
 package route
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"net/http"
 	"testing"
 
@@ -19,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 ////////////////////////////////////////////////////////////////////////
@@ -289,5 +292,154 @@ func TestGeneratedTasksGetHandler(t *testing.T) {
 
 			tCase(ctx, t, rh, generatorID, generated)
 		})
+	}
+}
+
+func TestUpdateArtifactURLHandler(t *testing.T) {
+	for name, test := range map[string]func(t *testing.T){
+		"SuccessAndExecutionOverride": func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			require.NoError(t, db.ClearCollections(task.Collection, artifact.Collection, user.Collection))
+
+			tsk := task.Task{Id: "t1", BuildId: "b1", DisplayName: "disp", Execution: 0}
+			require.NoError(t, tsk.Insert(t.Context()))
+			entry := artifact.Entry{TaskId: tsk.Id, TaskDisplayName: tsk.DisplayName, BuildId: tsk.BuildId, Execution: 0, Files: []artifact.File{{Name: "f1", Link: "http://old.com/a"}}}
+			require.NoError(t, entry.Upsert(t.Context()))
+
+			projCtx := serviceModel.Context{Task: &tsk}
+			u := &user.DBUser{Id: "u1"}
+			require.NoError(t, u.Insert(t.Context()))
+			ctxWithUser := gimlet.AttachUser(ctx, u)
+			ctxWithProj := context.WithValue(ctxWithUser, RequestContext, &projCtx)
+
+			body := map[string]string{"artifact_name": "f1", "current_url": "http://old.com/a", "new_url": "https://new.com/a"}
+			data, _ := json.Marshal(body)
+			h := makeUpdateArtifactURLRoute().(*updateArtifactURLHandler)
+			req, _ := http.NewRequest(http.MethodPatch, "/tasks/t1/artifacts/url", bytes.NewReader(data))
+			req = gimlet.SetURLVars(req, map[string]string{"task_id": "t1"})
+			require.NoError(t, h.Parse(ctxWithProj, req))
+			resp := h.Run(ctxWithProj)
+			assert.Equal(t, http.StatusOK, resp.Status())
+			apiTask, ok := resp.Data().(*model.APITask)
+			require.True(t, ok)
+			foundUpdated := false
+			for _, f := range apiTask.Artifacts {
+				if utility.FromStringPtr(f.Name) == "f1" && utility.FromStringPtr(f.Link) == "https://new.com/a" {
+					foundUpdated = true
+				}
+			}
+			assert.True(t, foundUpdated)
+
+			bad := map[string]string{"artifact_name": "f1", "current_url": "https://new.com/a", "new_url": "notaurl"}
+			badData, _ := json.Marshal(bad)
+			hBad := makeUpdateArtifactURLRoute().(*updateArtifactURLHandler)
+			badReq, _ := http.NewRequest(http.MethodPatch, "/tasks/t1/artifacts/url", bytes.NewReader(badData))
+			badReq = gimlet.SetURLVars(badReq, map[string]string{"task_id": "t1"})
+			err := hBad.Parse(ctxWithProj, badReq)
+			assert.Error(t, err)
+
+			entry1 := artifact.Entry{TaskId: tsk.Id, TaskDisplayName: tsk.DisplayName, BuildId: tsk.BuildId, Execution: 1, Files: []artifact.File{{Name: "f1", Link: "http://old.com/a1"}}}
+			require.NoError(t, entry1.Upsert(t.Context()))
+			require.NoError(t, db.Update(task.Collection, bson.M{"_id": tsk.Id}, bson.M{"$set": bson.M{"execution": 1}}))
+			refreshed, err := task.FindOneId(ctx, tsk.Id)
+			require.NoError(t, err)
+			projCtx.Task = refreshed
+			ctxWithProj = context.WithValue(ctxWithUser, RequestContext, &projCtx)
+
+			bodyExec := map[string]string{"artifact_name": "f1", "current_url": "http://old.com/a1", "new_url": "https://new.com/a1"}
+			dataExec, _ := json.Marshal(bodyExec)
+			hExec := makeUpdateArtifactURLRoute().(*updateArtifactURLHandler)
+			reqExec, _ := http.NewRequest(http.MethodPatch, "/tasks/t1/artifacts/url?execution=1", bytes.NewReader(dataExec))
+			reqExec = gimlet.SetURLVars(reqExec, map[string]string{"task_id": "t1"})
+			require.NoError(t, hExec.Parse(ctxWithProj, reqExec))
+			respExec := hExec.Run(ctxWithProj)
+			assert.Equal(t, http.StatusOK, respExec.Status())
+			apiTaskExec, ok := respExec.Data().(*model.APITask)
+			require.True(t, ok)
+			updated := false
+			for _, f := range apiTaskExec.Artifacts {
+				if utility.FromStringPtr(f.Name) == "f1" && utility.FromStringPtr(f.Link) == "https://new.com/a1" {
+					updated = true
+				}
+			}
+			assert.True(t, updated)
+		},
+		"NotFoundScenarios": func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			require.NoError(t, db.ClearCollections(task.Collection, artifact.Collection, user.Collection))
+
+			tsk := task.Task{Id: "nf1", BuildId: "b1", DisplayName: "disp", Execution: 0}
+			require.NoError(t, tsk.Insert(t.Context()))
+			entry := artifact.Entry{TaskId: tsk.Id, TaskDisplayName: tsk.DisplayName, BuildId: tsk.BuildId, Execution: 0, Files: []artifact.File{{Name: "afile", Link: "http://old.example/x"}}}
+			require.NoError(t, entry.Upsert(t.Context()))
+
+			projCtx := serviceModel.Context{Task: &tsk}
+			u := &user.DBUser{Id: "userNF"}
+			require.NoError(t, u.Insert(t.Context()))
+			ctxWithUser := gimlet.AttachUser(ctx, u)
+			ctxWithProj := context.WithValue(ctxWithUser, RequestContext, &projCtx)
+
+			bodyBadName := map[string]string{"artifact_name": "wrong", "current_url": "http://old.example/x", "new_url": "https://new.example/x"}
+			dataBadName, _ := json.Marshal(bodyBadName)
+			hBadName := makeUpdateArtifactURLRoute().(*updateArtifactURLHandler)
+			reqBadName, _ := http.NewRequest(http.MethodPatch, "/tasks/nf1/artifacts/url", bytes.NewReader(dataBadName))
+			reqBadName = gimlet.SetURLVars(reqBadName, map[string]string{"task_id": "nf1"})
+			require.NoError(t, hBadName.Parse(ctxWithProj, reqBadName))
+			respBadName := hBadName.Run(ctxWithProj)
+			assert.Equal(t, http.StatusNotFound, respBadName.Status())
+
+			bodyBadURL := map[string]string{"artifact_name": "afile", "current_url": "http://does-not-match", "new_url": "https://new.example/x"}
+			dataBadURL, _ := json.Marshal(bodyBadURL)
+			hBadURL := makeUpdateArtifactURLRoute().(*updateArtifactURLHandler)
+			reqBadURL, _ := http.NewRequest(http.MethodPatch, "/tasks/nf1/artifacts/url", bytes.NewReader(dataBadURL))
+			reqBadURL = gimlet.SetURLVars(reqBadURL, map[string]string{"task_id": "nf1"})
+			require.NoError(t, hBadURL.Parse(ctxWithProj, reqBadURL))
+			respBadURL := hBadURL.Run(ctxWithProj)
+			assert.Equal(t, http.StatusNotFound, respBadURL.Status())
+		},
+		"DefaultsToLatestExecution": func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			require.NoError(t, db.ClearCollections(task.Collection, artifact.Collection, user.Collection))
+
+			// Task with two executions; latest is 2
+			tsk := task.Task{Id: "late1", BuildId: "b1", DisplayName: "disp", Execution: 2}
+			require.NoError(t, tsk.Insert(t.Context()))
+			// Execution 0
+			entry0 := artifact.Entry{TaskId: tsk.Id, TaskDisplayName: tsk.DisplayName, BuildId: tsk.BuildId, Execution: 0, Files: []artifact.File{{Name: "afile", Link: "http://old.example/x0"}}}
+			require.NoError(t, entry0.Upsert(t.Context()))
+			// Execution 2 (latest)
+			entry2 := artifact.Entry{TaskId: tsk.Id, TaskDisplayName: tsk.DisplayName, BuildId: tsk.BuildId, Execution: 2, Files: []artifact.File{{Name: "afile", Link: "http://old.example/x2"}}}
+			require.NoError(t, entry2.Upsert(t.Context()))
+
+			projCtx := serviceModel.Context{Task: &tsk}
+			u := &user.DBUser{Id: "userLate"}
+			require.NoError(t, u.Insert(t.Context()))
+			ctxWithUser := gimlet.AttachUser(ctx, u)
+			ctxWithProj := context.WithValue(ctxWithUser, RequestContext, &projCtx)
+
+			body := map[string]string{"artifact_name": "afile", "current_url": "http://old.example/x2", "new_url": "https://new.example/x2"}
+			data, _ := json.Marshal(body)
+			h := makeUpdateArtifactURLRoute().(*updateArtifactURLHandler)
+			req, _ := http.NewRequest(http.MethodPatch, "/tasks/late1/artifacts/url", bytes.NewReader(data))
+			req = gimlet.SetURLVars(req, map[string]string{"task_id": "late1"})
+			require.NoError(t, h.Parse(ctxWithProj, req))
+			resp := h.Run(ctxWithProj)
+			assert.Equal(t, http.StatusOK, resp.Status())
+			apiTask, ok := resp.Data().(*model.APITask)
+			require.True(t, ok)
+			// Ensure updated link is reflected.
+			found := false
+			for _, f := range apiTask.Artifacts {
+				if utility.FromStringPtr(f.Name) == "afile" && utility.FromStringPtr(f.Link) == "https://new.example/x2" {
+					found = true
+				}
+			}
+			assert.True(t, found)
+		},
+	} {
+		t.Run(name, test)
 	}
 }


### PR DESCRIPTION
DEVPROD-21468 

### Description
This adds an api endpoint that allows for a task artifact url to be updated by providing a task id, optionally an execution, the artifact name, the current url, an the new url. This is limited to project admins to limit who is able to make these changes. 

This is meant to address a pain point where sometimes files are needed for longer than the retention rate, and project admins want to be able to move a file to a different bucket and update the task artifacts url. 

### Testing
Unit tests and tested on staging by updating the files [here](https://spruce-staging.corp.mongodb.com/task/evg_build_and_push_build_darwin_amd64_patch_e3609f51acb7921763b72c89b7c9d3d365fc94e3_68deb5ae42a5c3000732a695_25_10_02_17_26_07/files?execution=1) to memes. 