### PR TITLE
DEVPROD-5442: Add index for HasMatchingTasks to reduce latency

### DIFF
--- a/cmd/load-smoke-data/load-smoke-data.go
+++ b/cmd/load-smoke-data/load-smoke-data.go
@@ -68,6 +68,7 @@ func insertFileDocsToDB(ctx context.Context, fn string, db *mongo.Database) erro
 		if _, err = collection.Indexes().CreateMany(ctx, []mongo.IndexModel{
 			{Keys: task.ActivatedTasksByDistroIndex},
 			{Keys: task.TaskHistoricalDataIndex},
+			{Keys: task.TasksByVersionIndex},
 			{Keys: model.TaskHistoryIndex},
 		}); err != nil {
 			return errors.Wrap(err, "creating task indexes")

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -40,6 +40,13 @@ var (
 		{Key: OverrideDependenciesKey, Value: 1},
 		{Key: UnattainableDependencyKey, Value: 1},
 	}
+
+	// TasksByVersionIndex pins HasMatchingTasks's plan to a stable
+	// version-prefixed scan so mainlineCommits latency stops fluctuating.
+	TasksByVersionIndex = bson.D{
+		{Key: VersionKey, Value: 1},
+		{Key: ActivatedTimeKey, Value: 1},
+	}
 )
 
 var (
@@ -2263,19 +2270,19 @@ type HasMatchingTasksOptions struct {
 // HasMatchingTasks returns true if the version has tasks with the given statuses
 func HasMatchingTasks(ctx context.Context, versionID string, opts HasMatchingTasksOptions) (bool, error) {
 	ctx = utility.ContextWithAttributes(ctx, []attribute.KeyValue{attribute.String(evergreen.AggregationNameOtelAttribute, "HasMatchingTasks")})
-	options := GetTasksByVersionOptions{
+	pipelineOpts := GetTasksByVersionOptions{
 		TaskNames:                  opts.TaskNames,
 		Variants:                   opts.Variants,
 		Statuses:                   opts.Statuses,
 		IncludeNeverActivatedTasks: !opts.IncludeNeverActivatedTasks,
 	}
-	pipeline, err := getTasksByVersionPipeline(versionID, options)
+	pipeline, err := getTasksByVersionPipeline(versionID, pipelineOpts)
 	if err != nil {
 		return false, errors.Wrap(err, "getting tasks by version pipeline")
 	}
 	pipeline = append(pipeline, bson.M{"$limit": 1})
 	env := evergreen.GetEnvironment()
-	cursor, err := env.DB().Collection(Collection).Aggregate(ctx, pipeline)
+	cursor, err := env.DB().Collection(Collection).Aggregate(ctx, pipeline, options.Aggregate().SetHint(TasksByVersionIndex))
 	if err != nil {
 		// If the pipeline stage is too large we should use the slow annotations lookup
 		if db.IsErrorCode(err, db.FacetPipelineStageTooLargeCode) && !opts.UseSlowAnnotationsLookup {
@@ -2338,9 +2345,11 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 	if !opts.IncludeNeverActivatedTasks {
 		match[ActivatedTimeKey] = bson.M{"$ne": utility.ZeroTime}
 	}
+	// Match before project so the planner can use a version-prefixed index
+	// without relying on its $project/$match reordering optimization.
 	pipeline := []bson.M{
-		{"$project": projectOut},
 		{"$match": match},
+		{"$project": projectOut},
 	}
 
 	if !opts.IncludeExecutionTasks {

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 func checkStatuses(t *testing.T, expected string, toCheck Task) {
@@ -1726,6 +1727,7 @@ func compareGroupedTaskStatusCounts(t *testing.T, expected, actual []*GroupedTas
 
 func TestHasMatchingTasks(t *testing.T) {
 	require.NoError(t, db.ClearCollections(Collection))
+	require.NoError(t, db.EnsureIndex(Collection, mongo.IndexModel{Keys: TasksByVersionIndex}))
 	t1 := Task{
 		Id:                      "t1",
 		Version:                 "v1",


### PR DESCRIPTION
DEVPROD-5442

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Mainlinecommits latency was too variable as sometimes the query planner picked a bad plan. To fix we're:
- Adding a new `TasksByVersionIndex` index on `tasks`
- Use hints to ensure HasMatchingTasks uses the (above) index `TasksByVersionIndex`
- Put the filter($match) _before_ $project to ensure we use the index as if $project goes first in the planner it can do a full scan.

Will monitor performance before and after to determine success.

### Testing
Holding off merging and testing till index issue is resolved 

Latency dashboard: https://ui.honeycomb.io/mongodb-4b/environments/production/board/dZzWSXm9YCZ