### PR TITLE
DEVPROD-31914 Fix windows daemon tests

### DIFF
--- a/operations/local_client_test.go
+++ b/operations/local_client_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen/agent/taskexec"
@@ -22,41 +21,43 @@ import (
 	"github.com/urfave/cli"
 )
 
-func getHomeEnvVar() string {
-	if runtime.GOOS == "windows" {
-		return "USERPROFILE"
+// setHomeDir overrides all environment variables that home directory lookups
+// may consult (HOME, USERPROFILE) and resets the go-homedir cache. It returns
+// a cleanup function that restores the original values.
+func setHomeDir(t *testing.T, dir string) {
+	envVars := []string{"HOME", "USERPROFILE"}
+	originals := make(map[string]string, len(envVars))
+	for _, v := range envVars {
+		originals[v] = os.Getenv(v)
+		require.NoError(t, os.Setenv(v, dir))
 	}
-	return "HOME"
+	homedir.Reset()
+
+	t.Cleanup(func() {
+		for _, v := range envVars {
+			os.Setenv(v, originals[v])
+		}
+		homedir.Reset()
+	})
 }
 
 func TestGetDaemonDir(t *testing.T) {
+	tempDir := t.TempDir()
+	setHomeDir(t, tempDir)
+
 	dir, err := getDaemonDir()
 	require.NoError(t, err)
 
-	homeDir, err := os.UserHomeDir()
-	require.NoError(t, err)
-
-	expected := filepath.Join(homeDir, daemonDir)
+	expected := filepath.Join(tempDir, daemonDir)
 	assert.Equal(t, expected, dir)
 }
 
 func TestGetDaemonURL(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "daemon_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
-
-	homeEnvVar := getHomeEnvVar()
-	origHome := os.Getenv(homeEnvVar)
-	err = os.Setenv(homeEnvVar, tempDir)
-	require.NoError(t, err)
-	homedir.Reset()
-	defer func() {
-		os.Setenv(homeEnvVar, origHome)
-		homedir.Reset()
-	}()
+	tempDir := t.TempDir()
+	setHomeDir(t, tempDir)
 
 	daemonDir := filepath.Join(tempDir, ".evergreen-local")
-	err = os.MkdirAll(daemonDir, 0755)
+	err := os.MkdirAll(daemonDir, 0755)
 	require.NoError(t, err)
 
 	t.Run("daemon not running", func(t *testing.T) {
@@ -234,22 +235,11 @@ buildvariants:
 }
 
 func TestWriteDaemonInfo(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "daemon_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
-
-	homeEnvVar := getHomeEnvVar()
-	origHome := os.Getenv(homeEnvVar)
-	err = os.Setenv(homeEnvVar, tempDir)
-	require.NoError(t, err)
-	homedir.Reset()
-	defer func() {
-		os.Setenv(homeEnvVar, origHome)
-		homedir.Reset()
-	}()
+	tempDir := t.TempDir()
+	setHomeDir(t, tempDir)
 
 	daemon := newLocalDaemonREST(9090, &ClientSettings{})
-	err = daemon.writeDaemonInfo()
+	err := daemon.writeDaemonInfo()
 	require.NoError(t, err)
 
 	daemonDir := filepath.Join(tempDir, ".evergreen-local")
@@ -319,26 +309,14 @@ func TestJumpToCmd(t *testing.T) {
 		}))
 		defer server.Close()
 
-		tempDir, err := os.MkdirTemp("", "jump_to_test")
-		require.NoError(t, err)
-		defer os.RemoveAll(tempDir)
-
-		homeEnvVar := getHomeEnvVar()
-		origHome := os.Getenv(homeEnvVar)
-		err = os.Setenv(homeEnvVar, tempDir)
-		require.NoError(t, err)
-		homedir.Reset()
-		defer func() {
-			os.Setenv(homeEnvVar, origHome)
-			homedir.Reset()
-		}()
+		tempDir := t.TempDir()
+		setHomeDir(t, tempDir)
 
 		daemonDir := filepath.Join(tempDir, ".evergreen-local")
-		err = os.MkdirAll(daemonDir, 0755)
-		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(daemonDir, 0755))
 
 		var port int
-		_, err = fmt.Sscanf(server.URL, "http://127.0.0.1:%d", &port)
+		_, err := fmt.Sscanf(server.URL, "http://127.0.0.1:%d", &port)
 		require.NoError(t, err)
 
 		portFile := filepath.Join(daemonDir, "daemon.port")
@@ -382,26 +360,14 @@ func TestSelectTaskCmd(t *testing.T) {
 		}))
 		defer server.Close()
 
-		tempDir, err := os.MkdirTemp("", "select_task_test")
-		require.NoError(t, err)
-		defer os.RemoveAll(tempDir)
-
-		homeEnvVar := getHomeEnvVar()
-		origHome := os.Getenv(homeEnvVar)
-		err = os.Setenv(homeEnvVar, tempDir)
-		require.NoError(t, err)
-		homedir.Reset()
-		defer func() {
-			os.Setenv(homeEnvVar, origHome)
-			homedir.Reset()
-		}()
+		tempDir := t.TempDir()
+		setHomeDir(t, tempDir)
 
 		daemonDir := filepath.Join(tempDir, ".evergreen-local")
-		err = os.MkdirAll(daemonDir, 0755)
-		require.NoError(t, err)
+		require.NoError(t, os.MkdirAll(daemonDir, 0755))
 
 		var port int
-		_, err = fmt.Sscanf(server.URL, "http://127.0.0.1:%d", &port)
+		_, err := fmt.Sscanf(server.URL, "http://127.0.0.1:%d", &port)
 		require.NoError(t, err)
 
 		portFile := filepath.Join(daemonDir, "daemon.port")

--- a/operations/local_client_test.go
+++ b/operations/local_client_test.go
@@ -22,8 +22,7 @@ import (
 )
 
 // setHomeDir overrides all environment variables that home directory lookups
-// may consult (HOME, USERPROFILE) and resets the go-homedir cache. It returns
-// a cleanup function that restores the original values.
+// may consult (HOME, USERPROFILE) and resets the homedir cache.
 func setHomeDir(t *testing.T, dir string) {
 	envVars := []string{"HOME", "USERPROFILE"}
 	originals := make(map[string]string, len(envVars))


### PR DESCRIPTION
DEVPROD-31914

### Description
Need to modify our unit tests to handle windows machines when testing the task debugger. Wasn't caught in PR because we don't have windows checks there.

### Testing
[Test passes on windows and ubuntu](https://spruce.corp.mongodb.com/version/69eb8fcd2fcce10007ff2f77/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)