### PR TITLE
DEVPROD-31295: Make gqlgen.yml owned by UI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 * @evergreen-ci/evg-app
 graphql/ @evergreen-ci/evg-ui
+gqlgen.yml @evergreen-ci/evg-ui
 
 # Don't automatically assign reviewers on PRs that only modify these files.
 # As they have no owner listed, these files are not owned by anyone.


### PR DESCRIPTION
DEVPROD-31295

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Since we own `graphql/`, I figured we should also own `gqlgen.yml`.