### PR TITLE
DEVPROD-26290 Use corp url for token exchange

### DIFF
--- a/rest/route/auth.go
+++ b/rest/route/auth.go
@@ -145,7 +145,7 @@ func (h *tokenExchangeCallbackHandler) Run(ctx context.Context) gimlet.Responder
 	}
 
 	// The Okta web app config is used to exchange the authorization code for a user access token.
-	callbackURL := fmt.Sprintf("%s/rest/v2/auth/token_exchange/callback", strings.TrimRight(settings.Ui.Url, "/"))
+	callbackURL := fmt.Sprintf("%s/rest/v2/auth/token_exchange/callback", strings.TrimRight(settings.Api.CorpURL, "/"))
 	userAccessToken, err := thirdparty.ExchangeAuthCodeForToken(ctx, thirdparty.AuthCodeExchangeOptions{
 		TokenURL:     settings.AuthConfig.Okta.Issuer,
 		ClientID:     settings.AuthConfig.Okta.ClientID,

--- a/rest/route/auth.go
+++ b/rest/route/auth.go
@@ -73,7 +73,7 @@ func tokenExchangeAuthorizeHandler(env evergreen.Environment) http.HandlerFunc {
 			Issuer:      settings.AuthConfig.Okta.Issuer,
 			ClientID:    settings.AuthConfig.Okta.ClientID,
 			Scopes:      settings.AuthConfig.Okta.Scopes,
-			RedirectURI: fmt.Sprintf("%s/rest/v2/auth/token_exchange/callback", strings.TrimRight(settings.Ui.Url, "/")),
+			RedirectURI: fmt.Sprintf("%s/rest/v2/auth/token_exchange/callback", strings.TrimRight(settings.Api.CorpURL, "/")),
 		})
 		if err != nil {
 			http.Error(w, errors.Wrap(err, "building authorize URL").Error(), http.StatusInternalServerError)

--- a/rest/route/auth_test.go
+++ b/rest/route/auth_test.go
@@ -135,7 +135,7 @@ func TestTokenExchangeAuthorizeHandler(t *testing.T) {
 			Issuer:       oktaDiscoverySrv.URL,
 			Scopes:       []string{"openid", "email", "profile", "offline_access"},
 		}
-		env.EvergreenSettings.Ui.Url = "https://evergreen.example.com"
+		env.EvergreenSettings.Api.CorpURL = "https://evergreen.example.com"
 		return env
 	}
 


### PR DESCRIPTION
DEVPROD-26290

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Use the corp url for token exchange.

<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

### Testing
I updated our testing. I can DM more about the testing, but I manually updated the redirect uri and it works with the corp one (our Okta app is only configured with the corp url)