### PR TITLE
DEVPROD-33236: check both statuses when handling OOM

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1137,7 +1137,8 @@ func (a *Agent) handleTimeoutAndOOM(ctx context.Context, tc *taskContext, detail
 		a.runTaskTimeoutCommands(ctx, tc)
 	}
 
-	if tc.oomTrackerEnabled(a.opts.CloudProvider) && status == evergreen.TaskFailed {
+	// Check both statuses, as this may have changed via user endpoint or etc.
+	if tc.oomTrackerEnabled(a.opts.CloudProvider) && (detail.Status == evergreen.TaskFailed || status == evergreen.TaskFailed) {
 		startTime := time.Now()
 		oomCtx, oomCancel := context.WithTimeout(ctx, 10*time.Second)
 		defer oomCancel()

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1514,6 +1514,28 @@ post:
 	s.Equal(pids, s.mockCommunicator.EndTaskResult.Detail.OOMTracker.Pids)
 }
 
+func (s *AgentSuite) TestOOMTrackerRunsForSuccessStatusWithFailedDetailStatus() {
+	s.mockCommunicator.EndTaskResponse = &apimodels.EndTaskResponse{}
+	s.a.opts.CloudProvider = "provider"
+	s.tc.taskConfig.Project.OomTracker = true
+
+	pids := []int{1, 2, 3}
+	lines := []string{"line 1", "line 2", "line 3"}
+	s.tc.oomTracker = &mock.OOMTracker{
+		Lines: lines,
+		PIDs:  pids,
+	}
+	// Simulate the task status being overridden to failed via the HTTP endpoint
+	// while the originally computed status is still successful.
+	s.tc.setUserEndTaskResponse(&triggerEndTaskResp{Status: evergreen.TaskFailed})
+
+	_, err := s.a.finishTask(s.ctx, s.tc, evergreen.TaskSucceeded, "")
+	s.NoError(err)
+	s.Require().NotNil(s.mockCommunicator.EndTaskResult.Detail.OOMTracker)
+	s.True(s.mockCommunicator.EndTaskResult.Detail.OOMTracker.Detected)
+	s.Equal(pids, s.mockCommunicator.EndTaskResult.Detail.OOMTracker.Pids)
+}
+
 func (s *AgentSuite) TestFinishPrevTaskWithoutTaskGroup() {
 	const buildID = "build_id"
 	const versionID = "not_a_task_group_version"

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-05-08"
+	AgentVersion = "2026-05-18"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-33236

### Description
Brian and I found this in https://mongodb.slack.com/archives/C69UXN1CP/p1778615911978659 -- when the task status is set via the http endpoint, we update the detail. Status but not the passed in status. (DOesn't seem worth the work right now to figure out _why_ we've got two statuses though.) Fix is to consider both statuses when determining if we should run the oom checker. 

### Testing
Added a unit test to verify this scenario.