### PR TITLE
DEVPROD-31963 Add Total Cost to Cost struct 

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -901,6 +901,9 @@ models:
     model: github.com/evergreen-ci/evergreen/rest/model.APIPodTaskContainerCreationOptions
   Cost:
     model: github.com/evergreen-ci/evergreen/model/cost.Cost
+    fields:
+      total:
+        resolver: true
   TaskEndDetail:
     model: github.com/evergreen-ci/evergreen/rest/model.ApiTaskEndDetail
   TaskEventLogData:

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -54,6 +54,7 @@ type ResolverRoot interface {
 	AdminSettings() AdminSettingsResolver
 	Annotation() AnnotationResolver
 	ContainerPool() ContainerPoolResolver
+	Cost() CostResolver
 	Distro() DistroResolver
 	Host() HostResolver
 	Image() ImageResolver
@@ -413,6 +414,7 @@ type ComplexityRoot struct {
 		AdjustedS3LogPutCost          func(childComplexity int) int
 		AdjustedS3LogStorageCost      func(childComplexity int) int
 		OnDemandEC2Cost               func(childComplexity int) int
+		Total                         func(childComplexity int) int
 	}
 
 	CostConfig struct {
@@ -1211,7 +1213,6 @@ type ComplexityRoot struct {
 		ChildPatchAliases     func(childComplexity int) int
 		ChildPatches          func(childComplexity int) int
 		Cost                  func(childComplexity int) int
-		CostTotal             func(childComplexity int) int
 		CreateTime            func(childComplexity int) int
 		Description           func(childComplexity int) int
 		Duration              func(childComplexity int) int
@@ -1228,7 +1229,6 @@ type ComplexityRoot struct {
 		PatchNumber           func(childComplexity int) int
 		PatchTriggerAliases   func(childComplexity int) int
 		PredictedCost         func(childComplexity int) int
-		PredictedCostTotal    func(childComplexity int) int
 		Project               func(childComplexity int) int
 		ProjectId             func(childComplexity int) int
 		ProjectIdentifier     func(childComplexity int) int
@@ -1936,7 +1936,6 @@ type ComplexityRoot struct {
 		Patch                   func(childComplexity int) int
 		PatchNumber             func(childComplexity int) int
 		PredictedTaskCost       func(childComplexity int) int
-		PredictedTaskCostTotal  func(childComplexity int) int
 		PrevTask                func(childComplexity int) int
 		PrevTaskCompleted       func(childComplexity int) int
 		PrevTaskFailing         func(childComplexity int) int
@@ -1955,7 +1954,6 @@ type ComplexityRoot struct {
 		StepbackInfo            func(childComplexity int) int
 		Tags                    func(childComplexity int) int
 		TaskCost                func(childComplexity int) int
-		TaskCostTotal           func(childComplexity int) int
 		TaskGroup               func(childComplexity int) int
 		TaskGroupMaxHosts       func(childComplexity int) int
 		TaskLogs                func(childComplexity int) int
@@ -2307,7 +2305,6 @@ type ComplexityRoot struct {
 		BuildVariants            func(childComplexity int, options BuildVariantOptions) int
 		ChildVersions            func(childComplexity int) int
 		Cost                     func(childComplexity int) int
-		CostTotal                func(childComplexity int) int
 		CreateTime               func(childComplexity int) int
 		Errors                   func(childComplexity int) int
 		ExternalLinksForMetadata func(childComplexity int) int
@@ -2324,7 +2321,6 @@ type ComplexityRoot struct {
 		Parameters               func(childComplexity int) int
 		Patch                    func(childComplexity int) int
 		PredictedCost            func(childComplexity int) int
-		PredictedCostTotal       func(childComplexity int) int
 		PreviousVersion          func(childComplexity int) int
 		Project                  func(childComplexity int) int
 		ProjectIdentifier        func(childComplexity int) int
@@ -2465,6 +2461,9 @@ type AnnotationResolver interface {
 }
 type ContainerPoolResolver interface {
 	Port(ctx context.Context, obj *model.APIContainerPool) (int, error)
+}
+type CostResolver interface {
+	Total(ctx context.Context, obj *cost.Cost) (*float64, error)
 }
 type DistroResolver interface {
 	AvailableRegions(ctx context.Context, obj *model.APIDistro) ([]string, error)
@@ -4171,6 +4170,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Cost.OnDemandEC2Cost(childComplexity), true
+	case "Cost.total":
+		if e.complexity.Cost.Total == nil {
+			break
+		}
+
+		return e.complexity.Cost.Total(childComplexity), true
 
 	case "CostConfig.ebsCost":
 		if e.complexity.CostConfig.EBSCost == nil {
@@ -7546,12 +7551,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Patch.Cost(childComplexity), true
-	case "Patch.costTotal":
-		if e.complexity.Patch.CostTotal == nil {
-			break
-		}
-
-		return e.complexity.Patch.CostTotal(childComplexity), true
 	case "Patch.createTime":
 		if e.complexity.Patch.CreateTime == nil {
 			break
@@ -7648,12 +7647,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Patch.PredictedCost(childComplexity), true
-	case "Patch.predictedCostTotal":
-		if e.complexity.Patch.PredictedCostTotal == nil {
-			break
-		}
-
-		return e.complexity.Patch.PredictedCostTotal(childComplexity), true
 	case "Patch.project":
 		if e.complexity.Patch.Project == nil {
 			break
@@ -10886,12 +10879,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Task.PredictedTaskCost(childComplexity), true
-	case "Task.predictedTaskCostTotal":
-		if e.complexity.Task.PredictedTaskCostTotal == nil {
-			break
-		}
-
-		return e.complexity.Task.PredictedTaskCostTotal(childComplexity), true
 	case "Task.prevTask":
 		if e.complexity.Task.PrevTask == nil {
 			break
@@ -11000,12 +10987,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Task.TaskCost(childComplexity), true
-	case "Task.taskCostTotal":
-		if e.complexity.Task.TaskCostTotal == nil {
-			break
-		}
-
-		return e.complexity.Task.TaskCostTotal(childComplexity), true
 	case "Task.taskGroup":
 		if e.complexity.Task.TaskGroup == nil {
 			break
@@ -12435,12 +12416,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Version.Cost(childComplexity), true
-	case "Version.costTotal":
-		if e.complexity.Version.CostTotal == nil {
-			break
-		}
-
-		return e.complexity.Version.CostTotal(childComplexity), true
 	case "Version.createTime":
 		if e.complexity.Version.CreateTime == nil {
 			break
@@ -12537,12 +12512,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Version.PredictedCost(childComplexity), true
-	case "Version.predictedCostTotal":
-		if e.complexity.Version.PredictedCostTotal == nil {
-			break
-		}
-
-		return e.complexity.Version.PredictedCostTotal(childComplexity), true
 	case "Version.previousVersion":
 		if e.complexity.Version.PreviousVersion == nil {
 			break
@@ -20386,12 +20355,8 @@ func (ec *executionContext) fieldContext_AdminTasksToRestartPayload_tasksToResta
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -24105,6 +24070,35 @@ func (ec *executionContext) fieldContext_ContainerPoolsConfig_pools(_ context.Co
 				return ec.fieldContext_ContainerPool_port(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ContainerPool", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Cost_total(ctx context.Context, field graphql.CollectedField, obj *cost.Cost) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Cost_total,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Cost().Total(ctx, obj)
+		},
+		nil,
+		ec.marshalOFloat2ᚖfloat64,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_Cost_total(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Cost",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -29196,12 +29190,8 @@ func (ec *executionContext) fieldContext_GroupedBuildVariant_tasks(_ context.Con
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -32701,12 +32691,8 @@ func (ec *executionContext) fieldContext_Image_latestTask(_ context.Context, fie
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -35439,12 +35425,8 @@ func (ec *executionContext) fieldContext_LogkeeperBuild_task(_ context.Context, 
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -35713,8 +35695,6 @@ func (ec *executionContext) fieldContext_MainlineCommitVersion_rolledUpVersions(
 				return ec.fieldContext_Version_childVersions(ctx, field)
 			case "cost":
 				return ec.fieldContext_Version_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Version_costTotal(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
 			case "ingestTime":
@@ -35745,8 +35725,6 @@ func (ec *executionContext) fieldContext_MainlineCommitVersion_rolledUpVersions(
 				return ec.fieldContext_Version_patch(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Version_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Version_predictedCostTotal(ctx, field)
 			case "previousVersion":
 				return ec.fieldContext_Version_previousVersion(ctx, field)
 			case "project":
@@ -35834,8 +35812,6 @@ func (ec *executionContext) fieldContext_MainlineCommitVersion_version(_ context
 				return ec.fieldContext_Version_childVersions(ctx, field)
 			case "cost":
 				return ec.fieldContext_Version_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Version_costTotal(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
 			case "ingestTime":
@@ -35866,8 +35842,6 @@ func (ec *executionContext) fieldContext_MainlineCommitVersion_version(_ context
 				return ec.fieldContext_Version_patch(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Version_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Version_predictedCostTotal(ctx, field)
 			case "previousVersion":
 				return ec.fieldContext_Version_previousVersion(ctx, field)
 			case "project":
@@ -37420,12 +37394,8 @@ func (ec *executionContext) fieldContext_Mutation_setPatchVisibility(ctx context
 				return ec.fieldContext_Patch_versionFull(ctx, field)
 			case "cost":
 				return ec.fieldContext_Patch_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Patch_costTotal(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Patch_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Patch_predictedCostTotal(ctx, field)
 			case "invalidatedByUpstream":
 				return ec.fieldContext_Patch_invalidatedByUpstream(ctx, field)
 			}
@@ -37543,12 +37513,8 @@ func (ec *executionContext) fieldContext_Mutation_schedulePatch(ctx context.Cont
 				return ec.fieldContext_Patch_versionFull(ctx, field)
 			case "cost":
 				return ec.fieldContext_Patch_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Patch_costTotal(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Patch_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Patch_predictedCostTotal(ctx, field)
 			case "invalidatedByUpstream":
 				return ec.fieldContext_Patch_invalidatedByUpstream(ctx, field)
 			}
@@ -39451,12 +39417,8 @@ func (ec *executionContext) fieldContext_Mutation_abortTask(ctx context.Context,
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -39678,12 +39640,8 @@ func (ec *executionContext) fieldContext_Mutation_overrideTaskDependencies(ctx c
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -39905,12 +39863,8 @@ func (ec *executionContext) fieldContext_Mutation_restartTask(ctx context.Contex
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -40132,12 +40086,8 @@ func (ec *executionContext) fieldContext_Mutation_scheduleTasks(ctx context.Cont
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -40359,12 +40309,8 @@ func (ec *executionContext) fieldContext_Mutation_setTaskPriority(ctx context.Co
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -40586,12 +40532,8 @@ func (ec *executionContext) fieldContext_Mutation_setTaskPriorities(ctx context.
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -40813,12 +40755,8 @@ func (ec *executionContext) fieldContext_Mutation_unscheduleTask(ctx context.Con
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -41792,8 +41730,6 @@ func (ec *executionContext) fieldContext_Mutation_restartVersions(ctx context.Co
 				return ec.fieldContext_Version_childVersions(ctx, field)
 			case "cost":
 				return ec.fieldContext_Version_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Version_costTotal(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
 			case "ingestTime":
@@ -41824,8 +41760,6 @@ func (ec *executionContext) fieldContext_Mutation_restartVersions(ctx context.Co
 				return ec.fieldContext_Version_patch(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Version_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Version_predictedCostTotal(ctx, field)
 			case "previousVersion":
 				return ec.fieldContext_Version_previousVersion(ctx, field)
 			case "project":
@@ -42069,12 +42003,8 @@ func (ec *executionContext) fieldContext_Mutation_scheduleUndispatchedBaseTasks(
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -44224,12 +44154,8 @@ func (ec *executionContext) fieldContext_Patch_childPatches(_ context.Context, f
 				return ec.fieldContext_Patch_versionFull(ctx, field)
 			case "cost":
 				return ec.fieldContext_Patch_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Patch_costTotal(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Patch_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Patch_predictedCostTotal(ctx, field)
 			case "invalidatedByUpstream":
 				return ec.fieldContext_Patch_invalidatedByUpstream(ctx, field)
 			}
@@ -45307,8 +45233,6 @@ func (ec *executionContext) fieldContext_Patch_versionFull(_ context.Context, fi
 				return ec.fieldContext_Version_childVersions(ctx, field)
 			case "cost":
 				return ec.fieldContext_Version_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Version_costTotal(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
 			case "ingestTime":
@@ -45339,8 +45263,6 @@ func (ec *executionContext) fieldContext_Patch_versionFull(_ context.Context, fi
 				return ec.fieldContext_Version_patch(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Version_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Version_predictedCostTotal(ctx, field)
 			case "previousVersion":
 				return ec.fieldContext_Version_previousVersion(ctx, field)
 			case "project":
@@ -45408,6 +45330,8 @@ func (ec *executionContext) fieldContext_Patch_cost(_ context.Context, field gra
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "total":
+				return ec.fieldContext_Cost_total(ctx, field)
 			case "onDemandEC2Cost":
 				return ec.fieldContext_Cost_onDemandEC2Cost(ctx, field)
 			case "adjustedEC2Cost":
@@ -45426,35 +45350,6 @@ func (ec *executionContext) fieldContext_Patch_cost(_ context.Context, field gra
 				return ec.fieldContext_Cost_adjustedS3LogStorageCost(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Cost", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Patch_costTotal(ctx context.Context, field graphql.CollectedField, obj *model.APIPatch) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_Patch_costTotal,
-		func(ctx context.Context) (any, error) {
-			return obj.CostTotal, nil
-		},
-		nil,
-		ec.marshalOFloat2ᚖfloat64,
-		true,
-		false,
-	)
-}
-
-func (ec *executionContext) fieldContext_Patch_costTotal(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Patch",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -45484,6 +45379,8 @@ func (ec *executionContext) fieldContext_Patch_predictedCost(_ context.Context, 
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "total":
+				return ec.fieldContext_Cost_total(ctx, field)
 			case "onDemandEC2Cost":
 				return ec.fieldContext_Cost_onDemandEC2Cost(ctx, field)
 			case "adjustedEC2Cost":
@@ -45502,35 +45399,6 @@ func (ec *executionContext) fieldContext_Patch_predictedCost(_ context.Context, 
 				return ec.fieldContext_Cost_adjustedS3LogStorageCost(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Cost", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Patch_predictedCostTotal(ctx context.Context, field graphql.CollectedField, obj *model.APIPatch) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_Patch_predictedCostTotal,
-		func(ctx context.Context) (any, error) {
-			return obj.PredictedCostTotal, nil
-		},
-		nil,
-		ec.marshalOFloat2ᚖfloat64,
-		true,
-		false,
-	)
-}
-
-func (ec *executionContext) fieldContext_Patch_predictedCostTotal(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Patch",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -46155,12 +46023,8 @@ func (ec *executionContext) fieldContext_Patches_patches(_ context.Context, fiel
 				return ec.fieldContext_Patch_versionFull(ctx, field)
 			case "cost":
 				return ec.fieldContext_Patch_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Patch_costTotal(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Patch_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Patch_predictedCostTotal(ctx, field)
 			case "invalidatedByUpstream":
 				return ec.fieldContext_Patch_invalidatedByUpstream(ctx, field)
 			}
@@ -52867,12 +52731,8 @@ func (ec *executionContext) fieldContext_Query_patch(ctx context.Context, field 
 				return ec.fieldContext_Patch_versionFull(ctx, field)
 			case "cost":
 				return ec.fieldContext_Patch_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Patch_costTotal(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Patch_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Patch_predictedCostTotal(ctx, field)
 			case "invalidatedByUpstream":
 				return ec.fieldContext_Patch_invalidatedByUpstream(ctx, field)
 			}
@@ -53802,12 +53662,8 @@ func (ec *executionContext) fieldContext_Query_task(ctx context.Context, field g
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -54029,12 +53885,8 @@ func (ec *executionContext) fieldContext_Query_taskAllExecutions(ctx context.Con
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -54617,8 +54469,6 @@ func (ec *executionContext) fieldContext_Query_version(ctx context.Context, fiel
 				return ec.fieldContext_Version_childVersions(ctx, field)
 			case "cost":
 				return ec.fieldContext_Version_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Version_costTotal(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
 			case "ingestTime":
@@ -54649,8 +54499,6 @@ func (ec *executionContext) fieldContext_Query_version(ctx context.Context, fiel
 				return ec.fieldContext_Version_patch(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Version_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Version_predictedCostTotal(ctx, field)
 			case "previousVersion":
 				return ec.fieldContext_Version_previousVersion(ctx, field)
 			case "project":
@@ -61510,12 +61358,8 @@ func (ec *executionContext) fieldContext_Task_baseTask(_ context.Context, field 
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -62312,12 +62156,8 @@ func (ec *executionContext) fieldContext_Task_displayTask(_ context.Context, fie
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -62715,12 +62555,8 @@ func (ec *executionContext) fieldContext_Task_executionTasksFull(_ context.Conte
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -63139,12 +62975,8 @@ func (ec *executionContext) fieldContext_Task_generator(_ context.Context, field
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -63596,12 +63428,8 @@ func (ec *executionContext) fieldContext_Task_nextTask(_ context.Context, field 
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -63811,12 +63639,8 @@ func (ec *executionContext) fieldContext_Task_nextTaskCompleted(_ context.Contex
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -64026,12 +63850,8 @@ func (ec *executionContext) fieldContext_Task_nextTaskFailing(_ context.Context,
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -64241,12 +64061,8 @@ func (ec *executionContext) fieldContext_Task_nextTaskPassing(_ context.Context,
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -64422,12 +64238,8 @@ func (ec *executionContext) fieldContext_Task_patch(_ context.Context, field gra
 				return ec.fieldContext_Patch_versionFull(ctx, field)
 			case "cost":
 				return ec.fieldContext_Patch_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Patch_costTotal(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Patch_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Patch_predictedCostTotal(ctx, field)
 			case "invalidatedByUpstream":
 				return ec.fieldContext_Patch_invalidatedByUpstream(ctx, field)
 			}
@@ -64654,12 +64466,8 @@ func (ec *executionContext) fieldContext_Task_prevTask(_ context.Context, field 
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -64869,12 +64677,8 @@ func (ec *executionContext) fieldContext_Task_prevTaskCompleted(_ context.Contex
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -65084,12 +64888,8 @@ func (ec *executionContext) fieldContext_Task_prevTaskFailing(_ context.Context,
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -65299,12 +65099,8 @@ func (ec *executionContext) fieldContext_Task_prevTaskPassing(_ context.Context,
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -65948,6 +65744,8 @@ func (ec *executionContext) fieldContext_Task_taskCost(_ context.Context, field 
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "total":
+				return ec.fieldContext_Cost_total(ctx, field)
 			case "onDemandEC2Cost":
 				return ec.fieldContext_Cost_onDemandEC2Cost(ctx, field)
 			case "adjustedEC2Cost":
@@ -65966,35 +65764,6 @@ func (ec *executionContext) fieldContext_Task_taskCost(_ context.Context, field 
 				return ec.fieldContext_Cost_adjustedS3LogStorageCost(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Cost", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Task_taskCostTotal(ctx context.Context, field graphql.CollectedField, obj *model.APITask) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_Task_taskCostTotal,
-		func(ctx context.Context) (any, error) {
-			return obj.TaskCostTotal, nil
-		},
-		nil,
-		ec.marshalOFloat2ᚖfloat64,
-		true,
-		false,
-	)
-}
-
-func (ec *executionContext) fieldContext_Task_taskCostTotal(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Task",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -66024,6 +65793,8 @@ func (ec *executionContext) fieldContext_Task_predictedTaskCost(_ context.Contex
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "total":
+				return ec.fieldContext_Cost_total(ctx, field)
 			case "onDemandEC2Cost":
 				return ec.fieldContext_Cost_onDemandEC2Cost(ctx, field)
 			case "adjustedEC2Cost":
@@ -66042,35 +65813,6 @@ func (ec *executionContext) fieldContext_Task_predictedTaskCost(_ context.Contex
 				return ec.fieldContext_Cost_adjustedS3LogStorageCost(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Cost", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Task_predictedTaskCostTotal(ctx context.Context, field graphql.CollectedField, obj *model.APITask) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_Task_predictedTaskCostTotal,
-		func(ctx context.Context) (any, error) {
-			return obj.PredictedTaskCostTotal, nil
-		},
-		nil,
-		ec.marshalOFloat2ᚖfloat64,
-		true,
-		false,
-	)
-}
-
-func (ec *executionContext) fieldContext_Task_predictedTaskCostTotal(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Task",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -66366,8 +66108,6 @@ func (ec *executionContext) fieldContext_Task_versionMetadata(_ context.Context,
 				return ec.fieldContext_Version_childVersions(ctx, field)
 			case "cost":
 				return ec.fieldContext_Version_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Version_costTotal(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
 			case "ingestTime":
@@ -66398,8 +66138,6 @@ func (ec *executionContext) fieldContext_Task_versionMetadata(_ context.Context,
 				return ec.fieldContext_Version_patch(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Version_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Version_predictedCostTotal(ctx, field)
 			case "previousVersion":
 				return ec.fieldContext_Version_previousVersion(ctx, field)
 			case "project":
@@ -67692,12 +67430,8 @@ func (ec *executionContext) fieldContext_TaskHistory_tasks(_ context.Context, fi
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -71912,12 +71646,8 @@ func (ec *executionContext) fieldContext_UpstreamProject_task(_ context.Context,
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -72041,8 +71771,6 @@ func (ec *executionContext) fieldContext_UpstreamProject_version(_ context.Conte
 				return ec.fieldContext_Version_childVersions(ctx, field)
 			case "cost":
 				return ec.fieldContext_Version_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Version_costTotal(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
 			case "ingestTime":
@@ -72073,8 +71801,6 @@ func (ec *executionContext) fieldContext_UpstreamProject_version(_ context.Conte
 				return ec.fieldContext_Version_patch(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Version_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Version_predictedCostTotal(ctx, field)
 			case "previousVersion":
 				return ec.fieldContext_Version_previousVersion(ctx, field)
 			case "project":
@@ -73475,8 +73201,6 @@ func (ec *executionContext) fieldContext_Version_baseVersion(_ context.Context, 
 				return ec.fieldContext_Version_childVersions(ctx, field)
 			case "cost":
 				return ec.fieldContext_Version_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Version_costTotal(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
 			case "ingestTime":
@@ -73507,8 +73231,6 @@ func (ec *executionContext) fieldContext_Version_baseVersion(_ context.Context, 
 				return ec.fieldContext_Version_patch(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Version_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Version_predictedCostTotal(ctx, field)
 			case "previousVersion":
 				return ec.fieldContext_Version_previousVersion(ctx, field)
 			case "project":
@@ -73723,8 +73445,6 @@ func (ec *executionContext) fieldContext_Version_childVersions(_ context.Context
 				return ec.fieldContext_Version_childVersions(ctx, field)
 			case "cost":
 				return ec.fieldContext_Version_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Version_costTotal(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
 			case "ingestTime":
@@ -73755,8 +73475,6 @@ func (ec *executionContext) fieldContext_Version_childVersions(_ context.Context
 				return ec.fieldContext_Version_patch(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Version_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Version_predictedCostTotal(ctx, field)
 			case "previousVersion":
 				return ec.fieldContext_Version_previousVersion(ctx, field)
 			case "project":
@@ -73824,6 +73542,8 @@ func (ec *executionContext) fieldContext_Version_cost(_ context.Context, field g
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "total":
+				return ec.fieldContext_Cost_total(ctx, field)
 			case "onDemandEC2Cost":
 				return ec.fieldContext_Cost_onDemandEC2Cost(ctx, field)
 			case "adjustedEC2Cost":
@@ -73842,35 +73562,6 @@ func (ec *executionContext) fieldContext_Version_cost(_ context.Context, field g
 				return ec.fieldContext_Cost_adjustedS3LogStorageCost(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Cost", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Version_costTotal(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_Version_costTotal,
-		func(ctx context.Context) (any, error) {
-			return obj.CostTotal, nil
-		},
-		nil,
-		ec.marshalOFloat2ᚖfloat64,
-		true,
-		false,
-	)
-}
-
-func (ec *executionContext) fieldContext_Version_costTotal(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Version",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -74393,12 +74084,8 @@ func (ec *executionContext) fieldContext_Version_patch(_ context.Context, field 
 				return ec.fieldContext_Patch_versionFull(ctx, field)
 			case "cost":
 				return ec.fieldContext_Patch_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Patch_costTotal(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Patch_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Patch_predictedCostTotal(ctx, field)
 			case "invalidatedByUpstream":
 				return ec.fieldContext_Patch_invalidatedByUpstream(ctx, field)
 			}
@@ -74432,6 +74119,8 @@ func (ec *executionContext) fieldContext_Version_predictedCost(_ context.Context
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "total":
+				return ec.fieldContext_Cost_total(ctx, field)
 			case "onDemandEC2Cost":
 				return ec.fieldContext_Cost_onDemandEC2Cost(ctx, field)
 			case "adjustedEC2Cost":
@@ -74450,35 +74139,6 @@ func (ec *executionContext) fieldContext_Version_predictedCost(_ context.Context
 				return ec.fieldContext_Cost_adjustedS3LogStorageCost(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Cost", field.Name)
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Version_predictedCostTotal(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_Version_predictedCostTotal,
-		func(ctx context.Context) (any, error) {
-			return obj.PredictedCostTotal, nil
-		},
-		nil,
-		ec.marshalOFloat2ᚖfloat64,
-		true,
-		false,
-	)
-}
-
-func (ec *executionContext) fieldContext_Version_predictedCostTotal(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Version",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Float does not have child fields")
 		},
 	}
 	return fc, nil
@@ -74528,8 +74188,6 @@ func (ec *executionContext) fieldContext_Version_previousVersion(_ context.Conte
 				return ec.fieldContext_Version_childVersions(ctx, field)
 			case "cost":
 				return ec.fieldContext_Version_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Version_costTotal(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
 			case "ingestTime":
@@ -74560,8 +74218,6 @@ func (ec *executionContext) fieldContext_Version_previousVersion(_ context.Conte
 				return ec.fieldContext_Version_patch(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Version_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Version_predictedCostTotal(ctx, field)
 			case "previousVersion":
 				return ec.fieldContext_Version_previousVersion(ctx, field)
 			case "project":
@@ -75431,6 +75087,8 @@ func (ec *executionContext) fieldContext_VersionLite_cost(_ context.Context, fie
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "total":
+				return ec.fieldContext_Cost_total(ctx, field)
 			case "onDemandEC2Cost":
 				return ec.fieldContext_Cost_onDemandEC2Cost(ctx, field)
 			case "adjustedEC2Cost":
@@ -76227,12 +75885,8 @@ func (ec *executionContext) fieldContext_VersionTasks_data(_ context.Context, fi
 				return ec.fieldContext_Task_taskLogs(ctx, field)
 			case "taskCost":
 				return ec.fieldContext_Task_taskCost(ctx, field)
-			case "taskCostTotal":
-				return ec.fieldContext_Task_taskCostTotal(ctx, field)
 			case "predictedTaskCost":
 				return ec.fieldContext_Task_predictedTaskCost(ctx, field)
-			case "predictedTaskCostTotal":
-				return ec.fieldContext_Task_predictedTaskCostTotal(ctx, field)
 			case "taskOwnerTeam":
 				return ec.fieldContext_Task_taskOwnerTeam(ctx, field)
 			case "tests":
@@ -76820,8 +76474,6 @@ func (ec *executionContext) fieldContext_Waterfall_flattenedVersions(_ context.C
 				return ec.fieldContext_Version_childVersions(ctx, field)
 			case "cost":
 				return ec.fieldContext_Version_cost(ctx, field)
-			case "costTotal":
-				return ec.fieldContext_Version_costTotal(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Version_createTime(ctx, field)
 			case "ingestTime":
@@ -76852,8 +76504,6 @@ func (ec *executionContext) fieldContext_Waterfall_flattenedVersions(_ context.C
 				return ec.fieldContext_Version_patch(ctx, field)
 			case "predictedCost":
 				return ec.fieldContext_Version_predictedCost(ctx, field)
-			case "predictedCostTotal":
-				return ec.fieldContext_Version_predictedCostTotal(ctx, field)
 			case "previousVersion":
 				return ec.fieldContext_Version_previousVersion(ctx, field)
 			case "project":
@@ -92183,6 +91833,39 @@ func (ec *executionContext) _Cost(ctx context.Context, sel ast.SelectionSet, obj
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("Cost")
+		case "total":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Cost_total(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "onDemandEC2Cost":
 			out.Values[i] = ec._Cost_onDemandEC2Cost(ctx, field, obj)
 		case "adjustedEC2Cost":
@@ -99080,12 +98763,8 @@ func (ec *executionContext) _Patch(ctx context.Context, sel ast.SelectionSet, ob
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "cost":
 			out.Values[i] = ec._Patch_cost(ctx, field, obj)
-		case "costTotal":
-			out.Values[i] = ec._Patch_costTotal(ctx, field, obj)
 		case "predictedCost":
 			out.Values[i] = ec._Patch_predictedCost(ctx, field, obj)
-		case "predictedCostTotal":
-			out.Values[i] = ec._Patch_predictedCostTotal(ctx, field, obj)
 		case "invalidatedByUpstream":
 			out.Values[i] = ec._Patch_invalidatedByUpstream(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -106202,12 +105881,8 @@ func (ec *executionContext) _Task(ctx context.Context, sel ast.SelectionSet, obj
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "taskCost":
 			out.Values[i] = ec._Task_taskCost(ctx, field, obj)
-		case "taskCostTotal":
-			out.Values[i] = ec._Task_taskCostTotal(ctx, field, obj)
 		case "predictedTaskCost":
 			out.Values[i] = ec._Task_predictedTaskCost(ctx, field, obj)
-		case "predictedTaskCostTotal":
-			out.Values[i] = ec._Task_predictedTaskCostTotal(ctx, field, obj)
 		case "taskOwnerTeam":
 			field := field
 
@@ -109016,8 +108691,6 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "cost":
 			out.Values[i] = ec._Version_cost(ctx, field, obj)
-		case "costTotal":
-			out.Values[i] = ec._Version_costTotal(ctx, field, obj)
 		case "createTime":
 			out.Values[i] = ec._Version_createTime(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -109230,8 +108903,6 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "predictedCost":
 			out.Values[i] = ec._Version_predictedCost(ctx, field, obj)
-		case "predictedCostTotal":
-			out.Values[i] = ec._Version_predictedCostTotal(ctx, field, obj)
 		case "previousVersion":
 			field := field
 

--- a/graphql/schema/types/patch.graphql
+++ b/graphql/schema/types/patch.graphql
@@ -102,12 +102,8 @@ type Patch {
   versionFull: Version
   """Aggregated actual cost for the patch's version, when cost data exists."""
   cost: Cost
-  """Sum of adjusted cost components in cost; excludes on-demand components."""
-  costTotal: Float
   """Aggregated predicted cost for the patch's version."""
   predictedCost: Cost
-  """Sum of adjusted cost components in predictedCost."""
-  predictedCostTotal: Float
   invalidatedByUpstream: Boolean!
 }
 

--- a/graphql/schema/types/task.graphql
+++ b/graphql/schema/types/task.graphql
@@ -149,11 +149,7 @@ type Task {
   stepbackInfo: StepbackInfo
   taskLogs: TaskLogs!
   taskCost: Cost
-  """Sum of adjusted cost components in taskCost; excludes on-demand components."""
-  taskCostTotal: Float
   predictedTaskCost: Cost
-  """Sum of adjusted cost components in predictedTaskCost."""
-  predictedTaskCostTotal: Float
   taskOwnerTeam: TaskOwnerTeam
   tests(opts: TestFilterOptions): TaskTestResult!
   testSelectionEnabled: Boolean!
@@ -337,6 +333,8 @@ type TaskOwnerTeam {
 Cost represents the cost breakdown for a task or version.
 """
 type Cost {
+  """Sum of adjusted cost components; excludes on-demand components."""
+  total: Float
   onDemandEC2Cost: Float
   adjustedEC2Cost: Float
   adjustedEBSStorageCost: Float

--- a/graphql/schema/types/version.graphql
+++ b/graphql/schema/types/version.graphql
@@ -60,8 +60,6 @@ type Version {
   buildVariantStats(options: BuildVariantOptions!): [GroupedTaskStatusCount!]
   childVersions: [Version!]
   cost: Cost
-  """Sum of adjusted cost components in cost; excludes on-demand components."""
-  costTotal: Float
   createTime: Time!
   ingestTime: Time
   errors: [String!]!
@@ -77,8 +75,6 @@ type Version {
   parameters: [Parameter!]!
   patch: Patch
   predictedCost: Cost
-  """Sum of adjusted cost components in predictedCost."""
-  predictedCostTotal: Float
   previousVersion: Version
   project: String!
   projectIdentifier: String!

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/annotations"
 	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/cost"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -19,6 +20,14 @@ import (
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 )
+
+// Total is the field resolver for Cost.total.
+func (r *costResolver) Total(ctx context.Context, obj *cost.Cost) (*float64, error) {
+	if obj == nil {
+		return nil, nil
+	}
+	return utility.ToFloat64Ptr(obj.TotalAdjusted()), nil
+}
 
 // AbortInfo is the resolver for the abortInfo field.
 func (r *taskResolver) AbortInfo(ctx context.Context, obj *restModel.APITask) (*AbortInfo, error) {
@@ -866,7 +875,11 @@ func (r *taskResolver) VersionMetadata(ctx context.Context, obj *restModel.APITa
 	return apiVersion, nil
 }
 
+// Cost returns CostResolver implementation.
+func (r *Resolver) Cost() CostResolver { return &costResolver{r} }
+
 // Task returns TaskResolver implementation.
 func (r *Resolver) Task() TaskResolver { return &taskResolver{r} }
 
+type costResolver struct{ *Resolver }
 type taskResolver struct{ *Resolver }

--- a/model/cost/cost.go
+++ b/model/cost/cost.go
@@ -21,6 +21,8 @@ var (
 
 // Cost represents a cost breakdown for tasks and versions
 type Cost struct {
+	// Total is the sum of adjusted cost components.
+	Total float64 `bson:"-" json:"total,omitempty"`
 	// OnDemandEC2Cost is the cost calculated using only on-demand rates.
 	OnDemandEC2Cost float64 `bson:"on_demand_ec2_cost,omitempty" json:"on_demand_ec2_cost,omitempty"`
 	// AdjustedEC2Cost is the cost calculated using the finance formula with savings plan and on-demand components.

--- a/model/cost/cost_test.go
+++ b/model/cost/cost_test.go
@@ -71,3 +71,14 @@ func TestCostJSONIncludesEBSThroughputFieldsWhenZero(t *testing.T) {
 	assert.Equal(t, 0.0, unmarshaled["adjusted_ebs_throughput_cost"])
 	assert.Equal(t, 0.0, unmarshaled["adjusted_ebs_storage_cost"])
 }
+
+func TestCostJSONSerializesTotalWhenSet(t *testing.T) {
+	c := Cost{OnDemandEC2Cost: 1, AdjustedEC2Cost: 0.5}
+	c.Total = c.TotalAdjusted()
+	data, err := json.Marshal(c)
+	require.NoError(t, err)
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &m))
+	assert.InDelta(t, 0.5, m["total"], 1e-9)
+	assert.InDelta(t, 1.0, m["on_demand_ec2_cost"], 1e-9)
+}

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -43,12 +43,8 @@ type APIPatch struct {
 	Version *string `json:"version"`
 	// Aggregated actual cost of the patch's version (empty until the patch is finalized to a version with cost data).
 	Cost *cost.Cost `json:"cost,omitempty"`
-	// CostTotal is the sum of all adjusted cost components in Cost.
-	CostTotal *float64 `json:"cost_total,omitempty"`
 	// Aggregated predicted cost of the patch's version.
 	PredictedCost *cost.Cost `json:"predicted_cost,omitempty"`
-	// PredictedCostTotal is the sum of all adjusted cost components in PredictedCost.
-	PredictedCostTotal *float64 `json:"predicted_cost_total,omitempty"`
 	// Status of patch (possible values are "created", "started", "success", or "failed")
 	Status *string `json:"status"`
 	// Time patch was created
@@ -342,13 +338,13 @@ func (apiPatch *APIPatch) populateCostFromVersion(ctx context.Context, versionID
 	}
 	if !v.Cost.IsZero() {
 		versionCost := v.Cost
+		versionCost.Total = versionCost.TotalAdjusted()
 		apiPatch.Cost = &versionCost
-		apiPatch.CostTotal = utility.ToFloat64Ptr(TotalAdjustedCost(versionCost))
 	}
 	if !v.PredictedCost.IsZero() {
 		predictedCost := v.PredictedCost
+		predictedCost.Total = predictedCost.TotalAdjusted()
 		apiPatch.PredictedCost = &predictedCost
-		apiPatch.PredictedCostTotal = utility.ToFloat64Ptr(TotalAdjustedCost(predictedCost))
 	}
 }
 

--- a/rest/model/patch_test.go
+++ b/rest/model/patch_test.go
@@ -146,11 +146,9 @@ func TestAPIPatchBuildFromServiceVersionCost(t *testing.T) {
 	require.NoError(t, api.BuildFromService(ctx, p, nil))
 
 	require.NotNil(t, api.Cost)
-	require.NotNil(t, api.CostTotal)
-	assert.InDelta(t, 10.5, *api.CostTotal, 0.001)
+	assert.InDelta(t, 10.5, api.Cost.Total, 0.001)
 	require.NotNil(t, api.PredictedCost)
-	require.NotNil(t, api.PredictedCostTotal)
-	assert.InDelta(t, 2.0, *api.PredictedCostTotal, 0.001)
+	assert.InDelta(t, 2.0, api.PredictedCost.Total, 0.001)
 }
 
 func TestAPIPatchBuildModuleChanges(t *testing.T) {

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -727,4 +727,3 @@ func (i *APIGeneratedTaskInfo) BuildFromService(dbInfo task.GeneratedTaskInfo) {
 type APINumTasksToFinalize struct {
 	NumTasksToFinalize *int `json:"num_tasks_to_finalize"`
 }
-

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -93,12 +93,8 @@ type APITask struct {
 	TimeTaken APIDuration `json:"time_taken_ms"`
 	// Cost breakdown for running this task
 	TaskCost *cost.Cost `json:"task_cost,omitempty"`
-	// TaskCostTotal is the sum of all adjusted cost components in TaskCost (convenience for clients).
-	TaskCostTotal *float64 `json:"task_cost_total,omitempty"`
 	// Predicted cost breakdown based on historical task costs
 	PredictedTaskCost *cost.Cost `json:"predicted_task_cost,omitempty"`
-	// PredictedTaskCostTotal is the sum of all adjusted cost components in PredictedTaskCost.
-	PredictedTaskCostTotal *float64 `json:"predicted_task_cost_total,omitempty"`
 	// S3 API usage metrics for this task
 	S3Usage *s3usage.S3Usage `json:"s3_usage,omitempty"`
 	// Number of milliseconds expected for this task to execute
@@ -412,15 +408,15 @@ func (at *APITask) buildTask(t *task.Task) error {
 
 	if !t.TaskCost.IsZero() {
 		taskCost := t.TaskCost
+		taskCost.Total = taskCost.TotalAdjusted()
 		at.TaskCost = &taskCost
-		at.TaskCostTotal = utility.ToFloat64Ptr(TotalAdjustedCost(taskCost))
 	}
 
 	// Populate expected cost fields if they exist (not zero)
 	if !t.PredictedTaskCost.IsZero() {
 		predictedCost := t.PredictedTaskCost
+		predictedCost.Total = predictedCost.TotalAdjusted()
 		at.PredictedTaskCost = &predictedCost
-		at.PredictedTaskCostTotal = utility.ToFloat64Ptr(TotalAdjustedCost(predictedCost))
 	}
 
 	if !t.S3Usage.IsZero() {
@@ -606,6 +602,7 @@ func (at *APITask) ToService() (*task.Task, error) {
 
 	if at.TaskCost != nil {
 		st.TaskCost = *at.TaskCost
+		st.TaskCost.Total = 0
 	}
 
 	if at.S3Usage != nil {
@@ -731,7 +728,3 @@ type APINumTasksToFinalize struct {
 	NumTasksToFinalize *int `json:"num_tasks_to_finalize"`
 }
 
-// TotalAdjustedCost returns the sum of all adjusted cost components.
-func TotalAdjustedCost(c cost.Cost) float64 {
-	return c.TotalAdjusted()
-}

--- a/rest/model/version.go
+++ b/rest/model/version.go
@@ -61,12 +61,8 @@ type APIVersion struct {
 	Ignored *bool `json:"ignored"`
 	// Aggregated actual cost of all tasks in the version
 	Cost *cost.Cost `json:"cost,omitempty"`
-	// CostTotal is the sum of all adjusted cost components in Cost (convenience for clients).
-	CostTotal *float64 `json:"cost_total,omitempty"`
 	// Aggregated predicted cost of all tasks in the version
 	PredictedCost *cost.Cost `json:"predicted_cost,omitempty"`
-	// PredictedCostTotal is the sum of all adjusted cost components in PredictedCost.
-	PredictedCostTotal *float64 `json:"predicted_cost_total,omitempty"`
 	// Aggregated S3 upload metrics across all tasks in the version
 	S3Usage *APIVersionS3Usage `json:"s3_usage,omitempty"`
 }
@@ -156,13 +152,13 @@ func (apiVersion *APIVersion) BuildFromService(ctx context.Context, v model.Vers
 
 	if !v.Cost.IsZero() {
 		versionCost := v.Cost
+		versionCost.Total = versionCost.TotalAdjusted()
 		apiVersion.Cost = &versionCost
-		apiVersion.CostTotal = utility.ToFloat64Ptr(TotalAdjustedCost(versionCost))
 	}
 	if !v.PredictedCost.IsZero() {
 		predictedCost := v.PredictedCost
+		predictedCost.Total = predictedCost.TotalAdjusted()
 		apiVersion.PredictedCost = &predictedCost
-		apiVersion.PredictedCostTotal = utility.ToFloat64Ptr(TotalAdjustedCost(predictedCost))
 	}
 	if !v.S3Usage.IsZero() {
 		apiVersion.S3Usage = &APIVersionS3Usage{

--- a/rest/model/version_test.go
+++ b/rest/model/version_test.go
@@ -132,14 +132,12 @@ func TestVersionBuildFromServiceCost(t *testing.T) {
 		assert.InDelta(t, 12.0, apiVersion.Cost.AdjustedEC2Cost, 0.01)
 		assert.InDelta(t, 0.08, apiVersion.Cost.AdjustedS3ArtifactPutCost, 0.001)
 		assert.InDelta(t, 0.03, apiVersion.Cost.AdjustedS3LogPutCost, 0.001)
-		require.NotNil(t, apiVersion.CostTotal)
-		assert.InDelta(t, 12.0+0.08+0.03, *apiVersion.CostTotal, 0.001)
+		assert.InDelta(t, 12.0+0.08+0.03, apiVersion.Cost.Total, 0.001)
 
 		require.NotNil(t, apiVersion.PredictedCost)
 		assert.InDelta(t, 5.0, apiVersion.PredictedCost.OnDemandEC2Cost, 0.01)
 		assert.InDelta(t, 4.0, apiVersion.PredictedCost.AdjustedEC2Cost, 0.01)
-		require.NotNil(t, apiVersion.PredictedCostTotal)
-		assert.InDelta(t, 4.0, *apiVersion.PredictedCostTotal, 0.01)
+		assert.InDelta(t, 4.0, apiVersion.PredictedCost.Total, 0.01)
 	})
 
 	t.Run("ZeroCostIsNil", func(t *testing.T) {
@@ -211,8 +209,8 @@ func TestAPITaskBuildFromServiceSetsCostTotals(t *testing.T) {
 	}
 	var api APITask
 	require.NoError(t, api.BuildFromService(t.Context(), tsk, nil))
-	require.NotNil(t, api.TaskCostTotal)
-	require.NotNil(t, api.PredictedTaskCostTotal)
-	assert.InDelta(t, 10.05, *api.TaskCostTotal, 0.0001)
-	assert.InDelta(t, 3.0, *api.PredictedTaskCostTotal, 0.0001)
+	require.NotNil(t, api.TaskCost)
+	require.NotNil(t, api.PredictedTaskCost)
+	assert.InDelta(t, 10.05, api.TaskCost.Total, 0.0001)
+	assert.InDelta(t, 3.0, api.PredictedTaskCost.Total, 0.0001)
 }


### PR DESCRIPTION
DEVPROD-31963

### Description
I merged https://github.com/evergreen-ci/evergreen/pull/10119, but 

<img width="480" height="270" alt="Chris Pratt Marvel GIF by BuzzFeed" src="https://github.com/user-attachments/assets/21ec2753-b573-49b5-86ef-2e0df6d04c43" />

This changes the total cost to be part of the cost struct. 

### Testing
Existing tests 
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- 
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models - If you're adding a field to the Task, Build, Version, or Patch structs, consider creating a
  DPIPE ticket to expose this in the data warehouse.

-->
