### PR TITLE
DEVPROD-31752: Bound retry failed log-move find with a 20 minute timeout

### DIFF
--- a/units/crons.go
+++ b/units/crons.go
@@ -922,6 +922,7 @@ const defaultRetryFailedLogMoveMaxJobsPerRun = 50
 const retryFailedLogMoveFindMinLimit = 500
 const retryFailedLogMoveFindMaxLimit = 5000
 const retryFailedLogMoveCandidateMultiplier = 50
+const retryFailedLogMoveFindTimeout = 20 * time.Minute
 
 // PopulateRetryFailedLogMoveJobs finds failed tasks whose logs are still in the regular
 // bucket (move job failed or never ran) and enqueues one move-logs-to-failed-bucket job per task.
@@ -966,7 +967,9 @@ func PopulateRetryFailedLogMoveJobs(env evergreen.Environment) amboy.QueueOperat
 		query := db.Query(filter).WithFields(
 			task.IdKey, task.ProjectKey, task.FinishTimeKey, task.TaskOutputInfoKey,
 		).Sort([]string{"-" + task.FinishTimeKey}).Limit(queryLimit)
-		tasks, err := task.FindAll(ctx, query)
+		findCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), retryFailedLogMoveFindTimeout)
+		defer cancel()
+		tasks, err := task.FindAll(findCtx, query)
 		if err != nil {
 			return errors.Wrap(err, "finding failed tasks whose logs need moving")
 		}


### PR DESCRIPTION
DEVPROD-31752

### Description
PopulateRetryFailedLogMoveJobs is hitting  [MaxTimeMSExpired](https://mongodb.splunkcloud.com/en-US/app/search/search?earliest=-15m&latest=now&q=search%20index%3Devergreen%20crons-remote-week%7C%20spath%20error%20%7C%20search%20error%3D%22finding%20failed%20tasks%20whose%20logs%20need%20moving%3A%20(MaxTimeMSExpired)%20Executor%20error%20during%20getMore%20%3A%3A%20caused%20by%20%3A%3A%20operation%20exceeded%20time%20limit%22&display.page.search.mode=smart&dispatch.sample_ratio=1&display.general.type=events&display.page.search.tab=events&workload_pool=&sid=1776271034.250143) on the tasks find. This adds a 20m context.WithTimeout so the cursor can finish without inheriting the tight outer deadline.

