### PR TITLE
DEVPROD-31767: Add S3 storage cost admin fields for AWS account lists

### DIFF
--- a/config_cost.go
+++ b/config_cost.go
@@ -60,6 +60,18 @@ var (
 	financeConfigOnDemandDiscountKey    = bsonutil.MustHaveTag(CostConfig{}, "OnDemandDiscount")
 	financeConfigS3CostKey              = bsonutil.MustHaveTag(CostConfig{}, "S3Cost")
 	financeConfigEBSCostKey             = bsonutil.MustHaveTag(CostConfig{}, "EBSCost")
+
+	s3CostConfigUploadKey  = bsonutil.MustHaveTag(S3CostConfig{}, "Upload")
+	s3CostConfigStorageKey = bsonutil.MustHaveTag(S3CostConfig{}, "Storage")
+
+	s3UploadCostUploadCostDiscountKey = bsonutil.MustHaveTag(S3UploadCostConfig{}, "UploadCostDiscount")
+
+	s3StorageCostStandardStorageCostDiscountKey              = bsonutil.MustHaveTag(S3StorageCostConfig{}, "StandardStorageCostDiscount")
+	s3StorageCostIAStorageCostDiscountKey                    = bsonutil.MustHaveTag(S3StorageCostConfig{}, "IAStorageCostDiscount")
+	s3StorageCostArchiveStorageCostDiscountKey               = bsonutil.MustHaveTag(S3StorageCostConfig{}, "ArchiveStorageCostDiscount")
+	s3StorageCostDefaultMaxArtifactExpirationDaysKey         = bsonutil.MustHaveTag(S3StorageCostConfig{}, "DefaultMaxArtifactExpirationDays")
+	s3StorageCostDevprodOwnedAWSAccountIDsKey                = bsonutil.MustHaveTag(S3StorageCostConfig{}, "DevprodOwnedAWSAccountIDs")
+	s3StorageCostArtifactAWSAccountsWithoutLifecycleRulesKey = bsonutil.MustHaveTag(S3StorageCostConfig{}, "ArtifactAWSAccountsWithoutLifecycleRules")
 )
 
 func (*CostConfig) SectionId() string { return "cost" }
@@ -74,13 +86,13 @@ func (c *CostConfig) Set(ctx context.Context) error {
 			financeConfigFormulaKey:             c.FinanceFormula,
 			financeConfigSavingsPlanDiscountKey: c.SavingsPlanDiscount,
 			financeConfigOnDemandDiscountKey:    c.OnDemandDiscount,
-			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "upload", "upload_cost_discount"):                           c.S3Cost.Upload.UploadCostDiscount,
-			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "storage", "standard_storage_cost_discount"):                c.S3Cost.Storage.StandardStorageCostDiscount,
-			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "storage", "i_a_storage_cost_discount"):                     c.S3Cost.Storage.IAStorageCostDiscount,
-			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "storage", "archive_storage_cost_discount"):                 c.S3Cost.Storage.ArchiveStorageCostDiscount,
-			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "storage", "default_max_artifact_expiration_days"):          c.S3Cost.Storage.DefaultMaxArtifactExpirationDays,
-			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "storage", "devprod_owned_aws_account_ids"):                 c.S3Cost.Storage.DevprodOwnedAWSAccountIDs,
-			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "storage", "artifact_aws_accounts_without_lifecycle_rules"): c.S3Cost.Storage.ArtifactAWSAccountsWithoutLifecycleRules,
+			bsonutil.GetDottedKeyName(financeConfigS3CostKey, s3CostConfigUploadKey, s3UploadCostUploadCostDiscountKey):                         c.S3Cost.Upload.UploadCostDiscount,
+			bsonutil.GetDottedKeyName(financeConfigS3CostKey, s3CostConfigStorageKey, s3StorageCostStandardStorageCostDiscountKey):              c.S3Cost.Storage.StandardStorageCostDiscount,
+			bsonutil.GetDottedKeyName(financeConfigS3CostKey, s3CostConfigStorageKey, s3StorageCostIAStorageCostDiscountKey):                    c.S3Cost.Storage.IAStorageCostDiscount,
+			bsonutil.GetDottedKeyName(financeConfigS3CostKey, s3CostConfigStorageKey, s3StorageCostArchiveStorageCostDiscountKey):               c.S3Cost.Storage.ArchiveStorageCostDiscount,
+			bsonutil.GetDottedKeyName(financeConfigS3CostKey, s3CostConfigStorageKey, s3StorageCostDefaultMaxArtifactExpirationDaysKey):         c.S3Cost.Storage.DefaultMaxArtifactExpirationDays,
+			bsonutil.GetDottedKeyName(financeConfigS3CostKey, s3CostConfigStorageKey, s3StorageCostDevprodOwnedAWSAccountIDsKey):                c.S3Cost.Storage.DevprodOwnedAWSAccountIDs,
+			bsonutil.GetDottedKeyName(financeConfigS3CostKey, s3CostConfigStorageKey, s3StorageCostArtifactAWSAccountsWithoutLifecycleRulesKey): c.S3Cost.Storage.ArtifactAWSAccountsWithoutLifecycleRules,
 			financeConfigEBSCostKey: c.EBSCost,
 		}}), "updating config section '%s'", c.SectionId(),
 	)
@@ -107,14 +119,10 @@ func (c *CostConfig) ValidateAndDefault() error {
 		catcher.New("default max artifact expiration days must be non-negative")
 	}
 	for _, id := range c.S3Cost.Storage.DevprodOwnedAWSAccountIDs {
-		if err := validateAWSAccountID(id, "devprod owned AWS account ID"); err != nil {
-			catcher.Add(err)
-		}
+		catcher.Add(validateAWSAccountID(id, "devprod owned AWS account ID"))
 	}
 	for _, id := range c.S3Cost.Storage.ArtifactAWSAccountsWithoutLifecycleRules {
-		if err := validateAWSAccountID(id, "artifact AWS account without lifecycle rules"); err != nil {
-			catcher.Add(err)
-		}
+		catcher.Add(validateAWSAccountID(id, "artifact AWS account without lifecycle rules"))
 	}
 
 	return catcher.Resolve()

--- a/config_cost.go
+++ b/config_cost.go
@@ -2,6 +2,7 @@ package evergreen
 
 import (
 	"context"
+	"strings"
 
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
@@ -35,6 +36,10 @@ type S3StorageCostConfig struct {
 	ArchiveStorageCostDiscount  float64 `bson:"archive_storage_cost_discount" json:"archive_storage_cost_discount" yaml:"archive_storage_cost_discount"`
 	// DefaultMaxArtifactExpirationDays is the fallback retention period used when no lifecycle rule is found for a bucket.
 	DefaultMaxArtifactExpirationDays int `bson:"default_max_artifact_expiration_days" json:"default_max_artifact_expiration_days" yaml:"default_max_artifact_expiration_days"`
+	// DevprodOwnedAWSAccountIDs contains the AWS account IDs of the accounts that are owned by Devprod that we want to calculate s3 costs for.
+	DevprodOwnedAWSAccountIDs []string `bson:"devprod_owned_aws_account_ids,omitempty" json:"devprod_owned_aws_account_ids,omitempty" yaml:"devprod_owned_aws_account_ids,omitempty"`
+	// ArtifactAWSAccountsWithoutLifecycleRules contains the AWS account IDs of the accounts that we want to calculate s3 costs for but don't have lifecycle rules for.
+	ArtifactAWSAccountsWithoutLifecycleRules []string `bson:"artifact_aws_accounts_without_lifecycle_rules,omitempty" json:"artifact_aws_accounts_without_lifecycle_rules,omitempty" yaml:"artifact_aws_accounts_without_lifecycle_rules,omitempty"`
 }
 
 // S3CostConfig represents S3 cost configuration with separate upload and storage settings.
@@ -69,11 +74,13 @@ func (c *CostConfig) Set(ctx context.Context) error {
 			financeConfigFormulaKey:             c.FinanceFormula,
 			financeConfigSavingsPlanDiscountKey: c.SavingsPlanDiscount,
 			financeConfigOnDemandDiscountKey:    c.OnDemandDiscount,
-			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "upload", "upload_cost_discount"):                  c.S3Cost.Upload.UploadCostDiscount,
-			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "storage", "standard_storage_cost_discount"):       c.S3Cost.Storage.StandardStorageCostDiscount,
-			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "storage", "i_a_storage_cost_discount"):            c.S3Cost.Storage.IAStorageCostDiscount,
-			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "storage", "archive_storage_cost_discount"):        c.S3Cost.Storage.ArchiveStorageCostDiscount,
-			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "storage", "default_max_artifact_expiration_days"): c.S3Cost.Storage.DefaultMaxArtifactExpirationDays,
+			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "upload", "upload_cost_discount"):                           c.S3Cost.Upload.UploadCostDiscount,
+			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "storage", "standard_storage_cost_discount"):                c.S3Cost.Storage.StandardStorageCostDiscount,
+			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "storage", "i_a_storage_cost_discount"):                     c.S3Cost.Storage.IAStorageCostDiscount,
+			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "storage", "archive_storage_cost_discount"):                 c.S3Cost.Storage.ArchiveStorageCostDiscount,
+			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "storage", "default_max_artifact_expiration_days"):          c.S3Cost.Storage.DefaultMaxArtifactExpirationDays,
+			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "storage", "devprod_owned_aws_account_ids"):                 c.S3Cost.Storage.DevprodOwnedAWSAccountIDs,
+			bsonutil.GetDottedKeyName(financeConfigS3CostKey, "storage", "artifact_aws_accounts_without_lifecycle_rules"): c.S3Cost.Storage.ArtifactAWSAccountsWithoutLifecycleRules,
 			financeConfigEBSCostKey: c.EBSCost,
 		}}), "updating config section '%s'", c.SectionId(),
 	)
@@ -99,8 +106,34 @@ func (c *CostConfig) ValidateAndDefault() error {
 	if c.S3Cost.Storage.DefaultMaxArtifactExpirationDays < 0 {
 		catcher.New("default max artifact expiration days must be non-negative")
 	}
+	for _, id := range c.S3Cost.Storage.DevprodOwnedAWSAccountIDs {
+		if err := validateAWSAccountID(id, "devprod owned AWS account ID"); err != nil {
+			catcher.Add(err)
+		}
+	}
+	for _, id := range c.S3Cost.Storage.ArtifactAWSAccountsWithoutLifecycleRules {
+		if err := validateAWSAccountID(id, "artifact AWS account without lifecycle rules"); err != nil {
+			catcher.Add(err)
+		}
+	}
 
 	return catcher.Resolve()
+}
+
+func validateAWSAccountID(id, fieldLabel string) error {
+	s := strings.TrimSpace(id)
+	if s == "" {
+		return errors.Errorf("%s cannot be empty", fieldLabel)
+	}
+	if len(s) != 12 {
+		return errors.Errorf("%s must be a 12-digit AWS account ID", fieldLabel)
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return errors.Errorf("%s must contain only digits", fieldLabel)
+		}
+	}
+	return nil
 }
 
 // IsConfigured returns true if any finance config field is set.

--- a/config_cost_test.go
+++ b/config_cost_test.go
@@ -122,6 +122,29 @@ func TestCostConfigValidateAndDefault(t *testing.T) {
 		err := c.ValidateAndDefault()
 		assert.Error(t, err)
 	})
+
+	t.Run("InvalidDevprodOwnedAWSAccountID", func(t *testing.T) {
+		c := CostConfig{
+			S3Cost: S3CostConfig{
+				Storage: S3StorageCostConfig{
+					DevprodOwnedAWSAccountIDs: []string{"not-digits"},
+				},
+			},
+		}
+		assert.Error(t, c.ValidateAndDefault())
+	})
+
+	t.Run("ValidDevprodOwnedAndNoLifecycleAccountIDs", func(t *testing.T) {
+		c := CostConfig{
+			S3Cost: S3CostConfig{
+				Storage: S3StorageCostConfig{
+					DevprodOwnedAWSAccountIDs:                []string{"123456789012", " 210987654321 "},
+					ArtifactAWSAccountsWithoutLifecycleRules: []string{"123456789012"},
+				},
+			},
+		}
+		assert.NoError(t, c.ValidateAndDefault())
+	})
 }
 
 func TestCostConfigIsConfigured(t *testing.T) {
@@ -279,5 +302,28 @@ func TestCostConfigSetAndGet(t *testing.T) {
 		assert.Equal(t, 0.1, retrieved.S3Cost.Upload.UploadCostDiscount)
 		assert.Equal(t, 0.2, retrieved.S3Cost.Storage.StandardStorageCostDiscount)
 		assert.Equal(t, 0.0, retrieved.S3Cost.Storage.IAStorageCostDiscount)
+	})
+
+	t.Run("SetAndGetS3ArtifactAccountLists", func(t *testing.T) {
+		require.NoError(t, GetEnvironment().DB().Collection(ConfigCollection).Drop(t.Context()))
+		defer func() {
+			require.NoError(t, GetEnvironment().DB().Collection(ConfigCollection).Drop(t.Context()))
+		}()
+
+		original := CostConfig{
+			S3Cost: S3CostConfig{
+				Storage: S3StorageCostConfig{
+					DevprodOwnedAWSAccountIDs:                []string{"123456789012"},
+					ArtifactAWSAccountsWithoutLifecycleRules: []string{"210987654321"},
+				},
+			},
+		}
+		require.NoError(t, original.Set(t.Context()))
+
+		retrieved := CostConfig{}
+		require.NoError(t, retrieved.Get(t.Context()))
+
+		assert.Equal(t, []string{"123456789012"}, retrieved.S3Cost.Storage.DevprodOwnedAWSAccountIDs)
+		assert.Equal(t, []string{"210987654321"}, retrieved.S3Cost.Storage.ArtifactAWSAccountsWithoutLifecycleRules)
 	})
 }

--- a/config_cost_test.go
+++ b/config_cost_test.go
@@ -1,6 +1,7 @@
 package evergreen
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -307,7 +308,8 @@ func TestCostConfigSetAndGet(t *testing.T) {
 	t.Run("SetAndGetS3ArtifactAccountLists", func(t *testing.T) {
 		require.NoError(t, GetEnvironment().DB().Collection(ConfigCollection).Drop(t.Context()))
 		t.Cleanup(func() {
-			require.NoError(t, GetEnvironment().DB().Collection(ConfigCollection).Drop(t.Context()))
+			// Use a non-test context: t.Context() is canceled before cleanup runs.
+			require.NoError(t, GetEnvironment().DB().Collection(ConfigCollection).Drop(context.Background()))
 		})
 
 		original := CostConfig{

--- a/config_cost_test.go
+++ b/config_cost_test.go
@@ -306,9 +306,9 @@ func TestCostConfigSetAndGet(t *testing.T) {
 
 	t.Run("SetAndGetS3ArtifactAccountLists", func(t *testing.T) {
 		require.NoError(t, GetEnvironment().DB().Collection(ConfigCollection).Drop(t.Context()))
-		defer func() {
+		t.Cleanup(func() {
 			require.NoError(t, GetEnvironment().DB().Collection(ConfigCollection).Drop(t.Context()))
-		}()
+		})
 
 		original := CostConfig{
 			S3Cost: S3CostConfig{

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1681,7 +1681,7 @@ type ComplexityRoot struct {
 		ArchiveStorageCostDiscount               func(childComplexity int) int
 		ArtifactAwsAccountsWithoutLifecycleRules func(childComplexity int) int
 		DefaultMaxArtifactExpirationDays         func(childComplexity int) int
-		DevprodOwnedAwsAccountIds                func(childComplexity int) int
+		DevprodOwnedAWSAccountIds                func(childComplexity int) int
 		IAStorageCostDiscount                    func(childComplexity int) int
 		StandardStorageCostDiscount              func(childComplexity int) int
 	}
@@ -9820,11 +9820,11 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.S3StorageCostConfig.DefaultMaxArtifactExpirationDays(childComplexity), true
 	case "S3StorageCostConfig.devprodOwnedAwsAccountIds":
-		if e.complexity.S3StorageCostConfig.DevprodOwnedAwsAccountIds == nil {
+		if e.complexity.S3StorageCostConfig.DevprodOwnedAWSAccountIds == nil {
 			break
 		}
 
-		return e.complexity.S3StorageCostConfig.DevprodOwnedAwsAccountIds(childComplexity), true
+		return e.complexity.S3StorageCostConfig.DevprodOwnedAWSAccountIds(childComplexity), true
 	case "S3StorageCostConfig.iAStorageCostDiscount":
 		if e.complexity.S3StorageCostConfig.IAStorageCostDiscount == nil {
 			break
@@ -57323,7 +57323,7 @@ func (ec *executionContext) _S3StorageCostConfig_devprodOwnedAwsAccountIds(ctx c
 		field,
 		ec.fieldContext_S3StorageCostConfig_devprodOwnedAwsAccountIds,
 		func(ctx context.Context) (any, error) {
-			return obj.DevprodOwnedAwsAccountIds, nil
+			return obj.DevprodOwnedAWSAccountIds, nil
 		},
 		nil,
 		ec.marshalOString2ᚕstringᚄ,
@@ -86404,7 +86404,7 @@ func (ec *executionContext) unmarshalInputS3StorageCostConfigInput(ctx context.C
 			if err != nil {
 				return it, err
 			}
-			it.DevprodOwnedAwsAccountIds = data
+			it.DevprodOwnedAWSAccountIds = data
 		case "artifactAwsAccountsWithoutLifecycleRules":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("artifactAwsAccountsWithoutLifecycleRules"))
 			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1678,10 +1678,12 @@ type ComplexityRoot struct {
 	}
 
 	S3StorageCostConfig struct {
-		ArchiveStorageCostDiscount       func(childComplexity int) int
-		DefaultMaxArtifactExpirationDays func(childComplexity int) int
-		IAStorageCostDiscount            func(childComplexity int) int
-		StandardStorageCostDiscount      func(childComplexity int) int
+		ArchiveStorageCostDiscount               func(childComplexity int) int
+		ArtifactAwsAccountsWithoutLifecycleRules func(childComplexity int) int
+		DefaultMaxArtifactExpirationDays         func(childComplexity int) int
+		DevprodOwnedAwsAccountIds                func(childComplexity int) int
+		IAStorageCostDiscount                    func(childComplexity int) int
+		StandardStorageCostDiscount              func(childComplexity int) int
 	}
 
 	S3UploadCostConfig struct {
@@ -9805,12 +9807,24 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.S3StorageCostConfig.ArchiveStorageCostDiscount(childComplexity), true
+	case "S3StorageCostConfig.artifactAwsAccountsWithoutLifecycleRules":
+		if e.complexity.S3StorageCostConfig.ArtifactAwsAccountsWithoutLifecycleRules == nil {
+			break
+		}
+
+		return e.complexity.S3StorageCostConfig.ArtifactAwsAccountsWithoutLifecycleRules(childComplexity), true
 	case "S3StorageCostConfig.defaultMaxArtifactExpirationDays":
 		if e.complexity.S3StorageCostConfig.DefaultMaxArtifactExpirationDays == nil {
 			break
 		}
 
 		return e.complexity.S3StorageCostConfig.DefaultMaxArtifactExpirationDays(childComplexity), true
+	case "S3StorageCostConfig.devprodOwnedAwsAccountIds":
+		if e.complexity.S3StorageCostConfig.DevprodOwnedAwsAccountIds == nil {
+			break
+		}
+
+		return e.complexity.S3StorageCostConfig.DevprodOwnedAwsAccountIds(childComplexity), true
 	case "S3StorageCostConfig.iAStorageCostDiscount":
 		if e.complexity.S3StorageCostConfig.IAStorageCostDiscount == nil {
 			break
@@ -57075,6 +57089,10 @@ func (ec *executionContext) fieldContext_S3CostConfig_storage(_ context.Context,
 				return ec.fieldContext_S3StorageCostConfig_archiveStorageCostDiscount(ctx, field)
 			case "defaultMaxArtifactExpirationDays":
 				return ec.fieldContext_S3StorageCostConfig_defaultMaxArtifactExpirationDays(ctx, field)
+			case "devprodOwnedAwsAccountIds":
+				return ec.fieldContext_S3StorageCostConfig_devprodOwnedAwsAccountIds(ctx, field)
+			case "artifactAwsAccountsWithoutLifecycleRules":
+				return ec.fieldContext_S3StorageCostConfig_artifactAwsAccountsWithoutLifecycleRules(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type S3StorageCostConfig", field.Name)
 		},
@@ -57293,6 +57311,64 @@ func (ec *executionContext) fieldContext_S3StorageCostConfig_defaultMaxArtifactE
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _S3StorageCostConfig_devprodOwnedAwsAccountIds(ctx context.Context, field graphql.CollectedField, obj *model.APIS3StorageCostConfig) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_S3StorageCostConfig_devprodOwnedAwsAccountIds,
+		func(ctx context.Context) (any, error) {
+			return obj.DevprodOwnedAwsAccountIds, nil
+		},
+		nil,
+		ec.marshalOString2ᚕstringᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_S3StorageCostConfig_devprodOwnedAwsAccountIds(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "S3StorageCostConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _S3StorageCostConfig_artifactAwsAccountsWithoutLifecycleRules(ctx context.Context, field graphql.CollectedField, obj *model.APIS3StorageCostConfig) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_S3StorageCostConfig_artifactAwsAccountsWithoutLifecycleRules,
+		func(ctx context.Context) (any, error) {
+			return obj.ArtifactAwsAccountsWithoutLifecycleRules, nil
+		},
+		nil,
+		ec.marshalOString2ᚕstringᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_S3StorageCostConfig_artifactAwsAccountsWithoutLifecycleRules(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "S3StorageCostConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -86287,7 +86363,7 @@ func (ec *executionContext) unmarshalInputS3StorageCostConfigInput(ctx context.C
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"standardStorageCostDiscount", "iAStorageCostDiscount", "archiveStorageCostDiscount", "defaultMaxArtifactExpirationDays"}
+	fieldsInOrder := [...]string{"standardStorageCostDiscount", "iAStorageCostDiscount", "archiveStorageCostDiscount", "defaultMaxArtifactExpirationDays", "devprodOwnedAwsAccountIds", "artifactAwsAccountsWithoutLifecycleRules"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -86322,6 +86398,20 @@ func (ec *executionContext) unmarshalInputS3StorageCostConfigInput(ctx context.C
 				return it, err
 			}
 			it.DefaultMaxArtifactExpirationDays = data
+		case "devprodOwnedAwsAccountIds":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("devprodOwnedAwsAccountIds"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.DevprodOwnedAwsAccountIds = data
+		case "artifactAwsAccountsWithoutLifecycleRules":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("artifactAwsAccountsWithoutLifecycleRules"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ArtifactAwsAccountsWithoutLifecycleRules = data
 		}
 	}
 
@@ -102359,6 +102449,10 @@ func (ec *executionContext) _S3StorageCostConfig(ctx context.Context, sel ast.Se
 			out.Values[i] = ec._S3StorageCostConfig_archiveStorageCostDiscount(ctx, field, obj)
 		case "defaultMaxArtifactExpirationDays":
 			out.Values[i] = ec._S3StorageCostConfig_defaultMaxArtifactExpirationDays(ctx, field, obj)
+		case "devprodOwnedAwsAccountIds":
+			out.Values[i] = ec._S3StorageCostConfig_devprodOwnedAwsAccountIds(ctx, field, obj)
+		case "artifactAwsAccountsWithoutLifecycleRules":
+			out.Values[i] = ec._S3StorageCostConfig_artifactAwsAccountsWithoutLifecycleRules(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/schema/types/adminSettings/other.graphql
+++ b/graphql/schema/types/adminSettings/other.graphql
@@ -227,6 +227,8 @@ input S3StorageCostConfigInput {
     iAStorageCostDiscount: Float
     archiveStorageCostDiscount: Float
     defaultMaxArtifactExpirationDays: Int
+    devprodOwnedAwsAccountIds: [String!]
+    artifactAwsAccountsWithoutLifecycleRules: [String!]
 }
 
 type S3StorageCostConfig {
@@ -234,6 +236,8 @@ type S3StorageCostConfig {
     iAStorageCostDiscount: Float
     archiveStorageCostDiscount: Float
     defaultMaxArtifactExpirationDays: Int
+    devprodOwnedAwsAccountIds: [String!]
+    artifactAwsAccountsWithoutLifecycleRules: [String!]
 }
 
 input S3CostConfigInput {

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -3187,10 +3187,12 @@ func (a *APIS3UploadCostConfig) ToService() (any, error) {
 }
 
 type APIS3StorageCostConfig struct {
-	StandardStorageCostDiscount      float64 `json:"standard_storage_cost_discount"`
-	IAStorageCostDiscount            float64 `json:"i_a_storage_cost_discount"`
-	ArchiveStorageCostDiscount       float64 `json:"archive_storage_cost_discount"`
-	DefaultMaxArtifactExpirationDays int     `json:"default_max_artifact_expiration_days"`
+	StandardStorageCostDiscount              float64  `json:"standard_storage_cost_discount"`
+	IAStorageCostDiscount                    float64  `json:"i_a_storage_cost_discount"`
+	ArchiveStorageCostDiscount               float64  `json:"archive_storage_cost_discount"`
+	DefaultMaxArtifactExpirationDays         int      `json:"default_max_artifact_expiration_days"`
+	DevprodOwnedAwsAccountIds                []string `json:"devprod_owned_aws_account_ids"`
+	ArtifactAwsAccountsWithoutLifecycleRules []string `json:"artifact_aws_accounts_without_lifecycle_rules"`
 }
 
 func (a *APIS3StorageCostConfig) BuildFromService(h any) error {
@@ -3200,6 +3202,8 @@ func (a *APIS3StorageCostConfig) BuildFromService(h any) error {
 		a.IAStorageCostDiscount = v.IAStorageCostDiscount
 		a.ArchiveStorageCostDiscount = v.ArchiveStorageCostDiscount
 		a.DefaultMaxArtifactExpirationDays = v.DefaultMaxArtifactExpirationDays
+		a.DevprodOwnedAwsAccountIds = v.DevprodOwnedAWSAccountIDs
+		a.ArtifactAwsAccountsWithoutLifecycleRules = v.ArtifactAWSAccountsWithoutLifecycleRules
 		return nil
 	default:
 		return errors.Errorf("incorrect type %T", v)
@@ -3208,10 +3212,12 @@ func (a *APIS3StorageCostConfig) BuildFromService(h any) error {
 
 func (a *APIS3StorageCostConfig) ToService() (any, error) {
 	return evergreen.S3StorageCostConfig{
-		StandardStorageCostDiscount:      a.StandardStorageCostDiscount,
-		IAStorageCostDiscount:            a.IAStorageCostDiscount,
-		ArchiveStorageCostDiscount:       a.ArchiveStorageCostDiscount,
-		DefaultMaxArtifactExpirationDays: a.DefaultMaxArtifactExpirationDays,
+		StandardStorageCostDiscount:              a.StandardStorageCostDiscount,
+		IAStorageCostDiscount:                    a.IAStorageCostDiscount,
+		ArchiveStorageCostDiscount:               a.ArchiveStorageCostDiscount,
+		DefaultMaxArtifactExpirationDays:         a.DefaultMaxArtifactExpirationDays,
+		DevprodOwnedAWSAccountIDs:                a.DevprodOwnedAwsAccountIds,
+		ArtifactAWSAccountsWithoutLifecycleRules: a.ArtifactAwsAccountsWithoutLifecycleRules,
 	}, nil
 }
 

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -3191,7 +3191,7 @@ type APIS3StorageCostConfig struct {
 	IAStorageCostDiscount                    float64  `json:"i_a_storage_cost_discount"`
 	ArchiveStorageCostDiscount               float64  `json:"archive_storage_cost_discount"`
 	DefaultMaxArtifactExpirationDays         int      `json:"default_max_artifact_expiration_days"`
-	DevprodOwnedAwsAccountIds                []string `json:"devprod_owned_aws_account_ids"`
+	DevprodOwnedAWSAccountIds                []string `json:"devprod_owned_aws_account_ids"`
 	ArtifactAwsAccountsWithoutLifecycleRules []string `json:"artifact_aws_accounts_without_lifecycle_rules"`
 }
 
@@ -3202,7 +3202,7 @@ func (a *APIS3StorageCostConfig) BuildFromService(h any) error {
 		a.IAStorageCostDiscount = v.IAStorageCostDiscount
 		a.ArchiveStorageCostDiscount = v.ArchiveStorageCostDiscount
 		a.DefaultMaxArtifactExpirationDays = v.DefaultMaxArtifactExpirationDays
-		a.DevprodOwnedAwsAccountIds = v.DevprodOwnedAWSAccountIDs
+		a.DevprodOwnedAWSAccountIds = v.DevprodOwnedAWSAccountIDs
 		a.ArtifactAwsAccountsWithoutLifecycleRules = v.ArtifactAWSAccountsWithoutLifecycleRules
 		return nil
 	default:
@@ -3216,7 +3216,7 @@ func (a *APIS3StorageCostConfig) ToService() (any, error) {
 		IAStorageCostDiscount:                    a.IAStorageCostDiscount,
 		ArchiveStorageCostDiscount:               a.ArchiveStorageCostDiscount,
 		DefaultMaxArtifactExpirationDays:         a.DefaultMaxArtifactExpirationDays,
-		DevprodOwnedAWSAccountIDs:                a.DevprodOwnedAwsAccountIds,
+		DevprodOwnedAWSAccountIDs:                a.DevprodOwnedAWSAccountIds,
 		ArtifactAWSAccountsWithoutLifecycleRules: a.ArtifactAwsAccountsWithoutLifecycleRules,
 	}, nil
 }

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -658,7 +658,7 @@ func TestAPIS3StorageCostConfig(t *testing.T) {
 
 		t.Run("AwsAccountListsRoundTrip", func(t *testing.T) {
 			api := APIS3StorageCostConfig{
-				DevprodOwnedAwsAccountIds:                []string{"123456789012"},
+				DevprodOwnedAWSAccountIds:                []string{"123456789012"},
 				ArtifactAwsAccountsWithoutLifecycleRules: []string{"210987654321"},
 			}
 			svcInterface, err := api.ToService()
@@ -669,7 +669,7 @@ func TestAPIS3StorageCostConfig(t *testing.T) {
 
 			var out APIS3StorageCostConfig
 			require.NoError(t, out.BuildFromService(svc))
-			assert.Equal(t, api.DevprodOwnedAwsAccountIds, out.DevprodOwnedAwsAccountIds)
+			assert.Equal(t, api.DevprodOwnedAWSAccountIds, out.DevprodOwnedAWSAccountIds)
 			assert.Equal(t, api.ArtifactAwsAccountsWithoutLifecycleRules, out.ArtifactAwsAccountsWithoutLifecycleRules)
 		})
 	})

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -655,6 +655,23 @@ func TestAPIS3StorageCostConfig(t *testing.T) {
 			assert.Equal(t, 0.25, svc.StandardStorageCostDiscount)
 			assert.Equal(t, 0.35, svc.IAStorageCostDiscount)
 		})
+
+		t.Run("AwsAccountListsRoundTrip", func(t *testing.T) {
+			api := APIS3StorageCostConfig{
+				DevprodOwnedAwsAccountIds:                []string{"123456789012"},
+				ArtifactAwsAccountsWithoutLifecycleRules: []string{"210987654321"},
+			}
+			svcInterface, err := api.ToService()
+			require.NoError(t, err)
+			svc := svcInterface.(evergreen.S3StorageCostConfig)
+			assert.Equal(t, []string{"123456789012"}, svc.DevprodOwnedAWSAccountIDs)
+			assert.Equal(t, []string{"210987654321"}, svc.ArtifactAWSAccountsWithoutLifecycleRules)
+
+			var out APIS3StorageCostConfig
+			require.NoError(t, out.BuildFromService(svc))
+			assert.Equal(t, api.DevprodOwnedAwsAccountIds, out.DevprodOwnedAwsAccountIds)
+			assert.Equal(t, api.ArtifactAwsAccountsWithoutLifecycleRules, out.ArtifactAwsAccountsWithoutLifecycleRules)
+		})
 	})
 }
 


### PR DESCRIPTION
DEVPROD-31767

### Description
Add S3 storage cost admin fields for AWS account lists. This is needed so we can only calculate costs for Devprod owned accounts, and so that we can skip fetching rules for accounts we won't be able to fetch it for. 

### Testing
added
