### PR TITLE
DEVPROD-26349 Allow modules to target a wiki

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -161,6 +161,34 @@ func (opts cloneOpts) getCloneCommand() ([]string, error) {
 	}, nil
 }
 
+func (opts cloneOpts) getCloneCommandForWiki() ([]string, error) {
+	if err := opts.validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid clone command options")
+	}
+
+	gitURL := thirdparty.FormGitURLForApp(opts.owner, opts.repo, opts.token)
+
+	clone := fmt.Sprintf("git clone %s '%s'", gitURL, opts.dir)
+
+	if opts.useVerbose {
+		clone = fmt.Sprintf("GIT_TRACE=1 %s", clone)
+	}
+	if opts.cloneDepth > 0 {
+		clone = fmt.Sprintf("%s --depth %d", clone, opts.cloneDepth)
+	}
+	if opts.branch != "" {
+		clone = fmt.Sprintf("%s --branch '%s'", clone, opts.branch)
+	}
+
+	return []string{
+		"set +o xtrace",
+		fmt.Sprintf(`echo %s`, strconv.Quote(clone)),
+		clone,
+		"set -o xtrace",
+		fmt.Sprintf("cd %s", opts.dir),
+	}, nil
+}
+
 func moduleRevExpansionName(name string) string { return fmt.Sprintf("%s_rev", name) }
 
 func loadModulesManifestInToExpansions(ctx context.Context, comm client.Communicator, conf *internal.TaskConfig) error {
@@ -263,6 +291,16 @@ func (c *gitFetchProject) buildModuleCloneCommand(conf *internal.TaskConfig, opt
 	}
 	if ref == "" && !isGitHubPRModulePatch(conf, modulePatch) {
 		return nil, errors.New("empty ref/branch to check out")
+	}
+
+	// Wiki modules do not support Evergreen's advance module options due to limitations on the GitHub API for wikis.
+	if strings.HasSuffix(opts.repo, ".wiki") {
+		cloneCmd, err := opts.getCloneCommandForWiki()
+		if err != nil {
+			return nil, errors.Wrap(err, "getting command to clone repo")
+		}
+		gitCommands = append(gitCommands, cloneCmd...)
+		return append(gitCommands, "git checkout '%s'", ref), nil
 	}
 
 	cloneCmd, err := opts.getCloneCommand()
@@ -478,12 +516,23 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 
 	moduleBase := filepath.ToSlash(filepath.Join(conf.ModulePaths[module.Name], module.Name))
 
+	var revision string
+
+	// If the module is a wiki, then always use the provided branch or ref as the revision.
+	// Wiki modules do not support Evergreen's advance module options due to limitations on the
+	// GitHub API for wikis.
+	if strings.HasSuffix(module.Repo, ".wiki") {
+		revision = module.Branch
+		if revision == "" {
+			revision = module.Ref
+		}
+	}
+
 	// use submodule revisions based on the main patch. If there is a need in the future,
 	// this could maybe use the most recent submodule revision of all requested patches.
 	// We ignore set-module changes for commit queue and GitHub merge queue, since we should verify HEAD before merging.
 	var modulePatch *patch.ModulePatch
-	var revision string
-	if p != nil {
+	if revision == "" && p != nil {
 		modulePatch := p.FindModule(moduleName)
 		if modulePatch != nil {
 			if conf.Task.Requester == evergreen.GithubMergeRequester {

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -57,6 +57,8 @@ type GitGetProjectSuite struct {
 	taskConfig6 *internal.TaskConfig     // GitHub merge queue
 	modelData7  *modelutil.TestModelData // Multiple modules (parallelized)
 	taskConfig7 *internal.TaskConfig     // Multiple modules (parallelized)
+	modelData8  *modelutil.TestModelData // Wiki module (uses branch/ref, ignores set-module)
+	taskConfig8 *internal.TaskConfig     // Wiki module
 
 	comm   *client.Mock
 	jasper jasper.Manager
@@ -98,6 +100,7 @@ func (s *GitGetProjectSuite) SetupTest() {
 	configPath2 := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "test_config.yml")
 	configPath3 := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "no_token.yml")
 	configPath4 := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "multiple_modules.yml")
+	configPath5 := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "wiki_module.yml")
 	patchPath := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "test.patch")
 
 	s.modelData1, err = modelutil.SetupAPITestData(s.settings, "testtask1", "rhel55", configPath1, modelutil.NoPatch)
@@ -162,6 +165,14 @@ func (s *GitGetProjectSuite) SetupTest() {
 	s.taskConfig7.Expansions.Put("prefixpath", "hello")
 	// SetupAPITestData always creates BuildVariant with no modules so this line works around that
 	s.taskConfig7.BuildVariant.Modules = []string{"sample-1", "sample-2"}
+
+	s.modelData8, err = modelutil.SetupAPITestData(s.settings, "testtask1", "rhel55", configPath5, modelutil.NoPatch)
+	s.Require().NoError(err)
+	s.taskConfig8, err = agenttestutil.MakeTaskConfigFromModelData(s.ctx, s.settings, s.modelData8)
+	s.Require().NoError(err)
+	s.taskConfig8.Expansions.Put("prefixpath", "hello")
+	s.taskConfig8.NewExpansions = agentutil.NewDynamicExpansions(s.taskConfig8.Expansions)
+	s.taskConfig8.BuildVariant.Modules = []string{"wiki", "wiki-ref"}
 
 	s.comm.CreateInstallationTokenResult = mockedGitHubAppToken
 	s.comm.CreateInstallationTokenFail = false
@@ -724,6 +735,62 @@ func (s *GitGetProjectSuite) TestCorrectModuleRevisionSetModule() {
 	}
 	s.True(foundMsg)
 	s.Equal("hello/module", conf.ModulePaths["sample"])
+}
+
+func (s *GitGetProjectSuite) TestWikiModule() {
+	// Wiki modules always use branch/ref from config and ignore set-module githash
+	// due to GitHub API limitations for wikis.
+	const patchGithash = "7b817a1908f7505cb9c05ac5601d4692793e1c0a"
+	const yamlRef = "82d5fbf5d7c920d4e8fe7a5805752ae167454584"
+	conf := s.taskConfig8
+	logger, err := s.comm.GetLoggerProducer(s.ctx, &conf.Task, nil)
+	s.Require().NoError(err)
+	s.modelData8.Task.Requester = evergreen.PatchVersionRequester
+	s.taskConfig8.Task.Requester = evergreen.PatchVersionRequester
+	s.comm.GetTaskPatchResponse = &patch.Patch{
+		Patches: []patch.ModulePatch{
+			{
+				ModuleName: "wiki",
+				Githash:    patchGithash,
+			},
+		},
+	}
+
+	for _, task := range conf.Project.Tasks {
+		s.NotEmpty(task.Commands)
+		for _, command := range task.Commands {
+			var pluginCmds []Command
+			pluginCmds, err = Render(command, &conf.Project, BlockInfo{})
+			s.NoError(err)
+			s.NotNil(pluginCmds)
+			pluginCmds[0].SetJasperManager(s.jasper)
+			err = pluginCmds[0].Execute(s.ctx, s.comm, logger, conf)
+			s.NoError(err)
+		}
+	}
+
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = filepath.Join(conf.WorkDir, "src", "hello", "wiki", "wiki")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err = cmd.Run()
+	s.NoError(err)
+	ref := strings.Trim(out.String(), "\n")
+	s.NotEqual(patchGithash, ref)
+	s.NotEqual(yamlRef, ref)
+	s.NoError(logger.Close())
+	s.Equal("hello/wiki", conf.ModulePaths["wiki"])
+
+	cmd = exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = filepath.Join(conf.WorkDir, "src", "hello", "wiki-ref", "wiki-ref")
+	out = bytes.Buffer{}
+	cmd.Stdout = &out
+	err = cmd.Run()
+	s.NoError(err)
+	ref = strings.Trim(out.String(), "\n")
+	s.Equal(yamlRef, ref)
+	s.NoError(logger.Close())
+	s.Equal("hello/wiki-ref", conf.ModulePaths["wiki-ref"])
 }
 
 func (s *GitGetProjectSuite) TestMultipleModules() {

--- a/agent/command/testdata/git/wiki_module.yml
+++ b/agent/command/testdata/git/wiki_module.yml
@@ -1,0 +1,31 @@
+batch_time: 180
+
+tasks:
+  - name: testtask1
+    commands:
+      - command: git.get_project
+        params:
+          directory: src
+          token: ${github}
+
+modules:
+  - name: wiki
+    owner: mongodb
+    repo: mongo.wiki
+    branch: master
+    prefix: ${prefixpath}/wiki
+  - name: wiki-ref
+    owner: mongodb
+    repo: mongo.wiki
+    ref: 82d5fbf5d7c920d4e8fe7a5805752ae167454584
+    prefix: ${prefixpath}/wiki-ref
+
+buildvariants:
+  - name: linux-64
+    display_name: Linux 64-bit
+    modules:
+      - wiki
+    test_flags: --continue-on-failure
+    expansions:
+      blah: "blah"
+    push: true

--- a/globals.go
+++ b/globals.go
@@ -373,6 +373,10 @@ const (
 	PresignMinimumValidTime = 15 * time.Minute
 )
 
+var (
+	ErrNotFound = errors.New("not found")
+)
+
 var TestFailureStatuses = []string{
 	TestFailedStatus,
 	TestSilentlyFailedStatus,

--- a/model/githubapp/github_app_installation.go
+++ b/model/githubapp/github_app_installation.go
@@ -30,7 +30,7 @@ const (
 )
 
 var (
-	gitHubAppNotInstalledError = errors.New("GitHub app is not installed")
+	gitHubAppNotInstalledError = errors.Wrapf(evergreen.ErrNotFound, "GitHub app")
 )
 
 // GitHubAppInstallation holds information about a GitHub app, notably its

--- a/model/version.go
+++ b/model/version.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -878,6 +879,20 @@ func getManifestModule(ctx context.Context, projectRef *ProjectRef, module Modul
 	owner, repo, err := module.GetOwnerAndRepo()
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting owner and repo for '%s'", module.Name)
+	}
+
+	// Wiki's are limited in the GitHub API and we cannot query any
+	// information about them. Wiki modules are treated as a special case
+	// where Evergreen does not attempt any of our module features, but
+	// instead just clones the wiki and the specified branch and ref.
+	if strings.HasSuffix(repo, ".wiki") {
+		return &manifest.Module{
+			Branch:   module.Branch,
+			Revision: module.Ref,
+			Repo:     repo,
+			Owner:    owner,
+			URL:      "",
+		}, nil
 	}
 
 	if module.Ref == "" {

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1389,6 +1389,9 @@ func (h *manifestLoadHandler) Run(ctx context.Context) gimlet.Responder {
 		if apiErr, ok := errors.Cause(err).(thirdparty.APIRequestError); ok && apiErr.StatusCode == http.StatusNotFound {
 			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "manifest resource not found"))
 		}
+		if errors.Is(err, evergreen.ErrNotFound) {
+			return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "storing new manifest"))
+		}
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "storing new manifest"))
 	}
 	return gimlet.NewJSONResponse(manifest)

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/model/manifest"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/s3usage"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -1143,4 +1144,147 @@ func TestReportS3Usage(t *testing.T) {
 		assert.Equal(t, 25, dbTask.S3Usage.Logs.PutRequests)
 		assert.Equal(t, int64(8192), dbTask.S3Usage.Logs.UploadBytes)
 	})
+}
+
+func TestManifestLoad(t *testing.T) {
+	taskID := "taskID"
+	versionID := "version_id"
+	projectID := "project_id"
+	projectName := "project_name"
+	revision := "5e4819db48fdbf84550d16cc648ad88612edee53"
+	branch := "zackary_bisect_2"
+	moduleName := "module_name"
+
+	url := fmt.Sprintf("/task/%s/manifest/load", taskID)
+
+	for tName, tCase := range map[string]struct {
+		taskID  string
+		modules []model.Module
+		run     func(t *testing.T, rh *manifestLoadHandler)
+	}{
+		"RunErrorsOnNilTask": {
+			taskID: "invalid_task_id",
+			run: func(t *testing.T, rh *manifestLoadHandler) {
+				resp := rh.Run(t.Context())
+				require.NotNil(t, resp)
+				assert.Equal(t, http.StatusNotFound, resp.Status(), resp.Data())
+			},
+		},
+		"RunSucceedsWithNoModules": {
+			run: func(t *testing.T, rh *manifestLoadHandler) {
+				resp := rh.Run(t.Context())
+				require.NotNil(t, resp)
+				assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
+
+				manifest, ok := resp.Data().(*manifest.Manifest)
+				require.True(t, ok)
+				require.Nil(t, manifest)
+			},
+		},
+		"RunSucceedsWithModule": {
+			modules: []model.Module{
+				{
+					Name:   moduleName,
+					Owner:  "evergreen-ci",
+					Repo:   "evergreen",
+					Branch: "main",
+				},
+			},
+			run: func(t *testing.T, rh *manifestLoadHandler) {
+				resp := rh.Run(t.Context())
+				require.NotNil(t, resp)
+				assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
+
+				manifest, ok := resp.Data().(*manifest.Manifest)
+				require.True(t, ok)
+				require.NotNil(t, manifest)
+
+				assert.Equal(t, versionID, manifest.Id)
+				assert.Equal(t, revision, manifest.Revision)
+				assert.Equal(t, projectName, manifest.ProjectName)
+				assert.Equal(t, branch, manifest.Branch)
+
+				require.Len(t, manifest.Modules, 1)
+				require.Contains(t, manifest.Modules, moduleName)
+
+				module := manifest.Modules[moduleName]
+				assert.Equal(t, "evergreen-ci", module.Owner)
+				assert.Equal(t, "evergreen", module.Repo)
+				assert.Equal(t, "main", module.Branch)
+				assert.Equal(t, "5ebb9f3083144c96de0c05794550feb9ec20b15a", module.Revision)
+				assert.Equal(t, "https://api.github.com/repos/evergreen-ci/evergreen/commits/5ebb9f3083144c96de0c05794550feb9ec20b15a", module.URL)
+			},
+		},
+		"RunSucceedsWithWikiModule": {
+			modules: []model.Module{
+				{
+					Name:   moduleName,
+					Owner:  "mongodb",
+					Repo:   "mongo.wiki",
+					Branch: "master",
+				},
+			},
+			run: func(t *testing.T, rh *manifestLoadHandler) {
+				resp := rh.Run(t.Context())
+				require.NotNil(t, resp)
+				assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
+
+				manifest, ok := resp.Data().(*manifest.Manifest)
+				require.True(t, ok)
+				require.NotNil(t, manifest)
+
+				assert.Equal(t, versionID, manifest.Id)
+				assert.Equal(t, revision, manifest.Revision)
+				assert.Equal(t, projectName, manifest.ProjectName)
+				assert.Equal(t, branch, manifest.Branch)
+
+				require.Len(t, manifest.Modules, 1)
+				require.Contains(t, manifest.Modules, moduleName)
+
+				module := manifest.Modules[moduleName]
+				assert.Equal(t, "mongodb", module.Owner)
+				assert.Equal(t, "mongo.wiki", module.Repo)
+				assert.Equal(t, "master", module.Branch)
+			},
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(task.Collection, model.ProjectRefCollection, model.VersionCollection, model.ParserProjectCollection, manifest.Collection))
+
+			env := &mock.Environment{}
+			require.NoError(t, env.Configure(t.Context()))
+
+			rh, ok := makeManifestLoad(env.Settings()).(*manifestLoadHandler)
+			require.True(t, ok)
+
+			t1 := task.Task{Id: taskID, Project: projectID, Version: versionID}
+			require.NoError(t, t1.Insert(t.Context()))
+			v1 := model.Version{Id: versionID, Branch: projectID, Revision: revision, Identifier: projectName}
+			require.NoError(t, v1.Insert(t.Context()))
+			p1 := model.ProjectRef{Id: projectID, Owner: "evergreen-ci", Repo: "commit-queue-sandbox", Branch: branch}
+			require.NoError(t, p1.Insert(t.Context()))
+			pp1 := &model.ParserProject{Id: versionID, Modules: tCase.modules}
+			require.NoError(t, pp1.Insert(t.Context()))
+
+			if tCase.taskID == "" {
+				tCase.taskID = taskID
+			}
+
+			t.Run("Parse", func(t *testing.T) {
+				request, err := http.NewRequestWithContext(t.Context(), http.MethodPost, url, bytes.NewReader([]byte("")))
+				require.NoError(t, err)
+				require.NotNil(t, request)
+
+				options := map[string]string{"task_id": tCase.taskID}
+				request = gimlet.SetURLVars(request, options)
+
+				require.NoError(t, rh.Parse(t.Context(), request))
+				assert.Equal(t, tCase.taskID, rh.taskID)
+			})
+
+			t.Run("Run", func(t *testing.T) {
+				tCase.run(t, rh)
+			})
+		})
+	}
 }


### PR DESCRIPTION
DEVPROD-26349

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
This allows modules to be a wiki. Wikis are git repositories but the GitHub API does **not** fully support these in its API.

<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

### Testing
I added some unit tests on the API and agent side.

I ran this yaml:

And got a test that clones the wiki:



### Documentation
TBA