### PR TITLE
DEVPROD-31874: Address S3 Artifact bug on how 0KB File Files are handled

### DIFF
--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -394,7 +394,6 @@ func (s3pc *s3put) Execute(ctx context.Context, comm client.Communicator, logger
 
 	if s3pc.isPrivate(s3pc.Visibility) {
 		logger.Task().Infof(ctx, "Putting private files into S3.")
-
 	} else {
 		if s3pc.isMulti() {
 			logger.Task().Infof(ctx, "Putting files matching filter '%s' into path '%s' in S3 bucket '%s'.",
@@ -425,7 +424,6 @@ func (s3pc *s3put) Execute(ctx context.Context, comm client.Communicator, logger
 		logger.Execution().Infof(ctx, "Canceled while running command '%s': %s.", s3pc.Name(), ctx.Err())
 		return nil
 	}
-
 }
 
 // Wrapper around the Put() function to retry it.
@@ -547,13 +545,8 @@ retryLoop:
 					continue retryLoop
 				}
 
-				uploadPath := fpath
-				if s3pc.preservePath {
-					uploadPath = remoteName
-				}
-
 				uploadedFiles = append(uploadedFiles, s3usage.FileMetrics{
-					LocalPath:  uploadPath,
+					LocalPath:  fpath,
 					RemotePath: remoteName,
 				})
 

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -30,17 +30,13 @@ import (
 )
 
 func TestS3PutValidateParams(t *testing.T) {
-
 	Convey("With an s3 put command", t, func() {
-
 		var cmd *s3put
 
 		Convey("when validating command params", func() {
-
 			cmd = &s3put{}
 
 			Convey("a missing aws key should cause an error", func() {
-
 				params := map[string]any{
 					"aws_secret":   "secret",
 					"local_file":   "local",
@@ -55,7 +51,6 @@ func TestS3PutValidateParams(t *testing.T) {
 				So(err.Error(), ShouldContainSubstring, "AWS key cannot be blank")
 			})
 			Convey("a defined local file and inclusion filter should cause an error", func() {
-
 				params := map[string]any{
 					"aws_secret":                 "secret",
 					"aws_key":                    "key",
@@ -72,7 +67,6 @@ func TestS3PutValidateParams(t *testing.T) {
 				So(err.Error(), ShouldContainSubstring, "local file and local files include filter cannot both be specified")
 			})
 			Convey("a defined inclusion filter with optional upload should cause an error", func() {
-
 				params := map[string]any{
 					"aws_secret":                 "secret",
 					"aws_key":                    "key",
@@ -103,7 +97,6 @@ func TestS3PutValidateParams(t *testing.T) {
 			})
 
 			Convey("a missing aws secret should cause an error", func() {
-
 				params := map[string]any{
 					"aws_key":      "key",
 					"local_file":   "local",
@@ -119,7 +112,6 @@ func TestS3PutValidateParams(t *testing.T) {
 			})
 
 			Convey("a missing local file should cause an error", func() {
-
 				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
@@ -135,7 +127,6 @@ func TestS3PutValidateParams(t *testing.T) {
 			})
 
 			Convey("a missing remote file should cause an error", func() {
-
 				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
@@ -151,7 +142,6 @@ func TestS3PutValidateParams(t *testing.T) {
 			})
 
 			Convey("a missing bucket should cause an error", func() {
-
 				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
@@ -167,7 +157,6 @@ func TestS3PutValidateParams(t *testing.T) {
 			})
 
 			Convey("a missing s3 permission should cause an error", func() {
-
 				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
@@ -183,7 +172,6 @@ func TestS3PutValidateParams(t *testing.T) {
 			})
 
 			Convey("an invalid s3 permission should cause an error", func() {
-
 				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
@@ -200,7 +188,6 @@ func TestS3PutValidateParams(t *testing.T) {
 			})
 
 			Convey("an expansion s3 permission should pass", func() {
-
 				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
@@ -216,7 +203,6 @@ func TestS3PutValidateParams(t *testing.T) {
 			})
 
 			Convey("an expansion s3 visibility should pass", func() {
-
 				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
@@ -233,7 +219,6 @@ func TestS3PutValidateParams(t *testing.T) {
 			})
 
 			Convey("a missing content type should cause an error", func() {
-
 				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
@@ -249,7 +234,6 @@ func TestS3PutValidateParams(t *testing.T) {
 			})
 
 			Convey("an invalid visibility type should cause an error", func() {
-
 				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
@@ -267,7 +251,6 @@ func TestS3PutValidateParams(t *testing.T) {
 			})
 
 			Convey("a valid set of params should not cause an error", func() {
-
 				params := map[string]any{
 					"aws_key":      "key",
 					"aws_secret":   "secret",
@@ -304,7 +287,6 @@ func TestS3PutValidateParams(t *testing.T) {
 				So(cmd.ParseParams(params), ShouldBeNil)
 			})
 		})
-
 	})
 }
 
@@ -325,7 +307,6 @@ func TestS3PutOptionsStorageClass(t *testing.T) {
 }
 
 func TestExpandS3PutParams(t *testing.T) {
-
 	Convey("With an s3 put command and a task config", t, func() {
 		abs, err := filepath.Abs("working_directory")
 		So(err, ShouldBeNil)
@@ -338,7 +319,6 @@ func TestExpandS3PutParams(t *testing.T) {
 
 		Convey("when expanding the command's params all appropriate values should be expanded, if they"+
 			" contain expansions", func() {
-
 			cmd.AwsKey = "${aws_key}"
 			cmd.AwsSecret = "${aws_secret}"
 			cmd.RemoteFile = "${remote_file}"
@@ -402,9 +382,7 @@ func TestExpandS3PutParams(t *testing.T) {
 				So(cmd.expandParams(conf), ShouldNotBeNil)
 				So(cmd.skipMissing, ShouldBeFalse)
 			}
-
 		})
-
 	})
 }
 
@@ -415,8 +393,8 @@ func TestSignedUrlVisibility(t *testing.T) {
 	tempDir := t.TempDir()
 	file1 := filepath.Join(tempDir, "file1")
 	file2 := filepath.Join(tempDir, "file2")
-	require.NoError(t, os.WriteFile(file1, []byte("content1"), 0644))
-	require.NoError(t, os.WriteFile(file2, []byte("content2"), 0644))
+	require.NoError(t, os.WriteFile(file1, []byte("content1"), 0o644))
+	require.NoError(t, os.WriteFile(file2, []byte("content2"), 0o644))
 
 	for _, vis := range []string{"signed", "private"} {
 		s := s3put{
@@ -480,8 +458,8 @@ func TestContentTypeSaved(t *testing.T) {
 	tempDir := t.TempDir()
 	file1 := filepath.Join(tempDir, "file1")
 	file2 := filepath.Join(tempDir, "file2")
-	require.NoError(t, os.WriteFile(file1, []byte("content1"), 0644))
-	require.NoError(t, os.WriteFile(file2, []byte("content2"), 0644))
+	require.NoError(t, os.WriteFile(file1, []byte("content1"), 0o644))
+	require.NoError(t, os.WriteFile(file2, []byte("content2"), 0o644))
 
 	s := s3put{
 		AwsKey:        "key",
@@ -535,7 +513,6 @@ func TestContentTypeSaved(t *testing.T) {
 	for _, file := range files {
 		assert.Equal(t, file.ContentType, s.ContentType)
 	}
-
 }
 
 func TestS3LocalFilesIncludeFilterPrefix(t *testing.T) {
@@ -549,7 +526,7 @@ func TestS3LocalFilesIncludeFilterPrefix(t *testing.T) {
 			f, err := os.Create(filepath.Join(dir, "foo"))
 			require.NoError(t, err)
 			require.NoError(t, f.Close())
-			require.NoError(t, os.Mkdir(filepath.Join(dir, "subDir"), 0755))
+			require.NoError(t, os.Mkdir(filepath.Join(dir, "subDir"), 0o755))
 			f, err = os.Create(filepath.Join(dir, "subDir", "bar"))
 			require.NoError(t, err)
 			require.NoError(t, f.Close())
@@ -571,7 +548,7 @@ func TestS3LocalFilesIncludeFilterPrefix(t *testing.T) {
 				Permissions:                   string(s3Types.BucketCannedACLPublicRead),
 				RemoteFile:                    "remote",
 			}
-			require.NoError(t, os.Mkdir(filepath.Join(dir, "destination"), 0755))
+			require.NoError(t, os.Mkdir(filepath.Join(dir, "destination"), 0o755))
 			opts := pail.LocalOptions{
 				Path: filepath.Join(dir, "destination"),
 			}
@@ -617,7 +594,7 @@ func TestFileUploadNaming(t *testing.T) {
 	defer cancel()
 
 	dir := t.TempDir()
-	require.NoError(t, os.Mkdir(filepath.Join(dir, "subDir"), 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "subDir"), 0o755))
 	f, err := os.Create(filepath.Join(dir, "subDir", "bar"))
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
@@ -633,7 +610,7 @@ func TestFileUploadNaming(t *testing.T) {
 		LocalFilesIncludeFilterPrefix: "",
 		RemoteFile:                    "remote",
 	}
-	require.NoError(t, os.Mkdir(filepath.Join(dir, "destination"), 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "destination"), 0o755))
 	opts := pail.LocalOptions{
 		Path: filepath.Join(dir, "destination"),
 	}
@@ -677,9 +654,9 @@ func TestPreservePath(t *testing.T) {
 	dir := t.TempDir()
 
 	// Create the directories
-	require.NoError(t, os.Mkdir(filepath.Join(dir, "myWebsite"), 0755))
-	require.NoError(t, os.Mkdir(filepath.Join(dir, "myWebsite", "assets"), 0755))
-	require.NoError(t, os.Mkdir(filepath.Join(dir, "myWebsite", "assets", "images"), 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "myWebsite"), 0o755))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "myWebsite", "assets"), 0o755))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "myWebsite", "assets", "images"), 0o755))
 
 	// Create the files in in the assets directory
 	f, err := os.Create(filepath.Join(dir, "foo"))
@@ -714,7 +691,7 @@ func TestPreservePath(t *testing.T) {
 		RemoteFile:              "remote",
 		PreservePath:            "true",
 	}
-	require.NoError(t, os.Mkdir(filepath.Join(dir, "destination"), 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "destination"), 0o755))
 	opts := pail.LocalOptions{
 		Path: filepath.Join(dir, "destination"),
 	}
@@ -753,6 +730,11 @@ func TestPreservePath(t *testing.T) {
 		require.True(t, exists, item)
 	}
 
+	require.NotNil(t, conf.S3Usage)
+	// Each zero-byte file counts as 1 PUT; preserve_path uploads were previously broken because LocalPath was set to the S3 key.
+	assert.Equal(t, 6, conf.S3Usage.Artifacts.PutRequests)
+	assert.Equal(t, 6, conf.S3Usage.Artifacts.Count)
+	assert.Equal(t, int64(0), conf.S3Usage.Artifacts.UploadBytes)
 }
 
 func TestS3PutSkipExisting(t *testing.T) {
@@ -768,8 +750,8 @@ func TestS3PutSkipExisting(t *testing.T) {
 	secondFilePath := filepath.Join(temproot, "second-file.txt")
 
 	payload := []byte("hello world")
-	require.NoError(t, os.WriteFile(firstFilePath, payload, 0755))
-	require.NoError(t, os.WriteFile(secondFilePath, []byte("second file"), 0755))
+	require.NoError(t, os.WriteFile(firstFilePath, payload, 0o755))
+	require.NoError(t, os.WriteFile(secondFilePath, []byte("second file"), 0o755))
 
 	accessKeyID := settings.Expansions["aws_key"]
 	secretAccessKey := settings.Expansions["aws_secret"]
@@ -916,7 +898,7 @@ func TestReadAssociatedLinksFile(t *testing.T) {
 		}
 		data, err := json.Marshal(links)
 		require.NoError(t, err)
-		require.NoError(t, os.WriteFile(linksFile, data, 0644))
+		require.NoError(t, os.WriteFile(linksFile, data, 0o644))
 
 		conf := &internal.TaskConfig{
 			WorkDir:    tempDir,
@@ -950,7 +932,7 @@ func TestReadAssociatedLinksFile(t *testing.T) {
 		tempDir := t.TempDir()
 		linksFile := filepath.Join(tempDir, "invalid.json")
 
-		require.NoError(t, os.WriteFile(linksFile, []byte("not valid json"), 0644))
+		require.NoError(t, os.WriteFile(linksFile, []byte("not valid json"), 0o644))
 
 		conf := &internal.TaskConfig{
 			WorkDir:    tempDir,
@@ -971,7 +953,7 @@ func TestReadAssociatedLinksFile(t *testing.T) {
 		}
 		data, err := json.Marshal(links)
 		require.NoError(t, err)
-		require.NoError(t, os.WriteFile(linksFile, data, 0644))
+		require.NoError(t, os.WriteFile(linksFile, data, 0o644))
 
 		conf := &internal.TaskConfig{
 			WorkDir: tempDir,
@@ -994,7 +976,7 @@ func TestS3PutWithAssociatedLinks(t *testing.T) {
 
 	tempDir := t.TempDir()
 	s3PutFile := filepath.Join(tempDir, "file1")
-	require.NoError(t, os.WriteFile(s3PutFile, []byte("content1"), 0644))
+	require.NoError(t, os.WriteFile(s3PutFile, []byte("content1"), 0o644))
 
 	associatedLinks := []artifact.AssociatedLink{
 		{Name: "Documentation", Link: "https://example.com/docs"},

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-04-30"
+	AgentVersion = "2026-04-30b"
 )
 
 const (
@@ -161,7 +161,8 @@ func (c *Settings) Set(ctx context.Context) error {
 			sshKey:                     c.SSH,
 			spawnhostKey:               c.Spawnhost,
 			shutdownWaitKey:            c.ShutdownWaitSeconds,
-		}}), "updating config section '%s'", c.SectionId(),
+		},
+	}), "updating config section '%s'", c.SectionId(),
 	)
 }
 
@@ -257,7 +258,7 @@ func getSettings(ctx context.Context, includeOverrides, includeParameterStore bo
 	catcher := grip.NewSimpleCatcher()
 	baseConfig := config.Sections[ConfigDocID].(*Settings)
 	valConfig := reflect.ValueOf(*baseConfig)
-	//iterate over each field in the config struct
+	// iterate over each field in the config struct
 	for i := 0; i < valConfig.NumField(); i++ {
 		// retrieve the 'id' struct tag
 		sectionId := valConfig.Type().Field(i).Tag.Get("id")
@@ -519,7 +520,7 @@ func UpdateConfig(ctx context.Context, config *Settings) error {
 	catcher := grip.NewSimpleCatcher()
 	valConfig := reflect.ValueOf(*config)
 
-	//iterate over each field in the config struct
+	// iterate over each field in the config struct
 	for i := 0; i < valConfig.NumField(); i++ {
 		// retrieve the 'id' struct tag
 		sectionId := valConfig.Type().Field(i).Tag.Get("id")
@@ -779,7 +780,6 @@ type ReadConcern struct {
 }
 
 func (rc ReadConcern) Resolve() *readconcern.ReadConcern {
-
 	if rc.Level == "majority" {
 		return readconcern.Majority()
 	} else if rc.Level == "local" {
@@ -789,7 +789,8 @@ func (rc ReadConcern) Resolve() *readconcern.ReadConcern {
 	} else {
 		grip.Error(context.Background(), message.Fields{
 			"error":   "ReadConcern Level is not majority or local, setting to majority",
-			"rcLevel": rc.Level})
+			"rcLevel": rc.Level,
+		})
 		return readconcern.Majority()
 	}
 }

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-04-30b"
+	AgentVersion = "2026-05-01a"
 )
 
 const (

--- a/model/s3usage/s3usage.go
+++ b/model/s3usage/s3usage.go
@@ -77,8 +77,10 @@ type FileMetrics struct {
 	PutRequests   int
 }
 
-type S3BucketType string
-type S3UploadMethod string
+type (
+	S3BucketType   string
+	S3UploadMethod string
+)
 
 const (
 	S3PutRequestCost = 0.000005
@@ -147,7 +149,7 @@ func CalculateUploadMetrics(
 // CalculatePutRequestsWithContext returns the number of S3 PUT API calls
 // needed to upload a file based on bucket type, upload method, and file size.
 func CalculatePutRequestsWithContext(bucketType S3BucketType, method S3UploadMethod, fileSize int64) int {
-	if fileSize <= 0 {
+	if fileSize < 0 {
 		return 0
 	}
 

--- a/model/s3usage/s3usage_test.go
+++ b/model/s3usage/s3usage_test.go
@@ -55,7 +55,6 @@ func TestS3Usage(t *testing.T) {
 		s3Usage = S3Usage{}
 		s3Usage.Logs.UploadBytes = 100
 		assert.False(t, s3Usage.IsZero())
-
 	})
 
 	t.Run("IncrementArtifacts", func(t *testing.T) {
@@ -156,11 +155,15 @@ func TestS3Usage(t *testing.T) {
 func TestCalculatePutRequestsWithContext(t *testing.T) {
 	const MB = 1024 * 1024
 
-	t.Run("ZeroOrNegativeSize", func(t *testing.T) {
-		assert.Equal(t, 0, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodPut, 0))
+	t.Run("NegativeSizeShouldReturnZero", func(t *testing.T) {
 		assert.Equal(t, 0, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, -100))
 		assert.Equal(t, 0, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodWriter, -1*MB))
-		assert.Equal(t, 0, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodWriter, 0))
+	})
+
+	t.Run("ZeroByteFileShouldReturnOnePut", func(t *testing.T) {
+		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodPut, 0))
+		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, 0))
+		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodWriter, 0))
 	})
 
 	t.Run("CopyMethod", func(t *testing.T) {
@@ -278,7 +281,6 @@ func TestCalculateS3PutCostWithConfig(t *testing.T) {
 		assert.InDelta(t, 0.005, standard, 0.000001)
 		assert.Equal(t, 0.0, adjusted)
 	})
-
 }
 
 func TestCalculateS3StorageCostWithConfig(t *testing.T) {


### PR DESCRIPTION
DEVPROD-31874

### Description
This PR addresses 2 bugs. During testing it was discovered files of size 0KB are not being correctly counted in terms of puts request. Based on [AWS Pricing Docs](https://aws.amazon.com/s3/pricing/) the API request charges is based on the number of requests made and is irrespective of data size.

So when we make a put request for a file size of 0, we need to increment the put counts correctly. In this case it will count as 1 put

Also while debugging this issues to make sure areas where files are 0KB are accounted for, found an issue where files might not be getting the correct size (0KB or not)
When `preserve_path: true`, the upload logic stored  S3 remote key as the Local file Path instead of the local filesystem path. We calculate puts based on the file size from the path. So files that might or might not be 0KB are not getting calculated correctly.  Addressed this as well.

### Testing
Added test coverage and tested in staging.