### PR TITLE
DEVPROD-33014: Standardize usage of `volumeId` and `hostId` in GraphQL params

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -82930,7 +82930,7 @@ func (ec *executionContext) unmarshalInputEditSpawnHostInput(ctx context.Context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"addedInstanceTags", "deletedInstanceTags", "displayName", "expiration", "hostId", "instanceType", "noExpiration", "publicKey", "savePublicKey", "servicePassword", "sleepSchedule", "volume"}
+	fieldsInOrder := [...]string{"addedInstanceTags", "deletedInstanceTags", "displayName", "expiration", "hostId", "instanceType", "noExpiration", "publicKey", "savePublicKey", "servicePassword", "sleepSchedule", "volume", "volumeId"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -83090,6 +83090,30 @@ func (ec *executionContext) unmarshalInputEditSpawnHostInput(ctx context.Context
 				it.Volume = data
 			} else if tmp == nil {
 				it.Volume = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+		case "volumeId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("volumeId"))
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				if ec.directives.RequireVolumeAccess == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive requireVolumeAccess is not implemented")
+				}
+				return ec.directives.RequireVolumeAccess(ctx, obj, directive0)
+			}
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.VolumeID = data
+			} else if tmp == nil {
+				it.VolumeID = nil
 			} else {
 				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
 				return it, graphql.ErrorOnPath(ctx, err)
@@ -88740,7 +88764,7 @@ func (ec *executionContext) unmarshalInputSpawnVolumeInput(ctx context.Context, 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"availabilityZone", "expiration", "host", "noExpiration", "size", "type"}
+	fieldsInOrder := [...]string{"availabilityZone", "expiration", "host", "hostId", "noExpiration", "size", "type"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -88786,6 +88810,35 @@ func (ec *executionContext) unmarshalInputSpawnVolumeInput(ctx context.Context, 
 				it.Host = data
 			} else if tmp == nil {
 				it.Host = nil
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+		case "hostId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("hostId"))
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalOString2ᚖstring(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				access, err := ec.unmarshalNHostAccessLevel2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐHostAccessLevel(ctx, "EDIT")
+				if err != nil {
+					var zeroVal *string
+					return zeroVal, err
+				}
+				if ec.directives.RequireHostAccess == nil {
+					var zeroVal *string
+					return zeroVal, errors.New("directive requireHostAccess is not implemented")
+				}
+				return ec.directives.RequireHostAccess(ctx, obj, directive0, access)
+			}
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(*string); ok {
+				it.HostID = data
+			} else if tmp == nil {
+				it.HostID = nil
 			} else {
 				err := fmt.Errorf(`unexpected type %T from directive, should be *string`, tmp)
 				return it, graphql.ErrorOnPath(ctx, err)

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -185,6 +185,7 @@ type EditSpawnHostInput struct {
 	ServicePassword     *string                 `json:"servicePassword,omitempty"`
 	SleepSchedule       *host.SleepScheduleInfo `json:"sleepSchedule,omitempty"`
 	Volume              *string                 `json:"volume,omitempty"`
+	VolumeID            *string                 `json:"volumeId,omitempty"`
 }
 
 type ExternalLinkForMetadata struct {
@@ -541,6 +542,7 @@ type SpawnVolumeInput struct {
 	AvailabilityZone string     `json:"availabilityZone"`
 	Expiration       *time.Time `json:"expiration,omitempty"`
 	Host             *string    `json:"host,omitempty"`
+	HostID           *string    `json:"hostId,omitempty"`
 	NoExpiration     *bool      `json:"noExpiration,omitempty"`
 	Size             int        `json:"size"`
 	Type             string     `json:"type"`

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -779,9 +779,9 @@ func (r *mutationResolver) EditSpawnHost(ctx context.Context, spawnHost *EditSpa
 	}
 	// TODO: Delete volume option.
 	if spawnHost.Volume != nil || spawnHost.VolumeID != nil {
-		shVolume := utility.FromStringPtr(spawnHost.Volume)
-		shVolumeId := utility.FromStringPtr(spawnHost.VolumeID)
-		volumeID := util.CoalesceString(shVolumeId, shVolume)
+		volumeParam := utility.FromStringPtr(spawnHost.Volume)
+		volumeIDParam := utility.FromStringPtr(spawnHost.VolumeID)
+		volumeID := util.CoalesceString(volumeIDParam, volumeParam)
 		v, err = host.FindVolumeByID(ctx, volumeID)
 		if err != nil {
 			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("fetching volume '%s': %s", volumeID, err.Error()))
@@ -938,9 +938,9 @@ func (r *mutationResolver) SpawnVolume(ctx context.Context, spawnVolumeInput Spa
 	}
 	// TODO: Delete host option.
 	if spawnVolumeInput.Host != nil || spawnVolumeInput.HostID != nil {
-		svHost := utility.FromStringPtr(spawnVolumeInput.Host)
-		svHostId := utility.FromStringPtr(spawnVolumeInput.HostID)
-		hostID := util.CoalesceString(svHostId, svHost)
+		hostParam := utility.FromStringPtr(spawnVolumeInput.Host)
+		hostIDParam := utility.FromStringPtr(spawnVolumeInput.HostID)
+		hostID := util.CoalesceString(hostIDParam, hostParam)
 		statusCode, err := cloud.AttachVolume(ctx, vol.ID, hostID)
 		if err != nil {
 			return false, mapHTTPStatusToGqlError(ctx, statusCode, werrors.Wrapf(err, "attaching volume '%s' to host: %s", vol.ID, err.Error()))

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -777,8 +777,11 @@ func (r *mutationResolver) EditSpawnHost(ctx context.Context, spawnHost *EditSpa
 		opts.AddInstanceTags = addedTags
 		opts.DeleteInstanceTags = deletedTags
 	}
-	if spawnHost.Volume != nil {
-		volumeID := utility.FromStringPtr(spawnHost.Volume)
+	// TODO: Delete volume option.
+	if spawnHost.Volume != nil || spawnHost.VolumeID != nil {
+		shVolume := utility.FromStringPtr(spawnHost.Volume)
+		shVolumeId := utility.FromStringPtr(spawnHost.VolumeID)
+		volumeID := util.CoalesceString(shVolumeId, shVolume)
 		v, err = host.FindVolumeByID(ctx, volumeID)
 		if err != nil {
 			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("fetching volume '%s': %s", volumeID, err.Error()))
@@ -933,8 +936,12 @@ func (r *mutationResolver) SpawnVolume(ctx context.Context, spawnVolumeInput Spa
 	if err != nil {
 		return false, InternalServerError.Send(ctx, fmt.Sprintf("applying expiration options to volume '%s': %s", vol.ID, err.Error()))
 	}
-	if spawnVolumeInput.Host != nil {
-		statusCode, err := cloud.AttachVolume(ctx, vol.ID, utility.FromStringPtr(spawnVolumeInput.Host))
+	// TODO: Delete host option.
+	if spawnVolumeInput.Host != nil || spawnVolumeInput.HostID != nil {
+		svHost := utility.FromStringPtr(spawnVolumeInput.Host)
+		svHostId := utility.FromStringPtr(spawnVolumeInput.HostID)
+		hostID := util.CoalesceString(svHostId, svHost)
+		statusCode, err := cloud.AttachVolume(ctx, vol.ID, hostID)
 		if err != nil {
 			return false, mapHTTPStatusToGqlError(ctx, statusCode, werrors.Wrapf(err, "attaching volume '%s' to host: %s", vol.ID, err.Error()))
 		}

--- a/graphql/schema/types/spawn.graphql
+++ b/graphql/schema/types/spawn.graphql
@@ -64,7 +64,10 @@ Its fields determine the properties of the volume that will be spawned.
 input SpawnVolumeInput {
   availabilityZone: String!
   expiration: Time
-  host: String @requireHostAccess(access: EDIT)
+  host: String
+    @requireHostAccess(access: EDIT)
+    @deprecated(reason: "Use hostId instead of host.")
+  hostId: String @requireHostAccess(access: EDIT)
   noExpiration: Boolean
   size: Int!
   type: String!
@@ -98,7 +101,10 @@ input EditSpawnHostInput {
   savePublicKey: Boolean
   servicePassword: String @redactSecrets
   sleepSchedule: SleepScheduleInput
-  volume: String @requireVolumeAccess
+  volume: String
+    @requireVolumeAccess
+    @deprecated(reason: "Use volumeId instead of volume.")
+  volumeId: String @requireVolumeAccess
 }
 
 input InstanceTagInput {

--- a/graphql/tests/mutation/editSpawnHost/queries/no_permissions_volume.graphql
+++ b/graphql/tests/mutation/editSpawnHost/queries/no_permissions_volume.graphql
@@ -1,6 +1,6 @@
 mutation {
   editSpawnHost(
-    spawnHost: { hostId: "i-0f81a2d39744003dd", volume: "vol-two" }
+    spawnHost: { hostId: "i-0f81a2d39744003dd", volumeId: "vol-two" }
   ) {
     id
   }

--- a/graphql/tests/mutation/editSpawnHost/queries/no_permissions_volume_old.graphql
+++ b/graphql/tests/mutation/editSpawnHost/queries/no_permissions_volume_old.graphql
@@ -1,0 +1,7 @@
+mutation {
+  editSpawnHost(
+    spawnHost: { hostId: "i-0f81a2d39744003dd", volume: "vol-two" }
+  ) {
+    id
+  }
+}

--- a/graphql/tests/mutation/editSpawnHost/results.json
+++ b/graphql/tests/mutation/editSpawnHost/results.json
@@ -55,6 +55,22 @@
         "errors": [
           {
             "message": "user 'regular_user' does not have permission to access volume 'vol-two'",
+            "path": ["editSpawnHost", "spawnHost", "volumeId"],
+            "extensions": {
+              "code": "FORBIDDEN"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "query_file": "no_permissions_volume_old.graphql",
+      "test_user_id": "regular_user",
+      "result": {
+        "data": null,
+        "errors": [
+          {
+            "message": "user 'regular_user' does not have permission to access volume 'vol-two'",
             "path": ["editSpawnHost", "spawnHost", "volume"],
             "extensions": {
               "code": "FORBIDDEN"

--- a/graphql/tests/mutation/spawnVolume/queries/no_permissions_host.graphql
+++ b/graphql/tests/mutation/spawnVolume/queries/no_permissions_host.graphql
@@ -5,7 +5,7 @@ mutation {
       size: 300
       type: "standard"
       noExpiration: true
-      host: "i-1104943f"
+      hostId: "i-1104943f"
     }
   )
 }

--- a/graphql/tests/mutation/spawnVolume/queries/no_permissions_host_old.graphql
+++ b/graphql/tests/mutation/spawnVolume/queries/no_permissions_host_old.graphql
@@ -5,7 +5,7 @@ mutation {
       size: 300
       type: "standard"
       noExpiration: true
-      expiration: "2020-08-06T17:42:12Z"
+      host: "i-1104943f"
     }
   )
 }

--- a/graphql/tests/mutation/spawnVolume/queries/spawn_and_attach_success.graphql
+++ b/graphql/tests/mutation/spawnVolume/queries/spawn_and_attach_success.graphql
@@ -4,7 +4,7 @@ mutation {
       availabilityZone: "us-east-1a"
       size: 300
       type: "standard"
-      host: "i-1104943f"
+      hostId: "i-1104943f"
     }
   )
 }

--- a/graphql/tests/mutation/spawnVolume/queries/spawn_and_attach_success_old.graphql
+++ b/graphql/tests/mutation/spawnVolume/queries/spawn_and_attach_success_old.graphql
@@ -4,8 +4,7 @@ mutation {
       availabilityZone: "us-east-1a"
       size: 300
       type: "standard"
-      noExpiration: true
-      expiration: "2020-08-06T17:42:12Z"
+      host: "i-1104943f"
     }
   )
 }

--- a/graphql/tests/mutation/spawnVolume/results.json
+++ b/graphql/tests/mutation/spawnVolume/results.json
@@ -18,6 +18,10 @@
       "result": { "data": { "spawnVolume": true } }
     },
     {
+      "query_file": "spawn_and_attach_success_old.graphql",
+      "result": { "data": { "spawnVolume": true } }
+    },
+    {
       "query_file": "spawn_and_attach_success.graphql",
       "result": { "data": { "spawnVolume": true } }
     },
@@ -44,6 +48,22 @@
     },
     {
       "query_file": "no_permissions_host.graphql",
+      "test_user_id": "regular_user",
+      "result": {
+        "errors": [
+          {
+            "message": "user 'regular_user' does not have permission to access host 'i-1104943f'",
+            "path": ["spawnVolume", "spawnVolumeInput", "hostId"],
+            "extensions": {
+              "code": "FORBIDDEN"
+            }
+          }
+        ],
+        "data": null
+      }
+    },
+    {
+      "query_file": "no_permissions_host_old.graphql",
       "test_user_id": "regular_user",
       "result": {
         "errors": [


### PR DESCRIPTION
DEVPROD-33014

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Step 1 of tech debt cleanup: change `volume` => `volumeId` and `host` => `hostId` to standardize GraphQL args. 

There will be 2 follow up PRs.