### PR TITLE
DEVPROD-32950 Only extend expiration for hosts that have been up for at least an hour

### DIFF
--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -157,7 +157,7 @@ func makeTags(intentHost *host.Host) []host.Tag {
 		// which the reaper could act on before the hourly extension job can bump the tag.
 		now := time.Now()
 		midnight := time.Date(now.Year(), now.Month(), now.Day()+1, 0, 0, 0, 0, now.Location())
-		if midnight.Sub(now) <= 3*time.Hour {
+		if midnight.Sub(now) <= 4*time.Hour {
 			expireDays++
 		}
 

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3205,7 +3205,7 @@ func FindTaskHostsNearingExpiration(ctx context.Context) ([]Host, error) {
 		UserHostKey:  false,
 		StartedByKey: evergreen.User,
 		StatusKey:    bson.M{"$in": []string{evergreen.HostStarting, evergreen.HostRunning, evergreen.HostDecommissioned}},
-		StartTimeKey: bson.M{"$lte": time.Now().Add(-time.Hour)},
+		StartTimeKey: bson.M{"$lte": time.Now().Add(-2 * time.Hour)},
 		InstanceTagsKey: bson.M{
 			"$elemMatch": bson.M{
 				instanceTagKeyKey:   evergreen.TagExpireOn,

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3197,14 +3197,15 @@ func CountIntentHosts(ctx context.Context) (int, error) {
 	return Count(ctx, query)
 }
 
-// FindTaskHostsNearingExpiration returns all task hosts whose expire-on tag is
-// within the next day and are currently running a task or completed one within
-// the last 30 minutes.
+// FindTaskHostsNearingExpiration returns all task hosts that have been up for
+// at least an hour, whose expire-on tag is within the next day, and are
+// currently running a task or completed one within the last 30 minutes.
 func FindTaskHostsNearingExpiration(ctx context.Context) ([]Host, error) {
 	query := bson.M{
 		UserHostKey:  false,
 		StartedByKey: evergreen.User,
 		StatusKey:    bson.M{"$in": []string{evergreen.HostStarting, evergreen.HostRunning, evergreen.HostDecommissioned}},
+		StartTimeKey: bson.M{"$lte": time.Now().Add(-time.Hour)},
 		InstanceTagsKey: bson.M{
 			"$elemMatch": bson.M{
 				instanceTagKeyKey:   evergreen.TagExpireOn,

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -4530,6 +4530,16 @@ func TestFindTaskHostsNearingExpiration(t *testing.T) {
 			InstanceTags: makeExpireOnTag(expiringSoon),
 			RunningTask:  "task-6",
 		},
+		{
+			// Should not match: started less than an hour ago.
+			Id:           "new-host",
+			UserHost:     false,
+			StartedBy:    evergreen.User,
+			Status:       evergreen.HostRunning,
+			InstanceTags: makeExpireOnTag(expiringSoon),
+			RunningTask:  "task-7",
+			StartTime:    time.Now().Add(-30 * time.Minute),
+		},
 	}
 	for _, h := range hosts {
 		assert.NoError(t, h.Insert(ctx))


### PR DESCRIPTION
DEVPROD-32950

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
After merging https://github.com/evergreen-ci/evergreen/pull/10185 I noticed that we are being rate limited. Only extending the expire on tag for hosts that were up for at least two hour should drastically decrease the calls we make because the average host is only up for one hour. I bumped out close to midnight guard to 4 hours to accomodate it. 


<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!-- 
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models - If you're adding a field to the Task, Build, Version, or Patch structs, consider creating a
  DPIPE ticket to expose this in the data warehouse.

-->
