### PR TITLE
DEVPROD-32880 prevent release mode from updating max hosts for some distros

### DIFF
--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -682,8 +682,9 @@ func (d *Distro) GetResolvedHostAllocatorSettings(s *evergreen.Settings) (HostAl
 		catcher.Errorf("'%s' is not a valid host allocator version", resolved.Version)
 	}
 
-	// If release mode is enabled, multiply the distro max hosts by this factor.
-	if !s.ServiceFlags.ReleaseModeDisabled && s.ReleaseMode.DistroMaxHostsFactor > 0 {
+	// If release mode is enabled and the distro supports auto-tuning, multiply the distro max hosts by this factor.
+	// If it doesn't, we should assume that the distro has set its maximum hosts very intentionally.
+	if !s.ServiceFlags.ReleaseModeDisabled && s.ReleaseMode.DistroMaxHostsFactor > 0 && d.HostAllocatorSettings.AutoTuneMaximumHosts {
 		resolved.MaximumHosts = int(math.Ceil(float64(resolved.MaximumHosts) * s.ReleaseMode.DistroMaxHostsFactor))
 	}
 

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -354,12 +354,26 @@ func TestGetResolvedHostAllocatorSettings(t *testing.T) {
 	assert.Equal(t, evergreen.HostsOverallocatedTerminate, resolved0.HostsOverallocatedRule)
 
 	settings1 := &evergreen.Settings{Scheduler: config0, ReleaseMode: releaseModeConfig}
+
+	// Release mode does not apply the max hosts factor when the distro is not using auto-tuning.
 	resolved1, err := d0.GetResolvedHostAllocatorSettings(settings1)
 	assert.NoError(t, err)
-
-	// Factor in release mode when enabled.
-	assert.Equal(t, 20, resolved1.MaximumHosts)
+	assert.Equal(t, 10, resolved1.MaximumHosts)
 	assert.Equal(t, time.Duration(300)*time.Second, resolved1.AcceptableHostIdleTime)
+
+	// Release mode applies the max hosts factor when the distro is using auto-tuning.
+	d0.HostAllocatorSettings.AutoTuneMaximumHosts = true
+	d0.HostAllocatorSettings.MaximumHosts = 10
+	resolved1, err = d0.GetResolvedHostAllocatorSettings(settings1)
+	assert.NoError(t, err)
+	assert.Equal(t, 20, resolved1.MaximumHosts)
+
+	// Release mode does not apply the max hosts factor when the factor is not configured.
+	d0.HostAllocatorSettings.MaximumHosts = 10
+	settingsNoFactor := &evergreen.Settings{Scheduler: config0, ReleaseMode: evergreen.ReleaseModeConfig{IdleTimeSecondsOverride: 300}}
+	resolved1, err = d0.GetResolvedHostAllocatorSettings(settingsNoFactor)
+	assert.NoError(t, err)
+	assert.Equal(t, 10, resolved1.MaximumHosts)
 }
 
 func TestGetResolvedPlannerSettings(t *testing.T) {


### PR DESCRIPTION
DEVPROD-32880
<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Perf sets their max hosts for their distros very intentionally, and it causes a big problem for them when this isn't respected by release mode (which increases max hosts for all distros). 

I think we can make a reasonable assumption that distros that care about max hosts are opted-out of auto-tuning (which is also kind of what this is), so release mode shouldn't apply to distros that do this. 

### Testing
Added a unit test.