### PR TITLE
DEVPROD-33246 require users to have authentication for project to run repotracker

### DIFF
--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -130,6 +130,7 @@ while still allowing for other kinds of versions (periodic builds, patches, etc)
 
 Additionally, admins can **Force Repotracker Run** to check for new commits if needed
 (Evergreen occasionally misses commits due to misconfiguration or GitHub outages).
+(Users for the project can also trigger the repotracker via an undocumented rest route.)
 
 The repotracker does not guarantee every commit runs their corresponding version, please see [run every mainline commit](#run-every-mainline-commit) for more details.
 

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -195,7 +195,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/projects/{project_id}").Version(2).Delete().Wrap(requireUser, addProject, requireProjectAdmin, editProjectSettings).RouteHandler(makeDeleteProject())
 	app.AddRoute("/projects/{project_id}").Version(2).Get().Wrap(requireUser, addProject, viewProjectSettings).RouteHandler(makeGetProjectByID())
 	app.AddRoute("/projects/{project_id}").Version(2).Patch().Wrap(requireUser, addProject, requireProjectAdmin, editProjectSettings).RouteHandler(makePatchProjectByID(settings))
-	app.AddRoute("/projects/{project_id}/repotracker").Version(2).Post().Wrap(requireUser, addProject).RouteHandler(makeRunRepotrackerForProject())
+	app.AddRoute("/projects/{project_id}/repotracker").Version(2).Post().Wrap(requireUser, addProject, editTasks).RouteHandler(makeRunRepotrackerForProject())
 	app.AddRoute("/projects/{project_id}").Version(2).Put().Wrap(requireUser, createProject).RouteHandler(makePutProjectByID(env))
 	app.AddRoute("/projects/{project_id}/copy").Version(2).Post().Wrap(requireUser, addProject, requireProjectAdmin, editProjectSettings).RouteHandler(makeCopyProject(env))
 	app.AddRoute("/projects/{project_id}/copy/variables").Version(2).Post().Wrap(requireUser, addProject, requireProjectAdmin, editProjectSettings).RouteHandler(makeCopyVariables())


### PR DESCRIPTION
DEVPROD-33246

### Description
This route honestly only even exists for the smoke tests, but yeah need to lock it down for a SECBUG. 

### Testing
Verify the smoke tests still pass.

### Documentation
Added a documentation that I think edit tasks permission is fine rather than project setting permission, so this isn't considered a bug.
