### PR TITLE
DEVPROD-26349 Allow modules to target a wiki

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -555,13 +555,8 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 		return errors.Wrap(err, "validating clone options")
 	}
 
-	modulePatch := p.FindModule(moduleName)
-	if modulePatch != nil {
-		return errors.New("module patch not found")
-	}
-
 	var moduleCmds []string
-	moduleCmds, err = c.buildModuleCloneCommand(conf, opts, revision, modulePatch)
+	moduleCmds, err = c.buildModuleCloneCommand(conf, opts, revision, p.FindModule(moduleName))
 	if err != nil {
 		return err
 	}

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -555,8 +555,13 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 		return errors.Wrap(err, "validating clone options")
 	}
 
+	var modulePatch *patch.ModulePatch
+	if p != nil {
+		modulePatch = p.FindModule(moduleName)
+	}
+
 	var moduleCmds []string
-	moduleCmds, err = c.buildModuleCloneCommand(conf, opts, revision, p.FindModule(moduleName))
+	moduleCmds, err = c.buildModuleCloneCommand(conf, opts, revision, modulePatch)
 	if err != nil {
 		return err
 	}

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -576,7 +576,7 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 			" to https format. Please update your project config.", module.Repo)
 	}
 
-	appToken, err := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), owner, model.ParentRepoForGitHubAppToken(repo))
+	appToken, err := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), owner, parentRepoForGitHubAppToken(repo))
 	if err != nil {
 		return errors.Wrap(err, "creating app token")
 	}
@@ -885,4 +885,15 @@ func isGitHubPRModulePatch(conf *internal.TaskConfig, modulePatch *patch.ModuleP
 
 func isGitHub(conf *internal.TaskConfig) bool {
 	return conf.GithubPatchData.PRNumber != 0 || conf.GithubMergeData.HeadSHA != ""
+}
+
+// parentRepoForGitHubAppToken returns the repository name to pass when resolving
+// a GitHub App installation for clone tokens. Installations are on the parent
+// repository; clone URLs may still use the ".wiki" repository name.
+func parentRepoForGitHubAppToken(repo string) string {
+	if !model.IsWikiRepo(repo) {
+		return repo
+	}
+	r := strings.TrimSuffix(strings.TrimSpace(repo), ".git")
+	return strings.TrimSuffix(r, ".wiki")
 }

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -161,6 +161,29 @@ func (opts cloneOpts) getCloneCommand() ([]string, error) {
 	}, nil
 }
 
+// getCloneCommandForWikiModule runs a plain git clone to opts.dir. GitHub
+// wikis are cloned at the remote default branch (HEAD) only; branch, ref,
+// depth, and submodules are not used.
+func (opts cloneOpts) getCloneCommandForWikiModule() ([]string, error) {
+	if err := opts.validate(); err != nil {
+		return nil, errors.Wrap(err, "invalid clone command options")
+	}
+
+	gitURL := thirdparty.FormGitURLForApp(opts.owner, opts.repo, opts.token)
+	clone := fmt.Sprintf("git clone %s '%s'", gitURL, opts.dir)
+	if opts.useVerbose {
+		clone = fmt.Sprintf("GIT_TRACE=1 %s", clone)
+	}
+
+	return []string{
+		"set +o xtrace",
+		fmt.Sprintf(`echo %s`, strconv.Quote(clone)),
+		clone,
+		"set -o xtrace",
+		fmt.Sprintf("cd %s", opts.dir),
+	}, nil
+}
+
 func moduleRevExpansionName(name string) string { return fmt.Sprintf("%s_rev", name) }
 
 func loadModulesManifestInToExpansions(ctx context.Context, comm client.Communicator, conf *internal.TaskConfig) error {
@@ -261,6 +284,15 @@ func (c *gitFetchProject) buildModuleCloneCommand(conf *internal.TaskConfig, opt
 	if opts.dir == "" {
 		return nil, errors.New("empty clone path")
 	}
+	if model.IsWikiModuleRepo(opts.repo) {
+		cloneCmd, err := opts.getCloneCommandForWikiModule()
+		if err != nil {
+			return nil, errors.Wrap(err, "getting command to clone wiki")
+		}
+		gitCommands = append(gitCommands, cloneCmd...)
+		return gitCommands, nil
+	}
+
 	if ref == "" && !isGitHubPRModulePatch(conf, modulePatch) {
 		return nil, errors.New("empty ref/branch to check out")
 	}
@@ -478,45 +510,54 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 
 	moduleBase := filepath.ToSlash(filepath.Join(conf.ModulePaths[module.Name], module.Name))
 
+	owner, repo, err := module.GetOwnerAndRepo()
+	if err != nil {
+		return errors.Wrapf(err, "getting owner and repo for '%s'", moduleName)
+	}
+	wiki := model.IsWikiModuleRepo(repo)
+
 	// use submodule revisions based on the main patch. If there is a need in the future,
 	// this could maybe use the most recent submodule revision of all requested patches.
 	// We ignore set-module changes for commit queue and GitHub merge queue, since we should verify HEAD before merging.
+	// GitHub wikis are always cloned at remote HEAD; ref, set-module, manifest, and command params are ignored.
 	var modulePatch *patch.ModulePatch
 	var revision string
-	if p != nil {
-		modulePatch := p.FindModule(moduleName)
-		if modulePatch != nil {
-			if conf.Task.Requester == evergreen.GithubMergeRequester {
-				revision = module.Branch
-				c.logModuleRevision(ctx, logger, revision, moduleName, "defaulting to HEAD for merge")
-			} else {
-				revision = modulePatch.Githash
-				if revision != "" {
-					c.logModuleRevision(ctx, logger, revision, moduleName, "specified in set-module")
+	if !wiki {
+		if p != nil {
+			modulePatch = p.FindModule(moduleName)
+			if modulePatch != nil {
+				if conf.Task.Requester == evergreen.GithubMergeRequester {
+					revision = module.Branch
+					c.logModuleRevision(ctx, logger, revision, moduleName, "defaulting to HEAD for merge")
+				} else {
+					revision = modulePatch.Githash
+					if revision != "" {
+						c.logModuleRevision(ctx, logger, revision, moduleName, "specified in set-module")
+					}
 				}
 			}
 		}
-	}
-	if revision == "" {
-		revision = c.Revisions[moduleName]
-		if revision != "" {
-			c.logModuleRevision(ctx, logger, revision, moduleName, "specified as parameter to git.get_project")
+		if revision == "" {
+			revision = c.Revisions[moduleName]
+			if revision != "" {
+				c.logModuleRevision(ctx, logger, revision, moduleName, "specified as parameter to git.get_project")
+			}
 		}
-	}
-	if revision == "" {
-		revision = conf.Expansions.Get(moduleRevExpansionName(moduleName))
-		if revision != "" {
-			c.logModuleRevision(ctx, logger, revision, moduleName, "from manifest")
+		if revision == "" {
+			revision = conf.Expansions.Get(moduleRevExpansionName(moduleName))
+			if revision != "" {
+				c.logModuleRevision(ctx, logger, revision, moduleName, "from manifest")
+			}
 		}
-	}
-	// if there is no revision, then use the revision from the module, then branch name
-	if revision == "" {
-		if module.Ref != "" {
-			revision = module.Ref
-			c.logModuleRevision(ctx, logger, revision, moduleName, "ref field in config file")
-		} else {
-			revision = module.Branch
-			c.logModuleRevision(ctx, logger, revision, moduleName, "branch field in config file")
+		// if there is no revision, then use the revision from the module, then branch name
+		if revision == "" {
+			if module.Ref != "" {
+				revision = module.Ref
+				c.logModuleRevision(ctx, logger, revision, moduleName, "ref field in config file")
+			} else {
+				revision = module.Branch
+				c.logModuleRevision(ctx, logger, revision, moduleName, "branch field in config file")
+			}
 		}
 	}
 
@@ -529,11 +570,6 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 	// and repo from the string and save it to clone options so that the an https cloning link
 	// can be constructed manually by opts.setLocation.
 	// This is a temporary workaround which will be removed once users have switched over.
-	owner, repo, err := module.GetOwnerAndRepo()
-	if err != nil {
-		return errors.Wrapf(err, "getting module owner and repo '%s'", module.Name)
-	}
-
 	opts.owner = owner
 	opts.repo = repo
 	if strings.Contains(module.Repo, "git@github.com:") {
@@ -541,7 +577,7 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 			" to https format. Please update your project config.", module.Repo)
 	}
 
-	appToken, err := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), opts.owner, opts.repo)
+	appToken, err := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), owner, model.ParentRepoForGitHubAppToken(repo))
 	if err != nil {
 		return errors.Wrap(err, "creating app token")
 	}

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -514,7 +514,6 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 	if err != nil {
 		return errors.Wrapf(err, "getting owner and repo for '%s'", moduleName)
 	}
-	wiki := model.IsWikiRepo(repo)
 
 	// use submodule revisions based on the main patch. If there is a need in the future,
 	// this could maybe use the most recent submodule revision of all requested patches.
@@ -522,7 +521,7 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 	// GitHub wikis are always cloned at remote HEAD; ref, set-module, manifest, and command params are ignored.
 	var modulePatch *patch.ModulePatch
 	var revision string
-	if !wiki {
+	if !model.IsWikiRepo(repo) {
 		if p != nil {
 			modulePatch = p.FindModule(moduleName)
 			if modulePatch != nil {

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -515,48 +515,13 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 		return errors.Wrapf(err, "getting owner and repo for '%s'", moduleName)
 	}
 
-	// use submodule revisions based on the main patch. If there is a need in the future,
-	// this could maybe use the most recent submodule revision of all requested patches.
-	// We ignore set-module changes for commit queue and GitHub merge queue, since we should verify HEAD before merging.
-	// GitHub wikis are always cloned at remote HEAD; ref, set-module, manifest, and command params are ignored.
-	var modulePatch *patch.ModulePatch
 	var revision string
+
+	// GitHub wikis are always cloned at remote HEAD; ref, set-module, manifest, and command params are ignored.
 	if !model.IsWikiRepo(repo) {
-		if p != nil {
-			modulePatch = p.FindModule(moduleName)
-			if modulePatch != nil {
-				if conf.Task.Requester == evergreen.GithubMergeRequester {
-					revision = module.Branch
-					c.logModuleRevision(ctx, logger, revision, moduleName, "defaulting to HEAD for merge")
-				} else {
-					revision = modulePatch.Githash
-					if revision != "" {
-						c.logModuleRevision(ctx, logger, revision, moduleName, "specified in set-module")
-					}
-				}
-			}
-		}
-		if revision == "" {
-			revision = c.Revisions[moduleName]
-			if revision != "" {
-				c.logModuleRevision(ctx, logger, revision, moduleName, "specified as parameter to git.get_project")
-			}
-		}
-		if revision == "" {
-			revision = conf.Expansions.Get(moduleRevExpansionName(moduleName))
-			if revision != "" {
-				c.logModuleRevision(ctx, logger, revision, moduleName, "from manifest")
-			}
-		}
-		// if there is no revision, then use the revision from the module, then branch name
-		if revision == "" {
-			if module.Ref != "" {
-				revision = module.Ref
-				c.logModuleRevision(ctx, logger, revision, moduleName, "ref field in config file")
-			} else {
-				revision = module.Branch
-				c.logModuleRevision(ctx, logger, revision, moduleName, "branch field in config file")
-			}
+		revision, err = c.getModuleRevision(ctx, conf, logger, p, module)
+		if err != nil {
+			return errors.Wrapf(err, "getting module revision for '%s'", moduleName)
 		}
 	}
 
@@ -588,6 +553,11 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 
 	if err = opts.validate(); err != nil {
 		return errors.Wrap(err, "validating clone options")
+	}
+
+	modulePatch := p.FindModule(moduleName)
+	if modulePatch != nil {
+		return errors.New("module patch not found")
 	}
 
 	var moduleCmds []string
@@ -637,6 +607,53 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 
 		return err
 	})
+}
+
+// getModuleRevision returns the git ref (commit, branch name, etc.) to use for a module.
+// Sources are checked in order; the first non-empty applicable value wins:
+//
+//  1. For GitHub merge queue tasks, use the module.Branch (aka merge queue group's HEAD).
+//  2. The ref specified by set-module
+//  3. The ref specified by the parameter to git.get_project
+//  4. The revision specified by the manifest expansion
+//  5. module.Ref from project config.
+//  6. module.Branch from project config.
+//
+// Wiki modules should not call this function as they do not checkout a specific revision.
+func (c *gitFetchProject) getModuleRevision(ctx context.Context, conf *internal.TaskConfig, logger client.LoggerProducer, p *patch.Patch, module *model.Module) (string, error) {
+	if p != nil {
+		modulePatch := p.FindModule(module.Name)
+		if modulePatch != nil {
+			if conf.Task.Requester == evergreen.GithubMergeRequester {
+				c.logModuleRevision(ctx, logger, module.Branch, module.Name, "defaulting to HEAD for merge")
+				return module.Branch, nil
+			} else {
+				if revision := modulePatch.Githash; revision != "" {
+					c.logModuleRevision(ctx, logger, revision, module.Name, "specified in set-module")
+					return revision, nil
+				}
+			}
+		}
+	}
+
+	if revision := c.Revisions[module.Name]; revision != "" {
+		c.logModuleRevision(ctx, logger, revision, module.Name, "specified as parameter to git.get_project")
+		return revision, nil
+	}
+
+	if revision := conf.Expansions.Get(moduleRevExpansionName(module.Name)); revision != "" {
+		c.logModuleRevision(ctx, logger, revision, module.Name, "from manifest")
+		return revision, nil
+	}
+
+	if revision := module.Ref; revision != "" {
+		c.logModuleRevision(ctx, logger, revision, module.Name, "ref field in config file")
+		return revision, nil
+	}
+
+	// Always fallback to the module's branch.
+	c.logModuleRevision(ctx, logger, module.Branch, module.Name, "branch field in config file")
+	return module.Branch, nil
 }
 
 func (c *gitFetchProject) fetch(ctx context.Context,

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -284,7 +284,7 @@ func (c *gitFetchProject) buildModuleCloneCommand(conf *internal.TaskConfig, opt
 	if opts.dir == "" {
 		return nil, errors.New("empty clone path")
 	}
-	if model.IsWikiModuleRepo(opts.repo) {
+	if model.IsWikiRepo(opts.repo) {
 		cloneCmd, err := opts.getCloneCommandForWikiModule()
 		if err != nil {
 			return nil, errors.Wrap(err, "getting command to clone wiki")
@@ -514,7 +514,7 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 	if err != nil {
 		return errors.Wrapf(err, "getting owner and repo for '%s'", moduleName)
 	}
-	wiki := model.IsWikiModuleRepo(repo)
+	wiki := model.IsWikiRepo(repo)
 
 	// use submodule revisions based on the main patch. If there is a need in the future,
 	// this could maybe use the most recent submodule revision of all requested patches.

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -59,7 +59,7 @@ type GitGetProjectSuite struct {
 	taskConfig6 *internal.TaskConfig     // GitHub merge queue
 	modelData7  *modelutil.TestModelData // Multiple modules (parallelized)
 	taskConfig7 *internal.TaskConfig     // Multiple modules (parallelized)
-	modelData8  *modelutil.TestModelData // Wiki module: clones mongodb/mongo.wiki
+	modelData8  *modelutil.TestModelData // Wiki module: clones evergreen-ci/evergreen.wiki
 	taskConfig8 *internal.TaskConfig     // Wiki module
 
 	comm   *client.Mock
@@ -102,7 +102,7 @@ func (s *GitGetProjectSuite) SetupTest() {
 	configPath2 := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "test_config.yml")
 	configPath3 := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "no_token.yml")
 	configPath4 := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "multiple_modules.yml")
-	configPath5 := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "wiki_mongo_module.yml")
+	configPath5 := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "wiki_module.yml")
 	patchPath := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "test.patch")
 
 	s.modelData1, err = modelutil.SetupAPITestData(s.settings, "testtask1", "rhel55", configPath1, modelutil.NoPatch)
@@ -174,7 +174,7 @@ func (s *GitGetProjectSuite) SetupTest() {
 	s.Require().NoError(err)
 	s.taskConfig8.Expansions.Put("prefixpath", "hello")
 	s.taskConfig8.NewExpansions = agentutil.NewDynamicExpansions(s.taskConfig8.Expansions)
-	s.taskConfig8.BuildVariant.Modules = []string{"mongo-wiki"}
+	s.taskConfig8.BuildVariant.Modules = []string{"evergreen-wiki"}
 
 	s.comm.CreateInstallationTokenResult = mockedGitHubAppToken
 	s.comm.CreateInstallationTokenFail = false
@@ -826,11 +826,7 @@ func (s *GitGetProjectSuite) TestMultipleModules() {
 	s.Equal("hello/module-2", conf.ModulePaths["sample-2"])
 }
 
-// TestWikiModuleClonesMongoDBWiki runs git.get_project against a real project YAML with
-// module repo mongodb/mongo.wiki and verifies the wiki is cloned at remote HEAD (network).
-// Run only this test, with creds, e.g.:
-// SETTINGS_OVERRIDE=creds.yml make test-agent-command RUN_TEST=TestGitGetProjectSuite/TestWikiModuleClonesMongoDBWiki
-func (s *GitGetProjectSuite) TestWikiModuleClonesMongoDBWiki() {
+func (s *GitGetProjectSuite) TestCloningWikiModule() {
 	if testing.Short() {
 		s.T().Skip("skipping network integration test in short mode")
 	}
@@ -846,7 +842,7 @@ func (s *GitGetProjectSuite) TestWikiModuleClonesMongoDBWiki() {
 	s.taskConfig8.Task.Requester = evergreen.PatchVersionRequester
 	s.comm.GetTaskPatchResponse = &patch.Patch{
 		Patches: []patch.ModulePatch{
-			{ModuleName: "mongo-wiki", Githash: ignoredPatchHash},
+			{ModuleName: "evergreen-wiki", Githash: ignoredPatchHash},
 		},
 	}
 
@@ -863,7 +859,7 @@ func (s *GitGetProjectSuite) TestWikiModuleClonesMongoDBWiki() {
 		}
 	}
 
-	wikiDir := filepath.Join(conf.WorkDir, "src", "hello", "w", "mongo-wiki")
+	wikiDir := filepath.Join(conf.WorkDir, "src", "hello", "w", "evergreen-wiki")
 	cmd := exec.Command("git", "rev-parse", "HEAD")
 	cmd.Dir = wikiDir
 	var out bytes.Buffer
@@ -875,7 +871,7 @@ func (s *GitGetProjectSuite) TestWikiModuleClonesMongoDBWiki() {
 	s.NotEqual(ignoredPatchHash, ref, "set-module must not pin wiki revision")
 	s.NotEqual(ignoredYAMLRef, ref, "YAML ref must not pin wiki revision")
 	s.NoError(logger.Close())
-	s.Equal("hello/w", conf.ModulePaths["mongo-wiki"])
+	s.Equal("hello/w", conf.ModulePaths["evergreen-wiki"])
 }
 
 func (s *GitGetProjectSuite) TestCorrectModuleRevisionManifest() {

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -33,6 +33,8 @@ import (
 	"github.com/mongodb/jasper"
 	"github.com/pkg/errors"
 	"github.com/smartystreets/goconvey/convey/reporting"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -57,6 +59,8 @@ type GitGetProjectSuite struct {
 	taskConfig6 *internal.TaskConfig     // GitHub merge queue
 	modelData7  *modelutil.TestModelData // Multiple modules (parallelized)
 	taskConfig7 *internal.TaskConfig     // Multiple modules (parallelized)
+	modelData8  *modelutil.TestModelData // Wiki module: clones mongodb/mongo.wiki
+	taskConfig8 *internal.TaskConfig     // Wiki module
 
 	comm   *client.Mock
 	jasper jasper.Manager
@@ -98,6 +102,7 @@ func (s *GitGetProjectSuite) SetupTest() {
 	configPath2 := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "test_config.yml")
 	configPath3 := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "no_token.yml")
 	configPath4 := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "multiple_modules.yml")
+	configPath5 := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "wiki_mongo_module.yml")
 	patchPath := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "test.patch")
 
 	s.modelData1, err = modelutil.SetupAPITestData(s.settings, "testtask1", "rhel55", configPath1, modelutil.NoPatch)
@@ -162,6 +167,14 @@ func (s *GitGetProjectSuite) SetupTest() {
 	s.taskConfig7.Expansions.Put("prefixpath", "hello")
 	// SetupAPITestData always creates BuildVariant with no modules so this line works around that
 	s.taskConfig7.BuildVariant.Modules = []string{"sample-1", "sample-2"}
+
+	s.modelData8, err = modelutil.SetupAPITestData(s.settings, "testtask1", "rhel55", configPath5, modelutil.NoPatch)
+	s.Require().NoError(err)
+	s.taskConfig8, err = agenttestutil.MakeTaskConfigFromModelData(s.ctx, s.settings, s.modelData8)
+	s.Require().NoError(err)
+	s.taskConfig8.Expansions.Put("prefixpath", "hello")
+	s.taskConfig8.NewExpansions = agentutil.NewDynamicExpansions(s.taskConfig8.Expansions)
+	s.taskConfig8.BuildVariant.Modules = []string{"mongo-wiki"}
 
 	s.comm.CreateInstallationTokenResult = mockedGitHubAppToken
 	s.comm.CreateInstallationTokenFail = false
@@ -660,6 +673,24 @@ func (s *GitGetProjectSuite) TestBuildModuleCommand() {
 	}), cmds)
 }
 
+func TestBuildModuleCloneCommandWiki(t *testing.T) {
+	c := &gitFetchProject{Directory: "dir", Token: projectGitHubToken}
+	conf := &internal.TaskConfig{}
+	opts := cloneOpts{
+		token: projectGitHubToken,
+		owner: "myorg",
+		repo:  "parent.wiki",
+		dir:   "wiki_dir",
+	}
+	cmds, err := c.buildModuleCloneCommand(conf, opts, "deadbeef0000", nil)
+	require.NoError(t, err)
+	joined := strings.Join(cmds, "\n")
+	assert.NotContains(t, joined, "git checkout")
+	assert.NotContains(t, joined, "deadbeef")
+	assert.Contains(t, joined, "git clone")
+	assert.Contains(t, joined, "myorg/parent.wiki")
+}
+
 func (s *GitGetProjectSuite) TestGetApplyCommand() {
 	c := &gitFetchProject{
 		Directory:      "dir",
@@ -793,6 +824,58 @@ func (s *GitGetProjectSuite) TestMultipleModules() {
 	}
 	s.True(foundMsg)
 	s.Equal("hello/module-2", conf.ModulePaths["sample-2"])
+}
+
+// TestWikiModuleClonesMongoDBWiki runs git.get_project against a real project YAML with
+// module repo mongodb/mongo.wiki and verifies the wiki is cloned at remote HEAD (network).
+// Run only this test, with creds, e.g.:
+// SETTINGS_OVERRIDE=creds.yml make test-agent-command RUN_TEST=TestGitGetProjectSuite/TestWikiModuleClonesMongoDBWiki
+func (s *GitGetProjectSuite) TestWikiModuleClonesMongoDBWiki() {
+	if testing.Short() {
+		s.T().Skip("skipping network integration test in short mode")
+	}
+	const ignoredPatchHash = "7b817a1908f7505cb9c05ac5601d4692793e1c0a"
+	const ignoredYAMLRef = "0000000000000000000000000000000000000001"
+
+	conf := s.taskConfig8
+	logger, err := s.comm.GetLoggerProducer(s.ctx, &conf.Task, nil)
+	s.Require().NoError(err)
+
+	// set-module and YAML ref must not control the clone for wikis
+	s.modelData8.Task.Requester = evergreen.PatchVersionRequester
+	s.taskConfig8.Task.Requester = evergreen.PatchVersionRequester
+	s.comm.GetTaskPatchResponse = &patch.Patch{
+		Patches: []patch.ModulePatch{
+			{ModuleName: "mongo-wiki", Githash: ignoredPatchHash},
+		},
+	}
+
+	for _, task := range conf.Project.Tasks {
+		s.NotEmpty(task.Commands)
+		for _, command := range task.Commands {
+			var pluginCmds []Command
+			pluginCmds, err = Render(command, &conf.Project, BlockInfo{})
+			s.NoError(err)
+			s.NotNil(pluginCmds)
+			pluginCmds[0].SetJasperManager(s.jasper)
+			err = pluginCmds[0].Execute(s.ctx, s.comm, logger, conf)
+			s.NoError(err)
+		}
+	}
+
+	wikiDir := filepath.Join(conf.WorkDir, "src", "hello", "w", "mongo-wiki")
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	cmd.Dir = wikiDir
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err = cmd.Run()
+	s.NoError(err)
+	ref := strings.TrimSpace(out.String())
+	s.Len(ref, 40, "wiki clone should yield a full commit SHA at HEAD")
+	s.NotEqual(ignoredPatchHash, ref, "set-module must not pin wiki revision")
+	s.NotEqual(ignoredYAMLRef, ref, "YAML ref must not pin wiki revision")
+	s.NoError(logger.Close())
+	s.Equal("hello/w", conf.ModulePaths["mongo-wiki"])
 }
 
 func (s *GitGetProjectSuite) TestCorrectModuleRevisionManifest() {

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -1042,3 +1042,9 @@ func (s *GitGetProjectSuite) TestReorderPatches() {
 	s.Equal("m1", patches[1].ModuleName)
 	s.Equal("", patches[2].ModuleName)
 }
+
+func TestParentRepoForGitHubAppToken(t *testing.T) {
+	assert.Equal(t, "mongo", parentRepoForGitHubAppToken("mongo.wiki"))
+	assert.Equal(t, "mongo", parentRepoForGitHubAppToken("mongo.wiki.git"))
+	assert.Equal(t, "other", parentRepoForGitHubAppToken("other"))
+}

--- a/agent/command/testdata/git/wiki_module.yml
+++ b/agent/command/testdata/git/wiki_module.yml
@@ -7,12 +7,10 @@ tasks:
         params:
           directory: src
 
-# Official MongoDB product wiki: https://github.com/mongodb/mongo.wiki
-# branch/ref are ignored; Evergreen always clones default-branch HEAD.
 modules:
-  - name: mongo-wiki
-    owner: mongodb
-    repo: mongo.wiki
+  - name: evergreen-wiki
+    owner: evergreen-ci
+    repo: evergreen.wiki
     branch: main
     ref: 0000000000000000000000000000000000000001
     prefix: ${prefixpath}/w
@@ -21,7 +19,7 @@ buildvariants:
   - name: linux-64
     display_name: Linux 64-bit
     modules:
-      - mongo-wiki
+      - evergreen-wiki
     test_flags: --continue-on-failure
     expansions:
       blah: "blah"

--- a/agent/command/testdata/git/wiki_mongo_module.yml
+++ b/agent/command/testdata/git/wiki_mongo_module.yml
@@ -6,7 +6,6 @@ tasks:
       - command: git.get_project
         params:
           directory: src
-          token: ${github}
 
 # Official MongoDB product wiki: https://github.com/mongodb/mongo.wiki
 # branch/ref are ignored; Evergreen always clones default-branch HEAD.

--- a/agent/command/testdata/git/wiki_mongo_module.yml
+++ b/agent/command/testdata/git/wiki_mongo_module.yml
@@ -1,0 +1,29 @@
+batch_time: 180
+
+tasks:
+  - name: testtask1
+    commands:
+      - command: git.get_project
+        params:
+          directory: src
+          token: ${github}
+
+# Official MongoDB product wiki: https://github.com/mongodb/mongo.wiki
+# branch/ref are ignored; Evergreen always clones default-branch HEAD.
+modules:
+  - name: mongo-wiki
+    owner: mongodb
+    repo: mongo.wiki
+    branch: main
+    ref: 0000000000000000000000000000000000000001
+    prefix: ${prefixpath}/w
+
+buildvariants:
+  - name: linux-64
+    display_name: Linux 64-bit
+    modules:
+      - mongo-wiki
+    test_flags: --continue-on-failure
+    expansions:
+      blah: "blah"
+    push: true

--- a/config.go
+++ b/config.go
@@ -33,11 +33,11 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-04-29b"
+	ClientVersion = "2026-04-30"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-04-28"
+	AgentVersion = "2026-04-30"
 )
 
 const (

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -495,7 +495,7 @@ The `${<module_name>_rev}` expansion and other manifest-based revision fields ar
 
 The GitHub App used for private clones must be installed on the **parent** repository (e.g. `org/parent`); the clone URL still uses the `parent.wiki` repository.
 
-Wiki modules are intended for use with **git.get_project** cloning. [Includes](#include) that pull project YAML from a module repository are not supported for wikis unless separately implemented.
+Wiki modules are intended for use with **git.get_project** cloning. [Includes](#include) that pull project YAML from a module repository are not supported for wikis.
 
 Example `modules` entry using a wiki repository:
 

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -497,6 +497,16 @@ The GitHub App used for private clones must be installed on the **parent** repos
 
 Wiki modules are intended for use with **git.get_project** cloning. [Includes](#include) that pull project YAML from a module repository are not supported for wikis unless separately implemented.
 
+Example `modules` entry using a wiki repository:
+
+```yaml
+modules:
+  - name: product-wiki
+    owner: mongodb
+    repo: mongo.wiki
+    prefix: src/wiki
+```
+
 ### Pre and Post
 
 All projects can have a `pre` and `post` field which define a list of commands

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -482,6 +482,21 @@ Fields:
 - `auto_update`: if true, the latest revision for the module will be
   dynamically retrieved for each Github PR, CLI patch, and periodic build submission
 
+#### Wiki modules
+
+A module whose `repo` is a [GitHub wiki](https://docs.github.com/en/communities/documenting-your-project-with-wikis/about-wikis) (repository name `parent.wiki` for the `parent` repository) is cloned **only** at the remote’s **default branch (HEAD)**. Evergreen does not pin wikis to a specific commit, mainline time, or patch selection.
+
+The following are **ignored** for wiki modules (they still apply to normal modules):
+
+- `branch`, `ref`, and `auto_update` for the purpose of choosing a revision
+- `revisions` on [`git.get_project`](../Project-Commands#gitgetproject), the version manifest, and [evergreen set-module](../CLI/#operating-on-existing-patches)
+
+The `${<module_name>_rev}` expansion and other manifest-based revision fields are **empty** and not useful for wikis.
+
+The GitHub App used for private clones must be installed on the **parent** repository (e.g. `org/parent`); the clone URL still uses the `parent.wiki` repository.
+
+Wiki modules are intended for use with **git.get_project** cloning. [Includes](#include) that pull project YAML from a module repository are not supported for wikis unless separately implemented.
+
 ### Pre and Post
 
 All projects can have a `pre` and `post` field which define a list of commands

--- a/model/githubapp/github_app_installation.go
+++ b/model/githubapp/github_app_installation.go
@@ -30,7 +30,9 @@ const (
 )
 
 var (
-	gitHubAppNotInstalledError = errors.New("GitHub app is not installed")
+	// ErrGitHubAppNotInstalled is returned when the Evergreen GitHub App has no
+	// installation for the requested owner/repo.
+	ErrGitHubAppNotInstalled = errors.New("GitHub app is not installed")
 )
 
 // GitHubAppInstallation holds information about a GitHub app, notably its
@@ -232,7 +234,7 @@ func getInstallationIDFromGitHub(ctx context.Context, authFields *GithubAppAuth,
 			return 0, errors.Wrapf(err, "finding installation id for '%s/%s'", owner, repo)
 		}
 		if resp.StatusCode == http.StatusNotFound {
-			return 0, errors.Wrapf(gitHubAppNotInstalledError, "installation id for '%s/%s' not found", owner, repo)
+			return 0, errors.Wrapf(ErrGitHubAppNotInstalled, "installation id for '%s/%s' not found", owner, repo)
 		}
 		return 0, errors.Wrapf(err, "finding installation id for '%s/%s'", owner, repo)
 	}

--- a/model/project.go
+++ b/model/project.go
@@ -483,6 +483,24 @@ func (m Module) GetOwnerAndRepo() (string, string, error) {
 	return m.Owner, m.Repo, nil
 }
 
+// IsWikiModuleRepo reports whether repo names a GitHub wiki remote (e.g. "mongo.wiki").
+// Trailing ".git" is ignored when matching.
+func IsWikiModuleRepo(repo string) bool {
+	r := strings.TrimSuffix(strings.TrimSpace(repo), ".git")
+	return strings.HasSuffix(r, ".wiki")
+}
+
+// ParentRepoForGitHubAppToken returns the repository name to pass when resolving
+// a GitHub App installation for clone tokens. Installations are on the parent
+// repository; clone URLs may still use the ".wiki" repository name.
+func ParentRepoForGitHubAppToken(repo string) string {
+	if !IsWikiModuleRepo(repo) {
+		return repo
+	}
+	r := strings.TrimSuffix(strings.TrimSpace(repo), ".git")
+	return strings.TrimSuffix(r, ".wiki")
+}
+
 type ModuleList []Module
 
 func (l *ModuleList) IsIdentical(m manifest.Manifest) bool {

--- a/model/project.go
+++ b/model/project.go
@@ -483,9 +483,9 @@ func (m Module) GetOwnerAndRepo() (string, string, error) {
 	return m.Owner, m.Repo, nil
 }
 
-// IsWikiModuleRepo reports whether repo names a GitHub wiki remote (e.g. "mongo.wiki").
+// IsWikiRepo reports whether repo names a GitHub wiki remote (e.g. "mongo.wiki").
 // Trailing ".git" is ignored when matching.
-func IsWikiModuleRepo(repo string) bool {
+func IsWikiRepo(repo string) bool {
 	r := strings.TrimSuffix(strings.TrimSpace(repo), ".git")
 	return strings.HasSuffix(r, ".wiki")
 }
@@ -494,7 +494,7 @@ func IsWikiModuleRepo(repo string) bool {
 // a GitHub App installation for clone tokens. Installations are on the parent
 // repository; clone URLs may still use the ".wiki" repository name.
 func ParentRepoForGitHubAppToken(repo string) string {
-	if !IsWikiModuleRepo(repo) {
+	if !IsWikiRepo(repo) {
 		return repo
 	}
 	r := strings.TrimSuffix(strings.TrimSpace(repo), ".git")

--- a/model/project.go
+++ b/model/project.go
@@ -490,17 +490,6 @@ func IsWikiRepo(repo string) bool {
 	return strings.HasSuffix(r, ".wiki")
 }
 
-// ParentRepoForGitHubAppToken returns the repository name to pass when resolving
-// a GitHub App installation for clone tokens. Installations are on the parent
-// repository; clone URLs may still use the ".wiki" repository name.
-func ParentRepoForGitHubAppToken(repo string) string {
-	if !IsWikiRepo(repo) {
-		return repo
-	}
-	r := strings.TrimSuffix(strings.TrimSpace(repo), ".git")
-	return strings.TrimSuffix(r, ".wiki")
-}
-
 type ModuleList []Module
 
 func (l *ModuleList) IsIdentical(m manifest.Manifest) bool {

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -2049,6 +2049,16 @@ func TestModuleList(t *testing.T) {
 	assert.False(projModules.IsIdentical(manifest4))
 }
 
+func TestWikiModuleRepoHelpers(t *testing.T) {
+	assert.True(t, IsWikiModuleRepo("mongo.wiki"))
+	assert.True(t, IsWikiModuleRepo("mongo.wiki.git"))
+	assert.False(t, IsWikiModuleRepo("mongo"))
+	assert.False(t, IsWikiModuleRepo("wiki"))
+	assert.Equal(t, "mongo", ParentRepoForGitHubAppToken("mongo.wiki"))
+	assert.Equal(t, "mongo", ParentRepoForGitHubAppToken("mongo.wiki.git"))
+	assert.Equal(t, "other", ParentRepoForGitHubAppToken("other"))
+}
+
 func TestInjectTaskGroupInfo(t *testing.T) {
 	tg := TaskGroup{
 		Name:     "group-one",

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -2049,14 +2049,11 @@ func TestModuleList(t *testing.T) {
 	assert.False(projModules.IsIdentical(manifest4))
 }
 
-func TestWikiModuleRepoHelpers(t *testing.T) {
+func TestIsWikiRepo(t *testing.T) {
 	assert.True(t, IsWikiRepo("mongo.wiki"))
 	assert.True(t, IsWikiRepo("mongo.wiki.git"))
 	assert.False(t, IsWikiRepo("mongo"))
 	assert.False(t, IsWikiRepo("wiki"))
-	assert.Equal(t, "mongo", ParentRepoForGitHubAppToken("mongo.wiki"))
-	assert.Equal(t, "mongo", ParentRepoForGitHubAppToken("mongo.wiki.git"))
-	assert.Equal(t, "other", ParentRepoForGitHubAppToken("other"))
 }
 
 func TestInjectTaskGroupInfo(t *testing.T) {

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -2050,10 +2050,10 @@ func TestModuleList(t *testing.T) {
 }
 
 func TestWikiModuleRepoHelpers(t *testing.T) {
-	assert.True(t, IsWikiModuleRepo("mongo.wiki"))
-	assert.True(t, IsWikiModuleRepo("mongo.wiki.git"))
-	assert.False(t, IsWikiModuleRepo("mongo"))
-	assert.False(t, IsWikiModuleRepo("wiki"))
+	assert.True(t, IsWikiRepo("mongo.wiki"))
+	assert.True(t, IsWikiRepo("mongo.wiki.git"))
+	assert.False(t, IsWikiRepo("mongo"))
+	assert.False(t, IsWikiRepo("wiki"))
 	assert.Equal(t, "mongo", ParentRepoForGitHubAppToken("mongo.wiki"))
 	assert.Equal(t, "mongo", ParentRepoForGitHubAppToken("mongo.wiki.git"))
 	assert.Equal(t, "other", ParentRepoForGitHubAppToken("other"))

--- a/model/version.go
+++ b/model/version.go
@@ -996,7 +996,7 @@ func constructManifest(ctx context.Context, v *Version, projectRef *ProjectRef, 
 		}
 		// GitHub wikis are always cloned at default-branch HEAD. Do not reuse
 		// base manifest pins; every run must resolve via getManifestModule.
-		if shouldUseBaseRevision && !module.AutoUpdate && baseManifest != nil && !IsWikiModuleRepo(modRepo) {
+		if shouldUseBaseRevision && !module.AutoUpdate && baseManifest != nil && !IsWikiRepo(modRepo) {
 			if baseModule, ok := baseManifest.Modules[module.Name]; ok {
 				// Use base module revision unless the YAML explicitly specifies a different ref.
 				if module.Ref == "" || module.Ref == baseModule.Revision {
@@ -1023,7 +1023,7 @@ func getManifestModule(ctx context.Context, projectRef *ProjectRef, module Modul
 		return nil, errors.Wrapf(err, "getting owner and repo for '%s'", module.Name)
 	}
 
-	if IsWikiModuleRepo(repo) {
+	if IsWikiRepo(repo) {
 		// No GitHub Commits API for wikis; clone uses HEAD only. Keep Branch
 		// in sync with project YAML for manifest identity checks.
 		return &manifest.Module{

--- a/model/version.go
+++ b/model/version.go
@@ -990,7 +990,13 @@ func constructManifest(ctx context.Context, v *Version, projectRef *ProjectRef, 
 
 	modules := map[string]*manifest.Module{}
 	for _, module := range moduleList {
-		if shouldUseBaseRevision && !module.AutoUpdate && baseManifest != nil {
+		_, modRepo, err := module.GetOwnerAndRepo()
+		if err != nil {
+			return nil, errors.Wrapf(err, "getting owner and repo for '%s'", module.Name)
+		}
+		// GitHub wikis are always cloned at default-branch HEAD. Do not reuse
+		// base manifest pins; every run must resolve via getManifestModule.
+		if shouldUseBaseRevision && !module.AutoUpdate && baseManifest != nil && !IsWikiModuleRepo(modRepo) {
 			if baseModule, ok := baseManifest.Modules[module.Name]; ok {
 				// Use base module revision unless the YAML explicitly specifies a different ref.
 				if module.Ref == "" || module.Ref == baseModule.Revision {
@@ -1015,6 +1021,18 @@ func getManifestModule(ctx context.Context, projectRef *ProjectRef, module Modul
 	owner, repo, err := module.GetOwnerAndRepo()
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting owner and repo for '%s'", module.Name)
+	}
+
+	if IsWikiModuleRepo(repo) {
+		// No GitHub Commits API for wikis; clone uses HEAD only. Keep Branch
+		// in sync with project YAML for manifest identity checks.
+		return &manifest.Module{
+			Branch:   module.Branch,
+			Revision: "",
+			Repo:     repo,
+			Owner:    owner,
+			URL:      "",
+		}, nil
 	}
 
 	if module.Ref == "" {

--- a/model/version_test.go
+++ b/model/version_test.go
@@ -926,3 +926,17 @@ func TestUpdateAggregateTaskCosts(t *testing.T) {
 		assert.InDelta(t, 0.21, v.Cost.AdjustedS3LogStorageCost, 0.001)
 	})
 }
+
+func TestGetManifestModuleWiki(t *testing.T) {
+	ctx := t.Context()
+	pRef := &ProjectRef{Owner: "foo", Repo: "bar"}
+	mod := Module{Name: "w", Owner: "myorg", Repo: "service.wiki", Branch: "master"}
+	m, err := getManifestModule(ctx, pRef, mod, evergreen.RepotrackerVersionRequester, "abc123")
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	assert.Equal(t, "myorg", m.Owner)
+	assert.Equal(t, "service.wiki", m.Repo)
+	assert.Empty(t, m.Revision)
+	assert.Equal(t, "master", m.Branch)
+	assert.Empty(t, m.URL)
+}

--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -265,6 +265,9 @@ type cloneOptions struct {
 	token      string
 	depth      uint
 	isAppToken bool
+	// wikiModule clones only the remote default branch (HEAD) with no revision checkout;
+	// branch, ref, and manifest are ignored, matching agent git.get_project.
+	wikiModule bool
 }
 
 func clone(ctx context.Context, opts cloneOptions) error {
@@ -302,6 +305,15 @@ func clone(ctx context.Context, opts cloneOptions) error {
 	err := c.Run()
 	if err != nil {
 		return err
+	}
+
+	if opts.wikiModule {
+		if opts.isAppToken {
+			if err = resetGitRemoteToSSH(opts.owner, opts.repository, opts.rootDir); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
 	// try to check out the revision we want
@@ -390,6 +402,34 @@ func cloneSource(ctx context.Context, task *service.RestTask, project *model.Pro
 			moduleToken = token
 		}
 
+		modulePrefix := module.Prefix
+		if task.ModulePaths != nil && task.ModulePaths[module.Name] != "" {
+			modulePrefix = task.ModulePaths[module.Name]
+		}
+
+		moduleBase := filepath.Join(cloneDir, modulePrefix, module.Name)
+
+		owner, repo, err := module.GetOwnerAndRepo()
+		if err != nil {
+			return errors.Wrapf(err, "getting owner and repo for '%s'", module.Name)
+		}
+
+		if model.IsWikiModuleRepo(repo) {
+			fmt.Printf("Fetching wiki module %v at default branch (HEAD only)\n", moduleName)
+			err = clone(ctx, cloneOptions{
+				owner:      owner,
+				repository: repo,
+				rootDir:    filepath.ToSlash(moduleBase),
+				token:      moduleToken,
+				isAppToken: useAppToken,
+				wikiModule: true,
+			})
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
 		revision := module.Branch
 		if mfest != nil {
 			mfestModule, ok := mfest.Modules[moduleName]
@@ -401,18 +441,8 @@ func cloneSource(ctx context.Context, task *service.RestTask, project *model.Pro
 			}
 		}
 
-		modulePrefix := module.Prefix
-		if task.ModulePaths != nil && task.ModulePaths[module.Name] != "" {
-			modulePrefix = task.ModulePaths[module.Name]
-		}
-
-		moduleBase := filepath.Join(cloneDir, modulePrefix, module.Name)
 		fmt.Printf("Fetching module %v at %v\n", moduleName, module.Branch)
 
-		owner, repo, err := module.GetOwnerAndRepo()
-		if err != nil {
-			return errors.Wrapf(err, "getting owner and repo for '%s'", module.Name)
-		}
 		err = clone(ctx, cloneOptions{
 			owner:      owner,
 			repository: repo,

--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -414,7 +414,7 @@ func cloneSource(ctx context.Context, task *service.RestTask, project *model.Pro
 			return errors.Wrapf(err, "getting owner and repo for '%s'", module.Name)
 		}
 
-		if model.IsWikiModuleRepo(repo) {
+		if model.IsWikiRepo(repo) {
 			fmt.Printf("Fetching wiki module %v at default branch (HEAD only)\n", moduleName)
 			err = clone(ctx, cloneOptions{
 				owner:      owner,

--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -416,7 +416,7 @@ func cloneSource(ctx context.Context, task *service.RestTask, project *model.Pro
 		}
 
 		if model.IsWikiRepo(repo) {
-			fmt.Printf("Fetching wiki module %v at default branch (HEAD only)\n", moduleName)
+			fmt.Printf("Fetching wiki module %s at default branch (HEAD only)\n", moduleName)
 			err = clone(ctx, cloneOptions{
 				owner:      owner,
 				repository: repo,

--- a/operations/fetch.go
+++ b/operations/fetch.go
@@ -307,6 +307,7 @@ func clone(ctx context.Context, opts cloneOptions) error {
 		return err
 	}
 
+	// If the module is a wiki, we do not support other clone options.
 	if opts.wikiModule {
 		if opts.isAppToken {
 			if err = resetGitRemoteToSSH(opts.owner, opts.repository, opts.rootDir); err != nil {

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1575,6 +1575,12 @@ func (g *createInstallationTokenForClone) Run(ctx context.Context) gimlet.Respon
 	}
 	token, err := githubapp.CreateGitHubAppAuth(g.env.Settings()).CreateCachedInstallationToken(ctx, g.owner, g.repo, lifetime, opts)
 	if err != nil {
+		if errors.Is(err, githubapp.ErrGitHubAppNotInstalled) {
+			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+				StatusCode: http.StatusNotFound,
+				Message:    fmt.Sprintf("no GitHub App installation for '%s/%s'", g.owner, g.repo),
+			})
+		}
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "creating installation token for '%s/%s'", g.owner, g.repo))
 	}
 	if token == "" {


### PR DESCRIPTION
DEVPROD-26349

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
This allows modules to be a wiki. Wikis are git repositories that are attached to a parent repository, and are denoted by a `.wiki` suffix (e.g. [mongodb/mongo.wiki](https://github.com/mongodb/mongo/wiki)). As a consequence, these are not fully working GitHub repositories and most/all of GitHub's API do not work on them.

### Testing
Unit tests. Deployed to staging and tested it with yaml:

```yaml
tasks:
  - name: wikitest
    commands:
      - command: git.get_project
        params:
          directory: src
      - command: shell.exec
        params:
          script: |
            cd src
            cd evergreen-wiki
            git remote -v

modules:
  - name: evergreen-wiki
    owner: evergreen-ci
    repo: evergreen.wiki
```

[The task](https://spruce-staging.corp.mongodb.com/task/zackary_bisect_2_wiki_module_clone_wikitest_patch_2805cd25b45e216a4952bb637e7d0e1f8301123c_69efdce25085090007b7d87b_26_04_27_22_02_28/logs?execution=0) ran and printed out the remotes ([link](https://parsley-staging.corp.mongodb.com/evergreen/zackary_bisect_2_wiki_module_clone_wikitest_patch_2805cd25b45e216a4952bb637e7d0e1f8301123c_69efdce25085090007b7d87b_26_04_27_22_02_28/0/task?bookmarks=0,45&shareLine=40)):

```
[2026/04/27 18:03:17.576] evergreen-wiki: Cloning into 'evergreen-wiki'...
[2026/04/27 18:03:17.576] Finished command 'git.get_project' (step 1 of 2) in 799.990223ms.
...
[2026/04/27 18:03:17.578] origin	[https://x-access-token:<REDACTED:EVERGREEN_GENERATED_GITHUB_TOKEN>@github.com/evergreen-ci/evergreen.wiki.git](https://x-access-token:%3CREDACTED%3AEVERGREEN_GENERATED_GITHUB_TOKEN%3E@github.com/evergreen-ci/evergreen.wiki.git) (fetch)
[2026/04/27 18:03:17.578] origin	[https://x-access-token:<REDACTED:EVERGREEN_GENERATED_GITHUB_TOKEN>@github.com/evergreen-ci/evergreen.wiki.git](https://x-access-token:%3CREDACTED%3AEVERGREEN_GENERATED_GITHUB_TOKEN%3E@github.com/evergreen-ci/evergreen.wiki.git) (push)
```

### Documentation
Documented how to use it with an example.