### PR TITLE
DEVPROD-30265: add more detailed considerations for PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,8 +5,6 @@ DEVPROD-XXXX
 ### Description
 add description, context, thought process, etc
 
-<!-- Are you adding a field to the Task, Build, Version, or Patch structs? Create a DPIPE ticket to expose this in data warehouse. -->
-
 ### Testing
 add a description of how you tested it
 
@@ -14,4 +12,28 @@ add a description of how you tested it
 Remember to add or edit docs in the docs/ directory if relevant.
 <!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->
 
-<!-- Remember to check that any TODOs for this ticket are cleaned up! -->
+<!-- 
+Also please briefly consider before putting up for review (or mention in the PR description):
+
+* Usability
+    * Does it fulfill the user's need?
+    * Is it reasonably easy for users to understand/use?
+* Correctness
+    * Does the code do what it's expected to do?
+    * Is there enough automated test coverage?
+* Performance
+    * Does it do anything that's slow or resource-intensive?
+    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
+      indexes, deep recursive calls, etc.
+* Code health
+    * Does it follow Evergreen's conventions/style?
+    * Is it readable, easy to understand, and maintainable?
+* Backward compatibility
+    * Does it break existing behavior or APIs?
+    * Do we need to send out comms to users?
+* Ops - Is there any ops work that needs to be done alongside this change?
+* Monitoring - Does this change need to be monitored post-deploy?
+* Data warehouse models - If you're adding a field to the Task, Build, Version, or Patch structs, consider creating a
+  DPIPE ticket to expose this in the data warehouse.
+
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Remember to add or edit docs in the docs/ directory if relevant.
 <!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->
 
 <!-- 
-Also please briefly consider before putting up for review (or mention in the PR description):
+Before putting up for review, briefly consider (or mention in the PR description):
 
 * Usability
     * Does it fulfill the user's need?
@@ -28,6 +28,8 @@ Also please briefly consider before putting up for review (or mention in the PR 
 * Code health
     * Does it follow Evergreen's conventions/style?
     * Is it readable, easy to understand, and maintainable?
+    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
+* Security - Does this change have any security implications?
 * Backward compatibility
     * Does it break existing behavior or APIs?
     * Do we need to send out comms to users?


### PR DESCRIPTION
DEVPROD-30265

### Description
Update the PR template to include an list of things to think about before putting up for code review. Adding any of this info to your PR is optional but is a useful checklist to mentally run through. Roughly based on the [code review living guide](https://docs.google.com/document/d/1KxK2-JhKiHg7ydoEJN6rAf63k94KE_5-DqlYBj48pig/edit?tab=t.0#heading=h.a76jxlxme1h6).