### PR TITLE
DEVPROD-32872: Add more clarification on doc comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,9 @@ The Evergreen codebase has automated tests defined in `self-tests.yml`, which it
   capitalization.
 * Inline code comments should be used intentionally. Do not write a comment if it just explains exactly what the code is
   doing. However, they can be used if they will explain the "why", such as context, intent, or non-obvious behavior.
+* Documentation comments should focus on high-level information relevant to usage, such as intent, expected
+  inputs/outputs, behavior. It is also valid to highlight hazardous gotchas to be careful about, if any. It should not
+  describe implementation details; those should be left to inline comments.
 
 **Good use of comments:**
 * Documentation for exported structs, functions, fields, and methods.


### PR DESCRIPTION
[DEVPROD-32872](https://jira.mongodb.org/browse/DEVPROD-32872)

### Description
I've noticed a lot of AI-generated code is generating doc comments, but a lot of those comments are basically re-describing the implementation in words. Updated the instructions to make it clearer what a good doc comment should do.