### PR TITLE
DEVPROD-32859 Terminate EC2 instance for building intent hosts that already have a cloud instance

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -865,8 +865,16 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 		return errors.Wrap(err, "creating client")
 	}
 
-	if !IsEC2InstanceID(h.Id) {
-		return errors.Wrap(h.Terminate(ctx, user, fmt.Sprintf("detected invalid instance ID '%s'", h.Id)), "terminating instance in DB")
+	instanceID := h.Id
+	if !IsEC2InstanceID(instanceID) {
+		instance, err := m.client.GetInstanceInfo(ctx, h.Id)
+		if err != nil {
+			if isEC2InstanceNotFound(err) {
+				return errors.Wrap(h.Terminate(ctx, user, fmt.Sprintf("no cloud instance found for host '%s'", h.Id)), "terminating instance in DB")
+			}
+			return errors.Wrapf(err, "finding cloud instance for host '%s'", h.Id)
+		}
+		instanceID = aws.ToString(instance.InstanceId)
 	}
 
 	// Any host that has been unexpirable will have been given a DNS name, which we need to clean up.
@@ -892,7 +900,7 @@ func (m *ec2Manager) TerminateInstance(ctx context.Context, h *host.Host, user, 
 	}
 
 	resp, err := m.client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
-		InstanceIds: []string{h.Id},
+		InstanceIds: []string{instanceID},
 	})
 	if err != nil {
 		grip.Error(ctx, message.WrapError(err, message.Fields{

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -631,12 +631,19 @@ func (c *awsClientImpl) DescribeVolumes(ctx context.Context, input *ec2.Describe
 }
 
 func (c *awsClientImpl) GetInstanceInfo(ctx context.Context, id string) (*types.Instance, error) {
+	var input *ec2.DescribeInstancesInput
 	if host.IsIntentHostId(id) {
-		return nil, errors.Errorf("host ID '%s' is for an intent host", id)
+		// The host's cloud instance ID was never recorded, so look up the
+		// instance using the name tag, which is always set to the intent host ID before launch.
+		input = &ec2.DescribeInstancesInput{
+			Filters: []types.Filter{
+				{Name: aws.String("tag:" + evergreen.TagName), Values: []string{id}},
+			},
+		}
+	} else {
+		input = &ec2.DescribeInstancesInput{InstanceIds: []string{id}}
 	}
-	resp, err := c.ec2Client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
-		InstanceIds: []string{id},
-	})
+	resp, err := c.ec2Client.DescribeInstances(ctx, input)
 	if err != nil {
 		return nil, errors.Wrap(err, "EC2 API returned error for DescribeInstances")
 	}

--- a/cloud/ec2_integration_test.go
+++ b/cloud/ec2_integration_test.go
@@ -103,16 +103,3 @@ func TestSpawnEC2InstanceOnDemand(t *testing.T) {
 	assert.NoError(err)
 	assert.NotContains([]CloudStatus{StatusRunning, StatusStopping, StatusStopped}, info.Status)
 }
-
-func (s *EC2Suite) TestGetInstanceInfoFailsEarlyForIntentHosts() {
-	opts := &EC2ManagerOptions{
-		client: &awsClientImpl{},
-	}
-	m := &ec2Manager{env: s.env, EC2ManagerOptions: opts}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	info, err := m.client.GetInstanceInfo(ctx, "evg-ubuntu-1234")
-	s.Nil(info)
-	s.Errorf(err, "intent host")
-}

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -763,6 +763,38 @@ func (s *EC2Suite) TestTerminateInstance() {
 	s.NoError(err)
 }
 
+func (s *EC2Suite) TestTerminateInstanceIntentHostWithCloudInstance() {
+	s.h.Id = "evg-amazon2-cloud-medium-20260427131846-1234567890"
+	s.Require().NoError(s.h.Insert(s.ctx))
+
+	realInstanceID := "i-real-instance-id"
+	s.mock.Instance = &types.Instance{InstanceId: aws.String(realInstanceID)}
+
+	s.NoError(s.onDemandManager.TerminateInstance(s.ctx, s.h, evergreen.User, ""))
+
+	s.Require().NotNil(s.mock.TerminateInstancesInput)
+	s.Equal([]string{realInstanceID}, s.mock.TerminateInstancesInput.InstanceIds, "should terminate using the real instance ID found via tag lookup")
+
+	found, err := host.FindOne(s.ctx, host.ById(s.h.Id))
+	s.Require().NoError(err)
+	s.Equal(evergreen.HostTerminated, found.Status)
+}
+
+func (s *EC2Suite) TestTerminateInstanceIntentHostWithNoCloudInstance() {
+	s.h.Id = "evg-amazon2-cloud-medium-20260427131846-1234567890"
+	s.Require().NoError(s.h.Insert(s.ctx))
+
+	s.mock.RequestGetInstanceInfoError = noReservationError
+
+	s.NoError(s.onDemandManager.TerminateInstance(s.ctx, s.h, evergreen.User, ""))
+
+	s.Nil(s.mock.TerminateInstancesInput, "should not call AWS TerminateInstances when no cloud instance is found")
+
+	found, err := host.FindOne(s.ctx, host.ById(s.h.Id))
+	s.Require().NoError(err)
+	s.Equal(evergreen.HostTerminated, found.Status)
+}
+
 func (s *EC2Suite) TestTerminateInstanceWithUserDataBootstrappedHost() {
 	s.h.Distro.BootstrapSettings.Method = distro.BootstrapMethodUserData
 	s.NoError(s.h.Insert(s.ctx))

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -776,6 +776,7 @@ func (s *EC2Suite) TestTerminateInstanceIntentHostWithCloudInstance() {
 	s.Equal([]string{realInstanceID}, s.mock.TerminateInstancesInput.InstanceIds, "should terminate using the real instance ID found via tag lookup")
 
 	found, err := host.FindOne(s.ctx, host.ById(s.h.Id))
+	s.Require().NotNil(found)
 	s.Require().NoError(err)
 	s.Equal(evergreen.HostTerminated, found.Status)
 }
@@ -791,6 +792,7 @@ func (s *EC2Suite) TestTerminateInstanceIntentHostWithNoCloudInstance() {
 	s.Nil(s.mock.TerminateInstancesInput, "should not call AWS TerminateInstances when no cloud instance is found")
 
 	found, err := host.FindOne(s.ctx, host.ById(s.h.Id))
+	s.Require().NotNil(found)
 	s.Require().NoError(err)
 	s.Equal(evergreen.HostTerminated, found.Status)
 }

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -737,6 +738,15 @@ func (s *EC2Suite) TestModifyHostInvalidSchedule() {
 	s.Equal(originalSchedule.DailyStopTime, modifiedHost.SleepSchedule.DailyStopTime)
 	s.Equal(originalSchedule.TimeZone, modifiedHost.SleepSchedule.TimeZone)
 	s.True(temporarilyExemptUntil.Equal(modifiedHost.SleepSchedule.TemporarilyExemptUntil))
+}
+
+func (s *EC2Suite) TestGetInstanceInfoNoReservationForIntentStyleHostID() {
+	s.Require().True(host.IsIntentHostId("evg-ubuntu-1234"))
+	s.mock.RequestGetInstanceInfoError = noReservationError
+	info, err := s.impl.client.GetInstanceInfo(s.ctx, "evg-ubuntu-1234")
+	s.Nil(info)
+	s.Require().Error(err)
+	s.True(errors.Is(err, noReservationError))
 }
 
 func (s *EC2Suite) TestGetInstanceInformation() {

--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -157,14 +157,20 @@ func (j *hostTerminationJob) Run(ctx context.Context) {
 	// Intent hosts are just marked terminated in the DB without further
 	// processing, because it's not possible for an intent host to run tasks,
 	// nor is the intent host associated with any instance in the cloud that
-	// we're aware of.
+	// we're aware of. The exception is HostBuilding, where RunInstances may
+	// have already been called before the host ID was recorded.
 	switch j.host.Status {
-	case evergreen.HostUninitialized, evergreen.HostBuilding, evergreen.HostBuildingFailed, evergreen.HostDecommissioned:
-		// If the host never successfully started, this means the host is an
-		// intent host, and should be marked terminated. There's no host
-		// associated with it in the cloud provider.
+	case evergreen.HostUninitialized, evergreen.HostBuildingFailed, evergreen.HostDecommissioned:
 		if host.IsIntentHostId(j.host.Id) {
 			j.AddError(errors.Wrapf(j.cleanupIntentHost(ctx), "cleaning up intent host '%s'", j.host.Id))
+			return
+		}
+	case evergreen.HostBuilding:
+		if host.IsIntentHostId(j.host.Id) {
+			// A building intent host may already have a cloud instance if the
+			// host ID was never recorded after launch. Perform a tag-based lookup
+			// to find and terminate it.
+			j.AddError(errors.Wrapf(j.checkAndTerminateCloudHost(ctx), "terminating cloud host for building intent host '%s'", j.host.Id))
 			return
 		}
 	case evergreen.HostTerminated:

--- a/units/host_termination_test.go
+++ b/units/host_termination_test.go
@@ -194,6 +194,30 @@ func TestHostTerminationJob(t *testing.T) {
 			require.NotZero(t, dbHost)
 			assert.Equal(t, evergreen.HostTerminated, dbHost.Status)
 		},
+		"TerminatesBuildingIntentHostWithCloudInstance": func(ctx context.Context, t *testing.T, env evergreen.Environment, mcp cloud.MockProvider, h *host.Host) {
+			h.Id = h.Distro.GenerateName()
+			h.Status = evergreen.HostBuilding
+			require.NoError(t, h.Insert(ctx))
+
+			mcp.Set(h.Id, cloud.MockInstance{Status: cloud.StatusRunning})
+
+			j := NewHostTerminationJob(env, h, HostTerminationOptions{
+				TerminateIfBusy:   true,
+				TerminationReason: reason,
+			})
+			j.Run(ctx)
+			require.NoError(t, j.Error())
+
+			checkTerminationEvent(t, h.Id, reason)
+
+			dbHost, err := host.FindOneId(ctx, h.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+			assert.Equal(t, evergreen.HostTerminated, dbHost.Status)
+
+			cloudInstance := mcp.Get(h.Id)
+			assert.Equal(t, cloud.StatusTerminated, cloudInstance.Status, "cloud instance should be terminated")
+		},
 		"MarksBuildingIntentHostAsTerminated": func(ctx context.Context, t *testing.T, env evergreen.Environment, mcp cloud.MockProvider, h *host.Host) {
 			// The ID must be a valid intent host ID.
 			h.Id = h.Distro.GenerateName()


### PR DESCRIPTION
DEVPROD-32859

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

@sblevine-mongodb found many host that were marked as terminated in Evergreen with the ID still being the intent host ID (evg-something rather than i-something), but whose EC2 instance was still created in AWS. The root cause seems to be the provisioning-create-host job running and RunInstances completing on AWS's side, but the replace to remove/re-insert the document not running. (spot checking some sample hosts showed either an error with the replace or logs from the initial host creation missing completely, indicating something wonky potentially happening with the pod or the process).  Because it then takes 10 days for the reaper to kill these hosts, it ends up costing a lot of money. 
  
For hosts in this situation, when the termination job later ran, because it was an intent ID it assumed it had no associated cloud instance, so it only updated the DB and left the EC2 instance running. The fix here instead looks for hosts using the tag we set with the intent ID to find and terminate the host even if we don't have the host ID. 

### Testing
Added unit tests




<!-- 
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models - If you're adding a field to the Task, Build, Version, or Patch structs, consider creating a
  DPIPE ticket to expose this in the data warehouse.

-->
