### PR TITLE
DEVPROD-31988 Pass successful metadata into host script executed notification

### DIFF
--- a/model/event/host_event.go
+++ b/model/event/host_event.go
@@ -328,7 +328,7 @@ func LogAlertableInstanceTypeWarningSent(ctx context.Context, hostID string) {
 }
 
 func LogHostScriptExecuted(ctx context.Context, hostID string, logs string) {
-	LogHostEvent(ctx, hostID, EventHostScriptExecuted, HostEventData{Logs: logs})
+	LogHostEvent(ctx, hostID, EventHostScriptExecuted, HostEventData{Logs: logs, Successful: true})
 }
 
 func LogHostScriptExecuteFailed(ctx context.Context, hostID, logs string, err error) {


### PR DESCRIPTION
DEVPROD-31988

### Description
Spawn host setup script notifications dont pass in any indication of whether they were successful so their slacks always show as red even when they succeed. They just need to pass in successful: true for when they succeed!

### Testing
Verified in staging