### PR TITLE
DEVPROD-33393 add assignee to logs

### DIFF
--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -216,6 +216,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 				"pr_number": event.GetPullRequest().GetNumber(),
 				"hash":      event.GetPullRequest().GetHead().GetSHA(),
 				"user":      event.GetSender().GetLogin(),
+				"assignee":  event.GetAssignee().GetLogin(),
 				"message":   "PR accepted, attempting to queue",
 			})
 


### PR DESCRIPTION
DEVPROD-33393
<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Would like to see how assignee is populated by pull request event, to potentially use for Sage. Confirmed that this just returns the empty string if assignee is nil. 