### PR TITLE
DEVPROD-33175: Add nested virtualization support to EC2 provider

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -84,6 +84,11 @@ type EC2ProviderSettings struct {
 	// ElasticIPsEnabled determines if hosts can use elastic IPs to obtain their
 	// IP addresses.
 	ElasticIPsEnabled bool `mapstructure:"elastic_ips_enabled" json:"elastic_ips_enabled,omitempty" bson:"elastic_ips_enabled,omitempty"`
+
+	// NestedVirtualization, if true, enables EC2 nested virtualization at launch
+	// via CpuOptions. Only supported on 8th generation Intel-based instance types
+	// (c8i, m8i, r8i, and their flex variants).
+	NestedVirtualization bool `mapstructure:"nested_virtualization,omitempty" json:"nested_virtualization,omitempty" bson:"nested_virtualization,omitempty"`
 }
 
 // Validate that essential EC2ProviderSettings fields are not empty.
@@ -267,6 +272,12 @@ func (m *ec2Manager) spawnOnDemandHost(ctx context.Context, h *host.Host, ec2Set
 
 	if ec2Settings.IAMInstanceProfileARN != "" {
 		input.IamInstanceProfile = &types.IamInstanceProfileSpecification{Arn: aws.String(ec2Settings.IAMInstanceProfileARN)}
+	}
+
+	if ec2Settings.NestedVirtualization {
+		input.CpuOptions = &types.CpuOptionsRequest{
+			NestedVirtualization: types.NestedVirtualizationSpecificationEnabled,
+		}
 	}
 
 	assignPublicIPv4 := shouldAssignPublicIPv4Address(h, ec2Settings)

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -510,6 +510,47 @@ func (s *EC2Suite) TestSpawnHostForTaskWithoutPublicIPv4Address() {
 	s.Equal(base64OfSomeUserData, *runInput.UserData)
 }
 
+func (s *EC2Suite) TestSpawnHostNestedVirtualizationEnabled() {
+	s.h.Distro.Id = "distro_id"
+	s.h.Distro.Provider = evergreen.ProviderNameEc2OnDemand
+	providerSettings := validEC2ProviderSettings()
+	providerSettings.Append(birch.EC.Boolean("nested_virtualization", true))
+	s.h.Distro.ProviderSettingsList = []*birch.Document{providerSettings}
+	s.Require().NoError(s.h.Insert(s.ctx))
+
+	_, err := s.onDemandManager.SpawnHost(s.ctx, s.h)
+	s.NoError(err)
+
+	manager, ok := s.onDemandManager.(*ec2Manager)
+	s.Require().True(ok)
+	mock, ok := manager.client.(*awsClientMock)
+	s.Require().True(ok)
+
+	s.Require().NotNil(mock.RunInstancesInput)
+	runInput := *mock.RunInstancesInput
+	s.Require().NotNil(runInput.CpuOptions)
+	s.Equal(types.NestedVirtualizationSpecificationEnabled, runInput.CpuOptions.NestedVirtualization)
+}
+
+func (s *EC2Suite) TestSpawnHostNestedVirtualizationDisabled() {
+	s.h.Distro.Id = "distro_id"
+	s.h.Distro.Provider = evergreen.ProviderNameEc2OnDemand
+	s.h.Distro.ProviderSettingsList = []*birch.Document{validEC2ProviderSettings()}
+	s.Require().NoError(s.h.Insert(s.ctx))
+
+	_, err := s.onDemandManager.SpawnHost(s.ctx, s.h)
+	s.NoError(err)
+
+	manager, ok := s.onDemandManager.(*ec2Manager)
+	s.Require().True(ok)
+	mock, ok := manager.client.(*awsClientMock)
+	s.Require().True(ok)
+
+	s.Require().NotNil(mock.RunInstancesInput)
+	runInput := *mock.RunInstancesInput
+	s.Nil(runInput.CpuOptions)
+}
+
 func (s *EC2Suite) TestModifyHost() {
 	changes := host.HostModifyOptions{
 		AddInstanceTags: []host.Tag{


### PR DESCRIPTION

DEVPROD-33175

### Description
Adds a new `nested_virtualization` boolean field to EC2ProviderSettings and threads it through the on-demand EC2 launch path by setting CpuOptions.NestedVirtualization=enabled on the RunInstances request.  This is in support of SKUNK-109, reducing cost of windows builds overall using bazel remote execution via dazel, a linux containerized bazel.

### Testing
Includes test coverage for enabled and disabled cases.


