### PR TITLE
DEVPROD-26276 tweak fallbacks for project-configured github app usage

### DIFF
--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -606,7 +606,7 @@ func GetGithubFile(ctx context.Context, owner, repo, path, ref string, ghAppAuth
 	defer span.End()
 
 	var outputFile *github.RepositoryContent
-	if err := runGitHubOp(ctx, owner, repo, caller, ghAppAuth, func(ctx context.Context, githubClient *githubapp.GitHubClient) error {
+	if err := runGitHubOp(ctx, owner, repo, caller, ghAppAuth, true, func(ctx context.Context, githubClient *githubapp.GitHubClient) error {
 		var opt *github.RepositoryContentGetOptions
 		if len(ref) != 0 {
 			opt = &github.RepositoryContentGetOptions{
@@ -644,29 +644,32 @@ func GetGithubFile(ctx context.Context, owner, repo, path, ref string, ghAppAuth
 	return outputFile, nil
 }
 
-// runGitHubOp attempts to run the given GitHub operation. It first attempts
-// with GitHub app to authenticate (if provided). If that fails (e.g. due to
-// insufficient GitHub app permissions) or no app is available, it falls back
-// to using the internal app for installation tokens.
-func runGitHubOp(ctx context.Context, owner, repo, caller string, ghAppAuth *githubapp.GithubAppAuth, op func(ctx context.Context, ghClient *githubapp.GitHubClient) error) error {
+// runGitHubOp attempts to run the given GitHub operation using the external
+// GitHub app if provided. If the external app fails, it falls back to the
+// internal app when shouldFallback is true (i.e. only for critical operations).
+// If shouldFallback is false, errors from the external app are returned directly without fallback.
+func runGitHubOp(ctx context.Context, owner, repo, caller string, ghAppAuth *githubapp.GithubAppAuth, shouldFallback bool, op func(ctx context.Context, ghClient *githubapp.GitHubClient) error) error {
 	if ghAppAuth != nil {
 		err := runGitHubOpWithExternalGitHubApp(ctx, owner, repo, caller, ghAppAuth, op)
 		if err == nil {
 			return nil
 		}
-
-		grip.Warning(ctx, message.WrapError(err, message.Fields{
-			"message":    "GitHub operation with external GitHub app failed, falling back to attempt with internal app",
-			"caller":     caller,
-			"owner":      owner,
-			"repo":       repo,
-			"project_id": ghAppAuth.Id,
-			"app_id":     ghAppAuth.AppID,
+		grip.Debug(ctx, message.WrapError(err, message.Fields{
+			"message":         "GitHub operation with external GitHub app failed",
+			"caller":          caller,
+			"owner":           owner,
+			"repo":            repo,
+			"project_id":      ghAppAuth.Id,
+			"app_id":          ghAppAuth.AppID,
+			"should_fallback": shouldFallback,
 		}))
+		if !shouldFallback {
+			return errors.Wrap(err, "running GitHub operation with external GitHub app")
+		}
+
 	}
 
-	// Fall back to using the internal app if the project does not have a token
-	// available or if the operation with the GitHub app failed. This is
+	// Fall back to using the internal app if no auth is given or if fallback is configured. This is
 	// needed because the project's GitHub app may have insufficient permissions
 	// to perform the operation, whereas the internal app has broad permissions.
 	ctx, span := tracer.Start(ctx, "github-op-with-internal-app", trace.WithAttributes(
@@ -686,6 +689,10 @@ func runGitHubOp(ctx context.Context, owner, repo, caller string, ghAppAuth *git
 	return err
 }
 
+// runGitHubOpWithExternalGitHubApp runs the given operation using the external
+// GitHub app. It retries on transient errors but not on 401 auth errors, since
+// a 401 indicates the app lacks the necessary credentials and retrying would
+// be futile.
 func runGitHubOpWithExternalGitHubApp(ctx context.Context, owner, repo, caller string, ghAppAuth *githubapp.GithubAppAuth, op func(ctx context.Context, ghClient *githubapp.GitHubClient) error) error {
 	token, err := ghAppAuth.CreateCachedInstallationToken(ctx, owner, repo, defaultGitHubAPIRequestLifetime, nil)
 	if err != nil {
@@ -696,12 +703,7 @@ func runGitHubOpWithExternalGitHubApp(ctx context.Context, owner, repo, caller s
 	))
 	defer span.End()
 
-	// This intentionally does not retry because if the GitHub app doesn't have
-	// the necessary permissions or has other issues like rate limits, then it's
-	// better to fall back to the internal app immediately.
-	// TODO (DEVPROD-26276): reconsider whether this should retry and whether
-	// it's okay to continue falling back to the internal app.
-	ghClient := getGithubClient(token, caller, retryConfig{})
+	ghClient := getGithubClient(token, caller, retryConfig{retry: true, ignoreCodes: []int{http.StatusUnauthorized}})
 	defer ghClient.Close()
 
 	return op(ctx, ghClient)
@@ -1853,9 +1855,9 @@ func makeCheckRunName(task *task.Task) string {
 }
 
 // CreateCheckRun creates a checkRun and returns a Github CheckRun object.
-// If ghAppAuth is provided, it will first attempt to use the project's GitHub app
-// credentials. If that fails or no app is available, it falls back to using the
-// internal app for installation tokens.
+// If ghAppAuth is provided, it will use the project's GitHub app credentials.
+// If the external app fails, the error is returned without falling back to the
+// internal app.
 func CreateCheckRun(ctx context.Context, owner, repo, headSHA, uiBase string, task *task.Task, output *github.CheckRunOutput, ghAppAuth *githubapp.GithubAppAuth) (*github.CheckRun, error) {
 	caller := "createCheckrun"
 	ctx, span := tracer.Start(ctx, caller, trace.WithAttributes(
@@ -1878,7 +1880,7 @@ func CreateCheckRun(ctx context.Context, owner, repo, headSHA, uiBase string, ta
 	}
 
 	var checkRun *github.CheckRun
-	err := runGitHubOp(ctx, owner, repo, caller, ghAppAuth, func(ctx context.Context, ghClient *githubapp.GitHubClient) error {
+	err := runGitHubOp(ctx, owner, repo, caller, ghAppAuth, false, func(ctx context.Context, ghClient *githubapp.GitHubClient) error {
 		var resp *github.Response
 		var opErr error
 		checkRun, resp, opErr = ghClient.Checks.CreateCheckRun(ctx, owner, repo, opts)
@@ -1900,9 +1902,9 @@ func CreateCheckRun(ctx context.Context, owner, repo, headSHA, uiBase string, ta
 
 // UpdateCheckRun updates a checkRun and returns a Github CheckRun object.
 // UpdateCheckRunOptions must specify a name for the check run.
-// If ghAppAuth is provided, it will first attempt to use the project's GitHub app
-// credentials. If that fails or no app is available, it falls back to using the
-// internal app for installation tokens.
+// If ghAppAuth is provided, it will use the project's GitHub app credentials.
+// If the external app fails, the error is returned without falling back to the
+// internal app.
 func UpdateCheckRun(ctx context.Context, owner, repo, uiBase string, checkRunID int64, task *task.Task, output *github.CheckRunOutput, ghAppAuth *githubapp.GithubAppAuth) (*github.CheckRun, error) {
 	caller := "updateCheckrun"
 	ctx, span := tracer.Start(ctx, caller, trace.WithAttributes(
@@ -1928,7 +1930,7 @@ func UpdateCheckRun(ctx context.Context, owner, repo, uiBase string, checkRunID 
 	}
 
 	var checkRun *github.CheckRun
-	err := runGitHubOp(ctx, owner, repo, caller, ghAppAuth, func(ctx context.Context, ghClient *githubapp.GitHubClient) error {
+	err := runGitHubOp(ctx, owner, repo, caller, ghAppAuth, false, func(ctx context.Context, ghClient *githubapp.GitHubClient) error {
 		var resp *github.Response
 		var opErr error
 		checkRun, resp, opErr = ghClient.Checks.UpdateCheckRun(ctx, owner, repo, checkRunID, updateOpts)

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -158,6 +158,22 @@ func (s *githubSuite) TestGithubShouldRetry() {
 		retryFn = githubShouldRetry("", retryConfig{retry: true, ignoreCodes: []int{code}})
 		s.False(retryFn(0, req, resp, nil))
 	})
+
+	s.Run("UnauthorizedNotRetried", func() {
+		resp := &http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Header: http.Header{
+				"X-Ratelimit-Limit":     []string{"10"},
+				"X-Ratelimit-Remaining": []string{"10"},
+			},
+		}
+
+		// Without ignoreCodes, 401 would fall through without retrying (no
+		// explicit retry path for it), but with ignoreCodes it is explicitly
+		// short-circuited.
+		retryFn := githubShouldRetry("", retryConfig{retry: true, ignoreCodes: []int{http.StatusUnauthorized}})
+		s.False(retryFn(0, req, resp, nil))
+	})
 }
 
 func (s *githubSuite) TestCheckGithubAPILimit() {
@@ -606,6 +622,32 @@ func TestExtractPRNumberFromHeadRef(t *testing.T) {
 			assert.Equal(t, tCase.expected, result)
 		})
 	}
+}
+
+// TestRunGitHubOpNoFallback verifies that when shouldFallback is false and the
+// external app fails, the error is returned directly without attempting the
+// internal app fallback.
+func TestRunGitHubOpNoFallback(t *testing.T) {
+	ctx := t.Context()
+
+	// An invalid private key causes token creation to fail locally, without any
+	// network calls. This simulates a failing external GitHub app.
+	invalidAuth := &githubapp.GithubAppAuth{
+		Id:         "test-project",
+		AppID:      12345,
+		PrivateKey: []byte("not-a-valid-rsa-key"),
+	}
+
+	opCalled := false
+	op := func(_ context.Context, _ *githubapp.GitHubClient) error {
+		opCalled = true
+		return nil
+	}
+
+	err := runGitHubOp(ctx, "owner", "repo", "caller", invalidAuth, false, op)
+	require.Error(t, err)
+	assert.False(t, opCalled, "op should not be called when token creation fails")
+	assert.Contains(t, err.Error(), "getting installation token with external GitHub app")
 }
 
 func TestBuildGithubHeadPRURL(t *testing.T) {


### PR DESCRIPTION
DEVPROD-26276
<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Changed fallback behavior for project-configured github apps. Previously, all calls would fallback to use our app. Now, we also retry with their app, unless its an auth error (looking at our logs, transient github errors seem expected). We only retry with our own app for certain operations (like fetching project files should still work, even if its not ideal to be doing fallback).

I'll probably set up an alert if we're hitting this a lot for getting projects so we can look at auth, and i'll explain what to do in that alert.

### Testing
Added unit test

### Documentation
Internal behavior so i think no documentation is needed here, beyond what we already have.
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- 
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models - If you're adding a field to the Task, Build, Version, or Patch structs, consider creating a
  DPIPE ticket to expose this in the data warehouse.

-->
