### PR TITLE
DEVPROD-32957 Debug list-steps command shows pre/post blocks for task groups

### DIFF
--- a/agent/taskexec/local_executor.go
+++ b/agent/taskexec/local_executor.go
@@ -672,14 +672,11 @@ func (e *LocalExecutor) PrepareTask(ctx context.Context, taskName, variantName s
 		if bv == nil {
 			return errors.Errorf("build variant '%s' not found in project", variantName)
 		}
-		if _, err := bv.Get(taskName); err != nil {
-			tg = e.project.FindTaskGroupForTask(variantName, taskName)
-			if tg == nil {
+		tg = e.project.FindTaskGroupForTask(variantName, taskName)
+		if tg == nil {
+			if _, err := bv.Get(taskName); err != nil {
 				return errors.Wrapf(err, "task '%s' is not defined on build variant '%s'", taskName, variantName)
 			}
-		}
-		if tg == nil {
-			tg = e.project.FindTaskGroupForTask(variantName, taskName)
 		}
 		e.debugState.SelectedVariant = variantName
 		e.taskConfig.Expansions.Put("build_variant", variantName)
@@ -706,13 +703,25 @@ func (e *LocalExecutor) PrepareTask(ctx context.Context, taskName, variantName s
 				canFailTask: tg.SetupTaskCanFailTask,
 			})
 		}
-		blocks = append(blocks, executorBlock{
-			blockType: command.MainTaskBlock,
-			commands: &model.YAMLCommandSet{
-				MultiCommand: task.Commands,
-			},
-			canFailTask: true,
-		})
+	} else {
+		if e.project.Pre != nil && len(e.project.Pre.List()) > 0 {
+			blocks = append(blocks, executorBlock{
+				blockType:   command.PreBlock,
+				commands:    e.project.Pre,
+				canFailTask: e.project.PreErrorFailsTask,
+			})
+		}
+	}
+
+	blocks = append(blocks, executorBlock{
+		blockType: command.MainTaskBlock,
+		commands: &model.YAMLCommandSet{
+			MultiCommand: task.Commands,
+		},
+		canFailTask: true,
+	})
+
+	if tg != nil {
 		if tg.TeardownTask != nil && len(tg.TeardownTask.List()) > 0 {
 			blocks = append(blocks, executorBlock{
 				blockType:   command.TeardownTaskBlock,
@@ -728,20 +737,6 @@ func (e *LocalExecutor) PrepareTask(ctx context.Context, taskName, variantName s
 			})
 		}
 	} else {
-		if e.project.Pre != nil && len(e.project.Pre.List()) > 0 {
-			blocks = append(blocks, executorBlock{
-				blockType:   command.PreBlock,
-				commands:    e.project.Pre,
-				canFailTask: e.project.PreErrorFailsTask,
-			})
-		}
-		blocks = append(blocks, executorBlock{
-			blockType: command.MainTaskBlock,
-			commands: &model.YAMLCommandSet{
-				MultiCommand: task.Commands,
-			},
-			canFailTask: true,
-		})
 		if e.project.Post != nil && len(e.project.Post.List()) > 0 {
 			blocks = append(blocks, executorBlock{
 				blockType:   command.PostBlock,

--- a/agent/taskexec/local_executor.go
+++ b/agent/taskexec/local_executor.go
@@ -666,13 +666,20 @@ func (e *LocalExecutor) PrepareTask(ctx context.Context, taskName, variantName s
 	e.debugState.SelectedTask = taskName
 	e.logger.Infof(ctx, "Preparing task: %s", taskName)
 
+	var tg *model.TaskGroup
 	if variantName != "" {
 		bv := e.project.FindBuildVariant(variantName)
 		if bv == nil {
 			return errors.Errorf("build variant '%s' not found in project", variantName)
 		}
 		if _, err := bv.Get(taskName); err != nil {
-			return errors.Wrapf(err, "task '%s' is not defined on build variant '%s'", taskName, variantName)
+			tg = e.project.FindTaskGroupForTask(variantName, taskName)
+			if tg == nil {
+				return errors.Wrapf(err, "task '%s' is not defined on build variant '%s'", taskName, variantName)
+			}
+		}
+		if tg == nil {
+			tg = e.project.FindTaskGroupForTask(variantName, taskName)
 		}
 		e.debugState.SelectedVariant = variantName
 		e.taskConfig.Expansions.Put("build_variant", variantName)
@@ -680,29 +687,68 @@ func (e *LocalExecutor) PrepareTask(ctx context.Context, taskName, variantName s
 		e.logger.Infof(ctx, "Applied expansions from build variant: %s", variantName)
 	}
 
-	// Build command blocks array with pre, main, and post blocks
+	// Build command blocks array. If the task belongs to a task group, use
+	// the group's setup/teardown blocks instead of project-level pre/post.
 	var blocks []executorBlock
 
-	if e.project.Pre != nil && len(e.project.Pre.List()) > 0 {
+	if tg != nil {
+		if tg.SetupGroup != nil && len(tg.SetupGroup.List()) > 0 {
+			blocks = append(blocks, executorBlock{
+				blockType:   command.SetupGroupBlock,
+				commands:    tg.SetupGroup,
+				canFailTask: tg.SetupGroupCanFailTask,
+			})
+		}
+		if tg.SetupTask != nil && len(tg.SetupTask.List()) > 0 {
+			blocks = append(blocks, executorBlock{
+				blockType:   command.SetupTaskBlock,
+				commands:    tg.SetupTask,
+				canFailTask: tg.SetupTaskCanFailTask,
+			})
+		}
 		blocks = append(blocks, executorBlock{
-			blockType:   command.PreBlock,
-			commands:    e.project.Pre,
-			canFailTask: e.project.PreErrorFailsTask,
+			blockType: command.MainTaskBlock,
+			commands: &model.YAMLCommandSet{
+				MultiCommand: task.Commands,
+			},
+			canFailTask: true,
 		})
-	}
-	blocks = append(blocks, executorBlock{
-		blockType: command.MainTaskBlock,
-		commands: &model.YAMLCommandSet{
-			MultiCommand: task.Commands,
-		},
-		canFailTask: true,
-	})
-	if e.project.Post != nil && len(e.project.Post.List()) > 0 {
+		if tg.TeardownTask != nil && len(tg.TeardownTask.List()) > 0 {
+			blocks = append(blocks, executorBlock{
+				blockType:   command.TeardownTaskBlock,
+				commands:    tg.TeardownTask,
+				canFailTask: tg.TeardownTaskCanFailTask,
+			})
+		}
+		if tg.TeardownGroup != nil && len(tg.TeardownGroup.List()) > 0 {
+			blocks = append(blocks, executorBlock{
+				blockType:   command.TeardownGroupBlock,
+				commands:    tg.TeardownGroup,
+				canFailTask: false,
+			})
+		}
+	} else {
+		if e.project.Pre != nil && len(e.project.Pre.List()) > 0 {
+			blocks = append(blocks, executorBlock{
+				blockType:   command.PreBlock,
+				commands:    e.project.Pre,
+				canFailTask: e.project.PreErrorFailsTask,
+			})
+		}
 		blocks = append(blocks, executorBlock{
-			blockType:   command.PostBlock,
-			commands:    e.project.Post,
-			canFailTask: e.project.PostErrorFailsTask,
+			blockType: command.MainTaskBlock,
+			commands: &model.YAMLCommandSet{
+				MultiCommand: task.Commands,
+			},
+			canFailTask: true,
 		})
+		if e.project.Post != nil && len(e.project.Post.List()) > 0 {
+			blocks = append(blocks, executorBlock{
+				blockType:   command.PostBlock,
+				commands:    e.project.Post,
+				canFailTask: e.project.PostErrorFailsTask,
+			})
+		}
 	}
 	e.commandBlocks = blocks
 	if err := e.rebuildCommandList(); err != nil {

--- a/agent/taskexec/local_executor_test.go
+++ b/agent/taskexec/local_executor_test.go
@@ -407,6 +407,93 @@ buildvariants:
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "not defined on build variant")
 	})
+
+	t.Run("TaskGroupUsesSetupAndTeardownBlocks", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		yamlFile := filepath.Join(tmpDir, "test.yml")
+		yamlContent := `
+tasks:
+  - name: lint-agent
+    commands:
+      - command: subprocess.exec
+        params:
+          command: make lint-agent
+task_groups:
+  - name: lint-group
+    setup_group:
+      - command: git.get_project
+      - command: shell.exec
+        params:
+          script: go mod tidy
+    teardown_task:
+      - command: gotest.parse_files
+      - command: attach.xunit_results
+    tasks:
+      - lint-agent
+buildvariants:
+  - name: lint
+    tasks:
+      - name: lint-group
+`
+		err := os.WriteFile(yamlFile, []byte(yamlContent), 0644)
+		require.NoError(t, err)
+
+		executor, err := NewLocalExecutor(t.Context(), LocalExecutorOptions{})
+		require.NoError(t, err)
+
+		_, err = executor.LoadProject(yamlFile)
+		require.NoError(t, err)
+
+		err = executor.PrepareTask(t.Context(), "lint-agent", "lint")
+		require.NoError(t, err)
+		assert.Equal(t, "lint-agent", executor.debugState.SelectedTask)
+		assert.Equal(t, "lint", executor.debugState.SelectedVariant)
+
+		require.Len(t, executor.commandBlocks, 3)
+		assert.Equal(t, command.SetupGroupBlock, executor.commandBlocks[0].blockType)
+		assert.Equal(t, command.MainTaskBlock, executor.commandBlocks[1].blockType)
+		assert.Equal(t, command.TeardownTaskBlock, executor.commandBlocks[2].blockType)
+	})
+
+	t.Run("TaskGroupValidatesOnVariant", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		yamlFile := filepath.Join(tmpDir, "test.yml")
+		yamlContent := `
+tasks:
+  - name: lint-agent
+    commands:
+      - command: subprocess.exec
+  - name: other-task
+    commands:
+      - command: shell.exec
+task_groups:
+  - name: lint-group
+    tasks:
+      - lint-agent
+buildvariants:
+  - name: lint
+    tasks:
+      - name: lint-group
+  - name: other
+    tasks:
+      - name: other-task
+`
+		err := os.WriteFile(yamlFile, []byte(yamlContent), 0644)
+		require.NoError(t, err)
+
+		executor, err := NewLocalExecutor(t.Context(), LocalExecutorOptions{})
+		require.NoError(t, err)
+
+		_, err = executor.LoadProject(yamlFile)
+		require.NoError(t, err)
+
+		err = executor.PrepareTask(t.Context(), "lint-agent", "lint")
+		require.NoError(t, err)
+
+		err = executor.PrepareTask(t.Context(), "lint-agent", "other")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not defined on build variant")
+	})
 }
 
 func TestCommandInfoStepNumber(t *testing.T) {

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-05-01a"
+	AgentVersion = "2026-05-07"
 )
 
 const (

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -391,7 +391,8 @@ func (r *taskResolver) ExecutionSteps(ctx context.Context, obj *restModel.APITas
 	}
 
 	taskName := utility.FromStringPtr(obj.DisplayName)
-	steps, err := model.GetTaskExecutionSteps(project, taskName)
+	variantName := utility.FromStringPtr(obj.BuildVariant)
+	steps, err := model.GetTaskExecutionSteps(project, taskName, variantName)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("building execution steps: %s", err.Error()))
 	}

--- a/model/task_steps.go
+++ b/model/task_steps.go
@@ -18,7 +18,7 @@ type TaskExecutionStep struct {
 
 // GetTaskExecutionSteps builds a flat list of execution steps for a task,
 // mirroring the logic used in the "list-steps" command in the task debugger CLI.
-func GetTaskExecutionSteps(project *Project, taskName string) ([]TaskExecutionStep, error) {
+func GetTaskExecutionSteps(project *Project, taskName, variantName string) ([]TaskExecutionStep, error) {
 	task := project.FindProjectTask(taskName)
 	if task == nil {
 		return nil, errors.Errorf("task '%s' not found in project", taskName)
@@ -31,17 +31,51 @@ func GetTaskExecutionSteps(project *Project, taskName string) ([]TaskExecutionSt
 
 	var blocks []commandBlock
 
-	if project.Pre != nil {
-		if cmds := project.Pre.List(); len(cmds) > 0 {
-			blocks = append(blocks, commandBlock{blockType: "pre", commands: cmds})
-		}
+	var tg *TaskGroup
+	if variantName != "" {
+		tg = project.FindTaskGroupForTask(variantName, taskName)
 	}
 
-	blocks = append(blocks, commandBlock{blockType: "", commands: task.Commands})
+	// If variantName is provided and the task belongs to a task group on that
+	// variant, the task group's setup/teardown blocks are used instead of the
+	// project-level pre/post blocks.
+	if tg != nil {
+		if tg.SetupGroup != nil {
+			if cmds := tg.SetupGroup.List(); len(cmds) > 0 {
+				blocks = append(blocks, commandBlock{blockType: "setup_group", commands: cmds})
+			}
+		}
+		if tg.SetupTask != nil {
+			if cmds := tg.SetupTask.List(); len(cmds) > 0 {
+				blocks = append(blocks, commandBlock{blockType: "setup_task", commands: cmds})
+			}
+		}
 
-	if project.Post != nil {
-		if cmds := project.Post.List(); len(cmds) > 0 {
-			blocks = append(blocks, commandBlock{blockType: "post", commands: cmds})
+		blocks = append(blocks, commandBlock{blockType: "", commands: task.Commands})
+
+		if tg.TeardownTask != nil {
+			if cmds := tg.TeardownTask.List(); len(cmds) > 0 {
+				blocks = append(blocks, commandBlock{blockType: "teardown_task", commands: cmds})
+			}
+		}
+		if tg.TeardownGroup != nil {
+			if cmds := tg.TeardownGroup.List(); len(cmds) > 0 {
+				blocks = append(blocks, commandBlock{blockType: "teardown_group", commands: cmds})
+			}
+		}
+	} else {
+		if project.Pre != nil {
+			if cmds := project.Pre.List(); len(cmds) > 0 {
+				blocks = append(blocks, commandBlock{blockType: "pre", commands: cmds})
+			}
+		}
+
+		blocks = append(blocks, commandBlock{blockType: "", commands: task.Commands})
+
+		if project.Post != nil {
+			if cmds := project.Post.List(); len(cmds) > 0 {
+				blocks = append(blocks, commandBlock{blockType: "post", commands: cmds})
+			}
 		}
 	}
 

--- a/model/task_steps_test.go
+++ b/model/task_steps_test.go
@@ -21,7 +21,7 @@ func TestGetTaskExecutionSteps(t *testing.T) {
 			},
 		}
 
-		steps, err := GetTaskExecutionSteps(project, "my_task")
+		steps, err := GetTaskExecutionSteps(project, "my_task", "")
 		require.NoError(t, err)
 		require.Len(t, steps, 2)
 
@@ -54,7 +54,7 @@ func TestGetTaskExecutionSteps(t *testing.T) {
 			},
 		}
 
-		steps, err := GetTaskExecutionSteps(project, "my_task")
+		steps, err := GetTaskExecutionSteps(project, "my_task", "")
 		require.NoError(t, err)
 		require.Len(t, steps, 3)
 
@@ -92,7 +92,7 @@ func TestGetTaskExecutionSteps(t *testing.T) {
 			},
 		}
 
-		steps, err := GetTaskExecutionSteps(project, "my_task")
+		steps, err := GetTaskExecutionSteps(project, "my_task", "")
 		require.NoError(t, err)
 		require.Len(t, steps, 4)
 
@@ -133,7 +133,7 @@ func TestGetTaskExecutionSteps(t *testing.T) {
 			},
 		}
 
-		steps, err := GetTaskExecutionSteps(project, "my_task")
+		steps, err := GetTaskExecutionSteps(project, "my_task", "")
 		require.NoError(t, err)
 		require.Len(t, steps, 3)
 
@@ -150,7 +150,7 @@ func TestGetTaskExecutionSteps(t *testing.T) {
 			},
 		}
 
-		_, err := GetTaskExecutionSteps(project, "nonexistent")
+		_, err := GetTaskExecutionSteps(project, "nonexistent", "")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
 	})
@@ -172,11 +172,76 @@ func TestGetTaskExecutionSteps(t *testing.T) {
 			},
 		}
 
-		steps, err := GetTaskExecutionSteps(project, "my_task")
+		steps, err := GetTaskExecutionSteps(project, "my_task", "")
 		require.NoError(t, err)
 		require.Len(t, steps, 1)
 
 		assert.Equal(t, "1", steps[0].StepNumber)
 		assert.True(t, steps[0].IsFunction)
+	})
+
+	t.Run("TaskGroupWithSetupAndTeardown", func(t *testing.T) {
+		project := &Project{
+			Pre: &YAMLCommandSet{
+				SingleCommand: &PluginCommandConf{Command: "ec2.assume_role"},
+			},
+			Post: &YAMLCommandSet{
+				SingleCommand: &PluginCommandConf{Command: "attach.results"},
+			},
+			Tasks: []ProjectTask{
+				{
+					Name:     "lint-agent",
+					Commands: []PluginCommandConf{{Command: "subprocess.exec"}},
+				},
+			},
+			TaskGroups: []TaskGroup{
+				{
+					Name: "lint-group",
+					SetupGroup: &YAMLCommandSet{
+						MultiCommand: []PluginCommandConf{
+							{Command: "git.get_project"},
+							{Command: "shell.exec"},
+						},
+					},
+					TeardownTask: &YAMLCommandSet{
+						MultiCommand: []PluginCommandConf{
+							{Command: "gotest.parse_files"},
+							{Command: "attach.xunit_results"},
+						},
+					},
+					Tasks: []string{"lint-agent"},
+				},
+			},
+			BuildVariants: []BuildVariant{
+				{
+					Name:  "lint",
+					Tasks: []BuildVariantTaskUnit{{Name: "lint-group", IsGroup: true}},
+				},
+			},
+		}
+
+		steps, err := GetTaskExecutionSteps(project, "lint-agent", "lint")
+		require.NoError(t, err)
+		require.Len(t, steps, 5)
+
+		assert.Equal(t, "setup_group:1", steps[0].StepNumber)
+		assert.Equal(t, "git.get_project", steps[0].CommandName)
+		assert.Equal(t, "setup_group", steps[0].BlockType)
+
+		assert.Equal(t, "setup_group:2", steps[1].StepNumber)
+		assert.Equal(t, "shell.exec", steps[1].CommandName)
+		assert.Equal(t, "setup_group", steps[1].BlockType)
+
+		assert.Equal(t, "1", steps[2].StepNumber)
+		assert.Equal(t, "subprocess.exec", steps[2].CommandName)
+		assert.Empty(t, steps[2].BlockType)
+
+		assert.Equal(t, "teardown_task:1", steps[3].StepNumber)
+		assert.Equal(t, "gotest.parse_files", steps[3].CommandName)
+		assert.Equal(t, "teardown_task", steps[3].BlockType)
+
+		assert.Equal(t, "teardown_task:2", steps[4].StepNumber)
+		assert.Equal(t, "attach.xunit_results", steps[4].CommandName)
+		assert.Equal(t, "teardown_task", steps[4].BlockType)
 	})
 }


### PR DESCRIPTION
DEVPROD-32957

### Description
The debug list-steps command shows project-level pre/post blocks for tasks belonging to a task group, which is confusing for users who run `evergreen debug list-steps` for these tasks since those commands aren't actually part of the plan.

Updated the resolver & logic that prints out the plan to detect task group and display the correct execution plan based on that.
### Testing
Verified in staging + added some test cases