### PR TITLE
DEVPROD-31398: Move "Run Every Mainline Commit" to Repotracker Settings on General tab

### DIFF
--- a/graphql/tests/mutation/saveProjectSettingsForSection/queries/general_section.graphql
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/queries/general_section.graphql
@@ -10,6 +10,7 @@ mutation {
                 owner: "evergreen-ci"
                 repo: "commit-queue-sandbox"
                 branch: "main"
+                runEveryMainlineCommit: true
             }
         },
         section: GENERAL
@@ -18,6 +19,7 @@ mutation {
             enabled
             remotePath
             spawnHostScriptPath ## overwritten
+            runEveryMainlineCommit
         }
         vars {
             vars ## should be unchanged

--- a/graphql/tests/mutation/saveProjectSettingsForSection/results.json
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/results.json
@@ -8,7 +8,8 @@
             "projectRef": {
               "enabled": true,
               "remotePath": "my_path_is_new",
-              "spawnHostScriptPath": ""
+              "spawnHostScriptPath": "",
+              "runEveryMainlineCommit": true
             },
             "vars": {
               "vars": {

--- a/graphql/tests/mutation/saveRepoSettingsForSection/queries/general_section.graphql
+++ b/graphql/tests/mutation/saveRepoSettingsForSection/queries/general_section.graphql
@@ -8,6 +8,7 @@ mutation {
         repo: "world"
         enabled: true
         remotePath: "my_path_is_new"
+        runEveryMainlineCommit: true
       }
     }
     section: GENERAL
@@ -16,6 +17,7 @@ mutation {
       enabled
       remotePath
       spawnHostScriptPath ## overwritten
+      runEveryMainlineCommit
     }
     vars {
       ## should be unchanged

--- a/graphql/tests/mutation/saveRepoSettingsForSection/queries/github_and_commit_queue_section.graphql
+++ b/graphql/tests/mutation/saveRepoSettingsForSection/queries/github_and_commit_queue_section.graphql
@@ -5,7 +5,6 @@ mutation {
       projectRef: {
         id: "sandbox_repo_id"
         commitQueue: { enabled: true }
-        runEveryMainlineCommit: true
       }
       aliases: [
         {
@@ -26,7 +25,6 @@ mutation {
       commitQueue {
         enabled
       }
-      runEveryMainlineCommit
     }
     vars {
       ## should be unchanged

--- a/graphql/tests/mutation/saveRepoSettingsForSection/queries/github_and_commit_queue_section.graphql
+++ b/graphql/tests/mutation/saveRepoSettingsForSection/queries/github_and_commit_queue_section.graphql
@@ -5,6 +5,8 @@ mutation {
       projectRef: {
         id: "sandbox_repo_id"
         commitQueue: { enabled: true }
+        # TODO DEVPROD-8355: remove runEveryMainlineCommit
+        runEveryMainlineCommit: true
       }
       aliases: [
         {
@@ -25,6 +27,8 @@ mutation {
       commitQueue {
         enabled
       }
+      # TODO DEVPROD-8355: remove runEveryMainlineCommit
+      runEveryMainlineCommit
     }
     vars {
       ## should be unchanged

--- a/graphql/tests/mutation/saveRepoSettingsForSection/queries/github_and_commit_queue_section.graphql
+++ b/graphql/tests/mutation/saveRepoSettingsForSection/queries/github_and_commit_queue_section.graphql
@@ -5,8 +5,6 @@ mutation {
       projectRef: {
         id: "sandbox_repo_id"
         commitQueue: { enabled: true }
-        # TODO DEVPROD-8355: remove runEveryMainlineCommit
-        runEveryMainlineCommit: true
       }
       aliases: [
         {
@@ -27,8 +25,6 @@ mutation {
       commitQueue {
         enabled
       }
-      # TODO DEVPROD-8355: remove runEveryMainlineCommit
-      runEveryMainlineCommit
     }
     vars {
       ## should be unchanged

--- a/graphql/tests/mutation/saveRepoSettingsForSection/results.json
+++ b/graphql/tests/mutation/saveRepoSettingsForSection/results.json
@@ -8,7 +8,8 @@
             "projectRef": {
               "enabled": true,
               "remotePath": "my_path_is_new",
-              "spawnHostScriptPath": ""
+              "spawnHostScriptPath": "",
+              "runEveryMainlineCommit": true
             },
             "vars": {
               "vars": { "hello": "" },
@@ -26,8 +27,7 @@
             "projectRef": {
               "commitQueue": {
                 "enabled": true
-              },
-              "runEveryMainlineCommit": true
+              }
             },
             "vars": {
               "vars": { "hello": "" },

--- a/graphql/tests/mutation/saveRepoSettingsForSection/results.json
+++ b/graphql/tests/mutation/saveRepoSettingsForSection/results.json
@@ -27,8 +27,7 @@
             "projectRef": {
               "commitQueue": {
                 "enabled": true
-              },
-              "runEveryMainlineCommit": true
+              }
             },
             "vars": {
               "vars": { "hello": "" },

--- a/graphql/tests/mutation/saveRepoSettingsForSection/results.json
+++ b/graphql/tests/mutation/saveRepoSettingsForSection/results.json
@@ -27,7 +27,8 @@
             "projectRef": {
               "commitQueue": {
                 "enabled": true
-              }
+              },
+              "runEveryMainlineCommit": true
             },
             "vars": {
               "vars": { "hello": "" },

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2258,6 +2258,7 @@ func SaveProjectPageForSection(ctx context.Context, projectId string, p *Project
 			projectRefPatchingDisabledKey:        p.PatchingDisabled,
 			ProjectRefDisabledStatsCacheKey:      p.DisabledStatsCache,
 			projectRefDebugSpawnHostsDisabledKey: p.DebugSpawnHostsDisabled,
+			projectRefRunEveryMainlineCommitKey:  p.RunEveryMainlineCommit,
 		}
 		// Unlike other fields, this will only be set if we're actually modifying it since it's used by the backend.
 		if p.TracksPushEvents != nil {
@@ -2314,7 +2315,6 @@ func SaveProjectPageForSection(ctx context.Context, projectId string, p *Project
 					ProjectRefGitTagAuthorizedTeamsKey:  p.GitTagAuthorizedTeams,
 					projectRefCommitQueueKey:            p.CommitQueue,
 					projectRefOldestAllowedMergeBaseKey: p.OldestAllowedMergeBase,
-					projectRefRunEveryMainlineCommitKey: p.RunEveryMainlineCommit,
 				},
 			})
 	case ProjectPageNotificationsSection:

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2315,8 +2315,6 @@ func SaveProjectPageForSection(ctx context.Context, projectId string, p *Project
 					ProjectRefGitTagAuthorizedTeamsKey:  p.GitTagAuthorizedTeams,
 					projectRefCommitQueueKey:            p.CommitQueue,
 					projectRefOldestAllowedMergeBaseKey: p.OldestAllowedMergeBase,
-					// TODO DEVPROD-8355: remove after UI changes are merged
-					projectRefRunEveryMainlineCommitKey: p.RunEveryMainlineCommit,
 				},
 			})
 	case ProjectPageNotificationsSection:

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2315,6 +2315,8 @@ func SaveProjectPageForSection(ctx context.Context, projectId string, p *Project
 					ProjectRefGitTagAuthorizedTeamsKey:  p.GitTagAuthorizedTeams,
 					projectRefCommitQueueKey:            p.CommitQueue,
 					projectRefOldestAllowedMergeBaseKey: p.OldestAllowedMergeBase,
+					// TODO DEVPROD-8355: remove after UI changes are merged
+					projectRefRunEveryMainlineCommitKey: p.RunEveryMainlineCommit,
 				},
 			})
 	case ProjectPageNotificationsSection:


### PR DESCRIPTION
DEVPROD-31398

### Description
Run Every Mainline Commit is not a GitHub setting and should be moved to the General tab instead.

### Testing
No change

### Documentation
None
