### PR TITLE
DEVPROD-31816 Fix generate.tasks incorrectly activating and labeling dependency tasks

### DIFF
--- a/model/dependency.go
+++ b/model/dependency.go
@@ -190,16 +190,27 @@ func (di *dependencyIncluder) inactiveGeneratedRootMarksDepsInactive(pair TVPair
 	if bvt == nil {
 		return false
 	}
-	if bvt.BatchTime != nil || bvt.CronBatchTime != "" || utility.FromBoolPtr(bvt.Disable) {
+	bv := di.Project.FindBuildVariant(pair.Variant)
+
+	// activate: false takes precedence over cron/batchtime, so propagate
+	// inactivity to dependencies
+	taskExplicitDeactivate := bvt.Activate != nil && !utility.FromBoolPtr(bvt.Activate)
+	variantExplicitDeactivate := bv != nil && bv.Activate != nil && !utility.FromBoolPtr(bv.Activate)
+	if taskExplicitDeactivate || variantExplicitDeactivate {
+		return true
+	}
+
+	if utility.FromBoolPtr(bvt.Disable) {
 		return false
 	}
-	bv := di.Project.FindBuildVariant(pair.Variant)
+	if bvt.BatchTime != nil || bvt.CronBatchTime != "" {
+		return false
+	}
 	if bv != nil && (bv.BatchTime != nil || bv.CronBatchTime != "" || utility.FromBoolPtr(bv.Disable)) {
 		return false
 	}
-	taskExplicitDeactivate := bvt.Activate != nil && !utility.FromBoolPtr(bvt.Activate)
-	variantExplicitDeactivate := bv != nil && bv.Activate != nil && !utility.FromBoolPtr(bv.Activate)
-	return taskExplicitDeactivate || variantExplicitDeactivate
+
+	return false
 }
 
 func (di *dependencyIncluder) updateDeactivationMap(pair TVPair, pairSpecifiesActivation bool) {

--- a/model/dependency_test.go
+++ b/model/dependency_test.go
@@ -500,3 +500,46 @@ func TestIncludeDependencies(t *testing.T) {
 		So(pairs, ShouldContain, TVPair{TaskName: "b", Variant: "bv-with-group"})
 	})
 }
+
+func TestInactiveGeneratedRootMarksDepsInactive(t *testing.T) {
+	t.Run("ExplicitDeactivateWithBVCronPropagatesInactivity", func(t *testing.T) {
+		p := &Project{
+			Tasks: []ProjectTask{{Name: "my_task"}},
+			BuildVariants: []BuildVariant{{
+				Name:          "bv1",
+				CronBatchTime: "0 * * * *",
+				Tasks:         []BuildVariantTaskUnit{{Name: "my_task", Activate: utility.FalsePtr()}},
+			}},
+		}
+		di := &dependencyIncluder{Project: p}
+		result := di.inactiveGeneratedRootMarksDepsInactive(TVPair{Variant: "bv1", TaskName: "my_task"})
+		assert.True(t, result)
+	})
+
+	t.Run("BVCronWithoutExplicitDeactivateDoesNotPropagate", func(t *testing.T) {
+		p := &Project{
+			Tasks: []ProjectTask{{Name: "my_task"}},
+			BuildVariants: []BuildVariant{{
+				Name:          "bv1",
+				CronBatchTime: "0 * * * *",
+				Tasks:         []BuildVariantTaskUnit{{Name: "my_task"}},
+			}},
+		}
+		di := &dependencyIncluder{Project: p}
+		result := di.inactiveGeneratedRootMarksDepsInactive(TVPair{Variant: "bv1", TaskName: "my_task"})
+		assert.False(t, result)
+	})
+
+	t.Run("ExplicitDeactivateWithoutCronPropagatesInactivity", func(t *testing.T) {
+		p := &Project{
+			Tasks: []ProjectTask{{Name: "my_task"}},
+			BuildVariants: []BuildVariant{{
+				Name:  "bv1",
+				Tasks: []BuildVariantTaskUnit{{Name: "my_task", Activate: utility.FalsePtr()}},
+			}},
+		}
+		di := &dependencyIncluder{Project: p}
+		result := di.inactiveGeneratedRootMarksDepsInactive(TVPair{Variant: "bv1", TaskName: "my_task"})
+		assert.True(t, result)
+	})
+}

--- a/model/generate.go
+++ b/model/generate.go
@@ -41,9 +41,12 @@ type GeneratedProject struct {
 	TaskGroups    []parserTaskGroup          `yaml:"task_groups"`
 
 	// Task is the task that is running generate.tasks.
-	Task                     *task.Task
-	ActivationInfo           *specificActivationInfo
-	NewTVPairs               *TaskVariantPairs
+	Task           *task.Task
+	ActivationInfo *specificActivationInfo
+	NewTVPairs     *TaskVariantPairs
+	// ExplicitlyGeneratedTasks tracks task/variant pairs from the generated
+	// JSON before dependency resolution. Tasks that get pulled in solely as dependencies of
+	// generated tasks are excluded so that they don't get a GeneratedBy field set.
 	ExplicitlyGeneratedTasks map[TVPair]bool
 }
 

--- a/model/generate.go
+++ b/model/generate.go
@@ -41,9 +41,10 @@ type GeneratedProject struct {
 	TaskGroups    []parserTaskGroup          `yaml:"task_groups"`
 
 	// Task is the task that is running generate.tasks.
-	Task           *task.Task
-	ActivationInfo *specificActivationInfo
-	NewTVPairs     *TaskVariantPairs
+	Task                     *task.Task
+	ActivationInfo           *specificActivationInfo
+	NewTVPairs               *TaskVariantPairs
+	ExplicitlyGeneratedTasks map[TVPair]bool
 }
 
 // MergeGeneratedProjects takes a slice of generated projects and returns a single, deduplicated project.
@@ -335,6 +336,7 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 		// If the parent generator is required to finish, then its generated
 		// tasks inherit that requirement.
 		ActivatedTasksAreEssentialToSucceed: g.Task.IsEssentialToSucceed,
+		ExplicitlyGeneratedTasks:            g.ExplicitlyGeneratedTasks,
 	}
 	// This will only be populated for patches, not mainline commits.
 	if evergreen.IsPatchRequester(v.Requester) {
@@ -500,6 +502,17 @@ func (g *GeneratedProject) getNewTasksWithDependencies(ctx context.Context, v *V
 	newTVPairs := TaskVariantPairs{}
 	for _, bv := range g.BuildVariants {
 		newTVPairs = appendTasks(newTVPairs, bv, p)
+	}
+
+	// Remember which tasks are explicitly generated before dependency expansion
+	// adds tasks that already exist in YAML. Only explicitly generated tasks should
+	// set GeneratedBy.
+	g.ExplicitlyGeneratedTasks = make(map[TVPair]bool, len(newTVPairs.ExecTasks)+len(newTVPairs.DisplayTasks))
+	for _, pair := range newTVPairs.ExecTasks {
+		g.ExplicitlyGeneratedTasks[pair] = true
+	}
+	for _, pair := range newTVPairs.DisplayTasks {
+		g.ExplicitlyGeneratedTasks[pair] = true
 	}
 
 	var err error

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -765,7 +765,9 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 			newTask.Tags = projectTask.Tags
 		}
 		newTask.DependsOn = makeDeps(t.DependsOn, newTask, execTable)
-		newTask.GeneratedBy = creationInfo.GeneratedBy
+		if creationInfo.ExplicitlyGeneratedTasks == nil || creationInfo.ExplicitlyGeneratedTasks[TVPair{Variant: creationInfo.Build.BuildVariant, TaskName: t.Name}] {
+			newTask.GeneratedBy = creationInfo.GeneratedBy
+		}
 		if generatorIsGithubCheck {
 			newTask.IsGithubCheck = true
 		}
@@ -842,7 +844,9 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 			if err != nil {
 				return nil, errors.Wrapf(err, "creating display task '%s'", id)
 			}
-			newDisplayTask.GeneratedBy = creationInfo.GeneratedBy
+			if creationInfo.ExplicitlyGeneratedTasks == nil || creationInfo.ExplicitlyGeneratedTasks[TVPair{Variant: creationInfo.Build.BuildVariant, TaskName: dt.Name}] {
+				newDisplayTask.GeneratedBy = creationInfo.GeneratedBy
+			}
 			newDisplayTask.DependsOn, err = task.GetAllDependencies(ctx, newDisplayTask.ExecutionTasks, taskMap)
 			if err != nil {
 				return nil, errors.Wrapf(err, "getting dependencies for display task '%s'", newDisplayTask.Id)
@@ -1477,6 +1481,7 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 			GeneratedBy:                         creationInfo.GeneratedBy,
 			TaskCreateTime:                      createTime,
 			ActivatedTasksAreEssentialToSucceed: creationInfo.ActivatedTasksAreEssentialToSucceed,
+			ExplicitlyGeneratedTasks:            creationInfo.ExplicitlyGeneratedTasks,
 			TestSelectionParams:                 tsParams,
 		}
 

--- a/model/task_creation.go
+++ b/model/task_creation.go
@@ -38,7 +38,11 @@ type TaskCreationInfo struct {
 	// in order for the build/version to be finished. Tasks with specific
 	// activation conditions (e.g. cron, activate) are not considered essential.
 	ActivatedTasksAreEssentialToSucceed bool
-	TestSelectionParams                 TestSelectionParams // Task creation parameters for test selection
+	// ExplicitlyGeneratedTasks tracks task/variant pairs that came
+	// directly from the generated JSON, as opposed to being pulled in
+	// as dependencies.
+	ExplicitlyGeneratedTasks map[TVPair]bool
+	TestSelectionParams      TestSelectionParams // Task creation parameters for test selection
 }
 
 // TestSelectionParams contains parameters for enabling test selection on tasks


### PR DESCRIPTION
DEVPROD-31816

### Description
When generate.tasks creates tasks that depend on tasks that already exist in YAML, those dependency tasks were being incorrectly activated and labeled as GeneratedBy the generator task. 

This happened specifically when the build variant had a cron set. Furthermore, when a generated task had `activate: false` set, its dependencies were still being activated if the build variant had cron scheduling, because the cron check was happening before the explicit deactivation check.

### Solution
Track which tasks are actually generated versus pulled in as dependencies, and only apply GeneratedBy to the former. Also, check explicit deactivation before cron settings.

### Testing
I verified the bug by making a sandbox [patch](https://spruce-staging.corp.mongodb.com/version/6a0b4d527d1a3c0007a8bde5/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) and scheduled the `bug_repro_generator` task. Bug confirms that the generated `compile_task` is activated and shows "Generated by: bug_repro_generator" despite the fact that it already existed in YAML and has `activate: false` set.

Deployed this change and [resubmitted](https://spruce-staging.corp.mongodb.com/version/6a0b508d406e46000691454d/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) the same patch, and verified the `compile_task` task was not activated and has no GeneratedBy label. I also verified that actual generated tasks still correctly show the GeneratedBy label.

Added a couple unit tests as well to verify the deactivation logic works correctly when a build variant has cron and a task has activate: false.