### PR TITLE
 DEVPROD-29981 allow small number of check runs to proceed without project auth

### DIFF
--- a/docs/Project-Configuration/Github-Integrations.md
+++ b/docs/Project-Configuration/Github-Integrations.md
@@ -96,12 +96,7 @@ Evergreen offers integration with the GitHub checks API. Users have the option t
 
 ### Configuration
 
-A GitHub App must be configured in the project or repo settings to use check runs. The app must have `checks:write` permission.
-
-The behavior when no GitHub app is configured depends on how many check-run-configured tasks the project has:
-
-- **Below the threshold (fewer than 10 check-run-configured tasks):** a project-level GitHub app is not required, and no validation warning is issued.
-- **At or above the threshold (10 or more check-run-configured tasks):** a validation warning is issued, and check run operations fail with an error at runtime. At this scale, a GitHub app is required for check runs to work.
+A GitHub App must be configured in the project or repo settings to have more than 10 check runs defined in a project. The app must have `checks:write` permission.
 
 To add a check run to a task, specify it in the list of tasks in the build variant definition.
 Check runs cannot be defined in the task level and will be ignored if done so.

--- a/docs/Project-Configuration/Github-Integrations.md
+++ b/docs/Project-Configuration/Github-Integrations.md
@@ -96,7 +96,12 @@ Evergreen offers integration with the GitHub checks API. Users have the option t
 
 ### Configuration
 
-A GitHub App must be configured in the project or repo settings to use check runs. Without one, enabling check runs will result in a validation warning. The app must have `checks:write` permission.
+A GitHub App must be configured in the project or repo settings to use check runs. The app must have `checks:write` permission.
+
+The behavior when no GitHub app is configured depends on how many check-run-configured tasks the project has:
+
+- **Below the threshold (fewer than 10 check-run-configured tasks):** a project-level GitHub app is not required, and no validation warning is issued.
+- **At or above the threshold (10 or more check-run-configured tasks):** a validation warning is issued, and check run operations fail with an error at runtime. At this scale, a GitHub app is required for check runs to work.
 
 To add a check run to a task, specify it in the list of tasks in the build variant definition.
 Check runs cannot be defined in the task level and will be ignored if done so.

--- a/model/generate.go
+++ b/model/generate.go
@@ -274,11 +274,18 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 
 	newTVPairs, activationInfo := g.GetNewTasksAndActivationInfo(ctx, v, p)
 
+	projectRef, err := FindMergedProjectRef(ctx, p.Identifier, v.Id, true)
+	if err != nil {
+		return errors.Wrapf(err, "finding merged project ref '%s' for version '%s'", p.Identifier, v.Id)
+	}
+	if projectRef == nil {
+		return errors.Errorf("project '%s' not found", p.Identifier)
+	}
+
 	if v.Requester == evergreen.GithubPRRequester {
 		numCheckRuns := p.GetNumCheckRunsFromTaskVariantPairs(newTVPairs)
-		hasGitHubAppAuth := GetGitHubAppAuthForProject(ctx, v.Identifier) != nil
-		if CheckRunLimitExceeded(numCheckRuns, settings.GitHubCheckRun.CheckRunLimit, hasGitHubAppAuth) {
-			return errors.Errorf("total number of checkRuns (%d) exceeds maximum limit (%d)", numCheckRuns, settings.GitHubCheckRun.CheckRunLimit)
+		if err := VerifyCheckRunLimit(numCheckRuns, settings.GitHubCheckRun.CheckRunLimit, projectRef.HasGitHubAppAuth(ctx)); err != nil {
+			return err
 		}
 	}
 
@@ -298,15 +305,6 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 		} else {
 			newTVPairsForNewVariants.DisplayTasks = append(newTVPairsForNewVariants.DisplayTasks, dispTask)
 		}
-	}
-
-	// This will only be populated for patches, not mainline commits.
-	projectRef, err := FindMergedProjectRef(ctx, p.Identifier, v.Id, true)
-	if err != nil {
-		return errors.Wrapf(err, "finding merged project ref '%s' for version '%s'", p.Identifier, v.Id)
-	}
-	if projectRef == nil {
-		return errors.Errorf("project '%s' not found", p.Identifier)
 	}
 
 	// Compile a lookup table of task IDs for all tasks to be created, both in
@@ -338,6 +336,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 		// tasks inherit that requirement.
 		ActivatedTasksAreEssentialToSucceed: g.Task.IsEssentialToSucceed,
 	}
+	// This will only be populated for patches, not mainline commits.
 	if evergreen.IsPatchRequester(v.Requester) {
 		patchDoc, err := patch.FindOneId(ctx, v.Id)
 		if err != nil {

--- a/model/generate.go
+++ b/model/generate.go
@@ -276,9 +276,9 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 
 	if v.Requester == evergreen.GithubPRRequester {
 		numCheckRuns := p.GetNumCheckRunsFromTaskVariantPairs(newTVPairs)
-		checkRunLimit := settings.GitHubCheckRun.CheckRunLimit
-		if numCheckRuns > checkRunLimit {
-			return errors.Errorf("total number of checkRuns (%d) exceeds maximum limit (%d)", numCheckRuns, checkRunLimit)
+		hasGitHubAppAuth := GetGitHubAppAuthForProject(ctx, v.Identifier) != nil
+		if CheckRunLimitExceeded(numCheckRuns, settings.GitHubCheckRun.CheckRunLimit, hasGitHubAppAuth) {
+			return errors.Errorf("total number of checkRuns (%d) exceeds maximum limit (%d)", numCheckRuns, settings.GitHubCheckRun.CheckRunLimit)
 		}
 	}
 

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -196,9 +196,8 @@ func ConfigurePatch(ctx context.Context, settings *evergreen.Settings, p *patch.
 
 	if p.IsGithubPRPatch() {
 		numCheckRuns := project.GetNumCheckRunsFromVariantTasks(p.VariantsTasks)
-		checkRunLimit := settings.GitHubCheckRun.CheckRunLimit
-		if numCheckRuns > checkRunLimit {
-			return http.StatusInternalServerError, errors.Errorf("total number of checkRuns (%d) exceeds maximum limit (%d)", numCheckRuns, checkRunLimit)
+		if CheckRunLimitExceeded(numCheckRuns, settings.GitHubCheckRun.CheckRunLimit, proj.HasGitHubAppAuth(ctx)) {
+			return http.StatusInternalServerError, errors.Errorf("total number of checkRuns (%d) exceeds maximum limit (%d)", numCheckRuns, settings.GitHubCheckRun.CheckRunLimit)
 		}
 	}
 

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -196,8 +196,8 @@ func ConfigurePatch(ctx context.Context, settings *evergreen.Settings, p *patch.
 
 	if p.IsGithubPRPatch() {
 		numCheckRuns := project.GetNumCheckRunsFromVariantTasks(p.VariantsTasks)
-		if CheckRunLimitExceeded(numCheckRuns, settings.GitHubCheckRun.CheckRunLimit, proj.HasGitHubAppAuth(ctx)) {
-			return http.StatusInternalServerError, errors.Errorf("total number of checkRuns (%d) exceeds maximum limit (%d)", numCheckRuns, settings.GitHubCheckRun.CheckRunLimit)
+		if err := VerifyCheckRunLimit(numCheckRuns, settings.GitHubCheckRun.CheckRunLimit, proj.HasGitHubAppAuth(ctx)); err != nil {
+			return http.StatusInternalServerError, err
 		}
 	}
 

--- a/model/project.go
+++ b/model/project.go
@@ -1502,16 +1502,31 @@ func (p *Project) GetNumCheckRunsFromTaskVariantPairs(variantTasks *TaskVariantP
 	return numCheckRuns
 }
 
-// HasCheckRuns returns true if the project has any check runs.
-func (p *Project) HasCheckRuns() bool {
+// CheckRunGitHubAppAuthThreshold is the minimum number of check-run-configured tasks at or
+// above which a project-level GitHub app auth is required.
+const CheckRunGitHubAppAuthThreshold = 10
+
+// CountCheckRuns returns the number of build variant tasks that have check runs configured.
+func (p *Project) CountCheckRuns() int {
+	count := 0
 	for _, b := range p.BuildVariants {
 		for _, t := range b.Tasks {
 			if t.HasCheckRun() {
-				return true
+				count++
 			}
 		}
 	}
-	return false
+	return count
+}
+
+// CheckRunLimitExceeded reports whether numCheckRuns exceeds the applicable limit.
+// If the project has a GitHub app configured, the admin-configured settingsLimit applies (when > 0).
+// If the project has no GitHub app configured, CheckRunGitHubAppAuthThreshold applies instead.
+func CheckRunLimitExceeded(numCheckRuns, settingsLimit int, hasGitHubAppAuth bool) bool {
+	if hasGitHubAppAuth {
+		return numCheckRuns > settingsLimit
+	}
+	return numCheckRuns > CheckRunGitHubAppAuthThreshold
 }
 
 func (p *Project) getNumCheckRuns(taskName, variantName string) int {

--- a/model/project.go
+++ b/model/project.go
@@ -1519,14 +1519,20 @@ func (p *Project) CountCheckRuns() int {
 	return count
 }
 
-// CheckRunLimitExceeded reports whether numCheckRuns exceeds the applicable limit.
-// If the project has a GitHub app configured, the admin-configured settingsLimit applies (when > 0).
+// VerifyCheckRunLimit returns an error if numCheckRuns exceeds the applicable limit.
+// If the project has a GitHub app configured, the admin-configured settingsLimit applies.
 // If the project has no GitHub app configured, CheckRunGitHubAppAuthThreshold applies instead.
-func CheckRunLimitExceeded(numCheckRuns, settingsLimit int, hasGitHubAppAuth bool) bool {
+func VerifyCheckRunLimit(numCheckRuns, settingsLimit int, hasGitHubAppAuth bool) error {
 	if hasGitHubAppAuth {
-		return numCheckRuns > settingsLimit
+		if numCheckRuns > settingsLimit {
+			return errors.Errorf("total number of check runs (%d) exceeds maximum limit (%d)", numCheckRuns, settingsLimit)
+		}
+		return nil
 	}
-	return numCheckRuns > CheckRunGitHubAppAuthThreshold
+	if numCheckRuns > CheckRunGitHubAppAuthThreshold {
+		return errors.Errorf("total number of check runs (%d) exceeds maximum limit without a configured GitHub App (%d)", numCheckRuns, CheckRunGitHubAppAuthThreshold)
+	}
+	return nil
 }
 
 func (p *Project) getNumCheckRuns(taskName, variantName string) int {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -273,21 +273,18 @@ func getGitHubAppAuthForProject(ctx context.Context, projectID string) *githubap
 }
 
 // GetAndValidateCheckRunGitHubAppAuth returns the GitHub app auth for the task's project, if available. Returns an error
-// if the project doesn't have a GitHub App configured, and has more check runs configured than is allowed.
+// if the project doesn't have a GitHub App configured and has more check runs configured than is allowed.
 func GetAndValidateCheckRunGitHubAppAuth(ctx context.Context, t *task.Task) (*githubapp.GithubAppAuth, error) {
 	ghAppAuth := getGitHubAppAuthForProject(ctx, t.Project)
 	if ghAppAuth != nil {
 		return ghAppAuth, nil
 	}
-	// Only load the project config in the nil-auth case to count check runs.
 	p, err := FindProjectFromVersionID(ctx, t.Version)
 	if err != nil {
 		return nil, errors.Wrap(err, "loading project config for check run operation")
 	}
-	if p == nil {
-		return nil, errors.New("project config not found for check run operation")
-	}
 	checkRunCount := p.CountCheckRuns()
+	// Returning no error and no auth is the signal to fall back to the internal app.
 	if checkRunCount < CheckRunGitHubAppAuthThreshold {
 		return nil, nil
 	}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -252,10 +252,10 @@ func (p *ProjectRef) GetGitHubAppAuthForAPI(ctx context.Context) (*githubapp.Git
 	return appAuth, nil
 }
 
-// GetGitHubAppAuthForProject retrieves the GitHub app auth for a project.
+// getGitHubAppAuthForProject retrieves the GitHub app auth for a project.
 // Returns nil (not an error) if the project ref or app auth cannot be found,
 // allowing callers to fall back to the internal app.
-func GetGitHubAppAuthForProject(ctx context.Context, projectID string) *githubapp.GithubAppAuth {
+func getGitHubAppAuthForProject(ctx context.Context, projectID string) *githubapp.GithubAppAuth {
 	pRef, _ := FindMergedProjectRef(ctx, projectID, "", false)
 	if pRef == nil {
 		return nil
@@ -270,6 +270,28 @@ func GetGitHubAppAuthForProject(ctx context.Context, projectID string) *githubap
 		return nil
 	}
 	return ghAppAuth
+}
+
+// GetAndValidateCheckRunGitHubAppAuth returns the GitHub app auth for the task's project, if available. Returns an error
+// if the project doesn't have a GitHub App configured, and has more check runs configured than is allowed.
+func GetAndValidateCheckRunGitHubAppAuth(ctx context.Context, t *task.Task) (*githubapp.GithubAppAuth, error) {
+	ghAppAuth := getGitHubAppAuthForProject(ctx, t.Project)
+	if ghAppAuth != nil {
+		return ghAppAuth, nil
+	}
+	// Only load the project config in the nil-auth case to count check runs.
+	p, err := FindProjectFromVersionID(ctx, t.Version)
+	if err != nil {
+		return nil, errors.Wrap(err, "loading project config for check run operation")
+	}
+	if p == nil {
+		return nil, errors.New("project config not found for check run operation")
+	}
+	checkRunCount := p.CountCheckRuns()
+	if checkRunCount < CheckRunGitHubAppAuthThreshold {
+		return nil, nil
+	}
+	return nil, errors.Errorf("project '%s' does not have a GitHub app configured and has more than %d check runs configured", t.Project, CheckRunGitHubAppAuthThreshold)
 }
 
 func (p *ProjectRef) ValidateGitHubPermissionGroupsByRequester() error {

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -3120,3 +3120,32 @@ func BenchmarkFindProjectTask(b *testing.B) {
 		}
 	})
 }
+
+func TestVerifyCheckRunLimit(t *testing.T) {
+	const settingsLimit = 5
+
+	t.Run("WithAppAuthBelowLimitShouldNotError", func(t *testing.T) {
+		assert.NoError(t, VerifyCheckRunLimit(settingsLimit-1, settingsLimit, true))
+	})
+	t.Run("WithAppAuthAtLimitShouldNotError", func(t *testing.T) {
+		assert.NoError(t, VerifyCheckRunLimit(settingsLimit, settingsLimit, true))
+	})
+	t.Run("WithAppAuthAboveLimitShouldError", func(t *testing.T) {
+		assert.Error(t, VerifyCheckRunLimit(settingsLimit+1, settingsLimit, true))
+	})
+	t.Run("WithoutAppAuthBelowThresholdShouldNotError", func(t *testing.T) {
+		assert.NoError(t, VerifyCheckRunLimit(CheckRunGitHubAppAuthThreshold-1, settingsLimit, false))
+	})
+	t.Run("WithoutAppAuthAtThresholdShouldNotError", func(t *testing.T) {
+		assert.NoError(t, VerifyCheckRunLimit(CheckRunGitHubAppAuthThreshold, settingsLimit, false))
+	})
+	t.Run("WithoutAppAuthAboveThresholdShouldError", func(t *testing.T) {
+		assert.Error(t, VerifyCheckRunLimit(CheckRunGitHubAppAuthThreshold+1, settingsLimit, false))
+	})
+	t.Run("WithoutAppAuthIgnoresSettingsLimit", func(t *testing.T) {
+		assert.NoError(t, VerifyCheckRunLimit(settingsLimit+1, settingsLimit, false))
+	})
+	t.Run("WithAppAuthIgnoresThreshold", func(t *testing.T) {
+		assert.NoError(t, VerifyCheckRunLimit(CheckRunGitHubAppAuthThreshold+1, CheckRunGitHubAppAuthThreshold+2, true))
+	})
+}

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1521,34 +1521,6 @@ func (g *createInstallationTokenForClone) Run(ctx context.Context) gimlet.Respon
 	})
 }
 
-// getCheckRunGitHubAppAuth returns the GitHub app auth for the task's project, if available. Returns an error
-// if the project doesn't have a GitHub App configured, and has more check runs configured than is allowed.
-func getCheckRunGitHubAppAuth(ctx context.Context, t *task.Task) (*githubapp.GithubAppAuth, error) {
-	ghAppAuth := model.GetGitHubAppAuthForProject(ctx, t.Project)
-	if ghAppAuth != nil {
-		return ghAppAuth, nil
-	}
-	// Only load the project config in the nil-auth case to count check runs.
-	p, err := model.FindProjectFromVersionID(ctx, t.Version)
-	if err != nil {
-		return nil, errors.Wrap(err, "loading project config for check run operation")
-	}
-	if p == nil {
-		return nil, errors.New("project config not found for check run operation")
-	}
-	checkRunCount := p.CountCheckRuns()
-	if checkRunCount < model.CheckRunGitHubAppAuthThreshold {
-		return nil, nil
-	}
-	grip.Debug(ctx, message.Fields{
-		"message":         "check run operation skipped, project has no GitHub app configured",
-		"task_id":         t.Id,
-		"project":         t.Project,
-		"check_run_count": checkRunCount,
-	})
-	return nil, errors.Errorf("project '%s' has no GitHub app configured and has more than %d check runs configured", t.Project, model.CheckRunGitHubAppAuthThreshold)
-}
-
 // POST /task/{task_id}/check_run
 type checkRunHandler struct {
 	taskID         string
@@ -1623,7 +1595,7 @@ func (h *checkRunHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	// Get the project's GitHub app auth for check run operations.
-	ghAppAuth, err := getCheckRunGitHubAppAuth(ctx, t)
+	ghAppAuth, err := model.GetAndValidateCheckRunGitHubAppAuth(ctx, t)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(err)
 	}

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1521,6 +1521,34 @@ func (g *createInstallationTokenForClone) Run(ctx context.Context) gimlet.Respon
 	})
 }
 
+// getCheckRunGitHubAppAuth returns the GitHub app auth for the task's project, if available. Returns an error
+// if the project doesn't have a GitHub App configured, and has more check runs configured than is allowed.
+func getCheckRunGitHubAppAuth(ctx context.Context, t *task.Task) (*githubapp.GithubAppAuth, error) {
+	ghAppAuth := model.GetGitHubAppAuthForProject(ctx, t.Project)
+	if ghAppAuth != nil {
+		return ghAppAuth, nil
+	}
+	// Only load the project config in the nil-auth case to count check runs.
+	p, err := model.FindProjectFromVersionID(ctx, t.Version)
+	if err != nil {
+		return nil, errors.Wrap(err, "loading project config for check run operation")
+	}
+	if p == nil {
+		return nil, errors.New("project config not found for check run operation")
+	}
+	checkRunCount := p.CountCheckRuns()
+	if checkRunCount < model.CheckRunGitHubAppAuthThreshold {
+		return nil, nil
+	}
+	grip.Debug(ctx, message.Fields{
+		"message":         "check run operation skipped, project has no GitHub app configured",
+		"task_id":         t.Id,
+		"project":         t.Project,
+		"check_run_count": checkRunCount,
+	})
+	return nil, errors.Errorf("project '%s' has no GitHub app configured and has more than %d check runs configured", t.Project, model.CheckRunGitHubAppAuthThreshold)
+}
+
 // POST /task/{task_id}/check_run
 type checkRunHandler struct {
 	taskID         string
@@ -1595,10 +1623,10 @@ func (h *checkRunHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	// Get the project's GitHub app auth for check run operations.
-	// If this fails or the project doesn't have a GitHub app configured,
-	// the check run functions will fall back to using the internal app.
-	ghAppAuth := model.GetGitHubAppAuthForProject(ctx, t.Project)
-
+	ghAppAuth, err := getCheckRunGitHubAppAuth(ctx, t)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(err)
+	}
 	gh := p.GithubPatchData
 	if t.CheckRunId != nil {
 		_, err := thirdparty.UpdateCheckRun(ctx, gh.BaseOwner, gh.BaseRepo, env.Settings().Api.URL, utility.FromInt64Ptr(t.CheckRunId), t, h.checkRunOutput, ghAppAuth)

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1597,7 +1597,10 @@ func (h *checkRunHandler) Run(ctx context.Context) gimlet.Responder {
 	// Get the project's GitHub app auth for check run operations.
 	ghAppAuth, err := model.GetAndValidateCheckRunGitHubAppAuth(ctx, t)
 	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(err)
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    err.Error(),
+		})
 	}
 	gh := p.GithubPatchData
 	if t.CheckRunId != nil {

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -721,6 +720,7 @@ func TestGetCheckRunGitHubAppAuth(t *testing.T) {
 	require.NoError(t, db.ClearCollections(
 		model.VersionCollection, model.ParserProjectCollection,
 		githubapp.GitHubAppAuthCollection, model.ProjectRefCollection,
+		fakeparameter.Collection,
 	))
 
 	const (
@@ -749,17 +749,64 @@ tasks:
 	ppFew.Id = fewVersionID
 	require.NoError(t, ppFew.Insert(t.Context()))
 
-	var manyYAML strings.Builder
-	manyYAML.WriteString("buildvariants:\n  - name: bv\n    tasks:\n")
-	for i := range model.CheckRunGitHubAppAuthThreshold {
-		fmt.Fprintf(&manyYAML, "      - name: task%d\n        create_check_run:\n          path_to_outputs: output.json\n", i)
-	}
-	manyYAML.WriteString("tasks:\n")
-	for i := range model.CheckRunGitHubAppAuthThreshold {
-		fmt.Fprintf(&manyYAML, "  - name: task%d\n    commands: []\n", i)
-	}
+	manyCheckRunYAML := `
+buildvariants:
+  - name: bv
+    tasks:
+      - name: task0
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task1
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task2
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task3
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task4
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task5
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task6
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task7
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task8
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task9
+        create_check_run:
+          path_to_outputs: output.json
+tasks:
+  - name: task0
+    commands: []
+  - name: task1
+    commands: []
+  - name: task2
+    commands: []
+  - name: task3
+    commands: []
+  - name: task4
+    commands: []
+  - name: task5
+    commands: []
+  - name: task6
+    commands: []
+  - name: task7
+    commands: []
+  - name: task8
+    commands: []
+  - name: task9
+    commands: []
+`
 	var manyProj model.Project
-	ppMany, err := model.LoadProjectInto(t.Context(), []byte(manyYAML.String()), nil, projectID, &manyProj)
+	ppMany, err := model.LoadProjectInto(t.Context(), []byte(manyCheckRunYAML), nil, projectID, &manyProj)
 	require.NoError(t, err)
 	ppMany.Id = manyVersionID
 	require.NoError(t, ppMany.Insert(t.Context()))
@@ -772,10 +819,13 @@ tasks:
 	noVersionTask := task.Task{Project: projectID, Version: "nonexistent_version"}
 
 	t.Run("AuthExistsShouldProceed", func(t *testing.T) {
-		require.NoError(t, db.Insert(t.Context(), githubapp.GitHubAppAuthCollection, &githubapp.GithubAppAuth{
-			Id: projectID, AppID: 12345,
+		require.NoError(t, githubapp.UpsertGitHubAppAuth(t.Context(), &githubapp.GithubAppAuth{
+			Id: projectID, AppID: 12345, PrivateKey: []byte("fake-private-key"),
 		}))
-		defer func() { require.NoError(t, db.Clear(githubapp.GitHubAppAuthCollection)) }()
+		defer func() {
+			require.NoError(t, db.Clear(githubapp.GitHubAppAuthCollection))
+			require.NoError(t, db.Clear(fakeparameter.Collection))
+		}()
 
 		auth, err := model.GetAndValidateCheckRunGitHubAppAuth(t.Context(), &fewTask)
 		require.NotNil(t, auth)
@@ -791,10 +841,10 @@ tasks:
 		assert.Nil(t, auth)
 		assert.Error(t, err)
 	})
-	t.Run("ProjectConfigNotFoundShouldProceedWithNilAuth", func(t *testing.T) {
+	t.Run("ProjectConfigNotFoundShouldError", func(t *testing.T) {
 		auth, err := model.GetAndValidateCheckRunGitHubAppAuth(t.Context(), &noVersionTask)
 		assert.Nil(t, auth)
-		assert.NoError(t, err)
+		assert.Error(t, err)
 	})
 }
 

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -822,10 +822,9 @@ tasks:
 		require.NoError(t, githubapp.UpsertGitHubAppAuth(t.Context(), &githubapp.GithubAppAuth{
 			Id: projectID, AppID: 12345, PrivateKey: []byte("fake-private-key"),
 		}))
-		defer func() {
-			require.NoError(t, db.Clear(githubapp.GitHubAppAuthCollection))
-			require.NoError(t, db.Clear(fakeparameter.Collection))
-		}()
+		t.Cleanup(func() {
+			require.NoError(t, db.ClearCollections(githubapp.GitHubAppAuthCollection, fakeparameter.Collection))
+		})
 
 		auth, err := model.GetAndValidateCheckRunGitHubAppAuth(t.Context(), &fewTask)
 		require.NotNil(t, auth)
@@ -946,7 +945,7 @@ tasks:
 			Requester: evergreen.RepotrackerVersionRequester,
 		}
 		require.NoError(t, t1.Insert(t.Context()))
-		defer func() { require.NoError(t, db.Clear(task.Collection)) }()
+		t.Cleanup(func() { require.NoError(t, db.Clear(task.Collection)) })
 
 		h := &checkRunHandler{}
 		taskCtx := context.WithValue(t.Context(), model.ApiTaskKey, &t1)
@@ -969,7 +968,7 @@ tasks:
 		taskCtx := context.WithValue(t.Context(), model.ApiTaskKey, &t2)
 		resp := h.Run(taskCtx)
 		require.NotNil(t, resp)
-		assert.Equal(t, http.StatusInternalServerError, resp.Status())
+		assert.Equal(t, http.StatusBadRequest, resp.Status())
 		assert.Contains(t, fmt.Sprintf("%v", resp.Data()), "does not have a GitHub app configured")
 	})
 }

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/githubapp"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/s3usage"
@@ -713,6 +715,166 @@ func TestUpsertCheckRunParse(t *testing.T) {
 
 	assert.Equal(t, "This is my report", utility.FromStringPtr(r.checkRunOutput.Title))
 	assert.Len(t, r.checkRunOutput.Annotations, 1)
+}
+
+func TestGetCheckRunGitHubAppAuth(t *testing.T) {
+	require.NoError(t, db.ClearCollections(
+		model.VersionCollection, model.ParserProjectCollection,
+		githubapp.GitHubAppAuthCollection, model.ProjectRefCollection,
+	))
+
+	const (
+		projectID     = "proj"
+		fewVersionID  = "aaaaaaaaaaff001122334400"
+		manyVersionID = "aaaaaaaaaaff001122334401"
+	)
+
+	require.NoError(t, (&model.Version{Id: fewVersionID}).Insert(t.Context()))
+	require.NoError(t, (&model.Version{Id: manyVersionID}).Insert(t.Context()))
+
+	fewCheckRunYAML := `
+buildvariants:
+  - name: bv
+    tasks:
+      - name: task1
+        create_check_run:
+          path_to_outputs: output.json
+tasks:
+  - name: task1
+    commands: []
+`
+	var fewProj model.Project
+	ppFew, err := model.LoadProjectInto(t.Context(), []byte(fewCheckRunYAML), nil, projectID, &fewProj)
+	require.NoError(t, err)
+	ppFew.Id = fewVersionID
+	require.NoError(t, ppFew.Insert(t.Context()))
+
+	var manyYAML strings.Builder
+	manyYAML.WriteString("buildvariants:\n  - name: bv\n    tasks:\n")
+	for i := range model.CheckRunGitHubAppAuthThreshold {
+		fmt.Fprintf(&manyYAML, "      - name: task%d\n        create_check_run:\n          path_to_outputs: output.json\n", i)
+	}
+	manyYAML.WriteString("tasks:\n")
+	for i := range model.CheckRunGitHubAppAuthThreshold {
+		fmt.Fprintf(&manyYAML, "  - name: task%d\n    commands: []\n", i)
+	}
+	var manyProj model.Project
+	ppMany, err := model.LoadProjectInto(t.Context(), []byte(manyYAML.String()), nil, projectID, &manyProj)
+	require.NoError(t, err)
+	ppMany.Id = manyVersionID
+	require.NoError(t, ppMany.Insert(t.Context()))
+
+	// Project ref needed for GetGitHubAppAuthForProject to find a ref and check auth.
+	require.NoError(t, (&model.ProjectRef{Id: projectID}).Insert(t.Context()))
+
+	fewTask := task.Task{Project: projectID, Version: fewVersionID}
+	manyTask := task.Task{Project: projectID, Version: manyVersionID}
+	noVersionTask := task.Task{Project: projectID, Version: "nonexistent_version"}
+
+	t.Run("AuthExistsShouldProceed", func(t *testing.T) {
+		require.NoError(t, db.Insert(t.Context(), githubapp.GitHubAppAuthCollection, &githubapp.GithubAppAuth{
+			Id: projectID, AppID: 12345,
+		}))
+		defer func() { require.NoError(t, db.Clear(githubapp.GitHubAppAuthCollection)) }()
+
+		auth, err := getCheckRunGitHubAppAuth(t.Context(), &fewTask)
+		require.NotNil(t, auth)
+		assert.NoError(t, err)
+	})
+	t.Run("FewCheckRunsNoAuthShouldProceedWithNilAuth", func(t *testing.T) {
+		auth, err := getCheckRunGitHubAppAuth(t.Context(), &fewTask)
+		assert.Nil(t, auth)
+		assert.NoError(t, err)
+	})
+	t.Run("ManyCheckRunsNoAuthShouldError", func(t *testing.T) {
+		auth, err := getCheckRunGitHubAppAuth(t.Context(), &manyTask)
+		assert.Nil(t, auth)
+		assert.Error(t, err)
+	})
+	t.Run("ProjectConfigNotFoundShouldProceedWithNilAuth", func(t *testing.T) {
+		auth, err := getCheckRunGitHubAppAuth(t.Context(), &noVersionTask)
+		assert.Nil(t, auth)
+		assert.NoError(t, err)
+	})
+}
+
+func TestCheckRunHandlerRun(t *testing.T) {
+	const (
+		projectID     = "proj"
+		versionID     = "aaaaaaaaaaff001122334455"
+		manyVersionID = "aaaaaaaaaaff001122334456"
+	)
+	require.NoError(t, db.ClearCollections(
+		task.Collection, patch.Collection,
+		model.VersionCollection, model.ParserProjectCollection,
+		githubapp.GitHubAppAuthCollection, model.ProjectRefCollection,
+	))
+
+	p := patch.Patch{
+		Id:      patch.NewId(versionID),
+		Version: versionID,
+	}
+	require.NoError(t, p.Insert(t.Context()))
+	pMany := patch.Patch{
+		Id:      patch.NewId(manyVersionID),
+		Version: manyVersionID,
+	}
+	require.NoError(t, pMany.Insert(t.Context()))
+
+	require.NoError(t, (&model.Version{Id: versionID}).Insert(t.Context()))
+	require.NoError(t, (&model.Version{Id: manyVersionID}).Insert(t.Context()))
+	require.NoError(t, (&model.ProjectRef{Id: projectID}).Insert(t.Context()))
+
+	// Parser project with >= threshold check runs so the handler returns an error when no auth.
+	var manyYAML strings.Builder
+	manyYAML.WriteString("buildvariants:\n  - name: bv\n    tasks:\n")
+	for i := range model.CheckRunGitHubAppAuthThreshold {
+		fmt.Fprintf(&manyYAML, "      - name: task%d\n        create_check_run:\n          path_to_outputs: output.json\n", i)
+	}
+	manyYAML.WriteString("tasks:\n")
+	for i := range model.CheckRunGitHubAppAuthThreshold {
+		fmt.Fprintf(&manyYAML, "  - name: task%d\n    commands: []\n", i)
+	}
+	var manyProj model.Project
+	ppMany, err := model.LoadProjectInto(t.Context(), []byte(manyYAML.String()), nil, projectID, &manyProj)
+	require.NoError(t, err)
+	ppMany.Id = manyVersionID
+	require.NoError(t, ppMany.Insert(t.Context()))
+
+	t.Run("NonGitHubPRRequesterShouldSkip", func(t *testing.T) {
+		t1 := task.Task{
+			Id:        "t1_non_pr",
+			Project:   projectID,
+			Version:   versionID,
+			Requester: evergreen.RepotrackerVersionRequester,
+		}
+		require.NoError(t, t1.Insert(t.Context()))
+		defer func() { require.NoError(t, db.Clear(task.Collection)) }()
+
+		h := &checkRunHandler{}
+		taskCtx := context.WithValue(t.Context(), model.ApiTaskKey, &t1)
+		resp := h.Run(taskCtx)
+		require.NotNil(t, resp)
+		assert.Equal(t, http.StatusOK, resp.Status())
+		assert.Contains(t, fmt.Sprintf("%v", resp.Data()), "requester is not a github patch")
+	})
+	t.Run("ManyCheckRunsNoAuthShouldReturnError", func(t *testing.T) {
+		t2 := task.Task{
+			Id:        "t2_many_no_auth",
+			Project:   projectID,
+			Version:   manyVersionID,
+			Requester: evergreen.GithubPRRequester,
+		}
+		require.NoError(t, t2.Insert(t.Context()))
+		defer func() { require.NoError(t, db.Clear(task.Collection)) }()
+
+		h := &checkRunHandler{}
+		taskCtx := context.WithValue(t.Context(), model.ApiTaskKey, &t2)
+		resp := h.Run(taskCtx)
+		require.NotNil(t, resp)
+		assert.Equal(t, http.StatusInternalServerError, resp.Status())
+		assert.Contains(t, fmt.Sprintf("%v", resp.Data()), "does not have a GitHub app configured")
+	})
 }
 
 func TestCreateGitHubDynamicAccessToken(t *testing.T) {

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -764,7 +764,7 @@ tasks:
 	ppMany.Id = manyVersionID
 	require.NoError(t, ppMany.Insert(t.Context()))
 
-	// Project ref needed for GetGitHubAppAuthForProject to find a ref and check auth.
+	// Project ref needed for GetAndValidateCheckRunGitHubAppAuth to find a ref and check auth.
 	require.NoError(t, (&model.ProjectRef{Id: projectID}).Insert(t.Context()))
 
 	fewTask := task.Task{Project: projectID, Version: fewVersionID}
@@ -777,22 +777,22 @@ tasks:
 		}))
 		defer func() { require.NoError(t, db.Clear(githubapp.GitHubAppAuthCollection)) }()
 
-		auth, err := getCheckRunGitHubAppAuth(t.Context(), &fewTask)
+		auth, err := model.GetAndValidateCheckRunGitHubAppAuth(t.Context(), &fewTask)
 		require.NotNil(t, auth)
 		assert.NoError(t, err)
 	})
 	t.Run("FewCheckRunsNoAuthShouldProceedWithNilAuth", func(t *testing.T) {
-		auth, err := getCheckRunGitHubAppAuth(t.Context(), &fewTask)
+		auth, err := model.GetAndValidateCheckRunGitHubAppAuth(t.Context(), &fewTask)
 		assert.Nil(t, auth)
 		assert.NoError(t, err)
 	})
 	t.Run("ManyCheckRunsNoAuthShouldError", func(t *testing.T) {
-		auth, err := getCheckRunGitHubAppAuth(t.Context(), &manyTask)
+		auth, err := model.GetAndValidateCheckRunGitHubAppAuth(t.Context(), &manyTask)
 		assert.Nil(t, auth)
 		assert.Error(t, err)
 	})
 	t.Run("ProjectConfigNotFoundShouldProceedWithNilAuth", func(t *testing.T) {
-		auth, err := getCheckRunGitHubAppAuth(t.Context(), &noVersionTask)
+		auth, err := model.GetAndValidateCheckRunGitHubAppAuth(t.Context(), &noVersionTask)
 		assert.Nil(t, auth)
 		assert.NoError(t, err)
 	})
@@ -826,17 +826,64 @@ func TestCheckRunHandlerRun(t *testing.T) {
 	require.NoError(t, (&model.ProjectRef{Id: projectID}).Insert(t.Context()))
 
 	// Parser project with >= threshold check runs so the handler returns an error when no auth.
-	var manyYAML strings.Builder
-	manyYAML.WriteString("buildvariants:\n  - name: bv\n    tasks:\n")
-	for i := range model.CheckRunGitHubAppAuthThreshold {
-		fmt.Fprintf(&manyYAML, "      - name: task%d\n        create_check_run:\n          path_to_outputs: output.json\n", i)
-	}
-	manyYAML.WriteString("tasks:\n")
-	for i := range model.CheckRunGitHubAppAuthThreshold {
-		fmt.Fprintf(&manyYAML, "  - name: task%d\n    commands: []\n", i)
-	}
+	manyCheckRunYAML := `
+buildvariants:
+  - name: bv
+    tasks:
+      - name: task0
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task1
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task2
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task3
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task4
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task5
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task6
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task7
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task8
+        create_check_run:
+          path_to_outputs: output.json
+      - name: task9
+        create_check_run:
+          path_to_outputs: output.json
+tasks:
+  - name: task0
+    commands: []
+  - name: task1
+    commands: []
+  - name: task2
+    commands: []
+  - name: task3
+    commands: []
+  - name: task4
+    commands: []
+  - name: task5
+    commands: []
+  - name: task6
+    commands: []
+  - name: task7
+    commands: []
+  - name: task8
+    commands: []
+  - name: task9
+    commands: []
+`
 	var manyProj model.Project
-	ppMany, err := model.LoadProjectInto(t.Context(), []byte(manyYAML.String()), nil, projectID, &manyProj)
+	ppMany, err := model.LoadProjectInto(t.Context(), []byte(manyCheckRunYAML), nil, projectID, &manyProj)
 	require.NoError(t, err)
 	ppMany.Id = manyVersionID
 	require.NoError(t, ppMany.Insert(t.Context()))

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -380,10 +380,10 @@ func (gh *githubHookApi) rerunCheckRun(ctx context.Context, owner, repo string, 
 	}
 
 	// Get the project's GitHub app auth for check run operations.
-	// If this fails or the project doesn't have a GitHub app configured,
-	// the check run functions will fall back to using the internal app.
-	ghAppAuth := model.GetGitHubAppAuthForProject(ctx, taskToRestart.Project)
-
+	ghAppAuth, err := getCheckRunGitHubAppAuth(ctx, taskToRestart)
+	if err != nil {
+		return errors.Wrapf(err, "checkRun not updated for task '%s'", taskToRestart.Id)
+	}
 	// Check run status should stay the same while task is being re-run.
 	latestExecutionForTask.Status = taskToRestart.Status
 	_, err = thirdparty.UpdateCheckRun(ctx, owner, repo, gh.settings.Api.URL, checkRun.GetID(), latestExecutionForTask, output, ghAppAuth)

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -382,7 +382,18 @@ func (gh *githubHookApi) rerunCheckRun(ctx context.Context, owner, repo string, 
 	// Get the project's GitHub app auth for check run operations.
 	ghAppAuth, err := model.GetAndValidateCheckRunGitHubAppAuth(ctx, taskToRestart)
 	if err != nil {
-		return errors.Wrapf(err, "checkRun not updated for task '%s'", taskToRestart.Id)
+		grip.Debug(ctx, message.WrapError(err, message.Fields{
+			"source":    "GitHub hook",
+			"operation": "check run",
+			"msg_id":    gh.msgID,
+			"event":     gh.eventType,
+			"owner":     owner,
+			"repo":      repo,
+			"task":      taskToRestart.Id,
+			"message":   "checkRun not updated for task",
+		}))
+		// Don't want to retry on this case, so log but return no error.
+		return nil
 	}
 	// Check run status should stay the same while task is being re-run.
 	latestExecutionForTask.Status = taskToRestart.Status

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -380,7 +380,7 @@ func (gh *githubHookApi) rerunCheckRun(ctx context.Context, owner, repo string, 
 	}
 
 	// Get the project's GitHub app auth for check run operations.
-	ghAppAuth, err := getCheckRunGitHubAppAuth(ctx, taskToRestart)
+	ghAppAuth, err := model.GetAndValidateCheckRunGitHubAppAuth(ctx, taskToRestart)
 	if err != nil {
 		return errors.Wrapf(err, "checkRun not updated for task '%s'", taskToRestart.Id)
 	}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -422,7 +422,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	if patchDoc.IsGithubPRPatch() {
 		numCheckRuns := patchedProject.GetNumCheckRunsFromVariantTasks(patchDoc.VariantsTasks)
 		checkRunLimit := j.env.Settings().GitHubCheckRun.CheckRunLimit
-		if numCheckRuns > checkRunLimit {
+		if model.CheckRunLimitExceeded(numCheckRuns, checkRunLimit, pref.HasGitHubAppAuth(ctx)) {
 			j.gitHubError = checkRunLimitExceeded
 			return errors.Errorf("total number of checkRuns (%d) exceeds maximum limit (%d)", numCheckRuns, checkRunLimit)
 		}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -421,10 +421,9 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 
 	if patchDoc.IsGithubPRPatch() {
 		numCheckRuns := patchedProject.GetNumCheckRunsFromVariantTasks(patchDoc.VariantsTasks)
-		checkRunLimit := j.env.Settings().GitHubCheckRun.CheckRunLimit
-		if model.CheckRunLimitExceeded(numCheckRuns, checkRunLimit, pref.HasGitHubAppAuth(ctx)) {
+		if err := model.VerifyCheckRunLimit(numCheckRuns, j.env.Settings().GitHubCheckRun.CheckRunLimit, pref.HasGitHubAppAuth(ctx)); err != nil {
 			j.gitHubError = checkRunLimitExceeded
-			return errors.Errorf("total number of checkRuns (%d) exceeds maximum limit (%d)", numCheckRuns, checkRunLimit)
+			return err
 		}
 		catcher.Wrap(j.createGitHubSubscriptions(ctx, patchDoc), "creating GitHub PR patch subscriptions")
 	}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1040,15 +1040,11 @@ func validateGitHubAppCheckRuns(ctx context.Context, settings *evergreen.Setting
 	if numCheckRuns == 0 {
 		return errs
 	}
-	hasAppAuth := ref.HasGitHubAppAuth(ctx)
-	if model.CheckRunLimitExceeded(numCheckRuns, settings.GitHubCheckRun.CheckRunLimit, hasAppAuth) {
-		var msg string
-		if hasAppAuth {
-			msg = fmt.Sprintf("check runs will be skipped; total number of checkRuns (%d) exceeds maximum limit (%d)", numCheckRuns, settings.GitHubCheckRun.CheckRunLimit)
-		} else {
-			msg = fmt.Sprintf("check runs will be skipped; total number of checkRuns (%d) exceeds maximum limit without configured GitHub App (%d)", numCheckRuns, model.CheckRunGitHubAppAuthThreshold)
-		}
-		errs = append(errs, ValidationError{Message: msg, Level: Warning})
+	if err := model.VerifyCheckRunLimit(numCheckRuns, settings.GitHubCheckRun.CheckRunLimit, ref.HasGitHubAppAuth(ctx)); err != nil {
+		errs = append(errs, ValidationError{
+			Message: fmt.Sprintf("check runs will be skipped; %s", err.Error()),
+			Level:   Warning,
+		})
 	}
 	return errs
 }

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -170,7 +170,6 @@ var projectMixedValidators = []projectValidator{
 
 var projectAliasWarningValidators = []projectAliasValidator{
 	validateAliasCoverage,
-	validateCheckRuns,
 }
 
 // Functions used to validate a project configuration that requires additional
@@ -612,44 +611,6 @@ func getAliasCoverage(p *model.Project, aliasMap map[string]model.ProjectAlias) 
 	return aliasNeedsVariant, aliasNeedsTask, nil
 }
 
-// validateCheckRuns returns warnings if PR aliases are going to violate check run rules for the given config.
-func validateCheckRuns(p *model.Project, aliases model.ProjectAliases) ValidationErrors {
-	errs := ValidationErrors{}
-	aliasMap := map[string][]model.ProjectAlias{} // map of alias name to aliases
-	for _, a := range aliases {
-		if _, ok := aliasMap[a.Alias]; !ok {
-			aliasMap[a.Alias] = []model.ProjectAlias{}
-		}
-		aliasMap[a.Alias] = append(aliasMap[a.Alias], a)
-	}
-
-	tvPairs, err := p.BuildProjectTVPairsWithAlias(aliasMap[evergreen.GithubPRAlias], evergreen.GithubPRRequester)
-	if err != nil {
-		errs = append(errs, ValidationError{
-			Message: "problem getting task variant pairs for PR aliases",
-			Level:   Warning,
-		})
-		return errs
-	}
-	tvPairs.ExecTasks, err = model.IncludeDependencies(p, tvPairs.ExecTasks, evergreen.GithubPRRequester, nil)
-	if err != nil {
-		errs = append(errs, ValidationError{
-			Message: "problem adding dependencies to PR alias tasks",
-			Level:   Warning,
-		})
-		return errs
-	}
-	numCheckRuns := p.GetNumCheckRunsFromTaskVariantPairs(&tvPairs)
-	checkRunLimit := evergreen.GetEnvironment().Settings().GitHubCheckRun.CheckRunLimit
-	if numCheckRuns > checkRunLimit {
-		errs = append(errs, ValidationError{
-			Message: fmt.Sprintf("total number of checkRuns (%d) exceeds maximum limit (%d)", numCheckRuns, checkRunLimit),
-			Level:   Warning,
-		})
-	}
-	return errs
-}
-
 func aliasMatchesTaskGroupTask(p *model.Project, alias model.ProjectAlias, tgName string) (bool, error) {
 	tg := p.FindTaskGroup(tgName)
 	if tg == nil {
@@ -1072,18 +1033,23 @@ func validateReferentialIntegrity(ctx context.Context, settings *evergreen.Setti
 	return validationErrs
 }
 
+// validateGitHubAppCheckRuns returns warnings if the project has more check runs configured than allowed (which varies depending on GitHub App setup).
 func validateGitHubAppCheckRuns(ctx context.Context, settings *evergreen.Settings, p *model.Project, ref *model.ProjectRef, _ bool) ValidationErrors {
 	errs := ValidationErrors{}
-	if ref.HasGitHubAppAuth(ctx) {
+	numCheckRuns := p.CountCheckRuns()
+	if numCheckRuns == 0 {
 		return errs
 	}
-	if !p.HasCheckRuns() {
-		return errs
+	hasAppAuth := ref.HasGitHubAppAuth(ctx)
+	if model.CheckRunLimitExceeded(numCheckRuns, settings.GitHubCheckRun.CheckRunLimit, hasAppAuth) {
+		var msg string
+		if hasAppAuth {
+			msg = fmt.Sprintf("check runs will be skipped; total number of checkRuns (%d) exceeds maximum limit (%d)", numCheckRuns, settings.GitHubCheckRun.CheckRunLimit)
+		} else {
+			msg = fmt.Sprintf("check runs will be skipped; total number of checkRuns (%d) exceeds maximum limit without configured GitHub App (%d)", numCheckRuns, model.CheckRunGitHubAppAuthThreshold)
+		}
+		errs = append(errs, ValidationError{Message: msg, Level: Warning})
 	}
-	errs = append(errs, ValidationError{
-		Message: "project has check runs but no GitHub app is configured for the project",
-		Level:   Warning,
-	})
 	return errs
 }
 

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2961,7 +2961,6 @@ func TestValidateGitHubAppCheckRuns(t *testing.T) {
 	})
 }
 
-
 func TestValidateProjectAliases(t *testing.T) {
 	Convey("When validating a project", t, func() {
 		Convey("ensure misconfigured aliases throw an error", func() {

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2942,7 +2942,8 @@ func TestValidateGitHubAppCheckRuns(t *testing.T) {
 		defer func() {
 			require.NoError(t, db.Clear(githubapp.GitHubAppAuthCollection))
 		}()
-		errs := validateGitHubAppCheckRuns(t.Context(), settings, projectWithCheckRuns, ref, false)
+		settingsWithLimit := &evergreen.Settings{GitHubCheckRun: evergreen.GitHubCheckRunConfig{CheckRunLimit: 100}}
+		errs := validateGitHubAppCheckRuns(t.Context(), settingsWithLimit, projectWithCheckRuns, ref, false)
 		assert.Empty(t, errs)
 	})
 	t.Run("CheckRunsWithRepoAppAuth", func(t *testing.T) {
@@ -2954,7 +2955,8 @@ func TestValidateGitHubAppCheckRuns(t *testing.T) {
 		defer func() {
 			require.NoError(t, db.Clear(githubapp.GitHubAppAuthCollection))
 		}()
-		errs := validateGitHubAppCheckRuns(t.Context(), settings, projectWithCheckRuns, refWithRepo, false)
+		settingsWithLimit := &evergreen.Settings{GitHubCheckRun: evergreen.GitHubCheckRunConfig{CheckRunLimit: 100}}
+		errs := validateGitHubAppCheckRuns(t.Context(), settingsWithLimit, projectWithCheckRuns, refWithRepo, false)
 		assert.Empty(t, errs)
 	})
 }

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2900,6 +2900,21 @@ func TestValidateGitHubAppCheckRuns(t *testing.T) {
 			},
 		},
 	}
+
+	// Build a project with enough check runs to exceed the threshold (must be strictly greater than).
+	manyCheckRunTasks := make([]model.BuildVariantTaskUnit, model.CheckRunGitHubAppAuthThreshold+1)
+	for i := range manyCheckRunTasks {
+		manyCheckRunTasks[i] = model.BuildVariantTaskUnit{
+			Name:           fmt.Sprintf("task%d", i),
+			CreateCheckRun: &model.CheckRun{PathToOutputs: "output.json"},
+		}
+	}
+	projectWithManyCheckRuns := &model.Project{
+		BuildVariants: []model.BuildVariant{
+			{Name: "bv", Tasks: manyCheckRunTasks},
+		},
+	}
+
 	projectWithoutCheckRuns := &model.Project{}
 
 	ref := &model.ProjectRef{Id: "my-project"}
@@ -2909,11 +2924,15 @@ func TestValidateGitHubAppCheckRuns(t *testing.T) {
 		errs := validateGitHubAppCheckRuns(t.Context(), settings, projectWithoutCheckRuns, ref, false)
 		assert.Empty(t, errs)
 	})
-	t.Run("CheckRunsNoAppAuth", func(t *testing.T) {
+	t.Run("FewCheckRunsNoAppAuthShouldNotWarn", func(t *testing.T) {
 		errs := validateGitHubAppCheckRuns(t.Context(), settings, projectWithCheckRuns, ref, false)
+		assert.Empty(t, errs)
+	})
+	t.Run("ManyCheckRunsNoAppAuthShouldWarn", func(t *testing.T) {
+		errs := validateGitHubAppCheckRuns(t.Context(), settings, projectWithManyCheckRuns, ref, false)
 		require.Len(t, errs, 1)
 		assert.Equal(t, Warning, errs[0].Level)
-		assert.Contains(t, errs[0].Message, "no GitHub app is configured")
+		assert.Contains(t, errs[0].Message, "exceeds maximum limit without configured GitHub App")
 	})
 	t.Run("CheckRunsWithAppAuth", func(t *testing.T) {
 		require.NoError(t, db.Insert(t.Context(), githubapp.GitHubAppAuthCollection, &githubapp.GithubAppAuth{
@@ -2940,93 +2959,6 @@ func TestValidateGitHubAppCheckRuns(t *testing.T) {
 	})
 }
 
-func TestValidateCheckRuns(t *testing.T) {
-	for testName, testCase := range map[string]func(*testing.T, *model.Project){
-		"NoPRAliases": func(t *testing.T, p *model.Project) {
-			alias1 := model.ProjectAlias{
-				ID:          mgobson.NewObjectId(),
-				Alias:       evergreen.CommitQueueAlias,
-				VariantTags: []string{"notTheVariantTag"},
-				TaskTags:    []string{"taskTag1", "taskTag2"},
-				Source:      model.AliasSourceConfig,
-			}
-			alias2 := model.ProjectAlias{
-				ID:      mgobson.NewObjectId(),
-				Alias:   evergreen.CommitQueueAlias,
-				Variant: "nonsense",
-				Task:    ".*",
-				Source:  model.AliasSourceConfig,
-			}
-
-			errs := validateCheckRuns(p, model.ProjectAliases{alias1, alias2})
-			require.Empty(t, errs)
-		},
-		"CheckRunsBelowLimit": func(t *testing.T, p *model.Project) {
-			alias1 := model.ProjectAlias{
-				ID:      mgobson.NewObjectId(),
-				Alias:   evergreen.GithubPRAlias,
-				Variant: "variant1",
-				Task:    ".*",
-				Source:  model.AliasSourceConfig,
-			}
-
-			errs := validateCheckRuns(p, model.ProjectAliases{alias1})
-			require.Empty(t, errs)
-		},
-		"CheckRunsAboveLimit": func(t *testing.T, p *model.Project) {
-			alias1 := model.ProjectAlias{
-				ID:      mgobson.NewObjectId(),
-				Alias:   evergreen.GithubPRAlias,
-				Variant: ".*",
-				Task:    ".*",
-				Source:  model.AliasSourceConfig,
-			}
-
-			errs := validateCheckRuns(p, model.ProjectAliases{alias1})
-			require.Len(t, errs, 1)
-			assert.Equal(t, Warning, errs[0].Level)
-			assert.Contains(t, errs[0].Message, "total number of checkRuns (2) exceeds maximum limit (1)")
-		},
-	} {
-		t.Run(testName, func(t *testing.T) {
-			p := &model.Project{
-				Tasks: []model.ProjectTask{
-					{
-						Name: "myTask",
-					},
-					{
-						Name: "myOtherTask",
-					},
-				},
-				BuildVariants: model.BuildVariants{
-					{
-						Name: "variant1",
-						Tasks: []model.BuildVariantTaskUnit{
-							{
-								Name: "myTask",
-								CreateCheckRun: &model.CheckRun{
-									PathToOutputs: "myPath",
-								},
-							},
-						},
-					},
-					{
-						Name: "variant2",
-						Tasks: []model.BuildVariantTaskUnit{
-							{
-								Name: "myOtherTask",
-								CreateCheckRun: &model.CheckRun{
-									PathToOutputs: "myPath",
-								},
-							},
-						},
-					},
-				},
-			}
-			testCase(t, p)
-		})
-	}
-}
 
 func TestValidateProjectAliases(t *testing.T) {
 	Convey("When validating a project", t, func() {

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2932,7 +2932,7 @@ func TestValidateGitHubAppCheckRuns(t *testing.T) {
 		errs := validateGitHubAppCheckRuns(t.Context(), settings, projectWithManyCheckRuns, ref, false)
 		require.Len(t, errs, 1)
 		assert.Equal(t, Warning, errs[0].Level)
-		assert.Contains(t, errs[0].Message, "exceeds maximum limit without configured GitHub App")
+		assert.Contains(t, errs[0].Message, "exceeds maximum limit without a configured GitHub App")
 	})
 	t.Run("CheckRunsWithAppAuth", func(t *testing.T) {
 		require.NoError(t, db.Insert(t.Context(), githubapp.GitHubAppAuthCollection, &githubapp.GithubAppAuth{


### PR DESCRIPTION
DEVPROD-29981
<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
I ran validation against all configs, and only one project has no auth configured and are using check runs, but they're a good example of a small project that may want to use this feature and shouldn't be restricted here. Added logic to allow projects with fewer than 10 check runs to proceed without auth (hardcoding this value bc it's not likely to change). 

### Testing
Added unit tests
### Documentation
Updated documentation
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
