### PR TITLE
DEVPROD-33318: include project identifier in high exec timeout log

### DIFF
--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -853,10 +853,15 @@ func (h *reportHighExecTimeoutHandler) Parse(ctx context.Context, r *http.Reques
 
 func (h *reportHighExecTimeoutHandler) Run(ctx context.Context) gimlet.Responder {
 	t := MustHaveTask(ctx)
+	// Ignore errors because the project identifier is a nice-to-have for
+	// alerting.
+	projectIdentifier, _ := model.GetIdentifierForProject(ctx, t.Project)
+
 	grip.Warning(ctx, message.Fields{
 		"message":                          "task dynamically set an unusually high exec timeout",
 		"task_id":                          t.Id,
-		"project":                          t.Project,
+		"project_id":                       t.Project,
+		"project_identifier":               projectIdentifier,
 		"display_name":                     t.DisplayName,
 		"exec_timeout_secs":                h.report.ExecTimeoutSecs,
 		"threshold_high_exec_timeout_secs": int(evergreen.HighExecTimeoutThreshold.Seconds()),


### PR DESCRIPTION
DEVPROD-33318

### Description
Small improvement to log the project identifier when there's a high exec timeout alert so we can more easily filter projects.

Will update the high exec timeout alert to exclude by project identifier once this is deployed.

### Testing
Verified in personal staging that this logs as expected.