### PR TITLE
DEVPROD-31530: Add status and taskStatusStats resolvers to VersionLite

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -1009,6 +1009,8 @@ models:
     fields:
       order:
         fieldName: "RevisionOrderNumber"
+      status:
+        resolver: true
   VersionToRestart:
     model: github.com/evergreen-ci/evergreen/model.VersionToRestart
   Volume:

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1234,6 +1234,7 @@ type ComplexityRoot struct {
 		User                 func(childComplexity int) int
 		Variants             func(childComplexity int) int
 		VariantsTasks        func(childComplexity int) int
+		Version              func(childComplexity int) int
 		VersionFull          func(childComplexity int) int
 	}
 
@@ -2581,6 +2582,7 @@ type PatchResolver interface {
 	Time(ctx context.Context, obj *model.APIPatch) (*PatchTime, error)
 	User(ctx context.Context, obj *model.APIPatch) (*model.APIDBUser, error)
 
+	Version(ctx context.Context, obj *model.APIPatch) (*model1.Version, error)
 	VersionFull(ctx context.Context, obj *model.APIPatch) (*model.APIVersion, error)
 }
 type PatchesResolver interface {
@@ -7664,6 +7666,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Patch.VariantsTasks(childComplexity), true
+	case "Patch.version":
+		if e.complexity.Patch.Version == nil {
+			break
+		}
+
+		return e.complexity.Patch.Version(childComplexity), true
 	case "Patch.versionFull":
 		if e.complexity.Patch.VersionFull == nil {
 			break
@@ -37217,6 +37225,8 @@ func (ec *executionContext) fieldContext_Mutation_setPatchVisibility(ctx context
 				return ec.fieldContext_Patch_variants(ctx, field)
 			case "variantsTasks":
 				return ec.fieldContext_Patch_variantsTasks(ctx, field)
+			case "version":
+				return ec.fieldContext_Patch_version(ctx, field)
 			case "versionFull":
 				return ec.fieldContext_Patch_versionFull(ctx, field)
 			}
@@ -37326,6 +37336,8 @@ func (ec *executionContext) fieldContext_Mutation_schedulePatch(ctx context.Cont
 				return ec.fieldContext_Patch_variants(ctx, field)
 			case "variantsTasks":
 				return ec.fieldContext_Patch_variantsTasks(ctx, field)
+			case "version":
+				return ec.fieldContext_Patch_version(ctx, field)
 			case "versionFull":
 				return ec.fieldContext_Patch_versionFull(ctx, field)
 			}
@@ -43939,6 +43951,8 @@ func (ec *executionContext) fieldContext_Patch_childPatches(_ context.Context, f
 				return ec.fieldContext_Patch_variants(ctx, field)
 			case "variantsTasks":
 				return ec.fieldContext_Patch_variantsTasks(ctx, field)
+			case "version":
+				return ec.fieldContext_Patch_version(ctx, field)
 			case "versionFull":
 				return ec.fieldContext_Patch_versionFull(ctx, field)
 			}
@@ -44872,6 +44886,75 @@ func (ec *executionContext) fieldContext_Patch_variantsTasks(_ context.Context, 
 	return fc, nil
 }
 
+func (ec *executionContext) _Patch_version(ctx context.Context, field graphql.CollectedField, obj *model.APIPatch) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Patch_version,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Patch().Version(ctx, obj)
+		},
+		nil,
+		ec.marshalOVersionLite2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersion,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_Patch_version(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Patch",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_VersionLite_id(ctx, field)
+			case "activated":
+				return ec.fieldContext_VersionLite_activated(ctx, field)
+			case "branch":
+				return ec.fieldContext_VersionLite_branch(ctx, field)
+			case "cost":
+				return ec.fieldContext_VersionLite_cost(ctx, field)
+			case "createTime":
+				return ec.fieldContext_VersionLite_createTime(ctx, field)
+			case "errors":
+				return ec.fieldContext_VersionLite_errors(ctx, field)
+			case "finishTime":
+				return ec.fieldContext_VersionLite_finishTime(ctx, field)
+			case "ignored":
+				return ec.fieldContext_VersionLite_ignored(ctx, field)
+			case "message":
+				return ec.fieldContext_VersionLite_message(ctx, field)
+			case "order":
+				return ec.fieldContext_VersionLite_order(ctx, field)
+			case "project":
+				return ec.fieldContext_VersionLite_project(ctx, field)
+			case "repo":
+				return ec.fieldContext_VersionLite_repo(ctx, field)
+			case "requester":
+				return ec.fieldContext_VersionLite_requester(ctx, field)
+			case "revision":
+				return ec.fieldContext_VersionLite_revision(ctx, field)
+			case "startTime":
+				return ec.fieldContext_VersionLite_startTime(ctx, field)
+			case "status":
+				return ec.fieldContext_VersionLite_status(ctx, field)
+			case "taskStatusStats":
+				return ec.fieldContext_VersionLite_taskStatusStats(ctx, field)
+			case "user":
+				return ec.fieldContext_VersionLite_user(ctx, field)
+			case "warnings":
+				return ec.fieldContext_VersionLite_warnings(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type VersionLite", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Patch_versionFull(ctx context.Context, field graphql.CollectedField, obj *model.APIPatch) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -45569,6 +45652,8 @@ func (ec *executionContext) fieldContext_Patches_patches(_ context.Context, fiel
 				return ec.fieldContext_Patch_variants(ctx, field)
 			case "variantsTasks":
 				return ec.fieldContext_Patch_variantsTasks(ctx, field)
+			case "version":
+				return ec.fieldContext_Patch_version(ctx, field)
 			case "versionFull":
 				return ec.fieldContext_Patch_versionFull(ctx, field)
 			}
@@ -52267,6 +52352,8 @@ func (ec *executionContext) fieldContext_Query_patch(ctx context.Context, field 
 				return ec.fieldContext_Patch_variants(ctx, field)
 			case "variantsTasks":
 				return ec.fieldContext_Patch_variantsTasks(ctx, field)
+			case "version":
+				return ec.fieldContext_Patch_version(ctx, field)
 			case "versionFull":
 				return ec.fieldContext_Patch_versionFull(ctx, field)
 			}
@@ -63651,6 +63738,8 @@ func (ec *executionContext) fieldContext_Task_patch(_ context.Context, field gra
 				return ec.fieldContext_Patch_variants(ctx, field)
 			case "variantsTasks":
 				return ec.fieldContext_Patch_variantsTasks(ctx, field)
+			case "version":
+				return ec.fieldContext_Patch_version(ctx, field)
 			case "versionFull":
 				return ec.fieldContext_Patch_versionFull(ctx, field)
 			}
@@ -73395,6 +73484,8 @@ func (ec *executionContext) fieldContext_Version_patch(_ context.Context, field 
 				return ec.fieldContext_Patch_variants(ctx, field)
 			case "variantsTasks":
 				return ec.fieldContext_Patch_variantsTasks(ctx, field)
+			case "version":
+				return ec.fieldContext_Patch_version(ctx, field)
 			case "versionFull":
 				return ec.fieldContext_Patch_versionFull(ctx, field)
 			}
@@ -97903,6 +97994,39 @@ func (ec *executionContext) _Patch(ctx context.Context, sel ast.SelectionSet, ob
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "version":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Patch_version(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "versionFull":
 			field := field
 
@@ -119846,6 +119970,13 @@ func (ec *executionContext) marshalOVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋe
 		return graphql.Null
 	}
 	return ec._Version(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOVersionLite2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersion(ctx context.Context, sel ast.SelectionSet, v *model1.Version) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._VersionLite(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalOVersionTiming2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐVersionTiming(ctx context.Context, sel ast.SelectionSet, v *VersionTiming) graphql.Marshaler {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -2344,6 +2344,8 @@ type ComplexityRoot struct {
 		Revision            func(childComplexity int) int
 		RevisionOrderNumber func(childComplexity int) int
 		StartTime           func(childComplexity int) int
+		Status              func(childComplexity int) int
+		TaskStatusStats     func(childComplexity int) int
 		User                func(childComplexity int) int
 		Warnings            func(childComplexity int) int
 	}
@@ -2804,6 +2806,8 @@ type VersionResolver interface {
 type VersionLiteResolver interface {
 	Project(ctx context.Context, obj *model1.Version) (*model1.ProjectRef, error)
 
+	Status(ctx context.Context, obj *model1.Version) (string, error)
+	TaskStatusStats(ctx context.Context, obj *model1.Version) (*task.TaskStats, error)
 	User(ctx context.Context, obj *model1.Version) (*user.DBUser, error)
 }
 type VolumeResolver interface {
@@ -12631,6 +12635,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.VersionLite.StartTime(childComplexity), true
+	case "VersionLite.status":
+		if e.complexity.VersionLite.Status == nil {
+			break
+		}
+
+		return e.complexity.VersionLite.Status(childComplexity), true
+	case "VersionLite.taskStatusStats":
+		if e.complexity.VersionLite.TaskStatusStats == nil {
+			break
+		}
+
+		return e.complexity.VersionLite.TaskStatusStats(childComplexity), true
 	case "VersionLite.user":
 		if e.complexity.VersionLite.User == nil {
 			break
@@ -65426,6 +65442,10 @@ func (ec *executionContext) fieldContext_Task_version(_ context.Context, field g
 				return ec.fieldContext_VersionLite_revision(ctx, field)
 			case "startTime":
 				return ec.fieldContext_VersionLite_startTime(ctx, field)
+			case "status":
+				return ec.fieldContext_VersionLite_status(ctx, field)
+			case "taskStatusStats":
+				return ec.fieldContext_VersionLite_taskStatusStats(ctx, field)
 			case "user":
 				return ec.fieldContext_VersionLite_user(ctx, field)
 			case "warnings":
@@ -74783,6 +74803,70 @@ func (ec *executionContext) fieldContext_VersionLite_startTime(_ context.Context
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _VersionLite_status(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_VersionLite_status,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.VersionLite().Status(ctx, obj)
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_VersionLite_status(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "VersionLite",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _VersionLite_taskStatusStats(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_VersionLite_taskStatusStats,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.VersionLite().TaskStatusStats(ctx, obj)
+		},
+		nil,
+		ec.marshalOTaskStats2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐTaskStats,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_VersionLite_taskStatusStats(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "VersionLite",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "counts":
+				return ec.fieldContext_TaskStats_counts(ctx, field)
+			case "eta":
+				return ec.fieldContext_TaskStats_eta(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TaskStats", field.Name)
 		},
 	}
 	return fc, nil
@@ -108507,6 +108591,75 @@ func (ec *executionContext) _VersionLite(ctx context.Context, sel ast.SelectionS
 			}
 		case "startTime":
 			out.Values[i] = ec._VersionLite_startTime(ctx, field, obj)
+		case "status":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._VersionLite_status(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "taskStatusStats":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._VersionLite_taskStatusStats(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "user":
 			field := field
 

--- a/graphql/patch_resolver.go
+++ b/graphql/patch_resolver.go
@@ -328,6 +328,22 @@ func (r *patchResolver) User(ctx context.Context, obj *restModel.APIPatch) (*res
 	return apiUser, nil
 }
 
+// Version is the resolver for the version field.
+func (r *patchResolver) Version(ctx context.Context, obj *restModel.APIPatch) (*model.Version, error) {
+	versionID := utility.FromStringPtr(obj.Version)
+	if versionID == "" {
+		return nil, nil
+	}
+	v, err := model.VersionFindOneId(ctx, versionID)
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionID, err.Error()))
+	}
+	if v == nil {
+		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("version '%s' not found", versionID))
+	}
+	return v, nil
+}
+
 // VersionFull is the resolver for the versionFull field.
 func (r *patchResolver) VersionFull(ctx context.Context, obj *restModel.APIPatch) (*restModel.APIVersion, error) {
 	versionID := utility.FromStringPtr(obj.Version)

--- a/graphql/schema/types/patch.graphql
+++ b/graphql/schema/types/patch.graphql
@@ -97,6 +97,7 @@ type Patch {
   user: User!
   variants: [String!]!
   variantsTasks: [VariantTask!]!
+  version: VersionLite
   versionFull: Version
 }
 

--- a/graphql/schema/types/version.graphql
+++ b/graphql/schema/types/version.graphql
@@ -177,6 +177,8 @@ type VersionLite {
   requester: String!
   revision: String!
   startTime: Time
+  status: String!
+  taskStatusStats: TaskStats
   user: UserLite!
   warnings: [String!]!
 }

--- a/graphql/tests/patch/version/data.json
+++ b/graphql/tests/patch/version/data.json
@@ -5,7 +5,32 @@
       "identifier": "spruce",
       "gitspec": "5e823e1f28baeaa22ae00823d83e03082cd148ab",
       "r": "gitter_request",
-      "requester": "gitter_request"
+      "requester": "gitter_request",
+      "status": "failed"
+    }
+  ],
+  "tasks": [
+    {
+      "_id": "patch_version_task_1",
+      "version": "5dd2e89cd1fe07048e43bb9c",
+      "r": "gitter_request",
+      "execution": 0,
+      "display_task_id": "",
+      "display_status_cache": "succeeded",
+      "activated_time": {
+        "$date": "2020-01-01T00:00:00.000Z"
+      }
+    },
+    {
+      "_id": "patch_version_task_2",
+      "version": "5dd2e89cd1fe07048e43bb9c",
+      "r": "gitter_request",
+      "execution": 0,
+      "display_task_id": "",
+      "display_status_cache": "failed",
+      "activated_time": {
+        "$date": "2020-01-01T00:00:00.000Z"
+      }
     }
   ],
   "patches": [

--- a/graphql/tests/patch/version/results.json
+++ b/graphql/tests/patch/version/results.json
@@ -17,6 +17,22 @@
           "patch": {
             "versionFull": {
               "id": "5dd2e89cd1fe07048e43bb9c"
+            },
+            "version": {
+              "id": "5dd2e89cd1fe07048e43bb9c",
+              "status": "failed",
+              "taskStatusStats": {
+                "counts": [
+                  {
+                    "status": "failed",
+                    "count": 1
+                  },
+                  {
+                    "status": "succeeded",
+                    "count": 1
+                  }
+                ]
+              }
             }
           }
         }

--- a/graphql/tests/task/versionMetadata/data.json
+++ b/graphql/tests/task/versionMetadata/data.json
@@ -92,7 +92,27 @@
       "distro": "archlinux-small",
       "r": "gitter_request",
       "execution": 0,
-      "branch": "spruce"
+      "branch": "spruce",
+      "display_task_id": "",
+      "display_status_cache": "succeeded",
+      "activated_time": {
+        "$date": "2020-02-22T10:00:00.000Z"
+      }
+    },
+    {
+      "_id": "taskity_task_3",
+      "order": 2568,
+      "version": "version_admin_user",
+      "host_id": "i-0bb70e2ac4c1a9ac10",
+      "distro": "archlinux-small",
+      "r": "gitter_request",
+      "execution": 0,
+      "branch": "spruce",
+      "display_task_id": "",
+      "display_status_cache": "failed",
+      "activated_time": {
+        "$date": "2020-02-22T10:00:00.000Z"
+      }
     }
   ],
   "users": [

--- a/graphql/tests/task/versionMetadata/queries/version_status_and_stats.graphql
+++ b/graphql/tests/task/versionMetadata/queries/version_status_and_stats.graphql
@@ -1,8 +1,6 @@
 {
-  patch(patchId: "9e4ff3abe3c3317e352062e4") {
-    versionFull {
-      id
-    }
+  task(taskId: "taskity_task_2") {
+    id
     version {
       id
       status

--- a/graphql/tests/task/versionMetadata/results.json
+++ b/graphql/tests/task/versionMetadata/results.json
@@ -59,6 +59,32 @@
           }
         }
       }
+    },
+    {
+      "query_file": "version_status_and_stats.graphql",
+      "result": {
+        "data": {
+          "task": {
+            "id": "taskity_task_2",
+            "version": {
+              "id": "version_admin_user",
+              "status": "succeeded",
+              "taskStatusStats": {
+                "counts": [
+                  {
+                    "status": "failed",
+                    "count": 1
+                  },
+                  {
+                    "status": "succeeded",
+                    "count": 1
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -399,7 +399,7 @@ func (r *versionResolver) TaskStatusStats(ctx context.Context, obj *restModel.AP
 	}
 
 	versionID := utility.FromStringPtr(obj.Id)
-	stats, err := task.GetTaskStatsByVersion(ctx, versionID, opts)
+	stats, err := task.GetFilteredTaskStatsByVersion(ctx, versionID, opts)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting task status stats for version '%s': %s", versionID, err.Error()))
 	}
@@ -631,6 +631,17 @@ func (r *versionLiteResolver) Project(ctx context.Context, obj *model.Version) (
 		return nil, nil
 	}
 	return projectRef, nil
+}
+
+// Status is the resolver for the status field.
+func (r *versionLiteResolver) Status(ctx context.Context, obj *model.Version) (string, error) {
+	return getDisplayStatus(ctx, obj)
+}
+
+// TaskStatusStats is the resolver for the taskStatusStats field.
+func (r *versionLiteResolver) TaskStatusStats(ctx context.Context, obj *model.Version) (*task.TaskStats, error) {
+	includeNeverActivated := !evergreen.IsPatchRequester(obj.Requester)
+	return task.GetTaskStatsByVersion(ctx, obj.Id, includeNeverActivated)
 }
 
 // User is the resolver for the user field.

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2030,8 +2030,41 @@ type GroupedTaskStatusCount struct {
 	StatusCounts []*StatusCount `bson:"status_counts"`
 }
 
-func GetTaskStatsByVersion(ctx context.Context, versionID string, opts GetTasksByVersionOptions) (*TaskStats, error) {
+// GetTaskStatsByVersion returns aggregate task status counts for a version
+// using a lean pipeline that references display_status_cache directly.
+func GetTaskStatsByVersion(ctx context.Context, versionID string, includeNeverActivated bool) (*TaskStats, error) {
 	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String(evergreen.AggregationNameOtelAttribute, "GetTaskStatsByVersion")})
+
+	match := bson.M{
+		VersionKey:       versionID,
+		DisplayTaskIdKey: "",
+	}
+	if !includeNeverActivated {
+		match[ActivatedTimeKey] = bson.M{"$ne": utility.ZeroTime}
+	}
+
+	pipeline := []bson.M{
+		{"$match": match},
+		{"$group": bson.M{"_id": "$" + DisplayStatusCacheKey, "count": bson.M{"$sum": 1}}},
+		{"$sort": bson.M{"_id": 1}},
+		{"$project": bson.M{"status": "$_id", "count": 1}},
+	}
+
+	env := evergreen.GetEnvironment()
+	cursor, err := env.DB().Collection(Collection).Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, errors.Wrap(err, "aggregating task stats for version")
+	}
+	var counts []StatusCount
+	if err := cursor.All(ctx, &counts); err != nil {
+		return nil, errors.Wrap(err, "decoding task stats for version")
+	}
+
+	return &TaskStats{Counts: counts}, nil
+}
+
+func GetFilteredTaskStatsByVersion(ctx context.Context, versionID string, opts GetTasksByVersionOptions) (*TaskStats, error) {
+	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String(evergreen.AggregationNameOtelAttribute, "GetFilteredTaskStatsByVersion")})
 
 	pipeline, err := getTasksByVersionPipeline(versionID, opts)
 	if err != nil {

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -1380,7 +1380,7 @@ func TestGetTasksByVersionSorting(t *testing.T) {
 	assert.Equal(t, "t3", tasks[3].Id)
 }
 
-func TestGetTaskStatsByVersion(t *testing.T) {
+func TestGetFilteredTaskStatsByVersion(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection))
 	t1 := Task{
 		Id:                 "t1",
@@ -1437,16 +1437,141 @@ func TestGetTaskStatsByVersion(t *testing.T) {
 	assert.NoError(t, db.InsertMany(t.Context(), Collection, t1, t2, t3, t4, t5, t6))
 	ctx := context.TODO()
 	opts := GetTasksByVersionOptions{}
-	stats, err := GetTaskStatsByVersion(ctx, "v1", opts)
+	stats, err := GetFilteredTaskStatsByVersion(ctx, "v1", opts)
 	assert.NoError(t, err)
 	assert.Len(t, stats.Counts, 4)
 	assert.True(t, stats.ETA.Equal(time.Date(2009, time.November, 10, 14, 30, 0, 0, time.UTC)))
 
 	assert.NoError(t, db.ClearCollections(Collection))
 	assert.NoError(t, db.InsertMany(t.Context(), Collection, t3, t4, t5, t6))
-	stats, err = GetTaskStatsByVersion(ctx, "v1", opts)
+	stats, err = GetFilteredTaskStatsByVersion(ctx, "v1", opts)
 	assert.NoError(t, err)
 	assert.Nil(t, stats.ETA)
+}
+
+func TestGetTaskStatsByVersion(t *testing.T) {
+	t.Run("BasicCountsByStatus", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(Collection))
+		tasks := []Task{
+			{
+				Id:                 "started1",
+				Version:            "v1",
+				Status:             evergreen.TaskStarted,
+				DisplayTaskId:      utility.ToStringPtr(""),
+				DisplayStatusCache: evergreen.TaskStarted,
+				ActivatedTime:      time.Now(),
+			},
+			{
+				Id:                 "started2",
+				Version:            "v1",
+				Status:             evergreen.TaskStarted,
+				DisplayTaskId:      utility.ToStringPtr(""),
+				DisplayStatusCache: evergreen.TaskStarted,
+				ActivatedTime:      time.Now(),
+			},
+			{
+				Id:                 "succeeded1",
+				Version:            "v1",
+				Status:             evergreen.TaskSucceeded,
+				DisplayTaskId:      utility.ToStringPtr(""),
+				DisplayStatusCache: evergreen.TaskSucceeded,
+				ActivatedTime:      time.Now(),
+			},
+			{
+				Id:                 "failed1",
+				Version:            "v1",
+				Status:             evergreen.TaskFailed,
+				DisplayTaskId:      utility.ToStringPtr(""),
+				DisplayStatusCache: evergreen.TaskFailed,
+				ActivatedTime:      time.Now(),
+			},
+		}
+		for _, task := range tasks {
+			require.NoError(t, task.Insert(t.Context()))
+		}
+
+		stats, err := GetTaskStatsByVersion(t.Context(), "v1", true)
+		require.NoError(t, err)
+		assert.Len(t, stats.Counts, 3)
+	})
+
+	t.Run("ExcludesNeverActivatedTasks", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(Collection))
+		tasks := []Task{
+			{
+				Id:                 "activated1",
+				Version:            "v1",
+				Status:             evergreen.TaskSucceeded,
+				DisplayTaskId:      utility.ToStringPtr(""),
+				DisplayStatusCache: evergreen.TaskSucceeded,
+				ActivatedTime:      time.Now(),
+			},
+			{
+				Id:                 "never_activated",
+				Version:            "v1",
+				Status:             evergreen.TaskUndispatched,
+				DisplayTaskId:      utility.ToStringPtr(""),
+				DisplayStatusCache: evergreen.TaskUndispatched,
+				ActivatedTime:      utility.ZeroTime,
+			},
+		}
+		for _, task := range tasks {
+			require.NoError(t, task.Insert(t.Context()))
+		}
+
+		stats, err := GetTaskStatsByVersion(t.Context(), "v1", false)
+		require.NoError(t, err)
+		require.Len(t, stats.Counts, 1)
+		assert.Equal(t, evergreen.TaskSucceeded, stats.Counts[0].Status)
+		assert.Equal(t, 1, stats.Counts[0].Count)
+
+		stats, err = GetTaskStatsByVersion(t.Context(), "v1", true)
+		require.NoError(t, err)
+		assert.Len(t, stats.Counts, 2)
+	})
+
+	t.Run("ExcludesExecutionTasksUnderDisplayTasks", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(Collection))
+		tasks := []Task{
+			{
+				Id:                 "display_task",
+				Version:            "v1",
+				Status:             evergreen.TaskStarted,
+				DisplayTaskId:      utility.ToStringPtr(""),
+				DisplayStatusCache: evergreen.TaskStarted,
+				ActivatedTime:      time.Now(),
+			},
+			{
+				Id:                 "exec_task_under_display",
+				Version:            "v1",
+				Status:             evergreen.TaskSucceeded,
+				DisplayTaskId:      utility.ToStringPtr("display_task"),
+				DisplayStatusCache: evergreen.TaskSucceeded,
+				ActivatedTime:      time.Now(),
+			},
+			{
+				Id:                 "standalone_task",
+				Version:            "v1",
+				Status:             evergreen.TaskFailed,
+				DisplayTaskId:      utility.ToStringPtr(""),
+				DisplayStatusCache: evergreen.TaskFailed,
+				ActivatedTime:      time.Now(),
+			},
+		}
+		for _, task := range tasks {
+			require.NoError(t, task.Insert(t.Context()))
+		}
+
+		stats, err := GetTaskStatsByVersion(t.Context(), "v1", true)
+		require.NoError(t, err)
+		assert.Len(t, stats.Counts, 2)
+
+		totalCount := 0
+		for _, c := range stats.Counts {
+			totalCount += c.Count
+		}
+		assert.Equal(t, 2, totalCount)
+	})
 }
 
 func TestGetGroupedTaskStatsByVersion(t *testing.T) {


### PR DESCRIPTION
DEVPROD-31530

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
These are some of the most expensive `Version` resolvers ([Honeycomb](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen/result/FUfviR71Www)). For `VersionLite` (based on DB type, not `APIVersion`), update them:
- Remove extra trips to DB now that the version is already fetched
- Simplify TaskStatusStats pipeline by creating separate pipeline (i.e. not reusing `getTasksByVersion`)
  - Remove unused ETA result
  - Remove unused filters
  - Only query for status field
- Add `VersionLite` to `Patch`

<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

### Testing
- Test patch's version data
- Add pipeline tests