### PR TITLE
DEVPROD-31477 Add highest_task_execution in version spans

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -541,6 +541,7 @@ const (
 	VersionFinishTimeOtelAttribute            = "evergreen.version.finish_time"
 	VersionAuthorOtelAttribute                = "evergreen.version.author"
 	VersionBranchOtelAttribute                = "evergreen.version.branch"
+	VersionHighestExecutionTaskOtelAttribute  = "evergreen.version.highest_execution_task"
 	VersionMakespanSecondsOtelAttribute       = "evergreen.version.makespan_seconds"
 	VersionTimeTakenSecondsOtelAttribute      = "evergreen.version.time_taken_seconds"
 	VersionPRNumOtelAttribute                 = "evergreen.version.pr_num"

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -974,6 +974,11 @@ func getVersionCtxForTracing(ctx context.Context, v *Version, project string, p 
 		return nil, errors.Wrap(err, "getting time spent")
 	}
 
+	highestExecutionTask, err := v.GetHighestExecutionTask(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting highest execution task")
+	}
+
 	attrs := []attribute.KeyValue{
 		attribute.String(evergreen.VersionIDOtelAttribute, v.Id),
 		attribute.String(evergreen.VersionRequesterOtelAttribute, v.Requester),
@@ -987,6 +992,7 @@ func getVersionCtxForTracing(ctx context.Context, v *Version, project string, p 
 		attribute.Int(evergreen.VersionMakespanSecondsOtelAttribute, int(makespan.Seconds())),
 		attribute.String(evergreen.VersionAuthorOtelAttribute, v.Author),
 		attribute.String(evergreen.VersionBranchOtelAttribute, v.Branch),
+		attribute.Int(evergreen.VersionHighestExecutionTaskOtelAttribute, highestExecutionTask),
 	}
 
 	if !v.Cost.IsZero() {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -974,7 +974,7 @@ func getVersionCtxForTracing(ctx context.Context, v *Version, project string, p 
 		return nil, errors.Wrap(err, "getting time spent")
 	}
 
-	highestExecutionTask, err := v.GetHighestExecutionTask(ctx)
+	highestExecutionTask, err := v.GetHighestTaskExecution(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting highest execution task")
 	}

--- a/model/version.go
+++ b/model/version.go
@@ -452,17 +452,14 @@ func (v *Version) UpdateAggregateTaskCosts(ctx context.Context) error {
 
 // GetHighestExecutionTask returns the highest execution number of all tasks in the version.
 func (v *Version) GetHighestExecutionTask(ctx context.Context) (int, error) {
-	tasks, err := task.FindAll(ctx, db.Query(task.ByVersion(v.Id)))
+	t, err := task.FindOne(ctx, db.Query(task.ByVersion(v.Id)).WithFields(task.ExecutionKey).Sort([]string{"-" + task.ExecutionKey}).Limit(1))
 	if err != nil {
-		return 0, errors.Wrap(err, "getting tasks for version")
+		return 0, errors.Wrap(err, "getting highest execution task for version")
 	}
-	highestExecutionTask := 0
-	for _, t := range tasks {
-		if t.Execution > highestExecutionTask {
-			highestExecutionTask = t.Execution
-		}
+	if t == nil {
+		return 0, nil
 	}
-	return highestExecutionTask, nil
+	return t.Execution, nil
 }
 
 // VersionBuildStatus stores metadata relating to each build

--- a/model/version.go
+++ b/model/version.go
@@ -450,6 +450,21 @@ func (v *Version) UpdateAggregateTaskCosts(ctx context.Context) error {
 	return nil
 }
 
+// GetHighestExecutionTask returns the highest execution number of all tasks in the version.
+func (v *Version) GetHighestExecutionTask(ctx context.Context) (int, error) {
+	tasks, err := task.FindAll(ctx, db.Query(task.ByVersion(v.Id)))
+	if err != nil {
+		return 0, errors.Wrap(err, "getting tasks for version")
+	}
+	highestExecutionTask := 0
+	for _, t := range tasks {
+		if t.Execution > highestExecutionTask {
+			highestExecutionTask = t.Execution
+		}
+	}
+	return highestExecutionTask, nil
+}
+
 // VersionBuildStatus stores metadata relating to each build
 type VersionBuildStatus struct {
 	BuildVariant     string                `bson:"build_variant" json:"id"`

--- a/model/version.go
+++ b/model/version.go
@@ -452,6 +452,8 @@ func (v *Version) UpdateAggregateTaskCosts(ctx context.Context) error {
 
 // GetHighestExecutionTask returns the highest execution number of all tasks in the version.
 func (v *Version) GetHighestExecutionTask(ctx context.Context) (int, error) {
+	// FindAll, an aggregation, and a FindOne sort query were considered
+	// but after testing, the FindOne sort query was found to be the most performant.
 	t, err := task.FindOne(ctx, db.Query(task.ByVersion(v.Id)).WithFields(task.ExecutionKey).Sort([]string{"-" + task.ExecutionKey}).Limit(1))
 	if err != nil {
 		return 0, errors.Wrap(err, "getting highest execution task for version")

--- a/model/version.go
+++ b/model/version.go
@@ -450,8 +450,8 @@ func (v *Version) UpdateAggregateTaskCosts(ctx context.Context) error {
 	return nil
 }
 
-// GetHighestExecutionTask returns the highest execution number of all tasks in the version.
-func (v *Version) GetHighestExecutionTask(ctx context.Context) (int, error) {
+// GetHighestTaskExecution returns the highest execution number of all tasks in the version.
+func (v *Version) GetHighestTaskExecution(ctx context.Context) (int, error) {
 	// FindAll, an aggregation, and a FindOne sort query were considered
 	// but after testing, the FindOne sort query was found to be the most performant.
 	t, err := task.FindOne(ctx, db.Query(task.ByVersion(v.Id)).WithFields(task.ExecutionKey).Sort([]string{"-" + task.ExecutionKey}).Limit(1))

--- a/model/version_db_test.go
+++ b/model/version_db_test.go
@@ -677,3 +677,95 @@ func TestVersionsAllUnactivatedNonIgnored(t *testing.T) {
 	}
 	assert.False(t, foundIds["future-version"], "Should not include version created after ts (race condition protection)")
 }
+
+func TestGetHighestExecutionTask(t *testing.T) {
+	ctx := t.Context()
+	const versionID = "version_get_highest_execution_task"
+
+	require.NoError(t, db.ClearCollections(VersionCollection, task.Collection))
+	defer func() {
+		require.NoError(t, db.ClearCollections(VersionCollection, task.Collection))
+	}()
+
+	tests := []struct {
+		name  string
+		setup func(t *testing.T)
+		want  int
+	}{
+		{
+			name: "EmptyVersionReturnsZero",
+			setup: func(t *testing.T) {
+				require.NoError(t, (&Version{Id: versionID}).Insert(ctx))
+			},
+			want: 0,
+		},
+		{
+			name: "SingleTaskExecutionZeroReturnsZero",
+			setup: func(t *testing.T) {
+				require.NoError(t, (&Version{Id: versionID}).Insert(ctx))
+				require.NoError(t, (&task.Task{
+					Id:        "exec_task_0",
+					Version:   versionID,
+					Execution: 0,
+					Status:    evergreen.TaskUndispatched,
+				}).Insert(ctx))
+			},
+			want: 0,
+		},
+		{
+			name: "ReturnsMaxExecutionAcrossTasks",
+			setup: func(t *testing.T) {
+				require.NoError(t, (&Version{Id: versionID}).Insert(ctx))
+				for _, tc := range []struct {
+					id        string
+					execution int
+				}{
+					{"exec_task_a", 0},
+					{"exec_task_b", 3},
+					{"exec_task_c", 1},
+				} {
+					require.NoError(t, (&task.Task{
+						Id:        tc.id,
+						Version:   versionID,
+						Execution: tc.execution,
+						Status:    evergreen.TaskUndispatched,
+					}).Insert(ctx))
+				}
+			},
+			want: 3,
+		},
+		{
+			name: "IgnoresTasksFromOtherVersions",
+			setup: func(t *testing.T) {
+				const otherVersionID = "other_version_get_highest_execution"
+				require.NoError(t, (&Version{Id: versionID}).Insert(ctx))
+				require.NoError(t, (&Version{Id: otherVersionID}).Insert(ctx))
+				require.NoError(t, (&task.Task{
+					Id:        "exec_in_target",
+					Version:   versionID,
+					Execution: 2,
+					Status:    evergreen.TaskUndispatched,
+				}).Insert(ctx))
+				require.NoError(t, (&task.Task{
+					Id:        "exec_in_other_version",
+					Version:   otherVersionID,
+					Execution: 50,
+					Status:    evergreen.TaskUndispatched,
+				}).Insert(ctx))
+			},
+			want: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(VersionCollection, task.Collection))
+			tt.setup(t)
+
+			v := &Version{Id: versionID}
+			got, err := v.GetHighestExecutionTask(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/model/version_db_test.go
+++ b/model/version_db_test.go
@@ -673,7 +673,7 @@ func TestVersionsAllUnactivatedNonIgnored(t *testing.T) {
 	assert.False(t, foundIds["future-version"], "Should not include version created after ts (race condition protection)")
 }
 
-func TestGetHighestExecutionTask(t *testing.T) {
+func TestGetHighestTaskExecution(t *testing.T) {
 	const versionID = "version_get_highest_execution_task"
 
 	require.NoError(t, db.ClearCollections(VersionCollection, task.Collection))
@@ -757,7 +757,7 @@ func TestGetHighestExecutionTask(t *testing.T) {
 			tt.setup(t)
 
 			v := &Version{Id: versionID}
-			got, err := v.GetHighestExecutionTask(t.Context())
+			got, err := v.GetHighestTaskExecution(t.Context())
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})

--- a/model/version_db_test.go
+++ b/model/version_db_test.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -51,14 +50,10 @@ func TestVersionByMostRecentNonIgnored(t *testing.T) {
 }
 
 func TestRestartVersion(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	// Insert data for the test paths.
-	assert.NoError(t, db.ClearCollections(VersionCollection, build.Collection, task.Collection, task.OldCollection))
-	defer func() {
-		assert.NoError(t, db.ClearCollections(VersionCollection, build.Collection, task.Collection, task.OldCollection))
-	}()
+	require.NoError(t, db.ClearCollections(VersionCollection, build.Collection, task.Collection, task.OldCollection))
+	t.Cleanup(func() {
+		require.NoError(t, db.ClearCollections(VersionCollection, build.Collection, task.Collection, task.OldCollection))
+	})
 
 	versionID := "version0"
 	versions := []*Version{
@@ -85,14 +80,14 @@ func TestRestartVersion(t *testing.T) {
 		require.NoError(t, item.Insert(t.Context()))
 	}
 	for _, item := range builds {
-		require.NoError(t, item.Insert(ctx))
+		require.NoError(t, item.Insert(t.Context()))
 	}
 
-	require.NoError(t, RestartVersion(ctx, versionID, nil, true, "caller"))
+	require.NoError(t, RestartVersion(t.Context(), versionID, nil, true, "caller"))
 
 	// Check that completed non-execution tasks are reset.
 	for _, taskID := range []string{"task0", "display1"} {
-		tsk, err := task.FindOneId(ctx, taskID)
+		tsk, err := task.FindOneId(t.Context(), taskID)
 		require.NoError(t, err)
 
 		assert.Equal(t, evergreen.TaskUndispatched, tsk.Status)
@@ -100,7 +95,7 @@ func TestRestartVersion(t *testing.T) {
 
 	// Check that completed execution tasks are neither aborted nor reset.
 	for _, taskID := range []string{"exec00", "exec01", "exec11"} {
-		tsk, err := task.FindOneId(ctx, taskID)
+		tsk, err := task.FindOneId(t.Context(), taskID)
 		require.NoError(t, err)
 
 		assert.Contains(t, evergreen.TaskCompletedStatuses, tsk.Status)
@@ -111,7 +106,7 @@ func TestRestartVersion(t *testing.T) {
 
 	// Check that in-progress tasks are aborted and marked for reset.
 	for _, taskID := range []string{"task1", "display0", "exec00", "exec10"} {
-		tsk, err := task.FindOneId(ctx, taskID)
+		tsk, err := task.FindOneId(t.Context(), taskID)
 		require.NoError(t, err)
 
 		if !utility.StringSliceContains(evergreen.TaskCompletedStatuses, tsk.Status) {
@@ -130,7 +125,7 @@ func TestRestartVersion(t *testing.T) {
 
 	// Build status for all builds containing the tasks that we touched
 	// should be updated.
-	b, err := build.FindOneId(ctx, buildID)
+	b, err := build.FindOneId(t.Context(), buildID)
 	require.NoError(t, err)
 	assert.Equal(t, evergreen.BuildStarted, b.Status)
 	assert.Equal(t, "caller", b.ActivatedBy)
@@ -145,9 +140,9 @@ func TestFindVersionByIdFail(t *testing.T) {
 }
 
 func TestGetVersionAuthorID(t *testing.T) {
-	defer func() {
+	t.Cleanup(func() {
 		assert.NoError(t, db.ClearCollections(VersionCollection))
-	}()
+	})
 
 	for name, test := range map[string]func(*testing.T){
 		"HasAuthorID": func(t *testing.T) {
@@ -679,13 +674,12 @@ func TestVersionsAllUnactivatedNonIgnored(t *testing.T) {
 }
 
 func TestGetHighestExecutionTask(t *testing.T) {
-	ctx := t.Context()
 	const versionID = "version_get_highest_execution_task"
 
 	require.NoError(t, db.ClearCollections(VersionCollection, task.Collection))
-	defer func() {
+	t.Cleanup(func() {
 		require.NoError(t, db.ClearCollections(VersionCollection, task.Collection))
-	}()
+	})
 
 	tests := []struct {
 		name  string
@@ -695,27 +689,27 @@ func TestGetHighestExecutionTask(t *testing.T) {
 		{
 			name: "EmptyVersionReturnsZero",
 			setup: func(t *testing.T) {
-				require.NoError(t, (&Version{Id: versionID}).Insert(ctx))
+				require.NoError(t, (&Version{Id: versionID}).Insert(t.Context()))
 			},
 			want: 0,
 		},
 		{
 			name: "SingleTaskExecutionZeroReturnsZero",
 			setup: func(t *testing.T) {
-				require.NoError(t, (&Version{Id: versionID}).Insert(ctx))
+				require.NoError(t, (&Version{Id: versionID}).Insert(t.Context()))
 				require.NoError(t, (&task.Task{
 					Id:        "exec_task_0",
 					Version:   versionID,
 					Execution: 0,
 					Status:    evergreen.TaskUndispatched,
-				}).Insert(ctx))
+				}).Insert(t.Context()))
 			},
 			want: 0,
 		},
 		{
 			name: "ReturnsMaxExecutionAcrossTasks",
 			setup: func(t *testing.T) {
-				require.NoError(t, (&Version{Id: versionID}).Insert(ctx))
+				require.NoError(t, (&Version{Id: versionID}).Insert(t.Context()))
 				for _, tc := range []struct {
 					id        string
 					execution int
@@ -729,7 +723,7 @@ func TestGetHighestExecutionTask(t *testing.T) {
 						Version:   versionID,
 						Execution: tc.execution,
 						Status:    evergreen.TaskUndispatched,
-					}).Insert(ctx))
+					}).Insert(t.Context()))
 				}
 			},
 			want: 3,
@@ -738,20 +732,20 @@ func TestGetHighestExecutionTask(t *testing.T) {
 			name: "IgnoresTasksFromOtherVersions",
 			setup: func(t *testing.T) {
 				const otherVersionID = "other_version_get_highest_execution"
-				require.NoError(t, (&Version{Id: versionID}).Insert(ctx))
-				require.NoError(t, (&Version{Id: otherVersionID}).Insert(ctx))
+				require.NoError(t, (&Version{Id: versionID}).Insert(t.Context()))
+				require.NoError(t, (&Version{Id: otherVersionID}).Insert(t.Context()))
 				require.NoError(t, (&task.Task{
 					Id:        "exec_in_target",
 					Version:   versionID,
 					Execution: 2,
 					Status:    evergreen.TaskUndispatched,
-				}).Insert(ctx))
+				}).Insert(t.Context()))
 				require.NoError(t, (&task.Task{
 					Id:        "exec_in_other_version",
 					Version:   otherVersionID,
 					Execution: 50,
 					Status:    evergreen.TaskUndispatched,
-				}).Insert(ctx))
+				}).Insert(t.Context()))
 			},
 			want: 2,
 		},
@@ -763,7 +757,7 @@ func TestGetHighestExecutionTask(t *testing.T) {
 			tt.setup(t)
 
 			v := &Version{Id: versionID}
-			got, err := v.GetHighestExecutionTask(ctx)
+			got, err := v.GetHighestExecutionTask(t.Context())
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 		})


### PR DESCRIPTION
DEVPROD-31477

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Adds `highest_task_execution` in version spans.


Different possible query types:
```
| Metric              | #1: FindAll (current) | #2: Aggregation ($group/$max) | #3: Find/Sort/Limit          |
|---------------------|-----------------------|-------------------------------|------------------------------|
| executionTimeMillis | 7ms                   | 3ms                           | 0ms (sub-millisecond)        |
| nReturned           | 62                    | 1                             | 1                            |
| totalKeysExamined   | 62                    | 62                            | 62                           |
| totalDocsExamined   | 62                    | 62                            | 62                           |
| Plan stages         | IXSCAN → FETCH       | IXSCAN → FETCH → GROUP       | IXSCAN → FETCH → SORT → PROJ |
| In-memory sort?     | No                    | No                            | Yes (SORT stage)             |
```

Here's another version that has many tasks:
```
| Metric              | #1: FindAll (current) | #2: Aggregation ($group/$max) | #3: Find/Sort/Limit            |
|---------------------|-----------------------|-------------------------------|---------------------------------|
| executionTimeMillis | 65ms                  | 83ms                          | 91ms                            |
| nReturned           | 51,275                | 1                             | 1                               |
| totalKeysExamined   | 51,275                | 51,275                        | 51,275                          |
| totalDocsExamined   | 51,275                | 51,275                        | 51,275                          |
| Plan stages         | IXSCAN → FETCH       | IXSCAN → FETCH → GROUP       | IXSCAN → FETCH → SORT → PROJ   |
| In-memory sort?     | No                    | No                            | Yes (SORT stage)                |
```

This doesn't account for actually sending the document(s) over, so the FindAll with cursor iteration will be much longer. The Sort actually looks like the best one, many task versions exist but I think they aren't the majority. The majority probably look like the first chart, sorting is O(nlogn), so the amount of tasks does matter here. 

The sort version is the best one for our use case.

<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

### Testing
Unit tests
