### PR TITLE
DEVPROD-26473: Aggregate S3 Costs across all Tasks and update Version Costs

### DIFF
--- a/model/cost/cost.go
+++ b/model/cost/cost.go
@@ -5,6 +5,10 @@ import "github.com/mongodb/anser/bsonutil"
 var (
 	OnDemandEC2CostKey               = bsonutil.MustHaveTag(Cost{}, "OnDemandEC2Cost")
 	AdjustedEC2CostKey               = bsonutil.MustHaveTag(Cost{}, "AdjustedEC2Cost")
+	OnDemandEBSThroughputCostKey     = bsonutil.MustHaveTag(Cost{}, "OnDemandEBSThroughputCost")
+	AdjustedEBSThroughputCostKey     = bsonutil.MustHaveTag(Cost{}, "AdjustedEBSThroughputCost")
+	OnDemandEBSStorageCostKey        = bsonutil.MustHaveTag(Cost{}, "OnDemandEBSStorageCost")
+	AdjustedEBSStorageCostKey        = bsonutil.MustHaveTag(Cost{}, "AdjustedEBSStorageCost")
 	OnDemandS3ArtifactPutCostKey     = bsonutil.MustHaveTag(Cost{}, "OnDemandS3ArtifactPutCost")
 	AdjustedS3ArtifactPutCostKey     = bsonutil.MustHaveTag(Cost{}, "AdjustedS3ArtifactPutCost")
 	OnDemandS3LogPutCostKey          = bsonutil.MustHaveTag(Cost{}, "OnDemandS3LogPutCost")

--- a/model/version.go
+++ b/model/version.go
@@ -25,24 +25,20 @@ import (
 )
 
 const (
-	taskCollection               = "tasks"
-	oldTaskCollection            = "old_tasks"
-	taskVersionKey               = "version"
-	taskDisplayOnlyKey           = "display_only"
-	taskCostKey                  = "cost"
-	taskPredictedCostKey         = "predicted_cost"
-	taskOnDemandCostKey          = "on_demand_ec2_cost"
-	taskAdjustedCostKey          = "adjusted_ec2_cost"
-	taskS3ArtifactPutCostKey     = "on_demand_s3_artifact_put_cost"
-	taskS3ArtifactStorageCostKey = "on_demand_s3_artifact_storage_cost"
-	taskS3LogPutCostKey          = "on_demand_s3_log_put_cost"
-	taskS3LogStorageCostKey      = "on_demand_s3_log_storage_cost"
-	taskS3UsageKey               = "s3_usage"
-	taskS3ArtifactsKey           = "artifacts"
-	taskS3LogsKey                = "logs"
-	taskS3PutRequestsKey         = "put_requests"
-	taskS3UploadBytesKey         = "upload_bytes"
-	taskS3ArtifactCountKey       = "count"
+	taskCollection         = "tasks"
+	oldTaskCollection      = "old_tasks"
+	taskVersionKey         = "version"
+	taskDisplayOnlyKey     = "display_only"
+	taskCostKey            = "cost"
+	taskPredictedCostKey   = "predicted_cost"
+	taskOnDemandCostKey    = "on_demand_ec2_cost"
+	taskAdjustedCostKey    = "adjusted_ec2_cost"
+	taskS3UsageKey         = "s3_usage"
+	taskS3ArtifactsKey     = "artifacts"
+	taskS3LogsKey          = "logs"
+	taskS3PutRequestsKey   = "put_requests"
+	taskS3UploadBytesKey   = "upload_bytes"
+	taskS3ArtifactCountKey = "count"
 )
 
 type Version struct {
@@ -373,20 +369,31 @@ func (v *Version) UpdateAggregateTaskCosts(ctx context.Context) error {
 			},
 		}},
 		{"$group": bson.M{
-			"_id":                            nil,
-			"total_on_demand":                bson.M{"$sum": "$" + taskCostKey + "." + taskOnDemandCostKey},
-			"total_adjusted":                 bson.M{"$sum": "$" + taskCostKey + "." + taskAdjustedCostKey},
-			"expected_on_demand":             bson.M{"$sum": "$" + taskPredictedCostKey + "." + taskOnDemandCostKey},
-			"expected_adjusted":              bson.M{"$sum": "$" + taskPredictedCostKey + "." + taskAdjustedCostKey},
-			"total_s3_artifact_put_cost":     bson.M{"$sum": "$" + taskCostKey + "." + taskS3ArtifactPutCostKey},
-			"total_s3_artifact_storage_cost": bson.M{"$sum": "$" + taskCostKey + "." + taskS3ArtifactStorageCostKey},
-			"total_s3_log_put_cost":          bson.M{"$sum": "$" + taskCostKey + "." + taskS3LogPutCostKey},
-			"total_s3_log_storage_cost":      bson.M{"$sum": "$" + taskCostKey + "." + taskS3LogStorageCostKey},
-			"total_artifact_put_requests":    bson.M{"$sum": "$" + taskS3UsageKey + "." + taskS3ArtifactsKey + "." + taskS3PutRequestsKey},
-			"total_artifact_upload_bytes":    bson.M{"$sum": "$" + taskS3UsageKey + "." + taskS3ArtifactsKey + "." + taskS3UploadBytesKey},
-			"total_artifact_count":           bson.M{"$sum": "$" + taskS3UsageKey + "." + taskS3ArtifactsKey + "." + taskS3ArtifactCountKey},
-			"total_log_put_requests":         bson.M{"$sum": "$" + taskS3UsageKey + "." + taskS3LogsKey + "." + taskS3PutRequestsKey},
-			"total_log_upload_bytes":         bson.M{"$sum": "$" + taskS3UsageKey + "." + taskS3LogsKey + "." + taskS3UploadBytesKey},
+			"_id":                nil,
+			"total_on_demand":    bson.M{"$sum": "$" + taskCostKey + "." + taskOnDemandCostKey},
+			"total_adjusted":     bson.M{"$sum": "$" + taskCostKey + "." + taskAdjustedCostKey},
+			"expected_on_demand": bson.M{"$sum": "$" + taskPredictedCostKey + "." + taskOnDemandCostKey},
+			"expected_adjusted":  bson.M{"$sum": "$" + taskPredictedCostKey + "." + taskAdjustedCostKey},
+
+			"total_on_demand_ebs_throughput": bson.M{"$sum": "$" + taskCostKey + "." + cost.OnDemandEBSThroughputCostKey},
+			"total_adjusted_ebs_throughput":  bson.M{"$sum": "$" + taskCostKey + "." + cost.AdjustedEBSThroughputCostKey},
+			"total_on_demand_ebs_storage":    bson.M{"$sum": "$" + taskCostKey + "." + cost.OnDemandEBSStorageCostKey},
+			"total_adjusted_ebs_storage":     bson.M{"$sum": "$" + taskCostKey + "." + cost.AdjustedEBSStorageCostKey},
+
+			"total_on_demand_s3_artifact_put_cost":     bson.M{"$sum": "$" + taskCostKey + "." + cost.OnDemandS3ArtifactPutCostKey},
+			"total_adjusted_s3_artifact_put_cost":      bson.M{"$sum": "$" + taskCostKey + "." + cost.AdjustedS3ArtifactPutCostKey},
+			"total_on_demand_s3_log_put_cost":          bson.M{"$sum": "$" + taskCostKey + "." + cost.OnDemandS3LogPutCostKey},
+			"total_adjusted_s3_log_put_cost":           bson.M{"$sum": "$" + taskCostKey + "." + cost.AdjustedS3LogPutCostKey},
+			"total_on_demand_s3_artifact_storage_cost": bson.M{"$sum": "$" + taskCostKey + "." + cost.OnDemandS3ArtifactStorageCostKey},
+			"total_adjusted_s3_artifact_storage_cost":  bson.M{"$sum": "$" + taskCostKey + "." + cost.AdjustedS3ArtifactStorageCostKey},
+			"total_on_demand_s3_log_storage_cost":      bson.M{"$sum": "$" + taskCostKey + "." + cost.OnDemandS3LogStorageCostKey},
+			"total_adjusted_s3_log_storage_cost":       bson.M{"$sum": "$" + taskCostKey + "." + cost.AdjustedS3LogStorageCostKey},
+
+			"total_artifact_put_requests": bson.M{"$sum": "$" + taskS3UsageKey + "." + taskS3ArtifactsKey + "." + taskS3PutRequestsKey},
+			"total_artifact_upload_bytes": bson.M{"$sum": "$" + taskS3UsageKey + "." + taskS3ArtifactsKey + "." + taskS3UploadBytesKey},
+			"total_artifact_count":        bson.M{"$sum": "$" + taskS3UsageKey + "." + taskS3ArtifactsKey + "." + taskS3ArtifactCountKey},
+			"total_log_put_requests":      bson.M{"$sum": "$" + taskS3UsageKey + "." + taskS3LogsKey + "." + taskS3PutRequestsKey},
+			"total_log_upload_bytes":      bson.M{"$sum": "$" + taskS3UsageKey + "." + taskS3LogsKey + "." + taskS3UploadBytesKey},
 		}},
 	}
 
@@ -396,19 +403,30 @@ func (v *Version) UpdateAggregateTaskCosts(ctx context.Context) error {
 	}
 
 	var results []struct {
-		TotalOnDemand              float64 `bson:"total_on_demand"`
-		TotalAdjusted              float64 `bson:"total_adjusted"`
-		PredictedOnDemand          float64 `bson:"expected_on_demand"`
-		PredictedAdjusted          float64 `bson:"expected_adjusted"`
-		TotalS3ArtifactPutCost     float64 `bson:"total_s3_artifact_put_cost"`
-		TotalS3ArtifactStorageCost float64 `bson:"total_s3_artifact_storage_cost"`
-		TotalS3LogPutCost          float64 `bson:"total_s3_log_put_cost"`
-		TotalS3LogStorageCost      float64 `bson:"total_s3_log_storage_cost"`
-		TotalArtifactPutRequests   int     `bson:"total_artifact_put_requests"`
-		TotalArtifactUploadBytes   int64   `bson:"total_artifact_upload_bytes"`
-		TotalArtifactCount         int     `bson:"total_artifact_count"`
-		TotalLogPutRequests        int     `bson:"total_log_put_requests"`
-		TotalLogUploadBytes        int64   `bson:"total_log_upload_bytes"`
+		TotalOnDemand     float64 `bson:"total_on_demand"`
+		TotalAdjusted     float64 `bson:"total_adjusted"`
+		PredictedOnDemand float64 `bson:"expected_on_demand"`
+		PredictedAdjusted float64 `bson:"expected_adjusted"`
+
+		TotalOnDemandEBSThroughput float64 `bson:"total_on_demand_ebs_throughput"`
+		TotalAdjustedEBSThroughput float64 `bson:"total_adjusted_ebs_throughput"`
+		TotalOnDemandEBSStorage    float64 `bson:"total_on_demand_ebs_storage"`
+		TotalAdjustedEBSStorage    float64 `bson:"total_adjusted_ebs_storage"`
+
+		TotalOnDemandS3ArtifactPutCost     float64 `bson:"total_on_demand_s3_artifact_put_cost"`
+		TotalAdjustedS3ArtifactPutCost     float64 `bson:"total_adjusted_s3_artifact_put_cost"`
+		TotalOnDemandS3LogPutCost          float64 `bson:"total_on_demand_s3_log_put_cost"`
+		TotalAdjustedS3LogPutCost          float64 `bson:"total_adjusted_s3_log_put_cost"`
+		TotalOnDemandS3ArtifactStorageCost float64 `bson:"total_on_demand_s3_artifact_storage_cost"`
+		TotalAdjustedS3ArtifactStorageCost float64 `bson:"total_adjusted_s3_artifact_storage_cost"`
+		TotalOnDemandS3LogStorageCost      float64 `bson:"total_on_demand_s3_log_storage_cost"`
+		TotalAdjustedS3LogStorageCost      float64 `bson:"total_adjusted_s3_log_storage_cost"`
+
+		TotalArtifactPutRequests int   `bson:"total_artifact_put_requests"`
+		TotalArtifactUploadBytes int64 `bson:"total_artifact_upload_bytes"`
+		TotalArtifactCount       int   `bson:"total_artifact_count"`
+		TotalLogPutRequests      int   `bson:"total_log_put_requests"`
+		TotalLogUploadBytes      int64 `bson:"total_log_upload_bytes"`
 	}
 	if err = cursor.All(ctx, &results); err != nil {
 		return errors.Wrap(err, "reading aggregated task cost results")
@@ -419,12 +437,23 @@ func (v *Version) UpdateAggregateTaskCosts(ctx context.Context) error {
 	if len(results) > 0 {
 		total.OnDemandEC2Cost = results[0].TotalOnDemand
 		total.AdjustedEC2Cost = results[0].TotalAdjusted
-		total.OnDemandS3ArtifactPutCost = results[0].TotalS3ArtifactPutCost
-		total.OnDemandS3ArtifactStorageCost = results[0].TotalS3ArtifactStorageCost
-		total.OnDemandS3LogPutCost = results[0].TotalS3LogPutCost
-		total.OnDemandS3LogStorageCost = results[0].TotalS3LogStorageCost
 		predicted.OnDemandEC2Cost = results[0].PredictedOnDemand
 		predicted.AdjustedEC2Cost = results[0].PredictedAdjusted
+
+		total.OnDemandEBSThroughputCost = results[0].TotalOnDemandEBSThroughput
+		total.AdjustedEBSThroughputCost = results[0].TotalAdjustedEBSThroughput
+		total.OnDemandEBSStorageCost = results[0].TotalOnDemandEBSStorage
+		total.AdjustedEBSStorageCost = results[0].TotalAdjustedEBSStorage
+
+		total.OnDemandS3ArtifactPutCost = results[0].TotalOnDemandS3ArtifactPutCost
+		total.AdjustedS3ArtifactPutCost = results[0].TotalAdjustedS3ArtifactPutCost
+		total.OnDemandS3LogPutCost = results[0].TotalOnDemandS3LogPutCost
+		total.AdjustedS3LogPutCost = results[0].TotalAdjustedS3LogPutCost
+		total.OnDemandS3ArtifactStorageCost = results[0].TotalOnDemandS3ArtifactStorageCost
+		total.AdjustedS3ArtifactStorageCost = results[0].TotalAdjustedS3ArtifactStorageCost
+		total.OnDemandS3LogStorageCost = results[0].TotalOnDemandS3LogStorageCost
+		total.AdjustedS3LogStorageCost = results[0].TotalAdjustedS3LogStorageCost
+
 		s3Total.Artifacts.PutRequests = results[0].TotalArtifactPutRequests
 		s3Total.Artifacts.UploadBytes = results[0].TotalArtifactUploadBytes
 		s3Total.Artifacts.Count = results[0].TotalArtifactCount
@@ -434,14 +463,25 @@ func (v *Version) UpdateAggregateTaskCosts(ctx context.Context) error {
 
 	if err := VersionUpdateOne(ctx, bson.M{VersionIdKey: v.Id}, bson.M{
 		"$set": bson.M{
-			bsonutil.GetDottedKeyName(VersionCostKey, cost.OnDemandEC2CostKey):               total.OnDemandEC2Cost,
-			bsonutil.GetDottedKeyName(VersionCostKey, cost.AdjustedEC2CostKey):               total.AdjustedEC2Cost,
+			bsonutil.GetDottedKeyName(VersionCostKey, cost.OnDemandEC2CostKey):          total.OnDemandEC2Cost,
+			bsonutil.GetDottedKeyName(VersionCostKey, cost.AdjustedEC2CostKey):          total.AdjustedEC2Cost,
+			bsonutil.GetDottedKeyName(VersionPredictedCostKey, cost.OnDemandEC2CostKey): predicted.OnDemandEC2Cost,
+			bsonutil.GetDottedKeyName(VersionPredictedCostKey, cost.AdjustedEC2CostKey): predicted.AdjustedEC2Cost,
+
+			bsonutil.GetDottedKeyName(VersionCostKey, cost.OnDemandEBSThroughputCostKey): total.OnDemandEBSThroughputCost,
+			bsonutil.GetDottedKeyName(VersionCostKey, cost.AdjustedEBSThroughputCostKey): total.AdjustedEBSThroughputCost,
+			bsonutil.GetDottedKeyName(VersionCostKey, cost.OnDemandEBSStorageCostKey):    total.OnDemandEBSStorageCost,
+			bsonutil.GetDottedKeyName(VersionCostKey, cost.AdjustedEBSStorageCostKey):    total.AdjustedEBSStorageCost,
+
 			bsonutil.GetDottedKeyName(VersionCostKey, cost.OnDemandS3ArtifactPutCostKey):     total.OnDemandS3ArtifactPutCost,
-			bsonutil.GetDottedKeyName(VersionCostKey, cost.OnDemandS3ArtifactStorageCostKey): total.OnDemandS3ArtifactStorageCost,
+			bsonutil.GetDottedKeyName(VersionCostKey, cost.AdjustedS3ArtifactPutCostKey):     total.AdjustedS3ArtifactPutCost,
 			bsonutil.GetDottedKeyName(VersionCostKey, cost.OnDemandS3LogPutCostKey):          total.OnDemandS3LogPutCost,
+			bsonutil.GetDottedKeyName(VersionCostKey, cost.AdjustedS3LogPutCostKey):          total.AdjustedS3LogPutCost,
+			bsonutil.GetDottedKeyName(VersionCostKey, cost.OnDemandS3ArtifactStorageCostKey): total.OnDemandS3ArtifactStorageCost,
+			bsonutil.GetDottedKeyName(VersionCostKey, cost.AdjustedS3ArtifactStorageCostKey): total.AdjustedS3ArtifactStorageCost,
 			bsonutil.GetDottedKeyName(VersionCostKey, cost.OnDemandS3LogStorageCostKey):      total.OnDemandS3LogStorageCost,
-			bsonutil.GetDottedKeyName(VersionPredictedCostKey, cost.OnDemandEC2CostKey):      predicted.OnDemandEC2Cost,
-			bsonutil.GetDottedKeyName(VersionPredictedCostKey, cost.AdjustedEC2CostKey):      predicted.AdjustedEC2Cost,
+			bsonutil.GetDottedKeyName(VersionCostKey, cost.AdjustedS3LogStorageCostKey):      total.AdjustedS3LogStorageCost,
+
 			VersionS3UsageKey: s3Total,
 		},
 	}); err != nil {

--- a/model/version_test.go
+++ b/model/version_test.go
@@ -837,4 +837,84 @@ func TestUpdateAggregateTaskCosts(t *testing.T) {
 		assert.Equal(t, 5, v.S3Usage.Artifacts.Count)
 		assert.Equal(t, 0, v.S3Usage.Logs.PutRequests)
 	})
+
+	t.Run("AggregatesEBSCosts", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(VersionCollection, taskCollection))
+		v := &Version{Id: "v5"}
+		require.NoError(t, v.Insert(ctx))
+
+		require.NoError(t, db.Insert(ctx, taskCollection, bson.M{
+			"_id": "t1", "version": "v5", "display_only": false,
+			"cost": bson.M{
+				"on_demand_ec2_cost":            1.0,
+				"on_demand_ebs_throughput_cost": 0.10,
+				"adjusted_ebs_throughput_cost":  0.08,
+				"on_demand_ebs_storage_cost":    0.20,
+				"adjusted_ebs_storage_cost":     0.16,
+			},
+		}))
+		require.NoError(t, db.Insert(ctx, taskCollection, bson.M{
+			"_id": "t2", "version": "v5", "display_only": false,
+			"cost": bson.M{
+				"on_demand_ec2_cost":            1.0,
+				"on_demand_ebs_throughput_cost": 0.05,
+				"adjusted_ebs_throughput_cost":  0.04,
+				"on_demand_ebs_storage_cost":    0.10,
+				"adjusted_ebs_storage_cost":     0.08,
+			},
+		}))
+
+		err := v.UpdateAggregateTaskCosts(ctx)
+		require.NoError(t, err)
+		assert.InDelta(t, 0.15, v.Cost.OnDemandEBSThroughputCost, 0.001)
+		assert.InDelta(t, 0.12, v.Cost.AdjustedEBSThroughputCost, 0.001)
+		assert.InDelta(t, 0.30, v.Cost.OnDemandEBSStorageCost, 0.001)
+		assert.InDelta(t, 0.24, v.Cost.AdjustedEBSStorageCost, 0.001)
+	})
+
+	t.Run("AggregatesS3Costs", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(VersionCollection, taskCollection))
+		v := &Version{Id: "v6"}
+		require.NoError(t, v.Insert(ctx))
+
+		require.NoError(t, db.Insert(ctx, taskCollection, bson.M{
+			"_id": "t1", "version": "v6", "display_only": false,
+			"cost": bson.M{
+				"on_demand_ec2_cost":                 1.0,
+				"on_demand_s3_artifact_put_cost":     0.10,
+				"adjusted_s3_artifact_put_cost":      0.07,
+				"on_demand_s3_log_put_cost":          0.04,
+				"adjusted_s3_log_put_cost":           0.028,
+				"on_demand_s3_artifact_storage_cost": 0.50,
+				"adjusted_s3_artifact_storage_cost":  0.35,
+				"on_demand_s3_log_storage_cost":      0.20,
+				"adjusted_s3_log_storage_cost":       0.14,
+			},
+		}))
+		require.NoError(t, db.Insert(ctx, taskCollection, bson.M{
+			"_id": "t2", "version": "v6", "display_only": false,
+			"cost": bson.M{
+				"on_demand_ec2_cost":                 1.0,
+				"on_demand_s3_artifact_put_cost":     0.05,
+				"adjusted_s3_artifact_put_cost":      0.035,
+				"on_demand_s3_log_put_cost":          0.02,
+				"adjusted_s3_log_put_cost":           0.014,
+				"on_demand_s3_artifact_storage_cost": 0.25,
+				"adjusted_s3_artifact_storage_cost":  0.175,
+				"on_demand_s3_log_storage_cost":      0.10,
+				"adjusted_s3_log_storage_cost":       0.07,
+			},
+		}))
+
+		err := v.UpdateAggregateTaskCosts(ctx)
+		require.NoError(t, err)
+		assert.InDelta(t, 0.15, v.Cost.OnDemandS3ArtifactPutCost, 0.001)
+		assert.InDelta(t, 0.105, v.Cost.AdjustedS3ArtifactPutCost, 0.001)
+		assert.InDelta(t, 0.06, v.Cost.OnDemandS3LogPutCost, 0.001)
+		assert.InDelta(t, 0.042, v.Cost.AdjustedS3LogPutCost, 0.001)
+		assert.InDelta(t, 0.75, v.Cost.OnDemandS3ArtifactStorageCost, 0.001)
+		assert.InDelta(t, 0.525, v.Cost.AdjustedS3ArtifactStorageCost, 0.001)
+		assert.InDelta(t, 0.30, v.Cost.OnDemandS3LogStorageCost, 0.001)
+		assert.InDelta(t, 0.21, v.Cost.AdjustedS3LogStorageCost, 0.001)
+	})
 }

--- a/rest/model/version.go
+++ b/rest/model/version.go
@@ -62,7 +62,20 @@ type APIVersion struct {
 	// Aggregated predicted cost of all tasks in the version
 	PredictedCost *cost.Cost `json:"predicted_cost,omitempty"`
 	// Aggregated S3 upload metrics across all tasks in the version
-	S3Usage *s3usage.S3Usage `json:"s3_usage,omitempty"`
+	S3Usage *APIVersionS3Usage `json:"s3_usage,omitempty"`
+}
+
+// APIVersionS3Usage holds aggregated S3 upload metrics for a version.
+// Logs only exposes puts and bytes since per-type breakdown is not aggregated at version level.
+type APIVersionS3Usage struct {
+	Artifacts s3usage.ArtifactMetrics `json:"artifacts,omitempty"`
+	Logs      APIVersionS3LogUsage    `json:"logs,omitempty"`
+}
+
+// APIVersionS3LogUsage holds aggregated S3 log upload metrics for a version.
+type APIVersionS3LogUsage struct {
+	PutRequests int   `json:"put_requests,omitempty"`
+	UploadBytes int64 `json:"upload_bytes,omitempty"`
 }
 
 type APIGitTag struct {
@@ -143,8 +156,13 @@ func (apiVersion *APIVersion) BuildFromService(ctx context.Context, v model.Vers
 		apiVersion.PredictedCost = &predictedCost
 	}
 	if !v.S3Usage.IsZero() {
-		s3Usage := v.S3Usage
-		apiVersion.S3Usage = &s3Usage
+		apiVersion.S3Usage = &APIVersionS3Usage{
+			Artifacts: v.S3Usage.Artifacts,
+			Logs: APIVersionS3LogUsage{
+				PutRequests: v.S3Usage.Logs.PutRequests,
+				UploadBytes: v.S3Usage.Logs.UploadBytes,
+			},
+		}
 	}
 	if apiVersion.IsPatchRequester() {
 		p, err := patch.FindOneId(ctx, v.Id)

--- a/rest/model/version.go
+++ b/rest/model/version.go
@@ -8,6 +8,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/cost"
 	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/s3usage"
 	"github.com/evergreen-ci/utility"
 )
 
@@ -60,6 +61,8 @@ type APIVersion struct {
 	Cost *cost.Cost `json:"cost,omitempty"`
 	// Aggregated predicted cost of all tasks in the version
 	PredictedCost *cost.Cost `json:"predicted_cost,omitempty"`
+	// Aggregated S3 upload metrics across all tasks in the version
+	S3Usage *s3usage.S3Usage `json:"s3_usage,omitempty"`
 }
 
 type APIGitTag struct {
@@ -138,6 +141,10 @@ func (apiVersion *APIVersion) BuildFromService(ctx context.Context, v model.Vers
 	if !v.PredictedCost.IsZero() {
 		predictedCost := v.PredictedCost
 		apiVersion.PredictedCost = &predictedCost
+	}
+	if !v.S3Usage.IsZero() {
+		s3Usage := v.S3Usage
+		apiVersion.S3Usage = &s3Usage
 	}
 	if apiVersion.IsPatchRequester() {
 		p, err := patch.FindOneId(ctx, v.Id)

--- a/rest/model/version_test.go
+++ b/rest/model/version_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/cost"
+	"github.com/evergreen-ci/evergreen/model/s3usage"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -142,5 +143,49 @@ func TestVersionBuildFromServiceCost(t *testing.T) {
 
 		assert.Nil(t, apiVersion.Cost)
 		assert.Nil(t, apiVersion.PredictedCost)
+	})
+}
+
+func TestVersionBuildFromServiceS3Usage(t *testing.T) {
+	t.Run("PopulatedS3UsageIsExposed", func(t *testing.T) {
+		v := model.Version{
+			Id: "v-with-s3-usage",
+			S3Usage: s3usage.S3Usage{
+				Artifacts: s3usage.ArtifactMetrics{
+					S3UploadMetrics: s3usage.S3UploadMetrics{
+						PutRequests: 100,
+						UploadBytes: 1024 * 1024,
+					},
+					Count: 5,
+				},
+				Logs: s3usage.LogMetrics{
+					S3UploadMetrics: s3usage.S3UploadMetrics{
+						PutRequests: 50,
+						UploadBytes: 512 * 1024,
+					},
+				},
+			},
+		}
+
+		apiVersion := &APIVersion{}
+		apiVersion.BuildFromService(t.Context(), v)
+
+		require.NotNil(t, apiVersion.S3Usage)
+		assert.Equal(t, 100, apiVersion.S3Usage.Artifacts.PutRequests)
+		assert.Equal(t, int64(1024*1024), apiVersion.S3Usage.Artifacts.UploadBytes)
+		assert.Equal(t, 5, apiVersion.S3Usage.Artifacts.Count)
+		assert.Equal(t, 50, apiVersion.S3Usage.Logs.PutRequests)
+		assert.Equal(t, int64(512*1024), apiVersion.S3Usage.Logs.UploadBytes)
+	})
+
+	t.Run("ZeroS3UsageIsNil", func(t *testing.T) {
+		v := model.Version{
+			Id: "v-no-s3-usage",
+		}
+
+		apiVersion := &APIVersion{}
+		apiVersion.BuildFromService(t.Context(), v)
+
+		assert.Nil(t, apiVersion.S3Usage)
 	})
 }

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -783,6 +783,7 @@ func (h *reportS3UsageHandler) Run(ctx context.Context) gimlet.Responder {
 	if err != nil {
 		grip.Error(ctx, errors.Wrapf(err, "finding version '%s' to update aggregate task costs", t.Version))
 	} else if v != nil {
+		// For task groups, this runs once for the group rather than once per task.
 		grip.Error(ctx, errors.Wrapf(v.UpdateAggregateTaskCosts(ctx), "updating aggregate task costs for version '%s' after S3 usage report", v.Id))
 	}
 

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -782,7 +782,7 @@ func (h *reportS3UsageHandler) Run(ctx context.Context) gimlet.Responder {
 	v, err := model.VersionFindOneId(ctx, t.Version)
 	if err != nil {
 		grip.Error(ctx, errors.Wrapf(err, "finding version '%s' to update aggregate task costs", t.Version))
-	} else if v != nil && evergreen.IsFinishedVersionStatus(v.Status) {
+	} else if v != nil {
 		grip.Error(ctx, errors.Wrapf(v.UpdateAggregateTaskCosts(ctx), "updating aggregate task costs for version '%s' after S3 usage report", v.Id))
 	}
 


### PR DESCRIPTION
DEVPROD-26473

### Description
To show the S3 cost of each patch, we need to aggregate all the S3 cost for all tasks that are run. 

Have checked Prod and both tasks and old_tasks collections have version as a leading index key, so each aggregation is an index-bounded --> This is helpful as we need to keep updating the cost as task complete.

### Testing
Added test coverage as well as tested in staging
