### PR TITLE
DEVPROD-30832 Unignore GRPC from vulnerability check

### DIFF
--- a/scripts/check-go-vulnerabilities.sh
+++ b/scripts/check-go-vulnerabilities.sh
@@ -21,7 +21,6 @@ IGNORED_PACKAGES=(
     "csrf"                        # DEVPROD-25429 CSRF vulnerability tracking
     "otel/sdk"                    # DEVPROD-28491 OTel SDK vulnerability tracking
     "filippo.io/edwards25519"     # DEVPROD-28491 Edwards25519 vulnerability tracking
-    "google.golang.org/grpc"      # DEVPROD-30832 Go Google GRPC vulnerability tracking
     "github.com/docker/docker"    # DEVPROD-31135 Docker vulnerability tracking
 )
 


### PR DESCRIPTION
DEVPROD-30832

### Description
We are actually already on the fixed version for this dependency: 
```
Module: google.golang.org/grpc[2026/03/27 16:28:44.478]
• GO-2026-4762 (Fix: v1.79.3)
```
So removing it from the vulnerability ignore list.
### Testing
Vuln check task passes