### PR TITLE
DEVPROD-33021: make swaggo-format exclusions match linter

### DIFF
--- a/makefile
+++ b/makefile
@@ -345,7 +345,7 @@ swaggo-install:
 	$(gobin) install github.com/swaggo/swag/cmd/swag@latest
 
 swaggo-format:
-	swag fmt -g service/service.go
+	swag fmt -g service/service.go --exclude thirdparty/clients,graphql
 
 swaggo-build:
 	swag init -g service/service.go -o $(buildDir) --outputTypes json --parseDependency --parseInternal


### PR DESCRIPTION
DEVPROD-33021

### Description
Noticed that swaggo-format differs from [the verify-swaggo-fmt lint script](https://github.com/evergreen-ci/evergreen/blob/3557c1180bf168d77de27ba209ef857587dcf4e3/scripts/verify-swaggo-fmt.sh#L25), so changed the command to have the same exclusion filters.

### Testing
Ran `make swaggo-format` locally to verify that it no longer fixes the excluded directories.