### PR TITLE
DEVPROD-29442 Get PR patch data rather than diff data

### DIFF
--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1535,9 +1535,9 @@ func GetGithubPullRequest(ctx context.Context, baseOwner, baseRepo string, prNum
 	return pr, nil
 }
 
-// GetGithubPullRequestDiff downloads a raw diff from a Github Pull Request.
-// This can fail if the PR is too large (e.g. greater than 300 files). See
-// GetGitHubPullRequestFiles.
+// GetGithubPullRequestDiff downloads the pull request diff using GitHub's
+// compare commits API (merge_base...head). This includes per-file patch data
+// that the pull request raw diff endpoint omits (e.g. binary files).
 func GetGithubPullRequestDiff(ctx context.Context, gh GithubPatch) (string, []Summary, error) {
 	caller := "GetGithubPullRequestDiff"
 	ctx, span := tracer.Start(ctx, caller, trace.WithAttributes(
@@ -1555,14 +1555,22 @@ func GetGithubPullRequestDiff(ctx context.Context, gh GithubPatch) (string, []Su
 	githubClient := getGithubClient(token, caller, retryConfig{retry404: true})
 	defer githubClient.Close()
 
-	diff, resp, err := githubClient.PullRequests.GetRaw(ctx, gh.BaseOwner, gh.BaseRepo, gh.PRNumber, github.RawOptions{Type: github.Diff})
+	diff, resp, err := githubClient.Repositories.CompareCommitsRaw(
+		ctx,
+		gh.BaseOwner,
+		gh.BaseRepo,
+		gh.MergeBase,
+		gh.HeadHash,
+		github.RawOptions{Type: github.Patch},
+	)
 	if resp != nil {
-		defer resp.Body.Close()
 		span.SetAttributes(attribute.Bool(githubCachedAttribute, respFromCache(resp.Response)))
+		resp.Body.Close()
 	}
 	if err != nil {
-		return "", nil, err
+		return "", nil, errors.Wrap(err, "failed to get pull request diff")
 	}
+
 	summaries, err := GetPatchSummaries(diff)
 	if err != nil {
 		return "", nil, errors.Wrap(err, "failed to get patch summary")

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1535,15 +1535,16 @@ func GetGithubPullRequest(ctx context.Context, baseOwner, baseRepo string, prNum
 	return pr, nil
 }
 
-// GetGithubPullRequestDiff downloads the pull request diff using GitHub's
+// GetGithubPullRequestPatch downloads the pull request diff using GitHub's
 // compare commits API (merge_base...head). This includes per-file patch data
 // that the pull request raw diff endpoint omits (e.g. binary files).
-func GetGithubPullRequestDiff(ctx context.Context, gh GithubPatch) (string, []Summary, error) {
-	caller := "GetGithubPullRequestDiff"
+func GetGithubPullRequestPatch(ctx context.Context, gh GithubPatch) (string, []Summary, error) {
+	caller := "GetGithubPullRequestPatch"
 	ctx, span := tracer.Start(ctx, caller, trace.WithAttributes(
 		attribute.String(githubEndpointAttribute, caller),
 		attribute.String(githubOwnerAttribute, gh.BaseOwner),
 		attribute.String(githubRepoAttribute, gh.BaseRepo),
+		attribute.String(githubRefAttribute, gh.HeadHash),
 	))
 	defer span.End()
 
@@ -1556,11 +1557,7 @@ func GetGithubPullRequestDiff(ctx context.Context, gh GithubPatch) (string, []Su
 	defer githubClient.Close()
 
 	diff, resp, err := githubClient.Repositories.CompareCommitsRaw(
-		ctx,
-		gh.BaseOwner,
-		gh.BaseRepo,
-		gh.MergeBase,
-		gh.HeadHash,
+		ctx, gh.BaseOwner, gh.BaseRepo, gh.BaseHash, gh.HeadHash,
 		github.RawOptions{Type: github.Patch},
 	)
 	if resp != nil {

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -422,23 +422,62 @@ func (s *githubSuite) TestGitHubUserPermissionLevel() {
 	s.False(hasPermission)
 }
 
-func (s *githubSuite) TestGetGithubPullRequestDiff() {
-	p := GithubPatch{
-		PRNumber:   448,
-		BaseOwner:  "evergreen-ci",
-		BaseRepo:   "evergreen",
-		BaseBranch: "main",
-	}
-
-	diff, summaries, err := GetGithubPullRequestDiff(s.ctx, p)
-	s.NoError(err)
-	s.Len(summaries, 2)
-	s.Contains(diff, "diff --git a/cli/host.go b/cli/host.go")
-}
-
 func (s *githubSuite) TestGetBranchProtectionRules() {
 	_, err := GetEvergreenBranchProtectionRules(s.ctx, "evergreen-ci", "evergreen", "main")
 	s.NoError(err)
+}
+
+func TestGetGithubPullRequestPatch(t *testing.T) {
+	config := testutil.TestConfig()
+	testutil.ConfigureIntegrationTest(t, config)
+
+	const (
+		owner, repo = "evergreen-ci", "evergreen"
+		// PR 448 — main at the time of the PR.
+		base448  = "776f608b5b12cd27b8d931c8ee4ca0c13f857299"
+		head448  = "729b1ab0e21514fb1af39fc298e3fae9b480d568"
+		ref448   = "EVG-2387-use-plain-logger"
+		// PR 9880 — main at the time of the PR.
+		base9880 = "cd147d8cbb698549a5bce79302075b86b029acd1"
+		head9880 = "1869c8add1cd54a76dd9fb52d6d7b8f9924bc3e9"
+		ref9880  = "DEVPROD-21346_docs"
+	)
+
+	for _, tc := range []struct{ name, head string }{
+		{"HeadHash", head448},
+		{"HeadRef", ref448},
+	} {
+		t.Run("PR448/"+tc.name, func(t *testing.T) {
+			diff, summaries, err := GetGithubPullRequestPatch(t.Context(), GithubPatch{
+				BaseOwner: owner,
+				BaseRepo:  repo,
+				BaseHash:  base448,
+				HeadHash:  tc.head,
+			})
+			require.NoError(t, err)
+			require.Len(t, summaries, 2)
+			require.Contains(t, diff, "diff --git a/cli/host.go b/cli/host.go")
+		})
+	}
+
+	const noBinaryShorthand = "Binary files /dev/null and b/docs/images/run-every-mainline-commit-project-setting.png differ"
+	for _, tc := range []struct{ name, head string }{
+		{"HeadHash", head9880},
+		{"HeadRef", ref9880},
+	} {
+		t.Run("PR9880/"+tc.name, func(t *testing.T) {
+			diff, summaries, err := GetGithubPullRequestPatch(t.Context(), GithubPatch{
+				BaseOwner: owner,
+				BaseRepo:  repo,
+				BaseHash:  base9880,
+				HeadHash:  tc.head,
+			})
+			require.NoError(t, err)
+			require.Len(t, summaries, 2)
+			require.Contains(t, diff, "GIT binary patch")
+			require.NotContains(t, diff, noBinaryShorthand)
+		})
+	}
 }
 
 func TestVerifyGithubAPILimitHeader(t *testing.T) {

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -459,7 +459,7 @@ func TestGetGithubPullRequestPatch(t *testing.T) {
 		// These are the headers that indicate a binary file is included in the patch.
 		assert.Contains(t, diff, "GIT binary patch")
 		assert.Contains(t, diff, "literal 1006867")
-		// This is the header that indicates a binray file is in the diff but not included
+		// This is the header that indicates a binary file is in the diff but not included
 		// in the patch.
 		assert.NotContains(t, diff, "Binary files /dev/null and b/docs/images/run-every-mainline-commit-project-setting.png differ")
 	})

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -434,9 +434,9 @@ func TestGetGithubPullRequestPatch(t *testing.T) {
 	const (
 		owner, repo = "evergreen-ci", "evergreen"
 		// PR 448 — main at the time of the PR.
-		base448  = "776f608b5b12cd27b8d931c8ee4ca0c13f857299"
-		head448  = "729b1ab0e21514fb1af39fc298e3fae9b480d568"
-		ref448   = "EVG-2387-use-plain-logger"
+		base448 = "776f608b5b12cd27b8d931c8ee4ca0c13f857299"
+		head448 = "729b1ab0e21514fb1af39fc298e3fae9b480d568"
+		ref448  = "EVG-2387-use-plain-logger"
 		// PR 9880 — main at the time of the PR.
 		base9880 = "cd147d8cbb698549a5bce79302075b86b029acd1"
 		head9880 = "1869c8add1cd54a76dd9fb52d6d7b8f9924bc3e9"
@@ -473,7 +473,7 @@ func TestGetGithubPullRequestPatch(t *testing.T) {
 				HeadHash:  tc.head,
 			})
 			require.NoError(t, err)
-			require.Len(t, summaries, 2)
+			require.Len(t, summaries, 7)
 			require.Contains(t, diff, "GIT binary patch")
 			require.NotContains(t, diff, noBinaryShorthand)
 		})

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -431,53 +431,34 @@ func TestGetGithubPullRequestPatch(t *testing.T) {
 	config := testutil.TestConfig()
 	testutil.ConfigureIntegrationTest(t, config)
 
-	const (
-		owner, repo = "evergreen-ci", "evergreen"
-		// PR 448 — main at the time of the PR.
-		base448 = "776f608b5b12cd27b8d931c8ee4ca0c13f857299"
-		head448 = "729b1ab0e21514fb1af39fc298e3fae9b480d568"
-		ref448  = "EVG-2387-use-plain-logger"
-		// PR 9880 — main at the time of the PR.
-		base9880 = "cd147d8cbb698549a5bce79302075b86b029acd1"
-		head9880 = "1869c8add1cd54a76dd9fb52d6d7b8f9924bc3e9"
-		ref9880  = "DEVPROD-21346_docs"
-	)
-
-	for _, tc := range []struct{ name, head string }{
-		{"HeadHash", head448},
-		{"HeadRef", ref448},
-	} {
-		t.Run("PR448/"+tc.name, func(t *testing.T) {
-			diff, summaries, err := GetGithubPullRequestPatch(t.Context(), GithubPatch{
-				BaseOwner: owner,
-				BaseRepo:  repo,
-				BaseHash:  base448,
-				HeadHash:  tc.head,
-			})
-			require.NoError(t, err)
-			require.Len(t, summaries, 2)
-			require.Contains(t, diff, "diff --git a/cli/host.go b/cli/host.go")
+	t.Run("PR448", func(t *testing.T) {
+		diff, summaries, err := GetGithubPullRequestPatch(t.Context(), GithubPatch{
+			BaseOwner: "evergreen-ci",
+			BaseRepo:  "evergreen",
+			// Main hash for PR 448.
+			BaseHash: "776f608b5b12cd27b8d931c8ee4ca0c13f857299",
+			// Head hash for PR 448.
+			HeadHash: "729b1ab0e21514fb1af39fc298e3fae9b480d568",
 		})
-	}
+		require.NoError(t, err)
+		require.Len(t, summaries, 2)
+		require.Contains(t, diff, "diff --git a/cli/host.go b/cli/host.go")
+	})
 
-	const noBinaryShorthand = "Binary files /dev/null and b/docs/images/run-every-mainline-commit-project-setting.png differ"
-	for _, tc := range []struct{ name, head string }{
-		{"HeadHash", head9880},
-		{"HeadRef", ref9880},
-	} {
-		t.Run("PR9880/"+tc.name, func(t *testing.T) {
-			diff, summaries, err := GetGithubPullRequestPatch(t.Context(), GithubPatch{
-				BaseOwner: owner,
-				BaseRepo:  repo,
-				BaseHash:  base9880,
-				HeadHash:  tc.head,
-			})
-			require.NoError(t, err)
-			require.Len(t, summaries, 7)
-			require.Contains(t, diff, "GIT binary patch")
-			require.NotContains(t, diff, noBinaryShorthand)
+	t.Run("PR9880BinaryPatch", func(t *testing.T) {
+		diff, summaries, err := GetGithubPullRequestPatch(t.Context(), GithubPatch{
+			BaseOwner: "evergreen-ci",
+			BaseRepo:  "evergreen",
+			// Main hash for PR 9880.
+			BaseHash: "cd147d8cbb698549a5bce79302075b86b029acd1",
+			// Head hash for PR 9880.
+			HeadHash: "1869c8add1cd54a76dd9fb52d6d7b8f9924bc3e9",
 		})
-	}
+		require.NoError(t, err)
+		require.Len(t, summaries, 7)
+		require.Contains(t, diff, "GIT binary patch")
+		require.NotContains(t, diff, "Binary files /dev/null and b/docs/images/run-every-mainline-commit-project-setting.png differ")
+	})
 }
 
 func TestVerifyGithubAPILimitHeader(t *testing.T) {

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -441,8 +441,8 @@ func TestGetGithubPullRequestPatch(t *testing.T) {
 			HeadHash: "729b1ab0e21514fb1af39fc298e3fae9b480d568",
 		})
 		require.NoError(t, err)
-		require.Len(t, summaries, 2)
-		require.Contains(t, diff, "diff --git a/cli/host.go b/cli/host.go")
+		assert.Len(t, summaries, 2)
+		assert.Contains(t, diff, "diff --git a/cli/host.go b/cli/host.go")
 	})
 
 	t.Run("PR9880BinaryPatch", func(t *testing.T) {
@@ -455,9 +455,13 @@ func TestGetGithubPullRequestPatch(t *testing.T) {
 			HeadHash: "1869c8add1cd54a76dd9fb52d6d7b8f9924bc3e9",
 		})
 		require.NoError(t, err)
-		require.Len(t, summaries, 7)
-		require.Contains(t, diff, "GIT binary patch")
-		require.NotContains(t, diff, "Binary files /dev/null and b/docs/images/run-every-mainline-commit-project-setting.png differ")
+		assert.Len(t, summaries, 7)
+		// These are the headers that indicate a binary file is included in the patch.
+		assert.Contains(t, diff, "GIT binary patch")
+		assert.Contains(t, diff, "literal 1006867")
+		// This is the header that indicates a binray file is in the diff but not included
+		// in the patch.
+		assert.NotContains(t, diff, "Binary files /dev/null and b/docs/images/run-every-mainline-commit-project-setting.png differ")
 	})
 }
 

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1018,7 +1018,7 @@ func (j *patchIntentProcessor) buildGithubPatchDoc(ctx context.Context, patchDoc
 	patchDoc.Author = j.user.Id
 	patchDoc.Project = projectRef.Id
 
-	patchContent, summaries, err := thirdparty.GetGithubPullRequestDiff(ctx, patchDoc.GithubPatchData)
+	patchContent, summaries, err := thirdparty.GetGithubPullRequestPatch(ctx, patchDoc.GithubPatchData)
 	if err != nil {
 		// Expected error when the PR diff is more than 3000 lines or 300 files.
 		if strings.Contains(err.Error(), thirdparty.PRDiffTooLargeErrorMessage) {

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1535,7 +1535,7 @@ func (s *PatchIntentUnitsSuite) TestGithubPRTestFromUnknownUserDoesntCreateVersi
 	s.Require().NoError(evergreen.SetServiceFlags(s.ctx, flags))
 
 	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings())
-	intent, err := patch.NewGithubIntent(s.ctx, "1", "", "", "", "", testutil.NewGithubPR(448, "evergreen-ci/evergreen", "776f608b5b12cd27b8d931c8ee4ca0c13f857299", "evergreen-ci/evergreen", "729b1ab0e21514fb1af39fc298e3fae9b480d568", "octocat", "title1"))
+	intent, err := patch.NewGithubIntent(s.ctx, "1", "", "", "", "", testutil.NewGithubPR(448, "evergreen-ci/evergreen", "776f608b5b12cd27b8d931c8ee4ca0c13f857299", s.headRepo, "729b1ab0e21514fb1af39fc298e3fae9b480d568", "octocat", "title1"))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert(s.ctx))

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -224,6 +224,7 @@ func (s *PatchIntentUnitsSuite) SetupTest() {
 		BaseOwner:  "evergreen-ci",
 		BaseRepo:   "evergreen",
 		BaseBranch: "main",
+		BaseHash:   "776f608b5b12cd27b8d931c8ee4ca0c13f857299",
 		HeadOwner:  "richardsamuels",
 		HeadRepo:   "evergreen",
 		HeadHash:   "729b1ab0e21514fb1af39fc298e3fae9b480d568",

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -226,7 +226,7 @@ func (s *PatchIntentUnitsSuite) SetupTest() {
 		BaseBranch: "main",
 		HeadOwner:  "richardsamuels",
 		HeadRepo:   "evergreen",
-		HeadHash:   "something",
+		HeadHash:   "729b1ab0e21514fb1af39fc298e3fae9b480d568",
 		Author:     "richardsamuels",
 	}
 	s.desc = "Test!"
@@ -1255,7 +1255,7 @@ func (s *PatchIntentUnitsSuite) TestProcessCliPatchIntent() {
 	s.NoError(evergreen.SetServiceFlags(s.ctx, flags))
 
 	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings())
-	patchContent, summaries, err := thirdparty.GetGithubPullRequestDiff(s.ctx, s.githubPatchData)
+	patchContent, summaries, err := thirdparty.GetGithubPullRequestPatch(s.ctx, s.githubPatchData)
 	s.Require().NoError(err)
 	s.Require().Len(summaries, 2)
 	s.NotEmpty(patchContent)
@@ -1323,7 +1323,7 @@ func (s *PatchIntentUnitsSuite) TestProcessCliPatchIntentWithoutFinalizing() {
 
 	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings())
 
-	patchContent, summaries, err := thirdparty.GetGithubPullRequestDiff(s.ctx, s.githubPatchData)
+	patchContent, summaries, err := thirdparty.GetGithubPullRequestPatch(s.ctx, s.githubPatchData)
 	s.Require().NoError(err)
 	s.Require().Len(summaries, 2)
 	s.NotEmpty(patchContent)

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1535,7 +1535,7 @@ func (s *PatchIntentUnitsSuite) TestGithubPRTestFromUnknownUserDoesntCreateVersi
 	s.Require().NoError(evergreen.SetServiceFlags(s.ctx, flags))
 
 	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings())
-	intent, err := patch.NewGithubIntent(s.ctx, "1", "", "", "", "", testutil.NewGithubPR(448, "evergreen-ci/evergreen", "776f608b5b12cd27b8d931c8ee4ca0c13f857299", s.headRepo, "729b1ab0e21514fb1af39fc298e3fae9b480d568", "octocat", "title1"))
+	intent, err := patch.NewGithubIntent(s.ctx, "1", "", "", "", "", testutil.NewGithubPR(448, "evergreen-ci/evergreen", "776f608b5b12cd27b8d931c8ee4ca0c13f857299", "evergreen-ci/evergreen", "729b1ab0e21514fb1af39fc298e3fae9b480d568", "octocat", "title1"))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert(s.ctx))

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1209,7 +1209,7 @@ func (s *PatchIntentUnitsSuite) TestProcessGitHubIntentWithMergeBase() {
 			Ref: utility.ToStringPtr("main"),
 		},
 		Head: &github.PullRequestBranch{
-			SHA: github.String("ed42b5e51e81724c5258686a0b9d515a99696eac"),
+			SHA: github.String("75296bc001a22600252f2d4e8f35d47c9b31221b"),
 			Repo: &github.Repository{
 				FullName: utility.ToStringPtr("evergreen-ci/DEVPROD-123"),
 			},

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -149,7 +149,7 @@ func (s *PatchIntentUnitsSuite) SetupTest() {
 		CommitQueue: model.CommitQueueParams{
 			Enabled: utility.TruePtr(),
 		},
-		OldestAllowedMergeBase: "536cde7f7b29f7e117371a48a3e59540a44af1ac",
+		OldestAllowedMergeBase: "0f8c636e54e61f50c02bd2a9cf178ef7b8623e8f",
 	}).Insert(s.ctx))
 
 	s.NoError((&model.ProjectRef{
@@ -1200,31 +1200,31 @@ func (s *PatchIntentUnitsSuite) TestProcessMergeGroupIntent() {
 
 func (s *PatchIntentUnitsSuite) TestProcessGitHubIntentWithMergeBase() {
 	pr := &github.PullRequest{
-		Title: utility.ToStringPtr("Test title"),
+		Title:  github.Ptr("Test title"),
+		Number: github.Ptr(816),
 		Base: &github.PullRequestBranch{
-			SHA: github.String("ed42b5e51e81724c5258686a0b9d515a99696eac"),
+			SHA: github.Ptr("0f8c636e54e61f50c02bd2a9cf178ef7b8623e8f"),
 			Repo: &github.Repository{
-				FullName: utility.ToStringPtr("evergreen-ci/commit-queue-sandbox"),
+				FullName: github.Ptr("evergreen-ci/commit-queue-sandbox"),
 			},
-			Ref: utility.ToStringPtr("main"),
+			Ref: github.Ptr("main"),
 		},
 		Head: &github.PullRequestBranch{
-			SHA: github.String("75296bc001a22600252f2d4e8f35d47c9b31221b"),
+			SHA: github.Ptr("69145f9bcac5c5f5d2b6de76c78e5b717f993097"),
 			Repo: &github.Repository{
-				FullName: utility.ToStringPtr("evergreen-ci/DEVPROD-123"),
+				FullName: github.Ptr("minnakt/commit-queue-sandbox"),
 			},
-			Ref: utility.ToStringPtr("abc"),
+			Ref: github.Ptr("refresh-statuses"),
 		},
 		User: &github.User{
 			ID:    github.Int64(1),
-			Login: utility.ToStringPtr("abc"),
+			Login: github.Ptr("abc"),
 		},
-		Number:         github.Int(1),
-		MergeCommitSHA: github.String("abcdef"),
+		MergeCommitSHA: github.Ptr("abcdef"),
 	}
 	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings())
-	// SHA ed42b5e51e81724c5258686a0b9d515a99696eac is newer than the oldest allowed merge base and should be accepted
-	intent, err := patch.NewGithubIntent(s.ctx, "id", "auto", "", "", "ed42b5e51e81724c5258686a0b9d515a99696eac", pr)
+	// SHA 0f8c636e54e61f50c02bd2a9cf178ef7b8623e8f is newer than the oldest allowed merge base and should be accepted
+	intent, err := patch.NewGithubIntent(s.ctx, "id", "auto", "", "", "0f8c636e54e61f50c02bd2a9cf178ef7b8623e8f", pr)
 
 	s.NoError(err)
 	s.Require().NotNil(intent)
@@ -1236,8 +1236,8 @@ func (s *PatchIntentUnitsSuite) TestProcessGitHubIntentWithMergeBase() {
 
 	s.Equal("main", patchDoc.Branch)
 
-	// SHA 4aa79c5e7ef7af351764b843a2c05fab98c23881 is older than the oldest allowed merge base and should be rejected
-	intent, err = patch.NewGithubIntent(s.ctx, "another_id", "auto", "", "", "4aa79c5e7ef7af351764b843a2c05fab98c23881", pr)
+	// SHA 6e8cd5c8e8fe18e38b1dc9a609465a732d29fb99 is older than the oldest allowed merge base and should be rejected
+	intent, err = patch.NewGithubIntent(s.ctx, "another_id", "auto", "", "", "6e8cd5c8e8fe18e38b1dc9a609465a732d29fb99", pr)
 
 	s.NoError(err)
 	s.Require().NotNil(intent)

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1535,7 +1535,7 @@ func (s *PatchIntentUnitsSuite) TestGithubPRTestFromUnknownUserDoesntCreateVersi
 	s.Require().NoError(evergreen.SetServiceFlags(s.ctx, flags))
 
 	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings())
-	intent, err := patch.NewGithubIntent(s.ctx, "1", "", "", "", "", testutil.NewGithubPR(s.prNumber, "evergreen-ci/evergreen", s.baseHash, s.headRepo, "8a425038834326c212d65289e0c9e80e48d07e7e", "octocat", "title1"))
+	intent, err := patch.NewGithubIntent(s.ctx, "1", "", "", "", "", testutil.NewGithubPR(448, "evergreen-ci/evergreen", "776f608b5b12cd27b8d931c8ee4ca0c13f857299", s.headRepo, "729b1ab0e21514fb1af39fc298e3fae9b480d568", "octocat", "title1"))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert(s.ctx))

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1535,7 +1535,7 @@ func (s *PatchIntentUnitsSuite) TestGithubPRTestFromUnknownUserDoesntCreateVersi
 	s.Require().NoError(evergreen.SetServiceFlags(s.ctx, flags))
 
 	testutil.ConfigureIntegrationTest(s.T(), s.env.Settings())
-	intent, err := patch.NewGithubIntent(s.ctx, "1", "", "", "", "", testutil.NewGithubPR(448, "evergreen-ci/evergreen", "776f608b5b12cd27b8d931c8ee4ca0c13f857299", s.headRepo, "729b1ab0e21514fb1af39fc298e3fae9b480d568", "octocat", "title1"))
+	intent, err := patch.NewGithubIntent(s.ctx, "1", "", "", "", "", testutil.NewGithubPR(s.prNumber, "evergreen-ci/evergreen", "350449672ccb53725cc59f01c674ef885f29babb", "hadjri/evergreen", "e32a76f1bc3b16bdc014e9f739565c6b42eed355", "octocat", "title1"))
 	s.NoError(err)
 	s.NotNil(intent)
 	s.NoError(intent.Insert(s.ctx))

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -194,6 +194,12 @@ func (s *PatchIntentUnitsSuite) SetupTest() {
 		Variant:   "^ubuntu2004$",
 		Task:      "^bynntask$",
 	}).Upsert(s.ctx))
+	s.NoError((&model.ProjectAlias{
+		ProjectID: "commit-queue-sandbox",
+		Alias:     evergreen.GithubPRAlias,
+		Variant:   "ubuntu.*",
+		Task:      "unit_tests",
+	}).Upsert(s.ctx))
 
 	s.NoError((&distro.Distro{Id: "ubuntu1604-test"}).Insert(s.ctx))
 	s.NoError((&distro.Distro{Id: "ubuntu1604-build"}).Insert(s.ctx))


### PR DESCRIPTION
DEVPROD-29442

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

(https://github.com/evergreen-ci/evergreen/pull/9895 previous attempt)

### Description
When we apply the diff for an Evergreen patch, we expect it to have the full contents (e.g. binary files).

This PR changes what we fetch from github from just `diff`, which is intended for viewing, to `patch`, which is intended for full changes. Unfortunately the `patch` version of the same route we are using does NOT account for a new merge-base (e.g. the user merges in main to their PR, this creates a merge commit and the route we use returns extra non-sense that makes the Git patch unapplicable) so we have to switch over to their [compare two commits](https://docs.github.com/en/rest/commits/commits?apiVersion=2026-03-10#compare-two-commits) API.

<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

If you want to see the difference for a png:

- [Just 'diff'](https://spruce.corp.mongodb.com/version/69a9d919615577000720dc80/file-diff?file_name=docs/images/run-every-mainline-commit-project-setting.png).
- [The full patch](https://spruce.corp.mongodb.com/version/69a9e134e5b9640007e21b3b/file-diff?file_name=docs%252Fimages%252Frun-every-mainline-commit-project-setting.png).

### Testing
I added a test to account for this.


I tested it in staging by running this specific scenario with and without the changes.

- [Without](https://spruce-staging.corp.mongodb.com/task/zackary_module_2_variant1_clone_patch_a34d40645de689a270011e046849fb87ba88d58f_69dd3d3d46717800070eb9d6_26_04_13_19_00_14/logs?execution=0)
- <img width="282" height="426" alt="Screenshot 2026-04-13 at 3 10 37 PM" src="https://github.com/user-attachments/assets/4b46a2fe-fa6c-459b-8b0f-f592de92e4d1" />
- [With](https://spruce-staging.corp.mongodb.com/task/zackary_module_2_variant1_clone_patch_a34d40645de689a270011e046849fb87ba88d58f_69dd439b4927d5000769f9e6_26_04_13_19_27_23/logs?execution=0)
- <img width="286" height="396" alt="Screenshot 2026-04-13 at 3 28 36 PM" src="https://github.com/user-attachments/assets/57f08500-66f4-48c7-9f1d-a50a2b4dfd57" />



[This PR contains the example](https://github.com/evergreen-ci/commit-queue-sandbox/pull/807).
