### PR TITLE
DEVPROD-31096 Use true zero time as default for GetGithubCommits calll

### DIFF
--- a/model/version.go
+++ b/model/version.go
@@ -907,7 +907,7 @@ func getManifestModule(ctx context.Context, projectRef *ProjectRef, module Modul
 		ghCtx, cancel := context.WithTimeout(ctx, time.Minute)
 		defer cancel()
 
-		revisionTime := time.Unix(0, 0)
+		revisionTime := time.Time{}
 
 		// If this is a mainline commit or a trigger version, retrieve the module's commit from the time of the mainline commit.
 		// If this is a periodic build, retrieve the module's commit from the time of the periodic build.


### PR DESCRIPTION
DEVPROD-31096

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Our old implementation used `utility.IsZeroTime` ([code](https://github.com/ZackarySantana/utility/blob/12c7d07c7b6519cef6f663f8335d3f2a56461ddb/time.go#L24)), which checks specifically for `time.Unix(0, 0)` and counts that as a zero time. This doesn't work well when we are marshaling- which relies specifically on `time.IsZero()`, which is `time.Time{}`.
