### PR TITLE
DEVPROD-29376 add github merge group to patch rest response

### DIFF
--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -64,10 +64,12 @@ type APIPatch struct {
 	VariantsTasks []VariantTask `json:"variants_tasks"`
 	// Whether the patch has been finalized and activated
 	Activated bool `json:"activated"`
-	// Whether the patch was invalidated because an item ahead of it in the merge queue failed.
+	// InvalidatedByUpstream is whether the patch was invalidated because an item ahead of it in the merge queue failed.
+	// Repeated from GithubMergeData to preserve backwards compatibility.
 	InvalidatedByUpstream bool                 `json:"invalidated_by_upstream"`
 	Alias                 *string              `json:"alias,omitempty"`
 	GithubPatchData       APIGithubPatch       `json:"github_patch_data"`
+	GithubMergeData       APIGithubMergeGroup  `json:"github_merge_data"`
 	ModuleCodeChanges     []APIModulePatch     `json:"module_code_changes"`
 	Parameters            []APIParameter       `json:"parameters"`
 	ProjectStorageMethod  *string              `json:"project_storage_method,omitempty"`
@@ -316,6 +318,8 @@ func (apiPatch *APIPatch) buildBasePatch(p patch.Patch) {
 
 	apiPatch.GithubPatchData = APIGithubPatch{}
 	apiPatch.GithubPatchData.BuildFromService(p.GithubPatchData)
+	apiPatch.GithubMergeData = APIGithubMergeGroup{}
+	apiPatch.GithubMergeData.BuildFromService(p.GithubMergeData)
 	apiPatch.InvalidatedByUpstream = p.GithubMergeData.InvalidatedByUpstream
 }
 
@@ -548,7 +552,12 @@ func (apiPatch *APIPatch) ToService() (patch.Patch, error) {
 	}
 
 	res.GithubPatchData = apiPatch.GithubPatchData.ToService()
-	res.GithubMergeData.InvalidatedByUpstream = apiPatch.InvalidatedByUpstream
+	res.GithubMergeData = apiPatch.GithubMergeData.ToService()
+	// Preserve the top-level InvalidatedByUpstream for clients that set it without
+	// populating the full GithubMergeData struct.
+	if apiPatch.InvalidatedByUpstream {
+		res.GithubMergeData.InvalidatedByUpstream = true
+	}
 	res.ProjectStorageMethod = evergreen.ParserProjectStorageMethod(utility.FromStringPtr(apiPatch.ProjectStorageMethod))
 	return res, catcher.Resolve()
 }
@@ -576,7 +585,7 @@ func (g *APIGithubPatch) BuildFromService(p thirdparty.GithubPatch) {
 	g.Author = utility.ToStringPtr(p.Author)
 }
 
-// ToService converts a service layer patch using the data from APIPatch
+// ToService converts an APIGithubPatch to a service-layer GithubPatch.
 func (g *APIGithubPatch) ToService() thirdparty.GithubPatch {
 	res := thirdparty.GithubPatch{}
 	res.PRNumber = g.PRNumber
@@ -587,5 +596,59 @@ func (g *APIGithubPatch) ToService() thirdparty.GithubPatch {
 	res.HeadBranch = utility.FromStringPtr(g.HeadBranch)
 	res.HeadHash = utility.FromStringPtr(g.HeadHash)
 	res.Author = utility.FromStringPtr(g.Author)
+	return res
+}
+
+// APIGithubMergeGroup is the REST API model for thirdparty.GithubMergeGroup.
+type APIGithubMergeGroup struct {
+	Org                   *string    `json:"org"`
+	Repo                  *string    `json:"repo"`
+	BaseBranch            *string    `json:"base_branch"`
+	HeadBranch            *string    `json:"head_branch"`
+	HeadSHA               *string    `json:"head_sha"`
+	BaseSHA               *string    `json:"base_sha"`
+	HeadCommit            *string    `json:"head_commit"`
+	HeadCommitDate        *time.Time `json:"head_commit_date"`
+	RemovedFromQueueAt    *time.Time `json:"removed_from_queue_at"`
+	RemovalReason         *string    `json:"removal_reason"`
+	GitRefNotFound        bool       `json:"git_ref_not_found"`
+	InvalidatedByUpstream bool       `json:"invalidated_by_upstream"`
+}
+
+// BuildFromService converts a service-layer GithubMergeGroup to an APIGithubMergeGroup.
+func (g *APIGithubMergeGroup) BuildFromService(mg thirdparty.GithubMergeGroup) {
+	g.Org = utility.ToStringPtr(mg.Org)
+	g.Repo = utility.ToStringPtr(mg.Repo)
+	g.BaseBranch = utility.ToStringPtr(mg.BaseBranch)
+	g.HeadBranch = utility.ToStringPtr(mg.HeadBranch)
+	g.HeadSHA = utility.ToStringPtr(mg.HeadSHA)
+	g.BaseSHA = utility.ToStringPtr(mg.BaseSHA)
+	g.HeadCommit = utility.ToStringPtr(mg.HeadCommit)
+	g.HeadCommitDate = ToTimePtr(mg.HeadCommitDate)
+	g.RemovedFromQueueAt = ToTimePtr(mg.RemovedFromQueueAt)
+	g.RemovalReason = utility.ToStringPtr(mg.RemovalReason)
+	g.GitRefNotFound = mg.GitRefNotFound
+	g.InvalidatedByUpstream = mg.InvalidatedByUpstream
+}
+
+// ToService converts an APIGithubMergeGroup to a service-layer GithubMergeGroup.
+func (g *APIGithubMergeGroup) ToService() thirdparty.GithubMergeGroup {
+	res := thirdparty.GithubMergeGroup{}
+	res.Org = utility.FromStringPtr(g.Org)
+	res.Repo = utility.FromStringPtr(g.Repo)
+	res.BaseBranch = utility.FromStringPtr(g.BaseBranch)
+	res.HeadBranch = utility.FromStringPtr(g.HeadBranch)
+	res.HeadSHA = utility.FromStringPtr(g.HeadSHA)
+	res.BaseSHA = utility.FromStringPtr(g.BaseSHA)
+	res.HeadCommit = utility.FromStringPtr(g.HeadCommit)
+	if g.HeadCommitDate != nil {
+		res.HeadCommitDate = *g.HeadCommitDate
+	}
+	if g.RemovedFromQueueAt != nil {
+		res.RemovedFromQueueAt = *g.RemovedFromQueueAt
+	}
+	res.RemovalReason = utility.FromStringPtr(g.RemovalReason)
+	res.GitRefNotFound = g.GitRefNotFound
+	res.InvalidatedByUpstream = g.InvalidatedByUpstream
 	return res
 }

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -641,12 +641,8 @@ func (g *APIGithubMergeGroup) ToService() thirdparty.GithubMergeGroup {
 	res.HeadSHA = utility.FromStringPtr(g.HeadSHA)
 	res.BaseSHA = utility.FromStringPtr(g.BaseSHA)
 	res.HeadCommit = utility.FromStringPtr(g.HeadCommit)
-	if g.HeadCommitDate != nil {
-		res.HeadCommitDate = *g.HeadCommitDate
-	}
-	if g.RemovedFromQueueAt != nil {
-		res.RemovedFromQueueAt = *g.RemovedFromQueueAt
-	}
+	res.HeadCommitDate = utility.FromTimePtr(g.HeadCommitDate)
+	res.RemovedFromQueueAt = utility.FromTimePtr(g.RemovedFromQueueAt)
 	res.RemovalReason = utility.FromStringPtr(g.RemovalReason)
 	res.GitRefNotFound = g.GitRefNotFound
 	res.InvalidatedByUpstream = g.InvalidatedByUpstream

--- a/rest/model/patch_test.go
+++ b/rest/model/patch_test.go
@@ -232,6 +232,74 @@ func TestGithubPatch(t *testing.T) {
 	assert.Equal("octocat", utility.FromStringPtr(a.Author))
 }
 
+func TestAPIGithubMergeGroup(t *testing.T) {
+	baseTime := time.Now().Truncate(time.Millisecond)
+	mg := thirdparty.GithubMergeGroup{
+		Org:                   "evergreen-ci",
+		Repo:                  "evergreen",
+		BaseBranch:            "main",
+		HeadBranch:            "gh-readonly-queue/main/pr-1-abc",
+		HeadSHA:               "abc123",
+		BaseSHA:               "def456",
+		HeadCommit:            "Merge pr #1",
+		HeadCommitDate:        baseTime,
+		RemovedFromQueueAt:    baseTime.Add(time.Hour),
+		RemovalReason:         "merged",
+		GitRefNotFound:        true,
+		InvalidatedByUpstream: false,
+	}
+
+	t.Run("BuildFromServiceRoundTrips", func(t *testing.T) {
+		a := APIGithubMergeGroup{}
+		a.BuildFromService(mg)
+
+		assert.Equal(t, mg.Org, utility.FromStringPtr(a.Org))
+		assert.Equal(t, mg.Repo, utility.FromStringPtr(a.Repo))
+		assert.Equal(t, mg.BaseBranch, utility.FromStringPtr(a.BaseBranch))
+		assert.Equal(t, mg.HeadBranch, utility.FromStringPtr(a.HeadBranch))
+		assert.Equal(t, mg.HeadSHA, utility.FromStringPtr(a.HeadSHA))
+		assert.Equal(t, mg.BaseSHA, utility.FromStringPtr(a.BaseSHA))
+		assert.Equal(t, mg.HeadCommit, utility.FromStringPtr(a.HeadCommit))
+		require.NotNil(t, a.HeadCommitDate)
+		assert.Equal(t, mg.HeadCommitDate, *a.HeadCommitDate)
+		require.NotNil(t, a.RemovedFromQueueAt)
+		assert.Equal(t, mg.RemovedFromQueueAt, *a.RemovedFromQueueAt)
+		assert.Equal(t, mg.RemovalReason, utility.FromStringPtr(a.RemovalReason))
+		assert.Equal(t, mg.GitRefNotFound, a.GitRefNotFound)
+		assert.Equal(t, mg.InvalidatedByUpstream, a.InvalidatedByUpstream)
+
+		svc := a.ToService()
+		assert.Equal(t, mg, svc)
+	})
+
+	t.Run("ZeroTimeFieldsAreNil", func(t *testing.T) {
+		a := APIGithubMergeGroup{}
+		a.BuildFromService(thirdparty.GithubMergeGroup{HeadSHA: "abc"})
+		assert.Nil(t, a.HeadCommitDate)
+		assert.Nil(t, a.RemovedFromQueueAt)
+	})
+
+	t.Run("APIPatchIncludesGithubMergeData", func(t *testing.T) {
+		p := patch.Patch{
+			Id:              mgobson.NewObjectId(),
+			GithubMergeData: mg,
+		}
+		a := APIPatch{}
+		require.NoError(t, a.BuildFromService(t.Context(), p, nil))
+
+		assert.Equal(t, mg.Org, utility.FromStringPtr(a.GithubMergeData.Org))
+		assert.Equal(t, mg.HeadSHA, utility.FromStringPtr(a.GithubMergeData.HeadSHA))
+		assert.Equal(t, mg.RemovalReason, utility.FromStringPtr(a.GithubMergeData.RemovalReason))
+		assert.Equal(t, mg.InvalidatedByUpstream, a.GithubMergeData.InvalidatedByUpstream)
+		// InvalidatedByUpstream is also mirrored in the top-level field for backward compatibility.
+		assert.Equal(t, mg.InvalidatedByUpstream, a.InvalidatedByUpstream)
+
+		svc, err := a.ToService()
+		require.NoError(t, err)
+		assert.Equal(t, mg, svc.GithubMergeData)
+	})
+}
+
 func TestDownstreamTasks(t *testing.T) {
 	assert := assert.New(t)
 	require.NoError(t, db.ClearCollections(patch.Collection, model.ProjectRefCollection))

--- a/trigger/payloads_test.go
+++ b/trigger/payloads_test.go
@@ -132,7 +132,7 @@ func (s *payloadSuite) TestEvergreenWebhook() {
 	s.NoError(err)
 	s.Require().NotNil(m)
 
-	s.Len(m.Body, 647)
+	s.Len(m.Body, 914)
 	s.Len(m.Headers, 1)
 }
 


### PR DESCRIPTION
DEVPROD-29376 
<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Add github merge group to rest response.

Preserved backwards compatibility by not removing InvalidatedByUpstream. Can make a follow up PR to remove it from the UI and then remove it here if we desire (but might just make a follow-up tech debt ticket for it).

### Testing
Added unit test.
