### PR TITLE
DEVPROD-31705: Limit find for PopulateRetryFailedLogMoveJobs

### DIFF
--- a/units/crons.go
+++ b/units/crons.go
@@ -919,6 +919,10 @@ const defaultRetryFailedLogMoveLookbackMonths = 2
 // defaultRetryFailedLogMoveMaxJobsPerRun caps enqueued jobs to avoid S3 rate limiting.
 const defaultRetryFailedLogMoveMaxJobsPerRun = 50
 
+const retryFailedLogMoveFindMinLimit = 500
+const retryFailedLogMoveFindMaxLimit = 5000
+const retryFailedLogMoveCandidateMultiplier = 50
+
 // PopulateRetryFailedLogMoveJobs finds failed tasks whose logs are still in the regular
 // bucket (move job failed or never ran) and enqueues one move-logs-to-failed-bucket job per task.
 // Caps enqueued jobs per run to avoid S3 rate limiting; newest failures are prioritized.
@@ -954,9 +958,14 @@ func PopulateRetryFailedLogMoveJobs(env evergreen.Environment) amboy.QueueOperat
 			filter[task.ProjectKey] = bson.M{"$nin": settings.Buckets.LongRetentionProjects}
 		}
 
+		// Limit find to maxJobs * multiplier, bounded by the min and max find limits.
+		queryLimit := maxJobs * retryFailedLogMoveCandidateMultiplier
+		queryLimit = max(queryLimit, retryFailedLogMoveFindMinLimit)
+		queryLimit = min(queryLimit, retryFailedLogMoveFindMaxLimit)
+
 		query := db.Query(filter).WithFields(
 			task.IdKey, task.ProjectKey, task.FinishTimeKey, task.TaskOutputInfoKey,
-		)
+		).Sort([]string{"-" + task.FinishTimeKey}).Limit(queryLimit)
 		tasks, err := task.FindAll(ctx, query)
 		if err != nil {
 			return errors.Wrap(err, "finding failed tasks whose logs need moving")


### PR DESCRIPTION
[DEVPROD-31705](https://jira.mongodb.org/browse/DEVPROD-31705)

### Description
PopulateRetryFailedLogMoveJobs was failing with operation exceeded time limit.  This adds a change that sorts by finish_time descending (following the “newest first” policy we were already following for these jobs) and limits how many documents are read per run. 


