### PR TITLE
DEVPROD-18815 Support suffixed strings in CLI version check

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,7 +32,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2025-10-01"
+	ClientVersion = "2025-10-07"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/model.go
+++ b/operations/model.go
@@ -300,8 +300,15 @@ func printUserMessages(ctx context.Context, c client.Communicator, checkForUpdat
 }
 
 func isFirstDateBefore(dateString1, dateString2 string) (bool, error) {
-	// The layout string specifies the format of the input date strings.
 	layout := "2006-01-02"
+	// Extract just the date portion if the string is long enough.
+	// This allows values such as "2024-08-10a" to be parsed as "2024-08-10"
+	if len(dateString1) >= 10 {
+		dateString1 = dateString1[:10]
+	}
+	if len(dateString2) >= 10 {
+		dateString2 = dateString2[:10]
+	}
 	t1, err := time.Parse(layout, dateString1)
 	if err != nil {
 		return false, fmt.Errorf("error parsing first date '%s': %w", dateString1, err)

--- a/operations/model_test.go
+++ b/operations/model_test.go
@@ -288,3 +288,113 @@ func TestShouldGenerateJWT(t *testing.T) {
 		})
 	}
 }
+
+func TestIsFirstDateBefore(t *testing.T) {
+	tests := []struct {
+		name          string
+		date1         string
+		date2         string
+		expectedBool  bool
+		expectedError bool
+		errorContains string
+	}{
+		{
+			name:          "FirstDateBeforeSecond",
+			date1:         "2023-01-15",
+			date2:         "2023-06-20",
+			expectedBool:  true,
+			expectedError: false,
+		},
+		{
+			name:          "FirstDateAfterSecond",
+			date1:         "2024-08-10",
+			date2:         "2024-03-05",
+			expectedBool:  false,
+			expectedError: false,
+		},
+		{
+			name:          "SameDates",
+			date1:         "2023-12-25",
+			date2:         "2023-12-25",
+			expectedBool:  false,
+			expectedError: false,
+		},
+		{
+			name:          "InvalidFirstDate",
+			date1:         "2023-13-01",
+			date2:         "2023-12-01",
+			expectedBool:  false,
+			expectedError: true,
+			errorContains: "error parsing first date '2023-13-01'",
+		},
+		{
+			name:          "InvalidSecondDate",
+			date1:         "2023-01-01",
+			date2:         "2023-02-30",
+			expectedBool:  false,
+			expectedError: true,
+			errorContains: "error parsing second date '2023-02-30'",
+		},
+		{
+			name:          "InvalidFormatDate",
+			date1:         "01-15-2023",
+			date2:         "2023-06-20",
+			expectedBool:  false,
+			expectedError: true,
+			errorContains: "error parsing first date '01-15-2023'",
+		},
+		{
+			name:          "EmptyDate",
+			date1:         "",
+			date2:         "2023-06-20",
+			expectedBool:  false,
+			expectedError: true,
+			errorContains: "error parsing first date ''",
+		},
+		{
+			name:          "DateWithLetterSuffix",
+			date1:         "2023-06-20a",
+			date2:         "2023-06-21",
+			expectedBool:  true,
+			expectedError: false,
+		},
+		{
+			name:          "DateWithNumberSuffix",
+			date1:         "2023-06-20-1",
+			date2:         "2023-06-21",
+			expectedBool:  true,
+			expectedError: false,
+		},
+		{
+			name:          "BothDatesWithSuffixes",
+			date1:         "2024-08-10a",
+			date2:         "2024-08-11-1",
+			expectedBool:  true,
+			expectedError: false,
+		},
+		{
+			name:          "IdenticalDatesWithDifferentSuffixes",
+			date1:         "2024-08-10",
+			date2:         "2024-08-10a",
+			expectedBool:  false,
+			expectedError: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := isFirstDateBefore(test.date1, test.date2)
+
+			if test.expectedError {
+				assert.Error(t, err)
+				if test.errorContains != "" {
+					assert.Contains(t, err.Error(), test.errorContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+
+			assert.Equal(t, test.expectedBool, result)
+		})
+	}
+}

--- a/operations/model_test.go
+++ b/operations/model_test.go
@@ -320,20 +320,12 @@ func TestIsFirstDateBefore(t *testing.T) {
 			expectedError: false,
 		},
 		{
-			name:          "InvalidFirstDate",
+			name:          "InvalidDate",
 			date1:         "2023-13-01",
 			date2:         "2023-12-01",
 			expectedBool:  false,
 			expectedError: true,
 			errorContains: "error parsing first date '2023-13-01'",
-		},
-		{
-			name:          "InvalidSecondDate",
-			date1:         "2023-01-01",
-			date2:         "2023-02-30",
-			expectedBool:  false,
-			expectedError: true,
-			errorContains: "error parsing second date '2023-02-30'",
 		},
 		{
 			name:          "InvalidFormatDate",
@@ -352,15 +344,8 @@ func TestIsFirstDateBefore(t *testing.T) {
 			errorContains: "error parsing first date ''",
 		},
 		{
-			name:          "DateWithLetterSuffix",
+			name:          "DateWithSuffix",
 			date1:         "2023-06-20a",
-			date2:         "2023-06-21",
-			expectedBool:  true,
-			expectedError: false,
-		},
-		{
-			name:          "DateWithNumberSuffix",
-			date1:         "2023-06-20-1",
 			date2:         "2023-06-21",
 			expectedBool:  true,
 			expectedError: false,


### PR DESCRIPTION
DEVPROD-18815

### Description
Sometimes the CLI version has a suffix, e.g. 2025-07-12b. This new change allows the minimum CLI version check to parse those strings correctly.

### Testing
Unit tests