### PR TITLE
DEVPROD-22776 Pass along ExternalID from ec2.assume_role to s3.put

### DIFF
--- a/agent/command/assume_ec2_role.go
+++ b/agent/command/assume_ec2_role.go
@@ -86,6 +86,7 @@ func (r *ec2AssumeRole) Execute(ctx context.Context, comm client.Communicator, l
 	if err == nil {
 		conf.AssumeRoleInformation[creds.SessionToken] = internal.AssumeRoleInformation{
 			RoleARN:    r.RoleARN,
+			ExternalID: creds.ExternalID,
 			Expiration: expiration,
 		}
 	} else {

--- a/agent/command/assume_ec2_role_test.go
+++ b/agent/command/assume_ec2_role_test.go
@@ -55,12 +55,13 @@ func TestEC2AssumeRoleExecute(t *testing.T) {
 		},
 		"Success": func(ctx context.Context, t *testing.T, comm *client.Mock, logger client.LoggerProducer, conf *internal.TaskConfig) {
 			expiration := time.Now()
+			externalID := "ext_id"
 			comm.AssumeRoleResponse = &apimodels.AWSCredentials{
 				AccessKeyID:     "access_key_id",
 				SecretAccessKey: "secret_access_key",
 				SessionToken:    "session_token",
 				Expiration:      expiration.Format(time.RFC3339),
-				ExternalID:      "external_id",
+				ExternalID:      externalID,
 			}
 
 			c := &ec2AssumeRole{
@@ -75,6 +76,7 @@ func TestEC2AssumeRoleExecute(t *testing.T) {
 			assert.Equal(t, expiration.Format(time.RFC3339), conf.NewExpansions.Get(globals.AWSRoleExpiration))
 
 			assert.Equal(t, c.RoleARN, conf.AssumeRoleInformation[comm.AssumeRoleResponse.SessionToken].RoleARN)
+			assert.Equal(t, externalID, conf.AssumeRoleInformation[comm.AssumeRoleResponse.SessionToken].ExternalID)
 			assert.WithinDuration(t, expiration, conf.AssumeRoleInformation[comm.AssumeRoleResponse.SessionToken].Expiration, time.Second)
 
 			t.Run("KeysAreRedacted", func(t *testing.T) {

--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -186,7 +186,7 @@ func (c *s3get) Execute(ctx context.Context, comm client.Communicator, logger cl
 	}
 
 	if expiration, found := getAssumedRoleExpiration(conf, c.AwsSessionToken); found {
-		c.assumedRoleARN = getAssumedRoleARN(conf, c.AwsSessionToken)
+		c.assumedRoleARN = getAssumedRoleInfo(conf, c.AwsSessionToken).RoleARN
 		c.existingCredentials = &aws.Credentials{
 			AccessKeyID:     c.AwsKey,
 			SecretAccessKey: c.AwsSecret,

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -315,7 +315,9 @@ func (s3pc *s3put) Execute(ctx context.Context, comm client.Communicator, logger
 	}
 
 	if expiration, found := getAssumedRoleExpiration(conf, s3pc.AwsSessionToken); found {
-		s3pc.assumedRoleARN = getAssumedRoleARN(conf, s3pc.AwsSessionToken)
+		info := getAssumedRoleInfo(conf, s3pc.AwsSessionToken)
+		s3pc.assumedRoleARN = info.RoleARN
+		s3pc.externalID = info.ExternalID
 		s3pc.existingCredentials = &aws.Credentials{
 			AccessKeyID:     s3pc.AwsKey,
 			SecretAccessKey: s3pc.AwsSecret,

--- a/agent/command/s3_util.go
+++ b/agent/command/s3_util.go
@@ -91,6 +91,18 @@ func getAssumedRoleARN(conf *internal.TaskConfig, sessionToken string) string {
 	return conf.AssumeRoleInformation[sessionToken].RoleARN
 }
 
+func getAssumedRoleInfo(conf *internal.TaskConfig, sessionToken string) *internal.AssumeRoleInformation {
+	if sessionToken == "" {
+		return nil
+	}
+
+	info, ok := conf.AssumeRoleInformation[sessionToken]
+	if !ok {
+		return nil
+	}
+	return &info
+}
+
 // getAssumedRoleExpiration checks if the provided session token
 // is associated with an assumed role. If it is, it returns
 // the expiration time of the role.

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -103,6 +103,7 @@ type CommandCleanup struct {
 
 type AssumeRoleInformation struct {
 	RoleARN    string
+	ExternalID string
 	Expiration time.Time
 }
 


### PR DESCRIPTION
DEVPROD-22776

### Description
This passes along the externalID when reusing credentials from a previous ec2.assume_role call inside a s3.put call.

### Testing
Unit tests
