### PR TITLE
DEVPROD-29724: tag host.create hosts with project

### DIFF
--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -169,6 +169,19 @@ func makeTags(intentHost *host.Host) []host.Tag {
 	if intentHost.UserHost {
 		systemTags = append(systemTags, host.Tag{Key: "mode", Value: "testing", CanBeModified: false})
 	}
+	if intentHost.SpawnOptions.SpawnedByTask {
+		// kim: TODO: confirm staging host.create host is tagged properly.
+		systemTags = append(systemTags, host.Tag{Key: evergreen.TagProject, Value: intentHost.SpawnOptions.ProjectID, CanBeModified: false})
+		if intentHost.SpawnOptions.TaskID != "" {
+			systemTags = append(systemTags,
+				host.Tag{Key: evergreen.TagTaskID, Value: intentHost.SpawnOptions.TaskID, CanBeModified: false},
+				host.Tag{Key: evergreen.TagTaskExecution, Value: fmt.Sprintf("%d", intentHost.SpawnOptions.TaskExecutionNumber), CanBeModified: false},
+			)
+		}
+		if intentHost.SpawnOptions.BuildID != "" {
+			systemTags = append(systemTags, host.Tag{Key: evergreen.TagBuildID, Value: intentHost.SpawnOptions.BuildID, CanBeModified: false})
+		}
+	}
 
 	// Add Evergreen-generated tags to host object
 	intentHost.AddTags(systemTags)

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -170,7 +170,6 @@ func makeTags(intentHost *host.Host) []host.Tag {
 		systemTags = append(systemTags, host.Tag{Key: "mode", Value: "testing", CanBeModified: false})
 	}
 	if intentHost.SpawnOptions.SpawnedByTask {
-		// kim: TODO: confirm staging host.create host is tagged properly.
 		systemTags = append(systemTags, host.Tag{Key: evergreen.TagProject, Value: intentHost.SpawnOptions.ProjectID, CanBeModified: false})
 		if intentHost.SpawnOptions.TaskID != "" {
 			systemTags = append(systemTags,

--- a/globals.go
+++ b/globals.go
@@ -296,6 +296,10 @@ const (
 	TagExpireOn          = "expire-on"
 	TagAllowRemoteAccess = "AllowRemoteAccess"
 	TagIsDebug           = "IsDebug"
+	TagTaskID            = "task-id"
+	TagTaskExecution     = "task-execution"
+	TagBuildID           = "build-id"
+	TagProject           = "project"
 
 	FinderVersionLegacy    = "legacy"
 	FinderVersionParallel  = "parallel"

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -322,6 +322,9 @@ type SpawnOptions struct {
 	// this host should be torn down. Only one of TaskID or BuildID should be set.
 	BuildID string `bson:"build_id,omitempty" json:"build_id,omitempty"`
 
+	// ProjectID is the ID of the project that's running the task.
+	ProjectID string `bson:"project_id,omitempty" json:"project_id,omitempty"`
+
 	// Retries is the number of times Evergreen should try to spawn this host.
 	Retries int `bson:"retries,omitempty" json:"retries,omitempty"`
 
@@ -331,9 +334,6 @@ type SpawnOptions struct {
 
 	// SpawnedByTask indicates that this host has been spawned by a task.
 	SpawnedByTask bool `bson:"spawned_by_task,omitempty" json:"spawned_by_task,omitempty"`
-
-	// ProjectID is the ID of the project that's running the task.
-	ProjectID string `bson:"project_id,omitempty" json:"project_id,omitempty"`
 }
 
 // SleepScheduleInfo stores information about a host's sleep schedule and

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -331,6 +331,9 @@ type SpawnOptions struct {
 
 	// SpawnedByTask indicates that this host has been spawned by a task.
 	SpawnedByTask bool `bson:"spawned_by_task,omitempty" json:"spawned_by_task,omitempty"`
+
+	// ProjectID is the ID of the project that's running the task.
+	ProjectID string `bson:"project_id,omitempty" json:"project_id,omitempty"`
 }
 
 // SleepScheduleInfo stores information about a host's sleep schedule and

--- a/rest/data/host_create.go
+++ b/rest/data/host_create.go
@@ -344,6 +344,7 @@ func getHostCreationOptions(ctx context.Context, d distro.Distro, taskID, userID
 			options.SpawnOptions.TaskID = taskID
 			options.SpawnOptions.TaskExecutionNumber = t.Execution
 		}
+		options.SpawnOptions.ProjectID = t.Project
 		options.SpawnOptions.TimeoutTeardown = time.Now().Add(time.Duration(createHost.TeardownTimeoutSecs) * time.Second)
 		options.SpawnOptions.TimeoutSetup = time.Now().Add(time.Duration(createHost.SetupTimeoutSecs) * time.Second)
 		options.SpawnOptions.Retries = createHost.Retries

--- a/rest/route/host_create_test.go
+++ b/rest/route/host_create_test.go
@@ -56,7 +56,10 @@ func TestMakeHost(t *testing.T) {
 	require.NoError(d.Insert(ctx))
 
 	sampleTask := &task.Task{
-		Id: "task-id",
+		Id:        "task-id",
+		Execution: 2,
+		BuildId:   "build-id",
+		Project:   "project",
 	}
 	require.NoError(sampleTask.Insert(t.Context()))
 
@@ -81,7 +84,10 @@ func TestMakeHost(t *testing.T) {
 	assert.Equal(evergreen.ProviderNameEc2OnDemand, h.Distro.Provider)
 	assert.Equal(distro.BootstrapMethodNone, h.Distro.BootstrapSettings.Method, "host provisioning should be set to none by default")
 
-	assert.Equal("task-id", h.SpawnOptions.TaskID)
+	assert.Equal(sampleTask.Id, h.SpawnOptions.TaskID)
+	assert.Equal(sampleTask.Execution, h.SpawnOptions.TaskExecutionNumber)
+	assert.Equal(sampleTask.Project, h.SpawnOptions.ProjectID)
+	assert.Empty(h.SpawnOptions.BuildID)
 	ec2Settings := &cloud.EC2ProviderSettings{}
 	require.Len(h.Distro.ProviderSettingsList, 1)
 	assert.NoError(ec2Settings.FromDistroSettings(h.Distro, ""))
@@ -105,6 +111,7 @@ func TestMakeHost(t *testing.T) {
 	myTask := task.Task{
 		Id:      "task-id",
 		BuildId: "build-id",
+		Project: "project",
 	}
 	require.NoError(myTask.Insert(t.Context()))
 	c = apimodels.CreateHost{
@@ -123,7 +130,10 @@ func TestMakeHost(t *testing.T) {
 	assert.NotNil(h)
 	ec2Settings = &cloud.EC2ProviderSettings{}
 	assert.NoError(ec2Settings.FromDistroSettings(h.Distro, ""))
-	assert.Equal("build-id", h.SpawnOptions.BuildID)
+	assert.Empty(h.SpawnOptions.TaskID)
+	assert.Zero(h.SpawnOptions.TaskExecutionNumber)
+	assert.Equal(myTask.Project, h.SpawnOptions.ProjectID)
+	assert.Equal(myTask.BuildId, h.SpawnOptions.BuildID)
 	assert.Empty(ec2Settings.KeyName)
 	assert.True(ec2Settings.IsVpc)
 

--- a/units/host_monitoring_check.go
+++ b/units/host_monitoring_check.go
@@ -256,6 +256,8 @@ func handleTerminatedHostSpawnedByTask(ctx context.Context, h *host.Host) error 
 			"host_id":        h.Id,
 			"task_id":        h.SpawnOptions.TaskID,
 			"task_execution": h.SpawnOptions.TaskExecutionNumber,
+			"build_id":       h.SpawnOptions.BuildID,
+			"project_id":     h.SpawnOptions.ProjectID,
 		})
 
 		catcher := grip.NewBasicCatcher()
@@ -271,6 +273,8 @@ func handleTerminatedHostSpawnedByTask(ctx context.Context, h *host.Host) error 
 		"new_host_id":          intent.Id,
 		"task_id":              h.SpawnOptions.TaskID,
 		"task_execution":       h.SpawnOptions.TaskExecutionNumber,
+		"build_id":             h.SpawnOptions.BuildID,
+		"project_id":           h.SpawnOptions.ProjectID,
 	})
 
 	return nil

--- a/units/host_stats.go
+++ b/units/host_stats.go
@@ -38,6 +38,7 @@ type taskSpawnedHost struct {
 	Task                string `json:"task_scope"`
 	TaskExecutionNumber int    `json:"task_execution_number"`
 	Build               string `json:"build_scope"`
+	Project             string `json:"project"`
 }
 
 func makeHostStats() *hostStatsJob {
@@ -88,6 +89,7 @@ func (j *hostStatsJob) Run(ctx context.Context) {
 			Task:                h.SpawnOptions.TaskID,
 			TaskExecutionNumber: h.SpawnOptions.TaskExecutionNumber,
 			Build:               h.SpawnOptions.BuildID,
+			Project:             h.SpawnOptions.ProjectID,
 		})
 	}
 	j.logger.Info(ctx, message.Fields{
@@ -106,6 +108,7 @@ func (j *hostStatsJob) Run(ctx context.Context) {
 				"task_scope":            h.SpawnOptions.TaskID,
 				"task_execution_number": h.SpawnOptions.TaskExecutionNumber,
 				"build_scope":           h.SpawnOptions.BuildID,
+				"project":               h.SpawnOptions.ProjectID,
 			})
 		}
 	}

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -323,9 +323,21 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		"creation_time":      j.host.CreationTime,
 		"started_by":         j.host.StartedBy,
 		"user_host":          j.host.UserHost,
+		"spawned_by_task":    j.host.SpawnOptions.SpawnedByTask,
 	}
 	if !utility.IsZeroTime(j.host.BillingStartTime) {
 		terminationMessage["total_billable_secs"] = j.host.TerminationTime.Sub(j.host.BillingStartTime).Seconds()
+	}
+	if j.host.SpawnOptions.SpawnedByTask {
+		// kim: TODO: verify logs look okay when spawned by task.
+		terminationMessage["spawned_by_project"] = j.host.SpawnOptions.ProjectID
+		if j.host.SpawnOptions.TaskID != "" {
+			terminationMessage["spawned_by_task_id"] = j.host.SpawnOptions.TaskID
+			terminationMessage["spawned_by_task_execution"] = j.host.SpawnOptions.TaskExecutionNumber
+		}
+		if j.host.SpawnOptions.BuildID != "" {
+			terminationMessage["spawned_by_build_id"] = j.host.SpawnOptions.BuildID
+		}
 	}
 	var instanceType string
 	if evergreen.IsEc2Provider(j.host.Distro.Provider) && len(j.host.Distro.ProviderSettingsList) > 0 {
@@ -348,9 +360,22 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		attribute.String(fmt.Sprintf("%s.started_by", hostTerminationAttributePrefix), j.host.StartedBy),
 		attribute.Bool(fmt.Sprintf("%s.user_host", hostTerminationAttributePrefix), j.host.UserHost),
 		attribute.Int(fmt.Sprintf("%s.task_count", hostTerminationAttributePrefix), j.host.TaskCount),
+		attribute.Bool(fmt.Sprintf("%s.spawned_by_task", hostTerminationAttributePrefix), j.host.SpawnOptions.SpawnedByTask),
 	)
 	if !utility.IsZeroTime(j.host.BillingStartTime) {
 		span.SetAttributes(attribute.Float64(fmt.Sprintf("%s.billable_secs", hostTerminationAttributePrefix), j.host.TerminationTime.Sub(j.host.BillingStartTime).Seconds()))
+	}
+	if j.host.SpawnOptions.SpawnedByTask {
+		span.SetAttributes(attribute.String(fmt.Sprintf("%s.spawned_by_project", hostTerminationAttributePrefix), j.host.SpawnOptions.ProjectID))
+		if j.host.SpawnOptions.TaskID != "" {
+			span.SetAttributes(
+				attribute.String(fmt.Sprintf("%s.spawned_by_task_id", hostTerminationAttributePrefix), j.host.SpawnOptions.TaskID),
+				attribute.Int64(fmt.Sprintf("%s.spawned_by_task_execution", hostTerminationAttributePrefix), int64(j.host.SpawnOptions.TaskExecutionNumber)),
+			)
+		}
+		if j.host.SpawnOptions.BuildID != "" {
+			span.SetAttributes(attribute.String(fmt.Sprintf("%s.spawned_by_build_id", hostTerminationAttributePrefix), j.host.SpawnOptions.BuildID))
+		}
 	}
 	if instanceType != "" {
 		span.SetAttributes(attribute.String(fmt.Sprintf("%s.instance_type", hostTerminationAttributePrefix), instanceType))

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -306,7 +306,26 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 	lastIdle, err := j.incrementIdleTime(ctx)
 	j.AddError(err)
 
-	terminationMessage := message.Fields{
+	j.logTerminationStats(ctx, lastIdle)
+
+	if j.host.StartedBy == evergreen.User && j.host.TaskCount == 0 {
+		grip.Info(ctx, message.Fields{
+			"message":          "task host ran no tasks before it was terminated",
+			"status":           prevStatus,
+			"host_id":          j.HostID,
+			"host_tag":         j.host.Tag,
+			"distro":           j.host.Distro.Id,
+			"uptime_secs":      time.Since(j.host.StartTime).Seconds(),
+			"provider":         j.host.Provider,
+			"spawn_host":       j.host.StartedBy != evergreen.User,
+			"is_ec2_host":      cloud.IsEC2InstanceID(j.HostID),
+			"agent_start_time": j.host.AgentStartTime,
+		})
+	}
+}
+
+func (j *hostTerminationJob) logTerminationStats(ctx context.Context, lastIdle time.Duration) {
+	msg := message.Fields{
 		"message":            "host successfully terminated",
 		"host_id":            j.host.Id,
 		"distro":             j.host.Distro.Id,
@@ -325,32 +344,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		"user_host":          j.host.UserHost,
 		"spawned_by_task":    j.host.SpawnOptions.SpawnedByTask,
 	}
-	if !utility.IsZeroTime(j.host.BillingStartTime) {
-		terminationMessage["total_billable_secs"] = j.host.TerminationTime.Sub(j.host.BillingStartTime).Seconds()
-	}
-	if j.host.SpawnOptions.SpawnedByTask {
-		// kim: TODO: verify logs look okay when spawned by task.
-		terminationMessage["spawned_by_project"] = j.host.SpawnOptions.ProjectID
-		if j.host.SpawnOptions.TaskID != "" {
-			terminationMessage["spawned_by_task_id"] = j.host.SpawnOptions.TaskID
-			terminationMessage["spawned_by_task_execution"] = j.host.SpawnOptions.TaskExecutionNumber
-		}
-		if j.host.SpawnOptions.BuildID != "" {
-			terminationMessage["spawned_by_build_id"] = j.host.SpawnOptions.BuildID
-		}
-	}
-	var instanceType string
-	if evergreen.IsEc2Provider(j.host.Distro.Provider) && len(j.host.Distro.ProviderSettingsList) > 0 {
-		var ok bool
-		instanceType, ok = j.host.Distro.ProviderSettingsList[0].Lookup("instance_type").StringValueOK()
-		if ok {
-			terminationMessage["instance_type"] = instanceType
-		}
-	}
-	grip.Info(ctx, terminationMessage)
-
-	span := trace.SpanFromContext(ctx)
-	span.SetAttributes(
+	attrs := []attribute.KeyValue{
 		attribute.String(evergreen.DistroIDOtelAttribute, j.host.Distro.Id),
 		attribute.String(evergreen.HostIDOtelAttribute, j.host.Id),
 		attribute.Float64(fmt.Sprintf("%s.idle_secs", hostTerminationAttributePrefix), j.host.TotalIdleTime.Seconds()),
@@ -361,40 +355,39 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 		attribute.Bool(fmt.Sprintf("%s.user_host", hostTerminationAttributePrefix), j.host.UserHost),
 		attribute.Int(fmt.Sprintf("%s.task_count", hostTerminationAttributePrefix), j.host.TaskCount),
 		attribute.Bool(fmt.Sprintf("%s.spawned_by_task", hostTerminationAttributePrefix), j.host.SpawnOptions.SpawnedByTask),
-	)
+	}
+
 	if !utility.IsZeroTime(j.host.BillingStartTime) {
-		span.SetAttributes(attribute.Float64(fmt.Sprintf("%s.billable_secs", hostTerminationAttributePrefix), j.host.TerminationTime.Sub(j.host.BillingStartTime).Seconds()))
+		billableSecs := j.host.TerminationTime.Sub(j.host.BillingStartTime).Seconds()
+		msg["total_billable_secs"] = billableSecs
+		attrs = append(attrs, attribute.Float64(fmt.Sprintf("%s.billable_secs", hostTerminationAttributePrefix), billableSecs))
 	}
 	if j.host.SpawnOptions.SpawnedByTask {
-		span.SetAttributes(attribute.String(fmt.Sprintf("%s.spawned_by_project", hostTerminationAttributePrefix), j.host.SpawnOptions.ProjectID))
+		msg["spawned_by_project"] = j.host.SpawnOptions.ProjectID
+		attrs = append(attrs, attribute.String(fmt.Sprintf("%s.spawned_by_project", hostTerminationAttributePrefix), j.host.SpawnOptions.ProjectID))
 		if j.host.SpawnOptions.TaskID != "" {
-			span.SetAttributes(
+			msg["spawned_by_task_id"] = j.host.SpawnOptions.TaskID
+			msg["spawned_by_task_execution"] = j.host.SpawnOptions.TaskExecutionNumber
+			attrs = append(attrs,
 				attribute.String(fmt.Sprintf("%s.spawned_by_task_id", hostTerminationAttributePrefix), j.host.SpawnOptions.TaskID),
 				attribute.Int64(fmt.Sprintf("%s.spawned_by_task_execution", hostTerminationAttributePrefix), int64(j.host.SpawnOptions.TaskExecutionNumber)),
 			)
 		}
 		if j.host.SpawnOptions.BuildID != "" {
-			span.SetAttributes(attribute.String(fmt.Sprintf("%s.spawned_by_build_id", hostTerminationAttributePrefix), j.host.SpawnOptions.BuildID))
+			msg["spawned_by_build_id"] = j.host.SpawnOptions.BuildID
+			attrs = append(attrs, attribute.String(fmt.Sprintf("%s.spawned_by_build_id", hostTerminationAttributePrefix), j.host.SpawnOptions.BuildID))
 		}
 	}
-	if instanceType != "" {
-		span.SetAttributes(attribute.String(fmt.Sprintf("%s.instance_type", hostTerminationAttributePrefix), instanceType))
+	if evergreen.IsEc2Provider(j.host.Distro.Provider) && len(j.host.Distro.ProviderSettingsList) > 0 {
+		instanceType, ok := j.host.Distro.ProviderSettingsList[0].Lookup("instance_type").StringValueOK()
+		if ok {
+			msg["instance_type"] = instanceType
+			attrs = append(attrs, attribute.String(fmt.Sprintf("%s.instance_type", hostTerminationAttributePrefix), instanceType))
+		}
 	}
 
-	if j.host.StartedBy == evergreen.User && j.host.TaskCount == 0 {
-		grip.Info(ctx, message.Fields{
-			"message":          "task host ran no tasks before it was terminated",
-			"status":           prevStatus,
-			"host_id":          j.HostID,
-			"host_tag":         j.host.Tag,
-			"distro":           j.host.Distro.Id,
-			"uptime_secs":      time.Since(j.host.StartTime).Seconds(),
-			"provider":         j.host.Provider,
-			"spawn_host":       j.host.StartedBy != evergreen.User,
-			"is_ec2_host":      cloud.IsEC2InstanceID(j.HostID),
-			"agent_start_time": j.host.AgentStartTime,
-		})
-	}
+	grip.Info(ctx, msg)
+	trace.SpanFromContext(ctx).SetAttributes(attrs...)
 }
 
 func (j *hostTerminationJob) incrementIdleTime(ctx context.Context) (time.Duration, error) {


### PR DESCRIPTION
DEVPROD-29724

### Description
Made it a little easier for the infra team to search for info on host.create hosts.

* Add more EC2 tags for host.create host including task/build/project IDs.
* Log info about host.create host during host termination.
* Refactor host termination logging/OTel spans to consolidate common logic.

### Testing
* Added unit tests.
* Tested in personal staging by running host.create. Verified that it was tagged in EC2 as expected and the host termination log included the expected info.