### PR TITLE
DEVPROD-30289: Fix patch ID for merge_queue.patch_processing spans

### DIFF
--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1115,7 +1115,7 @@ func (j *patchIntentProcessor) buildGithubMergeDoc(ctx context.Context, patchDoc
 		patchDoc.GithubMergeData.HeadSHA,
 		githubHeadPRURL,
 	)
-	baseAttrs = append(baseAttrs, attribute.String(patch.MergeQueueAttrPatchID, patchDoc.Id.Hex()))
+	baseAttrs = append(baseAttrs, attribute.String(patch.MergeQueueAttrPatchID, j.PatchID.Hex()))
 	ctx, span := tracer.Start(ctx, patch.MergeQueuePatchProcessingSpan,
 		trace.WithAttributes(baseAttrs...))
 	defer span.End()


### PR DESCRIPTION
DEVPROD-30289

### Description
The patch IDs for merge_queue.patch_processing spans were incorrect and didn't map to actual patches in our db. That is because NewPatch() creates a patch with a random ID that is later overwritten with j.PatchID before insert. This changes the span to use Use j.PatchID instead of patchDoc.Id. 