### PR TITLE
DEVPROD-26465: Add ArchiveStorageCostDiscount and DefaultMaxArtifactExpirationDays to Admin Settings page

### DIFF
--- a/config_cost.go
+++ b/config_cost.go
@@ -32,6 +32,9 @@ type S3UploadCostConfig struct {
 type S3StorageCostConfig struct {
 	StandardStorageCostDiscount float64 `bson:"standard_storage_cost_discount" json:"standard_storage_cost_discount" yaml:"standard_storage_cost_discount"`
 	IAStorageCostDiscount       float64 `bson:"i_a_storage_cost_discount" json:"i_a_storage_cost_discount" yaml:"i_a_storage_cost_discount"`
+	ArchiveStorageCostDiscount  float64 `bson:"archive_storage_cost_discount" json:"archive_storage_cost_discount" yaml:"archive_storage_cost_discount"`
+	// DefaultMaxArtifactExpirationDays is the fallback retention period used when no lifecycle rule is found for a bucket.
+	DefaultMaxArtifactExpirationDays int `bson:"default_max_artifact_expiration_days" json:"default_max_artifact_expiration_days" yaml:"default_max_artifact_expiration_days"`
 }
 
 // S3CostConfig represents S3 cost configuration with separate upload and storage settings.
@@ -87,7 +90,11 @@ func (c *CostConfig) ValidateAndDefault() error {
 	validateDiscountField(c.S3Cost.Upload.UploadCostDiscount, "S3 upload cost discount", catcher)
 	validateDiscountField(c.S3Cost.Storage.StandardStorageCostDiscount, "S3 standard storage cost discount", catcher)
 	validateDiscountField(c.S3Cost.Storage.IAStorageCostDiscount, "S3 infrequent access storage cost discount", catcher)
+	validateDiscountField(c.S3Cost.Storage.ArchiveStorageCostDiscount, "S3 archive storage cost discount", catcher)
 	validateDiscountField(c.EBSCost.EBSDiscount, "EBS cost discount", catcher)
+	if c.S3Cost.Storage.DefaultMaxArtifactExpirationDays < 0 {
+		catcher.New("default max artifact expiration days must be non-negative")
+	}
 
 	return catcher.Resolve()
 }
@@ -100,5 +107,7 @@ func (c *CostConfig) IsConfigured() bool {
 		c.S3Cost.Upload.UploadCostDiscount != 0 ||
 		c.S3Cost.Storage.StandardStorageCostDiscount != 0 ||
 		c.S3Cost.Storage.IAStorageCostDiscount != 0 ||
-		c.EBSCost.EBSDiscount != 0
+		c.S3Cost.Storage.ArchiveStorageCostDiscount != 0 ||
+		c.EBSCost.EBSDiscount != 0 ||
+		c.S3Cost.Storage.DefaultMaxArtifactExpirationDays != 0
 }

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1612,8 +1612,10 @@ type ComplexityRoot struct {
 	}
 
 	S3StorageCostConfig struct {
-		IAStorageCostDiscount       func(childComplexity int) int
-		StandardStorageCostDiscount func(childComplexity int) int
+		ArchiveStorageCostDiscount       func(childComplexity int) int
+		DefaultMaxArtifactExpirationDays func(childComplexity int) int
+		IAStorageCostDiscount            func(childComplexity int) int
+		StandardStorageCostDiscount      func(childComplexity int) int
 	}
 
 	S3UploadCostConfig struct {
@@ -9400,6 +9402,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.S3Credentials.Secret(childComplexity), true
 
+	case "S3StorageCostConfig.archiveStorageCostDiscount":
+		if e.complexity.S3StorageCostConfig.ArchiveStorageCostDiscount == nil {
+			break
+		}
+
+		return e.complexity.S3StorageCostConfig.ArchiveStorageCostDiscount(childComplexity), true
+	case "S3StorageCostConfig.defaultMaxArtifactExpirationDays":
+		if e.complexity.S3StorageCostConfig.DefaultMaxArtifactExpirationDays == nil {
+			break
+		}
+
+		return e.complexity.S3StorageCostConfig.DefaultMaxArtifactExpirationDays(childComplexity), true
 	case "S3StorageCostConfig.iAStorageCostDiscount":
 		if e.complexity.S3StorageCostConfig.IAStorageCostDiscount == nil {
 			break
@@ -55091,6 +55105,10 @@ func (ec *executionContext) fieldContext_S3CostConfig_storage(_ context.Context,
 				return ec.fieldContext_S3StorageCostConfig_standardStorageCostDiscount(ctx, field)
 			case "iAStorageCostDiscount":
 				return ec.fieldContext_S3StorageCostConfig_iAStorageCostDiscount(ctx, field)
+			case "archiveStorageCostDiscount":
+				return ec.fieldContext_S3StorageCostConfig_archiveStorageCostDiscount(ctx, field)
+			case "defaultMaxArtifactExpirationDays":
+				return ec.fieldContext_S3StorageCostConfig_defaultMaxArtifactExpirationDays(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type S3StorageCostConfig", field.Name)
 		},
@@ -55251,6 +55269,64 @@ func (ec *executionContext) fieldContext_S3StorageCostConfig_iAStorageCostDiscou
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _S3StorageCostConfig_archiveStorageCostDiscount(ctx context.Context, field graphql.CollectedField, obj *model.APIS3StorageCostConfig) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_S3StorageCostConfig_archiveStorageCostDiscount,
+		func(ctx context.Context) (any, error) {
+			return obj.ArchiveStorageCostDiscount, nil
+		},
+		nil,
+		ec.marshalOFloat2float64,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_S3StorageCostConfig_archiveStorageCostDiscount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "S3StorageCostConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _S3StorageCostConfig_defaultMaxArtifactExpirationDays(ctx context.Context, field graphql.CollectedField, obj *model.APIS3StorageCostConfig) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_S3StorageCostConfig_defaultMaxArtifactExpirationDays,
+		func(ctx context.Context) (any, error) {
+			return obj.DefaultMaxArtifactExpirationDays, nil
+		},
+		nil,
+		ec.marshalOInt2int,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_S3StorageCostConfig_defaultMaxArtifactExpirationDays(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "S3StorageCostConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
 		},
 	}
 	return fc, nil
@@ -84243,7 +84319,7 @@ func (ec *executionContext) unmarshalInputS3StorageCostConfigInput(ctx context.C
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"standardStorageCostDiscount", "iAStorageCostDiscount"}
+	fieldsInOrder := [...]string{"standardStorageCostDiscount", "iAStorageCostDiscount", "archiveStorageCostDiscount", "defaultMaxArtifactExpirationDays"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -84264,6 +84340,20 @@ func (ec *executionContext) unmarshalInputS3StorageCostConfigInput(ctx context.C
 				return it, err
 			}
 			it.IAStorageCostDiscount = data
+		case "archiveStorageCostDiscount":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("archiveStorageCostDiscount"))
+			data, err := ec.unmarshalOFloat2float64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ArchiveStorageCostDiscount = data
+		case "defaultMaxArtifactExpirationDays":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("defaultMaxArtifactExpirationDays"))
+			data, err := ec.unmarshalOInt2int(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DefaultMaxArtifactExpirationDays = data
 		}
 	}
 
@@ -100271,6 +100361,10 @@ func (ec *executionContext) _S3StorageCostConfig(ctx context.Context, sel ast.Se
 			out.Values[i] = ec._S3StorageCostConfig_standardStorageCostDiscount(ctx, field, obj)
 		case "iAStorageCostDiscount":
 			out.Values[i] = ec._S3StorageCostConfig_iAStorageCostDiscount(ctx, field, obj)
+		case "archiveStorageCostDiscount":
+			out.Values[i] = ec._S3StorageCostConfig_archiveStorageCostDiscount(ctx, field, obj)
+		case "defaultMaxArtifactExpirationDays":
+			out.Values[i] = ec._S3StorageCostConfig_defaultMaxArtifactExpirationDays(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/schema/types/adminSettings/other.graphql
+++ b/graphql/schema/types/adminSettings/other.graphql
@@ -225,11 +225,15 @@ type S3UploadCostConfig {
 input S3StorageCostConfigInput {
     standardStorageCostDiscount: Float
     iAStorageCostDiscount: Float
+    archiveStorageCostDiscount: Float
+    defaultMaxArtifactExpirationDays: Int
 }
 
 type S3StorageCostConfig {
     standardStorageCostDiscount: Float
     iAStorageCostDiscount: Float
+    archiveStorageCostDiscount: Float
+    defaultMaxArtifactExpirationDays: Int
 }
 
 input S3CostConfigInput {

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -3150,8 +3150,10 @@ func (a *APIS3UploadCostConfig) ToService() (any, error) {
 }
 
 type APIS3StorageCostConfig struct {
-	StandardStorageCostDiscount float64 `json:"standard_storage_cost_discount"`
-	IAStorageCostDiscount       float64 `json:"i_a_storage_cost_discount"`
+	StandardStorageCostDiscount      float64 `json:"standard_storage_cost_discount"`
+	IAStorageCostDiscount            float64 `json:"i_a_storage_cost_discount"`
+	ArchiveStorageCostDiscount       float64 `json:"archive_storage_cost_discount"`
+	DefaultMaxArtifactExpirationDays int     `json:"default_max_artifact_expiration_days"`
 }
 
 func (a *APIS3StorageCostConfig) BuildFromService(h any) error {
@@ -3159,6 +3161,8 @@ func (a *APIS3StorageCostConfig) BuildFromService(h any) error {
 	case evergreen.S3StorageCostConfig:
 		a.StandardStorageCostDiscount = v.StandardStorageCostDiscount
 		a.IAStorageCostDiscount = v.IAStorageCostDiscount
+		a.ArchiveStorageCostDiscount = v.ArchiveStorageCostDiscount
+		a.DefaultMaxArtifactExpirationDays = v.DefaultMaxArtifactExpirationDays
 		return nil
 	default:
 		return errors.Errorf("incorrect type %T", v)
@@ -3167,8 +3171,10 @@ func (a *APIS3StorageCostConfig) BuildFromService(h any) error {
 
 func (a *APIS3StorageCostConfig) ToService() (any, error) {
 	return evergreen.S3StorageCostConfig{
-		StandardStorageCostDiscount: a.StandardStorageCostDiscount,
-		IAStorageCostDiscount:       a.IAStorageCostDiscount,
+		StandardStorageCostDiscount:      a.StandardStorageCostDiscount,
+		IAStorageCostDiscount:            a.IAStorageCostDiscount,
+		ArchiveStorageCostDiscount:       a.ArchiveStorageCostDiscount,
+		DefaultMaxArtifactExpirationDays: a.DefaultMaxArtifactExpirationDays,
 	}, nil
 }
 


### PR DESCRIPTION
DEVPROD-26465

### Description
This is part 1 of this PR. This PR wires up the fields from the admin page on the UI to the backend fields that will be used to calculate the artifact costs. 

### Testing
Deployed to staging and test
<img width="1753" height="665" alt="image" src="https://github.com/user-attachments/assets/42aabf1b-8e44-452d-94f2-2b75e8b0508f" />

[UI PR](https://github.com/evergreen-ci/ui/pull/1488)
Verified DB and values are saved and updated
