### PR TITLE
DEVPROD-32515: Fix merged schema generation

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -779,8 +779,7 @@ tasks:
           working_dir: evergreen
           shell: bash
           script: |
-            cat graphql/schema/types/*.graphql \
-            graphql/schema/*.graphql > docs/merged-schema.graphql
+            find graphql/schema -name "*.graphql" | xargs cat > docs/merged-schema.graphql
       - command: s3.put
         params:
           role_arn: ${assume_role_arn}


### PR DESCRIPTION
DEVPROD-32515

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
I'm not too familiar with the `generate-graphql-merged-schema` Evergreen task, but it seemingly uploads a version of our schema to a static S3 route. It was missing some files due to the `cat` glob not reaching all directories/files. We can use `find` to fix this.

### Testing
File generated by [task](https://spruce.corp.mongodb.com/task/evergreen_ubuntu2204_generate_graphql_merged_schema_patch_38eaadafd41eaa4fdbafa14fccb8d10fd8a1ef0c_69f275bc299cff0007a79ec1_26_04_29_21_19_08/files?execution=0) includes previously missing fields like `APIConfigInput`

<!-- 
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models - If you're adding a field to the Task, Build, Version, or Patch structs, consider creating a
  DPIPE ticket to expose this in the data warehouse.

-->
