### PR TITLE
DEVPROD-27060 Add child patch costs to the total patch cost 

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -413,6 +413,7 @@ type ComplexityRoot struct {
 		AdjustedS3ArtifactStorageCost func(childComplexity int) int
 		AdjustedS3LogPutCost          func(childComplexity int) int
 		AdjustedS3LogStorageCost      func(childComplexity int) int
+		ChildPatchesTotalCost         func(childComplexity int) int
 		OnDemandEC2Cost               func(childComplexity int) int
 		Total                         func(childComplexity int) int
 	}
@@ -4164,6 +4165,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Cost.AdjustedS3LogStorageCost(childComplexity), true
+	case "Cost.childPatchesTotalCost":
+		if e.complexity.Cost.ChildPatchesTotalCost == nil {
+			break
+		}
+
+		return e.complexity.Cost.ChildPatchesTotalCost(childComplexity), true
 	case "Cost.onDemandEC2Cost":
 		if e.complexity.Cost.OnDemandEC2Cost == nil {
 			break
@@ -24097,6 +24104,35 @@ func (ec *executionContext) fieldContext_Cost_total(_ context.Context, field gra
 		Field:      field,
 		IsMethod:   true,
 		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Cost_childPatchesTotalCost(ctx context.Context, field graphql.CollectedField, obj *cost.Cost) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Cost_childPatchesTotalCost,
+		func(ctx context.Context) (any, error) {
+			return obj.ChildPatchesTotalCost, nil
+		},
+		nil,
+		ec.marshalOFloat2float64,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_Cost_childPatchesTotalCost(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Cost",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Float does not have child fields")
 		},
@@ -45332,6 +45368,8 @@ func (ec *executionContext) fieldContext_Patch_cost(_ context.Context, field gra
 			switch field.Name {
 			case "total":
 				return ec.fieldContext_Cost_total(ctx, field)
+			case "childPatchesTotalCost":
+				return ec.fieldContext_Cost_childPatchesTotalCost(ctx, field)
 			case "onDemandEC2Cost":
 				return ec.fieldContext_Cost_onDemandEC2Cost(ctx, field)
 			case "adjustedEC2Cost":
@@ -45381,6 +45419,8 @@ func (ec *executionContext) fieldContext_Patch_predictedCost(_ context.Context, 
 			switch field.Name {
 			case "total":
 				return ec.fieldContext_Cost_total(ctx, field)
+			case "childPatchesTotalCost":
+				return ec.fieldContext_Cost_childPatchesTotalCost(ctx, field)
 			case "onDemandEC2Cost":
 				return ec.fieldContext_Cost_onDemandEC2Cost(ctx, field)
 			case "adjustedEC2Cost":
@@ -65746,6 +65786,8 @@ func (ec *executionContext) fieldContext_Task_taskCost(_ context.Context, field 
 			switch field.Name {
 			case "total":
 				return ec.fieldContext_Cost_total(ctx, field)
+			case "childPatchesTotalCost":
+				return ec.fieldContext_Cost_childPatchesTotalCost(ctx, field)
 			case "onDemandEC2Cost":
 				return ec.fieldContext_Cost_onDemandEC2Cost(ctx, field)
 			case "adjustedEC2Cost":
@@ -65795,6 +65837,8 @@ func (ec *executionContext) fieldContext_Task_predictedTaskCost(_ context.Contex
 			switch field.Name {
 			case "total":
 				return ec.fieldContext_Cost_total(ctx, field)
+			case "childPatchesTotalCost":
+				return ec.fieldContext_Cost_childPatchesTotalCost(ctx, field)
 			case "onDemandEC2Cost":
 				return ec.fieldContext_Cost_onDemandEC2Cost(ctx, field)
 			case "adjustedEC2Cost":
@@ -73544,6 +73588,8 @@ func (ec *executionContext) fieldContext_Version_cost(_ context.Context, field g
 			switch field.Name {
 			case "total":
 				return ec.fieldContext_Cost_total(ctx, field)
+			case "childPatchesTotalCost":
+				return ec.fieldContext_Cost_childPatchesTotalCost(ctx, field)
 			case "onDemandEC2Cost":
 				return ec.fieldContext_Cost_onDemandEC2Cost(ctx, field)
 			case "adjustedEC2Cost":
@@ -74121,6 +74167,8 @@ func (ec *executionContext) fieldContext_Version_predictedCost(_ context.Context
 			switch field.Name {
 			case "total":
 				return ec.fieldContext_Cost_total(ctx, field)
+			case "childPatchesTotalCost":
+				return ec.fieldContext_Cost_childPatchesTotalCost(ctx, field)
 			case "onDemandEC2Cost":
 				return ec.fieldContext_Cost_onDemandEC2Cost(ctx, field)
 			case "adjustedEC2Cost":
@@ -75089,6 +75137,8 @@ func (ec *executionContext) fieldContext_VersionLite_cost(_ context.Context, fie
 			switch field.Name {
 			case "total":
 				return ec.fieldContext_Cost_total(ctx, field)
+			case "childPatchesTotalCost":
+				return ec.fieldContext_Cost_childPatchesTotalCost(ctx, field)
 			case "onDemandEC2Cost":
 				return ec.fieldContext_Cost_onDemandEC2Cost(ctx, field)
 			case "adjustedEC2Cost":
@@ -91866,6 +91916,8 @@ func (ec *executionContext) _Cost(ctx context.Context, sel ast.SelectionSet, obj
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "childPatchesTotalCost":
+			out.Values[i] = ec._Cost_childPatchesTotalCost(ctx, field, obj)
 		case "onDemandEC2Cost":
 			out.Values[i] = ec._Cost_onDemandEC2Cost(ctx, field, obj)
 		case "adjustedEC2Cost":

--- a/graphql/schema/types/task.graphql
+++ b/graphql/schema/types/task.graphql
@@ -335,6 +335,7 @@ Cost represents the cost breakdown for a task or version.
 type Cost {
   """Sum of adjusted cost components; excludes on-demand components."""
   total: Float
+  childPatchesTotalCost: Float
   onDemandEC2Cost: Float
   adjustedEC2Cost: Float
   adjustedEBSStorageCost: Float

--- a/model/cost/cost.go
+++ b/model/cost/cost.go
@@ -68,6 +68,20 @@ func (c Cost) TotalAdjusted() float64 {
 		c.ChildPatchesTotalCost
 }
 
+// SumPerChildVersionAdjustedTotals sums actual and predicted adjusted costs for n children;
+func SumPerChildVersionAdjustedTotals(n int, childAt func(int) (actual, predicted *Cost)) (sumActual, sumPred float64) {
+	for i := 0; i < n; i++ {
+		actual, predicted := childAt(i)
+		if actual != nil {
+			sumActual += actual.TotalAdjusted()
+		}
+		if predicted != nil {
+			sumPred += predicted.TotalAdjusted()
+		}
+	}
+	return
+}
+
 // IsZero returns true if all cost components are zero.
 func (c Cost) IsZero() bool {
 	return c.OnDemandEC2Cost == 0 &&

--- a/model/cost/cost.go
+++ b/model/cost/cost.go
@@ -51,6 +51,8 @@ type Cost struct {
 	OnDemandS3LogStorageCost float64 `bson:"on_demand_s3_log_storage_cost,omitempty" json:"-"`
 	// AdjustedS3LogStorageCost is the adjusted (discounted) S3 storage cost for log bytes over their retention period.
 	AdjustedS3LogStorageCost float64 `bson:"adjusted_s3_log_storage_cost,omitempty" json:"adjusted_s3_log_storage_cost,omitempty"`
+	// ChildPatchesTotalCost is the total cost for child patches.
+	ChildPatchesTotalCost float64 `bson:"-" json:"child_patches_total_cost,omitempty"`
 }
 
 // TotalAdjusted returns the sum of every adjusted component in this value, excluding on-demand fields,
@@ -62,7 +64,8 @@ func (c Cost) TotalAdjusted() float64 {
 		c.AdjustedS3ArtifactPutCost +
 		c.AdjustedS3LogPutCost +
 		c.AdjustedS3ArtifactStorageCost +
-		c.AdjustedS3LogStorageCost
+		c.AdjustedS3LogStorageCost +
+		c.ChildPatchesTotalCost
 }
 
 // IsZero returns true if all cost components are zero.
@@ -80,5 +83,6 @@ func (c Cost) IsZero() bool {
 		c.AdjustedS3ArtifactPutCost == 0 &&
 		c.AdjustedS3LogPutCost == 0 &&
 		c.AdjustedS3ArtifactStorageCost == 0 &&
-		c.AdjustedS3LogStorageCost == 0
+		c.AdjustedS3LogStorageCost == 0 &&
+		c.ChildPatchesTotalCost == 0
 }

--- a/model/cost/cost_test.go
+++ b/model/cost/cost_test.go
@@ -8,6 +8,35 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSumPerChildVersionAdjustedTotals(t *testing.T) {
+	one := Cost{AdjustedEC2Cost: 1.0}
+	two := Cost{AdjustedEBSStorageCost: 2.0}
+	three := Cost{AdjustedS3LogPutCost: 0.5}
+	t.Run("IndicesAndNils", func(t *testing.T) {
+		a, p := SumPerChildVersionAdjustedTotals(3, func(i int) (actual, predicted *Cost) {
+			switch i {
+			case 0:
+				return &one, &two
+			case 1:
+				return &two, nil
+			case 2:
+				return nil, &three
+			}
+			return nil, nil
+		})
+		// 1+2+0 actual; 2+0+0.5 predicted
+		assert.InDelta(t, 3.0, a, 1e-9)
+		assert.InDelta(t, 2.5, p, 1e-9)
+	})
+	t.Run("NZero", func(t *testing.T) {
+		a, p := SumPerChildVersionAdjustedTotals(0, func(int) (actual, predicted *Cost) {
+			return nil, nil
+		})
+		assert.InDelta(t, 0, a, 1e-9)
+		assert.InDelta(t, 0, p, 1e-9)
+	})
+}
+
 func TestCostTotalAdjusted(t *testing.T) {
 	c := Cost{
 		AdjustedEC2Cost:               1,

--- a/model/cost/cost_test.go
+++ b/model/cost/cost_test.go
@@ -20,6 +20,10 @@ func TestCostTotalAdjusted(t *testing.T) {
 		OnDemandEC2Cost:               100,
 	}
 	assert.InDelta(t, 8.0, c.TotalAdjusted(), 1e-9)
+
+	withChildren := c
+	withChildren.ChildPatchesTotalCost = 2
+	assert.InDelta(t, 10.0, withChildren.TotalAdjusted(), 1e-9)
 }
 
 func TestCostIsZero(t *testing.T) {
@@ -50,6 +54,11 @@ func TestCostIsZero(t *testing.T) {
 
 	t.Run("NonZeroOnDemandS3LogPutCost", func(t *testing.T) {
 		cost := Cost{OnDemandS3LogPutCost: 0.00003}
+		assert.False(t, cost.IsZero())
+	})
+
+	t.Run("NonZeroChildPatchesTotalCost", func(t *testing.T) {
+		cost := Cost{ChildPatchesTotalCost: 1.0}
 		assert.False(t, cost.IsZero())
 	})
 }

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -186,16 +186,12 @@ func (apiPatch *APIPatch) BuildFromService(ctx context.Context, p patch.Patch, a
 	apiPatch.buildModuleChanges(p, projectIdentifier)
 
 	if args != nil && args.IncludeChildPatches {
-		err := apiPatch.buildChildPatches(ctx, p)
+		childPatchDocs, err := apiPatch.buildChildPatches(ctx, p)
 		if err != nil {
 			return err
 		}
-		if p.IsParent() && len(p.Triggers.ChildPatches) > 0 {
-			childPatches, err := patch.Find(ctx, patch.ByStringIds(p.Triggers.ChildPatches))
-			if err != nil {
-				return errors.Wrap(err, "getting child patches for time calculations")
-			}
-			for _, childPatch := range childPatches {
+		if p.IsParent() && len(childPatchDocs) > 0 {
+			for _, childPatch := range childPatchDocs {
 				if !childPatch.StartTime.IsZero() && childPatch.StartTime.Before(utility.FromTimePtr(apiPatch.StartTime)) {
 					apiPatch.StartTime = ToTimePtr(childPatch.StartTime)
 				}
@@ -348,13 +344,13 @@ func (apiPatch *APIPatch) populateCostFromVersion(ctx context.Context, versionID
 	}
 }
 
-func getChildPatchesData(ctx context.Context, p patch.Patch) ([]DownstreamTasks, []APIPatch, error) {
+func getChildPatchesData(ctx context.Context, p patch.Patch) ([]DownstreamTasks, []APIPatch, []patch.Patch, error) {
 	if len(p.Triggers.ChildPatches) <= 0 {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 	childPatches, err := patch.Find(ctx, patch.ByStringIds(p.Triggers.ChildPatches))
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "getting child patches")
+		return nil, nil, nil, errors.Wrap(err, "getting child patches")
 	}
 	downstreamTasks := []DownstreamTasks{}
 	apiChildPatches := []APIPatch{}
@@ -380,23 +376,48 @@ func getChildPatchesData(ctx context.Context, p patch.Patch) ([]DownstreamTasks,
 		apiPatch := APIPatch{}
 		err = apiPatch.BuildFromService(ctx, childPatch, &APIPatchArgs{IncludeProjectIdentifier: true})
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "converting child patch to API model")
+			return nil, nil, nil, errors.Wrap(err, "converting child patch to API model")
 		}
 		downstreamTasks = append(downstreamTasks, dt)
 		apiChildPatches = append(apiChildPatches, apiPatch)
 	}
-	return downstreamTasks, apiChildPatches, nil
+	return downstreamTasks, apiChildPatches, childPatches, nil
 }
 
-func (apiPatch *APIPatch) buildChildPatches(ctx context.Context, p patch.Patch) error {
-	downstreamTasks, childPatches, err := getChildPatchesData(ctx, p)
+func addChildPatchesCostToParent(apiPatch *APIPatch, childPatches []APIPatch) {
+	var actualSum, predictedSum float64
+	for _, c := range childPatches {
+		if c.Cost != nil {
+			actualSum += c.Cost.TotalAdjusted()
+		}
+		if c.PredictedCost != nil {
+			predictedSum += c.PredictedCost.TotalAdjusted()
+		}
+	}
+	merge := func(dest **cost.Cost, sum float64) {
+		if sum == 0 {
+			return
+		}
+		if *dest == nil {
+			*dest = &cost.Cost{}
+		}
+		(*dest).ChildPatchesTotalCost = sum
+		(*dest).Total = (*dest).TotalAdjusted()
+	}
+	merge(&apiPatch.Cost, actualSum)
+	merge(&apiPatch.PredictedCost, predictedSum)
+}
+
+func (apiPatch *APIPatch) buildChildPatches(ctx context.Context, p patch.Patch) ([]patch.Patch, error) {
+	downstreamTasks, childPatches, childPatchDocs, err := getChildPatchesData(ctx, p)
 	if err != nil {
-		return errors.Wrap(err, "getting downstream tasks")
+		return nil, errors.Wrap(err, "getting downstream tasks")
 	}
 	apiPatch.DownstreamTasks = downstreamTasks
 	apiPatch.ChildPatches = childPatches
+	addChildPatchesCostToParent(apiPatch, childPatches)
 	if len(childPatches) == 0 {
-		return nil
+		return childPatchDocs, nil
 	}
 	// set the patch status to the collective status between the parent and child patches
 	// Also correlate each child patch ID with the alias that invoked it
@@ -416,7 +437,7 @@ func (apiPatch *APIPatch) buildChildPatches(ctx context.Context, p patch.Patch) 
 	apiPatch.Status = utility.ToStringPtr(patch.GetCollectiveStatusFromPatchStatuses(allStatuses))
 	apiPatch.ChildPatchAliases = childPatchAliases
 
-	return nil
+	return childPatchDocs, nil
 }
 
 func (apiPatch *APIPatch) buildModuleChanges(p patch.Patch, identifier string) {

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -385,15 +385,9 @@ func getChildPatchesData(ctx context.Context, p patch.Patch) ([]DownstreamTasks,
 }
 
 func addChildPatchesCostToParent(apiPatch *APIPatch, childPatches []APIPatch) {
-	var actualSum, predictedSum float64
-	for _, c := range childPatches {
-		if c.Cost != nil {
-			actualSum += c.Cost.TotalAdjusted()
-		}
-		if c.PredictedCost != nil {
-			predictedSum += c.PredictedCost.TotalAdjusted()
-		}
-	}
+	actualSum, predictedSum := cost.SumPerChildVersionAdjustedTotals(len(childPatches), func(i int) (actual, predicted *cost.Cost) {
+		return childPatches[i].Cost, childPatches[i].PredictedCost
+	})
 	merge := func(dest **cost.Cost, sum float64) {
 		if sum == 0 {
 			return

--- a/rest/model/patch_test.go
+++ b/rest/model/patch_test.go
@@ -105,6 +105,69 @@ func TestAPIPatch(t *testing.T) {
 	assert.Len(a.VariantsTasks[0].Tasks, 1)
 }
 
+func TestAddChildPatchesCostToParent(t *testing.T) {
+	t.Run("emptyLeavesCostsNil", func(t *testing.T) {
+		api := APIPatch{}
+		addChildPatchesCostToParent(&api, nil)
+		assert.Nil(t, api.Cost)
+		assert.Nil(t, api.PredictedCost)
+	})
+
+	t.Run("sumsActualAndPredictedAcrossChildren", func(t *testing.T) {
+		api := APIPatch{}
+		children := []APIPatch{
+			{
+				Cost:          &cost.Cost{AdjustedEC2Cost: 1},
+				PredictedCost: &cost.Cost{AdjustedEC2Cost: 10},
+			},
+			{
+				Cost:          &cost.Cost{AdjustedS3LogPutCost: 2},
+				PredictedCost: &cost.Cost{AdjustedS3LogPutCost: 3},
+			},
+		}
+		addChildPatchesCostToParent(&api, children)
+		require.NotNil(t, api.Cost)
+		assert.InDelta(t, 3.0, api.Cost.ChildPatchesTotalCost, 1e-9)
+		assert.InDelta(t, 3.0, api.Cost.Total, 1e-9)
+		require.NotNil(t, api.PredictedCost)
+		assert.InDelta(t, 13.0, api.PredictedCost.ChildPatchesTotalCost, 1e-9)
+		assert.InDelta(t, 13.0, api.PredictedCost.Total, 1e-9)
+	})
+
+	t.Run("mergesIntoExistingParentCost", func(t *testing.T) {
+		api := APIPatch{
+			Cost: &cost.Cost{AdjustedEC2Cost: 5},
+		}
+		addChildPatchesCostToParent(&api, []APIPatch{
+			{Cost: &cost.Cost{AdjustedEC2Cost: 2}},
+		})
+		require.NotNil(t, api.Cost)
+		assert.InDelta(t, 2.0, api.Cost.ChildPatchesTotalCost, 1e-9)
+		assert.InDelta(t, 7.0, api.Cost.Total, 1e-9)
+	})
+
+	t.Run("predictedOnlyWhenNoActual", func(t *testing.T) {
+		api := APIPatch{}
+		addChildPatchesCostToParent(&api, []APIPatch{
+			{PredictedCost: &cost.Cost{AdjustedEC2Cost: 4}},
+		})
+		assert.Nil(t, api.Cost)
+		require.NotNil(t, api.PredictedCost)
+		assert.InDelta(t, 4.0, api.PredictedCost.ChildPatchesTotalCost, 1e-9)
+		assert.InDelta(t, 4.0, api.PredictedCost.Total, 1e-9)
+	})
+
+	t.Run("allNilChildCostsLeavesParentNil", func(t *testing.T) {
+		api := APIPatch{}
+		addChildPatchesCostToParent(&api, []APIPatch{
+			{},
+			{Cost: nil, PredictedCost: nil},
+		})
+		assert.Nil(t, api.Cost)
+		assert.Nil(t, api.PredictedCost)
+	})
+}
+
 func TestAPIPatchBuildFromServiceVersionCost(t *testing.T) {
 	ctx := t.Context()
 	require.NoError(t, db.ClearCollections(model.VersionCollection, model.ProjectRefCollection))


### PR DESCRIPTION
DEVPROD-27060

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Adds a childPatchesTotalCost field on Cost and rolls up each child patch’s adjusted cost onto the parent patch when child patches are included.



### Testing
Added tests and tested on staging
<img width="508" height="160" alt="image" src="https://github.com/user-attachments/assets/a49178e0-c97f-4a14-b4b0-d287541b270b" />



<!-- 
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models - If you're adding a field to the Task, Build, Version, or Patch structs, consider creating a
  DPIPE ticket to expose this in the data warehouse.

-->
