### PR TITLE
DEVPROD-24629: Adding cost calculation functions for S3 Storage Costs

### DIFF
--- a/model/s3usage/s3usage.go
+++ b/model/s3usage/s3usage.go
@@ -52,6 +52,15 @@ const (
 	S3UploadMethodWriter S3UploadMethod = "writer"
 	S3UploadMethodPut    S3UploadMethod = "put"
 	S3UploadMethodCopy   S3UploadMethod = "copy"
+
+	// S3 Intelligent Tiering pricing and transition thresholds.
+	S3StandardPricePerGBMonth = 0.023
+	S3IAPricePerGBMonth       = 0.0125
+	S3ArchivePricePerGBMonth  = 0.004
+	S3TransitionToIADays      = 30
+	S3TransitionToArchiveDays = 90
+	S3BytesPerGB              = 1024 * 1024 * 1024
+	S3DaysPerMonth            = 30.0
 )
 
 // CalculateUploadMetrics populates file size and PUT requests for each uploaded file.
@@ -158,6 +167,50 @@ func CalculateS3PutCostWithConfig(putRequests int, costConfig *evergreen.CostCon
 	}
 
 	return float64(putRequests) * S3PutRequestCost * (1 - discount)
+}
+
+// CalculateS3StorageCostWithConfig calculates the S3 storage cost for uploadBytes over their retention period
+// using the bucket's Intelligent Tiering schedule. expirationDays must be positive; buckets without a
+// lifecycle expiration policy have no defined retention period and cannot have their cost calculated, so
+// this function returns 0 for them. Returns 0 if config is nil.
+func CalculateS3StorageCostWithConfig(uploadBytes int64, expirationDays int, costConfig *evergreen.CostConfig) float64 {
+	if uploadBytes <= 0 {
+		return 0.0
+	}
+	// TODO (DEVPROD-26465): callers must always supply a positive expirationDays. Use artifactExpirationDays
+	// as the minimum fallback so this guard is never reached.
+	if expirationDays <= 0 {
+		grip.Warning(message.Fields{
+			"message": "expiration days not configured, cannot calculate S3 storage cost",
+		})
+		return 0.0
+	}
+	if costConfig == nil {
+		grip.Warning(message.Fields{
+			"message": "cost config is not available to calculate S3 storage cost",
+		})
+		return 0.0
+	}
+
+	standardDiscount := costConfig.S3Cost.Storage.StandardStorageCostDiscount
+	iaDiscount := costConfig.S3Cost.Storage.IAStorageCostDiscount
+	archiveDiscount := costConfig.S3Cost.Storage.ArchiveStorageCostDiscount
+
+	// Each variable represents how many days the object spends in that Intelligent Tiering tier:
+	// Standard (days 0–30), Infrequent Access (days 30–90), Archive (days 90+).
+	daysInStandard := min(expirationDays, S3TransitionToIADays)
+	daysInIA := max(0, min(expirationDays, S3TransitionToArchiveDays)-S3TransitionToIADays)
+	daysInArchive := max(0, expirationDays-S3TransitionToArchiveDays)
+
+	pricePerBytePerDay := func(pricePerGBMonth float64) float64 {
+		return pricePerGBMonth / S3BytesPerGB / S3DaysPerMonth
+	}
+
+	standardCost := float64(daysInStandard) * pricePerBytePerDay(S3StandardPricePerGBMonth) * (1 - standardDiscount)
+	iaCost := float64(daysInIA) * pricePerBytePerDay(S3IAPricePerGBMonth) * (1 - iaDiscount)
+	archiveCost := float64(daysInArchive) * pricePerBytePerDay(S3ArchivePricePerGBMonth) * (1 - archiveDiscount)
+
+	return float64(uploadBytes) * (standardCost + iaCost + archiveCost)
 }
 
 // IncrementArtifacts increments the artifact upload metrics (from s3.put commands).

--- a/model/s3usage/s3usage_test.go
+++ b/model/s3usage/s3usage_test.go
@@ -198,3 +198,88 @@ func TestCalculateS3PutCostWithConfig(t *testing.T) {
 	})
 
 }
+
+func TestCalculateS3StorageCostWithConfig(t *testing.T) {
+	validConfig := &evergreen.CostConfig{
+		S3Cost: evergreen.S3CostConfig{
+			Storage: evergreen.S3StorageCostConfig{
+				StandardStorageCostDiscount: 0.37,
+				IAStorageCostDiscount:       0.312,
+				ArchiveStorageCostDiscount:  0.265,
+			},
+		},
+	}
+
+	const GB = 1024 * 1024 * 1024
+
+	t.Run("DefaultArtifacts365Days", func(t *testing.T) {
+		// ExpirationDays=365: Standard=30, IA=60, Archive=275
+		cost := CalculateS3StorageCostWithConfig(GB, 365, validConfig)
+		assert.Greater(t, cost, 0.0)
+		// Verify tier breakdown manually:
+		// Standard: 30 * (0.023/GB/30) * (1-0.37) = 0.023 * 0.63
+		// IA:       60 * (0.0125/GB/30) * (1-0.312) = 2 * 0.0125 * 0.688
+		// Archive:  275 * (0.004/GB/30) * (1-0.265)
+		standard := 30.0 * (0.023 / float64(GB) / 30.0) * (1 - 0.37)
+		ia := 60.0 * (0.0125 / float64(GB) / 30.0) * (1 - 0.312)
+		archive := 275.0 * (0.004 / float64(GB) / 30.0) * (1 - 0.265)
+		expected := float64(GB) * (standard + ia + archive)
+		assert.InDelta(t, expected, cost, 0.000001)
+	})
+
+	t.Run("MongoDBMongoArtifacts90Days", func(t *testing.T) {
+		// ExpirationDays=90: Standard=30, IA=60, Archive=0
+		cost := CalculateS3StorageCostWithConfig(GB, 90, validConfig)
+		standard := 30.0 * (0.023 / float64(GB) / 30.0) * (1 - 0.37)
+		ia := 60.0 * (0.0125 / float64(GB) / 30.0) * (1 - 0.312)
+		expected := float64(GB) * (standard + ia)
+		assert.InDelta(t, expected, cost, 0.000001)
+	})
+
+	t.Run("MongoSyncArtifacts180Days", func(t *testing.T) {
+		// ExpirationDays=180: Standard=30, IA=60, Archive=90
+		cost := CalculateS3StorageCostWithConfig(GB, 180, validConfig)
+		standard := 30.0 * (0.023 / float64(GB) / 30.0) * (1 - 0.37)
+		ia := 60.0 * (0.0125 / float64(GB) / 30.0) * (1 - 0.312)
+		archive := 90.0 * (0.004 / float64(GB) / 30.0) * (1 - 0.265)
+		expected := float64(GB) * (standard + ia + archive)
+		assert.InDelta(t, expected, cost, 0.000001)
+	})
+
+	t.Run("DefaultLog60Days", func(t *testing.T) {
+		// ExpirationDays=60: Standard=30, IA=30, Archive=0
+		cost := CalculateS3StorageCostWithConfig(GB, 60, validConfig)
+		standard := 30.0 * (0.023 / float64(GB) / 30.0) * (1 - 0.37)
+		ia := 30.0 * (0.0125 / float64(GB) / 30.0) * (1 - 0.312)
+		expected := float64(GB) * (standard + ia)
+		assert.InDelta(t, expected, cost, 0.000001)
+	})
+
+	t.Run("FailedLog180Days", func(t *testing.T) {
+		// ExpirationDays=180: Standard=30, IA=60, Archive=90
+		cost := CalculateS3StorageCostWithConfig(GB, 180, validConfig)
+		assert.Greater(t, cost, 0.0)
+	})
+
+	t.Run("LongRetentionLog365Days", func(t *testing.T) {
+		// ExpirationDays=365: Standard=30, IA=60, Archive=275
+		cost := CalculateS3StorageCostWithConfig(GB, 365, validConfig)
+		assert.Greater(t, cost, 0.0)
+	})
+
+	t.Run("ZeroBytes", func(t *testing.T) {
+		cost := CalculateS3StorageCostWithConfig(0, 365, validConfig)
+		assert.Equal(t, 0.0, cost)
+	})
+
+	t.Run("ZeroExpirationDays", func(t *testing.T) {
+		cost := CalculateS3StorageCostWithConfig(GB, 0, validConfig)
+		assert.Equal(t, 0.0, cost)
+	})
+
+	t.Run("NilConfig", func(t *testing.T) {
+		cost := CalculateS3StorageCostWithConfig(GB, 365, nil)
+		assert.Equal(t, 0.0, cost)
+	})
+
+}


### PR DESCRIPTION
DEVPROD-24629

### Description
The original PR was reverted as the PR was merged in the wrong order. [Reverted PR](https://github.com/evergreen-ci/evergreen/pull/10026) 
This ticket had UI changes associated to it. The new field in the UI is `ArchiveStorageCostDiscount`.

 In order for there to be no issues, the UI changes need to merged first and then any other code that uses the UI fields to be merged next.

This PR fixes the order of operations. The UI field that is needed for this PR - `ArchiveStorageCostDiscount`
The UI changes  that sets up `ArchiveStorageCostDiscount` is [here](https://github.com/evergreen-ci/ui/pull/1488)
Corresponding App PR is [here](https://github.com/evergreen-ci/evergreen/pull/10029)

This PR adds cost functions that will be used to calculate S3 Storage costs. 

### Testing
Added test cases for coverage and tests pass