### PR TITLE
DEVPROD-27693 Record last task completion time when clearing stranded tasks

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2297,7 +2297,7 @@ func ClearAndResetStrandedHostTask(ctx context.Context, settings *evergreen.Sett
 		return nil
 	}
 
-	if err = h.ClearRunningTask(ctx); err != nil {
+	if err = h.ClearRunningAndSetLastTask(ctx, t); err != nil {
 		return errors.Wrapf(err, "clearing running task from host '%s'", h.Id)
 	}
 

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -4246,6 +4246,7 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 	assert.Equal(evergreen.VersionCreated, foundVersion.Status)
 
 	h.RunningTask = "unschedulableTask"
+	assert.NoError(h.UpdateRunningTask(ctx, evergreen.GetEnvironment(), &tasks[2]))
 	assert.NoError(ClearAndResetStrandedHostTask(ctx, settings, h))
 
 	unschedulableTask, err := task.FindOne(ctx, db.Query(task.ById("unschedulableTask")))
@@ -4273,6 +4274,7 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 
 	h.RunningTask = "t2"
 	assert.NoError(resetTask(ctx, "t2", ""))
+	assert.NoError(h.UpdateRunningTask(ctx, evergreen.GetEnvironment(), &tasks[1]))
 	assert.NoError(ClearAndResetStrandedHostTask(ctx, settings, h))
 	foundTask, err := task.FindOne(ctx, db.Query(task.ById("t2")))
 	require.NoError(t, err)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -4246,7 +4246,8 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 	assert.Equal(evergreen.VersionCreated, foundVersion.Status)
 
 	h.RunningTask = "unschedulableTask"
-	assert.NoError(h.UpdateRunningTask(ctx, evergreen.GetEnvironment(), &tasks[2]))
+	h.RunningTaskExecution = 0
+	assert.NoError(db.Update(ctx, host.Collection, bson.M{host.IdKey: h.Id}, bson.M{"$set": bson.M{host.RunningTaskKey: "unschedulableTask", host.RunningTaskExecutionKey: 0}}))
 	assert.NoError(ClearAndResetStrandedHostTask(ctx, settings, h))
 
 	unschedulableTask, err := task.FindOne(ctx, db.Query(task.ById("unschedulableTask")))
@@ -4273,8 +4274,9 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 	assert.Equal(evergreen.VersionFailed, foundVersion.Status)
 
 	h.RunningTask = "t2"
+	h.RunningTaskExecution = 0
 	assert.NoError(resetTask(ctx, "t2", ""))
-	assert.NoError(h.UpdateRunningTask(ctx, evergreen.GetEnvironment(), &tasks[1]))
+	assert.NoError(db.Update(ctx, host.Collection, bson.M{host.IdKey: h.Id}, bson.M{"$set": bson.M{host.RunningTaskKey: "t2", host.RunningTaskExecutionKey: 0}}))
 	assert.NoError(ClearAndResetStrandedHostTask(ctx, settings, h))
 	foundTask, err := task.FindOne(ctx, db.Query(task.ById("t2")))
 	require.NoError(t, err)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -4228,6 +4228,11 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 
 	assert.NoError(ClearAndResetStrandedHostTask(ctx, settings, h))
 
+	dbHost, err := host.FindOneId(ctx, h.Id)
+	require.NoError(t, err)
+	assert.False(utility.IsZeroTime(dbHost.LastTaskCompletedTime))
+	assert.Equal("t", dbHost.LastTask)
+
 	runningTask, err := task.FindOne(ctx, db.Query(task.ById("t")))
 	require.NoError(t, err)
 	assert.Equal(evergreen.TaskUndispatched, runningTask.Status)

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -195,7 +195,10 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 				"task_execution": j.host.RunningTaskExecution,
 			})
 
-			j.AddError(model.ClearAndResetStrandedHostTask(ctx, j.env.Settings(), j.host))
+			if err := model.ClearAndResetStrandedHostTask(ctx, j.env.Settings(), j.host); err != nil {
+				j.AddError(errors.Wrapf(err, "clearing stranded task '%s' execution '%d' from host '%s'", j.host.RunningTask, j.host.RunningTaskExecution, j.host.Id))
+				return
+			}
 		} else {
 			return
 		}
@@ -274,7 +277,10 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 				"task_execution": j.host.RunningTaskExecution,
 			})
 
-			j.AddError(errors.Wrapf(model.ClearAndResetStrandedHostTask(ctx, j.env.Settings(), j.host), "fixing stranded task '%s' execution '%d'", j.host.RunningTask, j.host.RunningTaskExecution))
+			if err := model.ClearAndResetStrandedHostTask(ctx, j.env.Settings(), j.host); err != nil {
+				j.AddError(errors.Wrapf(err, "fixing stranded task '%s' execution '%d'", j.host.RunningTask, j.host.RunningTaskExecution))
+				return
+			}
 		} else {
 			return
 		}

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -195,10 +195,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 				"task_execution": j.host.RunningTaskExecution,
 			})
 
-			if err := model.ClearAndResetStrandedHostTask(ctx, j.env.Settings(), j.host); err != nil {
-				j.AddError(errors.Wrapf(err, "clearing stranded task '%s' execution '%d' from host '%s'", j.host.RunningTask, j.host.RunningTaskExecution, j.host.Id))
-				return
-			}
+			j.AddError(model.ClearAndResetStrandedHostTask(ctx, j.env.Settings(), j.host))
 		} else {
 			return
 		}
@@ -277,10 +274,7 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 				"task_execution": j.host.RunningTaskExecution,
 			})
 
-			if err := model.ClearAndResetStrandedHostTask(ctx, j.env.Settings(), j.host); err != nil {
-				j.AddError(errors.Wrapf(err, "fixing stranded task '%s' execution '%d'", j.host.RunningTask, j.host.RunningTaskExecution))
-				return
-			}
+			j.AddError(errors.Wrapf(model.ClearAndResetStrandedHostTask(ctx, j.env.Settings(), j.host), "fixing stranded task '%s' execution '%d'", j.host.RunningTask, j.host.RunningTaskExecution))
 		} else {
 			return
 		}


### PR DESCRIPTION
DEVPROD-27693

### Description
When a host is terminated while it still has a running task set, the host's last task completion timestamp does not get set. When the `task_stranded_cleanup` job later marks the task as finished, it uses the current timestamp, which can be after the host was actually terminated. In the data warehouse, this shows up as tasks finishing after the host's billing had ended.
 
Made a change to record the host's last task completion time when clearing stranded tasks during termination.

### Testing
Updated assertions to existing stranded host task tests to verify the host's last task completion time and last task ID are set after clearing.