### PR TITLE
DEVPROD-28614 Add github merge queue merge-base sha to version description

### DIFF
--- a/model/patch/github_merge.go
+++ b/model/patch/github_merge.go
@@ -267,6 +267,7 @@ func (g *githubMergeIntent) NewPatch() *Patch {
 			Repo:           g.Repo,
 			BaseBranch:     baseBranch,
 			HeadBranch:     headBranch,
+			BaseSHA:        g.BaseSHA,
 			HeadSHA:        g.HeadSHA,
 			HeadCommit:     g.HeadCommit,
 			HeadCommitDate: g.HeadCommitDate,

--- a/model/patch/github_merge_test.go
+++ b/model/patch/github_merge_test.go
@@ -133,6 +133,7 @@ func TestGithubMergeIntent(t *testing.T) {
 			p := intent.NewPatch()
 			assert.Equal(t, evergreen.CommitQueueAlias, p.Alias)
 			assert.Equal(t, *mge.MergeGroup.BaseSHA, p.Githash)
+			assert.Equal(t, *mge.MergeGroup.BaseSHA, p.GithubMergeData.BaseSHA)
 			assert.Equal(t, *mge.MergeGroup.HeadSHA, p.GithubMergeData.HeadSHA)
 			assert.Equal(t, mge.MergeGroup.GetHeadCommit().GetMessage(), p.GithubMergeData.HeadCommit)
 			assert.Equal(t, *mge.Org.Login, p.GithubMergeData.Org)

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -189,6 +189,10 @@ type GithubMergeGroup struct {
 	// so there are as many commits as there are PRs in the merge group. This is
 	// only the SHA of the first commit in the merge group.
 	HeadSHA string `bson:"head_sha"`
+	// BaseSHA is the merge base commit SHA for the merge group (GitHub's base_sha).
+	// It identifies which point on the base branch this merge group was built from,
+	// which helps distinguish merge groups that contain different sets of PRs.
+	BaseSHA string `bson:"base_sha,omitempty"`
 	// HeadCommit is the title of the commit at the head of the merge group. For
 	// each PR in the merge group, GitHub merges the commits from that PR
 	// together, so there are as many commits as there are PRs in the merge

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1172,7 +1172,19 @@ func (j *patchIntentProcessor) getChangedFilesForGithubMerge(ctx context.Context
 
 // makeMergeQueueDescription returns a new description for a merge queue patch using the merge group.
 func makeMergeQueueDescription(mergeGroup thirdparty.GithubMergeGroup) string {
-	return "GitHub Merge Queue: " + mergeGroup.HeadCommit + " (" + mergeGroup.HeadSHA[0:7] + ")"
+	headShort := mergeGroup.HeadSHA
+	if len(headShort) > 7 {
+		headShort = headShort[:7]
+	}
+	desc := "GitHub Merge Queue: " + mergeGroup.HeadCommit + " (" + headShort + ")"
+	if mergeGroup.BaseSHA != "" {
+		baseShort := mergeGroup.BaseSHA
+		if len(baseShort) > 7 {
+			baseShort = baseShort[:7]
+		}
+		desc += " [merge-base " + baseShort + "]"
+	}
+	return desc
 }
 
 func (j *patchIntentProcessor) buildTriggerPatchDoc(ctx context.Context, patchDoc *patch.Patch) (*model.Project, *model.ParserProject, error) {

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1895,6 +1895,17 @@ tasks:
 }
 
 func TestMakeMergeQueueDescription(t *testing.T) {
+	mergeGroup := thirdparty.GithubMergeGroup{
+		HeadSHA:    "0e312ffabcdefghijklmnop",
+		HeadCommit: "I'm a commit!",
+		BaseSHA:    "abcdef0123456789deadbeef",
+	}
+	assert.Equal(t,
+		"GitHub Merge Queue: I'm a commit! (0e312ff) [merge-base abcdef0]",
+		makeMergeQueueDescription(mergeGroup))
+}
+
+func TestMakeMergeQueueDescriptionOmitsMergeBaseWhenEmpty(t *testing.T) {
 	mergeGroup := thirdparty.GithubMergeGroup{HeadSHA: "0e312ffabcdefghijklmnop", HeadCommit: "I'm a commit!"}
 	assert.Equal(t, "GitHub Merge Queue: I'm a commit! (0e312ff)", makeMergeQueueDescription(mergeGroup))
 }


### PR DESCRIPTION
DEVPROD-28614

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Adds the github merge queue merge-base sha to the version description.

<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

### Testing
Added unit tests