### PR TITLE
DEVPROD-26466: Calculate and Save S3 Logs Storage cost to task

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-04-15"
+	AgentVersion = "2026-04-15a"
 )
 
 const (

--- a/globals.go
+++ b/globals.go
@@ -528,6 +528,7 @@ const (
 	S3LogPutRequestsOtelAttribute = "evergreen.task.s3_cost.log_put_requests"
 	S3LogUploadBytesOtelAttribute = "evergreen.task.s3_cost.log_upload_bytes"
 	S3LogPutCostOtelAttribute     = "evergreen.task.s3_cost.log_put_cost"
+	S3LogStorageCostOtelAttribute = "evergreen.task.s3_cost.log_storage_cost"
 
 	// display task otel attributes
 	DisplayTaskIDOtelAttribute   = "evergreen.display_task.id"

--- a/model/cost/cost.go
+++ b/model/cost/cost.go
@@ -8,6 +8,7 @@ var (
 	S3ArtifactPutCostKey     = bsonutil.MustHaveTag(Cost{}, "S3ArtifactPutCost")
 	S3LogPutCostKey          = bsonutil.MustHaveTag(Cost{}, "S3LogPutCost")
 	S3ArtifactStorageCostKey = bsonutil.MustHaveTag(Cost{}, "S3ArtifactStorageCost")
+	S3LogStorageCostKey      = bsonutil.MustHaveTag(Cost{}, "S3LogStorageCost")
 )
 
 // Cost represents a cost breakdown for tasks and versions
@@ -30,6 +31,8 @@ type Cost struct {
 	S3LogPutCost float64 `bson:"s3_log_put_cost,omitempty" json:"s3_log_put_cost,omitempty"`
 	// S3ArtifactStorageCost is the calculated S3 storage cost for artifact bytes over their retention period.
 	S3ArtifactStorageCost float64 `bson:"s3_artifact_storage_cost,omitempty" json:"s3_artifact_storage_cost,omitempty"`
+	// S3LogStorageCost is the calculated S3 storage cost for log bytes over their retention period.
+	S3LogStorageCost float64 `bson:"s3_log_storage_cost,omitempty" json:"s3_log_storage_cost,omitempty"`
 }
 
 // IsZero returns true if all cost components are zero.
@@ -42,5 +45,6 @@ func (c Cost) IsZero() bool {
 		c.AdjustedEBSStorageCost == 0 &&
 		c.S3ArtifactPutCost == 0 &&
 		c.S3LogPutCost == 0 &&
-		c.S3ArtifactStorageCost == 0
+		c.S3ArtifactStorageCost == 0 &&
+		c.S3LogStorageCost == 0
 }

--- a/model/s3usage/s3usage.go
+++ b/model/s3usage/s3usage.go
@@ -9,10 +9,31 @@ import (
 	"github.com/mongodb/grip/message"
 )
 
+// S3 log types for storage cost tracking.
+const (
+	LogTypeTask   = "task_log"
+	LogTypeAgent  = "agent_log"
+	LogTypeSystem = "system_log"
+)
+
+// LogTypeMetrics holds the S3 key and byte count for a single log type.
+type LogTypeMetrics struct {
+	LogKey string `bson:"log_key,omitempty" json:"log_key,omitempty"`
+	Bytes  int64  `bson:"bytes,omitempty" json:"bytes,omitempty"`
+}
+
+// LogMetrics tracks log upload metrics broken down by log type.
+type LogMetrics struct {
+	S3UploadMetrics `bson:",inline"`
+	Task            LogTypeMetrics `bson:"task_log,omitempty" json:"task_log,omitempty"`
+	Agent           LogTypeMetrics `bson:"agent_log,omitempty" json:"agent_log,omitempty"`
+	System          LogTypeMetrics `bson:"system_log,omitempty" json:"system_log,omitempty"`
+}
+
 // S3Usage tracks S3 API usage for cost calculation.
 type S3Usage struct {
 	Artifacts ArtifactMetrics `bson:"artifacts,omitempty" json:"artifacts,omitempty"`
-	Logs      S3UploadMetrics `bson:"logs,omitempty" json:"logs,omitempty"`
+	Logs      LogMetrics      `bson:"logs,omitempty" json:"logs,omitempty"`
 }
 
 // S3UploadMetrics tracks common S3 upload metrics shared across upload types.
@@ -271,10 +292,27 @@ func (s *S3Usage) IncrementArtifacts(opts ArtifactIncrementOptions) {
 	}
 }
 
-// IncrementLogs increments the log chunk upload metrics.
-func (s *S3Usage) IncrementLogs(putRequests int, uploadBytes int64) {
+// IncrementLogs increments log upload metrics and accumulates per-type bytes for storage cost tracking.
+func (s *S3Usage) IncrementLogs(putRequests int, uploadBytes int64, logType, logKey string) {
 	s.Logs.PutRequests += putRequests
 	s.Logs.UploadBytes += uploadBytes
+	switch logType {
+	case LogTypeTask:
+		s.Logs.Task.Bytes += uploadBytes
+		if logKey != "" {
+			s.Logs.Task.LogKey = logKey
+		}
+	case LogTypeAgent:
+		s.Logs.Agent.Bytes += uploadBytes
+		if logKey != "" {
+			s.Logs.Agent.LogKey = logKey
+		}
+	case LogTypeSystem:
+		s.Logs.System.Bytes += uploadBytes
+		if logKey != "" {
+			s.Logs.System.LogKey = logKey
+		}
+	}
 }
 
 // IsZero implements bsoncodec.Zeroer for BSON marshalling.

--- a/model/s3usage/s3usage_test.go
+++ b/model/s3usage/s3usage_test.go
@@ -106,11 +106,11 @@ func TestS3Usage(t *testing.T) {
 		assert.Equal(t, 0, s3Usage.Logs.PutRequests)
 		assert.Equal(t, int64(0), s3Usage.Logs.UploadBytes)
 
-		s3Usage.IncrementLogs(5, 1024)
+		s3Usage.IncrementLogs(5, 1024, "", "")
 		assert.Equal(t, 5, s3Usage.Logs.PutRequests)
 		assert.Equal(t, int64(1024), s3Usage.Logs.UploadBytes)
 
-		s3Usage.IncrementLogs(10, 2048)
+		s3Usage.IncrementLogs(10, 2048, "", "")
 		assert.Equal(t, 15, s3Usage.Logs.PutRequests)
 		assert.Equal(t, int64(3072), s3Usage.Logs.UploadBytes)
 	})

--- a/model/task/evergreen_sender.go
+++ b/model/task/evergreen_sender.go
@@ -48,6 +48,10 @@ type EvergreenSenderOptions struct {
 	// S3Usage tracks S3 API usage for log uploads. If set, flush() will
 	// increment log file metrics after each successful write.
 	S3Usage *s3usage.S3Usage
+	// LogType is the type of log being written (e.g., s3usage.LogTypeTask).
+	LogType string
+	// LogKey is the S3 key for the log being written, used for storage cost tracking.
+	LogKey string
 
 	appendLines logLineAppender
 }
@@ -245,7 +249,7 @@ func (s *evergreenSender) flush(ctx context.Context) error {
 	}
 
 	if s.opts.S3Usage != nil && uploadBytes > 0 {
-		s.opts.S3Usage.IncrementLogs(1, uploadBytes)
+		s.opts.S3Usage.IncrementLogs(1, uploadBytes, s.opts.LogType, s.opts.LogKey)
 	}
 
 	s.buffer = []log.LogLine{}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -4327,23 +4327,42 @@ func (t *Task) calculateRuntimeCost(financeConfig evergreen.CostConfig, costData
 type bucketExpirationLookup func(ctx context.Context, bucket, fileKey string) (days int, found bool)
 
 // SaveS3Usage persists the task's S3 usage metrics and calculates S3 costs.
-func (t *Task) SaveS3Usage(ctx context.Context, lookup bucketExpirationLookup) error {
+func (t *Task) SaveS3Usage(ctx context.Context, lookup bucketExpirationLookup, logBucketName string) error {
 	costConfig := &evergreen.CostConfig{}
 	if err := costConfig.Get(ctx); err != nil {
 		return errors.Wrap(err, "getting cost config")
 	}
 
 	t.calculateS3PutCosts(costConfig)
-	t.setS3StorageCosts(ctx, lookup, costConfig)
+	t.setS3ArtifactStorageCosts(ctx, lookup, costConfig)
+	t.setS3LogStorageCosts(ctx, logBucketName, lookup, costConfig)
 
 	setFields := bson.M{
 		S3UsageKey: t.S3Usage,
 		bsonutil.GetDottedKeyName(TaskCostKey, cost.S3ArtifactPutCostKey):     t.TaskCost.S3ArtifactPutCost,
 		bsonutil.GetDottedKeyName(TaskCostKey, cost.S3LogPutCostKey):          t.TaskCost.S3LogPutCost,
 		bsonutil.GetDottedKeyName(TaskCostKey, cost.S3ArtifactStorageCostKey): t.TaskCost.S3ArtifactStorageCost,
+		bsonutil.GetDottedKeyName(TaskCostKey, cost.S3LogStorageCostKey):      t.TaskCost.S3LogStorageCost,
 	}
 
 	return UpdateOne(ctx, bson.M{"_id": t.Id}, bson.M{"$set": setFields})
+}
+
+// setS3LogStorageCosts calculates and sets the task's S3 log storage cost using lifecycle rules for the log bucket.
+func (t *Task) setS3LogStorageCosts(ctx context.Context, logBucketName string, lookup bucketExpirationLookup, costConfig *evergreen.CostConfig) {
+	if logBucketName == "" || lookup == nil {
+		return
+	}
+	for _, lm := range []s3usage.LogTypeMetrics{t.S3Usage.Logs.Task, t.S3Usage.Logs.Agent, t.S3Usage.Logs.System} {
+		if lm.LogKey == "" {
+			continue
+		}
+		days, found := lookup(ctx, logBucketName, lm.LogKey)
+		if !found {
+			days = costConfig.S3Cost.Storage.DefaultMaxArtifactExpirationDays
+		}
+		t.TaskCost.S3LogStorageCost += s3usage.CalculateS3StorageCostWithConfig(ctx, lm.Bytes, days, costConfig)
+	}
 }
 
 // resolveArtifactExpirationDays looks up the expiration days for an artifact, falling back to DefaultMaxArtifactExpirationDays if no matching rule is found.
@@ -4366,8 +4385,8 @@ func (t *Task) calculateS3PutCosts(costConfig *evergreen.CostConfig) {
 	}
 }
 
-// setS3StorageCosts calculates and sets the task's S3 artifact storage cost. Skipped if the lifecycle rules lookup is nil.
-func (t *Task) setS3StorageCosts(ctx context.Context, lookup bucketExpirationLookup, costConfig *evergreen.CostConfig) {
+// setS3ArtifactStorageCosts calculates and sets the task's S3 artifact storage cost. Skipped if the lifecycle rules lookup is nil.
+func (t *Task) setS3ArtifactStorageCosts(ctx context.Context, lookup bucketExpirationLookup, costConfig *evergreen.CostConfig) {
 	if lookup == nil {
 		return
 	}

--- a/model/task/task_log.go
+++ b/model/task/task_log.go
@@ -93,9 +93,12 @@ func NewTaskLogSender(ctx context.Context, task *Task, senderOpts EvergreenSende
 		return nil, errors.Wrap(err, "getting log service")
 	}
 
+	logName := getLogName(*task, logType, output.TaskLogs.ID())
 	senderOpts.appendLines = func(ctx context.Context, lines []log.LogLine) (int64, error) {
-		return svc.Append(ctx, getLogName(*task, logType, output.TaskLogs.ID()), 0, lines)
+		return svc.Append(ctx, logName, 0, lines)
 	}
+	senderOpts.LogType = string(logType)
+	senderOpts.LogKey = logName
 
 	return newEvergreenSender(ctx, fmt.Sprintf("%s-%s", task.Id, logType), senderOpts)
 }
@@ -122,13 +125,14 @@ func AppendTaskLogs(ctx context.Context, task *Task, logType TaskLogType, lines 
 		return errors.Wrap(err, "getting log service")
 	}
 
-	uploadBytes, err := svc.Append(ctx, getLogName(*task, logType, output.TaskLogs.ID()), 0, lines)
+	logName := getLogName(*task, logType, output.TaskLogs.ID())
+	uploadBytes, err := svc.Append(ctx, logName, 0, lines)
 	if err != nil {
 		return err
 	}
 
 	if uploadBytes > 0 {
-		task.S3Usage.IncrementLogs(1, uploadBytes)
+		task.S3Usage.IncrementLogs(1, uploadBytes, string(logType), logName)
 	}
 
 	return nil

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -5203,11 +5203,12 @@ func TestSaveS3Usage(t *testing.T) {
 	}
 
 	for name, tc := range map[string]struct {
-		task       Task
-		costConfig *evergreen.CostConfig
-		setupUsage func(*s3usage.S3Usage)
-		lookup     bucketExpirationLookup
-		assertions func(*testing.T, *Task)
+		task          Task
+		costConfig    *evergreen.CostConfig
+		setupUsage    func(*s3usage.S3Usage)
+		lookup        bucketExpirationLookup
+		logBucketName string
+		assertions    func(*testing.T, *Task)
 	}{
 		"PersistsS3Usage": {
 			task: Task{Id: "t1"},
@@ -5240,7 +5241,7 @@ func TestSaveS3Usage(t *testing.T) {
 					Bucket:      "mciuploads",
 					Files:       multiFileArtifacts,
 				})
-				u.IncrementLogs(50, 500000)
+				u.IncrementLogs(50, 500000, "", "")
 			},
 			assertions: func(t *testing.T, dbTask *Task) {
 				assert.Equal(t, 1000, dbTask.S3Usage.Artifacts.PutRequests)
@@ -5262,7 +5263,7 @@ func TestSaveS3Usage(t *testing.T) {
 					Bucket:      "mciuploads",
 					Files:       multiFileArtifacts,
 				})
-				u.IncrementLogs(50, 500000)
+				u.IncrementLogs(50, 500000, "", "")
 			},
 			lookup: func(_ context.Context, _, _ string) (int, bool) {
 				return 0, false
@@ -5278,12 +5279,7 @@ func TestSaveS3Usage(t *testing.T) {
 		"CalculatesLogChunkCostOnly": {
 			task: Task{Id: "t4"},
 			setupUsage: func(u *s3usage.S3Usage) {
-				*u = s3usage.S3Usage{
-					Logs: s3usage.S3UploadMetrics{
-						PutRequests: 100,
-						UploadBytes: 200000,
-					},
-				}
+				u.IncrementLogs(100, 200000, "", "")
 			},
 			assertions: func(t *testing.T, dbTask *Task) {
 				assert.Equal(t, 0, dbTask.S3Usage.Artifacts.PutRequests)
@@ -5374,6 +5370,51 @@ func TestSaveS3Usage(t *testing.T) {
 				assert.True(t, dbTask.TaskCost.IsZero())
 			},
 		},
+		"CalculatesLogStorageCostWithLookupMatch": {
+			task:          Task{Id: "t10"},
+			costConfig:    &defaultCostConfig,
+			logBucketName: "log-bucket",
+			setupUsage: func(u *s3usage.S3Usage) {
+				u.IncrementLogs(10, 1024*1024, s3usage.LogTypeTask, "some-project/abc123/0/task_logs/task")
+			},
+			lookup: func(_ context.Context, _, _ string) (int, bool) {
+				return 60, true
+			},
+			assertions: func(t *testing.T, dbTask *Task) {
+				assert.True(t, dbTask.TaskCost.S3LogStorageCost > 0)
+				expectedCost := s3usage.CalculateS3StorageCostWithConfig(ctx, 1024*1024, 60, &defaultCostConfig)
+				assert.InDelta(t, expectedCost, dbTask.TaskCost.S3LogStorageCost, 0.0001)
+			},
+		},
+		"CalculatesLogStorageCostWithLookupMissUsesDefault": {
+			task:          Task{Id: "t11"},
+			costConfig:    &defaultCostConfig,
+			logBucketName: "log-bucket",
+			setupUsage: func(u *s3usage.S3Usage) {
+				u.IncrementLogs(10, 1024*1024, s3usage.LogTypeTask, "some-project/abc123/0/task_logs/task")
+			},
+			lookup: func(_ context.Context, _, _ string) (int, bool) {
+				return 0, false
+			},
+			assertions: func(t *testing.T, dbTask *Task) {
+				assert.True(t, dbTask.TaskCost.S3LogStorageCost > 0)
+				expectedCost := s3usage.CalculateS3StorageCostWithConfig(ctx, 1024*1024, defaultCostConfig.S3Cost.Storage.DefaultMaxArtifactExpirationDays, &defaultCostConfig)
+				assert.InDelta(t, expectedCost, dbTask.TaskCost.S3LogStorageCost, 0.0001)
+			},
+		},
+		"EmptyLogBucketNameSkipsLogStorageCost": {
+			task:       Task{Id: "t12"},
+			costConfig: &defaultCostConfig,
+			setupUsage: func(u *s3usage.S3Usage) {
+				u.IncrementLogs(10, 1024*1024, s3usage.LogTypeTask, "some-project/abc123/0/task_logs/task")
+			},
+			lookup: func(_ context.Context, _, _ string) (int, bool) {
+				return 60, true
+			},
+			assertions: func(t *testing.T, dbTask *Task) {
+				assert.Equal(t, float64(0), dbTask.TaskCost.S3LogStorageCost)
+			},
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			require.NoError(t, db.ClearCollections(Collection))
@@ -5387,7 +5428,7 @@ func TestSaveS3Usage(t *testing.T) {
 			if tc.setupUsage != nil {
 				tc.setupUsage(&tc.task.S3Usage)
 			}
-			require.NoError(t, tc.task.SaveS3Usage(ctx, tc.lookup))
+			require.NoError(t, tc.task.SaveS3Usage(ctx, tc.lookup, tc.logBucketName))
 
 			dbTask, err := FindOneId(ctx, tc.task.Id)
 			require.NoError(t, err)

--- a/model/version.go
+++ b/model/version.go
@@ -36,6 +36,7 @@ const (
 	taskS3ArtifactPutCostKey     = "s3_artifact_put_cost"
 	taskS3ArtifactStorageCostKey = "s3_artifact_storage_cost"
 	taskS3LogPutCostKey          = "s3_log_put_cost"
+	taskS3LogStorageCostKey      = "s3_log_storage_cost"
 
 	taskS3UsageKey         = "s3_usage"
 	taskS3ArtifactsKey     = "artifacts"
@@ -381,6 +382,7 @@ func (v *Version) UpdateAggregateTaskCosts(ctx context.Context) error {
 			"total_s3_artifact_put_cost":     bson.M{"$sum": "$" + taskCostKey + "." + taskS3ArtifactPutCostKey},
 			"total_s3_artifact_storage_cost": bson.M{"$sum": "$" + taskCostKey + "." + taskS3ArtifactStorageCostKey},
 			"total_s3_log_put_cost":          bson.M{"$sum": "$" + taskCostKey + "." + taskS3LogPutCostKey},
+			"total_s3_log_storage_cost":      bson.M{"$sum": "$" + taskCostKey + "." + taskS3LogStorageCostKey},
 			"total_artifact_put_requests":    bson.M{"$sum": "$" + taskS3UsageKey + "." + taskS3ArtifactsKey + "." + taskS3PutRequestsKey},
 			"total_artifact_upload_bytes":    bson.M{"$sum": "$" + taskS3UsageKey + "." + taskS3ArtifactsKey + "." + taskS3UploadBytesKey},
 			"total_artifact_count":           bson.M{"$sum": "$" + taskS3UsageKey + "." + taskS3ArtifactsKey + "." + taskS3ArtifactCountKey},
@@ -402,6 +404,7 @@ func (v *Version) UpdateAggregateTaskCosts(ctx context.Context) error {
 		TotalS3ArtifactPutCost     float64 `bson:"total_s3_artifact_put_cost"`
 		TotalS3ArtifactStorageCost float64 `bson:"total_s3_artifact_storage_cost"`
 		TotalS3LogPutCost          float64 `bson:"total_s3_log_put_cost"`
+		TotalS3LogStorageCost      float64 `bson:"total_s3_log_storage_cost"`
 		TotalArtifactPutRequests   int     `bson:"total_artifact_put_requests"`
 		TotalArtifactUploadBytes   int64   `bson:"total_artifact_upload_bytes"`
 		TotalArtifactCount         int     `bson:"total_artifact_count"`
@@ -420,6 +423,7 @@ func (v *Version) UpdateAggregateTaskCosts(ctx context.Context) error {
 		total.S3ArtifactPutCost = results[0].TotalS3ArtifactPutCost
 		total.S3ArtifactStorageCost = results[0].TotalS3ArtifactStorageCost
 		total.S3LogPutCost = results[0].TotalS3LogPutCost
+		total.S3LogStorageCost = results[0].TotalS3LogStorageCost
 		predicted.OnDemandEC2Cost = results[0].PredictedOnDemand
 		predicted.AdjustedEC2Cost = results[0].PredictedAdjusted
 		s3Total.Artifacts.PutRequests = results[0].TotalArtifactPutRequests
@@ -436,6 +440,7 @@ func (v *Version) UpdateAggregateTaskCosts(ctx context.Context) error {
 			bsonutil.GetDottedKeyName(VersionCostKey, cost.S3ArtifactPutCostKey):        total.S3ArtifactPutCost,
 			bsonutil.GetDottedKeyName(VersionCostKey, cost.S3ArtifactStorageCostKey):    total.S3ArtifactStorageCost,
 			bsonutil.GetDottedKeyName(VersionCostKey, cost.S3LogPutCostKey):             total.S3LogPutCost,
+			bsonutil.GetDottedKeyName(VersionCostKey, cost.S3LogStorageCostKey):         total.S3LogStorageCost,
 			bsonutil.GetDottedKeyName(VersionPredictedCostKey, cost.OnDemandEC2CostKey): predicted.OnDemandEC2Cost,
 			bsonutil.GetDottedKeyName(VersionPredictedCostKey, cost.AdjustedEC2CostKey): predicted.AdjustedEC2Cost,
 			VersionS3UsageKey: s3Total,

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -770,7 +770,12 @@ func (h *reportS3UsageHandler) Run(ctx context.Context) gimlet.Responder {
 		}
 	}
 
-	if err := t.SaveS3Usage(ctx, lookup); err != nil {
+	logBucketName := ""
+	if t.TaskOutputInfo != nil {
+		logBucketName = t.TaskOutputInfo.TaskLogs.BucketConfig.Name
+	}
+
+	if err := t.SaveS3Usage(ctx, lookup, logBucketName); err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "saving S3 usage for task '%s'", h.taskID))
 	}
 
@@ -799,6 +804,7 @@ func (h *reportS3UsageHandler) Run(ctx context.Context) gimlet.Responder {
 		attribute.Int(evergreen.S3LogPutRequestsOtelAttribute, t.S3Usage.Logs.PutRequests),
 		attribute.Int64(evergreen.S3LogUploadBytesOtelAttribute, t.S3Usage.Logs.UploadBytes),
 		attribute.Float64(evergreen.S3LogPutCostOtelAttribute, t.TaskCost.S3LogPutCost),
+		attribute.Float64(evergreen.S3LogStorageCostOtelAttribute, t.TaskCost.S3LogStorageCost),
 		attribute.Float64(evergreen.S3ArtifactAvgFilePutCostOtelAttribute, avgFilePutCost),
 		attribute.Float64(evergreen.S3ArtifactWithMaxPutRequestsCostOtelAttribute, maxFilePutCost),
 		attribute.Float64(evergreen.S3ArtifactWithMinPutRequestsCostOtelAttribute, minFilePutCost),

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -1096,7 +1096,7 @@ func TestReportS3Usage(t *testing.T) {
 					S3UploadMetrics: s3usage.S3UploadMetrics{PutRequests: 50, UploadBytes: 2048},
 					Count:           5,
 				},
-				Logs: s3usage.S3UploadMetrics{PutRequests: 10, UploadBytes: 4096},
+				Logs: s3usage.LogMetrics{S3UploadMetrics: s3usage.S3UploadMetrics{PutRequests: 10, UploadBytes: 4096}},
 			},
 			wantStatus: http.StatusOK,
 			assertions: func(t *testing.T, dbTask *task.Task) {
@@ -1110,7 +1110,7 @@ func TestReportS3Usage(t *testing.T) {
 		"SavesLogOnlyUsage": {
 			insertTask: &task.Task{Id: "t2", Status: evergreen.TaskStarted},
 			s3Usage: s3usage.S3Usage{
-				Logs: s3usage.S3UploadMetrics{PutRequests: 25, UploadBytes: 8192},
+				Logs: s3usage.LogMetrics{S3UploadMetrics: s3usage.S3UploadMetrics{PutRequests: 25, UploadBytes: 8192}},
 			},
 			wantStatus: http.StatusOK,
 			assertions: func(t *testing.T, dbTask *task.Task) {


### PR DESCRIPTION
DEVPROD-26466

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
This PR is to use the cost functions created in DEVPROD-24629 [PR](https://github.com/evergreen-ci/evergreen/pull/10030) to calculate and save S3 Logs storage costs for the task into the DB and report it on the task API

We are also emitting honeycomb metrics for this.

### Testing
Tested in staging and verified. Values are in DB and UI changes are there. Task End points print values as well
