### PR TITLE
DEVPROD-32198 Fix Panic in LIst patches 

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-04-23"
+	ClientVersion = "2026-04-27"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -404,7 +404,10 @@ func (r *mutationResolver) SetPatchVisibility(ctx context.Context, patchIds []st
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("setting visibility for patch '%s': %s", p.Id, err.Error()))
 		}
 		apiPatch := restModel.APIPatch{}
-		err = apiPatch.BuildFromService(ctx, p, &restModel.APIPatchArgs{IncludeProjectIdentifier: true})
+		err = apiPatch.BuildFromService(ctx, p, &restModel.APIPatchArgs{
+			IncludeProjectIdentifier: true,
+			IncludeVersionCost:       true,
+		})
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("converting patch '%s' to APIPatch: %s", p.Id, err.Error()))
 		}

--- a/graphql/patch_resolver.go
+++ b/graphql/patch_resolver.go
@@ -393,7 +393,9 @@ func (r *patchesResolver) Patches(ctx context.Context, obj *Patches) ([]*restMod
 	apiPatches := []*restModel.APIPatch{}
 	for _, p := range patches {
 		apiPatch := restModel.APIPatch{}
-		if err := apiPatch.BuildFromService(ctx, p, nil); err != nil {
+		if err := apiPatch.BuildFromService(ctx, p, &restModel.APIPatchArgs{
+			IncludeVersionCost: true,
+		}); err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("converting patch '%s' to APIPatch: %s", p.Id.Hex(), err.Error()))
 		}
 		apiPatches = append(apiPatches, &apiPatch)

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -626,7 +626,7 @@ func getJSONPatchDisplay(ctx context.Context, params outputPatchParams) (string,
 	display := []restModel.APIPatch{}
 	for _, p := range params.patches {
 		api := restModel.APIPatch{}
-		err := api.BuildFromService(ctx, p, &restModel.APIPatchArgs{SkipVersionCost: true})
+		err := api.BuildFromService(ctx, p, nil)
 		if err != nil {
 			return "", errors.Wrap(err, "converting patch to API model")
 		}

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -626,7 +626,7 @@ func getJSONPatchDisplay(ctx context.Context, params outputPatchParams) (string,
 	display := []restModel.APIPatch{}
 	for _, p := range params.patches {
 		api := restModel.APIPatch{}
-		err := api.BuildFromService(ctx, p, nil)
+		err := api.BuildFromService(ctx, p, &restModel.APIPatchArgs{SkipVersionCost: true})
 		if err != nil {
 			return "", errors.Wrap(err, "converting patch to API model")
 		}

--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -50,6 +50,7 @@ func FindPatchesByProject(ctx context.Context, projectId string, ts time.Time, l
 		err = apiPatch.BuildFromService(ctx, p, &restModel.APIPatchArgs{
 			IncludeProjectIdentifier: true,
 			IncludeChildPatches:      true,
+			IncludeVersionCost:       true,
 		})
 		if err != nil {
 			return nil, errors.Wrapf(err, "converting patch '%s' to API model", p.Id.Hex())
@@ -81,6 +82,7 @@ func FindPatchById(ctx context.Context, patchId string) (*restModel.APIPatch, er
 	err = apiPatch.BuildFromService(ctx, *p, &restModel.APIPatchArgs{
 		IncludeChildPatches:      true,
 		IncludeProjectIdentifier: true,
+		IncludeVersionCost:       true,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "converting patch '%s' to API model", p.Id.Hex())
@@ -192,6 +194,7 @@ func FindPatchesByUser(ctx context.Context, user string, ts time.Time, limit int
 		err = apiPatch.BuildFromService(ctx, p, &restModel.APIPatchArgs{
 			IncludeProjectIdentifier: true,
 			IncludeChildPatches:      true,
+			IncludeVersionCost:       true,
 		})
 		if err != nil {
 			return nil, errors.Wrapf(err, "converting patch '%s' to API model", p.Id.Hex())

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -164,6 +164,8 @@ func (p *APIParameter) BuildFromService(param *patch.Parameter) {
 type APIPatchArgs struct {
 	IncludeProjectIdentifier bool
 	IncludeChildPatches      bool
+	// SkipVersionCost omits DB lookups to load Cost/PredictedCost from the version document.
+	SkipVersionCost bool
 }
 
 // BuildFromService converts from service level structs to an APIPatch.
@@ -171,7 +173,10 @@ type APIPatchArgs struct {
 // If args are set, includes identifier, branch, and/or child patches from the DB, if applicable.
 func (apiPatch *APIPatch) BuildFromService(ctx context.Context, p patch.Patch, args *APIPatchArgs) error {
 	apiPatch.buildBasePatch(p)
-	apiPatch.populateCostFromVersion(ctx, p.Version)
+	shouldLoadVersionCost := args == nil || !args.SkipVersionCost
+	if shouldLoadVersionCost {
+		apiPatch.populateCostFromVersion(ctx, p.Version)
+	}
 
 	projectIdentifier := p.Project
 	if args != nil {

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -164,8 +164,8 @@ func (p *APIParameter) BuildFromService(param *patch.Parameter) {
 type APIPatchArgs struct {
 	IncludeProjectIdentifier bool
 	IncludeChildPatches      bool
-	// SkipVersionCost omits DB lookups to load Cost/PredictedCost from the version document.
-	SkipVersionCost bool
+	// IncludeVersionCost loads Cost/PredictedCost from the version document (extra DB read).
+	IncludeVersionCost bool
 }
 
 // BuildFromService converts from service level structs to an APIPatch.
@@ -173,13 +173,12 @@ type APIPatchArgs struct {
 // If args are set, includes identifier, branch, and/or child patches from the DB, if applicable.
 func (apiPatch *APIPatch) BuildFromService(ctx context.Context, p patch.Patch, args *APIPatchArgs) error {
 	apiPatch.buildBasePatch(p)
-	shouldLoadVersionCost := args == nil || !args.SkipVersionCost
-	if shouldLoadVersionCost {
-		apiPatch.populateCostFromVersion(ctx, p.Version)
-	}
 
 	projectIdentifier := p.Project
 	if args != nil {
+		if args.IncludeVersionCost {
+			apiPatch.populateCostFromVersion(ctx, p.Version)
+		}
 		if args.IncludeProjectIdentifier && p.Project != "" {
 			apiPatch.GetIdentifier(ctx)
 			if apiPatch.ProjectIdentifier != nil {
@@ -379,7 +378,10 @@ func getChildPatchesData(ctx context.Context, p patch.Patch) ([]DownstreamTasks,
 			VariantTasks: variantTasks,
 		}
 		apiPatch := APIPatch{}
-		err = apiPatch.BuildFromService(ctx, childPatch, &APIPatchArgs{IncludeProjectIdentifier: true})
+		err = apiPatch.BuildFromService(ctx, childPatch, &APIPatchArgs{
+			IncludeProjectIdentifier: true,
+			IncludeVersionCost:       true,
+		})
 		if err != nil {
 			return nil, nil, nil, errors.Wrap(err, "converting child patch to API model")
 		}

--- a/rest/model/patch_test.go
+++ b/rest/model/patch_test.go
@@ -168,8 +168,8 @@ func TestAddChildPatchesCostToParent(t *testing.T) {
 	})
 }
 
-// TestAPIPatchBuildFromServiceSkipsVersionCostWithNoDB make sure that when SkipVersionCost is true, the version cost is not populated.
-func TestAPIPatchBuildFromServiceSkipsVersionCostWithNoDB(t *testing.T) {
+// TestAPIPatchBuildFromServiceOmitsVersionCostWithoutOptIn ensures version cost is not loaded unless IncludeVersionCost is set.
+func TestAPIPatchBuildFromServiceOmitsVersionCostWithoutOptIn(t *testing.T) {
 	p := patch.Patch{
 		Id:          mgobson.NewObjectId(),
 		Description: "x",
@@ -182,7 +182,7 @@ func TestAPIPatchBuildFromServiceSkipsVersionCostWithNoDB(t *testing.T) {
 		Patches:     []patch.ModulePatch{{}},
 	}
 	var api APIPatch
-	err := api.BuildFromService(t.Context(), p, &APIPatchArgs{SkipVersionCost: true})
+	err := api.BuildFromService(t.Context(), p, &APIPatchArgs{})
 	require.NoError(t, err)
 	assert.Nil(t, api.Cost)
 	assert.Nil(t, api.PredictedCost)
@@ -226,7 +226,7 @@ func TestAPIPatchBuildFromServiceVersionCost(t *testing.T) {
 	}
 
 	var api APIPatch
-	require.NoError(t, api.BuildFromService(ctx, p, nil))
+	require.NoError(t, api.BuildFromService(ctx, p, &APIPatchArgs{IncludeVersionCost: true}))
 
 	require.NotNil(t, api.Cost)
 	assert.InDelta(t, 10.5, api.Cost.Total, 0.001)

--- a/rest/model/patch_test.go
+++ b/rest/model/patch_test.go
@@ -168,6 +168,26 @@ func TestAddChildPatchesCostToParent(t *testing.T) {
 	})
 }
 
+// TestAPIPatchBuildFromServiceSkipsVersionCostWithNoDB make sure that when SkipVersionCost is true, the version cost is not populated.
+func TestAPIPatchBuildFromServiceSkipsVersionCostWithNoDB(t *testing.T) {
+	p := patch.Patch{
+		Id:          mgobson.NewObjectId(),
+		Description: "x",
+		Project:     "mci",
+		Branch:      "main",
+		Githash:     "g",
+		Author:      "a",
+		PatchNumber: 1,
+		Version:     "version-id-would-need-DB",
+		Patches:     []patch.ModulePatch{{}},
+	}
+	var api APIPatch
+	err := api.BuildFromService(t.Context(), p, &APIPatchArgs{SkipVersionCost: true})
+	require.NoError(t, err)
+	assert.Nil(t, api.Cost)
+	assert.Nil(t, api.PredictedCost)
+}
+
 func TestAPIPatchBuildFromServiceVersionCost(t *testing.T) {
 	ctx := t.Context()
 	require.NoError(t, db.ClearCollections(model.VersionCollection, model.ProjectRefCollection))


### PR DESCRIPTION
DEVPROD-32198

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
This fixes the panic in evergreen list-patches -j by skipping version cost DB load in CLI. 

### Testing
Added a test 

### Documentation
Remember to add or edit docs in the docs/ directory if relevant.
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- 
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models - If you're adding a field to the Task, Build, Version, or Patch structs, consider creating a
  DPIPE ticket to expose this in the data warehouse.

-->
