### PR TITLE
DEVPROD-31472: Fix S3 Cost calculations by using correct Storage Tiers

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-04-09a"
+	AgentVersion = "2026-04-09b"
 )
 
 const (

--- a/model/s3usage/s3usage.go
+++ b/model/s3usage/s3usage.go
@@ -74,8 +74,6 @@ const (
 	S3StandardPricePerGBMonth = 0.023
 	S3IAPricePerGBMonth       = 0.0125
 	S3ArchivePricePerGBMonth  = 0.004
-	S3TransitionToIADays      = 30
-	S3TransitionToArchiveDays = 90
 	S3BytesPerGB              = 1024 * 1024 * 1024
 	S3DaysPerMonth            = 30.0
 )
@@ -182,15 +180,19 @@ func CalculateS3PutCostWithConfig(putRequests int, costConfig *evergreen.CostCon
 	return float64(putRequests) * S3PutRequestCost * (1 - discount)
 }
 
-// CalculateS3StorageCostWithConfig calculates the S3 storage cost for uploadBytes over their retention period
-// using the bucket's Intelligent Tiering schedule. expirationDays must be positive; buckets without a
-// lifecycle expiration policy have no defined retention period and cannot have their cost calculated, so
-// this function returns 0 for them. Returns 0 if config is nil.
-func CalculateS3StorageCostWithConfig(ctx context.Context, uploadBytes int64, expirationDays int, costConfig *evergreen.CostConfig) float64 {
+// StorageTierInfo holds the S3 lifecycle tier configuration for a bucket rule. Zero transition days mean no transition to that tier.
+type StorageTierInfo struct {
+	ExpirationDays          int
+	TransitionToIADays      int
+	TransitionToGlacierDays int
+}
+
+// CalculateS3StorageCostWithConfig calculates the S3 storage cost for uploadBytes over their retention period.
+func CalculateS3StorageCostWithConfig(ctx context.Context, uploadBytes int64, tierInfo StorageTierInfo, costConfig *evergreen.CostConfig) float64 {
 	if uploadBytes <= 0 {
 		return 0.0
 	}
-	if expirationDays <= 0 {
+	if tierInfo.ExpirationDays <= 0 {
 		return 0.0
 	}
 	if costConfig == nil {
@@ -204,11 +206,7 @@ func CalculateS3StorageCostWithConfig(ctx context.Context, uploadBytes int64, ex
 	iaDiscount := costConfig.S3Cost.Storage.IAStorageCostDiscount
 	archiveDiscount := costConfig.S3Cost.Storage.ArchiveStorageCostDiscount
 
-	// Each variable represents how many days the object spends in that Intelligent Tiering tier:
-	// Standard (days 0–30), Infrequent Access (days 30–90), Archive (days 90+).
-	daysInStandard := min(expirationDays, S3TransitionToIADays)
-	daysInIA := max(0, min(expirationDays, S3TransitionToArchiveDays)-S3TransitionToIADays)
-	daysInArchive := max(0, expirationDays-S3TransitionToArchiveDays)
+	daysInStandard, daysInIA, daysInArchive := storageTierDays(tierInfo)
 
 	pricePerBytePerDay := func(pricePerGBMonth float64) float64 {
 		return pricePerGBMonth / S3BytesPerGB / S3DaysPerMonth
@@ -219,6 +217,35 @@ func CalculateS3StorageCostWithConfig(ctx context.Context, uploadBytes int64, ex
 	archiveCost := float64(daysInArchive) * pricePerBytePerDay(S3ArchivePricePerGBMonth) * (1 - archiveDiscount)
 
 	return float64(uploadBytes) * (standardCost + iaCost + archiveCost)
+}
+
+// storageTierDays returns how many days an object spends in each S3 storage tier given its lifecycle rule.
+func storageTierDays(tierInfo StorageTierInfo) (daysInStandard, daysInIA, daysInArchive int) {
+	iaTransitionDays := tierInfo.TransitionToIADays
+	glacierTransitionDays := tierInfo.TransitionToGlacierDays
+	expirationDays := tierInfo.ExpirationDays
+
+	firstTransitionDays := expirationDays
+	if iaTransitionDays > 0 {
+		firstTransitionDays = iaTransitionDays
+	} else if glacierTransitionDays > 0 {
+		firstTransitionDays = glacierTransitionDays
+	}
+	daysInStandard = min(expirationDays, firstTransitionDays)
+
+	if iaTransitionDays > 0 {
+		iaEndDays := expirationDays
+		if glacierTransitionDays > 0 {
+			iaEndDays = glacierTransitionDays
+		}
+		daysInIA = max(0, min(expirationDays, iaEndDays)-iaTransitionDays)
+	}
+
+	if glacierTransitionDays > 0 {
+		daysInArchive = max(0, expirationDays-glacierTransitionDays)
+	}
+
+	return daysInStandard, daysInIA, daysInArchive
 }
 
 // ArtifactIncrementOptions holds the parameters for incrementing artifact upload metrics.

--- a/model/s3usage/s3usage_test.go
+++ b/model/s3usage/s3usage_test.go
@@ -244,6 +244,64 @@ func TestCalculateS3PutCostWithConfig(t *testing.T) {
 
 }
 
+func TestStorageTierDays(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		tierInfo     StorageTierInfo
+		wantStandard int
+		wantIA       int
+		wantArchive  int
+	}{
+		{
+			name: "BothIAAndGlacierTransitions",
+			tierInfo: StorageTierInfo{
+				ExpirationDays:          180,
+				TransitionToIADays:      30,
+				TransitionToGlacierDays: 90,
+			},
+			wantStandard: 30,
+			wantIA:       60,
+			wantArchive:  90,
+		},
+		{
+			name: "IATransitionOnly",
+			tierInfo: StorageTierInfo{
+				ExpirationDays:     60,
+				TransitionToIADays: 30,
+			},
+			wantStandard: 30,
+			wantIA:       30,
+			wantArchive:  0,
+		},
+		{
+			name: "GlacierTransitionOnly",
+			tierInfo: StorageTierInfo{
+				ExpirationDays:          90,
+				TransitionToGlacierDays: 30,
+			},
+			wantStandard: 30,
+			wantIA:       0,
+			wantArchive:  60,
+		},
+		{
+			name: "NoTransitions",
+			tierInfo: StorageTierInfo{
+				ExpirationDays: 30,
+			},
+			wantStandard: 30,
+			wantIA:       0,
+			wantArchive:  0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			standard, ia, archive := storageTierDays(tc.tierInfo)
+			assert.Equal(t, tc.wantStandard, standard)
+			assert.Equal(t, tc.wantIA, ia)
+			assert.Equal(t, tc.wantArchive, archive)
+		})
+	}
+}
+
 func TestCalculateS3StorageCostWithConfig(t *testing.T) {
 	validConfig := &evergreen.CostConfig{
 		S3Cost: evergreen.S3CostConfig{
@@ -258,13 +316,13 @@ func TestCalculateS3StorageCostWithConfig(t *testing.T) {
 	const GB = 1024 * 1024 * 1024
 
 	t.Run("DefaultArtifacts365Days", func(t *testing.T) {
-		// ExpirationDays=365: Standard=30, IA=60, Archive=275
-		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, 365, validConfig)
+		// ExpirationDays=365, default transitions (IA=30, Glacier=90): Standard=30, IA=60, Archive=275
+		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, StorageTierInfo{
+			ExpirationDays:          365,
+			TransitionToIADays:      30,
+			TransitionToGlacierDays: 90,
+		}, validConfig)
 		assert.Greater(t, cost, 0.0)
-		// Verify tier breakdown manually:
-		// Standard: 30 * (0.023/GB/30) * (1-0.37) = 0.023 * 0.63
-		// IA:       60 * (0.0125/GB/30) * (1-0.312) = 2 * 0.0125 * 0.688
-		// Archive:  275 * (0.004/GB/30) * (1-0.265)
 		standard := 30.0 * (0.023 / float64(GB) / 30.0) * (1 - 0.37)
 		ia := 60.0 * (0.0125 / float64(GB) / 30.0) * (1 - 0.312)
 		archive := 275.0 * (0.004 / float64(GB) / 30.0) * (1 - 0.265)
@@ -273,8 +331,12 @@ func TestCalculateS3StorageCostWithConfig(t *testing.T) {
 	})
 
 	t.Run("MongoDBMongoArtifacts90Days", func(t *testing.T) {
-		// ExpirationDays=90: Standard=30, IA=60, Archive=0
-		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, 90, validConfig)
+		// ExpirationDays=90, default transitions (IA=30, Glacier=90): Standard=30, IA=60, Archive=0
+		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, StorageTierInfo{
+			ExpirationDays:          90,
+			TransitionToIADays:      30,
+			TransitionToGlacierDays: 90,
+		}, validConfig)
 		standard := 30.0 * (0.023 / float64(GB) / 30.0) * (1 - 0.37)
 		ia := 60.0 * (0.0125 / float64(GB) / 30.0) * (1 - 0.312)
 		expected := float64(GB) * (standard + ia)
@@ -282,8 +344,12 @@ func TestCalculateS3StorageCostWithConfig(t *testing.T) {
 	})
 
 	t.Run("MongoSyncArtifacts180Days", func(t *testing.T) {
-		// ExpirationDays=180: Standard=30, IA=60, Archive=90
-		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, 180, validConfig)
+		// ExpirationDays=180, default transitions (IA=30, Glacier=90): Standard=30, IA=60, Archive=90
+		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, StorageTierInfo{
+			ExpirationDays:          180,
+			TransitionToIADays:      30,
+			TransitionToGlacierDays: 90,
+		}, validConfig)
 		standard := 30.0 * (0.023 / float64(GB) / 30.0) * (1 - 0.37)
 		ia := 60.0 * (0.0125 / float64(GB) / 30.0) * (1 - 0.312)
 		archive := 90.0 * (0.004 / float64(GB) / 30.0) * (1 - 0.265)
@@ -291,39 +357,66 @@ func TestCalculateS3StorageCostWithConfig(t *testing.T) {
 		assert.InDelta(t, expected, cost, 0.000001)
 	})
 
-	t.Run("DefaultLog60Days", func(t *testing.T) {
-		// ExpirationDays=60: Standard=30, IA=30, Archive=0
-		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, 60, validConfig)
+	t.Run("DefaultLog60DaysWithIATransition", func(t *testing.T) {
+		// ExpirationDays=60, IA=30, no glacier: Standard=30, IA=30, Archive=0
+		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, StorageTierInfo{
+			ExpirationDays:     60,
+			TransitionToIADays: 30,
+		}, validConfig)
 		standard := 30.0 * (0.023 / float64(GB) / 30.0) * (1 - 0.37)
 		ia := 30.0 * (0.0125 / float64(GB) / 30.0) * (1 - 0.312)
 		expected := float64(GB) * (standard + ia)
 		assert.InDelta(t, expected, cost, 0.000001)
 	})
 
-	t.Run("FailedLog180Days", func(t *testing.T) {
-		// ExpirationDays=180: Standard=30, IA=60, Archive=90
-		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, 180, validConfig)
-		assert.Greater(t, cost, 0.0)
+	t.Run("StandardOnlyBucket365Days", func(t *testing.T) {
+		// No tier transitions: object stays in Standard for all 365 days
+		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, StorageTierInfo{
+			ExpirationDays: 365,
+		}, validConfig)
+		standard := 365.0 * (0.023 / float64(GB) / 30.0) * (1 - 0.37)
+		expected := float64(GB) * standard
+		assert.InDelta(t, expected, cost, 0.000001)
 	})
 
-	t.Run("LongRetentionLog365Days", func(t *testing.T) {
-		// ExpirationDays=365: Standard=30, IA=60, Archive=275
-		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, 365, validConfig)
-		assert.Greater(t, cost, 0.0)
+	t.Run("NonDefaultTransitions365Days", func(t *testing.T) {
+		// IA=60, Glacier=180: Standard=60, IA=120, Archive=185
+		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, StorageTierInfo{
+			ExpirationDays:          365,
+			TransitionToIADays:      60,
+			TransitionToGlacierDays: 180,
+		}, validConfig)
+		standard := 60.0 * (0.023 / float64(GB) / 30.0) * (1 - 0.37)
+		ia := 120.0 * (0.0125 / float64(GB) / 30.0) * (1 - 0.312)
+		archive := 185.0 * (0.004 / float64(GB) / 30.0) * (1 - 0.265)
+		expected := float64(GB) * (standard + ia + archive)
+		assert.InDelta(t, expected, cost, 0.000001)
+	})
+
+	t.Run("IATransitionWithoutGlacier365Days", func(t *testing.T) {
+		// IA transition at 30 days, no glacier: Standard=30, IA=335, Archive=0
+		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, StorageTierInfo{
+			ExpirationDays:     365,
+			TransitionToIADays: 30,
+		}, validConfig)
+		standard := 30.0 * (0.023 / float64(GB) / 30.0) * (1 - 0.37)
+		ia := 335.0 * (0.0125 / float64(GB) / 30.0) * (1 - 0.312)
+		expected := float64(GB) * (standard + ia)
+		assert.InDelta(t, expected, cost, 0.000001)
 	})
 
 	t.Run("ZeroBytes", func(t *testing.T) {
-		cost := CalculateS3StorageCostWithConfig(t.Context(), 0, 365, validConfig)
+		cost := CalculateS3StorageCostWithConfig(t.Context(), 0, StorageTierInfo{ExpirationDays: 365}, validConfig)
 		assert.Equal(t, 0.0, cost)
 	})
 
 	t.Run("ZeroExpirationDays", func(t *testing.T) {
-		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, 0, validConfig)
+		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, StorageTierInfo{}, validConfig)
 		assert.Equal(t, 0.0, cost)
 	})
 
 	t.Run("NilConfig", func(t *testing.T) {
-		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, 365, nil)
+		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, StorageTierInfo{ExpirationDays: 365}, nil)
 		assert.Equal(t, 0.0, cost)
 	})
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -4323,8 +4323,8 @@ func (t *Task) calculateRuntimeCost(financeConfig evergreen.CostConfig, costData
 	t.TaskCost = CalculateTaskCost(t.TimeTaken.Seconds(), costData, financeConfig)
 }
 
-// bucketExpirationLookup resolves the S3 lifecycle expiration days for a given artifact file.
-type bucketExpirationLookup func(ctx context.Context, bucket, fileKey string) (days int, found bool)
+// bucketExpirationLookup resolves the S3 lifecycle tier info for a given artifact file.
+type bucketExpirationLookup func(ctx context.Context, bucket, fileKey string) (s3usage.StorageTierInfo, bool)
 
 // SaveS3Usage persists the task's S3 usage metrics and calculates S3 costs.
 func (t *Task) SaveS3Usage(ctx context.Context, lookup bucketExpirationLookup) error {
@@ -4346,14 +4346,16 @@ func (t *Task) SaveS3Usage(ctx context.Context, lookup bucketExpirationLookup) e
 	return UpdateOne(ctx, bson.M{"_id": t.Id}, bson.M{"$set": setFields})
 }
 
-// resolveArtifactExpirationDays looks up the expiration days for an artifact, falling back to DefaultMaxArtifactExpirationDays if no matching rule is found.
-func resolveArtifactExpirationDays(ctx context.Context, bucket, fileKey string, lookup bucketExpirationLookup, costConfig *evergreen.CostConfig) (days int, found bool) {
+// resolveArtifactStorageTierInfo returns the storage tier info for an artifact, falling back to the configured default expiration.
+func resolveArtifactStorageTierInfo(ctx context.Context, bucket, fileKey string, lookup bucketExpirationLookup, costConfig *evergreen.CostConfig) (s3usage.StorageTierInfo, bool) {
 	if lookup != nil {
-		if days, ok := lookup(ctx, bucket, fileKey); ok {
-			return days, true
+		if tierInfo, ok := lookup(ctx, bucket, fileKey); ok {
+			return tierInfo, true
 		}
 	}
-	return costConfig.S3Cost.Storage.DefaultMaxArtifactExpirationDays, false
+	return s3usage.StorageTierInfo{
+		ExpirationDays: costConfig.S3Cost.Storage.DefaultMaxArtifactExpirationDays,
+	}, false
 }
 
 // calculateS3PutCosts calculates S3 PUT costs for both artifact uploads and log uploads.
@@ -4373,7 +4375,7 @@ func (t *Task) setS3StorageCosts(ctx context.Context, lookup bucketExpirationLoo
 	}
 	for _, bucketEntry := range t.S3Usage.Artifacts.BytesByBucketAndKey {
 		for _, fileEntry := range bucketEntry.Files {
-			days, found := resolveArtifactExpirationDays(ctx, bucketEntry.Bucket, fileEntry.FileKey, lookup, costConfig)
+			tierInfo, found := resolveArtifactStorageTierInfo(ctx, bucketEntry.Bucket, fileEntry.FileKey, lookup, costConfig)
 			if !found {
 				grip.Info(ctx, message.Fields{
 					"message": "no S3 lifecycle rule found for artifact bucket, using default expiration days",
@@ -4381,7 +4383,7 @@ func (t *Task) setS3StorageCosts(ctx context.Context, lookup bucketExpirationLoo
 					"task_id": t.Id,
 				})
 			}
-			t.TaskCost.S3ArtifactStorageCost += s3usage.CalculateS3StorageCostWithConfig(ctx, fileEntry.Bytes, days, costConfig)
+			t.TaskCost.S3ArtifactStorageCost += s3usage.CalculateS3StorageCostWithConfig(ctx, fileEntry.Bytes, tierInfo, costConfig)
 		}
 	}
 }

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -5264,8 +5264,8 @@ func TestSaveS3Usage(t *testing.T) {
 				})
 				u.IncrementLogs(50, 500000)
 			},
-			lookup: func(_ context.Context, _, _ string) (int, bool) {
-				return 0, false
+			lookup: func(_ context.Context, _, _ string) (s3usage.StorageTierInfo, bool) {
+				return s3usage.StorageTierInfo{}, false
 			},
 			assertions: func(t *testing.T, dbTask *Task) {
 				assert.Equal(t, 1000, dbTask.S3Usage.Artifacts.PutRequests)
@@ -5306,8 +5306,8 @@ func TestSaveS3Usage(t *testing.T) {
 					},
 				})
 			},
-			lookup: func(_ context.Context, _, _ string) (int, bool) {
-				return 0, false
+			lookup: func(_ context.Context, _, _ string) (s3usage.StorageTierInfo, bool) {
+				return s3usage.StorageTierInfo{}, false
 			},
 			assertions: func(t *testing.T, dbTask *Task) {
 				assert.True(t, dbTask.TaskCost.S3ArtifactStorageCost > 0)
@@ -5339,12 +5339,25 @@ func TestSaveS3Usage(t *testing.T) {
 					Files:       singleFileArtifact,
 				})
 			},
-			lookup: func(_ context.Context, _, _ string) (int, bool) {
-				return 90, true
+			lookup: func(_ context.Context, _, _ string) (s3usage.StorageTierInfo, bool) {
+				return s3usage.StorageTierInfo{
+					ExpirationDays:          90,
+					TransitionToIADays:      30,
+					TransitionToGlacierDays: 90,
+				}, true
 			},
 			assertions: func(t *testing.T, dbTask *Task) {
 				assert.True(t, dbTask.TaskCost.S3ArtifactStorageCost > 0)
-				expectedCost := s3usage.CalculateS3StorageCostWithConfig(ctx, 5*1024*1024, 90, &defaultCostConfig)
+				expectedCost := s3usage.CalculateS3StorageCostWithConfig(
+					ctx,
+					5*1024*1024,
+					s3usage.StorageTierInfo{
+						ExpirationDays:          90,
+						TransitionToIADays:      30,
+						TransitionToGlacierDays: 90,
+					},
+					&defaultCostConfig,
+				)
 				assert.InDelta(t, expectedCost, dbTask.TaskCost.S3ArtifactStorageCost, 0.0001)
 			},
 		},
@@ -5359,12 +5372,17 @@ func TestSaveS3Usage(t *testing.T) {
 					Files:       singleFileArtifact,
 				})
 			},
-			lookup: func(_ context.Context, _, _ string) (int, bool) {
-				return 0, false
+			lookup: func(_ context.Context, _, _ string) (s3usage.StorageTierInfo, bool) {
+				return s3usage.StorageTierInfo{}, false
 			},
 			assertions: func(t *testing.T, dbTask *Task) {
 				assert.True(t, dbTask.TaskCost.S3ArtifactStorageCost > 0)
-				expectedCost := s3usage.CalculateS3StorageCostWithConfig(ctx, 5*1024*1024, 365, &defaultCostConfig)
+				expectedCost := s3usage.CalculateS3StorageCostWithConfig(
+					ctx,
+					5*1024*1024,
+					s3usage.StorageTierInfo{ExpirationDays: 365},
+					&defaultCostConfig,
+				)
 				assert.InDelta(t, expectedCost, dbTask.TaskCost.S3ArtifactStorageCost, 0.0001)
 			},
 		},

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -699,26 +699,40 @@ func discoverAndCacheBucketLifecycleRules(ctx context.Context, t *task.Task, fil
 	}
 }
 
-// findExpirationDaysForFileKey returns the expiration days from the most specific lifecycle rule
-// for the given file key.
-func findExpirationDaysForFileKey(rules []s3lifecycle.S3LifecycleRuleDoc, fileKey string) (days int, found bool) {
+// findLifecycleTierInfoForFileKey returns the storage tier info from the most specific lifecycle rule for the given file key.
+func findLifecycleTierInfoForFileKey(rules []s3lifecycle.S3LifecycleRuleDoc, fileKey string) (s3usage.StorageTierInfo, bool) {
 	pailRules := make([]pail.LifecycleRule, 0, len(rules))
 	for _, ruleDoc := range rules {
-		var expDays *int32
+		var expDays, iaDays, glacierDays *int32
 		if ruleDoc.ExpirationDays != nil {
 			expDays = utility.ToInt32Ptr(int32(*ruleDoc.ExpirationDays))
 		}
+		if ruleDoc.TransitionToIADays != nil {
+			iaDays = utility.ToInt32Ptr(int32(*ruleDoc.TransitionToIADays))
+		}
+		if ruleDoc.TransitionToGlacierDays != nil {
+			glacierDays = utility.ToInt32Ptr(int32(*ruleDoc.TransitionToGlacierDays))
+		}
 		pailRules = append(pailRules, pail.LifecycleRule{
-			Prefix:         ruleDoc.FilterPrefix,
-			Status:         ruleDoc.RuleStatus,
-			ExpirationDays: expDays,
+			Prefix:                  ruleDoc.FilterPrefix,
+			Status:                  ruleDoc.RuleStatus,
+			ExpirationDays:          expDays,
+			TransitionToIADays:      iaDays,
+			TransitionToGlacierDays: glacierDays,
 		})
 	}
 	rule := pail.FindMatchingRule(pailRules, fileKey)
 	if rule == nil || rule.ExpirationDays == nil {
-		return 0, false
+		return s3usage.StorageTierInfo{}, false
 	}
-	return int(*rule.ExpirationDays), true
+	tierInfo := s3usage.StorageTierInfo{ExpirationDays: int(*rule.ExpirationDays)}
+	if rule.TransitionToIADays != nil {
+		tierInfo.TransitionToIADays = int(*rule.TransitionToIADays)
+	}
+	if rule.TransitionToGlacierDays != nil {
+		tierInfo.TransitionToGlacierDays = int(*rule.TransitionToGlacierDays)
+	}
+	return tierInfo, true
 }
 
 // POST /rest/v2/task/{task_id}/s3_usage
@@ -753,20 +767,25 @@ func (h *reportS3UsageHandler) Run(ctx context.Context) gimlet.Responder {
 
 	t.S3Usage = h.s3Usage
 
-	allRules, err := s3lifecycle.FindAllRules(ctx)
-	var lookup func(ctx context.Context, bucket, fileKey string) (int, bool)
-	if err != nil {
-		grip.Warning(ctx, message.WrapError(err, message.Fields{
-			"message": "getting S3 lifecycle rules for storage cost calculation, skipping storage cost calculation",
+	rulesByBucket := map[string][]s3lifecycle.S3LifecycleRuleDoc{}
+	var rulesErr error
+	for _, bucketEntry := range t.S3Usage.Artifacts.BytesByBucketAndKey {
+		rules, err := s3lifecycle.FindAllRulesForBucket(ctx, bucketEntry.Bucket)
+		if err != nil {
+			rulesErr = err
+			break
+		}
+		rulesByBucket[bucketEntry.Bucket] = rules
+	}
+	var lookup func(ctx context.Context, bucket, fileKey string) (s3usage.StorageTierInfo, bool)
+	if rulesErr != nil {
+		grip.Debug(ctx, message.WrapError(rulesErr, message.Fields{
+			"message": "getting S3 lifecycle rules for storage cost calculation",
 			"task_id": t.Id,
 		}))
 	} else {
-		rulesByBucket := map[string][]s3lifecycle.S3LifecycleRuleDoc{}
-		for _, rule := range allRules {
-			rulesByBucket[rule.BucketName] = append(rulesByBucket[rule.BucketName], rule)
-		}
-		lookup = func(ctx context.Context, bucket, fileKey string) (int, bool) {
-			return findExpirationDaysForFileKey(rulesByBucket[bucket], fileKey)
+		lookup = func(ctx context.Context, bucket, fileKey string) (s3usage.StorageTierInfo, bool) {
+			return findLifecycleTierInfoForFileKey(rulesByBucket[bucket], fileKey)
 		}
 	}
 
@@ -776,9 +795,9 @@ func (h *reportS3UsageHandler) Run(ctx context.Context) gimlet.Responder {
 
 	v, err := model.VersionFindOneId(ctx, t.Version)
 	if err != nil {
-		grip.Error(ctx, errors.Wrapf(err, "finding version '%s' to update aggregate task costs", t.Version))
+		grip.Debug(ctx, errors.Wrapf(err, "finding version '%s' to update aggregate task costs", t.Version))
 	} else if v != nil && evergreen.IsFinishedVersionStatus(v.Status) {
-		grip.Error(ctx, errors.Wrapf(v.UpdateAggregateTaskCosts(ctx), "updating aggregate task costs for version '%s' after S3 usage report", v.Id))
+		grip.Debug(ctx, errors.Wrapf(v.UpdateAggregateTaskCosts(ctx), "updating aggregate task costs for version '%s' after S3 usage report", v.Id))
 	}
 
 	var avgFilePutCost, maxFilePutCost, minFilePutCost float64

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -1145,14 +1145,17 @@ func TestReportS3Usage(t *testing.T) {
 	}
 }
 
-func TestFindExpirationDaysForFileKey(t *testing.T) {
+func TestFindLifecycleTierInfoForFileKey(t *testing.T) {
 	enabled := "Enabled"
 	disabled := "Disabled"
+	days365 := 365
 	days90 := 90
 	days30 := 30
+	iaDays60 := 60
+	glacierDays180 := 180
 
 	t.Run("NoRulesShouldReturnNotFound", func(t *testing.T) {
-		_, ok := findExpirationDaysForFileKey(nil, "logs/build/output.txt")
+		_, ok := findLifecycleTierInfoForFileKey(nil, "logs/build/output.txt")
 		assert.False(t, ok)
 	})
 
@@ -1160,17 +1163,34 @@ func TestFindExpirationDaysForFileKey(t *testing.T) {
 		rules := []s3lifecycle.S3LifecycleRuleDoc{
 			{FilterPrefix: "sandbox/", RuleStatus: enabled, ExpirationDays: &days90},
 		}
-		_, ok := findExpirationDaysForFileKey(rules, "logs/build/output.txt")
+		_, ok := findLifecycleTierInfoForFileKey(rules, "logs/build/output.txt")
 		assert.False(t, ok)
 	})
 
-	t.Run("MatchingPrefixShouldReturnDays", func(t *testing.T) {
+	t.Run("MatchingPrefixShouldReturnExpirationDays", func(t *testing.T) {
 		rules := []s3lifecycle.S3LifecycleRuleDoc{
 			{FilterPrefix: "logs/", RuleStatus: enabled, ExpirationDays: &days90},
 		}
-		days, ok := findExpirationDaysForFileKey(rules, "logs/build/output.txt")
+		tierInfo, ok := findLifecycleTierInfoForFileKey(rules, "logs/build/output.txt")
 		assert.True(t, ok)
-		assert.Equal(t, 90, days)
+		assert.Equal(t, 90, tierInfo.ExpirationDays)
+	})
+
+	t.Run("MatchingPrefixShouldReturnTransitionDays", func(t *testing.T) {
+		rules := []s3lifecycle.S3LifecycleRuleDoc{
+			{
+				FilterPrefix:            "artifacts/",
+				RuleStatus:              enabled,
+				ExpirationDays:          &days365,
+				TransitionToIADays:      &iaDays60,
+				TransitionToGlacierDays: &glacierDays180,
+			},
+		}
+		tierInfo, ok := findLifecycleTierInfoForFileKey(rules, "artifacts/build/binary.tar.gz")
+		assert.True(t, ok)
+		assert.Equal(t, 365, tierInfo.ExpirationDays)
+		assert.Equal(t, 60, tierInfo.TransitionToIADays)
+		assert.Equal(t, 180, tierInfo.TransitionToGlacierDays)
 	})
 
 	t.Run("MostSpecificPrefixShouldWin", func(t *testing.T) {
@@ -1178,16 +1198,16 @@ func TestFindExpirationDaysForFileKey(t *testing.T) {
 			{FilterPrefix: "logs/", RuleStatus: enabled, ExpirationDays: &days90},
 			{FilterPrefix: "logs/build/", RuleStatus: enabled, ExpirationDays: &days30},
 		}
-		days, ok := findExpirationDaysForFileKey(rules, "logs/build/output.txt")
+		tierInfo, ok := findLifecycleTierInfoForFileKey(rules, "logs/build/output.txt")
 		assert.True(t, ok)
-		assert.Equal(t, 30, days)
+		assert.Equal(t, 30, tierInfo.ExpirationDays)
 	})
 
 	t.Run("DisabledRuleShouldBeIgnored", func(t *testing.T) {
 		rules := []s3lifecycle.S3LifecycleRuleDoc{
 			{FilterPrefix: "logs/", RuleStatus: disabled, ExpirationDays: &days90},
 		}
-		_, ok := findExpirationDaysForFileKey(rules, "logs/build/output.txt")
+		_, ok := findLifecycleTierInfoForFileKey(rules, "logs/build/output.txt")
 		assert.False(t, ok)
 	})
 
@@ -1195,7 +1215,7 @@ func TestFindExpirationDaysForFileKey(t *testing.T) {
 		rules := []s3lifecycle.S3LifecycleRuleDoc{
 			{FilterPrefix: "logs/", RuleStatus: enabled, ExpirationDays: nil},
 		}
-		_, ok := findExpirationDaysForFileKey(rules, "logs/build/output.txt")
+		_, ok := findLifecycleTierInfoForFileKey(rules, "logs/build/output.txt")
 		assert.False(t, ok)
 	})
 }


### PR DESCRIPTION
DEVPROD-31472

### Description
Currently S3 cost calculations are done using some hard coded values and do not use correct S3 Bucket rules. This is incorrect. We should be calculating the cost correctly based on how much time each item spends across the various storage tiers in AWS. This information is all available in the bucket rules and can be used to calculate the cost correctly. 

### Testing
Added test cases for coverage and all pass
