### PR TITLE
DEVPROD-29909: use repo webhooks for personal staging

### DIFF
--- a/mock/environment.go
+++ b/mock/environment.go
@@ -42,7 +42,6 @@ type Environment struct {
 	DBSession               db.Session
 	EvergreenSettings       *evergreen.Settings
 	MongoClient             *mongo.Client
-	SharedDatabase          *mongo.Database
 	mu                      sync.RWMutex
 	DatabaseName            string
 	EnvContext              context.Context
@@ -261,7 +260,7 @@ func (e *Environment) CedarDB() *mongo.Database {
 }
 
 func (e *Environment) SharedDB() *mongo.Database {
-	return e.SharedDatabase
+	return nil
 }
 
 func (e *Environment) JasperManager() jasper.Manager {

--- a/mock/environment.go
+++ b/mock/environment.go
@@ -42,6 +42,7 @@ type Environment struct {
 	DBSession               db.Session
 	EvergreenSettings       *evergreen.Settings
 	MongoClient             *mongo.Client
+	SharedDatabase          *mongo.Database
 	mu                      sync.RWMutex
 	DatabaseName            string
 	EnvContext              context.Context
@@ -260,7 +261,7 @@ func (e *Environment) CedarDB() *mongo.Database {
 }
 
 func (e *Environment) SharedDB() *mongo.Database {
-	return nil
+	return e.SharedDatabase
 }
 
 func (e *Environment) JasperManager() jasper.Manager {

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -138,10 +138,9 @@ func (gh *githubHookApi) Parse(ctx context.Context, r *http.Request) error {
 // not available for the owner/repo. This deduplicates event processing for
 // repos with both the GitHub app installed and a repo webhook installed.
 func (gh *githubHookApi) shouldSkipWebhook(ctx context.Context, owner, repo string, fromApp bool) bool {
-	if evergreen.GetEnvironment().SharedDB() != nil {
-		// For personal staging (i.e. using a shared DB across all staging
-		// instances), only use repo webhooks and ignore GitHub app webhooks
-		// because they're more convenient.
+	if gh.settings.Ui.StagingEnvironment != "" {
+		// For personal staging, only use repo webhooks and ignore GitHub app
+		// webhooks because they're more convenient.
 		//
 		// For context, it's easier to maintain personal staging if they use
 		// only repo webhooks because Evergreen devs have direct and visible

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -133,9 +133,26 @@ func (gh *githubHookApi) Parse(ctx context.Context, r *http.Request) error {
 	return nil
 }
 
-// shouldSkipWebhook returns true if the event is from a GitHub app and the app is available for the owner/repo or,
-// the event is from webhooks and the app is not available for the owner/repo.
+// shouldSkipWebhook returns true if the event is from a GitHub app and the app
+// is available for the owner/repo or, the event is from webhooks and the app is
+// not available for the owner/repo. This deduplicates event processing for
+// repos with both the GitHub app installed and a repo webhook installed.
 func (gh *githubHookApi) shouldSkipWebhook(ctx context.Context, owner, repo string, fromApp bool) bool {
+	if evergreen.GetEnvironment().SharedDB() != nil {
+		// For personal staging (i.e. using a shared DB across all staging
+		// instances), only use repo webhooks and ignore GitHub app webhooks
+		// because they're more convenient.
+		//
+		// For context, it's easier to maintain personal staging if they use
+		// only repo webhooks because Evergreen devs have direct and visible
+		// control over the repo webhook configurations (via repo settings). In
+		// contrast, GitHub apps have restrictive permissions and are not
+		// directly accessible by Evergreen devs, so making changes (e.g. adding
+		// webhooks to a new repo, changing webhook configuration, debugging) is
+		// slow and difficult.
+		return fromApp
+	}
+
 	hasApp, err := githubapp.CreateGitHubAppAuth(gh.settings).IsGithubAppInstalledOnRepo(ctx, owner, repo)
 	if err != nil {
 		hasApp = false

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -499,38 +499,28 @@ func TestHandleGitHubMergeGroup(t *testing.T) {
 func TestShouldSkipWebhookPersonalStaging(t *testing.T) {
 	ctx := t.Context()
 
-	mockEnv := &mock.Environment{}
-	require.NoError(t, mockEnv.Configure(ctx))
-
-	originalEnv := evergreen.GetEnvironment()
-	t.Cleanup(func() { evergreen.SetEnvironment(originalEnv) })
-
-	handler := &githubHookApi{settings: mockEnv.Settings()}
-
 	for testCase, tc := range map[string]struct {
-		isPersonalStaging bool
-		fromApp           bool
-		expectSkip        bool
+		stagingEnvironment string
+		fromApp            bool
+		expectSkip         bool
 	}{
 		"PersonalStagingSkipsAppWebhook": {
-			isPersonalStaging: true,
-			fromApp:           true,
-			expectSkip:        true,
+			stagingEnvironment: "mine",
+			fromApp:            true,
+			expectSkip:         true,
 		},
 		"PersonalStagingAcceptsRepoWebhook": {
-			isPersonalStaging: true,
-			fromApp:           false,
-			expectSkip:        false,
+			stagingEnvironment: "mine",
+			fromApp:            false,
+			expectSkip:         false,
 		},
 	} {
 		t.Run(testCase, func(t *testing.T) {
-			if tc.isPersonalStaging {
-				mockEnv.SharedDatabase = mockEnv.MongoClient.Database("shared")
-			} else {
-				mockEnv.SharedDatabase = nil
+			handler := &githubHookApi{
+				settings: &evergreen.Settings{
+					Ui: evergreen.UIConfig{StagingEnvironment: tc.stagingEnvironment},
+				},
 			}
-			evergreen.SetEnvironment(mockEnv)
-
 			result := handler.shouldSkipWebhook(ctx, "owner", "repo", tc.fromApp)
 			assert.Equal(t, tc.expectSkip, result)
 		})

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -495,3 +495,44 @@ func TestHandleGitHubMergeGroup(t *testing.T) {
 		t.Run(testCase, test)
 	}
 }
+
+func TestShouldSkipWebhookPersonalStaging(t *testing.T) {
+	ctx := t.Context()
+
+	mockEnv := &mock.Environment{}
+	require.NoError(t, mockEnv.Configure(ctx))
+
+	originalEnv := evergreen.GetEnvironment()
+	t.Cleanup(func() { evergreen.SetEnvironment(originalEnv) })
+
+	handler := &githubHookApi{settings: mockEnv.Settings()}
+
+	for testCase, tc := range map[string]struct {
+		isPersonalStaging bool
+		fromApp           bool
+		expectSkip        bool
+	}{
+		"PersonalStagingSkipsAppWebhook": {
+			isPersonalStaging: true,
+			fromApp:           true,
+			expectSkip:        true,
+		},
+		"PersonalStagingAcceptsRepoWebhook": {
+			isPersonalStaging: true,
+			fromApp:           false,
+			expectSkip:        false,
+		},
+	} {
+		t.Run(testCase, func(t *testing.T) {
+			if tc.isPersonalStaging {
+				mockEnv.SharedDatabase = mockEnv.MongoClient.Database("shared")
+			} else {
+				mockEnv.SharedDatabase = nil
+			}
+			evergreen.SetEnvironment(mockEnv)
+
+			result := handler.shouldSkipWebhook(ctx, "owner", "repo", tc.fromApp)
+			assert.Equal(t, tc.expectSkip, result)
+		})
+	}
+}


### PR DESCRIPTION
DEVPROD-29909

### Description
I got personal staging to work with GitHub webhooks, but it's more convenient for long-term personal staging maintenance if we use webhooks set up on individual repos rather than in the GitHub app. This is because the GitHub app is outside our direct access (so we would have to bug IT every time we wanted to check configuration, fix issues, or add new webhooks). Because of that, I think it's okay for personal staging to use the old method of getting webhooks from GitHub repo settings rather than GitHub apps.

### Testing
* Added unit tests.
* Tested in my personal staging to confirm that it receives webhooks and processes.