### PR TITLE
DEVPROD-30320: make project vars more resilient to interrupts

### DIFF
--- a/cloud/parameterstore/parameter_manager.go
+++ b/cloud/parameterstore/parameter_manager.go
@@ -3,6 +3,7 @@ package parameterstore
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -224,6 +225,9 @@ func (pm *ParameterManager) GetStrict(ctx context.Context, names ...string) ([]P
 				missingNames = append(missingNames, name)
 			}
 		}
+		// Sort the missing names so the error message returns them in a
+		// predictable order.
+		slices.Sort(missingNames)
 
 		if len(missingNames) > 0 {
 			return nil, errors.Errorf("parameter(s) not found: %s", missingNames)

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -10,7 +10,6 @@ import (
 	"regexp"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud/parameterstore"
@@ -251,6 +250,12 @@ func FindMergedProjectVars(ctx context.Context, projectID string) (*ProjectVars,
 
 // CopyProjectVars copies the variables for the first project to the second
 func CopyProjectVars(ctx context.Context, oldProjectId, newProjectId string) error {
+	// kim: NOTE: this is implementation for REST route project copy.
+	// kim: NOTE: Splunk logs: https://mongodb.splunkcloud.com/en-US/app/search/search?earliest=1774018800&latest=1774022400&q=search%20index%3Devergreen%20%2Fcopy&display.page.search.mode=fast&dispatch.sample_ratio=1&display.general.type=events&display.page.search.tab=events&workload_pool=&display.events.timelineEarliestTime=1774020840&display.events.timelineLatestTime=1774020900&sid=1776268615.249437
+	// kim: NOTE: this FindOneProjectVars passed, which means that for the old
+	// project to be copied, there were either no project vars at this moment,
+	// or the project vars were in a valid state (i.e. the project vars were
+	// valid in the old "mms" project).
 	vars, err := FindOneProjectVars(ctx, oldProjectId)
 	if err != nil {
 		return errors.Wrapf(err, "finding variables for project '%s'", oldProjectId)
@@ -300,20 +305,10 @@ func GetAWSKeyForProject(ctx context.Context, projectId string) (*AWSSSHKey, err
 	}, nil
 }
 
-// defaultParameterStoreAccessTimeout is the default timeout for accessing
-// Parameter Store. In general, the context timeout should prefer to be
-// inherited from a higher-level context (e.g. a REST request's context), so
-// this timeout should only be used as a last resort if the context cannot
-// easily be passed down.
-const defaultParameterStoreAccessTimeout = 30 * time.Second
-
 // Upsert creates or updates a project vars document and stores all the project
 // variables in the DB. If Parameter Store is enabled for the project, it also
 // stores the variables in Parameter Store.
 func (projectVars *ProjectVars) Upsert(ctx context.Context) (*adb.ChangeInfo, error) {
-	ctx, cancel := context.WithTimeout(ctx, defaultParameterStoreAccessTimeout)
-	defer cancel()
-
 	pm, err := projectVars.upsertParameterStore(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "upserting project variables into Parameter Store")
@@ -349,14 +344,27 @@ func (projectVars *ProjectVars) upsertParameterStore(ctx context.Context) (*Para
 	projectID := projectVars.Id
 	after := projectVars
 
+	// kim: NOTE: this errored
+	// but it was doing FindOneProjectVars using the new project ID
+	// ("mms-v20260325"). I would have expected this to return empty, but it
+	// didn't. From the Slack thread
+	// (https://mongodb.slack.com/archives/C69UXN1CP/p1774025257537879?thread_ts=1774022368.553139&cid=C69UXN1CP),
+	// it sounds like the new project already existed. If that initial copy
+	// errored or had issues, then it seems like it was already in a bad state.
+	// We don't have any record of what the original mms-v20260325 project vars
+	// looked like though or how the project was initialized.
 	before, err := FindOneProjectVars(ctx, projectID)
 	if err != nil {
+		// kim: NOTE: hit 500 on this line trying to find parameters that didn't
+		// exist.
 		return nil, errors.Wrapf(err, "finding original project vars for project '%s'", projectID)
 	}
 	if before == nil {
 		before = &ProjectVars{Id: projectID}
 	}
 
+	// kim: NOTE: when copying vars for the first time, before should have been
+	// empty because the project vars haven't been initialized yet.
 	varsToUpsert, varsToDelete := getProjectVarsDiff(before, after)
 
 	pm, err := projectVars.syncParameterDiff(ctx, before.Parameters, varsToUpsert, varsToDelete)
@@ -521,9 +529,6 @@ func (projectVars *ProjectVars) Insert(ctx context.Context) error {
 	// This has to be done after inserting the initial document because it
 	// upserts the project vars doc. If this ran first, it would cause the DB
 	// insert to fail due to the ID already existing.
-	ctx, cancel := context.WithTimeout(ctx, defaultParameterStoreAccessTimeout)
-	defer cancel()
-
 	pm, err := insertParameterStore(ctx, projectVars)
 	if err != nil {
 		return errors.Wrap(err, "inserting project vars into Parameter Store")
@@ -558,9 +563,6 @@ func insertParameterStore(ctx context.Context, vars *ProjectVars) (*ParameterMap
 // succeeds, projectVars will contain all the project variables, including those
 // that were not explicitly modified.
 func (projectVars *ProjectVars) FindAndModify(ctx context.Context, varsToDelete []string) (*adb.ChangeInfo, error) {
-	ctx, cancel := context.WithTimeoutCause(ctx, defaultParameterStoreAccessTimeout, errors.New("parameter store access timeout"))
-	defer cancel()
-
 	pm, err := projectVars.findAndModifyParameterStore(ctx, varsToDelete)
 	if err != nil {
 		return nil, errors.Wrap(err, "finding and modifying project vars in Parameter Store")
@@ -707,8 +709,7 @@ func (projectVars *ProjectVars) Clear(ctx context.Context) error {
 	// Ignore the context cancellation to ensure that the parameters are
 	// deleted from Parameter Store and cleared from the database, this should be as
 	// 'atomic' as possible.
-	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), defaultParameterStoreAccessTimeout)
-	defer cancel()
+	ctx = context.WithoutCancel(ctx)
 	if _, err := projectVars.upsertParameterStore(ctx); err != nil {
 		return errors.Wrap(err, "clearing project vars from Parameter Store")
 	}

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -306,15 +306,50 @@ func GetAWSKeyForProject(ctx context.Context, projectId string) (*AWSSSHKey, err
 }
 
 // Upsert creates or updates a project vars document and stores all the project
-// variables in the DB. If Parameter Store is enabled for the project, it also
-// stores the variables in Parameter Store.
+// variables as parameters in Parameter Store.
 func (projectVars *ProjectVars) Upsert(ctx context.Context) (*adb.ChangeInfo, error) {
-	pm, err := projectVars.upsertParameterStore(ctx)
+	// Ignore the context cancellation to ensure that the parameters are synced
+	// into Parameter Store and updated in the DB. These two operations should
+	// be as atomic as possible.
+	ctx = context.WithoutCancel(ctx)
+
+	before, err := FindOneProjectVars(ctx, projectVars.Id)
+	if err != nil {
+		return nil, errors.Wrapf(err, "finding original project vars for project '%s'", projectVars.Id)
+	}
+	if before == nil {
+		before = &ProjectVars{Id: projectVars.Id}
+	}
+
+	varsToUpsert, varsToDelete := getProjectVarsDiff(before, projectVars)
+
+	paramMappingsToUpsert, err := projectVars.upsertParameterStore(ctx, before.Parameters, varsToUpsert)
 	if err != nil {
 		return nil, errors.Wrap(err, "upserting project variables into Parameter Store")
 	}
-	projectVars.Parameters = *pm
 
+	paramMappingsToDelete := getParamMappingsToDelete(before.Parameters, varsToDelete)
+
+	// Update the DB with the final parameter state.
+	// This must happen before deleting any parameters from Parameter Store for
+	// correctness. If the order of operations were inverted (i.e. deleting from
+	// Parameter Store, then updating the DB), then there would be a risk that
+	// Upsert is interrupted partway through, which could result in the DB
+	// holding some lingering references to parameters that don't exist anymore.
+	projectVars.Parameters = getUpdatedParamMappings(before.Parameters, paramMappingsToUpsert, paramMappingsToDelete)
+	changeInfo, err := projectVars.upsertDB(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "upserting project vars in DB")
+	}
+
+	if err := projectVars.deleteParameterStore(ctx, paramMappingsToDelete); err != nil {
+		return nil, errors.Wrap(err, "deleting project variables from Parameter Store")
+	}
+
+	return changeInfo, nil
+}
+
+func (projectVars *ProjectVars) upsertDB(ctx context.Context) (*adb.ChangeInfo, error) {
 	setUpdate := bson.M{
 		privateVarsMapKey:      projectVars.PrivateVars,
 		adminOnlyVarsMapKey:    projectVars.AdminOnlyVars,
@@ -338,66 +373,10 @@ func (projectVars *ProjectVars) Upsert(ctx context.Context) (*adb.ChangeInfo, er
 	)
 }
 
-// upsertParameterStore upserts the diff of added/updated/deleted project
-// variables into Parameter Store.
-func (projectVars *ProjectVars) upsertParameterStore(ctx context.Context) (*ParameterMappings, error) {
-	projectID := projectVars.Id
-	after := projectVars
-
-	// kim: NOTE: this errored
-	// but it was doing FindOneProjectVars using the new project ID
-	// ("mms-v20260325"). I would have expected this to return empty, but it
-	// didn't. From the Slack thread
-	// (https://mongodb.slack.com/archives/C69UXN1CP/p1774025257537879?thread_ts=1774022368.553139&cid=C69UXN1CP),
-	// it sounds like the new project already existed. If that initial copy
-	// errored or had issues, then it seems like it was already in a bad state.
-	// We don't have any record of what the original mms-v20260325 project vars
-	// looked like though or how the project was initialized.
-	before, err := FindOneProjectVars(ctx, projectID)
-	if err != nil {
-		// kim: NOTE: hit 500 on this line trying to find parameters that didn't
-		// exist.
-		return nil, errors.Wrapf(err, "finding original project vars for project '%s'", projectID)
-	}
-	if before == nil {
-		before = &ProjectVars{Id: projectID}
-	}
-
-	// kim: NOTE: when copying vars for the first time, before should have been
-	// empty because the project vars haven't been initialized yet.
-	varsToUpsert, varsToDelete := getProjectVarsDiff(before, after)
-
-	pm, err := projectVars.syncParameterDiff(ctx, before.Parameters, varsToUpsert, varsToDelete)
-	if err != nil {
-		return nil, errors.Wrap(err, "syncing project vars diff to Parameter Store")
-	}
-
-	return pm, nil
-}
-
-// syncParameterDiff syncs the diff of project variables to Parameter Store. It
-// adds/updates varsToUpsert to Parameter Store, deletes varsToDelete from
-// Parameter Store, and updates the project variable parameter mappings.
-func (projectVars *ProjectVars) syncParameterDiff(ctx context.Context, pm ParameterMappings, varsToUpsert map[string]string, varsToDelete map[string]struct{}) (*ParameterMappings, error) {
-	paramMappingsToUpsert, err := projectVars.upsertParameters(ctx, pm, varsToUpsert)
-	if err != nil {
-		return nil, errors.Wrap(err, "upserting project variables into Parameter Store")
-	}
-
-	paramMappingsToDelete, err := projectVars.deleteParameters(ctx, pm, varsToDelete)
-	if err != nil {
-		return nil, errors.Wrap(err, "deleting project variables from Parameter Store")
-	}
-
-	updatedParamMappings := getUpdatedParamMappings(pm, paramMappingsToUpsert, paramMappingsToDelete)
-
-	return &updatedParamMappings, nil
-}
-
-// upsertParameters upserts the parameter mappings for project variables into
+// upsertParameterStore upserts the parameter mappings for project variables into
 // Parameter Store. It returns the parameter mappings for the upserted
 // variables.
-func (projectVars *ProjectVars) upsertParameters(ctx context.Context, pm ParameterMappings, varsToUpsert map[string]string) (map[string]ParameterMapping, error) {
+func (projectVars *ProjectVars) upsertParameterStore(ctx context.Context, pm ParameterMappings, varsToUpsert map[string]string) (map[string]ParameterMapping, error) {
 	projectID := projectVars.Id
 	nameToExistingParamMapping := pm.NameMap()
 	paramMgr := evergreen.GetEnvironment().ParameterManager()
@@ -446,10 +425,9 @@ func (projectVars *ProjectVars) upsertParameters(ctx context.Context, pm Paramet
 	return paramMappingsToUpsert, nil
 }
 
-// deleteParameters deletes parameters corresponding to deleted project variables
-// from Parameter Store. It returns the parameter mappings for the deleted
-// variables.
-func (projectVars *ProjectVars) deleteParameters(ctx context.Context, pm ParameterMappings, varsToDelete map[string]struct{}) (map[string]ParameterMapping, error) {
+// getParamMappingsToDelete returns the subset of parameter mappings that
+// correspond to the variables being deleted.
+func getParamMappingsToDelete(pm ParameterMappings, varsToDelete map[string]struct{}) map[string]ParameterMapping {
 	nameToExistingParamMapping := pm.NameMap()
 	paramMappingsToDelete := make(map[string]ParameterMapping, len(varsToDelete))
 	for varToDelete := range varsToDelete {
@@ -457,20 +435,23 @@ func (projectVars *ProjectVars) deleteParameters(ctx context.Context, pm Paramet
 			paramMappingsToDelete[varToDelete] = paramMapping
 		}
 	}
+	return paramMappingsToDelete
+}
 
+// deleteParameterStore deletes parameters corresponding to deleted project variables
+// from Parameter Store.
+func (projectVars *ProjectVars) deleteParameterStore(ctx context.Context, paramMappingsToDelete map[string]ParameterMapping) error {
 	namesToDelete := make([]string, 0, len(paramMappingsToDelete))
 	for _, m := range paramMappingsToDelete {
 		namesToDelete = append(namesToDelete, m.ParameterName)
 	}
 
-	if len(namesToDelete) > 0 {
-		paramMgr := evergreen.GetEnvironment().ParameterManager()
-		if err := paramMgr.Delete(ctx, namesToDelete...); err != nil {
-			return nil, err
-		}
+	if len(namesToDelete) == 0 {
+		return nil
 	}
 
-	return paramMappingsToDelete, nil
+	paramMgr := evergreen.GetEnvironment().ParameterManager()
+	return paramMgr.Delete(ctx, namesToDelete...)
 }
 
 // getProjectVarsDiff returns the diff of added/updated/deleted project
@@ -523,12 +504,13 @@ func getUpdatedParamMappings(original ParameterMappings, upserted, deleted map[s
 }
 
 // Insert creates a new project vars document and stores all the project
-// variables in the DB. If Parameter Store is enabled for the project, it also
-// stores the variables in Parameter Store.
+// variables as parameters in Parameter Store.
 func (projectVars *ProjectVars) Insert(ctx context.Context) error {
-	// This has to be done after inserting the initial document because it
-	// upserts the project vars doc. If this ran first, it would cause the DB
-	// insert to fail due to the ID already existing.
+	// Ignore the context cancellation to ensure that the parameters are synced
+	// into Parameter Store and inserted into the DB. These two operations should
+	// be as atomic as possible.
+	ctx = context.WithoutCancel(ctx)
+
 	pm, err := insertParameterStore(ctx, projectVars)
 	if err != nil {
 		return errors.Wrap(err, "inserting project vars into Parameter Store")
@@ -544,31 +526,84 @@ func (projectVars *ProjectVars) Insert(ctx context.Context) error {
 
 // insertParameterStore inserts all project variables into Parameter Store.
 func insertParameterStore(ctx context.Context, vars *ProjectVars) (*ParameterMappings, error) {
-	before := &ProjectVars{Id: vars.Id}
-	after := vars
-	varsToUpsert, _ := getProjectVarsDiff(before, after)
-
-	pm, err := vars.syncParameterDiff(ctx, ParameterMappings{}, varsToUpsert, nil)
+	paramMappingsToUpsert, err := vars.upsertParameterStore(ctx, ParameterMappings{}, vars.Vars)
 	if err != nil {
-		return nil, errors.Wrap(err, "syncing project vars diff to Parameter Store")
+		return nil, errors.Wrap(err, "upserting project variables into Parameter Store")
 	}
 
-	return pm, nil
+	pm := getUpdatedParamMappings(ParameterMappings{}, paramMappingsToUpsert, nil)
+	return &pm, nil
 }
 
 // FindAndModify is almost the same functionally as Upsert, except that it only
 // deletes project vars that are explicitly provided in varsToDelete. In other
 // words, even if a project variable is omitted from projectVars, it won't be
 // deleted unless that variable is explicitly listed in varsToDelete. If this
-// succeeds, projectVars will contain all the project variables, including those
-// that were not explicitly modified.
+// succeeds, the resulting projectVars will contain all the project variables,
+// including those that were not explicitly modified.
 func (projectVars *ProjectVars) FindAndModify(ctx context.Context, varsToDelete []string) (*adb.ChangeInfo, error) {
-	pm, err := projectVars.findAndModifyParameterStore(ctx, varsToDelete)
-	if err != nil {
-		return nil, errors.Wrap(err, "finding and modifying project vars in Parameter Store")
-	}
-	projectVars.Parameters = *pm
+	// Ignore the context cancellation to ensure that the parameters are synced
+	// into Parameter Store and updated in the DB. These two operations should
+	// be as atomic as possible.
+	ctx = context.WithoutCancel(ctx)
 
+	before, err := FindOneProjectVars(ctx, projectVars.Id)
+	if err != nil {
+		return nil, errors.Wrapf(err, "finding original project vars for project '%s'", projectVars.Id)
+	}
+	if before == nil {
+		before = &ProjectVars{Id: projectVars.Id}
+	}
+
+	// Ignore the vars that are deleted between before and after because
+	// FindAndModify only deletes variables that are explicitly specified in
+	// varsToDelete.
+	varsToUpsert, _ := getProjectVarsDiff(before, projectVars)
+
+	varSetToDelete := map[string]struct{}{}
+	for _, varName := range varsToDelete {
+		varSetToDelete[varName] = struct{}{}
+	}
+
+	paramMappingsToUpsert, err := projectVars.upsertParameterStore(ctx, before.Parameters, varsToUpsert)
+	if err != nil {
+		return nil, errors.Wrap(err, "upserting project variables into Parameter Store")
+	}
+
+	paramMappingsToDelete := getParamMappingsToDelete(before.Parameters, varSetToDelete)
+
+	// Update the DB with the final parameter state.
+	// The DB update must happen before deleting any parameters from Parameter
+	// Store for correctness. If the order of operations were inverted (i.e.
+	// deleting from Parameter Store, then updating the DB), then there would be
+	// a risk that FindAndModify is interrupted partway through, which could
+	// result in the DB holding some lingering references to parameters that
+	// don't exist anymore.
+	projectVars.Parameters = getUpdatedParamMappings(before.Parameters, paramMappingsToUpsert, paramMappingsToDelete)
+	change, err := projectVars.findAndModifyDB(ctx, varsToDelete)
+	if err != nil {
+		return nil, errors.Wrap(err, "finding and modifying project vars in DB")
+	}
+
+	if err := projectVars.deleteParameterStore(ctx, paramMappingsToDelete); err != nil {
+		return nil, errors.Wrap(err, "deleting project variables from Parameter Store")
+	}
+
+	// FindAndModify is expected to return all the project's vars. However,
+	// FindAndModify only receives as input the subset of vars to be modified.
+	// Therefore, it's necessary to look up all the vars in Parameter Store
+	// after the update to ensure that the returned project vars includes all
+	// the unmodified vars.
+	projectVarsFromPS, err := projectVars.findParameterStore(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "finding unmodified project vars in Parameter Store")
+	}
+	projectVars.Vars = projectVarsFromPS.Vars
+
+	return change, nil
+}
+
+func (projectVars *ProjectVars) findAndModifyDB(ctx context.Context, varsToDelete []string) (*adb.ChangeInfo, error) {
 	setUpdate := bson.M{}
 	unsetUpdate := bson.M{}
 	update := bson.M{}
@@ -624,18 +659,17 @@ func (projectVars *ProjectVars) FindAndModify(ctx context.Context, varsToDelete 
 			initializeUpdate[varsDescriptionsMapKey] = bson.M{}
 		}
 		if len(initializeUpdate) > 0 {
-			err := db.Update(ctx,
+			if err := db.Update(ctx,
 				ProjectVarsCollection,
 				bson.M{projectVarIdKey: projectVars.Id},
 				bson.M{"$set": initializeUpdate},
-			)
-			if err != nil {
+			); err != nil {
 				return nil, errors.Wrap(err, "initializing private vars, admin-only vars, and descriptions in DB")
 			}
 		}
 	}
 
-	change, err := db.FindAndModify(ctx,
+	return db.FindAndModify(ctx,
 		ProjectVarsCollection,
 		bson.M{projectVarIdKey: projectVars.Id},
 		nil,
@@ -646,75 +680,43 @@ func (projectVars *ProjectVars) FindAndModify(ctx context.Context, varsToDelete 
 		},
 		projectVars,
 	)
-	if err != nil {
-		return nil, errors.Wrap(err, "finding and modifying project vars in DB")
-	}
-
-	// FindAndModify is expected to return all the project's vars. However,
-	// FindAndModify only receives as input the subset of vars to be modified.
-	// Therefore, it's necessary to look up all the vars in Parameter Store
-	// after the update to ensure that the returned project vars includes all
-	// the unmodified vars.
-	projectVarsFromPS, err := projectVars.findParameterStore(ctx)
-	if err != nil {
-		return nil, errors.Wrap(err, "finding unmodified project vars in Parameter Store")
-	}
-	projectVars.Vars = projectVarsFromPS.Vars
-
-	return change, nil
 }
 
-// findAndModifyParameterStore is almost the same functionally as Upsert, except
-// that it only deletes project vars that are explicitly provided in
-// varsToDelete. In other words, even if a project variable is omitted from
-// projectVars, it won't be deleted unless that variable is explicitly listed in
-// varsToDelete.
-func (projectVars *ProjectVars) findAndModifyParameterStore(ctx context.Context, varsToDelete []string) (*ParameterMappings, error) {
-	projectID := projectVars.Id
+// Clear clears all variables for a project.
+func (projectVars *ProjectVars) Clear(ctx context.Context) error {
+	// Ignore the context cancellation to ensure that the parameters are deleted
+	// from Parameter Store and the DB. These two operations should be as atomic
+	// as possible.
+	ctx = context.WithoutCancel(ctx)
 
-	before, err := FindOneProjectVars(ctx, projectID)
+	before, err := FindOneProjectVars(ctx, projectVars.Id)
 	if err != nil {
-		return nil, errors.Wrapf(err, "finding original project vars for project '%s'", projectID)
+		return errors.Wrapf(err, "finding original project vars for project '%s'", projectVars.Id)
 	}
 	if before == nil {
-		before = &ProjectVars{Id: projectID}
+		before = &ProjectVars{Id: projectVars.Id}
 	}
 
-	// Ignore the vars that are deleted between before and after because
-	// FindAndModify only deletes variables that are explicitly specified in
-	// varsToDelete.
-	after := projectVars
-	varsToUpsert, _ := getProjectVarsDiff(before, after)
-
-	varSetToDelete := map[string]struct{}{}
-	for _, varName := range varsToDelete {
-		varSetToDelete[varName] = struct{}{}
-	}
-
-	pm, err := projectVars.syncParameterDiff(ctx, before.Parameters, varsToUpsert, varSetToDelete)
-	if err != nil {
-		return nil, errors.Wrap(err, "syncing project vars diff to Parameter Store")
-	}
-
-	return pm, nil
-}
-
-// Clears clears all variables for a project.
-func (projectVars *ProjectVars) Clear(ctx context.Context) error {
 	projectVars.Vars = map[string]string{}
 	projectVars.PrivateVars = map[string]bool{}
 	projectVars.AdminOnlyVars = map[string]bool{}
 	projectVars.VarsDescriptions = map[string]string{}
 
-	// Ignore the context cancellation to ensure that the parameters are
-	// deleted from Parameter Store and cleared from the database, this should be as
-	// 'atomic' as possible.
-	ctx = context.WithoutCancel(ctx)
-	if _, err := projectVars.upsertParameterStore(ctx); err != nil {
+	if err := projectVars.clearDB(ctx); err != nil {
+		return err
+	}
+
+	_, varsToDelete := getProjectVarsDiff(before, projectVars)
+	paramMappingsToDelete := getParamMappingsToDelete(before.Parameters, varsToDelete)
+	if err := projectVars.deleteParameterStore(ctx, paramMappingsToDelete); err != nil {
 		return errors.Wrap(err, "clearing project vars from Parameter Store")
 	}
 
-	err := db.Update(ctx, ProjectVarsCollection,
+	return nil
+}
+
+func (projectVars *ProjectVars) clearDB(ctx context.Context) error {
+	return db.Update(ctx, ProjectVarsCollection,
 		bson.M{ProjectRefIdKey: projectVars.Id},
 		bson.M{
 			"$unset": bson.M{
@@ -724,11 +726,6 @@ func (projectVars *ProjectVars) Clear(ctx context.Context) error {
 				varsDescriptionsMapKey:   1,
 			},
 		})
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func (projectVars *ProjectVars) GetVars(ctx context.Context, t *task.Task) map[string]string {

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -303,8 +303,8 @@ func GetAWSKeyForProject(ctx context.Context, projectId string) (*AWSSSHKey, err
 // variables as parameters in Parameter Store.
 func (projectVars *ProjectVars) Upsert(ctx context.Context) (*adb.ChangeInfo, error) {
 	// Ignore the context cancellation to ensure that the parameters are synced
-	// into Parameter Store and updated in the DB. These two operations should
-	// be as atomic as possible.
+	// into Parameter Store and updated in the DB. The Parameter Store and DB
+	// updates should be as atomic as possible.
 	ctx = context.WithoutCancel(ctx)
 
 	before, err := FindOneProjectVars(ctx, projectVars.Id)
@@ -325,11 +325,12 @@ func (projectVars *ProjectVars) Upsert(ctx context.Context) (*adb.ChangeInfo, er
 	paramMappingsToDelete := getParamMappingsToDelete(before.Parameters, varsToDelete)
 
 	// Update the DB with the final parameter state.
-	// This must happen before deleting any parameters from Parameter Store for
-	// correctness. If the order of operations were inverted (i.e. deleting from
-	// Parameter Store, then updating the DB), then there would be a risk that
-	// Upsert is interrupted partway through, which could result in the DB
-	// holding some lingering references to parameters that don't exist anymore.
+	// The DB update must happen before deleting any parameters from Parameter
+	// Store for correctness. If the order of operations were inverted (i.e.
+	// deleting from Parameter Store, then updating the DB), then there would be
+	// a risk that the Parameter Store deletion is interrupted partway through,
+	// which could result in the DB holding some lingering references to
+	// parameters that don't exist anymore.
 	projectVars.Parameters = getUpdatedParamMappings(before.Parameters, paramMappingsToUpsert, paramMappingsToDelete)
 	changeInfo, err := projectVars.upsertDB(ctx)
 	if err != nil {
@@ -537,8 +538,8 @@ func insertParameterStore(ctx context.Context, vars *ProjectVars) (*ParameterMap
 // including those that were not explicitly modified.
 func (projectVars *ProjectVars) FindAndModify(ctx context.Context, varsToDelete []string) (*adb.ChangeInfo, error) {
 	// Ignore the context cancellation to ensure that the parameters are synced
-	// into Parameter Store and updated in the DB. These two operations should
-	// be as atomic as possible.
+	// into Parameter Store and updated in the DB. The Parameter Store and DB
+	// updates should be as atomic as possible.
 	ctx = context.WithoutCancel(ctx)
 
 	before, err := FindOneProjectVars(ctx, projectVars.Id)
@@ -679,8 +680,8 @@ func (projectVars *ProjectVars) findAndModifyDB(ctx context.Context, varsToDelet
 // Clear clears all variables for a project.
 func (projectVars *ProjectVars) Clear(ctx context.Context) error {
 	// Ignore the context cancellation to ensure that the parameters are deleted
-	// from Parameter Store and the DB. These two operations should be as atomic
-	// as possible.
+	// from Parameter Store and the DB. The Parameter Store and DB updates
+	// should be as atomic as possible.
 	ctx = context.WithoutCancel(ctx)
 
 	before, err := FindOneProjectVars(ctx, projectVars.Id)

--- a/model/project_vars.go
+++ b/model/project_vars.go
@@ -250,12 +250,6 @@ func FindMergedProjectVars(ctx context.Context, projectID string) (*ProjectVars,
 
 // CopyProjectVars copies the variables for the first project to the second
 func CopyProjectVars(ctx context.Context, oldProjectId, newProjectId string) error {
-	// kim: NOTE: this is implementation for REST route project copy.
-	// kim: NOTE: Splunk logs: https://mongodb.splunkcloud.com/en-US/app/search/search?earliest=1774018800&latest=1774022400&q=search%20index%3Devergreen%20%2Fcopy&display.page.search.mode=fast&dispatch.sample_ratio=1&display.general.type=events&display.page.search.tab=events&workload_pool=&display.events.timelineEarliestTime=1774020840&display.events.timelineLatestTime=1774020900&sid=1776268615.249437
-	// kim: NOTE: this FindOneProjectVars passed, which means that for the old
-	// project to be copied, there were either no project vars at this moment,
-	// or the project vars were in a valid state (i.e. the project vars were
-	// valid in the old "mms" project).
 	vars, err := FindOneProjectVars(ctx, oldProjectId)
 	if err != nil {
 		return errors.Wrapf(err, "finding variables for project '%s'", oldProjectId)

--- a/model/project_vars_test.go
+++ b/model/project_vars_test.go
@@ -578,6 +578,87 @@ func TestProjectVarsFindAndModify(t *testing.T) {
 
 }
 
+func TestProjectVarsClear(t *testing.T) {
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(ProjectVarsCollection, fakeparameter.Collection, ProjectRefCollection))
+	})
+
+	for tName, tCase := range map[string]func(t *testing.T){
+		"DeletesAllExistingVars": func(t *testing.T) {
+			pRef := ProjectRef{
+				Id: "123",
+			}
+			require.NoError(t, pRef.Insert(t.Context()))
+
+			vars := &ProjectVars{
+				Id:            pRef.Id,
+				Vars:          map[string]string{"a": "1", "b": "2", "c": "3"},
+				PrivateVars:   map[string]bool{"b": true},
+				AdminOnlyVars: map[string]bool{"c": true},
+			}
+			assert.NoError(t, vars.Insert(t.Context()))
+
+			dbVars, err := FindOneProjectVars(t.Context(), vars.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbVars)
+
+			assert.Len(t, dbVars.Vars, 3)
+			assert.Equal(t, "1", dbVars.Vars["a"])
+			assert.Equal(t, "2", dbVars.Vars["b"])
+			assert.Equal(t, "3", dbVars.Vars["c"])
+
+			assert.True(t, dbVars.PrivateVars["b"])
+			assert.True(t, dbVars.AdminOnlyVars["c"])
+
+			checkParametersMatchVars(t.Context(), t, dbVars.Parameters, dbVars.Vars)
+			checkParametersNamespacedByProject(t, *dbVars)
+
+			require.NoError(t, vars.Clear(t.Context()))
+
+			dbVars, err = FindOneProjectVars(t.Context(), vars.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbVars)
+
+			assert.Empty(t, dbVars.Vars)
+			assert.Empty(t, dbVars.PrivateVars)
+			assert.Empty(t, dbVars.AdminOnlyVars)
+			checkParametersMatchVars(t.Context(), t, dbVars.Parameters, dbVars.Vars)
+		},
+		"NoopsWithNoVars": func(t *testing.T) {
+			pRef := ProjectRef{
+				Id: "123",
+			}
+			require.NoError(t, pRef.Insert(t.Context()))
+
+			vars := &ProjectVars{
+				Id:            pRef.Id,
+				Vars:          map[string]string{},
+				PrivateVars:   map[string]bool{},
+				AdminOnlyVars: map[string]bool{},
+			}
+			assert.NoError(t, vars.Insert(t.Context()))
+
+			require.NoError(t, vars.Clear(t.Context()))
+
+			dbVars, err := FindOneProjectVars(t.Context(), vars.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbVars)
+
+			assert.Empty(t, dbVars.Vars)
+			assert.Empty(t, dbVars.PrivateVars)
+			assert.Empty(t, dbVars.AdminOnlyVars)
+			assert.Empty(t, dbVars.Parameters)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(ProjectVarsCollection, fakeparameter.Collection, ProjectRefCollection))
+
+			tCase(t)
+		})
+	}
+
+}
+
 func TestRedactPrivateVars(t *testing.T) {
 	assert := assert.New(t)
 

--- a/rest/route/project_copy.go
+++ b/rest/route/project_copy.go
@@ -138,8 +138,6 @@ func (p *copyVariablesHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	// Don't redact private variables unless it's a dry run
-	// kim: NOTE: this was not used in the original route, they used the route
-	// to copy the entire project, not just the vars.
 	varsToCopy, err := data.FindProjectVarsById(ctx, copyFromProjectId, "", p.opts.DryRun)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding vars for source project '%s'", p.copyFrom))

--- a/rest/route/project_copy.go
+++ b/rest/route/project_copy.go
@@ -138,6 +138,8 @@ func (p *copyVariablesHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	// Don't redact private variables unless it's a dry run
+	// kim: NOTE: this was not used in the original route, they used the route
+	// to copy the entire project, not just the vars.
 	varsToCopy, err := data.FindProjectVarsById(ctx, copyFromProjectId, "", p.opts.DryRun)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding vars for source project '%s'", p.copyFrom))


### PR DESCRIPTION
DEVPROD-30320

### Description
I couldn't actually deduce what exactly went wrong with the project that the user had due to the lack of Splunk logs, but it looks like from the event logs/Slack thread:

1. The project already existed when they tried creating it via copy.
2. The project's vars were likely already in a bad state long before they tried to copy to it again.

My best guess is that someone tried updating a bunch of project vars, pressed save, didn't wait for the request to finish before leaving the page (which aborted the request), and left the project vars in a bad state.

To handle this, I made the project vars updates/deletions more resilient to partially-completed requests that delete vars. The order of operations before this change was:

1. Do all the Parameter Store inserts/updates/deletes.
2. Update the DB to reflect the latest parameters.

This is vulnerable to DB-ParameterStore state mismatches because if the user aborts the request in step 1, then step 2 won't happen and the DB will have lingering references to parameters that no longer exist. To fix this, I added `context.WithoutCancel` to the project vars requests (so the project vars modifications continue even if the user cancels the request). I also reordered the operations to make it less likely that the DB can get in a bad state in case of unstoppable interrupts like app deploys. The new order of operations is:

1. Do all Parameter Store inserts/updates.
2. Update the DB to reflect _all_ parameter inserts/updates/deletes.
3. Actually delete any parameters from Parameter Store.

### Testing
* Existing tests pass.
* Added tests for `Clear`.
* Tested in staging to verify that adding/deleting vars from the UI works, as well as copying projects (from the UI and from REST routes). Also tested adding/deleting many vars and clicking away from the page (to abort the request), and confirmed that the vars were eventually updated.