### PR TITLE
DEVPROD-31588 Add ingest time to patch and version document

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1218,6 +1218,7 @@ type ComplexityRoot struct {
 		Hidden                func(childComplexity int) int
 		Id                    func(childComplexity int) int
 		IncludedLocalModules  func(childComplexity int) int
+		IngestTime            func(childComplexity int) int
 		InvalidatedByUpstream func(childComplexity int) int
 		ModuleCodeChanges     func(childComplexity int) int
 		Parameters            func(childComplexity int) int
@@ -2305,6 +2306,7 @@ type ComplexityRoot struct {
 		GitTags                  func(childComplexity int) int
 		Id                       func(childComplexity int) int
 		Ignored                  func(childComplexity int) int
+		IngestTime               func(childComplexity int) int
 		IsPatch                  func(childComplexity int) int
 		Manifest                 func(childComplexity int) int
 		Message                  func(childComplexity int) int
@@ -2341,6 +2343,7 @@ type ComplexityRoot struct {
 		FinishTime          func(childComplexity int) int
 		Id                  func(childComplexity int) int
 		Ignored             func(childComplexity int) int
+		IngestTime          func(childComplexity int) int
 		Message             func(childComplexity int) int
 		Project             func(childComplexity int) int
 		Repo                func(childComplexity int) int
@@ -7574,6 +7577,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Patch.IncludedLocalModules(childComplexity), true
+	case "Patch.ingestTime":
+		if e.complexity.Patch.IngestTime == nil {
+			break
+		}
+
+		return e.complexity.Patch.IngestTime(childComplexity), true
 	case "Patch.invalidatedByUpstream":
 		if e.complexity.Patch.InvalidatedByUpstream == nil {
 			break
@@ -12409,6 +12418,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Version.Ignored(childComplexity), true
+	case "Version.ingestTime":
+		if e.complexity.Version.IngestTime == nil {
+			break
+		}
+
+		return e.complexity.Version.IngestTime(childComplexity), true
 	case "Version.isPatch":
 		if e.complexity.Version.IsPatch == nil {
 			break
@@ -12623,6 +12638,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.VersionLite.Ignored(childComplexity), true
+	case "VersionLite.ingestTime":
+		if e.complexity.VersionLite.IngestTime == nil {
+			break
+		}
+
+		return e.complexity.VersionLite.IngestTime(childComplexity), true
 	case "VersionLite.message":
 		if e.complexity.VersionLite.Message == nil {
 			break
@@ -35572,6 +35593,8 @@ func (ec *executionContext) fieldContext_MainlineCommitVersion_rolledUpVersions(
 				return ec.fieldContext_Version_cost(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Version_ingestTime(ctx, field)
 			case "errors":
 				return ec.fieldContext_Version_errors(ctx, field)
 			case "externalLinksForMetadata":
@@ -35687,6 +35710,8 @@ func (ec *executionContext) fieldContext_MainlineCommitVersion_version(_ context
 				return ec.fieldContext_Version_cost(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Version_ingestTime(ctx, field)
 			case "errors":
 				return ec.fieldContext_Version_errors(ctx, field)
 			case "externalLinksForMetadata":
@@ -37211,6 +37236,8 @@ func (ec *executionContext) fieldContext_Mutation_setPatchVisibility(ctx context
 				return ec.fieldContext_Patch_childPatches(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Patch_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Patch_ingestTime(ctx, field)
 			case "description":
 				return ec.fieldContext_Patch_description(ctx, field)
 			case "duration":
@@ -37324,6 +37351,8 @@ func (ec *executionContext) fieldContext_Mutation_schedulePatch(ctx context.Cont
 				return ec.fieldContext_Patch_childPatches(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Patch_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Patch_ingestTime(ctx, field)
 			case "description":
 				return ec.fieldContext_Patch_description(ctx, field)
 			case "duration":
@@ -41591,6 +41620,8 @@ func (ec *executionContext) fieldContext_Mutation_restartVersions(ctx context.Co
 				return ec.fieldContext_Version_cost(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Version_ingestTime(ctx, field)
 			case "errors":
 				return ec.fieldContext_Version_errors(ctx, field)
 			case "externalLinksForMetadata":
@@ -43957,6 +43988,8 @@ func (ec *executionContext) fieldContext_Patch_childPatches(_ context.Context, f
 				return ec.fieldContext_Patch_childPatches(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Patch_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Patch_ingestTime(ctx, field)
 			case "description":
 				return ec.fieldContext_Patch_description(ctx, field)
 			case "duration":
@@ -44033,6 +44066,35 @@ func (ec *executionContext) _Patch_createTime(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext_Patch_createTime(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Patch",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Patch_ingestTime(ctx context.Context, field graphql.CollectedField, obj *model.APIPatch) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Patch_ingestTime,
+		func(ctx context.Context) (any, error) {
+			return obj.IngestTime, nil
+		},
+		nil,
+		ec.marshalOTime2ᚖtimeᚐTime,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_Patch_ingestTime(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Patch",
 		Field:      field,
@@ -44974,6 +45036,8 @@ func (ec *executionContext) fieldContext_Patch_version(_ context.Context, field 
 				return ec.fieldContext_VersionLite_cost(ctx, field)
 			case "createTime":
 				return ec.fieldContext_VersionLite_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_VersionLite_ingestTime(ctx, field)
 			case "errors":
 				return ec.fieldContext_VersionLite_errors(ctx, field)
 			case "finishTime":
@@ -45055,6 +45119,8 @@ func (ec *executionContext) fieldContext_Patch_versionFull(_ context.Context, fi
 				return ec.fieldContext_Version_cost(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Version_ingestTime(ctx, field)
 			case "errors":
 				return ec.fieldContext_Version_errors(ctx, field)
 			case "externalLinksForMetadata":
@@ -45689,6 +45755,8 @@ func (ec *executionContext) fieldContext_Patches_patches(_ context.Context, fiel
 				return ec.fieldContext_Patch_childPatches(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Patch_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Patch_ingestTime(ctx, field)
 			case "description":
 				return ec.fieldContext_Patch_description(ctx, field)
 			case "duration":
@@ -52391,6 +52459,8 @@ func (ec *executionContext) fieldContext_Query_patch(ctx context.Context, field 
 				return ec.fieldContext_Patch_childPatches(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Patch_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Patch_ingestTime(ctx, field)
 			case "description":
 				return ec.fieldContext_Patch_description(ctx, field)
 			case "duration":
@@ -54179,6 +54249,8 @@ func (ec *executionContext) fieldContext_Query_version(ctx context.Context, fiel
 				return ec.fieldContext_Version_cost(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Version_ingestTime(ctx, field)
 			case "errors":
 				return ec.fieldContext_Version_errors(ctx, field)
 			case "externalLinksForMetadata":
@@ -63828,6 +63900,8 @@ func (ec *executionContext) fieldContext_Task_patch(_ context.Context, field gra
 				return ec.fieldContext_Patch_childPatches(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Patch_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Patch_ingestTime(ctx, field)
 			case "description":
 				return ec.fieldContext_Patch_description(ctx, field)
 			case "duration":
@@ -65657,6 +65731,8 @@ func (ec *executionContext) fieldContext_Task_version(_ context.Context, field g
 				return ec.fieldContext_VersionLite_cost(ctx, field)
 			case "createTime":
 				return ec.fieldContext_VersionLite_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_VersionLite_ingestTime(ctx, field)
 			case "errors":
 				return ec.fieldContext_VersionLite_errors(ctx, field)
 			case "finishTime":
@@ -65738,6 +65814,8 @@ func (ec *executionContext) fieldContext_Task_versionMetadata(_ context.Context,
 				return ec.fieldContext_Version_cost(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Version_ingestTime(ctx, field)
 			case "errors":
 				return ec.fieldContext_Version_errors(ctx, field)
 			case "externalLinksForMetadata":
@@ -71399,6 +71477,8 @@ func (ec *executionContext) fieldContext_UpstreamProject_version(_ context.Conte
 				return ec.fieldContext_Version_cost(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Version_ingestTime(ctx, field)
 			case "errors":
 				return ec.fieldContext_Version_errors(ctx, field)
 			case "externalLinksForMetadata":
@@ -72827,6 +72907,8 @@ func (ec *executionContext) fieldContext_Version_baseVersion(_ context.Context, 
 				return ec.fieldContext_Version_cost(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Version_ingestTime(ctx, field)
 			case "errors":
 				return ec.fieldContext_Version_errors(ctx, field)
 			case "externalLinksForMetadata":
@@ -73069,6 +73151,8 @@ func (ec *executionContext) fieldContext_Version_childVersions(_ context.Context
 				return ec.fieldContext_Version_cost(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Version_ingestTime(ctx, field)
 			case "errors":
 				return ec.fieldContext_Version_errors(ctx, field)
 			case "externalLinksForMetadata":
@@ -73200,6 +73284,35 @@ func (ec *executionContext) _Version_createTime(ctx context.Context, field graph
 }
 
 func (ec *executionContext) fieldContext_Version_createTime(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Version",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Version_ingestTime(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Version_ingestTime,
+		func(ctx context.Context) (any, error) {
+			return obj.IngestTime, nil
+		},
+		nil,
+		ec.marshalOTime2ᚖtimeᚐTime,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_Version_ingestTime(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Version",
 		Field:      field,
@@ -73617,6 +73730,8 @@ func (ec *executionContext) fieldContext_Version_patch(_ context.Context, field 
 				return ec.fieldContext_Patch_childPatches(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Patch_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Patch_ingestTime(ctx, field)
 			case "description":
 				return ec.fieldContext_Patch_description(ctx, field)
 			case "duration":
@@ -73767,6 +73882,8 @@ func (ec *executionContext) fieldContext_Version_previousVersion(_ context.Conte
 				return ec.fieldContext_Version_cost(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Version_ingestTime(ctx, field)
 			case "errors":
 				return ec.fieldContext_Version_errors(ctx, field)
 			case "externalLinksForMetadata":
@@ -74700,6 +74817,35 @@ func (ec *executionContext) _VersionLite_createTime(ctx context.Context, field g
 }
 
 func (ec *executionContext) fieldContext_VersionLite_createTime(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "VersionLite",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _VersionLite_ingestTime(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_VersionLite_ingestTime,
+		func(ctx context.Context) (any, error) {
+			return obj.IngestTime, nil
+		},
+		nil,
+		ec.marshalOTime2timeᚐTime,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_VersionLite_ingestTime(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "VersionLite",
 		Field:      field,
@@ -76018,6 +76164,8 @@ func (ec *executionContext) fieldContext_Waterfall_flattenedVersions(_ context.C
 				return ec.fieldContext_Version_cost(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
+			case "ingestTime":
+				return ec.fieldContext_Version_ingestTime(ctx, field)
 			case "errors":
 				return ec.fieldContext_Version_errors(ctx, field)
 			case "externalLinksForMetadata":
@@ -97715,6 +97863,8 @@ func (ec *executionContext) _Patch(ctx context.Context, sel ast.SelectionSet, ob
 			out.Values[i] = ec._Patch_childPatches(ctx, field, obj)
 		case "createTime":
 			out.Values[i] = ec._Patch_createTime(ctx, field, obj)
+		case "ingestTime":
+			out.Values[i] = ec._Patch_ingestTime(ctx, field, obj)
 		case "description":
 			out.Values[i] = ec._Patch_description(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -108177,6 +108327,8 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "ingestTime":
+			out.Values[i] = ec._Version_ingestTime(ctx, field, obj)
 		case "errors":
 			out.Values[i] = ec._Version_errors(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -108873,6 +109025,8 @@ func (ec *executionContext) _VersionLite(ctx context.Context, sel ast.SelectionS
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "ingestTime":
+			out.Values[i] = ec._VersionLite_ingestTime(ctx, field, obj)
 		case "errors":
 			out.Values[i] = ec._VersionLite_errors(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/graphql/schema/types/patch.graphql
+++ b/graphql/schema/types/patch.graphql
@@ -74,6 +74,7 @@ type Patch {
   childPatchAliases: [ChildPatchAlias!]
   childPatches: [Patch!]
   createTime: Time
+  ingestTime: Time
   description: String!
   duration: PatchDuration
   generatedTaskCounts: [GeneratedTaskCountResults!]!

--- a/graphql/schema/types/version.graphql
+++ b/graphql/schema/types/version.graphql
@@ -61,6 +61,7 @@ type Version {
   childVersions: [Version!]
   cost: Cost
   createTime: Time!
+  ingestTime: Time
   errors: [String!]!
   externalLinksForMetadata: [ExternalLinkForMetadata!]!
   finishTime: Time
@@ -167,6 +168,7 @@ type VersionLite {
   branch: String!
   cost: Cost
   createTime: Time!
+  ingestTime: Time
   errors: [String!]!
   finishTime: Time
   ignored: Boolean!

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -37,6 +37,7 @@ var (
 	VersionKey              = bsonutil.MustHaveTag(Patch{}, "Version")
 	StatusKey               = bsonutil.MustHaveTag(Patch{}, "Status")
 	CreateTimeKey           = bsonutil.MustHaveTag(Patch{}, "CreateTime")
+	IngestTimeKey           = bsonutil.MustHaveTag(Patch{}, "IngestTime")
 	StartTimeKey            = bsonutil.MustHaveTag(Patch{}, "StartTime")
 	FinishTimeKey           = bsonutil.MustHaveTag(Patch{}, "FinishTime")
 	BuildVariantsKey        = bsonutil.MustHaveTag(Patch{}, "BuildVariants")

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -55,31 +55,31 @@ type LocalModuleInclude struct {
 
 // Patch stores all details related to a patch request
 type Patch struct {
-	Id                                      mgobson.ObjectId `bson:"_id,omitempty"`
-	Description                             string           `bson:"desc"`
-	Path                                    string           `bson:"path,omitempty"`
-	Githash                                 string           `bson:"githash"`
-	Hidden                                  bool             `bson:"hidden"`
-	PatchNumber                             int              `bson:"patch_number"`
-	Author                                  string           `bson:"author"`
-	Version                                 string           `bson:"version"`
-	Status                                  string           `bson:"status"`
-	CreateTime                              time.Time        `bson:"create_time"`
+	Id          mgobson.ObjectId `bson:"_id,omitempty"`
+	Description string           `bson:"desc"`
+	Path        string           `bson:"path,omitempty"`
+	Githash     string           `bson:"githash"`
+	Hidden      bool             `bson:"hidden"`
+	PatchNumber int              `bson:"patch_number"`
+	Author      string           `bson:"author"`
+	Version     string           `bson:"version"`
+	Status      string           `bson:"status"`
+	CreateTime  time.Time        `bson:"create_time"`
 	// IngestTime is the wall-clock time when this patch document was first persisted.
-	IngestTime                              time.Time        `bson:"ingest_time,omitempty"`
-	StartTime                               time.Time        `bson:"start_time"`
-	FinishTime                              time.Time        `bson:"finish_time"`
-	BuildVariants                           []string         `bson:"build_variants"`
-	RegexBuildVariants                      []string         `bson:"regex_build_variants"`
-	RegexTestSelectionBuildVariants         []string         `bson:"regex_test_selection_build_variants,omitempty"`
-	RegexTestSelectionExcludedBuildVariants []string         `bson:"regex_test_selection_excluded_build_variants,omitempty"`
-	Tasks                                   []string         `bson:"tasks"`
-	RegexTestSelectionTasks                 []string         `bson:"regex_test_selection_tasks,omitempty"`
-	RegexTestSelectionExcludedTasks         []string         `bson:"regex_test_selection_excluded_tasks,omitempty"`
-	RegexTasks                              []string         `bson:"regex_tasks"`
-	VariantsTasks                           []VariantTasks   `bson:"variants_tasks"`
-	Patches                                 []ModulePatch    `bson:"patches"`
-	Parameters                              []Parameter      `bson:"parameters,omitempty"`
+	IngestTime                              time.Time      `bson:"ingest_time,omitempty"`
+	StartTime                               time.Time      `bson:"start_time"`
+	FinishTime                              time.Time      `bson:"finish_time"`
+	BuildVariants                           []string       `bson:"build_variants"`
+	RegexBuildVariants                      []string       `bson:"regex_build_variants"`
+	RegexTestSelectionBuildVariants         []string       `bson:"regex_test_selection_build_variants,omitempty"`
+	RegexTestSelectionExcludedBuildVariants []string       `bson:"regex_test_selection_excluded_build_variants,omitempty"`
+	Tasks                                   []string       `bson:"tasks"`
+	RegexTestSelectionTasks                 []string       `bson:"regex_test_selection_tasks,omitempty"`
+	RegexTestSelectionExcludedTasks         []string       `bson:"regex_test_selection_excluded_tasks,omitempty"`
+	RegexTasks                              []string       `bson:"regex_tasks"`
+	VariantsTasks                           []VariantTasks `bson:"variants_tasks"`
+	Patches                                 []ModulePatch  `bson:"patches"`
+	Parameters                              []Parameter    `bson:"parameters,omitempty"`
 	// Activated indicates whether or not the patch is finalized (i.e.
 	// tasks/variants are now scheduled to run). If true, the patch has been
 	// finalized.

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -65,6 +65,8 @@ type Patch struct {
 	Version                                 string           `bson:"version"`
 	Status                                  string           `bson:"status"`
 	CreateTime                              time.Time        `bson:"create_time"`
+	// IngestTime is the wall-clock time when this patch document was first persisted.
+	IngestTime                              time.Time        `bson:"ingest_time,omitempty"`
 	StartTime                               time.Time        `bson:"start_time"`
 	FinishTime                              time.Time        `bson:"finish_time"`
 	BuildVariants                           []string         `bson:"build_variants"`
@@ -417,6 +419,7 @@ func TryMarkStarted(ctx context.Context, versionId string, startTime time.Time) 
 
 // Insert inserts the patch into the db, returning any errors that occur
 func (p *Patch) Insert(ctx context.Context) error {
+	p.IngestTime = time.Now()
 	return db.Insert(ctx, Collection, p)
 }
 

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -620,6 +620,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 	patchVersion := &Version{
 		Id:                   p.Id.Hex(),
 		CreateTime:           time.Now(),
+		IngestTime:           p.IngestTime,
 		Identifier:           p.Project,
 		Revision:             p.Githash,
 		Author:               p.Author,

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -83,8 +83,11 @@ var (
 type Task struct {
 	Id     string `bson:"_id" json:"id"`
 	Secret string `bson:"secret" json:"secret"`
-	// time information for task
-	// CreateTime - the creation time for the task, derived from the commit time or the patch creation time.
+	// Time fields (see also model.Version for the same CreateTime vs IngestTime distinction):
+	// CreateTime - logical time for this task, aligned with the parent version's semantics: derived from
+	// commit/revision metadata or patch timing (same idea as the version's CreateTime). It is not the
+	// wall-clock time the task row was written; use IngestTime for that.
+	// IngestTime - wall-clock time this task document was first inserted in Evergreen (set in createOneTask).
 	// DispatchTime - the time the task runner starts up the agent on the host.
 	// ScheduledTime - the time the task is scheduled.
 	// StartTime - the time the agent starts the task on the host after spinning it up.

--- a/model/version.go
+++ b/model/version.go
@@ -47,8 +47,15 @@ const (
 )
 
 type Version struct {
-	Id         string    `bson:"_id" json:"id,omitempty"`
+	Id string `bson:"_id" json:"id,omitempty"`
+	// CreateTime is the logical time associated with this version: typically the
+	// revision/commit timestamp from git (or related metadata for patches and triggers).
+	// It is not the wall-clock time Evergreen wrote the version document; use IngestTime for that.
 	CreateTime time.Time `bson:"create_time" json:"create_time,omitempty"`
+	// IngestTime is the wall-clock time the version document was first persisted in Evergreen.
+	// For patch requesters it is copied from the patch's IngestTime; for repotracker and other
+	// paths it is set at insert. Older documents may omit this field (zero in Go / null in APIs).
+	IngestTime time.Time `bson:"ingest_time,omitempty" json:"ingest_time,omitempty"`
 	StartTime  time.Time `bson:"start_time" json:"start_time,omitempty"`
 	FinishTime time.Time `bson:"finish_time" json:"finish_time,omitempty"`
 	Revision   string    `bson:"gitspec" json:"revision,omitempty"`
@@ -221,6 +228,11 @@ func (v *Version) SetAborted(ctx context.Context, aborted bool) error {
 }
 
 func (v *Version) Insert(ctx context.Context) error {
+	// Production paths set IngestTime explicitly (e.g. from patch ingest or repotracker).
+	// Stub and test callers that omit it get a wall-clock insert time here.
+	if utility.IsZeroTime(v.IngestTime) {
+		v.IngestTime = time.Now()
+	}
 	return db.Insert(ctx, VersionCollection, v)
 }
 

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -22,6 +22,7 @@ var (
 	// bson fields for the version struct
 	VersionIdKey          = bsonutil.MustHaveTag(Version{}, "Id")
 	VersionCreateTimeKey  = bsonutil.MustHaveTag(Version{}, "CreateTime")
+	VersionIngestTimeKey  = bsonutil.MustHaveTag(Version{}, "IngestTime")
 	VersionStartTimeKey   = bsonutil.MustHaveTag(Version{}, "StartTime")
 	VersionFinishTimeKey  = bsonutil.MustHaveTag(Version{}, "FinishTime")
 	VersionRevisionKey    = bsonutil.MustHaveTag(Version{}, "Revision")

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -1078,6 +1078,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			return errors.Wrap(err, "starting transaction")
 		}
 		database := env.DB()
+		v.IngestTime = time.Now()
 		_, err = database.Collection(model.VersionCollection).InsertOne(ctx, v)
 		if err != nil {
 			grip.Notice(ctx, message.WrapError(err, message.Fields{

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -44,6 +44,8 @@ type APIPatch struct {
 	Status *string `json:"status"`
 	// Time patch was created
 	CreateTime *time.Time `json:"create_time"`
+	// Time the patch document was first persisted in Evergreen
+	IngestTime *time.Time `json:"ingest_time,omitempty"`
 	// Time patch started to run
 	StartTime *time.Time `json:"start_time"`
 	// Time at patch completion
@@ -232,6 +234,7 @@ func (apiPatch *APIPatch) buildBasePatch(p patch.Patch) {
 	apiPatch.Version = utility.ToStringPtr(p.Version)
 	apiPatch.Hidden = p.Hidden
 	apiPatch.CreateTime = ToTimePtr(p.CreateTime)
+	apiPatch.IngestTime = ToTimePtr(p.IngestTime)
 	apiPatch.StartTime = ToTimePtr(p.StartTime)
 	apiPatch.FinishTime = ToTimePtr(p.FinishTime)
 	apiPatch.MergedFrom = utility.ToStringPtr(p.MergedFrom)

--- a/rest/model/version.go
+++ b/rest/model/version.go
@@ -16,6 +16,8 @@ type APIVersion struct {
 	Id *string `json:"version_id"`
 	// Time that the version was first created
 	CreateTime *time.Time `json:"create_time"`
+	// Time at which the version document was persisted in Evergreen. Will be null for versions created before this field was added.
+	IngestTime *time.Time `json:"ingest_time,omitempty"`
 	// Time at which tasks associated with this version started running
 	StartTime *time.Time `json:"start_time"`
 	// Time at which tasks associated with this version finished running
@@ -76,6 +78,7 @@ type buildDetail struct {
 func (apiVersion *APIVersion) BuildFromService(ctx context.Context, v model.Version) {
 	apiVersion.Id = utility.ToStringPtr(v.Id)
 	apiVersion.CreateTime = ToTimePtr(v.CreateTime)
+	apiVersion.IngestTime = ToTimePtr(v.IngestTime)
 	apiVersion.StartTime = ToTimePtr(v.StartTime)
 	apiVersion.FinishTime = ToTimePtr(v.FinishTime)
 	apiVersion.Revision = utility.ToStringPtr(v.Revision)

--- a/rest/model/version_test.go
+++ b/rest/model/version_test.go
@@ -16,7 +16,7 @@ import (
 func TestVersionBuildFromService(t *testing.T) {
 	assert := assert.New(t)
 
-	time := time.Now()
+	ts := time.Now()
 	versionId := "versionId"
 	revision := "revision"
 	author := "author"
@@ -52,11 +52,13 @@ func TestVersionBuildFromService(t *testing.T) {
 		Tag:    "my-triggered-tag",
 		Pusher: "pusher",
 	}
+	ingestTs := ts.Add(time.Minute)
 	v := model.Version{
 		Id:                versionId,
-		CreateTime:        time,
-		StartTime:         time,
-		FinishTime:        time,
+		CreateTime:        ts,
+		IngestTime:        ingestTs,
+		StartTime:         ts,
+		FinishTime:        ts,
 		Revision:          revision,
 		Author:            author,
 		AuthorEmail:       authorEmail,
@@ -75,9 +77,11 @@ func TestVersionBuildFromService(t *testing.T) {
 	apiVersion.BuildFromService(t.Context(), v)
 	// Each field should be as expected
 	assert.Equal(apiVersion.Id, utility.ToStringPtr(versionId))
-	assert.Equal(*apiVersion.CreateTime, time)
-	assert.Equal(*apiVersion.StartTime, time)
-	assert.Equal(*apiVersion.FinishTime, time)
+	assert.Equal(*apiVersion.CreateTime, ts)
+	require.NotNil(t, apiVersion.IngestTime)
+	assert.Equal(*apiVersion.IngestTime, ingestTs)
+	assert.Equal(*apiVersion.StartTime, ts)
+	assert.Equal(*apiVersion.FinishTime, ts)
 	assert.Equal(apiVersion.Revision, utility.ToStringPtr(revision))
 	assert.Equal(apiVersion.Author, utility.ToStringPtr(author))
 	assert.Equal(apiVersion.AuthorEmail, utility.ToStringPtr(authorEmail))


### PR DESCRIPTION
DEVPROD-31588

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Adds ingest time to the patch and version document. This is the same as the ingest time in the task document. I also updated the godoc to reflect what other fields, like created at, actually are.

<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

### Testing
Unit tests
