### PR TITLE
DEVPROD-32302: Validate only relevant GitHub aliases

### DIFF
--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -122,7 +122,13 @@ func updateAliasesForSection(ctx context.Context, projectId string, updatedAlias
 // validateFeaturesHaveAliases returns an error if project/repo aliases are not defined for a Github/CQ feature.
 // Does not error if version control is enabled. To check for version control, we pass in the original project ref
 // along with the newly changed project ref because the new project ref only contains github / CQ section data.
-func validateFeaturesHaveAliases(ctx context.Context, originalProjectRef *model.ProjectRef, newProjectRef *model.ProjectRef, aliases []restModel.APIProjectAlias) error {
+func validateFeaturesHaveAliases(
+	ctx context.Context,
+	originalProjectRef *model.ProjectRef,
+	newProjectRef *model.ProjectRef,
+	aliases []restModel.APIProjectAlias,
+	section model.ProjectPageSection,
+) error {
 	if originalProjectRef.IsVersionControlEnabled() {
 		return nil
 	}
@@ -140,22 +146,41 @@ func validateFeaturesHaveAliases(ctx context.Context, originalProjectRef *model.
 		for _, a := range repoAliases {
 			aliasesMap[a.Alias] = true
 		}
-
 	}
 
 	msg := "%s cannot be enabled without aliases"
 	catcher := grip.NewBasicCatcher()
-	if newProjectRef.IsPRTestingEnabled() && !aliasesMap[evergreen.GithubPRAlias] {
-		catcher.Errorf(msg, "PR testing")
-	}
-	if newProjectRef.CommitQueue.IsEnabled() && !aliasesMap[evergreen.CommitQueueAlias] {
-		catcher.Errorf(msg, "Commit queue")
-	}
-	if newProjectRef.IsGitTagVersionsEnabled() && !aliasesMap[evergreen.GitTagAlias] {
-		catcher.Errorf(msg, "Git tag versions")
-	}
-	if newProjectRef.IsGithubChecksEnabled() && !aliasesMap[evergreen.GithubChecksAlias] {
-		catcher.Errorf(msg, "GitHub checks")
+
+	switch section {
+	case model.ProjectPagePullRequestsSection:
+		if newProjectRef.IsPRTestingEnabled() && !aliasesMap[evergreen.GithubPRAlias] {
+			catcher.Errorf(msg, "PR testing")
+		}
+	case model.ProjectPageMergeQueueSection:
+		if newProjectRef.CommitQueue.IsEnabled() && !aliasesMap[evergreen.CommitQueueAlias] {
+			catcher.Errorf(msg, "Commit queue")
+		}
+	case model.ProjectPageGitTagsSection:
+		if newProjectRef.IsGitTagVersionsEnabled() && !aliasesMap[evergreen.GitTagAlias] {
+			catcher.Errorf(msg, "Git tag versions")
+		}
+	case model.ProjectPageCommitChecksSection:
+		if newProjectRef.IsGithubChecksEnabled() && !aliasesMap[evergreen.GithubChecksAlias] {
+			catcher.Errorf(msg, "GitHub checks")
+		}
+	default:
+		if newProjectRef.IsPRTestingEnabled() && !aliasesMap[evergreen.GithubPRAlias] {
+			catcher.Errorf(msg, "PR testing")
+		}
+		if newProjectRef.CommitQueue.IsEnabled() && !aliasesMap[evergreen.CommitQueueAlias] {
+			catcher.Errorf(msg, "Commit queue")
+		}
+		if newProjectRef.IsGitTagVersionsEnabled() && !aliasesMap[evergreen.GitTagAlias] {
+			catcher.Errorf(msg, "Git tag versions")
+		}
+		if newProjectRef.IsGithubChecksEnabled() && !aliasesMap[evergreen.GithubChecksAlias] {
+			catcher.Errorf(msg, "GitHub checks")
+		}
 	}
 
 	return catcher.Resolve()

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -168,6 +168,7 @@ func validateFeaturesHaveAliases(
 		if newProjectRef.IsGithubChecksEnabled() && !aliasesMap[evergreen.GithubChecksAlias] {
 			catcher.Errorf(msg, "GitHub checks")
 		}
+	// TODO DEVPROD-31532: no need for this once we remove GithubAndCQSection
 	default:
 		if newProjectRef.IsPRTestingEnabled() && !aliasesMap[evergreen.GithubPRAlias] {
 			catcher.Errorf(msg, "PR testing")

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -459,7 +459,7 @@ func TestValidateFeaturesHaveAliases(t *testing.T) {
 	}
 
 	// Errors when there aren't aliases for all enabled features.
-	err := validateFeaturesHaveAliases(t.Context(), oldPRef, pRef, aliases)
+	err := validateFeaturesHaveAliases(t.Context(), oldPRef, pRef, aliases, model.ProjectPageGithubAndCQSection)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "GitHub checks")
 
@@ -470,16 +470,129 @@ func TestValidateFeaturesHaveAliases(t *testing.T) {
 	}
 	assert.NoError(t, repoAlias1.Upsert(t.Context()))
 	// No error when there are aliases in the repo.
-	assert.NoError(t, validateFeaturesHaveAliases(t.Context(), oldPRef, pRef, aliases))
+	assert.NoError(t, validateFeaturesHaveAliases(t.Context(), oldPRef, pRef, aliases, model.ProjectPageGithubAndCQSection))
 
 	pRef.GitTagVersionsEnabled = utility.TruePtr()
 	pRef.CommitQueue.Enabled = utility.TruePtr()
-	err = validateFeaturesHaveAliases(t.Context(), oldPRef, pRef, aliases)
+	err = validateFeaturesHaveAliases(t.Context(), oldPRef, pRef, aliases, model.ProjectPageGithubAndCQSection)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Git tag")
 	assert.Contains(t, err.Error(), "Commit queue")
 
 	// No error when version control is enabled.
 	oldPRef.VersionControlEnabled = utility.TruePtr()
-	assert.NoError(t, validateFeaturesHaveAliases(t.Context(), oldPRef, pRef, aliases))
+	assert.NoError(t, validateFeaturesHaveAliases(t.Context(), oldPRef, pRef, aliases, model.ProjectPageGithubAndCQSection))
+}
+
+func TestValidateFeaturesHaveAliasesForGithubSections(t *testing.T) {
+	oldPRef := &model.ProjectRef{
+		VersionControlEnabled: utility.FalsePtr(),
+	}
+	basePRef := &model.ProjectRef{
+		Id:                    "p1",
+		PRTestingEnabled:      utility.TruePtr(),
+		GitTagVersionsEnabled: utility.TruePtr(),
+		GithubChecksEnabled:   utility.TruePtr(),
+	}
+	basePRef.CommitQueue.Enabled = utility.TruePtr()
+
+	makeAliases := func(names ...string) []restModel.APIProjectAlias {
+		var out []restModel.APIProjectAlias
+		for _, n := range names {
+			n := n
+			out = append(out, restModel.APIProjectAlias{
+				Alias: utility.ToStringPtr(n),
+			})
+		}
+		return out
+	}
+
+	type tc struct {
+		name           string
+		section        model.ProjectPageSection
+		aliases        []restModel.APIProjectAlias
+		expectErr      bool
+		wantSubstrings []string
+		notSubstrings  []string
+	}
+
+	cases := []tc{
+		{
+			name:    "PR tab passes with only PR alias",
+			section: model.ProjectPagePullRequestsSection,
+			aliases: makeAliases(evergreen.GithubPRAlias),
+		},
+		{
+			name:           "PR tab fails without PR alias even if others present",
+			section:        model.ProjectPagePullRequestsSection,
+			aliases:        makeAliases(evergreen.GitTagAlias, evergreen.GithubChecksAlias, evergreen.CommitQueueAlias),
+			expectErr:      true,
+			wantSubstrings: []string{"PR testing"},
+			notSubstrings:  []string{"Git tag", "Commit queue", "GitHub checks"},
+		},
+		{
+			name:    "Merge queue tab passes with only CQ alias",
+			section: model.ProjectPageMergeQueueSection,
+			aliases: makeAliases(evergreen.CommitQueueAlias),
+		},
+		{
+			name:           "Merge queue tab fails without CQ alias even if others present",
+			section:        model.ProjectPageMergeQueueSection,
+			aliases:        makeAliases(evergreen.GitTagAlias, evergreen.GithubChecksAlias, evergreen.GithubPRAlias),
+			expectErr:      true,
+			wantSubstrings: []string{"Commit queue"},
+			notSubstrings:  []string{"PR testing", "Git tag", "GitHub checks"},
+		},
+		{
+			name:    "Git tags tab passes with only Git tag alias",
+			section: model.ProjectPageGitTagsSection,
+			aliases: makeAliases(evergreen.GitTagAlias),
+		},
+		{
+			name:           "Git tags tab fails without Git tag alias even if others present",
+			section:        model.ProjectPageGitTagsSection,
+			aliases:        makeAliases(evergreen.CommitQueueAlias, evergreen.GithubChecksAlias, evergreen.GithubPRAlias),
+			expectErr:      true,
+			wantSubstrings: []string{"Git tag"},
+			notSubstrings:  []string{"PR testing", "Commit queue", "GitHub checks"},
+		}, {
+			name:    "Commit checks tab passes with only GitHub checks alias",
+			section: model.ProjectPageCommitChecksSection,
+			aliases: makeAliases(evergreen.GithubChecksAlias),
+		},
+		{
+			name:           "Commit checks tab fails without GitHub checks alias even if others present",
+			section:        model.ProjectPageCommitChecksSection,
+			aliases:        makeAliases(evergreen.CommitQueueAlias, evergreen.GitTagAlias, evergreen.GithubPRAlias),
+			expectErr:      true,
+			wantSubstrings: []string{"GitHub checks"},
+			notSubstrings:  []string{"PR testing", "Git tag", "Commit queue"},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			pRefCopy := *basePRef
+
+			err := validateFeaturesHaveAliases(
+				t.Context(),
+				oldPRef,
+				&pRefCopy,
+				test.aliases,
+				test.section,
+			)
+
+			if test.expectErr {
+				require.Error(t, err)
+				for _, s := range test.wantSubstrings {
+					assert.Contains(t, err.Error(), s, "expected error to contain %q", s)
+				}
+				for _, s := range test.notSubstrings {
+					assert.NotContains(t, err.Error(), s, "expected error NOT to contain %q", s)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
 }

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -439,6 +439,7 @@ func (a *AliasSuite) TestUpdateAliasesForGithubSections() {
 	}
 }
 
+// TODO DEVPROD-31534: Remove legacy test, see TestValidateFeaturesHaveAliasesForGithubSections
 func TestValidateFeaturesHaveAliases(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(model.ProjectAliasCollection))
 

--- a/rest/data/aliases_test.go
+++ b/rest/data/aliases_test.go
@@ -556,7 +556,8 @@ func TestValidateFeaturesHaveAliasesForGithubSections(t *testing.T) {
 			expectErr:      true,
 			wantSubstrings: []string{"Git tag"},
 			notSubstrings:  []string{"PR testing", "Commit queue", "GitHub checks"},
-		}, {
+		},
+		{
 			name:    "Commit checks tab passes with only GitHub checks alias",
 			section: model.ProjectPageCommitChecksSection,
 			aliases: makeAliases(evergreen.GithubChecksAlias),

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -397,7 +397,7 @@ func SaveProjectSettingsForSection(ctx context.Context, projectId string, change
 			return nil, err
 		}
 
-		if err = validateFeaturesHaveAliases(ctx, mergedBeforeRef, mergedSection, changes.Aliases); err != nil {
+		if err = validateFeaturesHaveAliases(ctx, mergedBeforeRef, mergedSection, changes.Aliases, section); err != nil {
 			return nil, err
 		}
 		if err = mergedSection.ValidateGitHubPermissionGroupsByRequester(); err != nil {


### PR DESCRIPTION
DEVPROD-32302

### Description
Part of epic [DEVPROD-31673](https://jira.mongodb.org/browse/DEVPROD-31673) which separates out components of the GithubCommitAndQueueTab into four individual tabs.

When a change is made on a specific GitHub section tab, the validator should only check aliases for that specific tab. For instance, a Commit Checks change should not error because no PR alias was provided.

### Testing
Added new test to `aliases_test.go`

### Documentation
None

<!-- 
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models - If you're adding a field to the Task, Build, Version, or Patch structs, consider creating a
  DPIPE ticket to expose this in the data warehouse.

-->
