### PR TITLE
DEVPROD-31145 Wrap splunk sender in trace url sender

### DIFF
--- a/config.go
+++ b/config.go
@@ -722,6 +722,10 @@ func (s *Settings) makeSplunkSender(ctx context.Context, client *http.Client, le
 		return nil, errors.Wrap(err, "setting Splunk error handler")
 	}
 
+	if s.Tracer.TraceURLTemplate != "" {
+		sender = send.NewTraceURLSender(sender, s.Tracer.TraceURLTemplate)
+	}
+
 	opts := send.BufferedSenderOptions{
 		FlushInterval: time.Duration(s.LoggerConfig.Buffer.DurationSeconds) * time.Second,
 		BufferSize:    s.LoggerConfig.Buffer.Count,

--- a/config.go
+++ b/config.go
@@ -722,10 +722,6 @@ func (s *Settings) makeSplunkSender(ctx context.Context, client *http.Client, le
 		return nil, errors.Wrap(err, "setting Splunk error handler")
 	}
 
-	if s.Tracer.TraceURLTemplate != "" {
-		sender = send.NewTraceURLSender(sender, s.Tracer.TraceURLTemplate)
-	}
-
 	opts := send.BufferedSenderOptions{
 		FlushInterval: time.Duration(s.LoggerConfig.Buffer.DurationSeconds) * time.Second,
 		BufferSize:    s.LoggerConfig.Buffer.Count,
@@ -743,6 +739,10 @@ func (s *Settings) makeSplunkSender(ctx context.Context, client *http.Client, le
 		if sender, err = send.NewBufferedSender(ctx, sender, opts); err != nil {
 			return nil, errors.Wrap(err, "making Splunk buffered sender")
 		}
+	}
+
+	if s.Tracer.TraceURLTemplate != "" {
+		sender = send.NewTraceURLSender(sender, s.Tracer.TraceURLTemplate)
 	}
 
 	return sender, nil

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mongodb/amboy v0.0.0-20260326190628-51c8dde3a7f5
 	github.com/mongodb/anser v0.0.0-20260326191204-f2d0a92e3f0a
-	github.com/mongodb/grip v0.0.0-20260325175240-dee15316ed15
+	github.com/mongodb/grip v0.0.0-20260416142205-66006126eeab
 	github.com/pkg/errors v0.9.1
 	github.com/ravilushqa/otelgqlgen v0.19.0
 	github.com/robbiet480/go.sns v0.0.0-20210223081447-c7c9eb6836cb
@@ -238,5 +238,3 @@ require (
 )
 
 tool github.com/99designs/gqlgen
-
-replace github.com/mongodb/grip => github.com/zackarysantana/grip v0.0.0-20260415160604-b042ee394aaf

--- a/go.mod
+++ b/go.mod
@@ -238,3 +238,5 @@ require (
 )
 
 tool github.com/99designs/gqlgen
+
+replace github.com/mongodb/grip => github.com/zackarysantana/grip v0.0.0-20260415160604-b042ee394aaf

--- a/go.sum
+++ b/go.sum
@@ -316,6 +316,8 @@ github.com/mongodb/anser v0.0.0-20260326191204-f2d0a92e3f0a h1:aerBBPXwQOo+s1BR7
 github.com/mongodb/anser v0.0.0-20260326191204-f2d0a92e3f0a/go.mod h1:y5tT5wIiax8QSqifu02lYQcumwsvAwAYb2PmpguRyfE=
 github.com/mongodb/ftdc v0.0.0-20251208183831-018e343a1aac h1:KL3+DC+q8yS+QmdPAvnJiMHNU9VcYD3+4+0U1F+Crzo=
 github.com/mongodb/ftdc v0.0.0-20251208183831-018e343a1aac/go.mod h1:iaQJgZ9mNDQzR9Y8BY6D/Y6i8IzadyjY91a20xE5sOE=
+github.com/mongodb/grip v0.0.0-20260416142205-66006126eeab h1:GRlQC6VgrV3fLFh5oVhOFX3B0f09hcgpGe05+rgHeq8=
+github.com/mongodb/grip v0.0.0-20260416142205-66006126eeab/go.mod h1:nIxXGOFRWYjuwlgZlhj7BvCE6MjPuOFr3xbe9IcbKDo=
 github.com/mongodb/jasper v0.0.0-20260330133616-5411573646d1 h1:SSUZlMk2YvlnqB8o8BxdQzEBACZ/m0/Biu8uljAYCTc=
 github.com/mongodb/jasper v0.0.0-20260330133616-5411573646d1/go.mod h1:dNPRgqt6EwehE2ADcYPuvtVy+3/RbgY956R+R6Ln58s=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
@@ -454,8 +456,6 @@ github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfS
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-github.com/zackarysantana/grip v0.0.0-20260415160604-b042ee394aaf h1:sn6n16SaAi+1nKVRl640MK0n2w0DPOtN7Zar8+Ra7yA=
-github.com/zackarysantana/grip v0.0.0-20260415160604-b042ee394aaf/go.mod h1:nIxXGOFRWYjuwlgZlhj7BvCE6MjPuOFr3xbe9IcbKDo=
 go.mongodb.org/mongo-driver v1.17.9 h1:IexDdCuuNJ3BHrELgBlyaH9p60JXAvdzWR128q+U5tU=
 go.mongodb.org/mongo-driver v1.17.9/go.mod h1:LlOhpH5NUEfhxcAwG0UEkMqwYcc4JU18gtCdGudk/tQ=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/go.sum
+++ b/go.sum
@@ -316,8 +316,6 @@ github.com/mongodb/anser v0.0.0-20260326191204-f2d0a92e3f0a h1:aerBBPXwQOo+s1BR7
 github.com/mongodb/anser v0.0.0-20260326191204-f2d0a92e3f0a/go.mod h1:y5tT5wIiax8QSqifu02lYQcumwsvAwAYb2PmpguRyfE=
 github.com/mongodb/ftdc v0.0.0-20251208183831-018e343a1aac h1:KL3+DC+q8yS+QmdPAvnJiMHNU9VcYD3+4+0U1F+Crzo=
 github.com/mongodb/ftdc v0.0.0-20251208183831-018e343a1aac/go.mod h1:iaQJgZ9mNDQzR9Y8BY6D/Y6i8IzadyjY91a20xE5sOE=
-github.com/mongodb/grip v0.0.0-20260325175240-dee15316ed15 h1:24uQdm0yD9ybTgkAyolNVjf6jf8UfLqPC3bfxnf1N0U=
-github.com/mongodb/grip v0.0.0-20260325175240-dee15316ed15/go.mod h1:nIxXGOFRWYjuwlgZlhj7BvCE6MjPuOFr3xbe9IcbKDo=
 github.com/mongodb/jasper v0.0.0-20260330133616-5411573646d1 h1:SSUZlMk2YvlnqB8o8BxdQzEBACZ/m0/Biu8uljAYCTc=
 github.com/mongodb/jasper v0.0.0-20260330133616-5411573646d1/go.mod h1:dNPRgqt6EwehE2ADcYPuvtVy+3/RbgY956R+R6Ln58s=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=
@@ -456,6 +454,8 @@ github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfS
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zackarysantana/grip v0.0.0-20260415160604-b042ee394aaf h1:sn6n16SaAi+1nKVRl640MK0n2w0DPOtN7Zar8+Ra7yA=
+github.com/zackarysantana/grip v0.0.0-20260415160604-b042ee394aaf/go.mod h1:nIxXGOFRWYjuwlgZlhj7BvCE6MjPuOFr3xbe9IcbKDo=
 go.mongodb.org/mongo-driver v1.17.9 h1:IexDdCuuNJ3BHrELgBlyaH9p60JXAvdzWR128q+U5tU=
 go.mongodb.org/mongo-driver v1.17.9/go.mod h1:LlOhpH5NUEfhxcAwG0UEkMqwYcc4JU18gtCdGudk/tQ=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=


### PR DESCRIPTION
DEVPROD-31145

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
This wraps our splunk sender in the new trace url sender. This is added in [grip#176](https://github.com/mongodb/grip/pull/176/changes).

<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->

### Testing
Unit tests in grip. Tested in staging and it showed up in logs