### PR TITLE
DEVPROD-32091: Individual GitHub tabs should only modify their own aliases

### DIFF
--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -646,7 +646,7 @@ func (r *mutationResolver) SaveProjectSettingsForSection(ctx context.Context, pr
 	projectId := utility.FromStringPtr(projectSettings.ProjectRef.Id)
 	usr := mustHaveUser(ctx)
 
-err := data.SaveProjectSettingsForSection(ctx, projectId, projectSettings, model.ProjectPageSection(section), false, usr.Username())
+	changes, err := data.SaveProjectSettingsForSection(ctx, projectId, projectSettings, model.ProjectPageSection(section), false, usr.Username())
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())
 	}

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -645,7 +645,28 @@ func (r *mutationResolver) PromoteVarsToRepo(ctx context.Context, opts PromoteVa
 func (r *mutationResolver) SaveProjectSettingsForSection(ctx context.Context, projectSettings *restModel.APIProjectSettings, section ProjectSettingsSection) (*restModel.APIProjectSettings, error) {
 	projectId := utility.FromStringPtr(projectSettings.ProjectRef.Id)
 	usr := mustHaveUser(ctx)
-	changes, err := data.SaveProjectSettingsForSection(ctx, projectId, projectSettings, model.ProjectPageSection(section), false, usr.Username())
+
+	var pageSection model.ProjectPageSection
+	switch section {
+	// TODO DEVPROD-31534: Remove GithubAndCommitQueueSection
+	case ProjectSettingsSectionGithubAndCommitQueue:
+		pageSection = model.ProjectPageGithubAndCQSection
+	case ProjectSettingsSectionPullRequests:
+		pageSection = model.ProjectPagePullRequestsSection
+	case ProjectSettingsSectionGitTags:
+		pageSection = model.ProjectPageGitTagsSection
+	case ProjectSettingsSectionMergeQueue:
+		pageSection = model.ProjectPageMergeQueueSection
+	case ProjectSettingsSectionCommitChecks:
+		pageSection = model.ProjectPageCommitChecksSection
+	case ProjectSettingsSectionPatchAliases:
+		pageSection = model.ProjectPagePatchAliasSection
+	default:
+		// Fallback to the previous behavior for any older/unknown values.
+		pageSection = model.ProjectPageSection(section)
+	}
+
+	changes, err := data.SaveProjectSettingsForSection(ctx, projectId, projectSettings, pageSection, false, usr.Username())
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())
 	}

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -646,27 +646,7 @@ func (r *mutationResolver) SaveProjectSettingsForSection(ctx context.Context, pr
 	projectId := utility.FromStringPtr(projectSettings.ProjectRef.Id)
 	usr := mustHaveUser(ctx)
 
-	var pageSection model.ProjectPageSection
-	switch section {
-	// TODO DEVPROD-31534: Remove GithubAndCommitQueueSection
-	case ProjectSettingsSectionGithubAndCommitQueue:
-		pageSection = model.ProjectPageGithubAndCQSection
-	case ProjectSettingsSectionPullRequests:
-		pageSection = model.ProjectPagePullRequestsSection
-	case ProjectSettingsSectionGitTags:
-		pageSection = model.ProjectPageGitTagsSection
-	case ProjectSettingsSectionMergeQueue:
-		pageSection = model.ProjectPageMergeQueueSection
-	case ProjectSettingsSectionCommitChecks:
-		pageSection = model.ProjectPageCommitChecksSection
-	case ProjectSettingsSectionPatchAliases:
-		pageSection = model.ProjectPagePatchAliasSection
-	default:
-		// Fallback to the previous behavior for any older/unknown values.
-		pageSection = model.ProjectPageSection(section)
-	}
-
-	changes, err := data.SaveProjectSettingsForSection(ctx, projectId, projectSettings, pageSection, false, usr.Username())
+err := data.SaveProjectSettingsForSection(ctx, projectId, projectSettings, model.ProjectPageSection(section), false, usr.Username())
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())
 	}

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -645,7 +645,6 @@ func (r *mutationResolver) PromoteVarsToRepo(ctx context.Context, opts PromoteVa
 func (r *mutationResolver) SaveProjectSettingsForSection(ctx context.Context, projectSettings *restModel.APIProjectSettings, section ProjectSettingsSection) (*restModel.APIProjectSettings, error) {
 	projectId := utility.FromStringPtr(projectSettings.ProjectRef.Id)
 	usr := mustHaveUser(ctx)
-
 	changes, err := data.SaveProjectSettingsForSection(ctx, projectId, projectSettings, model.ProjectPageSection(section), false, usr.Username())
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())

--- a/graphql/tests/mutation/saveProjectSettingsForSection/queries/commit_checks_section.graphql
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/queries/commit_checks_section.graphql
@@ -28,7 +28,6 @@ mutation {
       vars ## should be unchanged
     }
     aliases {
-      id
       alias
     }
   }

--- a/graphql/tests/mutation/saveProjectSettingsForSection/queries/commit_checks_section.graphql
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/queries/commit_checks_section.graphql
@@ -27,5 +27,9 @@ mutation {
     vars {
       vars ## should be unchanged
     }
+    aliases {
+      id
+      alias
+    }
   }
 }

--- a/graphql/tests/mutation/saveProjectSettingsForSection/queries/git_tags_section.graphql
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/queries/git_tags_section.graphql
@@ -31,5 +31,9 @@ mutation {
     vars {
       vars ## should be unchanged
     }
+    aliases {
+      id
+      alias
+    }
   }
 }

--- a/graphql/tests/mutation/saveProjectSettingsForSection/queries/git_tags_section.graphql
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/queries/git_tags_section.graphql
@@ -32,7 +32,6 @@ mutation {
       vars ## should be unchanged
     }
     aliases {
-      id
       alias
     }
   }

--- a/graphql/tests/mutation/saveProjectSettingsForSection/queries/merge_queue_section.graphql
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/queries/merge_queue_section.graphql
@@ -29,5 +29,9 @@ mutation {
     vars {
       vars ## should be unchanged
     }
+    aliases {
+      id
+      alias
+    }
   }
 }

--- a/graphql/tests/mutation/saveProjectSettingsForSection/queries/merge_queue_section.graphql
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/queries/merge_queue_section.graphql
@@ -30,7 +30,6 @@ mutation {
       vars ## should be unchanged
     }
     aliases {
-      id
       alias
     }
   }

--- a/graphql/tests/mutation/saveProjectSettingsForSection/queries/pull_requests_section.graphql
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/queries/pull_requests_section.graphql
@@ -31,5 +31,9 @@ mutation {
     vars {
       vars ## should be unchanged
     }
+    aliases {
+      id
+      alias
+    }
   }
 }

--- a/graphql/tests/mutation/saveProjectSettingsForSection/queries/pull_requests_section.graphql
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/queries/pull_requests_section.graphql
@@ -32,7 +32,6 @@ mutation {
       vars ## should be unchanged
     }
     aliases {
-      id
       alias
     }
   }

--- a/graphql/tests/mutation/saveProjectSettingsForSection/results.json
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/results.json
@@ -325,6 +325,7 @@
               { "alias": "__commit_queue" },
               { "alias": "test" },
               { "alias": "test2" },
+              { "alias": "__github" },
               { "alias": "__git_tag" }
             ]
           }
@@ -347,9 +348,11 @@
               }
             },
             "aliases": [
-              { "alias": "__commit_queue" },
               { "alias": "test" },
-              { "alias": "test2" }
+              { "alias": "test2" },
+              { "alias": "__github" },
+              { "alias": "__git_tag" },
+              { "alias": "__commit_queue" }
             ]
           }
         }
@@ -369,9 +372,11 @@
               }
             },
             "aliases": [
-              { "alias": "__commit_queue" },
               { "alias": "test" },
               { "alias": "test2" },
+              { "alias": "__github" },
+              { "alias": "__git_tag" },
+              { "alias": "__commit_queue" },
               { "alias": "__github_checks" }
             ]
           }

--- a/graphql/tests/mutation/saveProjectSettingsForSection/results.json
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/results.json
@@ -292,22 +292,10 @@
               }
             },
             "aliases": [
-              {
-                "id": "5ffe393097b1d3759dd3c1aa",
-                "alias": "__commit_queue"
-              },
-              {
-                "id": "pr-alias-id-1",
-                "alias": "__github"
-              },
-              {
-                "id": "64c80057d1d6f12b0d4c69d0",
-                "alias": "test"
-              },
-              {
-                "id": "65c80057d1d6f12b0d4c69d0",
-                "alias": "test2"
-              }
+              { "alias": "__commit_queue" },
+              { "alias": "test" },
+              { "alias": "test2" },
+              { "alias": "__github" }
             ]
           }
         }
@@ -334,26 +322,10 @@
               }
             },
             "aliases": [
-              {
-                "id": "5ffe393097b1d3759dd3c1aa",
-                "alias": "__commit_queue"
-              },
-              {
-                "id": "git-tag-alias-id-1",
-                "alias": "__git_tag"
-              },
-              {
-                "id": "pr-alias-id-1",
-                "alias": "__github"
-              },
-              {
-                "id": "64c80057d1d6f12b0d4c69d0",
-                "alias": "test"
-              },
-              {
-                "id": "65c80057d1d6f12b0d4c69d0",
-                "alias": "test2"
-              }
+              { "alias": "__commit_queue" },
+              { "alias": "test" },
+              { "alias": "test2" },
+              { "alias": "__git_tag" }
             ]
           }
         }
@@ -375,26 +347,9 @@
               }
             },
             "aliases": [
-              {
-                "id": "cq-alias-id-1",
-                "alias": "__commit_queue"
-              },
-              {
-                "id": "git-tag-alias-id-1",
-                "alias": "__git_tag"
-              },
-              {
-                "id": "pr-alias-id-1",
-                "alias": "__github"
-              },
-              {
-                "id": "64c80057d1d6f12b0d4c69d0",
-                "alias": "test"
-              },
-              {
-                "id": "65c80057d1d6f12b0d4c69d0",
-                "alias": "test2"
-              }
+              { "alias": "__commit_queue" },
+              { "alias": "test" },
+              { "alias": "test2" }
             ]
           }
         }
@@ -414,30 +369,10 @@
               }
             },
             "aliases": [
-              {
-                "id": "cq-alias-id-1",
-                "alias": "__commit_queue"
-              },
-              {
-                "id": "git-tag-alias-id-1",
-                "alias": "__git_tag"
-              },
-              {
-                "id": "pr-alias-id-1",
-                "alias": "__github"
-              },
-              {
-                "id": "checks-alias-id-1",
-                "alias": "__github_checks"
-              },
-              {
-                "id": "64c80057d1d6f12b0d4c69d0",
-                "alias": "test"
-              },
-              {
-                "id": "65c80057d1d6f12b0d4c69d0",
-                "alias": "test2"
-              }
+              { "alias": "__commit_queue" },
+              { "alias": "test" },
+              { "alias": "test2" },
+              { "alias": "__github_checks" }
             ]
           }
         }

--- a/graphql/tests/mutation/saveProjectSettingsForSection/results.json
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/results.json
@@ -290,7 +290,25 @@
               "vars": {
                 "goodbye": ""
               }
-            }
+            },
+            "aliases": [
+              {
+                "id": "5ffe393097b1d3759dd3c1aa",
+                "alias": "__commit_queue"
+              },
+              {
+                "id": "pr-alias-id-1",
+                "alias": "__github"
+              },
+              {
+                "id": "64c80057d1d6f12b0d4c69d0",
+                "alias": "test"
+              },
+              {
+                "id": "65c80057d1d6f12b0d4c69d0",
+                "alias": "test2"
+              }
+            ]
           }
         }
       }
@@ -314,7 +332,29 @@
               "vars": {
                 "goodbye": ""
               }
-            }
+            },
+            "aliases": [
+              {
+                "id": "5ffe393097b1d3759dd3c1aa",
+                "alias": "__commit_queue"
+              },
+              {
+                "id": "git-tag-alias-id-1",
+                "alias": "__git_tag"
+              },
+              {
+                "id": "pr-alias-id-1",
+                "alias": "__github"
+              },
+              {
+                "id": "64c80057d1d6f12b0d4c69d0",
+                "alias": "test"
+              },
+              {
+                "id": "65c80057d1d6f12b0d4c69d0",
+                "alias": "test2"
+              }
+            ]
           }
         }
       }
@@ -333,7 +373,29 @@
               "vars": {
                 "goodbye": ""
               }
-            }
+            },
+            "aliases": [
+              {
+                "id": "cq-alias-id-1",
+                "alias": "__commit_queue"
+              },
+              {
+                "id": "git-tag-alias-id-1",
+                "alias": "__git_tag"
+              },
+              {
+                "id": "pr-alias-id-1",
+                "alias": "__github"
+              },
+              {
+                "id": "64c80057d1d6f12b0d4c69d0",
+                "alias": "test"
+              },
+              {
+                "id": "65c80057d1d6f12b0d4c69d0",
+                "alias": "test2"
+              }
+            ]
           }
         }
       }
@@ -350,7 +412,33 @@
               "vars": {
                 "goodbye": ""
               }
-            }
+            },
+            "aliases": [
+              {
+                "id": "cq-alias-id-1",
+                "alias": "__commit_queue"
+              },
+              {
+                "id": "git-tag-alias-id-1",
+                "alias": "__git_tag"
+              },
+              {
+                "id": "pr-alias-id-1",
+                "alias": "__github"
+              },
+              {
+                "id": "checks-alias-id-1",
+                "alias": "__github_checks"
+              },
+              {
+                "id": "64c80057d1d6f12b0d4c69d0",
+                "alias": "test"
+              },
+              {
+                "id": "65c80057d1d6f12b0d4c69d0",
+                "alias": "test2"
+              }
+            ]
           }
         }
       }

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -161,19 +161,6 @@ func validateFeaturesHaveAliases(ctx context.Context, originalProjectRef *model.
 	return catcher.Resolve()
 }
 
-func isGithubAliasSection(section model.ProjectPageSection) bool {
-	switch section {
-	case model.ProjectPageGithubAndCQSection, // TODO DEVPROD-31534: remove GithubAndCQSection
-		model.ProjectPagePullRequestsSection,
-		model.ProjectPageMergeQueueSection,
-		model.ProjectPageCommitChecksSection,
-		model.ProjectPageGitTagsSection:
-		return true
-	default:
-		return false
-	}
-}
-
 func shouldSkipAliasForSection(section model.ProjectPageSection, alias string) bool {
 	switch section {
 	// TODO DEVPROD-31534: remove GithubAndCQSection

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -175,13 +175,27 @@ func isGithubAliasSection(section model.ProjectPageSection) bool {
 }
 
 func shouldSkipAliasForSection(section model.ProjectPageSection, alias string) bool {
-	// if we're updating internal aliases, skip non-internal aliases
-	if isGithubAliasSection(section) && model.IsPatchAlias(alias) {
+	switch section {
+	// TODO DEVPROD-31534: remove GithubAndCQSection
+	case model.ProjectPageGithubAndCQSection:
+		if model.IsPatchAlias(alias) {
+			return true
+		}
+		return false
+	case model.ProjectPagePullRequestsSection:
+		return alias != evergreen.GithubPRAlias
+	case model.ProjectPageMergeQueueSection:
+		return alias != evergreen.CommitQueueAlias
+	case model.ProjectPageGitTagsSection:
+		return alias != evergreen.GitTagAlias
+	case model.ProjectPageCommitChecksSection:
+		return alias != evergreen.GithubChecksAlias
+	case model.ProjectPagePatchAliasSection:
+		if !model.IsPatchAlias(alias) {
+			return true
+		}
+		return false
+	default:
 		return true
 	}
-	// if we're updating patch aliases, skip internal aliases
-	if section == model.ProjectPagePatchAliasSection && !model.IsPatchAlias(alias) {
-		return true
-	}
-	return false
 }

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -175,7 +175,7 @@ func shouldSkipAliasForSection(section model.ProjectPageSection, alias string) b
 	case model.ProjectPageCommitChecksSection:
 		return alias != evergreen.GithubChecksAlias
 	case model.ProjectPagePatchAliasSection:
-		return model.IsPatchAlias(alias)
+		return !model.IsPatchAlias(alias)
 	default:
 		return true
 	}

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -165,10 +165,7 @@ func shouldSkipAliasForSection(section model.ProjectPageSection, alias string) b
 	switch section {
 	// TODO DEVPROD-31534: remove GithubAndCQSection
 	case model.ProjectPageGithubAndCQSection:
-		if model.IsPatchAlias(alias) {
-			return true
-		}
-		return false
+		return model.IsPatchAlias(alias)
 	case model.ProjectPagePullRequestsSection:
 		return alias != evergreen.GithubPRAlias
 	case model.ProjectPageMergeQueueSection:
@@ -178,10 +175,7 @@ func shouldSkipAliasForSection(section model.ProjectPageSection, alias string) b
 	case model.ProjectPageCommitChecksSection:
 		return alias != evergreen.GithubChecksAlias
 	case model.ProjectPagePatchAliasSection:
-		if !model.IsPatchAlias(alias) {
-			return true
-		}
-		return false
+		return model.IsPatchAlias(alias)
 	default:
 		return true
 	}

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -304,38 +304,122 @@ func (a *AliasSuite) TestUpdateAliasesForSection() {
 		}
 	}
 
-	// All GitHub alias sections should add the internal alias
-	githubSections := []model.ProjectPageSection{
-		model.ProjectPageGithubAndCQSection, // TODO DEVPROD-31534: Delete this test
-		model.ProjectPagePullRequestsSection,
-		model.ProjectPageGitTagsSection,
-		model.ProjectPageMergeQueueSection,
-		model.ProjectPageCommitChecksSection,
+	// TODO DEVPROD-31534: Delete this test case
+	// The legacy combined GitHub + CQ section should still operate on all internal aliases.
+	a.Run(string(model.ProjectPageGithubAndCQSection), func() {
+		modified, err := updateAliasesForSection(
+			a.T().Context(),
+			"project_id",
+			updatedAliases,
+			originalAliases,
+			model.ProjectPageGithubAndCQSection,
+		)
+		a.NoError(err)
+		a.True(modified)
+
+		aliasesFromDb, err := model.FindAliasesForProjectFromDb(a.T().Context(), "project_id")
+		a.NoError(err)
+		a.Len(aliasesFromDb, 4) // net count stays the same (one removed, one added)
+
+		foundChecks := false
+		for _, alias := range aliasesFromDb {
+			if alias.Alias == evergreen.GithubChecksAlias {
+				foundChecks = true
+			}
+		}
+		a.True(
+			foundChecks,
+			"expected %s to be present after updating section %s",
+			evergreen.GithubChecksAlias,
+			model.ProjectPageGithubAndCQSection,
+		)
+	})
+}
+
+func (a *AliasSuite) TestUpdateAliasesForGithubSections() {
+	originalAliases, err := model.FindAliasesForProjectFromDb(a.T().Context(), "project_id")
+	a.NoError(err)
+	a.Len(originalAliases, 4)
+
+	type githubSectionCase struct {
+		section       model.ProjectPageSection
+		internalAlias string
 	}
 
-	for _, section := range githubSections {
-		a.Run(string(section), func() {
+	cases := []githubSectionCase{
+		{
+			section:       model.ProjectPagePullRequestsSection,
+			internalAlias: evergreen.GithubPRAlias,
+		},
+		{
+			section:       model.ProjectPageGitTagsSection,
+			internalAlias: evergreen.GitTagAlias,
+		},
+		{
+			section:       model.ProjectPageMergeQueueSection,
+			internalAlias: evergreen.CommitQueueAlias,
+		},
+		{
+			section:       model.ProjectPageCommitChecksSection,
+			internalAlias: evergreen.GithubChecksAlias,
+		},
+	}
+
+	for _, tc := range cases {
+		a.Run(string(tc.section), func() {
+			aliasToKeep := restModel.APIProjectAlias{}
+			aliasToKeep.BuildFromService(originalAliases[0])
+
+			aliasToModify := restModel.APIProjectAlias{}
+			aliasToModify.BuildFromService(originalAliases[1])
+			aliasToModify.Alias = utility.ToStringPtr("this is a new alias")
+
+			newAlias := restModel.APIProjectAlias{
+				ID:      utility.ToStringPtr(mgobson.NewObjectId().Hex()),
+				Alias:   utility.ToStringPtr("patchAlias"),
+				Variant: utility.ToStringPtr("var"),
+				Task:    utility.ToStringPtr("task"),
+			}
+			newInternalAlias := restModel.APIProjectAlias{
+				ID:      utility.ToStringPtr(mgobson.NewObjectId().Hex()),
+				Alias:   utility.ToStringPtr(tc.internalAlias), // section-specific internal alias
+				Variant: utility.ToStringPtr("var"),
+				Task:    utility.ToStringPtr("task"),
+			}
+
+			updatedAliases := []restModel.APIProjectAlias{
+				aliasToKeep,
+				aliasToModify,
+				newAlias,
+				newInternalAlias,
+			}
+
 			modified, err := updateAliasesForSection(
 				a.T().Context(),
 				"project_id",
 				updatedAliases,
 				originalAliases,
-				section,
+				tc.section,
 			)
 			a.NoError(err)
 			a.True(modified)
 
 			aliasesFromDb, err := model.FindAliasesForProjectFromDb(a.T().Context(), "project_id")
 			a.NoError(err)
-			a.Len(aliasesFromDb, 4) // net count stays the same (one removed, one added)
 
-			foundChecks := false
+			foundInternal := false
+			foundCommitQueue := false
 			for _, alias := range aliasesFromDb {
-				if alias.Alias == evergreen.GithubChecksAlias {
-					foundChecks = true
+				if alias.Alias == tc.internalAlias {
+					foundInternal = true
+				}
+				if alias.Alias == evergreen.CommitQueueAlias {
+					foundCommitQueue = true
 				}
 			}
-			a.True(foundChecks, "expected %s to be present after updating section %s", evergreen.GithubChecksAlias, section)
+
+			a.True(foundInternal, "expected %s to be present after updating section %s", tc.internalAlias, tc.section)
+			a.True(foundCommitQueue, "expected commit queue alias to remain after updating section %s", tc.section)
 		})
 	}
 }

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -387,6 +387,13 @@ func (a *AliasSuite) TestUpdateAliasesForGithubSections() {
 				Task:    utility.ToStringPtr("task"),
 			}
 
+			if tc.section == model.ProjectPageGitTagsSection {
+				newInternalAlias.Variant = nil
+				newInternalAlias.Task = nil
+				newInternalAlias.GitTag = utility.ToStringPtr(`^v[0-9]+.[0-9]+.[0-9]+$`)
+				newInternalAlias.RemotePath = utility.ToStringPtr("evergreen.yml")
+			}
+
 			updatedAliases := []restModel.APIProjectAlias{
 				aliasToKeep,
 				aliasToModify,

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -343,25 +343,45 @@ func (a *AliasSuite) TestUpdateAliasesForGithubSections() {
 
 	type githubSectionCase struct {
 		section       model.ProjectPageSection
-		internalAlias string
+		internalAlias restModel.APIProjectAlias
 	}
 
 	cases := []githubSectionCase{
 		{
-			section:       model.ProjectPagePullRequestsSection,
-			internalAlias: evergreen.GithubPRAlias,
+			section: model.ProjectPagePullRequestsSection,
+			internalAlias: restModel.APIProjectAlias{
+				ID:      utility.ToStringPtr(mgobson.NewObjectId().Hex()),
+				Alias:   utility.ToStringPtr(evergreen.GithubPRAlias),
+				Variant: utility.ToStringPtr("var"),
+				Task:    utility.ToStringPtr("task"),
+			},
 		},
 		{
-			section:       model.ProjectPageGitTagsSection,
-			internalAlias: evergreen.GitTagAlias,
+			section: model.ProjectPageGitTagsSection,
+			internalAlias: restModel.APIProjectAlias{
+				ID:         utility.ToStringPtr(mgobson.NewObjectId().Hex()),
+				Alias:      utility.ToStringPtr(evergreen.GitTagAlias),
+				GitTag:     utility.ToStringPtr(`^v[0-9]+.[0-9]+.[0-9]+$`),
+				RemotePath: utility.ToStringPtr("evergreen.yml"),
+			},
 		},
 		{
-			section:       model.ProjectPageMergeQueueSection,
-			internalAlias: evergreen.CommitQueueAlias,
+			section: model.ProjectPageMergeQueueSection,
+			internalAlias: restModel.APIProjectAlias{
+				ID:      utility.ToStringPtr(mgobson.NewObjectId().Hex()),
+				Alias:   utility.ToStringPtr(evergreen.CommitQueueAlias),
+				Variant: utility.ToStringPtr("var"),
+				Task:    utility.ToStringPtr("task"),
+			},
 		},
 		{
-			section:       model.ProjectPageCommitChecksSection,
-			internalAlias: evergreen.GithubChecksAlias,
+			section: model.ProjectPageCommitChecksSection,
+			internalAlias: restModel.APIProjectAlias{
+				ID:      utility.ToStringPtr(mgobson.NewObjectId().Hex()),
+				Alias:   utility.ToStringPtr(evergreen.GithubChecksAlias),
+				Variant: utility.ToStringPtr("var"),
+				Task:    utility.ToStringPtr("task"),
+			},
 		},
 	}
 
@@ -380,20 +400,7 @@ func (a *AliasSuite) TestUpdateAliasesForGithubSections() {
 				Variant: utility.ToStringPtr("var"),
 				Task:    utility.ToStringPtr("task"),
 			}
-			newInternalAlias := restModel.APIProjectAlias{
-				ID:      utility.ToStringPtr(mgobson.NewObjectId().Hex()),
-				Alias:   utility.ToStringPtr(tc.internalAlias), // section-specific internal alias
-				Variant: utility.ToStringPtr("var"),
-				Task:    utility.ToStringPtr("task"),
-			}
-
-			if tc.section == model.ProjectPageGitTagsSection {
-				newInternalAlias.Variant = nil
-				newInternalAlias.Task = nil
-				newInternalAlias.GitTag = utility.ToStringPtr(`^v[0-9]+.[0-9]+.[0-9]+$`)
-				newInternalAlias.RemotePath = utility.ToStringPtr("evergreen.yml")
-			}
-
+			newInternalAlias := tc.internalAlias
 			updatedAliases := []restModel.APIProjectAlias{
 				aliasToKeep,
 				aliasToModify,
@@ -416,11 +423,12 @@ func (a *AliasSuite) TestUpdateAliasesForGithubSections() {
 
 			foundInternal := false
 			foundCommitQueue := false
+			internalAliasName := utility.FromStringPtr(tc.internalAlias.Alias)
 			for _, alias := range aliasesFromDb {
-				if alias.Alias == tc.internalAlias {
+				switch alias.Alias {
+				case internalAliasName:
 					foundInternal = true
-				}
-				if alias.Alias == evergreen.CommitQueueAlias {
+				case evergreen.CommitQueueAlias:
 					foundCommitQueue = true
 				}
 			}

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -424,8 +424,7 @@ func (a *AliasSuite) TestUpdateAliasesForGithubSections() {
 			foundInternal := false
 			internalAliasName := utility.FromStringPtr(tc.internalAlias.Alias)
 			for _, alias := range aliasesFromDb {
-				switch alias.Alias {
-				case internalAliasName:
+				if alias.Alias == internalAliasName {
 					foundInternal = true
 				}
 			}

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -422,19 +422,20 @@ func (a *AliasSuite) TestUpdateAliasesForGithubSections() {
 			a.NoError(err)
 
 			foundInternal := false
-			foundCommitQueue := false
 			internalAliasName := utility.FromStringPtr(tc.internalAlias.Alias)
 			for _, alias := range aliasesFromDb {
 				switch alias.Alias {
 				case internalAliasName:
 					foundInternal = true
-				case evergreen.CommitQueueAlias:
-					foundCommitQueue = true
 				}
 			}
 
-			a.True(foundInternal, "expected %s to be present after updating section %s", tc.internalAlias, tc.section)
-			a.True(foundCommitQueue, "expected commit queue alias to remain after updating section %s", tc.section)
+			a.True(
+				foundInternal,
+				"expected %s to be present after updating section %s",
+				tc.internalAlias,
+				tc.section,
+			)
 		})
 	}
 }


### PR DESCRIPTION
[DEVPROD-32091](https://jira.mongodb.org/browse/DEVPROD-32091)

### Description
Builds off of work from https://github.com/evergreen-ci/evergreen/pull/10084. Ensure that the new tabs can only modify their own aliases.

### Testing
Modified relevant tests in `graphql/tests/mutation/saveProjectSettingsForSection` to check that other aliases are preserved.

### Documentation
None

<!-- 
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models - If you're adding a field to the Task, Build, Version, or Patch structs, consider creating a
  DPIPE ticket to expose this in the data warehouse.

-->
