### PR TITLE
DEVPROD-32312 Add demo to debug spawn host docs

### DIFF
--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -300,6 +300,9 @@ func generateConfigScript(ctx context.Context, taskID string, settings *evergree
 	if pp == nil {
 		return "", "", errors.Errorf("parser project not found for version '%s'", v.Id)
 	}
+	if err = pp.ClearParamsYAML(); err != nil {
+		return "", "", errors.Wrap(err, "clearing params YAML for debug config")
+	}
 	yamlBytes, err := yaml.Marshal(pp)
 	if err != nil {
 		return "", "", errors.Wrap(err, "marshalling parser project to YAML")

--- a/docs/Hosts/Debug-Spawn-Hosts.md
+++ b/docs/Hosts/Debug-Spawn-Hosts.md
@@ -1,6 +1,6 @@
 # Task Debugger
 
-Watch the demo [here](../images/Recreatable_Tasks_Demo.mp4).
+Watch the demo [here](https://drive.google.com/file/d/10g7cg9EisS-t_QKjLRrg5bKQUIJ59Fdr/view?usp=sharing).
 
 > **Notice:**
 > The task debugger is currently in **beta**. Features and behavior may change.

--- a/docs/Hosts/Debug-Spawn-Hosts.md
+++ b/docs/Hosts/Debug-Spawn-Hosts.md
@@ -1,5 +1,7 @@
 # Task Debugger
 
+Watch the demo [here](../images/Recreatable_Tasks_Demo.mp4).
+
 > **Notice:**
 > The task debugger is currently in **beta**. Features and behavior may change.
 

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -2024,3 +2024,48 @@ func evaluateRequesters(userRequesters []evergreen.UserRequester) []string {
 func preGeneratedParserProjectId(originalId string) string {
 	return fmt.Sprintf("%s_%s", "pre_generation", originalId)
 }
+
+// ClearParamsYAML resolves and removes the params_yaml field from all
+// commands in the parser project. This is used when serializing the project
+// to a human-editable YAML file (e.g. for debug spawn hosts) so that only
+// the params map is present. Without this, params_yaml takes precedence
+// over params during deserialization, silently discarding user edits.
+func (pp *ParserProject) ClearParamsYAML() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.Add(clearCommandSetParamsYAML(pp.Pre))
+	catcher.Add(clearCommandSetParamsYAML(pp.Post))
+	catcher.Add(clearCommandSetParamsYAML(pp.Timeout))
+	for _, f := range pp.Functions {
+		catcher.Add(clearCommandSetParamsYAML(f))
+	}
+	for i := range pp.Tasks {
+		for j := range pp.Tasks[i].Commands {
+			catcher.Add(pp.Tasks[i].Commands[j].resolveParams())
+			pp.Tasks[i].Commands[j].ParamsYAML = ""
+		}
+	}
+	for i := range pp.TaskGroups {
+		catcher.Add(clearCommandSetParamsYAML(pp.TaskGroups[i].SetupGroup))
+		catcher.Add(clearCommandSetParamsYAML(pp.TaskGroups[i].TeardownGroup))
+		catcher.Add(clearCommandSetParamsYAML(pp.TaskGroups[i].SetupTask))
+		catcher.Add(clearCommandSetParamsYAML(pp.TaskGroups[i].TeardownTask))
+		catcher.Add(clearCommandSetParamsYAML(pp.TaskGroups[i].Timeout))
+	}
+	return catcher.Resolve()
+}
+
+func clearCommandSetParamsYAML(cs *YAMLCommandSet) error {
+	if cs == nil {
+		return nil
+	}
+	catcher := grip.NewBasicCatcher()
+	if cs.SingleCommand != nil {
+		catcher.Add(cs.SingleCommand.resolveParams())
+		cs.SingleCommand.ParamsYAML = ""
+	}
+	for i := range cs.MultiCommand {
+		catcher.Add(cs.MultiCommand[i].resolveParams())
+		cs.MultiCommand[i].ParamsYAML = ""
+	}
+	return catcher.Resolve()
+}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -2025,11 +2025,10 @@ func preGeneratedParserProjectId(originalId string) string {
 	return fmt.Sprintf("%s_%s", "pre_generation", originalId)
 }
 
-// ClearParamsYAML resolves and removes the params_yaml field from all
-// commands in the parser project. This is used when serializing the project
+// ClearParamsYAML resolves and removes the params_yaml (which is a DB-only field)
+// from all commands in the parser project. This is used when serializing the project
 // to a human-editable YAML file (e.g. for debug spawn hosts) so that only
-// the params map is present. Without this, params_yaml takes precedence
-// over params during deserialization, silently discarding user edits.
+// the params map is present.
 func (pp *ParserProject) ClearParamsYAML() error {
 	catcher := grip.NewBasicCatcher()
 	catcher.Add(clearCommandSetParamsYAML(pp.Pre))

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -3248,3 +3248,95 @@ func TestSetupParallelGitIncludeDirs(t *testing.T) {
 		})
 	}
 }
+
+func TestClearParamsYAML(t *testing.T) {
+	paramsYAML := "binary: make\nargs:\n- test\n"
+
+	pp := &ParserProject{
+		Pre: &YAMLCommandSet{
+			SingleCommand: &PluginCommandConf{
+				Command:    "shell.exec",
+				ParamsYAML: paramsYAML,
+			},
+		},
+		Post: &YAMLCommandSet{
+			MultiCommand: []PluginCommandConf{
+				{Command: "s3.put", ParamsYAML: paramsYAML},
+			},
+		},
+		Functions: map[string]*YAMLCommandSet{
+			"run-make": {
+				SingleCommand: &PluginCommandConf{
+					Command:    "subprocess.exec",
+					ParamsYAML: paramsYAML,
+				},
+			},
+			"multi-func": {
+				MultiCommand: []PluginCommandConf{
+					{Command: "shell.exec", ParamsYAML: paramsYAML},
+					{Command: "s3.put", ParamsYAML: paramsYAML},
+				},
+			},
+		},
+		Tasks: []parserTask{
+			{
+				Name: "my-task",
+				Commands: []PluginCommandConf{
+					{Command: "shell.exec", ParamsYAML: paramsYAML},
+				},
+			},
+		},
+		TaskGroups: []parserTaskGroup{
+			{
+				Name: "my-group",
+				SetupGroup: &YAMLCommandSet{
+					SingleCommand: &PluginCommandConf{
+						Command:    "shell.exec",
+						ParamsYAML: paramsYAML,
+					},
+				},
+				SetupTask: &YAMLCommandSet{
+					MultiCommand: []PluginCommandConf{
+						{Command: "shell.exec", ParamsYAML: paramsYAML},
+					},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, pp.ClearParamsYAML())
+
+	t.Run("ParamsYAMLIsCleared", func(t *testing.T) {
+		assert.Empty(t, pp.Pre.SingleCommand.ParamsYAML)
+		assert.Empty(t, pp.Post.MultiCommand[0].ParamsYAML)
+		assert.Empty(t, pp.Functions["run-make"].SingleCommand.ParamsYAML)
+		assert.Empty(t, pp.Functions["multi-func"].MultiCommand[0].ParamsYAML)
+		assert.Empty(t, pp.Functions["multi-func"].MultiCommand[1].ParamsYAML)
+		assert.Empty(t, pp.Tasks[0].Commands[0].ParamsYAML)
+		assert.Empty(t, pp.TaskGroups[0].SetupGroup.SingleCommand.ParamsYAML)
+		assert.Empty(t, pp.TaskGroups[0].SetupTask.MultiCommand[0].ParamsYAML)
+	})
+
+	t.Run("ParamsIsPopulatedFromParamsYAML", func(t *testing.T) {
+		assert.Equal(t, "make", pp.Pre.SingleCommand.Params["binary"])
+		assert.Equal(t, "make", pp.Functions["run-make"].SingleCommand.Params["binary"])
+		assert.Equal(t, "make", pp.Tasks[0].Commands[0].Params["binary"])
+	})
+
+	t.Run("MarshaledYAMLDoesNotContainParamsYAML", func(t *testing.T) {
+		out, err := yaml.Marshal(pp)
+		require.NoError(t, err)
+		assert.NotContains(t, string(out), "params_yaml")
+		assert.Contains(t, string(out), "params")
+	})
+
+	t.Run("RoundtripPreservesParams", func(t *testing.T) {
+		out, err := yaml.Marshal(pp)
+		require.NoError(t, err)
+
+		var roundtripped ParserProject
+		require.NoError(t, yaml.Unmarshal(out, &roundtripped))
+		assert.Equal(t, "make", roundtripped.Functions["run-make"].SingleCommand.Params["binary"])
+		assert.Equal(t, "make", roundtripped.Tasks[0].Commands[0].Params["binary"])
+	})
+}

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -3317,26 +3317,10 @@ func TestClearParamsYAML(t *testing.T) {
 		assert.Empty(t, pp.TaskGroups[0].SetupTask.MultiCommand[0].ParamsYAML)
 	})
 
-	t.Run("ParamsIsPopulatedFromParamsYAML", func(t *testing.T) {
-		assert.Equal(t, "make", pp.Pre.SingleCommand.Params["binary"])
-		assert.Equal(t, "make", pp.Functions["run-make"].SingleCommand.Params["binary"])
-		assert.Equal(t, "make", pp.Tasks[0].Commands[0].Params["binary"])
-	})
-
 	t.Run("MarshaledYAMLDoesNotContainParamsYAML", func(t *testing.T) {
 		out, err := yaml.Marshal(pp)
 		require.NoError(t, err)
 		assert.NotContains(t, string(out), "params_yaml")
 		assert.Contains(t, string(out), "params")
-	})
-
-	t.Run("RoundtripPreservesParams", func(t *testing.T) {
-		out, err := yaml.Marshal(pp)
-		require.NoError(t, err)
-
-		var roundtripped ParserProject
-		require.NoError(t, yaml.Unmarshal(out, &roundtripped))
-		assert.Equal(t, "make", roundtripped.Functions["run-make"].SingleCommand.Params["binary"])
-		assert.Equal(t, "make", roundtripped.Tasks[0].Commands[0].Params["binary"])
 	})
 }


### PR DESCRIPTION
DEVPROD-32312

### Description
I filmed a comprehensive [demo](https://drive.google.com/drive/u/0/folders/1vnWbrH7Yp7iTJWKClPuNunSJ8GkYjoCT) for the new recreatable tasks feature, linking it into our official docs.

While filming the demo I noticed that both [params and params_yaml](https://github.com/evergreen-ci/evergreen/blob/23e4dd0fe7b6c861127c7c28545ed8b1254d2563/model/project.go#L547-L550) (the latter which is a DB-only parser project field) are present in the marshalled config YAML that appears on the debug spawn host, which is confusing. Added a driveby fix to prune the `params_yaml` field before fetching and unmarshaling the YAML in debug spawn hosts.
### Testing
Verified driveby fix in staging
### Documentation
Updated docs!