### PR TITLE
DEVPROD-32275: Change the Move Logs To Failed Bucket Job to Run Hourly 

### DIFF
--- a/config_bucket.go
+++ b/config_bucket.go
@@ -41,10 +41,10 @@ type BucketsConfig struct {
 	LogBucketFailedTasks BucketConfig `bson:"log_bucket_failed_tasks" json:"log_bucket_failed_tasks" yaml:"log_bucket_failed_tasks"`
 	// LongRetentionProjects is the list of project IDs that require long retention.
 	LongRetentionProjects []string `bson:"long_retention_projects" json:"long_retention_projects" yaml:"long_retention_projects"`
-	// RetryFailedLogMoveLookbackMonths is how many months back the weekly cron searches
+	// RetryFailedLogMoveLookbackMonths is how many months back the hourly retry cron searches
 	// for failed tasks whose logs need moving. Default 2 when unset or 0.
 	RetryFailedLogMoveLookbackMonths int `bson:"retry_failed_log_move_lookback_months" json:"retry_failed_log_move_lookback_months" yaml:"retry_failed_log_move_lookback_months"`
-	// RetryFailedLogMoveMaxJobsPerRun caps how many move jobs the weekly cron enqueues
+	// RetryFailedLogMoveMaxJobsPerRun caps how many move jobs the hourly retry cron enqueues
 	// per run to avoid S3 rate limiting. Newest failures are prioritized. Default 50 when unset or 0.
 	RetryFailedLogMoveMaxJobsPerRun int `bson:"retry_failed_log_move_max_jobs_per_run" json:"retry_failed_log_move_max_jobs_per_run" yaml:"retry_failed_log_move_max_jobs_per_run"`
 	// TestResultsBucket is the bucket information for test results.

--- a/units/crons.go
+++ b/units/crons.go
@@ -1021,7 +1021,7 @@ func PopulateRetryFailedLogMoveJobs(env evergreen.Environment) amboy.QueueOperat
 			}
 			taskIDsAttempted = append(taskIDsAttempted, t.Id)
 			sourceCfg := output.TaskLogs.BucketConfig
-			catcher.Wrapf(amboy.EnqueueUniqueJob(ctx, queue, NewMoveLogsToFailedBucketJob(env, t.Id, ts, sourceCfg, MoveLogsTriggerWeeklyRetry)), "enqueueing move logs job for task '%s'", t.Id)
+			catcher.Wrapf(amboy.EnqueueUniqueJob(ctx, queue, NewMoveLogsToFailedBucketJob(env, t.Id, ts, sourceCfg, MoveLogsTriggerHourlyRetry)), "enqueueing move logs job for task '%s'", t.Id)
 		}
 
 		grip.Info(ctx, message.Fields{

--- a/units/crons_remote_hour.go
+++ b/units/crons_remote_hour.go
@@ -46,6 +46,7 @@ func (j *cronsRemoteHourJob) Run(ctx context.Context) {
 	}
 
 	ops := []amboy.QueueOperation{
+		PopulateRetryFailedLogMoveJobs(j.env),
 		PopulateCacheHistoricalTaskDataJob(2),
 		PopulateSpawnhostExpirationCheckJob(),
 		PopulateCloudCleanupJob(j.env),

--- a/units/crons_remote_week.go
+++ b/units/crons_remote_week.go
@@ -47,7 +47,6 @@ func (j *cronsRemoteWeekJob) Run(ctx context.Context) {
 
 	ops := []amboy.QueueOperation{
 		PopulateS3LifecycleSyncProjectBucketsJob(),
-		PopulateRetryFailedLogMoveJobs(j.env),
 	}
 
 	queue := j.env.RemoteQueue()

--- a/units/move_logs_to_failed_bucket.go
+++ b/units/move_logs_to_failed_bucket.go
@@ -25,8 +25,8 @@ const (
 // MoveLogsTriggerTaskEnd is used when the app server enqueues after a failed task ends (agent path).
 const MoveLogsTriggerTaskEnd = "task_end"
 
-// MoveLogsTriggerWeeklyRetry is used by PopulateRetryFailedLogMoveJobs (weekly cron).
-const MoveLogsTriggerWeeklyRetry = "weekly_retry_failed_log_move"
+// MoveLogsTriggerHourlyRetry is used by PopulateRetryFailedLogMoveJobs (hourly remote cron).
+const MoveLogsTriggerHourlyRetry = "hourly_retry_failed_log_move"
 
 func init() {
 	registry.AddJobType(moveLogsToFailedBucketJobName, func() amboy.Job {


### PR DESCRIPTION
DEVPROD-32275

### Description
I found that NewMoveLogsToFailedBucketJob isn't hit when tasks go through FixStaleTask (for heartbeat failures) rather than EndTask. Rather than fixing it, it would be simpler to instead change the weekly job to run hourly. Because there is no rush to move these logs as nobody is waiting on the move, we simply need to get it done before they expire and we have a while for that. This will also help us get through our backlog without manual intervention. 

Because these are capped by retry_failed_log_move_max_jobs_per_run, it's safe to run it that frequently. 

### Testing 
Tested on staging and made sure it [ran on the hour.](https://mongodb.splunkcloud.com/en-US/app/search/search?earliest=1777057680&latest=1777061320&q=search%20index%3Devergreen-staging%20lookback_months&display.page.search.mode=fast&dispatch.sample_ratio=1&display.general.type=events&display.page.search.tab=events&workload_pool=&sid=1777061355.28185) 

<!-- 
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models - If you're adding a field to the Task, Build, Version, or Patch structs, consider creating a
  DPIPE ticket to expose this in the data warehouse.

-->
