### PR TITLE
DEVPROD-31541: Expose `LogsToMerge` field from GraphQL API

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -2128,6 +2128,7 @@ type ComplexityRoot struct {
 
 	TestLog struct {
 		LineNum       func(childComplexity int) int
+		LogsToMerge   func(childComplexity int) int
 		RenderingType func(childComplexity int) int
 		TestName      func(childComplexity int) int
 		URL           func(childComplexity int) int
@@ -11682,6 +11683,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.TestLog.LineNum(childComplexity), true
+	case "TestLog.logsToMerge":
+		if e.complexity.TestLog.LogsToMerge == nil {
+			break
+		}
+
+		return e.complexity.TestLog.LogsToMerge(childComplexity), true
 	case "TestLog.renderingType":
 		if e.complexity.TestLog.RenderingType == nil {
 			break
@@ -69503,6 +69510,93 @@ func (ec *executionContext) fieldContext_TestLog_lineNum(_ context.Context, fiel
 	return fc, nil
 }
 
+func (ec *executionContext) _TestLog_logsToMerge(ctx context.Context, field graphql.CollectedField, obj *model.TestLogs) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TestLog_logsToMerge,
+		func(ctx context.Context) (any, error) {
+			return obj.LogsToMerge, nil
+		},
+		nil,
+		ec.marshalOString2ᚕstringᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TestLog_logsToMerge(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TestLog",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TestLog_renderingType(ctx context.Context, field graphql.CollectedField, obj *model.TestLogs) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TestLog_renderingType,
+		func(ctx context.Context) (any, error) {
+			return obj.RenderingType, nil
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TestLog_renderingType(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TestLog",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TestLog_testName(ctx context.Context, field graphql.CollectedField, obj *model.TestLogs) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TestLog_testName,
+		func(ctx context.Context) (any, error) {
+			return obj.TestName, nil
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TestLog_testName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TestLog",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TestLog_url(ctx context.Context, field graphql.CollectedField, obj *model.TestLogs) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -69578,64 +69672,6 @@ func (ec *executionContext) _TestLog_urlRaw(ctx context.Context, field graphql.C
 }
 
 func (ec *executionContext) fieldContext_TestLog_urlRaw(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "TestLog",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _TestLog_renderingType(ctx context.Context, field graphql.CollectedField, obj *model.TestLogs) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_TestLog_renderingType,
-		func(ctx context.Context) (any, error) {
-			return obj.RenderingType, nil
-		},
-		nil,
-		ec.marshalOString2ᚖstring,
-		true,
-		false,
-	)
-}
-
-func (ec *executionContext) fieldContext_TestLog_renderingType(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "TestLog",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _TestLog_testName(ctx context.Context, field graphql.CollectedField, obj *model.TestLogs) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_TestLog_testName,
-		func(ctx context.Context) (any, error) {
-			return obj.TestName, nil
-		},
-		nil,
-		ec.marshalOString2ᚖstring,
-		true,
-		false,
-	)
-}
-
-func (ec *executionContext) fieldContext_TestLog_testName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "TestLog",
 		Field:      field,
@@ -69906,16 +69942,18 @@ func (ec *executionContext) fieldContext_TestResult_logs(_ context.Context, fiel
 			switch field.Name {
 			case "lineNum":
 				return ec.fieldContext_TestLog_lineNum(ctx, field)
+			case "logsToMerge":
+				return ec.fieldContext_TestLog_logsToMerge(ctx, field)
+			case "renderingType":
+				return ec.fieldContext_TestLog_renderingType(ctx, field)
+			case "testName":
+				return ec.fieldContext_TestLog_testName(ctx, field)
 			case "url":
 				return ec.fieldContext_TestLog_url(ctx, field)
 			case "urlParsley":
 				return ec.fieldContext_TestLog_urlParsley(ctx, field)
 			case "urlRaw":
 				return ec.fieldContext_TestLog_urlRaw(ctx, field)
-			case "renderingType":
-				return ec.fieldContext_TestLog_renderingType(ctx, field)
-			case "testName":
-				return ec.fieldContext_TestLog_testName(ctx, field)
 			case "version":
 				return ec.fieldContext_TestLog_version(ctx, field)
 			}
@@ -107454,16 +107492,18 @@ func (ec *executionContext) _TestLog(ctx context.Context, sel ast.SelectionSet, 
 			out.Values[i] = graphql.MarshalString("TestLog")
 		case "lineNum":
 			out.Values[i] = ec._TestLog_lineNum(ctx, field, obj)
+		case "logsToMerge":
+			out.Values[i] = ec._TestLog_logsToMerge(ctx, field, obj)
+		case "renderingType":
+			out.Values[i] = ec._TestLog_renderingType(ctx, field, obj)
+		case "testName":
+			out.Values[i] = ec._TestLog_testName(ctx, field, obj)
 		case "url":
 			out.Values[i] = ec._TestLog_url(ctx, field, obj)
 		case "urlParsley":
 			out.Values[i] = ec._TestLog_urlParsley(ctx, field, obj)
 		case "urlRaw":
 			out.Values[i] = ec._TestLog_urlRaw(ctx, field, obj)
-		case "renderingType":
-			out.Values[i] = ec._TestLog_renderingType(ctx, field, obj)
-		case "testName":
-			out.Values[i] = ec._TestLog_testName(ctx, field, obj)
 		case "version":
 			out.Values[i] = ec._TestLog_version(ctx, field, obj)
 		default:

--- a/graphql/schema/types/task.graphql
+++ b/graphql/schema/types/task.graphql
@@ -300,11 +300,12 @@ type TestResult {
 
 type TestLog {
   lineNum: Int
+  logsToMerge: [String!]
+  renderingType: String
+  testName: String
   url: String
   urlParsley: String
   urlRaw: String
-  renderingType: String
-  testName: String
   version: Int
 }
 
@@ -334,7 +335,9 @@ type TaskOwnerTeam {
 Cost represents the cost breakdown for a task or version.
 """
 type Cost {
-  """Sum of adjusted cost components; excludes on-demand components."""
+  """
+  Sum of adjusted cost components; excludes on-demand components.
+  """
   total: Float
   childPatchesTotalCost: Float
   adjustedEC2Cost: Float

--- a/graphql/tests/task/tests/data.json
+++ b/graphql/tests/task/tests/data.json
@@ -355,6 +355,36 @@
     },
     {
       "_id": {
+        "task_id": "logs_to_merge_task",
+        "execution": 0
+      },
+      "stats": {
+        "total_count": 1,
+        "failed_count": 0
+      },
+      "results": [
+        {
+          "test_name": "TestLogsToMerge",
+          "task_id": "logs_to_merge_task",
+          "execution": 0,
+          "status": "pass",
+          "log_info": {
+            "line_num": 10,
+            "rendering_type": "default",
+            "version": 1,
+            "logs_to_merge": ["job1", "job2"]
+          },
+          "test_start_time": {
+            "$date": "2020-02-21T15:15:56Z"
+          },
+          "test_end_time": {
+            "$date": "2020-02-21T15:15:56.020Z"
+          }
+        }
+      ]
+    },
+    {
+      "_id": {
         "task_id": "patch_task",
         "execution": 0
       },
@@ -820,6 +850,22 @@
       },
       "has_test_results": true,
       "results_failed": true,
+      "task_output_info": {
+        "test_results": {
+          "version": 2
+        }
+      }
+    },
+    {
+      "_id": "logs_to_merge_task",
+      "r": "github_pull_request",
+      "branch": "spruce",
+      "gitspec": "patch-revision",
+      "build_variant": "ubuntu1604",
+      "status": "success",
+      "display_name": "logs-to-merge-task",
+      "execution": 0,
+      "has_test_results": true,
       "task_output_info": {
         "test_results": {
           "version": 2

--- a/graphql/tests/task/tests/queries/logs_to_merge.graphql
+++ b/graphql/tests/task/tests/queries/logs_to_merge.graphql
@@ -1,0 +1,14 @@
+{
+  task(taskId: "logs_to_merge_task", execution: 0) {
+    id
+    execution
+    tests(opts: { limit: 1 }) {
+      testResults {
+        id
+        logs {
+          logsToMerge
+        }
+      }
+    }
+  }
+}

--- a/graphql/tests/task/tests/results.json
+++ b/graphql/tests/task/tests/results.json
@@ -504,6 +504,27 @@
           }
         }
       }
+    },
+    {
+      "query_file": "logs_to_merge.graphql",
+      "result": {
+        "data": {
+          "task": {
+            "id": "logs_to_merge_task",
+            "execution": 0,
+            "tests": {
+              "testResults": [
+                {
+                  "id": "TestLogsToMerge",
+                  "logs": {
+                    "logsToMerge": ["job1", "job2"]
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
     }
   ]
 }

--- a/rest/model/test.go
+++ b/rest/model/test.go
@@ -47,6 +47,8 @@ type TestLogs struct {
 	TestName      *string `json:"log_test_name"`
 	RenderingType *string `json:"rendering_type"`
 	Version       int32   `json:"version"`
+	// Logs to merge (used for resmoke test results that have multiple log files).
+	LogsToMerge []string `json:"logs_to_merge,omitempty"`
 }
 
 func (at *APITest) BuildFromService(st any) error {
@@ -86,6 +88,9 @@ func (at *APITest) BuildFromService(st any) error {
 			at.Logs.LineNum = int(v.LogInfo.LineNum)
 			if at.Logs.LineNum == 0 {
 				at.Logs.LineNum = int(v.LogInfo.LineNumCedar)
+			}
+			if v.LogInfo.LogsToMerge != nil {
+				at.Logs.LogsToMerge = utility.FromStringPtrSlice(v.LogInfo.LogsToMerge)
 			}
 		}
 	case string:

--- a/rest/model/test.go
+++ b/rest/model/test.go
@@ -89,9 +89,7 @@ func (at *APITest) BuildFromService(st any) error {
 			if at.Logs.LineNum == 0 {
 				at.Logs.LineNum = int(v.LogInfo.LineNumCedar)
 			}
-			if v.LogInfo.LogsToMerge != nil {
-				at.Logs.LogsToMerge = utility.FromStringPtrSlice(v.LogInfo.LogsToMerge)
-			}
+			at.Logs.LogsToMerge = utility.FromStringPtrSlice(v.LogInfo.LogsToMerge)
 		}
 	case string:
 		at.TaskID = utility.ToStringPtr(v)


### PR DESCRIPTION
DEVPROD-31541

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Exposes existing field `LogsToMerge`. This will allow us to provide a better command for downloading logs in Parsley.