### PR TITLE
DEVPROD-27407: Properly Calculate S3 Puts when we retry failures

### DIFF
--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -435,7 +435,11 @@ func (s3pc *s3put) putWithRetry(ctx context.Context, comm client.Communicator, l
 		uploadedFiles     []s3usage.FileMetrics
 		filesList         []string
 		skippedFilesCount int
+		totalRetryPuts    int
+		totalFileSize     int64
 	)
+
+	fileRetryPuts := make(map[string]int)
 
 	timer := time.NewTimer(0)
 	defer timer.Stop()
@@ -503,7 +507,15 @@ retryLoop:
 
 				fpath = filepath.Join(filepath.Join(s3pc.workDir, s3pc.LocalFilesIncludeFilterPrefix), fpath)
 
-				err = s3pc.bucket.Upload(ctx, remoteName, fpath)
+				// pail.PutCounter is implemented by *s3Bucket; the fallback handles other bucket types that don't track PUT counts.
+				var puts int
+				if pc, ok := s3pc.bucket.(pail.PutCounter); ok {
+					puts, err = pc.UploadWithCount(ctx, remoteName, fpath)
+				} else {
+					err = s3pc.bucket.Upload(ctx, remoteName, fpath)
+				}
+				totalRetryPuts += puts
+				fileRetryPuts[fpath] += puts
 				if err != nil {
 					// retry errors other than "file doesn't exist", which we handle differently based on what
 					// kind of upload it is
@@ -545,10 +557,9 @@ retryLoop:
 					continue retryLoop
 				}
 
-				uploadedFiles = append(uploadedFiles, s3usage.FileMetrics{
-					LocalPath:  fpath,
-					RemotePath: remoteName,
-				})
+				metrics, fileSize := s3usage.BuildFileMetrics(logger.Task(), fpath, remoteName, fileRetryPuts[fpath])
+				totalFileSize += fileSize
+				uploadedFiles = append(uploadedFiles, metrics)
 
 			}
 
@@ -561,16 +572,9 @@ retryLoop:
 		return nil
 	}
 
-	uploadedFiles, totalFileSize, totalPutRequests := s3usage.CalculateUploadMetrics(
-		logger.Task(),
-		uploadedFiles,
-		s3usage.S3BucketTypeLarge,
-		s3usage.S3UploadMethodPut,
-	)
-
-	maxPuts, minPuts := computePerFileExtremes(uploadedFiles)
+	maxPuts, minPuts := s3usage.ComputePerFileExtremes(uploadedFiles)
 	conf.S3Usage.IncrementArtifacts(s3usage.ArtifactIncrementOptions{
-		PutRequests:               totalPutRequests,
+		PutRequests:               totalRetryPuts,
 		UploadBytes:               totalFileSize,
 		FileCount:                 len(uploadedFiles),
 		MaxPuts:                   maxPuts,
@@ -596,24 +600,6 @@ retryLoop:
 	}
 
 	return nil
-}
-
-// computePerFileExtremes returns the max and min PutRequests across all uploaded files.
-func computePerFileExtremes(files []s3usage.FileMetrics) (maxPuts, minPuts int) {
-	if len(files) == 0 {
-		return 0, 0
-	}
-	maxPuts = files[0].PutRequests
-	minPuts = files[0].PutRequests
-	for i := 1; i < len(files); i++ {
-		if files[i].PutRequests > maxPuts {
-			maxPuts = files[i].PutRequests
-		}
-		if files[i].PutRequests < minPuts {
-			minPuts = files[i].PutRequests
-		}
-	}
-	return maxPuts, minPuts
 }
 
 // attachTaskFiles is responsible for sending the

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/pail"
 	"github.com/evergreen-ci/utility"
+	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -422,13 +423,13 @@ func TestSignedUrlVisibility(t *testing.T) {
 				LocalPath:     file1,
 				RemotePath:    remoteFile,
 				FileSizeBytes: file1Info.Size(),
-				PutRequests:   s3usage.CalculatePutRequestsWithContext(s3usage.S3BucketTypeLarge, s3usage.S3UploadMethodPut, file1Info.Size()),
+				PutRequests:   1,
 			},
 			{
 				LocalPath:     file2,
 				RemotePath:    remoteFile,
 				FileSizeBytes: file2Info.Size(),
-				PutRequests:   s3usage.CalculatePutRequestsWithContext(s3usage.S3BucketTypeLarge, s3usage.S3UploadMethodPut, file2Info.Size()),
+				PutRequests:   1,
 			},
 		}
 
@@ -493,13 +494,13 @@ func TestContentTypeSaved(t *testing.T) {
 			LocalPath:     file1,
 			RemotePath:    remoteFile,
 			FileSizeBytes: file1Info.Size(),
-			PutRequests:   s3usage.CalculatePutRequestsWithContext(s3usage.S3BucketTypeLarge, s3usage.S3UploadMethodPut, file1Info.Size()),
+			PutRequests:   1,
 		},
 		{
 			LocalPath:     file2,
 			RemotePath:    remoteFile,
 			FileSizeBytes: file2Info.Size(),
-			PutRequests:   s3usage.CalculatePutRequestsWithContext(s3usage.S3BucketTypeLarge, s3usage.S3UploadMethodPut, file2Info.Size()),
+			PutRequests:   1,
 		},
 	}
 
@@ -731,8 +732,8 @@ func TestPreservePath(t *testing.T) {
 	}
 
 	require.NotNil(t, conf.S3Usage)
-	// Each zero-byte file counts as 1 PUT; preserve_path uploads were previously broken because LocalPath was set to the S3 key.
-	assert.Equal(t, 6, conf.S3Usage.Artifacts.PutRequests)
+	// Local bucket does not implement PutCounter so PUT count is always 0.
+	assert.Equal(t, 0, conf.S3Usage.Artifacts.PutRequests)
 	assert.Equal(t, 6, conf.S3Usage.Artifacts.Count)
 	assert.Equal(t, int64(0), conf.S3Usage.Artifacts.UploadBytes)
 }
@@ -848,43 +849,6 @@ func TestS3PutSkipExisting(t *testing.T) {
 
 	_, err = apimodels.ReadLogToSlice(it)
 	require.NoError(t, err)
-}
-
-func TestComputePerFileExtremes(t *testing.T) {
-	t.Run("EmptyInput", func(t *testing.T) {
-		maxPuts, minPuts := computePerFileExtremes(nil)
-		assert.Zero(t, maxPuts)
-		assert.Zero(t, minPuts)
-	})
-	t.Run("SingleFile", func(t *testing.T) {
-		files := []s3usage.FileMetrics{
-			{PutRequests: 5},
-		}
-		maxPuts, minPuts := computePerFileExtremes(files)
-		assert.Equal(t, 5, maxPuts)
-		assert.Equal(t, 5, minPuts)
-	})
-	t.Run("MultipleFiles", func(t *testing.T) {
-		files := []s3usage.FileMetrics{
-			{PutRequests: 3},
-			{PutRequests: 10},
-			{PutRequests: 1},
-			{PutRequests: 7},
-		}
-		maxPuts, minPuts := computePerFileExtremes(files)
-		assert.Equal(t, 10, maxPuts)
-		assert.Equal(t, 1, minPuts)
-	})
-	t.Run("AllSameValue", func(t *testing.T) {
-		files := []s3usage.FileMetrics{
-			{PutRequests: 4},
-			{PutRequests: 4},
-			{PutRequests: 4},
-		}
-		maxPuts, minPuts := computePerFileExtremes(files)
-		assert.Equal(t, 4, maxPuts)
-		assert.Equal(t, 4, minPuts)
-	})
 }
 
 func TestReadAssociatedLinksFile(t *testing.T) {
@@ -1013,7 +977,7 @@ func TestS3PutWithAssociatedLinks(t *testing.T) {
 			LocalPath:     s3PutFile,
 			RemotePath:    remoteFile,
 			FileSizeBytes: s3PutFileInfo.Size(),
-			PutRequests:   s3usage.CalculatePutRequestsWithContext(s3usage.S3BucketTypeLarge, s3usage.S3UploadMethodPut, s3PutFileInfo.Size()),
+			PutRequests:   1,
 		},
 	}
 
@@ -1028,4 +992,111 @@ func TestS3PutWithAssociatedLinks(t *testing.T) {
 	assert.Equal(t, "https://example.com/docs", files[0].AssociatedLinks[0].Link)
 	assert.Equal(t, "Coverage", files[0].AssociatedLinks[1].Name)
 	assert.Equal(t, "https://example.com/coverage", files[0].AssociatedLinks[1].Link)
+}
+
+// putCounterBucket is a minimal mock that implements pail.PutCounter so tests can
+// control the per-call PUT count and trigger retries without hitting real S3.
+type putCounterBucket struct {
+	pail.Bucket
+
+	// putsPerCall is the count returned by each UploadWithCount call.
+	putsPerCall int
+	// failUntilCall causes the first N calls to return an error.
+	failUntilCall int
+	calls         int
+}
+
+func (m *putCounterBucket) Check(_ context.Context) error { return nil }
+
+func (m *putCounterBucket) Upload(ctx context.Context, key, path string) error {
+	_, err := m.UploadWithCount(ctx, key, path)
+	return err
+}
+
+func (m *putCounterBucket) UploadWithCount(_ context.Context, _, _ string) (int, error) {
+	m.calls++
+	if m.calls <= m.failUntilCall {
+		return m.putsPerCall, errors.New("transient upload error")
+	}
+	return m.putsPerCall, nil
+}
+
+func TestPutWithRetryAccumulatesPutsFromBucket(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+
+	localFile := filepath.Join(dir, "upload.txt")
+	require.NoError(t, os.WriteFile(localFile, []byte("data"), 0600))
+
+	mock := &putCounterBucket{putsPerCall: 3}
+	s := &s3put{
+		AwsKey:      "key",
+		AwsSecret:   "secret",
+		Bucket:      "bucket",
+		LocalFile:   localFile,
+		RemoteFile:  "remote/upload.txt",
+		ContentType: "application/octet-stream",
+		Permissions: string(s3Types.ObjectCannedACLPublicRead),
+		bucket:      mock,
+	}
+	s.workDir = dir
+
+	comm := client.NewMock("http://localhost.com")
+	conf := &internal.TaskConfig{
+		Expansions:   util.Expansions{},
+		Task:         task.Task{Id: "mock_id", Secret: "mock_secret"},
+		Project:      model.Project{},
+		WorkDir:      dir,
+		BuildVariant: model.BuildVariant{},
+		S3Usage:      &s3usage.S3Usage{},
+	}
+	logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, s.Execute(ctx, comm, logger, conf))
+	assert.Equal(t, 3, conf.S3Usage.Artifacts.PutRequests)
+	assert.Equal(t, 1, conf.S3Usage.Artifacts.Count)
+	assert.Equal(t, 3, conf.S3Usage.Artifacts.ArtifactWithMaxPutRequests)
+	assert.Equal(t, 3, conf.S3Usage.Artifacts.ArtifactWithMinPutRequests)
+}
+
+func TestPutWithRetryAccumulatesPutsAcrossRetries(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+
+	localFile := filepath.Join(dir, "upload.txt")
+	require.NoError(t, os.WriteFile(localFile, []byte("data"), 0600))
+
+	// Fails the first 2 attempts, succeeds on the 3rd. Each call returns 3 puts.
+	mock := &putCounterBucket{putsPerCall: 3, failUntilCall: 2}
+	s := &s3put{
+		AwsKey:      "key",
+		AwsSecret:   "secret",
+		Bucket:      "bucket",
+		LocalFile:   localFile,
+		RemoteFile:  "remote/upload.txt",
+		ContentType: "application/octet-stream",
+		Permissions: string(s3Types.ObjectCannedACLPublicRead),
+		bucket:      mock,
+	}
+	s.workDir = dir
+
+	comm := client.NewMock("http://localhost.com")
+	conf := &internal.TaskConfig{
+		Expansions:   util.Expansions{},
+		Task:         task.Task{Id: "mock_id", Secret: "mock_secret"},
+		Project:      model.Project{},
+		WorkDir:      dir,
+		BuildVariant: model.BuildVariant{},
+		S3Usage:      &s3usage.S3Usage{},
+	}
+	logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, s.Execute(ctx, comm, logger, conf))
+	// 3 attempts × 3 puts each = 9 total; all attributed to the single file.
+	assert.Equal(t, 9, conf.S3Usage.Artifacts.PutRequests)
+	assert.Equal(t, 1, conf.S3Usage.Artifacts.Count)
+	assert.Equal(t, 9, conf.S3Usage.Artifacts.ArtifactWithMaxPutRequests)
+	assert.Equal(t, 9, conf.S3Usage.Artifacts.ArtifactWithMinPutRequests)
 }

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-05-01a"
+	AgentVersion = "2026-05-07"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/evergreen-ci/birch v0.0.0-20250224221624-64f481f4b888
 	github.com/evergreen-ci/certdepot v0.0.0-20260326190252-5ab5e35f6cb7
 	github.com/evergreen-ci/gimlet v0.0.0-20260420181614-abe39e3a6fa7
-	github.com/evergreen-ci/pail v0.0.0-20260413131233-e5084eca59ac
+	github.com/evergreen-ci/pail v0.0.0-20260507160025-5cf2ef56c715
 	github.com/evergreen-ci/poplar v0.0.0-20260330180450-c8cf511d1bd6
 	github.com/evergreen-ci/shrub v0.0.0-20251017154811-4d3ed1599154
 	github.com/evergreen-ci/utility v0.0.0-20260116164328-250718d590d2

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/evergreen-ci/lru v0.0.0-20260326190734-0d627bf39810 h1:Q+MNMS3rHQw6bG
 github.com/evergreen-ci/lru v0.0.0-20260326190734-0d627bf39810/go.mod h1:A+sGkHeCogvvRBXUrF/Ghu5Gec6lyLtb1MKZN/xfWmI=
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035 h1:oVU/ni/sRq+GAogUMLa7LBGtvVHMVLbisuytxBC5KaY=
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035/go.mod h1:pvK7NM0ZC+sfTLuIiJN4BgM1S9S5Oo79PJReAFFph18=
-github.com/evergreen-ci/pail v0.0.0-20260413131233-e5084eca59ac h1:v1NP/2161vOomvk1sRkKIXfxhBAzd+xew92qEOsj9E0=
-github.com/evergreen-ci/pail v0.0.0-20260413131233-e5084eca59ac/go.mod h1:lj8oxBSqzEoapX1apBDy88B7wRjj27QQu9EXk2i3AOM=
+github.com/evergreen-ci/pail v0.0.0-20260507160025-5cf2ef56c715 h1:kPCrIdzDB+9t3ZxWiQdO2FL5Tt2fIkHxPeZc+SxI0K4=
+github.com/evergreen-ci/pail v0.0.0-20260507160025-5cf2ef56c715/go.mod h1:lj8oxBSqzEoapX1apBDy88B7wRjj27QQu9EXk2i3AOM=
 github.com/evergreen-ci/plank v0.0.0-20251203163536-53406252f581 h1:JOYnqPypLzZdjlFxS2ynWGKFPTrx0HAJwe6mi9P/lhk=
 github.com/evergreen-ci/plank v0.0.0-20251203163536-53406252f581/go.mod h1:visOo9VGGrTN+jNPSg56zhbCH81sSlMRnXpJCYb+kt4=
 github.com/evergreen-ci/poplar v0.0.0-20260330180450-c8cf511d1bd6 h1:leuRlgINHoR0/takPgoHYrfHt5mAtXcLdKdfQ0KVnyQ=

--- a/model/log/service_interface.go
+++ b/model/log/service_interface.go
@@ -14,8 +14,8 @@ type LogService interface {
 	// Get returns a log iterator with the given options.
 	Get(context.Context, GetOptions) (LogIterator, error)
 	// Append appends given lines to the specified log and sequence chunk.
-	// Returns the number of bytes written to storage.
-	Append(context.Context, string, int, []LogLine) (int64, error)
+	// Returns the number of bytes written to storage and the number of S3 PUT API calls made (including any that failed).
+	Append(context.Context, string, int, []LogLine) (int64, int, error)
 }
 
 // GetOptions represents the arguments for fetching Evergreen logs.

--- a/model/log/service_test.go
+++ b/model/log/service_test.go
@@ -388,4 +388,4 @@ func readLogLines(t *testing.T, svc LogService, ctx context.Context, opts GetOpt
 
 }
 
-func ignoreBytes(_ int64, err error) error { return err }
+func ignoreBytes(_ int64, _ int, err error) error { return err }

--- a/model/log/service_v0.go
+++ b/model/log/service_v0.go
@@ -65,9 +65,9 @@ func (s *logServiceV0) Get(ctx context.Context, getOpts GetOptions) (LogIterator
 	return it, nil
 }
 
-func (s *logServiceV0) Append(ctx context.Context, logName string, sequence int, lines []LogLine) (int64, error) {
+func (s *logServiceV0) Append(ctx context.Context, logName string, sequence int, lines []LogLine) (int64, int, error) {
 	if len(lines) == 0 {
-		return 0, nil
+		return 0, 0, nil
 	}
 
 	var rawLines []byte
@@ -76,11 +76,19 @@ func (s *logServiceV0) Append(ctx context.Context, logName string, sequence int,
 	}
 
 	key := fmt.Sprintf("%s/%s", logName, s.createChunkKey(sequence, lines[0].Timestamp, lines[len(lines)-1].Timestamp, len(lines)))
-	if err := s.bucket.Put(ctx, key, bytes.NewReader(rawLines)); err != nil {
-		return 0, errors.Wrap(err, "writing log chunk to bucket")
+	// pail.StreamPutCounter is implemented by *s3Bucket types; the fallback handles non-S3 buckets that don't track PUT counts.
+	var puts int
+	var err error
+	if pc, ok := s.bucket.(pail.StreamPutCounter); ok {
+		puts, err = pc.PutWithCount(ctx, key, bytes.NewReader(rawLines))
+	} else {
+		err = s.bucket.Put(ctx, key, bytes.NewReader(rawLines))
+	}
+	if err != nil {
+		return 0, puts, errors.Wrap(err, "writing log chunk to bucket")
 	}
 
-	return int64(len(rawLines)), nil
+	return int64(len(rawLines)), puts, nil
 }
 
 // getLogChunks maps each logical log to its chunk files stored in pail-backed

--- a/model/s3usage/s3usage.go
+++ b/model/s3usage/s3usage.go
@@ -105,80 +105,40 @@ const (
 	S3DaysPerMonth            = 30.0
 )
 
-// CalculateUploadMetrics populates file size and PUT requests for each uploaded file.
-// Returns the populated metrics plus aggregate totals.
-// If any file stat fails, logs a warning and uses zero values for that file.
-func CalculateUploadMetrics(
-	logger grip.Journaler,
-	files []FileMetrics,
-	bucketType S3BucketType,
-	method S3UploadMethod,
-) (populatedFiles []FileMetrics, totalSize int64, totalPuts int) {
-	populatedFiles = make([]FileMetrics, len(files))
-
-	for i, file := range files {
-		fileInfo, err := os.Stat(file.LocalPath)
-		if err != nil {
-			logger.Warningf(context.Background(), "Unable to calculate file size and PUT requests for '%s' after successful upload: %s. Using zero values for metadata.", file.LocalPath, err)
-			populatedFiles[i] = FileMetrics{
-				LocalPath:     file.LocalPath,
-				RemotePath:    file.RemotePath,
-				FileSizeBytes: 0,
-				PutRequests:   0,
-			}
-			continue
-		}
-
-		fileSize := fileInfo.Size()
-		putRequests := CalculatePutRequestsWithContext(bucketType, method, fileSize)
-
-		populatedFiles[i] = FileMetrics{
-			LocalPath:     file.LocalPath,
-			RemotePath:    file.RemotePath,
-			FileSizeBytes: fileSize,
-			PutRequests:   putRequests,
-		}
-
-		totalSize += fileSize
-		totalPuts += putRequests
+// BuildFileMetrics constructs a FileMetrics entry for a successfully uploaded file,
+// statting the file for size. If the stat fails, logs a warning and uses zero size.
+func BuildFileMetrics(logger grip.Journaler, localPath, remotePath string, puts int) (FileMetrics, int64) {
+	fileInfo, err := os.Stat(localPath)
+	var fileSize int64
+	if err != nil {
+		logger.Debugf(context.Background(), "Unable to calculate file size for '%s' after successful upload: %s. Using zero values for metadata.", localPath, err)
+	} else {
+		fileSize = fileInfo.Size()
 	}
-
-	return populatedFiles, totalSize, totalPuts
+	return FileMetrics{
+		LocalPath:     localPath,
+		RemotePath:    remotePath,
+		FileSizeBytes: fileSize,
+		PutRequests:   puts,
+	}, fileSize
 }
 
-// CalculatePutRequestsWithContext returns the number of S3 PUT API calls
-// needed to upload a file based on bucket type, upload method, and file size.
-func CalculatePutRequestsWithContext(bucketType S3BucketType, method S3UploadMethod, fileSize int64) int {
-	if fileSize < 0 {
-		return 0
+// ComputePerFileExtremes returns the max and min PutRequests across all uploaded files.
+func ComputePerFileExtremes(files []FileMetrics) (maxPuts, minPuts int) {
+	if len(files) == 0 {
+		return 0, 0
 	}
-
-	switch method {
-	case S3UploadMethodCopy:
-		return 1
-
-	case S3UploadMethodWriter:
-		if bucketType == S3BucketTypeSmall {
-			return 1
+	maxPuts = files[0].PutRequests
+	minPuts = files[0].PutRequests
+	for i := 1; i < len(files); i++ {
+		if files[i].PutRequests > maxPuts {
+			maxPuts = files[i].PutRequests
 		}
-		// Large bucket Writer uses multipart for all sizes, <= 5MB is simple multipart (3 PUTs)
-		if fileSize <= S3PartSize {
-			return 3
+		if files[i].PutRequests < minPuts {
+			minPuts = files[i].PutRequests
 		}
-		numParts := int((fileSize + S3PartSize - 1) / S3PartSize)
-		return 1 + numParts + 1
-
-	case S3UploadMethodPut:
-		// AWS SDK uses single PUT for < 5MB, multipart for >= 5MB
-		if fileSize < S3PartSize {
-			return 1
-		}
-		numParts := int((fileSize + S3PartSize - 1) / S3PartSize)
-		return 1 + numParts + 1
-
-	default:
-		return 0
 	}
+	return maxPuts, minPuts
 }
 
 // CalculateS3PutCostWithConfig calculates the S3 PUT request cost, returning both the standard

--- a/model/s3usage/s3usage_test.go
+++ b/model/s3usage/s3usage_test.go
@@ -1,9 +1,12 @@
 package s3usage
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/mongodb/grip"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -152,86 +155,66 @@ func TestS3Usage(t *testing.T) {
 	})
 }
 
-func TestCalculatePutRequestsWithContext(t *testing.T) {
-	const MB = 1024 * 1024
+func TestBuildFileMetrics(t *testing.T) {
+	t.Run("FileExistsShouldReturnCorrectMetrics", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		localPath := filepath.Join(tmpDir, "test.txt")
+		require.NoError(t, os.WriteFile(localPath, []byte("hello world"), 0644))
+		fi, err := os.Stat(localPath)
+		require.NoError(t, err)
+		expectedSize := fi.Size()
 
-	t.Run("NegativeSizeShouldReturnZero", func(t *testing.T) {
-		assert.Equal(t, 0, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, -100))
-		assert.Equal(t, 0, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodWriter, -1*MB))
+		metrics, fileSize := BuildFileMetrics(grip.NewJournaler("test"), localPath, "remote/path/test.txt", 3)
+		assert.Equal(t, localPath, metrics.LocalPath)
+		assert.Equal(t, "remote/path/test.txt", metrics.RemotePath)
+		assert.Equal(t, expectedSize, metrics.FileSizeBytes)
+		assert.Equal(t, 3, metrics.PutRequests)
+		assert.Equal(t, expectedSize, fileSize)
 	})
-
-	t.Run("ZeroByteFileShouldReturnOnePut", func(t *testing.T) {
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodPut, 0))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, 0))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodWriter, 0))
+	t.Run("FileNotExistShouldReturnZeroSize", func(t *testing.T) {
+		metrics, fileSize := BuildFileMetrics(grip.NewJournaler("test"), "/nonexistent/path/file.txt", "remote/path/file.txt", 1)
+		assert.Equal(t, "/nonexistent/path/file.txt", metrics.LocalPath)
+		assert.Equal(t, "remote/path/file.txt", metrics.RemotePath)
+		assert.Equal(t, int64(0), metrics.FileSizeBytes)
+		assert.Equal(t, 1, metrics.PutRequests)
+		assert.Equal(t, int64(0), fileSize)
 	})
+}
 
-	t.Run("CopyMethod", func(t *testing.T) {
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodCopy, 1))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodCopy, 1))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodCopy, 1*MB))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodCopy, 100*MB))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodCopy, 1000*MB))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodCopy, 1000*MB))
+func TestComputePerFileExtremes(t *testing.T) {
+	t.Run("EmptyInputReturnsZero", func(t *testing.T) {
+		maxPuts, minPuts := ComputePerFileExtremes(nil)
+		assert.Zero(t, maxPuts)
+		assert.Zero(t, minPuts)
 	})
-
-	t.Run("SmallBucketWriter", func(t *testing.T) {
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodWriter, 1))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodWriter, 1*MB))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodWriter, 4*MB))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodWriter, 5*MB))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodWriter, 10*MB))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodWriter, 100*MB))
+	t.Run("SingleFileReturnsSameMaxAndMin", func(t *testing.T) {
+		files := []FileMetrics{
+			{PutRequests: 5},
+		}
+		maxPuts, minPuts := ComputePerFileExtremes(files)
+		assert.Equal(t, 5, maxPuts)
+		assert.Equal(t, 5, minPuts)
 	})
-
-	t.Run("LargeBucketWriter", func(t *testing.T) {
-		assert.Equal(t, 3, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodWriter, 1))
-		assert.Equal(t, 3, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodWriter, 1*MB))
-		assert.Equal(t, 3, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodWriter, 5*MB))
-		assert.Equal(t, 4, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodWriter, 10*MB))
-		assert.Equal(t, 12, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodWriter, 50*MB))
-		assert.Equal(t, 22, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodWriter, 100*MB))
+	t.Run("MultipleFilesReturnsCorrectExtremes", func(t *testing.T) {
+		files := []FileMetrics{
+			{PutRequests: 3},
+			{PutRequests: 10},
+			{PutRequests: 1},
+			{PutRequests: 7},
+		}
+		maxPuts, minPuts := ComputePerFileExtremes(files)
+		assert.Equal(t, 10, maxPuts)
+		assert.Equal(t, 1, minPuts)
 	})
-
-	t.Run("PutMethodSmallBucket", func(t *testing.T) {
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodPut, 1))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodPut, 100*1024))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodPut, 1*MB))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodPut, 4*MB))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodPut, 5*MB-1))
-		assert.Equal(t, 3, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodPut, 5*MB))
-		assert.Equal(t, 4, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodPut, 5*MB+1))
-		assert.Equal(t, 4, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodPut, 10*MB))
-		assert.Equal(t, 22, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodPut, 100*MB))
-	})
-
-	t.Run("PutMethodLargeBucket", func(t *testing.T) {
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, 1))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, 2*MB))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, 4*MB))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, 5*MB-1))
-		assert.Equal(t, 3, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, 5*MB))
-		assert.Equal(t, 4, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, 5*MB+1))
-		assert.Equal(t, 5, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, 15*MB))
-		assert.Equal(t, 22, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, 100*MB))
-	})
-
-	t.Run("RealWorldScenarios", func(t *testing.T) {
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, 2*MB))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodWriter, 500*1024))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodCopy, 1000*MB))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, 300*1024))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodPut, 50*1024))
-		assert.Equal(t, 6, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, 20*MB))
-	})
-
-	t.Run("BoundaryConditions", func(t *testing.T) {
-		assert.Equal(t, 3, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodPut, 5*MB))
-		assert.Equal(t, 3, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, 5*MB))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodPut, 5*MB-1))
-		assert.Equal(t, 1, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, 5*MB-1))
-		assert.Equal(t, 4, CalculatePutRequestsWithContext(S3BucketTypeSmall, S3UploadMethodPut, 5*MB+1))
-		assert.Equal(t, 4, CalculatePutRequestsWithContext(S3BucketTypeLarge, S3UploadMethodPut, 5*MB+1))
+	t.Run("AllSameValueReturnsSameMaxAndMin", func(t *testing.T) {
+		files := []FileMetrics{
+			{PutRequests: 4},
+			{PutRequests: 4},
+			{PutRequests: 4},
+		}
+		maxPuts, minPuts := ComputePerFileExtremes(files)
+		assert.Equal(t, 4, maxPuts)
+		assert.Equal(t, 4, minPuts)
 	})
 }
 

--- a/model/task/evergreen_sender.go
+++ b/model/task/evergreen_sender.go
@@ -22,8 +22,8 @@ var defaultLogLineParser = func(rawLine string) (log.LogLine, error) {
 }
 
 // logLineAppender appends a chunk of lines to the underlying log store.
-// Returns the number of bytes written to storage.
-type logLineAppender func(context.Context, []log.LogLine) (int64, error)
+// Returns the number of bytes written to storage and the number of S3 PUT API calls made (including any that failed).
+type logLineAppender func(context.Context, []log.LogLine) (int64, int, error)
 
 // EvergreenSenderOptions support the use and creation of an Evergreen sender.
 type EvergreenSenderOptions struct {
@@ -243,13 +243,12 @@ func (s *evergreenSender) timedFlush() {
 }
 
 func (s *evergreenSender) flush(ctx context.Context) error {
-	uploadBytes, err := s.opts.appendLines(ctx, s.buffer)
+	uploadBytes, puts, err := s.opts.appendLines(ctx, s.buffer)
+	if s.opts.S3Usage != nil && puts > 0 {
+		s.opts.S3Usage.IncrementLogs(puts, uploadBytes, s.opts.LogType, s.opts.LogKey)
+	}
 	if err != nil {
 		return errors.Wrap(err, "appending lines to log")
-	}
-
-	if s.opts.S3Usage != nil && uploadBytes > 0 {
-		s.opts.S3Usage.IncrementLogs(1, uploadBytes, s.opts.LogType, s.opts.LogKey)
 	}
 
 	s.buffer = []log.LogLine{}

--- a/model/task/evergreen_sender_test.go
+++ b/model/task/evergreen_sender_test.go
@@ -378,7 +378,7 @@ func newSenderTestMock(ctx context.Context) *senderTestMock {
 				Parse: func(rawLine string) (log.LogLine, error) {
 					return log.LogLine{Data: rawLine}, nil
 				},
-				appendLines: func(ctx context.Context, lines []log.LogLine) (int64, error) {
+				appendLines: func(ctx context.Context, lines []log.LogLine) (int64, int, error) {
 					return svc.Append(ctx, lines)
 				},
 			},
@@ -407,9 +407,9 @@ type mockLogService struct {
 	hasWriteErr bool
 }
 
-func (s *mockLogService) Append(ctx context.Context, lines []log.LogLine) (int64, error) {
+func (s *mockLogService) Append(ctx context.Context, lines []log.LogLine) (int64, int, error) {
 	if s.hasWriteErr {
-		return 0, errors.New("write error")
+		return 0, 0, errors.New("write error")
 	}
 	var totalBytes int64
 	for _, line := range lines {
@@ -417,5 +417,5 @@ func (s *mockLogService) Append(ctx context.Context, lines []log.LogLine) (int64
 	}
 	s.lines = append(s.lines, lines...)
 
-	return totalBytes, nil
+	return totalBytes, 1, nil
 }

--- a/model/task/task_log.go
+++ b/model/task/task_log.go
@@ -94,7 +94,7 @@ func NewTaskLogSender(ctx context.Context, task *Task, senderOpts EvergreenSende
 	}
 
 	logName := getLogName(*task, logType, output.TaskLogs.ID())
-	senderOpts.appendLines = func(ctx context.Context, lines []log.LogLine) (int64, error) {
+	senderOpts.appendLines = func(ctx context.Context, lines []log.LogLine) (int64, int, error) {
 		return svc.Append(ctx, logName, 0, lines)
 	}
 	senderOpts.LogType = string(logType)
@@ -126,13 +126,12 @@ func AppendTaskLogs(ctx context.Context, task *Task, logType TaskLogType, lines 
 	}
 
 	logName := getLogName(*task, logType, output.TaskLogs.ID())
-	uploadBytes, err := svc.Append(ctx, logName, 0, lines)
+	uploadBytes, puts, err := svc.Append(ctx, logName, 0, lines)
+	if puts > 0 {
+		task.S3Usage.IncrementLogs(puts, uploadBytes, string(logType), logName)
+	}
 	if err != nil {
 		return err
-	}
-
-	if uploadBytes > 0 {
-		task.S3Usage.IncrementLogs(1, uploadBytes, string(logType), logName)
 	}
 
 	return nil

--- a/model/task/test_log.go
+++ b/model/task/test_log.go
@@ -59,7 +59,7 @@ func NewTestLogSender(ctx context.Context, task Task, senderOpts EvergreenSender
 		return nil, errors.Wrap(err, "getting log service")
 	}
 
-	senderOpts.appendLines = func(ctx context.Context, lines []log.LogLine) (int64, error) {
+	senderOpts.appendLines = func(ctx context.Context, lines []log.LogLine) (int64, int, error) {
 		return svc.Append(ctx, getLogNames(task, []string{logPath}, output.TestLogs.ID())[0], sequence, lines)
 	}
 


### PR DESCRIPTION
DEVPROD-27407

### Description
Currently when we retry on an S3 put failure we only count the puts for the successful uploads. We do not count the puts that occurred during the failures. This PR addressed that. 

Now we accumilate puts across failures and success so cost calculation is more accurate. This also handles file size with 0 correctly as we now get the accurate put counts directly from pail

Pail changes were required for this and have been made in this [PR](https://github.com/evergreen-ci/pail/pull/147)

### Testing
Testing this is staging and added test coverage