### PR TITLE
DEVPROD-20071 Migrate users config to include OAuth information

### DIFF
--- a/config_api.go
+++ b/config_api.go
@@ -29,6 +29,8 @@ type ClientConfig struct {
 
 	// These settings are to support a seemless migration for
 	// the switch to OAuth. They can be removed in DEVPROD-17405.
+	// The corresponding fields inside the APIClientConfig struct
+	// should also be removed then.
 	OAuthIssuer      string
 	OAuthClientID    string
 	OAuthConnectorID string

--- a/config_api.go
+++ b/config_api.go
@@ -26,6 +26,12 @@ type ClientConfig struct {
 	LatestRevision          string
 	S3URLPrefix             string
 	OldestAllowedCLIVersion string
+
+	// These settings are to support a seemless migration for
+	// the switch to OAuth. They can be removed in DEVPROD-17405.
+	OAuthIssuer      string
+	OAuthClientID    string
+	OAuthConnectorID string
 }
 
 func (c *ClientConfig) populateClientBinaries(ctx context.Context, s3URLPrefix string) {

--- a/config_auth.go
+++ b/config_auth.go
@@ -70,7 +70,8 @@ func (c *MultiAuthConfig) IsZero() bool {
 
 // KanopyAuthConfig configures the auth method that validates and consumes the JWT
 // that Kanopy provides with information about the user. Kanopy deals with authentication
-// so all we need to do is extract the information they provide about the user.
+// so all we need to do is extract the information they provide about the user. This is
+// for the UI, rather than the API.
 type KanopyAuthConfig struct {
 	// HeaderName is the name of the header that contains the JWT with information about the user.
 	HeaderName string `bson:"header_name" json:"header_name" yaml:"header_name"`
@@ -81,6 +82,17 @@ type KanopyAuthConfig struct {
 	KeysetURL string `bson:"keyset_url" json:"keyset_url" yaml:"keyset_url"`
 }
 
+// OAuthConfig configures the auth method that uses a generic OAuth provider.
+// This is for the API, rather than the UI.
+type OAuthConfig struct {
+	// Issuer is the expected OAuth issuer.
+	Issuer string `bson:"issuer" json:"issuer" yaml:"issuer"`
+	// ClientID is the OAuth client ID.
+	ClientID string `bson:"client_id" json:"client_id" yaml:"client_id"`
+	// ConnectorID is the OAuth connector ID.
+	ConnectorID string `bson:"connector_id" json:"connector_id" yaml:"connector_id"`
+}
+
 // AuthConfig contains the settings for the various auth managers.
 type AuthConfig struct {
 	Okta                    *OktaConfig       `bson:"okta,omitempty" json:"okta" yaml:"okta"`
@@ -88,6 +100,7 @@ type AuthConfig struct {
 	Github                  *GithubAuthConfig `bson:"github,omitempty" json:"github" yaml:"github"`
 	Multi                   *MultiAuthConfig  `bson:"multi" json:"multi" yaml:"multi"`
 	Kanopy                  *KanopyAuthConfig `bson:"kanopy" json:"kanopy" yaml:"kanopy"`
+	OAuth                   *OAuthConfig      `bson:"oauth,omitempty" json:"oauth" yaml:"oauth"`
 	AllowServiceUsers       bool              `bson:"allow_service_users" json:"allow_service_users" yaml:"allow_service_users"`
 	PreferredType           string            `bson:"preferred_type,omitempty" json:"preferred_type" yaml:"preferred_type"`
 	BackgroundReauthMinutes int               `bson:"background_reauth_minutes" json:"background_reauth_minutes" yaml:"background_reauth_minutes"`

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1122,11 +1122,25 @@ func (h *Host) spawnHostConfig(ctx context.Context, settings *evergreen.Settings
 		APIKey        string `yaml:"api_key"`
 		APIServerHost string `yaml:"api_server_host"`
 		UIServerHost  string `yaml:"ui_server_host"`
+		OAuth         struct {
+			Issuer      string `json:"issuer" yaml:"issuer"`
+			ClientID    string `json:"client_id" yaml:"client_id"`
+			ConnectorID string `json:"connector_id" yaml:"connector_id"`
+		} `json:"oauth" yaml:"oauth"`
 	}{
 		User:          owner.Id,
 		APIKey:        owner.APIKey,
 		APIServerHost: settings.Api.URL + "/api",
 		UIServerHost:  settings.Ui.Url,
+		OAuth: struct {
+			Issuer      string `json:"issuer" yaml:"issuer"`
+			ClientID    string `json:"client_id" yaml:"client_id"`
+			ConnectorID string `json:"connector_id" yaml:"connector_id"`
+		}{
+			Issuer:      settings.AuthConfig.OAuth.Issuer,
+			ClientID:    settings.AuthConfig.OAuth.ClientID,
+			ConnectorID: settings.AuthConfig.OAuth.ConnectorID,
+		},
 	}
 
 	return yaml.Marshal(conf)

--- a/operations/model.go
+++ b/operations/model.go
@@ -160,7 +160,7 @@ func (s *ClientSettings) setupRestCommunicator(ctx context.Context, printMessage
 
 	c.SetAPIUser(s.User)
 	c.SetAPIKey(s.APIKey)
-	if err = checkCLIVersion(c); err != nil {
+	if err = checkCLIVersion(ctx, c); err != nil {
 		return nil, err
 	}
 	if printMessages {
@@ -257,8 +257,8 @@ func (s *ClientSettings) getApiServerHost(useCorp bool) string {
 	return s.APIServerHost
 }
 
-func checkCLIVersion(c client.Communicator) error {
-	clients, err := c.GetClientConfig(context.Background())
+func checkCLIVersion(ctx context.Context, c client.Communicator) error {
+	clients, err := c.GetClientConfig(ctx)
 	if err != nil {
 		grip.Debug(errors.Wrap(err, "getting client config info"))
 	}

--- a/rest/data/cli_update.go
+++ b/rest/data/cli_update.go
@@ -7,6 +7,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/utility"
 )
 
 // GetCLIUpdate fetches the current cli version and the urls to download
@@ -30,6 +31,11 @@ func GetCLIUpdate(ctx context.Context, env evergreen.Environment) (*model.APICLI
 
 	update.BuildFromService(*config)
 	update.IgnoreUpdate = flags.CLIUpdatesDisabled
+
+	settings := env.Settings()
+	update.ClientConfig.OAuthIssuer = utility.ToStringPtr(settings.AuthConfig.OAuth.Issuer)
+	update.ClientConfig.OAuthClientID = utility.ToStringPtr(settings.AuthConfig.OAuth.ClientID)
+	update.ClientConfig.OAuthConnectorID = utility.ToStringPtr(settings.AuthConfig.OAuth.ConnectorID)
 
 	return update, nil
 }

--- a/rest/model/cli_update.go
+++ b/rest/model/cli_update.go
@@ -19,6 +19,10 @@ type APIClientConfig struct {
 	S3ClientBinaries        []APIClientBinary `json:"s3_client_binaries,omitempty"`
 	LatestRevision          *string           `json:"latest_revision"`
 	OldestAllowedCLIVersion *string           `json:"oldest_allowed_cli_version"`
+
+	OAuthIssuer      *string `json:"oauth_issuer,omitempty"`
+	OAuthClientID    *string `json:"oauth_client_id,omitempty"`
+	OAuthConnectorID *string `json:"oauth_connector_id,omitempty"`
 }
 
 func (a *APIClientConfig) BuildFromService(c evergreen.ClientConfig) {
@@ -28,6 +32,9 @@ func (a *APIClientConfig) BuildFromService(c evergreen.ClientConfig) {
 	}
 	a.OldestAllowedCLIVersion = utility.ToStringPtr(c.OldestAllowedCLIVersion)
 	a.LatestRevision = utility.ToStringPtr(c.LatestRevision)
+	a.OAuthIssuer = utility.ToStringPtr(c.OAuthIssuer)
+	a.OAuthClientID = utility.ToStringPtr(c.OAuthClientID)
+	a.OAuthConnectorID = utility.ToStringPtr(c.OAuthConnectorID)
 }
 
 func (a *APIClientConfig) ToService() evergreen.ClientConfig {
@@ -35,6 +42,9 @@ func (a *APIClientConfig) ToService() evergreen.ClientConfig {
 	c.LatestRevision = utility.FromStringPtr(a.LatestRevision)
 	c.OldestAllowedCLIVersion = utility.FromStringPtr(a.OldestAllowedCLIVersion)
 	c.ClientBinaries = make([]evergreen.ClientBinary, len(a.ClientBinaries))
+	c.OAuthIssuer = utility.FromStringPtr(a.OAuthIssuer)
+	c.OAuthClientID = utility.FromStringPtr(a.OAuthClientID)
+	c.OAuthConnectorID = utility.FromStringPtr(a.OAuthConnectorID)
 	for i := range c.ClientBinaries {
 		c.ClientBinaries[i] = a.ClientBinaries[i].ToService()
 	}

--- a/service/user.go
+++ b/service/user.go
@@ -118,15 +118,29 @@ func (uis *UIServer) userGetKey(w http.ResponseWriter, r *http.Request) {
 	}
 
 	out := struct {
-		User string `json:"user" yaml:"user" `
-		Key  string `json:"api_key" yaml:"api_key"`
-		UI   string `json:"ui_server_host" yaml:"ui_server_host"`
-		API  string `json:"api_server_host" yaml:"api_server_host"`
+		User  string `json:"user" yaml:"user" `
+		Key   string `json:"api_key" yaml:"api_key"`
+		UI    string `json:"ui_server_host" yaml:"ui_server_host"`
+		API   string `json:"api_server_host" yaml:"api_server_host"`
+		OAuth struct {
+			Issuer      string `json:"issuer" yaml:"issuer"`
+			ClientID    string `json:"client_id" yaml:"client_id"`
+			ConnectorID string `json:"connector_id" yaml:"connector_id"`
+		}
 	}{
 		User: creds.Username,
 		Key:  key,
 		UI:   uis.RootURL,
 		API:  uis.RootURL + "/api",
+		OAuth: struct {
+			Issuer      string `json:"issuer" yaml:"issuer"`
+			ClientID    string `json:"client_id" yaml:"client_id"`
+			ConnectorID string `json:"connector_id" yaml:"connector_id"`
+		}{
+			Issuer:      uis.Settings.AuthConfig.OAuth.Issuer,
+			ClientID:    uis.Settings.AuthConfig.OAuth.ClientID,
+			ConnectorID: uis.Settings.AuthConfig.OAuth.ConnectorID,
+		},
 	}
 
 	if ct := r.Header.Get("content-type"); strings.Contains(ct, "yaml") {

--- a/service/user.go
+++ b/service/user.go
@@ -126,7 +126,7 @@ func (uis *UIServer) userGetKey(w http.ResponseWriter, r *http.Request) {
 			Issuer      string `json:"issuer" yaml:"issuer"`
 			ClientID    string `json:"client_id" yaml:"client_id"`
 			ConnectorID string `json:"connector_id" yaml:"connector_id"`
-		}
+		} `json:"oauth" yaml:"oauth"`
 	}{
 		User: creds.Username,
 		Key:  key,


### PR DESCRIPTION
DEVPROD-20071

### Description
This PR:

1) Adds OAuth configuration to the admin settings.
2) Piggybacks on the min CLI version logic to silently prepare user's config to use OAuth.
3) Adds these fields to the UI and SpawnHost configuration yamls.

This PR is ready for review (once I request reviewers), there's only one part that I need to fill in (outlined as a comment ATM) but Im waiting on #9440 to merge in a struct field.

<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

### Testing
Deployed to staging, instead of setting the fields I just outputted them.
