### PR TITLE
DEVPROD-26466: Calculate and Save S3 Logs Storage cost to task

### DIFF
--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -576,7 +576,7 @@ retryLoop:
 	)
 
 	maxPuts, minPuts := computePerFileExtremes(uploadedFiles)
-	conf.S3Usage.IncrementArtifacts(s3usage.ArtifactIncrementOptions{
+	conf.S3Usage.IncrementArtifacts(s3usage.ArtifactUpload{
 		PutRequests: totalPutRequests,
 		UploadBytes: totalFileSize,
 		FileCount:   len(uploadedFiles),

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-04-14"
+	AgentVersion = "2026-04-14a"
 )
 
 const (

--- a/globals.go
+++ b/globals.go
@@ -512,8 +512,9 @@ const (
 	TaskEBSOnDemandStorageCostOtelAttribute = "evergreen.task.cost.ebs.on_demand_storage_cost"
 	TaskEBSAdjustedStorageCostOtelAttribute = "evergreen.task.cost.ebs.adjusted_storage_cost"
 
-	// S3 cost tracking otel span name — shared by per-file and aggregate events
-	S3CostTrackingOtelSpanName = "s3-cost-tracking"
+	// S3 cost tracking otel span name and top-level attributes
+	S3CostTrackingOtelSpanName    = "s3-cost-tracking"
+	S3CostCalculatedOtelAttribute = "evergreen.task.s3_cost.cost_calculated"
 
 	// S3 cost tracking otel attributes — artifact aggregates
 	S3ArtifactPutRequestsOtelAttribute = "evergreen.task.s3_cost.artifact_put_requests"
@@ -526,11 +527,18 @@ const (
 	S3ArtifactAvgFilePutCostOtelAttribute         = "evergreen.task.s3_cost.artifact_avg_file_put_cost"
 	S3ArtifactWithMaxPutRequestsCostOtelAttribute = "evergreen.task.s3_cost.artifact_with_max_put_requests_cost"
 	S3ArtifactWithMinPutRequestsCostOtelAttribute = "evergreen.task.s3_cost.artifact_with_min_put_requests_cost"
+	S3ArtifactAvgStorageCostOtelAttribute         = "evergreen.task.s3_cost.artifact_avg_storage_cost"
+	S3ArtifactMinStorageCostOtelAttribute         = "evergreen.task.s3_cost.artifact_min_storage_cost"
+	S3ArtifactMaxStorageCostOtelAttribute         = "evergreen.task.s3_cost.artifact_max_storage_cost"
 
 	// S3 cost tracking otel attributes — log aggregates
-	S3LogPutRequestsOtelAttribute = "evergreen.task.s3_cost.log_put_requests"
-	S3LogUploadBytesOtelAttribute = "evergreen.task.s3_cost.log_upload_bytes"
-	S3LogPutCostOtelAttribute     = "evergreen.task.s3_cost.log_put_cost"
+	S3LogPutRequestsOtelAttribute    = "evergreen.task.s3_cost.log_put_requests"
+	S3LogUploadBytesOtelAttribute    = "evergreen.task.s3_cost.log_upload_bytes"
+	S3LogPutCostOtelAttribute        = "evergreen.task.s3_cost.log_put_cost"
+	S3LogStorageCostOtelAttribute    = "evergreen.task.s3_cost.log_storage_cost"
+	S3LogAvgStorageCostOtelAttribute = "evergreen.task.s3_cost.log_avg_storage_cost"
+	S3LogMinStorageCostOtelAttribute = "evergreen.task.s3_cost.log_min_storage_cost"
+	S3LogMaxStorageCostOtelAttribute = "evergreen.task.s3_cost.log_max_storage_cost"
 
 	// display task otel attributes
 	DisplayTaskIDOtelAttribute   = "evergreen.display_task.id"

--- a/model/cost/cost.go
+++ b/model/cost/cost.go
@@ -8,6 +8,7 @@ var (
 	S3ArtifactPutCostKey     = bsonutil.MustHaveTag(Cost{}, "S3ArtifactPutCost")
 	S3LogPutCostKey          = bsonutil.MustHaveTag(Cost{}, "S3LogPutCost")
 	S3ArtifactStorageCostKey = bsonutil.MustHaveTag(Cost{}, "S3ArtifactStorageCost")
+	S3LogStorageCostKey      = bsonutil.MustHaveTag(Cost{}, "S3LogStorageCost")
 )
 
 // Cost represents a cost breakdown for tasks and versions
@@ -30,6 +31,8 @@ type Cost struct {
 	S3LogPutCost float64 `bson:"s3_log_put_cost,omitempty" json:"s3_log_put_cost,omitempty"`
 	// S3ArtifactStorageCost is the calculated S3 storage cost for artifact bytes over their retention period.
 	S3ArtifactStorageCost float64 `bson:"s3_artifact_storage_cost,omitempty" json:"s3_artifact_storage_cost,omitempty"`
+	// S3LogStorageCost is the calculated S3 storage cost for log bytes over their retention period.
+	S3LogStorageCost float64 `bson:"s3_log_storage_cost,omitempty" json:"s3_log_storage_cost,omitempty"`
 }
 
 // IsZero returns true if all cost components are zero.
@@ -42,5 +45,6 @@ func (c Cost) IsZero() bool {
 		c.AdjustedEBSStorageCost == 0 &&
 		c.S3ArtifactPutCost == 0 &&
 		c.S3LogPutCost == 0 &&
-		c.S3ArtifactStorageCost == 0
+		c.S3ArtifactStorageCost == 0 &&
+		c.S3LogStorageCost == 0
 }

--- a/model/s3lifecycle/s3_lifecycle.go
+++ b/model/s3lifecycle/s3_lifecycle.go
@@ -8,6 +8,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/s3usage"
 	"github.com/evergreen-ci/pail"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/anser/bsonutil"
@@ -20,14 +21,10 @@ import (
 
 const (
 	Collection = "s3_lifecycle_rules"
-)
 
-const (
 	BucketTypeAdminManaged  = "admin_managed"
 	BucketTypeUserSpecified = "user_specified"
-)
 
-const (
 	AdminBucketCategoryLog              = "log"
 	AdminBucketCategoryLogLongRetention = "log_long_retention"
 	AdminBucketCategoryLogFailedTasks   = "log_failed_tasks"
@@ -64,7 +61,6 @@ func DiscoverAdminManagedBuckets(ctx context.Context, settings *evergreen.Settin
 	buckets := make(map[string]BucketInfo)
 	bucketsConfig := settings.Buckets
 
-	// Admin-managed buckets
 	adminBuckets := []evergreen.BucketConfig{
 		bucketsConfig.LogBucket,
 		bucketsConfig.LogBucketLongRetention,
@@ -168,7 +164,7 @@ func DiscoverAndCacheProjectBucket(ctx context.Context, bucketName, region strin
 	return true
 }
 
-// convertPailTransitions converts pail.Transition to s3lifecycle.Transition.
+// convertPailTransitions converts pail.Transition to Transition.
 func convertPailTransitions(pailTransitions []pail.Transition) []Transition {
 	transitions := make([]Transition, 0, len(pailTransitions))
 	for _, pt := range pailTransitions {
@@ -352,4 +348,57 @@ func UpdateSyncError(ctx context.Context, bucketName, filterPrefix, syncError st
 		"updating sync error for bucket '%s' prefix '%s'",
 		bucketName, filterPrefix,
 	)
+}
+
+// BuildTierInfoByKey fetches all S3 lifecycle rules and resolves StorageTierInfo for every artifact and log file key in the given S3 usage data.
+func BuildTierInfoByKey(ctx context.Context, usage s3usage.S3Usage, logBucketName string, costConfig *evergreen.CostConfig) (map[string]s3usage.StorageTierInfo, error) {
+	if costConfig == nil {
+		return nil, errors.New("cost config is required to resolve storage tier info")
+	}
+
+	allRules, err := FindAllRules(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting S3 lifecycle rules")
+	}
+
+	rulesByBucket := map[string][]S3LifecycleRuleDoc{}
+	for _, rule := range allRules {
+		rulesByBucket[rule.BucketName] = append(rulesByBucket[rule.BucketName], rule)
+	}
+
+	defaultTierInfo := s3usage.StorageTierInfo{ExpirationDays: costConfig.S3Cost.Storage.DefaultMaxArtifactExpirationDays}
+
+	tierInfoByKey := map[string]s3usage.StorageTierInfo{}
+	for _, f := range usage.Artifacts.AllFiles() {
+		tierInfoByKey[f.FileKey] = findLifecycleTierInfoForFileKey(rulesByBucket[f.Bucket], f.FileKey, defaultTierInfo)
+	}
+	for _, lm := range []s3usage.LogTypeMetrics{usage.Logs.Task, usage.Logs.Agent, usage.Logs.System} {
+		if lm.LogKey == "" {
+			continue
+		}
+		tierInfoByKey[lm.LogKey] = findLifecycleTierInfoForFileKey(rulesByBucket[logBucketName], lm.LogKey, defaultTierInfo)
+	}
+	return tierInfoByKey, nil
+}
+
+// findLifecycleTierInfoForFileKey returns the storage tier info from the most specific matching lifecycle rule for the given file key,
+// or defaultTierInfo if no matching rule is found.
+func findLifecycleTierInfoForFileKey(rules []S3LifecycleRuleDoc, fileKey string, defaultTierInfo s3usage.StorageTierInfo) s3usage.StorageTierInfo {
+	pailRules := make([]pail.LifecycleRule, 0, len(rules))
+	for _, rule := range rules {
+		var expDays *int32
+		if rule.ExpirationDays != nil {
+			expDays = utility.ToInt32Ptr(int32(*rule.ExpirationDays))
+		}
+		pailRules = append(pailRules, pail.LifecycleRule{
+			Prefix:         rule.FilterPrefix,
+			Status:         rule.RuleStatus,
+			ExpirationDays: expDays,
+		})
+	}
+	matched := pail.FindMatchingRule(pailRules, fileKey)
+	if matched == nil || matched.ExpirationDays == nil {
+		return defaultTierInfo
+	}
+	return s3usage.StorageTierInfo{ExpirationDays: int(*matched.ExpirationDays)}
 }

--- a/model/s3lifecycle/s3_lifecycle_test.go
+++ b/model/s3lifecycle/s3_lifecycle_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/s3usage"
 	_ "github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/pail"
 	"github.com/pkg/errors"
@@ -16,7 +17,7 @@ import (
 
 func ptr[T any](v T) *T { return &v }
 
-func TestS3LifecycleRuleDoc_Upsert(t *testing.T) {
+func TestS3LifecycleRuleDocUpsert(t *testing.T) {
 	require.NoError(t, db.Clear(Collection))
 	now := time.Now().Truncate(time.Second)
 
@@ -47,18 +48,19 @@ func TestS3LifecycleRuleDoc_Upsert(t *testing.T) {
 	assert.Equal(t, doc.RuleID, found.RuleID)
 	assert.Equal(t, now.Unix(), found.LastSyncedAt.Unix())
 
-	// Test update
 	doc.ProjectAssociations = []string{"proj1", "proj2", "proj3"}
 	doc.ExpirationDays = ptr(90)
 	require.NoError(t, doc.Upsert(t.Context()))
 
 	found, err = FindByBucketAndPrefix(t.Context(), "test-bucket", "logs/")
 	require.NoError(t, err)
+	require.NotNil(t, found)
 	assert.Equal(t, []string{"proj1", "proj2", "proj3"}, found.ProjectAssociations)
+	require.NotNil(t, found.ExpirationDays)
 	assert.Equal(t, 90, *found.ExpirationDays)
 }
 
-func TestS3LifecycleRuleDoc_UpsertEmptyBucketName(t *testing.T) {
+func TestS3LifecycleRuleDocUpsertEmptyBucketName(t *testing.T) {
 	err := (&S3LifecycleRuleDoc{BucketName: "", BucketType: BucketTypeAdminManaged}).Upsert(t.Context())
 	assert.ErrorContains(t, err, "bucket name cannot be empty")
 }
@@ -71,19 +73,19 @@ func TestMakeRuleID(t *testing.T) {
 		expected     string
 	}{
 		{
-			name:         "with prefix",
+			name:         "WithPrefix",
 			bucketName:   "mciuploads",
 			filterPrefix: "sandbox/",
 			expected:     "mciuploads#sandbox/",
 		},
 		{
-			name:         "empty prefix (default rule)",
+			name:         "EmptyPrefixDefaultRule",
 			bucketName:   "mciuploads",
 			filterPrefix: "",
 			expected:     "mciuploads#",
 		},
 		{
-			name:         "multi-level prefix",
+			name:         "MultiLevelPrefix",
 			bucketName:   "mciuploads",
 			filterPrefix: "lifecycle/sandbox/",
 			expected:     "mciuploads#lifecycle/sandbox/",
@@ -155,7 +157,7 @@ func TestFindAllRulesForBucket(t *testing.T) {
 			assert.ErrorContains(t, err, tt.wantErr)
 		} else {
 			require.NoError(t, err)
-			assert.Len(t, found, tt.wantCount)
+			require.Len(t, found, tt.wantCount)
 			if tt.wantRuleID != "" {
 				assert.Equal(t, tt.wantRuleID, found[0].RuleID)
 			}
@@ -206,7 +208,7 @@ func TestDiscoverAdminManagedBuckets(t *testing.T) {
 		checkBucket func(t *testing.T, buckets map[string]BucketInfo)
 	}{
 		{
-			name: "basic discovery with role ARN",
+			name: "BasicDiscoveryWithRoleARN",
 			config: evergreen.BucketsConfig{
 				LogBucket:              evergreen.BucketConfig{Name: "log-bucket", Type: evergreen.BucketTypeS3, RoleARN: roleARN},
 				LogBucketLongRetention: evergreen.BucketConfig{Name: "retention-bucket", Type: evergreen.BucketTypeS3},
@@ -222,7 +224,7 @@ func TestDiscoverAdminManagedBuckets(t *testing.T) {
 			},
 		},
 		{
-			name: "skips non-S3 buckets",
+			name: "SkipsNonS3Buckets",
 			config: evergreen.BucketsConfig{
 				LogBucket:              evergreen.BucketConfig{Name: "gridfs", Type: evergreen.BucketTypeGridFS},
 				LogBucketLongRetention: evergreen.BucketConfig{Name: "s3-bucket", Type: evergreen.BucketTypeS3},
@@ -234,7 +236,7 @@ func TestDiscoverAdminManagedBuckets(t *testing.T) {
 			},
 		},
 		{
-			name: "skips empty names",
+			name: "SkipsEmptyNames",
 			config: evergreen.BucketsConfig{
 				LogBucket:              evergreen.BucketConfig{Name: "", Type: evergreen.BucketTypeS3},
 				LogBucketLongRetention: evergreen.BucketConfig{Name: "valid-bucket", Type: evergreen.BucketTypeS3},
@@ -245,7 +247,7 @@ func TestDiscoverAdminManagedBuckets(t *testing.T) {
 			},
 		},
 		{
-			name: "errors with no valid buckets",
+			name: "ErrorsWithNoValidBuckets",
 			config: evergreen.BucketsConfig{
 				LogBucket:              evergreen.BucketConfig{Name: "", Type: evergreen.BucketTypeS3},
 				LogBucketLongRetention: evergreen.BucketConfig{Name: "", Type: evergreen.BucketTypeGridFS},
@@ -273,7 +275,7 @@ func TestDiscoverAdminManagedBuckets(t *testing.T) {
 	}
 }
 
-// mockS3LifecycleClient is a mock implementation of cloud.S3LifecycleClient for testing.
+// mockS3LifecycleClient is a mock implementation of cloud.S3LifecycleClient.
 type mockS3LifecycleClient struct {
 	rules []pail.LifecycleRule
 	err   error
@@ -308,7 +310,7 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 		}
 
 		discovered := DiscoverAndCacheProjectBucket(t.Context(), "test-bucket", "us-east-1", nil, nil, "test-project", mockClient)
-		assert.True(t, discovered, "should trigger discovery for new bucket")
+		assert.True(t, discovered)
 
 		rules, err := FindAllRulesForBucket(t.Context(), "test-bucket")
 		require.NoError(t, err)
@@ -320,12 +322,14 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 		assert.Equal(t, "test-bucket#sandbox/", sandboxRule.ID)
 		assert.Equal(t, BucketTypeUserSpecified, sandboxRule.BucketType)
 		assert.Equal(t, []string{"test-project"}, sandboxRule.ProjectAssociations)
+		require.NotNil(t, sandboxRule.ExpirationDays)
 		assert.Equal(t, 30, *sandboxRule.ExpirationDays)
 
 		defaultRule, err := FindByBucketAndPrefix(t.Context(), "test-bucket", "")
 		require.NoError(t, err)
 		require.NotNil(t, defaultRule)
 		assert.Equal(t, "test-bucket#", defaultRule.ID)
+		require.NotNil(t, defaultRule.ExpirationDays)
 		assert.Equal(t, 90, *defaultRule.ExpirationDays)
 	})
 
@@ -348,11 +352,11 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 		}
 
 		discovered := DiscoverAndCacheProjectBucket(t.Context(), "cached-bucket", "us-east-1", nil, nil, "test-project", mockClient)
-		assert.False(t, discovered, "should skip discovery for cached bucket")
+		assert.False(t, discovered)
 
 		rules, err := FindAllRulesForBucket(t.Context(), "cached-bucket")
 		require.NoError(t, err)
-		assert.Len(t, rules, 1)
+		require.Len(t, rules, 1)
 		assert.Equal(t, "existing-rule", rules[0].RuleID)
 	})
 
@@ -364,7 +368,7 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 		}
 
 		discovered := DiscoverAndCacheProjectBucket(t.Context(), "error-bucket", "us-east-1", nil, nil, "test-project", mockClient)
-		assert.True(t, discovered, "should return true even if AWS call fails")
+		assert.False(t, discovered)
 
 		rules, err := FindAllRulesForBucket(t.Context(), "error-bucket")
 		require.NoError(t, err)
@@ -379,10 +383,63 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 		}
 
 		discovered := DiscoverAndCacheProjectBucket(t.Context(), "empty-bucket", "us-east-1", nil, nil, "test-project", mockClient)
-		assert.True(t, discovered, "should trigger discovery even if no rules returned")
+		assert.True(t, discovered)
 
 		rules, err := FindAllRulesForBucket(t.Context(), "empty-bucket")
 		require.NoError(t, err)
 		assert.Len(t, rules, 0)
+	})
+}
+
+func TestFindLifecycleTierInfoForFileKey(t *testing.T) {
+	enabled := "Enabled"
+	disabled := "Disabled"
+	defaultTierInfo := s3usage.StorageTierInfo{ExpirationDays: 365}
+	noMatch := s3usage.StorageTierInfo{}
+
+	t.Run("NoRulesShouldReturnDefault", func(t *testing.T) {
+		result := findLifecycleTierInfoForFileKey(nil, "logs/build/output.txt", defaultTierInfo)
+		assert.Equal(t, defaultTierInfo, result)
+	})
+
+	t.Run("NoMatchingPrefixShouldReturnDefault", func(t *testing.T) {
+		rules := []S3LifecycleRuleDoc{
+			{FilterPrefix: "sandbox/", RuleStatus: enabled, ExpirationDays: ptr(90)},
+		}
+		result := findLifecycleTierInfoForFileKey(rules, "logs/build/output.txt", defaultTierInfo)
+		assert.Equal(t, defaultTierInfo, result)
+	})
+
+	t.Run("MatchingPrefixShouldReturnExpirationDays", func(t *testing.T) {
+		rules := []S3LifecycleRuleDoc{
+			{FilterPrefix: "logs/", RuleStatus: enabled, ExpirationDays: ptr(90)},
+		}
+		result := findLifecycleTierInfoForFileKey(rules, "logs/build/output.txt", noMatch)
+		assert.Equal(t, 90, result.ExpirationDays)
+	})
+
+	t.Run("MostSpecificPrefixShouldWin", func(t *testing.T) {
+		rules := []S3LifecycleRuleDoc{
+			{FilterPrefix: "logs/", RuleStatus: enabled, ExpirationDays: ptr(90)},
+			{FilterPrefix: "logs/build/", RuleStatus: enabled, ExpirationDays: ptr(30)},
+		}
+		result := findLifecycleTierInfoForFileKey(rules, "logs/build/output.txt", noMatch)
+		assert.Equal(t, 30, result.ExpirationDays)
+	})
+
+	t.Run("DisabledRuleShouldReturnDefault", func(t *testing.T) {
+		rules := []S3LifecycleRuleDoc{
+			{FilterPrefix: "logs/", RuleStatus: disabled, ExpirationDays: ptr(90)},
+		}
+		result := findLifecycleTierInfoForFileKey(rules, "logs/build/output.txt", defaultTierInfo)
+		assert.Equal(t, defaultTierInfo, result)
+	})
+
+	t.Run("NilExpirationDaysShouldReturnDefault", func(t *testing.T) {
+		rules := []S3LifecycleRuleDoc{
+			{FilterPrefix: "logs/", RuleStatus: enabled, ExpirationDays: nil},
+		}
+		result := findLifecycleTierInfoForFileKey(rules, "logs/build/output.txt", defaultTierInfo)
+		assert.Equal(t, defaultTierInfo, result)
 	})
 }

--- a/model/s3usage/s3usage.go
+++ b/model/s3usage/s3usage.go
@@ -2,6 +2,7 @@ package s3usage
 
 import (
 	"context"
+	"math"
 	"os"
 
 	"github.com/evergreen-ci/evergreen"
@@ -12,13 +13,27 @@ import (
 // S3Usage tracks S3 API usage for cost calculation.
 type S3Usage struct {
 	Artifacts ArtifactMetrics `bson:"artifacts,omitempty" json:"artifacts,omitempty"`
-	Logs      S3UploadMetrics `bson:"logs,omitempty" json:"logs,omitempty"`
+	Logs      LogMetrics      `bson:"logs,omitempty" json:"logs,omitempty"`
 }
 
 // S3UploadMetrics tracks common S3 upload metrics shared across upload types.
 type S3UploadMetrics struct {
 	PutRequests int   `bson:"put_requests,omitempty" json:"put_requests,omitempty"`
 	UploadBytes int64 `bson:"upload_bytes,omitempty" json:"upload_bytes,omitempty"`
+}
+
+// LogMetrics tracks aggregate log upload metrics and per-type breakdown.
+type LogMetrics struct {
+	S3UploadMetrics `bson:",inline"`
+	Task            LogTypeMetrics `bson:"task_log,omitempty" json:"task_log,omitempty"`
+	Agent           LogTypeMetrics `bson:"agent_log,omitempty" json:"agent_log,omitempty"`
+	System          LogTypeMetrics `bson:"system_log,omitempty" json:"system_log,omitempty"`
+}
+
+// LogTypeMetrics tracks upload bytes and S3 key for a single log type.
+type LogTypeMetrics struct {
+	LogKey string `bson:"log_key,omitempty" json:"log_key,omitempty"`
+	Bytes  int64  `bson:"bytes,omitempty" json:"bytes,omitempty"`
 }
 
 // BucketFileMetrics groups per-file byte metrics for a single S3 bucket.
@@ -54,10 +69,54 @@ type FileMetrics struct {
 	PutRequests   int
 }
 
+// BucketFile is a flat representation of a single artifact file with its bucket.
+type BucketFile struct {
+	Bucket  string
+	FileKey string
+	Bytes   int64
+}
+
+// ArtifactUpload holds the metrics for a single artifact upload event.
+type ArtifactUpload struct {
+	PutRequests int
+	UploadBytes int64
+	FileCount   int
+	MaxPuts     int
+	MinPuts     int
+	Bucket      string
+	Files       []FileMetrics
+}
+
+// StorageTierInfo holds the S3 lifecycle expiration configuration for a bucket rule.
+type StorageTierInfo struct {
+	ExpirationDays int
+}
+
+// S3Costs holds the calculated S3 cost breakdown for a task.
+type S3Costs struct {
+	ArtifactPutCost        float64
+	LogPutCost             float64
+	ArtifactStorageCost    float64
+	LogStorageCost         float64
+	AvgFilePutCost         float64
+	MaxFilePutCost         float64
+	MinFilePutCost         float64
+	AvgArtifactStorageCost float64
+	MinArtifactStorageCost float64
+	MaxArtifactStorageCost float64
+	AvgLogStorageCost      float64
+	MinLogStorageCost      float64
+	MaxLogStorageCost      float64
+}
+
 type S3BucketType string
 type S3UploadMethod string
 
 const (
+	LogTypeTask   = "task_log"
+	LogTypeAgent  = "agent_log"
+	LogTypeSystem = "system_log"
+
 	S3PutRequestCost = 0.000005
 	S3PartSize       = 5 * 1024 * 1024 // 5 MB in bytes - S3 multipart upload threshold
 
@@ -74,11 +133,82 @@ const (
 	S3StandardPricePerGBMonth = 0.023
 	S3IAPricePerGBMonth       = 0.0125
 	S3ArchivePricePerGBMonth  = 0.004
-	S3TransitionToIADays      = 30
-	S3TransitionToArchiveDays = 90
 	S3BytesPerGB              = 1024 * 1024 * 1024
 	S3DaysPerMonth            = 30.0
+
+	// S3ITDefaultTransitionToIADays and S3ITDefaultTransitionToGlacierDays are the implicit
+	// tier transition thresholds for S3 Intelligent Tiering. All Evergreen S3 uploads use
+	// the IT storage class, so these defaults always apply regardless of lifecycle rule configuration.
+	S3ITDefaultTransitionToIADays      = 30
+	S3ITDefaultTransitionToGlacierDays = 90
 )
+
+// CalculateAllCosts calculates all S3 PUT and storage costs for the given usage.
+func CalculateAllCosts(ctx context.Context, usage S3Usage, tierInfoByKey map[string]StorageTierInfo, costConfig *evergreen.CostConfig) S3Costs {
+	var costs S3Costs
+	calculateArtifactPutCosts(&costs, usage, costConfig)
+	costs.LogPutCost = CalculateS3PutCostWithConfig(usage.Logs.PutRequests, costConfig)
+	calculateArtifactStorageCosts(ctx, &costs, usage, tierInfoByKey, costConfig)
+	calculateLogStorageCosts(ctx, &costs, usage, tierInfoByKey, costConfig)
+	return costs
+}
+
+func calculateArtifactPutCosts(costs *S3Costs, usage S3Usage, costConfig *evergreen.CostConfig) {
+	costs.ArtifactPutCost = CalculateS3PutCostWithConfig(usage.Artifacts.PutRequests, costConfig)
+	if usage.Artifacts.Count > 0 && usage.Artifacts.PutRequests > 0 {
+		costPerPut := costs.ArtifactPutCost / float64(usage.Artifacts.PutRequests)
+		costs.AvgFilePutCost = costs.ArtifactPutCost / float64(usage.Artifacts.Count)
+		costs.MaxFilePutCost = costPerPut * float64(usage.Artifacts.ArtifactWithMaxPutRequests)
+		costs.MinFilePutCost = costPerPut * float64(usage.Artifacts.ArtifactWithMinPutRequests)
+	}
+}
+
+func calculateArtifactStorageCosts(ctx context.Context, costs *S3Costs, usage S3Usage, tierInfoByKey map[string]StorageTierInfo, costConfig *evergreen.CostConfig) {
+	costs.MinArtifactStorageCost = math.MaxFloat64
+	costs.MaxArtifactStorageCost = -math.MaxFloat64
+	for _, f := range usage.Artifacts.AllFiles() {
+		fileCost := CalculateS3StorageCostWithConfig(ctx, f.Bytes, tierInfoByKey[f.FileKey], costConfig)
+		costs.ArtifactStorageCost += fileCost
+		if fileCost < costs.MinArtifactStorageCost {
+			costs.MinArtifactStorageCost = fileCost
+		}
+		if fileCost > costs.MaxArtifactStorageCost {
+			costs.MaxArtifactStorageCost = fileCost
+		}
+	}
+	if usage.Artifacts.Count == 0 {
+		costs.MinArtifactStorageCost = 0
+		costs.MaxArtifactStorageCost = 0
+	} else {
+		costs.AvgArtifactStorageCost = costs.ArtifactStorageCost / float64(usage.Artifacts.Count)
+	}
+}
+
+func calculateLogStorageCosts(ctx context.Context, costs *S3Costs, usage S3Usage, tierInfoByKey map[string]StorageTierInfo, costConfig *evergreen.CostConfig) {
+	costs.MinLogStorageCost = math.MaxFloat64
+	costs.MaxLogStorageCost = -math.MaxFloat64
+	count := 0
+	for _, lm := range []LogTypeMetrics{usage.Logs.Task, usage.Logs.Agent, usage.Logs.System} {
+		if lm.LogKey == "" {
+			continue
+		}
+		logCost := CalculateS3StorageCostWithConfig(ctx, lm.Bytes, tierInfoByKey[lm.LogKey], costConfig)
+		costs.LogStorageCost += logCost
+		if logCost < costs.MinLogStorageCost {
+			costs.MinLogStorageCost = logCost
+		}
+		if logCost > costs.MaxLogStorageCost {
+			costs.MaxLogStorageCost = logCost
+		}
+		count++
+	}
+	if count == 0 {
+		costs.MinLogStorageCost = 0
+		costs.MaxLogStorageCost = 0
+	} else {
+		costs.AvgLogStorageCost = costs.LogStorageCost / float64(count)
+	}
+}
 
 // CalculateUploadMetrics populates file size and PUT requests for each uploaded file.
 // Returns the populated metrics plus aggregate totals.
@@ -182,15 +312,12 @@ func CalculateS3PutCostWithConfig(putRequests int, costConfig *evergreen.CostCon
 	return float64(putRequests) * S3PutRequestCost * (1 - discount)
 }
 
-// CalculateS3StorageCostWithConfig calculates the S3 storage cost for uploadBytes over their retention period
-// using the bucket's Intelligent Tiering schedule. expirationDays must be positive; buckets without a
-// lifecycle expiration policy have no defined retention period and cannot have their cost calculated, so
-// this function returns 0 for them. Returns 0 if config is nil.
-func CalculateS3StorageCostWithConfig(ctx context.Context, uploadBytes int64, expirationDays int, costConfig *evergreen.CostConfig) float64 {
+// CalculateS3StorageCostWithConfig calculates the S3 storage cost for uploadBytes over their retention period.
+func CalculateS3StorageCostWithConfig(ctx context.Context, uploadBytes int64, tierInfo StorageTierInfo, costConfig *evergreen.CostConfig) float64 {
 	if uploadBytes <= 0 {
 		return 0.0
 	}
-	if expirationDays <= 0 {
+	if tierInfo.ExpirationDays <= 0 {
 		return 0.0
 	}
 	if costConfig == nil {
@@ -204,11 +331,7 @@ func CalculateS3StorageCostWithConfig(ctx context.Context, uploadBytes int64, ex
 	iaDiscount := costConfig.S3Cost.Storage.IAStorageCostDiscount
 	archiveDiscount := costConfig.S3Cost.Storage.ArchiveStorageCostDiscount
 
-	// Each variable represents how many days the object spends in that Intelligent Tiering tier:
-	// Standard (days 0–30), Infrequent Access (days 30–90), Archive (days 90+).
-	daysInStandard := min(expirationDays, S3TransitionToIADays)
-	daysInIA := max(0, min(expirationDays, S3TransitionToArchiveDays)-S3TransitionToIADays)
-	daysInArchive := max(0, expirationDays-S3TransitionToArchiveDays)
+	daysInStandard, daysInIA, daysInArchive := storageTierDays(tierInfo)
 
 	pricePerBytePerDay := func(pricePerGBMonth float64) float64 {
 		return pricePerGBMonth / S3BytesPerGB / S3DaysPerMonth
@@ -221,60 +344,80 @@ func CalculateS3StorageCostWithConfig(ctx context.Context, uploadBytes int64, ex
 	return float64(uploadBytes) * (standardCost + iaCost + archiveCost)
 }
 
-// ArtifactIncrementOptions holds the parameters for incrementing artifact upload metrics.
-type ArtifactIncrementOptions struct {
-	PutRequests int
-	UploadBytes int64
-	FileCount   int
-	MaxPuts     int
-	MinPuts     int
-	Bucket      string
-	Files       []FileMetrics
+// storageTierDays returns how many days an object spends in each S3 storage tier.
+// All Evergreen uploads use IT, which always transitions at S3ITDefaultTransitionToIADays and S3ITDefaultTransitionToGlacierDays.
+func storageTierDays(tierInfo StorageTierInfo) (daysInStandard, daysInIA, daysInArchive int) {
+	exp := tierInfo.ExpirationDays
+	daysInStandard = min(exp, S3ITDefaultTransitionToIADays)
+	daysInIA = max(0, min(exp, S3ITDefaultTransitionToGlacierDays)-S3ITDefaultTransitionToIADays)
+	daysInArchive = max(0, exp-S3ITDefaultTransitionToGlacierDays)
+	return daysInStandard, daysInIA, daysInArchive
+}
+
+// AllFiles returns a flat list of all artifact files across all buckets.
+func (a *ArtifactMetrics) AllFiles() []BucketFile {
+	var files []BucketFile
+	for _, b := range a.BytesByBucketAndKey {
+		for _, f := range b.Files {
+			files = append(files, BucketFile{Bucket: b.Bucket, FileKey: f.FileKey, Bytes: f.Bytes})
+		}
+	}
+	return files
 }
 
 // IncrementArtifacts updates aggregate artifact upload metrics after an s3.put command.
-func (s *S3Usage) IncrementArtifacts(opts ArtifactIncrementOptions) {
-	s.Artifacts.PutRequests += opts.PutRequests
-	s.Artifacts.UploadBytes += opts.UploadBytes
-	s.Artifacts.Count += opts.FileCount
+func (s *S3Usage) IncrementArtifacts(upload ArtifactUpload) {
+	s.Artifacts.PutRequests += upload.PutRequests
+	s.Artifacts.UploadBytes += upload.UploadBytes
 
-	if opts.MaxPuts > s.Artifacts.ArtifactWithMaxPutRequests {
-		s.Artifacts.ArtifactWithMaxPutRequests = opts.MaxPuts
+	if upload.MaxPuts > s.Artifacts.ArtifactWithMaxPutRequests {
+		s.Artifacts.ArtifactWithMaxPutRequests = upload.MaxPuts
 	}
-	if s.Artifacts.ArtifactWithMinPutRequests == 0 || opts.MinPuts < s.Artifacts.ArtifactWithMinPutRequests {
-		s.Artifacts.ArtifactWithMinPutRequests = opts.MinPuts
+	if s.Artifacts.Count == 0 || upload.MinPuts < s.Artifacts.ArtifactWithMinPutRequests {
+		s.Artifacts.ArtifactWithMinPutRequests = upload.MinPuts
 	}
+	s.Artifacts.Count += upload.FileCount
 
 	var bucketEntry *BucketFileMetrics
 	for i := range s.Artifacts.BytesByBucketAndKey {
-		if s.Artifacts.BytesByBucketAndKey[i].Bucket == opts.Bucket {
+		if s.Artifacts.BytesByBucketAndKey[i].Bucket == upload.Bucket {
 			bucketEntry = &s.Artifacts.BytesByBucketAndKey[i]
 			break
 		}
 	}
 	if bucketEntry == nil {
-		s.Artifacts.BytesByBucketAndKey = append(s.Artifacts.BytesByBucketAndKey, BucketFileMetrics{Bucket: opts.Bucket})
+		s.Artifacts.BytesByBucketAndKey = append(s.Artifacts.BytesByBucketAndKey, BucketFileMetrics{Bucket: upload.Bucket})
 		bucketEntry = &s.Artifacts.BytesByBucketAndKey[len(s.Artifacts.BytesByBucketAndKey)-1]
 	}
-	for _, f := range opts.Files {
-		found := false
-		for j := range bucketEntry.Files {
+	for _, f := range upload.Files {
+		j := 0
+		for ; j < len(bucketEntry.Files); j++ {
 			if bucketEntry.Files[j].FileKey == f.RemotePath {
 				bucketEntry.Files[j].Bytes += f.FileSizeBytes
-				found = true
 				break
 			}
 		}
-		if !found {
+		if j == len(bucketEntry.Files) {
 			bucketEntry.Files = append(bucketEntry.Files, FileBytes{FileKey: f.RemotePath, Bytes: f.FileSizeBytes})
 		}
 	}
 }
 
-// IncrementLogs increments the log chunk upload metrics.
-func (s *S3Usage) IncrementLogs(putRequests int, uploadBytes int64) {
+// IncrementLogs increments the log chunk upload metrics and accumulates bytes per log type.
+func (s *S3Usage) IncrementLogs(putRequests int, uploadBytes int64, logType, logKey string) {
 	s.Logs.PutRequests += putRequests
 	s.Logs.UploadBytes += uploadBytes
+	switch logType {
+	case LogTypeTask:
+		s.Logs.Task.Bytes += uploadBytes
+		s.Logs.Task.LogKey = logKey
+	case LogTypeAgent:
+		s.Logs.Agent.Bytes += uploadBytes
+		s.Logs.Agent.LogKey = logKey
+	case LogTypeSystem:
+		s.Logs.System.Bytes += uploadBytes
+		s.Logs.System.LogKey = logKey
+	}
 }
 
 // IsZero implements bsoncodec.Zeroer for BSON marshalling.

--- a/model/s3usage/s3usage_test.go
+++ b/model/s3usage/s3usage_test.go
@@ -70,7 +70,7 @@ func TestS3Usage(t *testing.T) {
 			{RemotePath: "path/file1.txt", FileSizeBytes: 600},
 			{RemotePath: "path/file2.txt", FileSizeBytes: 424},
 		}
-		s3Usage.IncrementArtifacts(ArtifactIncrementOptions{PutRequests: 5, UploadBytes: 1024, FileCount: 2, MaxPuts: 3, MinPuts: 2, Bucket: "bucket-a", Files: filesA})
+		s3Usage.IncrementArtifacts(ArtifactUpload{PutRequests: 5, UploadBytes: 1024, FileCount: 2, MaxPuts: 3, MinPuts: 2, Bucket: "bucket-a", Files: filesA})
 		assert.Equal(t, 5, s3Usage.Artifacts.PutRequests)
 		assert.Equal(t, int64(1024), s3Usage.Artifacts.UploadBytes)
 		assert.Equal(t, 2, s3Usage.Artifacts.Count)
@@ -84,7 +84,7 @@ func TestS3Usage(t *testing.T) {
 		filesB := []FileMetrics{
 			{RemotePath: "other/file3.txt", FileSizeBytes: 2048},
 		}
-		s3Usage.IncrementArtifacts(ArtifactIncrementOptions{PutRequests: 10, UploadBytes: 2048, FileCount: 3, MaxPuts: 8, MinPuts: 1, Bucket: "bucket-b", Files: filesB})
+		s3Usage.IncrementArtifacts(ArtifactUpload{PutRequests: 10, UploadBytes: 2048, FileCount: 3, MaxPuts: 8, MinPuts: 1, Bucket: "bucket-b", Files: filesB})
 		assert.Equal(t, 15, s3Usage.Artifacts.PutRequests)
 		assert.Equal(t, int64(3072), s3Usage.Artifacts.UploadBytes)
 		assert.Equal(t, 5, s3Usage.Artifacts.Count)
@@ -97,7 +97,7 @@ func TestS3Usage(t *testing.T) {
 		filesA2 := []FileMetrics{
 			{RemotePath: "path/file1.txt", FileSizeBytes: 512},
 		}
-		s3Usage.IncrementArtifacts(ArtifactIncrementOptions{PutRequests: 3, UploadBytes: 512, FileCount: 1, MaxPuts: 3, MinPuts: 3, Bucket: "bucket-a", Files: filesA2})
+		s3Usage.IncrementArtifacts(ArtifactUpload{PutRequests: 3, UploadBytes: 512, FileCount: 1, MaxPuts: 3, MinPuts: 3, Bucket: "bucket-a", Files: filesA2})
 		assert.Equal(t, int64(1112), bytesForFile(s3Usage.Artifacts.BytesByBucketAndKey, "bucket-a", "path/file1.txt"), "bucket-a file bytes should accumulate across invocations")
 	})
 
@@ -106,13 +106,17 @@ func TestS3Usage(t *testing.T) {
 		assert.Equal(t, 0, s3Usage.Logs.PutRequests)
 		assert.Equal(t, int64(0), s3Usage.Logs.UploadBytes)
 
-		s3Usage.IncrementLogs(5, 1024)
+		s3Usage.IncrementLogs(5, 1024, LogTypeTask, "project/task1/0/task.log")
 		assert.Equal(t, 5, s3Usage.Logs.PutRequests)
 		assert.Equal(t, int64(1024), s3Usage.Logs.UploadBytes)
+		assert.Equal(t, int64(1024), s3Usage.Logs.Task.Bytes)
+		assert.Equal(t, "project/task1/0/task.log", s3Usage.Logs.Task.LogKey)
 
-		s3Usage.IncrementLogs(10, 2048)
+		s3Usage.IncrementLogs(10, 2048, LogTypeAgent, "project/task1/0/agent.log")
 		assert.Equal(t, 15, s3Usage.Logs.PutRequests)
 		assert.Equal(t, int64(3072), s3Usage.Logs.UploadBytes)
+		assert.Equal(t, int64(2048), s3Usage.Logs.Agent.Bytes)
+		assert.Equal(t, "project/task1/0/agent.log", s3Usage.Logs.Agent.LogKey)
 	})
 
 	t.Run("NilReceiverIsZero", func(t *testing.T) {
@@ -244,6 +248,52 @@ func TestCalculateS3PutCostWithConfig(t *testing.T) {
 
 }
 
+func TestStorageTierDays(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		tierInfo     StorageTierInfo
+		wantStandard int
+		wantIA       int
+		wantArchive  int
+	}{
+		{
+			name:         "ExpirationBeforeIAThresholdShouldBeAllStandard",
+			tierInfo:     StorageTierInfo{ExpirationDays: 20},
+			wantStandard: 20,
+			wantIA:       0,
+			wantArchive:  0,
+		},
+		{
+			name:         "ExpirationBetweenThresholdsShouldSplitStandardAndIA",
+			tierInfo:     StorageTierInfo{ExpirationDays: 60},
+			wantStandard: 30,
+			wantIA:       30,
+			wantArchive:  0,
+		},
+		{
+			name:         "ExpirationAtGlacierThresholdShouldHaveNoArchiveDays",
+			tierInfo:     StorageTierInfo{ExpirationDays: 90},
+			wantStandard: 30,
+			wantIA:       60,
+			wantArchive:  0,
+		},
+		{
+			name:         "ExpirationAfterGlacierThresholdShouldSplitAllThreeTiers",
+			tierInfo:     StorageTierInfo{ExpirationDays: 365},
+			wantStandard: 30,
+			wantIA:       60,
+			wantArchive:  275,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			standard, ia, archive := storageTierDays(tc.tierInfo)
+			assert.Equal(t, tc.wantStandard, standard)
+			assert.Equal(t, tc.wantIA, ia)
+			assert.Equal(t, tc.wantArchive, archive)
+		})
+	}
+}
+
 func TestCalculateS3StorageCostWithConfig(t *testing.T) {
 	validConfig := &evergreen.CostConfig{
 		S3Cost: evergreen.S3CostConfig{
@@ -257,14 +307,9 @@ func TestCalculateS3StorageCostWithConfig(t *testing.T) {
 
 	const GB = 1024 * 1024 * 1024
 
-	t.Run("DefaultArtifacts365Days", func(t *testing.T) {
-		// ExpirationDays=365: Standard=30, IA=60, Archive=275
-		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, 365, validConfig)
+	t.Run("365DaysShouldSplitAcrossAllThreeTiers", func(t *testing.T) {
+		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, StorageTierInfo{ExpirationDays: 365}, validConfig)
 		assert.Greater(t, cost, 0.0)
-		// Verify tier breakdown manually:
-		// Standard: 30 * (0.023/GB/30) * (1-0.37) = 0.023 * 0.63
-		// IA:       60 * (0.0125/GB/30) * (1-0.312) = 2 * 0.0125 * 0.688
-		// Archive:  275 * (0.004/GB/30) * (1-0.265)
 		standard := 30.0 * (0.023 / float64(GB) / 30.0) * (1 - 0.37)
 		ia := 60.0 * (0.0125 / float64(GB) / 30.0) * (1 - 0.312)
 		archive := 275.0 * (0.004 / float64(GB) / 30.0) * (1 - 0.265)
@@ -272,18 +317,8 @@ func TestCalculateS3StorageCostWithConfig(t *testing.T) {
 		assert.InDelta(t, expected, cost, 0.000001)
 	})
 
-	t.Run("MongoDBMongoArtifacts90Days", func(t *testing.T) {
-		// ExpirationDays=90: Standard=30, IA=60, Archive=0
-		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, 90, validConfig)
-		standard := 30.0 * (0.023 / float64(GB) / 30.0) * (1 - 0.37)
-		ia := 60.0 * (0.0125 / float64(GB) / 30.0) * (1 - 0.312)
-		expected := float64(GB) * (standard + ia)
-		assert.InDelta(t, expected, cost, 0.000001)
-	})
-
-	t.Run("MongoSyncArtifacts180Days", func(t *testing.T) {
-		// ExpirationDays=180: Standard=30, IA=60, Archive=90
-		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, 180, validConfig)
+	t.Run("180DaysShouldSplitAcrossAllThreeTiers", func(t *testing.T) {
+		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, StorageTierInfo{ExpirationDays: 180}, validConfig)
 		standard := 30.0 * (0.023 / float64(GB) / 30.0) * (1 - 0.37)
 		ia := 60.0 * (0.0125 / float64(GB) / 30.0) * (1 - 0.312)
 		archive := 90.0 * (0.004 / float64(GB) / 30.0) * (1 - 0.265)
@@ -291,39 +326,169 @@ func TestCalculateS3StorageCostWithConfig(t *testing.T) {
 		assert.InDelta(t, expected, cost, 0.000001)
 	})
 
-	t.Run("DefaultLog60Days", func(t *testing.T) {
-		// ExpirationDays=60: Standard=30, IA=30, Archive=0
-		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, 60, validConfig)
+	t.Run("90DaysShouldExcludeArchiveTier", func(t *testing.T) {
+		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, StorageTierInfo{ExpirationDays: 90}, validConfig)
+		standard := 30.0 * (0.023 / float64(GB) / 30.0) * (1 - 0.37)
+		ia := 60.0 * (0.0125 / float64(GB) / 30.0) * (1 - 0.312)
+		expected := float64(GB) * (standard + ia)
+		assert.InDelta(t, expected, cost, 0.000001)
+	})
+
+	t.Run("60DaysShouldExcludeArchiveTier", func(t *testing.T) {
+		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, StorageTierInfo{ExpirationDays: 60}, validConfig)
 		standard := 30.0 * (0.023 / float64(GB) / 30.0) * (1 - 0.37)
 		ia := 30.0 * (0.0125 / float64(GB) / 30.0) * (1 - 0.312)
 		expected := float64(GB) * (standard + ia)
 		assert.InDelta(t, expected, cost, 0.000001)
 	})
 
-	t.Run("FailedLog180Days", func(t *testing.T) {
-		// ExpirationDays=180: Standard=30, IA=60, Archive=90
-		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, 180, validConfig)
-		assert.Greater(t, cost, 0.0)
-	})
-
-	t.Run("LongRetentionLog365Days", func(t *testing.T) {
-		// ExpirationDays=365: Standard=30, IA=60, Archive=275
-		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, 365, validConfig)
-		assert.Greater(t, cost, 0.0)
-	})
-
-	t.Run("ZeroBytes", func(t *testing.T) {
-		cost := CalculateS3StorageCostWithConfig(t.Context(), 0, 365, validConfig)
+	t.Run("ZeroBytesShouldReturnZero", func(t *testing.T) {
+		cost := CalculateS3StorageCostWithConfig(t.Context(), 0, StorageTierInfo{ExpirationDays: 365}, validConfig)
 		assert.Equal(t, 0.0, cost)
 	})
 
-	t.Run("ZeroExpirationDays", func(t *testing.T) {
-		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, 0, validConfig)
+	t.Run("ZeroExpirationDaysShouldReturnZero", func(t *testing.T) {
+		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, StorageTierInfo{}, validConfig)
 		assert.Equal(t, 0.0, cost)
 	})
 
-	t.Run("NilConfig", func(t *testing.T) {
-		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, 365, nil)
+	t.Run("NilConfigShouldReturnZero", func(t *testing.T) {
+		cost := CalculateS3StorageCostWithConfig(t.Context(), GB, StorageTierInfo{ExpirationDays: 365}, nil)
 		assert.Equal(t, 0.0, cost)
+	})
+}
+
+func TestCalculateArtifactPutCosts(t *testing.T) {
+	validConfig := &evergreen.CostConfig{
+		S3Cost: evergreen.S3CostConfig{
+			Upload: evergreen.S3UploadCostConfig{
+				UploadCostDiscount: 0.0,
+			},
+		},
+	}
+
+	t.Run("ZeroArtifactsShouldReturnZero", func(t *testing.T) {
+		var costs S3Costs
+		calculateArtifactPutCosts(&costs, S3Usage{}, validConfig)
+		assert.Equal(t, 0.0, costs.ArtifactPutCost)
+		assert.Equal(t, 0.0, costs.AvgFilePutCost)
+		assert.Equal(t, 0.0, costs.MaxFilePutCost)
+		assert.Equal(t, 0.0, costs.MinFilePutCost)
+	})
+
+	t.Run("SingleFileShouldHaveEqualAvgMinMax", func(t *testing.T) {
+		var costs S3Costs
+		usage := S3Usage{
+			Artifacts: ArtifactMetrics{
+				S3UploadMetrics:            S3UploadMetrics{PutRequests: 3},
+				Count:                      1,
+				ArtifactWithMaxPutRequests: 3,
+				ArtifactWithMinPutRequests: 3,
+			},
+		}
+		calculateArtifactPutCosts(&costs, usage, validConfig)
+		assert.Greater(t, costs.ArtifactPutCost, 0.0)
+		assert.Equal(t, costs.AvgFilePutCost, costs.MaxFilePutCost)
+		assert.Equal(t, costs.AvgFilePutCost, costs.MinFilePutCost)
+	})
+
+	t.Run("MultipleFilesWithDifferentPutsShouldComputeExtremes", func(t *testing.T) {
+		var costs S3Costs
+		usage := S3Usage{
+			Artifacts: ArtifactMetrics{
+				S3UploadMetrics:            S3UploadMetrics{PutRequests: 10},
+				Count:                      3,
+				ArtifactWithMaxPutRequests: 6,
+				ArtifactWithMinPutRequests: 1,
+			},
+		}
+		calculateArtifactPutCosts(&costs, usage, validConfig)
+		expectedPutCost := float64(10) * S3PutRequestCost
+		assert.InDelta(t, expectedPutCost, costs.ArtifactPutCost, 0.000001)
+		assert.InDelta(t, expectedPutCost/3, costs.AvgFilePutCost, 0.000001)
+		assert.Greater(t, costs.MaxFilePutCost, costs.MinFilePutCost)
+		costPerPut := expectedPutCost / 10
+		assert.InDelta(t, costPerPut*6, costs.MaxFilePutCost, 0.000001)
+		assert.InDelta(t, costPerPut*1, costs.MinFilePutCost, 0.000001)
+	})
+
+	t.Run("NilConfigShouldReturnZero", func(t *testing.T) {
+		var costs S3Costs
+		usage := S3Usage{
+			Artifacts: ArtifactMetrics{
+				S3UploadMetrics: S3UploadMetrics{PutRequests: 10},
+				Count:           3,
+			},
+		}
+		calculateArtifactPutCosts(&costs, usage, nil)
+		assert.Equal(t, 0.0, costs.ArtifactPutCost)
+		assert.Equal(t, 0.0, costs.AvgFilePutCost)
+		assert.Equal(t, 0.0, costs.MaxFilePutCost)
+		assert.Equal(t, 0.0, costs.MinFilePutCost)
+	})
+}
+
+func TestCalculateAllCosts(t *testing.T) {
+	validConfig := &evergreen.CostConfig{
+		S3Cost: evergreen.S3CostConfig{
+			Upload: evergreen.S3UploadCostConfig{UploadCostDiscount: 0.0},
+			Storage: evergreen.S3StorageCostConfig{
+				DefaultMaxArtifactExpirationDays: 365,
+			},
+		},
+	}
+	const MB = 1024 * 1024
+
+	t.Run("PutCostsCalculatedIndependentlyFromStorageCosts", func(t *testing.T) {
+		usage := S3Usage{
+			Artifacts: ArtifactMetrics{
+				S3UploadMetrics:            S3UploadMetrics{PutRequests: 10, UploadBytes: int64(5 * MB)},
+				Count:                      2,
+				ArtifactWithMaxPutRequests: 7,
+				ArtifactWithMinPutRequests: 3,
+			},
+			Logs: LogMetrics{S3UploadMetrics: S3UploadMetrics{PutRequests: 5}},
+		}
+		costs := CalculateAllCosts(t.Context(), usage, nil, validConfig)
+		assert.Greater(t, costs.ArtifactPutCost, 0.0)
+		assert.Greater(t, costs.LogPutCost, 0.0)
+		assert.Greater(t, costs.MaxFilePutCost, costs.MinFilePutCost)
+		assert.Equal(t, 0.0, costs.ArtifactStorageCost)
+		assert.Equal(t, 0.0, costs.LogStorageCost)
+	})
+
+	t.Run("StorageCostsCalculatedWithTierInfo", func(t *testing.T) {
+		fileKey := "project/task1/0/artifacts/binary.tar.gz"
+		usage := S3Usage{
+			Artifacts: ArtifactMetrics{
+				S3UploadMetrics: S3UploadMetrics{PutRequests: 1},
+				Count:           1,
+				BytesByBucketAndKey: []BucketFileMetrics{
+					{Bucket: "mciuploads", Files: []FileBytes{{FileKey: fileKey, Bytes: int64(5 * MB)}}},
+				},
+				ArtifactWithMaxPutRequests: 1,
+				ArtifactWithMinPutRequests: 1,
+			},
+		}
+		tierInfoByKey := map[string]StorageTierInfo{
+			fileKey: {ExpirationDays: 90},
+		}
+		costs := CalculateAllCosts(t.Context(), usage, tierInfoByKey, validConfig)
+		assert.Greater(t, costs.ArtifactPutCost, 0.0)
+		assert.Greater(t, costs.ArtifactStorageCost, 0.0)
+	})
+
+	t.Run("NilConfigShouldReturnZeroCosts", func(t *testing.T) {
+		usage := S3Usage{
+			Artifacts: ArtifactMetrics{
+				S3UploadMetrics: S3UploadMetrics{PutRequests: 10},
+				Count:           1,
+			},
+		}
+		costs := CalculateAllCosts(t.Context(), usage, nil, nil)
+		assert.Equal(t, 0.0, costs.ArtifactPutCost)
+		assert.Equal(t, 0.0, costs.LogPutCost)
+		assert.Equal(t, 0.0, costs.ArtifactStorageCost)
+		assert.Equal(t, 0.0, costs.LogStorageCost)
 	})
 }

--- a/model/task/evergreen_sender.go
+++ b/model/task/evergreen_sender.go
@@ -48,6 +48,9 @@ type EvergreenSenderOptions struct {
 	// S3Usage tracks S3 API usage for log uploads. If set, flush() will
 	// increment log file metrics after each successful write.
 	S3Usage *s3usage.S3Usage
+	// LogType and LogKey identify the log type and S3 key for per-type storage cost tracking.
+	LogType string
+	LogKey  string
 
 	appendLines logLineAppender
 }
@@ -245,7 +248,7 @@ func (s *evergreenSender) flush(ctx context.Context) error {
 	}
 
 	if s.opts.S3Usage != nil && uploadBytes > 0 {
-		s.opts.S3Usage.IncrementLogs(1, uploadBytes)
+		s.opts.S3Usage.IncrementLogs(1, uploadBytes, s.opts.LogType, s.opts.LogKey)
 	}
 
 	s.buffer = []log.LogLine{}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -4323,66 +4323,30 @@ func (t *Task) calculateRuntimeCost(financeConfig evergreen.CostConfig, costData
 	t.TaskCost = CalculateTaskCost(t.TimeTaken.Seconds(), costData, financeConfig)
 }
 
-// bucketExpirationLookup resolves the S3 lifecycle expiration days for a given artifact file.
-type bucketExpirationLookup func(ctx context.Context, bucket, fileKey string) (days int, found bool)
-
-// SaveS3Usage persists the task's S3 usage metrics and calculates S3 costs.
-func (t *Task) SaveS3Usage(ctx context.Context, lookup bucketExpirationLookup) error {
-	costConfig := &evergreen.CostConfig{}
-	if err := costConfig.Get(ctx); err != nil {
-		return errors.Wrap(err, "getting cost config")
-	}
-
-	t.calculateS3PutCosts(costConfig)
-	t.setS3StorageCosts(ctx, lookup, costConfig)
+// SaveS3Usage persists the task's S3 usage metrics and calculated S3 costs.
+func (t *Task) SaveS3Usage(ctx context.Context, costs s3usage.S3Costs) error {
+	t.TaskCost.S3ArtifactPutCost = costs.ArtifactPutCost
+	t.TaskCost.S3LogPutCost = costs.LogPutCost
+	t.TaskCost.S3ArtifactStorageCost = costs.ArtifactStorageCost
+	t.TaskCost.S3LogStorageCost = costs.LogStorageCost
 
 	setFields := bson.M{
 		S3UsageKey: t.S3Usage,
 		bsonutil.GetDottedKeyName(TaskCostKey, cost.S3ArtifactPutCostKey):     t.TaskCost.S3ArtifactPutCost,
 		bsonutil.GetDottedKeyName(TaskCostKey, cost.S3LogPutCostKey):          t.TaskCost.S3LogPutCost,
 		bsonutil.GetDottedKeyName(TaskCostKey, cost.S3ArtifactStorageCostKey): t.TaskCost.S3ArtifactStorageCost,
+		bsonutil.GetDottedKeyName(TaskCostKey, cost.S3LogStorageCostKey):      t.TaskCost.S3LogStorageCost,
 	}
 
 	return UpdateOne(ctx, bson.M{"_id": t.Id}, bson.M{"$set": setFields})
 }
 
-// resolveArtifactExpirationDays looks up the expiration days for an artifact, falling back to DefaultMaxArtifactExpirationDays if no matching rule is found.
-func resolveArtifactExpirationDays(ctx context.Context, bucket, fileKey string, lookup bucketExpirationLookup, costConfig *evergreen.CostConfig) (days int, found bool) {
-	if lookup != nil {
-		if days, ok := lookup(ctx, bucket, fileKey); ok {
-			return days, true
-		}
-	}
-	return costConfig.S3Cost.Storage.DefaultMaxArtifactExpirationDays, false
-}
-
-// calculateS3PutCosts calculates S3 PUT costs for both artifact uploads and log uploads.
 func (t *Task) calculateS3PutCosts(costConfig *evergreen.CostConfig) {
 	if t.S3Usage.Artifacts.PutRequests > 0 {
 		t.TaskCost.S3ArtifactPutCost = s3usage.CalculateS3PutCostWithConfig(t.S3Usage.Artifacts.PutRequests, costConfig)
 	}
 	if t.S3Usage.Logs.PutRequests > 0 {
 		t.TaskCost.S3LogPutCost = s3usage.CalculateS3PutCostWithConfig(t.S3Usage.Logs.PutRequests, costConfig)
-	}
-}
-
-// setS3StorageCosts calculates and sets the task's S3 artifact storage cost. Skipped if the lifecycle rules lookup is nil.
-func (t *Task) setS3StorageCosts(ctx context.Context, lookup bucketExpirationLookup, costConfig *evergreen.CostConfig) {
-	if lookup == nil {
-		return
-	}
-	for _, bucketEntry := range t.S3Usage.Artifacts.BytesByBucketAndKey {
-		for _, fileEntry := range bucketEntry.Files {
-			days, found := resolveArtifactExpirationDays(ctx, bucketEntry.Bucket, fileEntry.FileKey, lookup, costConfig)
-			if !found {
-				grip.Info(ctx, message.Fields{
-					"message": "no S3 lifecycle rule found for artifact bucket, using default expiration days",
-					"bucket":  bucketEntry.Bucket,
-					"task_id": t.Id,
-				})
-			}
-			t.TaskCost.S3ArtifactStorageCost += s3usage.CalculateS3StorageCostWithConfig(ctx, fileEntry.Bytes, days, costConfig)
-		}
 	}
 }
 

--- a/model/task/task_log.go
+++ b/model/task/task_log.go
@@ -79,8 +79,7 @@ func NewTaskLogSender(ctx context.Context, task *Task, senderOpts EvergreenSende
 
 	output, ok := task.GetTaskOutputSafe()
 	if !ok {
-		// We know there task cannot have task output, likely because
-		// it has not run yet. Return an empty iterator.
+		// The task cannot have task output, likely because it has not run yet.
 		return nil, nil
 	}
 
@@ -93,9 +92,12 @@ func NewTaskLogSender(ctx context.Context, task *Task, senderOpts EvergreenSende
 		return nil, errors.Wrap(err, "getting log service")
 	}
 
+	logName := getLogName(*task, logType, output.TaskLogs.ID())
 	senderOpts.appendLines = func(ctx context.Context, lines []log.LogLine) (int64, error) {
-		return svc.Append(ctx, getLogName(*task, logType, output.TaskLogs.ID()), 0, lines)
+		return svc.Append(ctx, logName, 0, lines)
 	}
+	senderOpts.LogType = string(logType)
+	senderOpts.LogKey = logName
 
 	return newEvergreenSender(ctx, fmt.Sprintf("%s-%s", task.Id, logType), senderOpts)
 }
@@ -108,8 +110,7 @@ func AppendTaskLogs(ctx context.Context, task *Task, logType TaskLogType, lines 
 
 	output, ok := task.GetTaskOutputSafe()
 	if !ok {
-		// We know there task cannot have task output, likely because
-		// it has not run yet. Return an empty iterator.
+		// The task cannot have task output, likely because it has not run yet.
 		return nil
 	}
 
@@ -122,13 +123,14 @@ func AppendTaskLogs(ctx context.Context, task *Task, logType TaskLogType, lines 
 		return errors.Wrap(err, "getting log service")
 	}
 
-	uploadBytes, err := svc.Append(ctx, getLogName(*task, logType, output.TaskLogs.ID()), 0, lines)
+	logName := getLogName(*task, logType, output.TaskLogs.ID())
+	uploadBytes, err := svc.Append(ctx, logName, 0, lines)
 	if err != nil {
 		return err
 	}
 
 	if uploadBytes > 0 {
-		task.S3Usage.IncrementLogs(1, uploadBytes)
+		task.S3Usage.IncrementLogs(1, uploadBytes, string(logType), logName)
 	}
 
 	return nil
@@ -138,8 +140,7 @@ func AppendTaskLogs(ctx context.Context, task *Task, logType TaskLogType, lines 
 func getTaskLogs(ctx context.Context, task Task, getOpts TaskLogGetOptions) (log.LogIterator, error) {
 	output, ok := task.GetTaskOutputSafe()
 	if !ok {
-		// We know there task cannot have task output, likely because
-		// it has not run yet. Return an empty iterator.
+		// The task cannot have task output, likely because it has not run yet.
 		return log.EmptyIterator(), nil
 	}
 
@@ -147,7 +148,6 @@ func getTaskLogs(ctx context.Context, task Task, getOpts TaskLogGetOptions) (log
 		return nil, err
 	}
 
-	// Get the appropriate bucket config for this project
 	bucketConfig := getBucketConfigForProject(task.Project, output.TaskLogs.BucketConfig)
 
 	taskLogOutput := TaskLogOutput{
@@ -197,8 +197,8 @@ func getLogService(ctx context.Context, o TaskLogOutput) (log.LogService, error)
 	return log.NewLogServiceV0(b), nil
 }
 
-// getBucketConfigForProject returns the appropriate bucket config for a project, using long
-// retention bucket if the project is in the long retention list. It returns a boolean indicating if the original bucket is being used.
+// getBucketConfigForProject returns the appropriate bucket config for a project, using the long
+// retention bucket if the project is in the long retention list.
 func getBucketConfigForProject(project string, originalBucketConfig evergreen.BucketConfig) evergreen.BucketConfig {
 	env := evergreen.GetEnvironment()
 	if env != nil && env.Settings() != nil && slices.Contains(env.Settings().Buckets.LongRetentionProjects, project) {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -5203,11 +5203,11 @@ func TestSaveS3Usage(t *testing.T) {
 	}
 
 	for name, tc := range map[string]struct {
-		task       Task
-		costConfig *evergreen.CostConfig
-		setupUsage func(*s3usage.S3Usage)
-		lookup     bucketExpirationLookup
-		assertions func(*testing.T, *Task)
+		task          Task
+		costConfig    *evergreen.CostConfig
+		setupUsage    func(*s3usage.S3Usage)
+		tierInfoByKey map[string]s3usage.StorageTierInfo
+		assertions    func(*testing.T, *Task)
 	}{
 		"PersistsS3Usage": {
 			task: Task{Id: "t1"},
@@ -5229,9 +5229,10 @@ func TestSaveS3Usage(t *testing.T) {
 			},
 		},
 		"CalculatesCostFromUsage": {
-			task: Task{Id: "t2"},
+			task:       Task{Id: "t2"},
+			costConfig: &defaultCostConfig,
 			setupUsage: func(u *s3usage.S3Usage) {
-				u.IncrementArtifacts(s3usage.ArtifactIncrementOptions{
+				u.IncrementArtifacts(s3usage.ArtifactUpload{
 					PutRequests: 1000,
 					UploadBytes: 5 * 1024 * 1024,
 					FileCount:   3,
@@ -5240,7 +5241,7 @@ func TestSaveS3Usage(t *testing.T) {
 					Bucket:      "mciuploads",
 					Files:       multiFileArtifacts,
 				})
-				u.IncrementLogs(50, 500000)
+				u.IncrementLogs(50, 500000, s3usage.LogTypeTask, "")
 			},
 			assertions: func(t *testing.T, dbTask *Task) {
 				assert.Equal(t, 1000, dbTask.S3Usage.Artifacts.PutRequests)
@@ -5249,11 +5250,11 @@ func TestSaveS3Usage(t *testing.T) {
 				assert.True(t, dbTask.TaskCost.S3LogPutCost > 0)
 			},
 		},
-		"CalculatesCostFromUsageWithDefaultExpiration": {
+		"CalculatesArtifactStorageCostWithDefaultExpiration": {
 			task:       Task{Id: "t3"},
 			costConfig: &defaultCostConfig,
 			setupUsage: func(u *s3usage.S3Usage) {
-				u.IncrementArtifacts(s3usage.ArtifactIncrementOptions{
+				u.IncrementArtifacts(s3usage.ArtifactUpload{
 					PutRequests: 1000,
 					UploadBytes: 5 * 1024 * 1024,
 					FileCount:   3,
@@ -5262,26 +5263,28 @@ func TestSaveS3Usage(t *testing.T) {
 					Bucket:      "mciuploads",
 					Files:       multiFileArtifacts,
 				})
-				u.IncrementLogs(50, 500000)
 			},
-			lookup: func(_ context.Context, _, _ string) (int, bool) {
-				return 0, false
+			tierInfoByKey: map[string]s3usage.StorageTierInfo{
+				"mongodb-mongo-master/abc123/artifacts/binary.tar.gz":        {ExpirationDays: 365},
+				"mongodb-mongo-master/abc123/artifacts/debug-symbols.tar.gz": {ExpirationDays: 365},
+				"mongodb-mongo-master/abc123/artifacts/test-results.json":    {ExpirationDays: 365},
 			},
 			assertions: func(t *testing.T, dbTask *Task) {
 				assert.Equal(t, 1000, dbTask.S3Usage.Artifacts.PutRequests)
 				assert.True(t, dbTask.TaskCost.S3ArtifactPutCost > 0)
 				assert.True(t, dbTask.TaskCost.S3ArtifactStorageCost > 0)
-				assert.Equal(t, 50, dbTask.S3Usage.Logs.PutRequests)
-				assert.True(t, dbTask.TaskCost.S3LogPutCost > 0)
 			},
 		},
 		"CalculatesLogChunkCostOnly": {
-			task: Task{Id: "t4"},
+			task:       Task{Id: "t4"},
+			costConfig: &defaultCostConfig,
 			setupUsage: func(u *s3usage.S3Usage) {
 				*u = s3usage.S3Usage{
-					Logs: s3usage.S3UploadMetrics{
-						PutRequests: 100,
-						UploadBytes: 200000,
+					Logs: s3usage.LogMetrics{
+						S3UploadMetrics: s3usage.S3UploadMetrics{
+							PutRequests: 100,
+							UploadBytes: 200000,
+						},
 					},
 				}
 			},
@@ -5292,32 +5295,11 @@ func TestSaveS3Usage(t *testing.T) {
 				assert.True(t, dbTask.TaskCost.S3LogPutCost > 0)
 			},
 		},
-		"CalculatesArtifactStorageCostWithDefaultExpiration": {
-			task:       Task{Id: "t5", Project: "some-project"},
-			costConfig: &defaultCostConfig,
-			setupUsage: func(u *s3usage.S3Usage) {
-				u.IncrementArtifacts(s3usage.ArtifactIncrementOptions{
-					UploadBytes: 10 * 1024 * 1024,
-					FileCount:   2,
-					Bucket:      "mciuploads",
-					Files: []s3usage.FileMetrics{
-						{RemotePath: "some-project/abc123/artifacts/core-dump.tar.gz", FileSizeBytes: 6 * 1024 * 1024},
-						{RemotePath: "some-project/abc123/artifacts/binary.tar.gz", FileSizeBytes: 4 * 1024 * 1024},
-					},
-				})
-			},
-			lookup: func(_ context.Context, _, _ string) (int, bool) {
-				return 0, false
-			},
-			assertions: func(t *testing.T, dbTask *Task) {
-				assert.True(t, dbTask.TaskCost.S3ArtifactStorageCost > 0)
-			},
-		},
-		"NilLookupSkipsStorageCostCalculation": {
+		"NilTierInfoByKeySkipsStorageCostCalculation": {
 			task:       Task{Id: "t9", Project: "some-project"},
 			costConfig: &defaultCostConfig,
 			setupUsage: func(u *s3usage.S3Usage) {
-				u.IncrementArtifacts(s3usage.ArtifactIncrementOptions{
+				u.IncrementArtifacts(s3usage.ArtifactUpload{
 					UploadBytes: 5 * 1024 * 1024,
 					FileCount:   1,
 					Bucket:      "mciuploads",
@@ -5328,43 +5310,28 @@ func TestSaveS3Usage(t *testing.T) {
 				assert.Equal(t, float64(0), dbTask.TaskCost.S3ArtifactStorageCost)
 			},
 		},
-		"CalculatesStorageCostWithLookupMatch": {
+		"CalculatesArtifactStorageCostWithTierInfo": {
 			task:       Task{Id: "t6", Project: "some-project"},
 			costConfig: &defaultCostConfig,
 			setupUsage: func(u *s3usage.S3Usage) {
-				u.IncrementArtifacts(s3usage.ArtifactIncrementOptions{
+				u.IncrementArtifacts(s3usage.ArtifactUpload{
 					UploadBytes: 5 * 1024 * 1024,
 					FileCount:   1,
 					Bucket:      "mciuploads",
 					Files:       singleFileArtifact,
 				})
 			},
-			lookup: func(_ context.Context, _, _ string) (int, bool) {
-				return 90, true
+			tierInfoByKey: map[string]s3usage.StorageTierInfo{
+				"some-project/abc123/artifacts/binary.tar.gz": {ExpirationDays: 90},
 			},
 			assertions: func(t *testing.T, dbTask *Task) {
 				assert.True(t, dbTask.TaskCost.S3ArtifactStorageCost > 0)
-				expectedCost := s3usage.CalculateS3StorageCostWithConfig(ctx, 5*1024*1024, 90, &defaultCostConfig)
-				assert.InDelta(t, expectedCost, dbTask.TaskCost.S3ArtifactStorageCost, 0.0001)
-			},
-		},
-		"CalculatesStorageCostWithLookupMiss": {
-			task:       Task{Id: "t7", Project: "some-project"},
-			costConfig: &defaultCostConfig,
-			setupUsage: func(u *s3usage.S3Usage) {
-				u.IncrementArtifacts(s3usage.ArtifactIncrementOptions{
-					UploadBytes: 5 * 1024 * 1024,
-					FileCount:   1,
-					Bucket:      "mciuploads",
-					Files:       singleFileArtifact,
-				})
-			},
-			lookup: func(_ context.Context, _, _ string) (int, bool) {
-				return 0, false
-			},
-			assertions: func(t *testing.T, dbTask *Task) {
-				assert.True(t, dbTask.TaskCost.S3ArtifactStorageCost > 0)
-				expectedCost := s3usage.CalculateS3StorageCostWithConfig(ctx, 5*1024*1024, 365, &defaultCostConfig)
+				expectedCost := s3usage.CalculateS3StorageCostWithConfig(
+					ctx,
+					5*1024*1024,
+					s3usage.StorageTierInfo{ExpirationDays: 90},
+					&defaultCostConfig,
+				)
 				assert.InDelta(t, expectedCost, dbTask.TaskCost.S3ArtifactStorageCost, 0.0001)
 			},
 		},
@@ -5374,20 +5341,65 @@ func TestSaveS3Usage(t *testing.T) {
 				assert.True(t, dbTask.TaskCost.IsZero())
 			},
 		},
+		"CalculatesLogStorageCostWithTierInfo": {
+			task:       Task{Id: "t10", Project: "some-project"},
+			costConfig: &defaultCostConfig,
+			setupUsage: func(u *s3usage.S3Usage) {
+				u.IncrementLogs(50, 5*1024*1024, s3usage.LogTypeTask, "evg-logs/some-project/t10/0/task_logs")
+			},
+			tierInfoByKey: map[string]s3usage.StorageTierInfo{
+				"evg-logs/some-project/t10/0/task_logs": {ExpirationDays: 90},
+			},
+			assertions: func(t *testing.T, dbTask *Task) {
+				assert.True(t, dbTask.TaskCost.S3LogStorageCost > 0)
+				expectedCost := s3usage.CalculateS3StorageCostWithConfig(
+					ctx,
+					5*1024*1024,
+					s3usage.StorageTierInfo{ExpirationDays: 90},
+					&defaultCostConfig,
+				)
+				assert.InDelta(t, expectedCost, dbTask.TaskCost.S3LogStorageCost, 0.0001)
+			},
+		},
+		"CalculatesLogStorageCostWithDefaultExpiration": {
+			task:       Task{Id: "t11", Project: "some-project"},
+			costConfig: &defaultCostConfig,
+			setupUsage: func(u *s3usage.S3Usage) {
+				u.IncrementLogs(50, 5*1024*1024, s3usage.LogTypeTask, "evg-logs/some-project/t11/0/task_logs")
+			},
+			tierInfoByKey: map[string]s3usage.StorageTierInfo{
+				"evg-logs/some-project/t11/0/task_logs": {ExpirationDays: 365},
+			},
+			assertions: func(t *testing.T, dbTask *Task) {
+				assert.True(t, dbTask.TaskCost.S3LogStorageCost > 0)
+				expectedCost := s3usage.CalculateS3StorageCostWithConfig(
+					ctx,
+					5*1024*1024,
+					s3usage.StorageTierInfo{ExpirationDays: 365},
+					&defaultCostConfig,
+				)
+				assert.InDelta(t, expectedCost, dbTask.TaskCost.S3LogStorageCost, 0.0001)
+			},
+		},
+		"EmptyLogKeySkipsLogStorageCostCalculation": {
+			task:       Task{Id: "t12", Project: "some-project"},
+			costConfig: &defaultCostConfig,
+			setupUsage: func(u *s3usage.S3Usage) {
+				u.IncrementLogs(50, 5*1024*1024, s3usage.LogTypeTask, "")
+			},
+			assertions: func(t *testing.T, dbTask *Task) {
+				assert.Equal(t, float64(0), dbTask.TaskCost.S3LogStorageCost)
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			require.NoError(t, db.ClearCollections(Collection))
-			if tc.costConfig != nil {
-				require.NoError(t, tc.costConfig.Set(ctx))
-				t.Cleanup(func() {
-					require.NoError(t, (&evergreen.CostConfig{}).Set(ctx))
-				})
-			}
 			require.NoError(t, tc.task.Insert(ctx))
 			if tc.setupUsage != nil {
 				tc.setupUsage(&tc.task.S3Usage)
 			}
-			require.NoError(t, tc.task.SaveS3Usage(ctx, tc.lookup))
+			costs := s3usage.CalculateAllCosts(ctx, tc.task.S3Usage, tc.tierInfoByKey, tc.costConfig)
+			require.NoError(t, tc.task.SaveS3Usage(ctx, costs))
 
 			dbTask, err := FindOneId(ctx, tc.task.Id)
 			require.NoError(t, err)

--- a/model/version.go
+++ b/model/version.go
@@ -36,6 +36,7 @@ const (
 	taskS3ArtifactPutCostKey     = "s3_artifact_put_cost"
 	taskS3ArtifactStorageCostKey = "s3_artifact_storage_cost"
 	taskS3LogPutCostKey          = "s3_log_put_cost"
+	taskS3LogStorageCostKey      = "s3_log_storage_cost"
 
 	taskS3UsageKey         = "s3_usage"
 	taskS3ArtifactsKey     = "artifacts"
@@ -381,6 +382,7 @@ func (v *Version) UpdateAggregateTaskCosts(ctx context.Context) error {
 			"total_s3_artifact_put_cost":     bson.M{"$sum": "$" + taskCostKey + "." + taskS3ArtifactPutCostKey},
 			"total_s3_artifact_storage_cost": bson.M{"$sum": "$" + taskCostKey + "." + taskS3ArtifactStorageCostKey},
 			"total_s3_log_put_cost":          bson.M{"$sum": "$" + taskCostKey + "." + taskS3LogPutCostKey},
+			"total_s3_log_storage_cost":      bson.M{"$sum": "$" + taskCostKey + "." + taskS3LogStorageCostKey},
 			"total_artifact_put_requests":    bson.M{"$sum": "$" + taskS3UsageKey + "." + taskS3ArtifactsKey + "." + taskS3PutRequestsKey},
 			"total_artifact_upload_bytes":    bson.M{"$sum": "$" + taskS3UsageKey + "." + taskS3ArtifactsKey + "." + taskS3UploadBytesKey},
 			"total_artifact_count":           bson.M{"$sum": "$" + taskS3UsageKey + "." + taskS3ArtifactsKey + "." + taskS3ArtifactCountKey},
@@ -402,6 +404,7 @@ func (v *Version) UpdateAggregateTaskCosts(ctx context.Context) error {
 		TotalS3ArtifactPutCost     float64 `bson:"total_s3_artifact_put_cost"`
 		TotalS3ArtifactStorageCost float64 `bson:"total_s3_artifact_storage_cost"`
 		TotalS3LogPutCost          float64 `bson:"total_s3_log_put_cost"`
+		TotalS3LogStorageCost      float64 `bson:"total_s3_log_storage_cost"`
 		TotalArtifactPutRequests   int     `bson:"total_artifact_put_requests"`
 		TotalArtifactUploadBytes   int64   `bson:"total_artifact_upload_bytes"`
 		TotalArtifactCount         int     `bson:"total_artifact_count"`
@@ -420,6 +423,7 @@ func (v *Version) UpdateAggregateTaskCosts(ctx context.Context) error {
 		total.S3ArtifactPutCost = results[0].TotalS3ArtifactPutCost
 		total.S3ArtifactStorageCost = results[0].TotalS3ArtifactStorageCost
 		total.S3LogPutCost = results[0].TotalS3LogPutCost
+		total.S3LogStorageCost = results[0].TotalS3LogStorageCost
 		predicted.OnDemandEC2Cost = results[0].PredictedOnDemand
 		predicted.AdjustedEC2Cost = results[0].PredictedAdjusted
 		s3Total.Artifacts.PutRequests = results[0].TotalArtifactPutRequests
@@ -436,6 +440,7 @@ func (v *Version) UpdateAggregateTaskCosts(ctx context.Context) error {
 			bsonutil.GetDottedKeyName(VersionCostKey, cost.S3ArtifactPutCostKey):        total.S3ArtifactPutCost,
 			bsonutil.GetDottedKeyName(VersionCostKey, cost.S3ArtifactStorageCostKey):    total.S3ArtifactStorageCost,
 			bsonutil.GetDottedKeyName(VersionCostKey, cost.S3LogPutCostKey):             total.S3LogPutCost,
+			bsonutil.GetDottedKeyName(VersionCostKey, cost.S3LogStorageCostKey):         total.S3LogStorageCost,
 			bsonutil.GetDottedKeyName(VersionPredictedCostKey, cost.OnDemandEC2CostKey): predicted.OnDemandEC2Cost,
 			bsonutil.GetDottedKeyName(VersionPredictedCostKey, cost.AdjustedEC2CostKey): predicted.AdjustedEC2Cost,
 			VersionS3UsageKey: s3Total,

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -26,7 +26,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/gimlet"
-	"github.com/evergreen-ci/pail"
 	"github.com/evergreen-ci/utility"
 	"github.com/google/go-github/v70/github"
 	"github.com/mongodb/grip"
@@ -699,28 +698,6 @@ func discoverAndCacheBucketLifecycleRules(ctx context.Context, t *task.Task, fil
 	}
 }
 
-// findExpirationDaysForFileKey returns the expiration days from the most specific lifecycle rule
-// for the given file key.
-func findExpirationDaysForFileKey(rules []s3lifecycle.S3LifecycleRuleDoc, fileKey string) (days int, found bool) {
-	pailRules := make([]pail.LifecycleRule, 0, len(rules))
-	for _, ruleDoc := range rules {
-		var expDays *int32
-		if ruleDoc.ExpirationDays != nil {
-			expDays = utility.ToInt32Ptr(int32(*ruleDoc.ExpirationDays))
-		}
-		pailRules = append(pailRules, pail.LifecycleRule{
-			Prefix:         ruleDoc.FilterPrefix,
-			Status:         ruleDoc.RuleStatus,
-			ExpirationDays: expDays,
-		})
-	}
-	rule := pail.FindMatchingRule(pailRules, fileKey)
-	if rule == nil || rule.ExpirationDays == nil {
-		return 0, false
-	}
-	return int(*rule.ExpirationDays), true
-}
-
 // POST /rest/v2/task/{task_id}/s3_usage
 type reportS3UsageHandler struct {
 	taskID  string
@@ -753,55 +730,67 @@ func (h *reportS3UsageHandler) Run(ctx context.Context) gimlet.Responder {
 
 	t.S3Usage = h.s3Usage
 
-	allRules, err := s3lifecycle.FindAllRules(ctx)
-	var lookup func(ctx context.Context, bucket, fileKey string) (int, bool)
+	var costConfig *evergreen.CostConfig
+	var tierInfoByKey map[string]s3usage.StorageTierInfo
+	settings, err := evergreen.GetConfig(ctx)
 	if err != nil {
-		grip.Warning(ctx, message.WrapError(err, message.Fields{
-			"message": "getting S3 lifecycle rules for storage cost calculation, skipping storage cost calculation",
+		grip.Debug(ctx, message.WrapError(err, message.Fields{
+			"message": "could not get admin settings, skipping cost calculations",
 			"task_id": t.Id,
 		}))
 	} else {
-		rulesByBucket := map[string][]s3lifecycle.S3LifecycleRuleDoc{}
-		for _, rule := range allRules {
-			rulesByBucket[rule.BucketName] = append(rulesByBucket[rule.BucketName], rule)
+		costConfig = &settings.Cost
+		var logBucketName string
+		if evergreen.IsFailedTaskStatus(t.Status) {
+			logBucketName = settings.Buckets.LogBucketFailedTasks.Name
+		} else {
+			logBucketName = settings.Buckets.GetLogBucket(t.Project).Name
 		}
-		lookup = func(ctx context.Context, bucket, fileKey string) (int, bool) {
-			return findExpirationDaysForFileKey(rulesByBucket[bucket], fileKey)
+		tierInfoByKey, err = s3lifecycle.BuildTierInfoByKey(ctx, t.S3Usage, logBucketName, costConfig)
+		if err != nil {
+			grip.Debug(ctx, message.WrapError(err, message.Fields{
+				"message": "resolving S3 lifecycle tier info",
+				"task_id": t.Id,
+			}))
 		}
 	}
 
-	if err := t.SaveS3Usage(ctx, lookup); err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "saving S3 usage for task '%s'", h.taskID))
+	costs := s3usage.CalculateAllCosts(ctx, t.S3Usage, tierInfoByKey, costConfig)
+	if err := t.SaveS3Usage(ctx, costs); err != nil {
+		grip.Error(ctx, message.WrapError(err, message.Fields{
+			"message": "saving S3 usage for task",
+			"task_id": t.Id,
+		}))
 	}
 
 	v, err := model.VersionFindOneId(ctx, t.Version)
 	if err != nil {
-		grip.Error(ctx, errors.Wrapf(err, "finding version '%s' to update aggregate task costs", t.Version))
+		grip.Debug(ctx, errors.Wrapf(err, "finding version '%s' to update aggregate task costs", t.Version))
 	} else if v != nil && evergreen.IsFinishedVersionStatus(v.Status) {
-		grip.Error(ctx, errors.Wrapf(v.UpdateAggregateTaskCosts(ctx), "updating aggregate task costs for version '%s' after S3 usage report", v.Id))
-	}
-
-	var avgFilePutCost, maxFilePutCost, minFilePutCost float64
-	if t.S3Usage.Artifacts.Count > 0 && t.S3Usage.Artifacts.PutRequests > 0 {
-		costPerPut := t.TaskCost.S3ArtifactPutCost / float64(t.S3Usage.Artifacts.PutRequests)
-		avgFilePutCost = t.TaskCost.S3ArtifactPutCost / float64(t.S3Usage.Artifacts.Count)
-		maxFilePutCost = costPerPut * float64(t.S3Usage.Artifacts.ArtifactWithMaxPutRequests)
-		minFilePutCost = costPerPut * float64(t.S3Usage.Artifacts.ArtifactWithMinPutRequests)
+		grip.Debug(ctx, errors.Wrapf(v.UpdateAggregateTaskCosts(ctx), "updating aggregate task costs for version '%s' after S3 usage report", v.Id))
 	}
 
 	s3Attrs := []attribute.KeyValue{
 		attribute.String(evergreen.TaskIDOtelAttribute, t.Id),
+		attribute.Bool(evergreen.S3CostCalculatedOtelAttribute, costConfig != nil),
 		attribute.Int(evergreen.S3ArtifactPutRequestsOtelAttribute, t.S3Usage.Artifacts.PutRequests),
 		attribute.Int64(evergreen.S3ArtifactUploadBytesOtelAttribute, t.S3Usage.Artifacts.UploadBytes),
 		attribute.Int(evergreen.S3ArtifactCountOtelAttribute, t.S3Usage.Artifacts.Count),
-		attribute.Float64(evergreen.S3ArtifactPutCostOtelAttribute, t.TaskCost.S3ArtifactPutCost),
-		attribute.Float64(evergreen.S3ArtifactStorageCostOtelAttribute, t.TaskCost.S3ArtifactStorageCost),
+		attribute.Float64(evergreen.S3ArtifactPutCostOtelAttribute, costs.ArtifactPutCost),
+		attribute.Float64(evergreen.S3ArtifactStorageCostOtelAttribute, costs.ArtifactStorageCost),
 		attribute.Int(evergreen.S3LogPutRequestsOtelAttribute, t.S3Usage.Logs.PutRequests),
 		attribute.Int64(evergreen.S3LogUploadBytesOtelAttribute, t.S3Usage.Logs.UploadBytes),
-		attribute.Float64(evergreen.S3LogPutCostOtelAttribute, t.TaskCost.S3LogPutCost),
-		attribute.Float64(evergreen.S3ArtifactAvgFilePutCostOtelAttribute, avgFilePutCost),
-		attribute.Float64(evergreen.S3ArtifactWithMaxPutRequestsCostOtelAttribute, maxFilePutCost),
-		attribute.Float64(evergreen.S3ArtifactWithMinPutRequestsCostOtelAttribute, minFilePutCost),
+		attribute.Float64(evergreen.S3LogPutCostOtelAttribute, costs.LogPutCost),
+		attribute.Float64(evergreen.S3LogStorageCostOtelAttribute, costs.LogStorageCost),
+		attribute.Float64(evergreen.S3ArtifactAvgFilePutCostOtelAttribute, costs.AvgFilePutCost),
+		attribute.Float64(evergreen.S3ArtifactWithMaxPutRequestsCostOtelAttribute, costs.MaxFilePutCost),
+		attribute.Float64(evergreen.S3ArtifactWithMinPutRequestsCostOtelAttribute, costs.MinFilePutCost),
+		attribute.Float64(evergreen.S3ArtifactAvgStorageCostOtelAttribute, costs.AvgArtifactStorageCost),
+		attribute.Float64(evergreen.S3ArtifactMinStorageCostOtelAttribute, costs.MinArtifactStorageCost),
+		attribute.Float64(evergreen.S3ArtifactMaxStorageCostOtelAttribute, costs.MaxArtifactStorageCost),
+		attribute.Float64(evergreen.S3LogAvgStorageCostOtelAttribute, costs.AvgLogStorageCost),
+		attribute.Float64(evergreen.S3LogMinStorageCostOtelAttribute, costs.MinLogStorageCost),
+		attribute.Float64(evergreen.S3LogMaxStorageCostOtelAttribute, costs.MaxLogStorageCost),
 	}
 
 	span.SetAttributes(s3Attrs...)

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -1096,7 +1096,7 @@ func TestReportS3Usage(t *testing.T) {
 					S3UploadMetrics: s3usage.S3UploadMetrics{PutRequests: 50, UploadBytes: 2048},
 					Count:           5,
 				},
-				Logs: s3usage.S3UploadMetrics{PutRequests: 10, UploadBytes: 4096},
+				Logs: s3usage.LogMetrics{S3UploadMetrics: s3usage.S3UploadMetrics{PutRequests: 10, UploadBytes: 4096}},
 			},
 			wantStatus: http.StatusOK,
 			assertions: func(t *testing.T, dbTask *task.Task) {
@@ -1110,7 +1110,7 @@ func TestReportS3Usage(t *testing.T) {
 		"SavesLogOnlyUsage": {
 			insertTask: &task.Task{Id: "t2", Status: evergreen.TaskStarted},
 			s3Usage: s3usage.S3Usage{
-				Logs: s3usage.S3UploadMetrics{PutRequests: 25, UploadBytes: 8192},
+				Logs: s3usage.LogMetrics{S3UploadMetrics: s3usage.S3UploadMetrics{PutRequests: 25, UploadBytes: 8192}},
 			},
 			wantStatus: http.StatusOK,
 			assertions: func(t *testing.T, dbTask *task.Task) {
@@ -1143,59 +1143,4 @@ func TestReportS3Usage(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestFindExpirationDaysForFileKey(t *testing.T) {
-	enabled := "Enabled"
-	disabled := "Disabled"
-	days90 := 90
-	days30 := 30
-
-	t.Run("NoRulesShouldReturnNotFound", func(t *testing.T) {
-		_, ok := findExpirationDaysForFileKey(nil, "logs/build/output.txt")
-		assert.False(t, ok)
-	})
-
-	t.Run("NoMatchingPrefixShouldReturnNotFound", func(t *testing.T) {
-		rules := []s3lifecycle.S3LifecycleRuleDoc{
-			{FilterPrefix: "sandbox/", RuleStatus: enabled, ExpirationDays: &days90},
-		}
-		_, ok := findExpirationDaysForFileKey(rules, "logs/build/output.txt")
-		assert.False(t, ok)
-	})
-
-	t.Run("MatchingPrefixShouldReturnDays", func(t *testing.T) {
-		rules := []s3lifecycle.S3LifecycleRuleDoc{
-			{FilterPrefix: "logs/", RuleStatus: enabled, ExpirationDays: &days90},
-		}
-		days, ok := findExpirationDaysForFileKey(rules, "logs/build/output.txt")
-		assert.True(t, ok)
-		assert.Equal(t, 90, days)
-	})
-
-	t.Run("MostSpecificPrefixShouldWin", func(t *testing.T) {
-		rules := []s3lifecycle.S3LifecycleRuleDoc{
-			{FilterPrefix: "logs/", RuleStatus: enabled, ExpirationDays: &days90},
-			{FilterPrefix: "logs/build/", RuleStatus: enabled, ExpirationDays: &days30},
-		}
-		days, ok := findExpirationDaysForFileKey(rules, "logs/build/output.txt")
-		assert.True(t, ok)
-		assert.Equal(t, 30, days)
-	})
-
-	t.Run("DisabledRuleShouldBeIgnored", func(t *testing.T) {
-		rules := []s3lifecycle.S3LifecycleRuleDoc{
-			{FilterPrefix: "logs/", RuleStatus: disabled, ExpirationDays: &days90},
-		}
-		_, ok := findExpirationDaysForFileKey(rules, "logs/build/output.txt")
-		assert.False(t, ok)
-	})
-
-	t.Run("NilExpirationDaysShouldReturnNotFound", func(t *testing.T) {
-		rules := []s3lifecycle.S3LifecycleRuleDoc{
-			{FilterPrefix: "logs/", RuleStatus: enabled, ExpirationDays: nil},
-		}
-		_, ok := findExpirationDaysForFileKey(rules, "logs/build/output.txt")
-		assert.False(t, ok)
-	})
 }


### PR DESCRIPTION
DEVPROD-26466

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
This PR is to use the cost functions created in DEVPROD-24629 [PR](https://github.com/evergreen-ci/evergreen/pull/10030) to calculate and save S3 Logs storage costs for the task into the DB and report it on the task API

We are also emitting honeycomb metrics for this.

### Testing
Tested in staging and verified. Values are in DB and UI changes are there. Task End points print values as well
