### PR TITLE
DEVPROD-32403: Add version as number to panic report

### DIFF
--- a/cmd/evergreen/evergreen.go
+++ b/cmd/evergreen/evergreen.go
@@ -148,8 +148,12 @@ func setupPanicReport(c *cli.Context) {
 			LoadedFrom: notFound,
 		}
 	}
+	// We ignore the error here and let versionDate default to the zero value because
+	// we only want to set the VersionAsNumber if the version is valid.
+	versionDate, _ := operations.ParseDateVersionString(evergreen.ClientVersion)
 	panicReport = &model.PanicReport{
 		Version:                 evergreen.ClientVersion,
+		VersionAsNumber:         versionDate.Unix(),
 		AgentVersion:            evergreen.AgentVersion,
 		BuildRevision:           evergreen.BuildRevision,
 		CurrentWorkingDirectory: cwd,

--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-04-27"
+	ClientVersion = "2026-04-29"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/model.go
+++ b/operations/model.go
@@ -385,24 +385,28 @@ func printUserMessages(ctx context.Context, c client.Communicator, checkForUpdat
 }
 
 func isFirstDateBefore(dateString1, dateString2 string) (bool, error) {
-	layout := "2006-01-02"
-	// Extract just the date portion if the string is long enough.
-	// This allows values such as "2024-08-10a" to be parsed as "2024-08-10"
-	if len(dateString1) >= 10 {
-		dateString1 = dateString1[:10]
-	}
-	if len(dateString2) >= 10 {
-		dateString2 = dateString2[:10]
-	}
-	t1, err := time.Parse(layout, dateString1)
+	t1, err := ParseDateVersionString(dateString1)
 	if err != nil {
 		return false, fmt.Errorf("error parsing first date '%s': %w", dateString1, err)
 	}
-	t2, err := time.Parse(layout, dateString2)
+	t2, err := ParseDateVersionString(dateString2)
 	if err != nil {
 		return false, fmt.Errorf("error parsing second date '%s': %w", dateString2, err)
 	}
 	return t1.Before(t2), nil
+}
+
+// ParseDateVersionString parses a date string into a time.Time object.
+// The date string is expected to be in the format YYYY-MM-DD, this is
+// how we format our ClientVersion and AgentVersion.
+func ParseDateVersionString(dateString string) (time.Time, error) {
+	layout := "2006-01-02"
+	// Extract just the date portion if the string is long enough.
+	// This allows values such as "2024-08-10a" to be parsed as "2024-08-10"
+	if len(dateString) >= 10 {
+		dateString = dateString[:10]
+	}
+	return time.Parse(layout, dateString)
 }
 
 func (s *ClientSettings) getLegacyClients() (*legacyClient, *legacyClient, error) {

--- a/rest/model/panic.go
+++ b/rest/model/panic.go
@@ -4,6 +4,7 @@ import "time"
 
 type PanicReport struct {
 	Version                 string
+	VersionAsNumber         int64
 	AgentVersion            string
 	BuildRevision           string
 	CurrentWorkingDirectory string


### PR DESCRIPTION
DEVPROD-32403

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Adds version as number to panic report, this allows for better filtering Splunk queries.