### PR TITLE
DEVPROD-32192 Add hourly Retry failed  Log Move Job for the old task collection 

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -4534,6 +4534,9 @@ func (t *Task) moveLogsByNamesToBucket(ctx context.Context, settings *evergreen.
 	if failedCfg.Name == "" {
 		return errors.New("failed bucket is not configured")
 	}
+	if runInOldTaskCollection && t.OldTaskId == "" {
+		return errors.Errorf("cannot move logs for task %q: runInOldTaskCollection is true but old_task_id is empty", t.Id)
+	}
 	// Use the provided source bucket config if available, otherwise use the task's current bucket config
 	srcCfg := output.TestLogs.BucketConfig
 	if sourceBucketCfg != nil && sourceBucketCfg.Name != "" {
@@ -4548,7 +4551,7 @@ func (t *Task) moveLogsByNamesToBucket(ctx context.Context, settings *evergreen.
 
 	// use OldTaskId because S3 log keys were written using that ID
 	logTaskID := t.Id
-	if runInOldTaskCollection && t.OldTaskId != "" {
+	if runInOldTaskCollection {
 		logTaskID = t.OldTaskId
 	}
 
@@ -4627,6 +4630,9 @@ func (t *Task) RevertBucketConfigToSource(ctx context.Context, sourceBucketCfg e
 	if t.TaskOutputInfo == nil {
 		return nil
 	}
+	// runInOldTaskCollection is always false because the stuck state only arises from the task-end stuck case where
+	// logger rotation set output to thefailed bucket but the move did not complete. Hourly retry on old_tasks does not create that
+	// state, so tasks in old_tasks do not need revert.
 	return t.setOutputBucketConfig(ctx, sourceBucketCfg, false)
 }
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -4507,9 +4507,16 @@ func allObjectsExistInBucket(ctx context.Context, bucket pail.Bucket, keys []str
 }
 
 // setOutputBucketConfig sets both task and test log bucket configs in memory and persists them.
-func (t *Task) setOutputBucketConfig(ctx context.Context, cfg evergreen.BucketConfig) error {
+func (t *Task) setOutputBucketConfig(ctx context.Context, cfg evergreen.BucketConfig, runInOldTaskCollection bool) error {
 	t.TaskOutputInfo.TaskLogs.BucketConfig = cfg
 	t.TaskOutputInfo.TestLogs.BucketConfig = cfg
+	if runInOldTaskCollection {
+		return errors.Wrap(updateOneOld(
+			ctx,
+			bson.M{IdKey: t.Id},
+			bson.M{"$set": bson.M{TaskOutputInfoKey: t.TaskOutputInfo}},
+		), "updating task output bucket config")
+	}
 	return errors.Wrap(UpdateOne(
 		ctx,
 		bson.M{IdKey: t.Id},
@@ -4518,7 +4525,7 @@ func (t *Task) setOutputBucketConfig(ctx context.Context, cfg evergreen.BucketCo
 }
 
 // moveLogsByNamesToBucket moves task + test logs to the specified bucket.
-func (t *Task) moveLogsByNamesToBucket(ctx context.Context, settings *evergreen.Settings, output *TaskOutput, sourceBucketCfg *evergreen.BucketConfig) error {
+func (t *Task) moveLogsByNamesToBucket(ctx context.Context, settings *evergreen.Settings, output *TaskOutput, sourceBucketCfg *evergreen.BucketConfig, runInOldTaskCollection bool) error {
 	if output.TestLogs.BucketConfig.Name != output.TaskLogs.BucketConfig.Name {
 		// moveLogsByNamesToBucket uses one source bucket for task and test log keys; names must agree.
 		return errors.New("test log and task log buckets do not match")
@@ -4539,13 +4546,21 @@ func (t *Task) moveLogsByNamesToBucket(ctx context.Context, settings *evergreen.
 
 	logService := log.NewLogServiceV0(srcBucket)
 
+	// use OldTaskId because S3 log keys were written using that ID
+	logTaskID := t.Id
+	if runInOldTaskCollection && t.OldTaskId != "" {
+		logTaskID = t.OldTaskId
+	}
+
+	logTask := *t
+	logTask.Id = logTaskID
 	logNames := make([]string, 0, 4)
 	// add task logs
 	for _, logType := range []TaskLogType{TaskLogTypeAgent, TaskLogTypeSystem, TaskLogTypeTask} {
-		logNames = append(logNames, getLogName(*t, logType, output.TaskLogs.ID()))
+		logNames = append(logNames, getLogName(logTask, logType, output.TaskLogs.ID()))
 	}
 	// add test logs
-	logNames = append(logNames, fmt.Sprintf("%s/%s/%d/%s", t.Project, t.Id, t.Execution, output.TestLogs.ID()))
+	logNames = append(logNames, fmt.Sprintf("%s/%s/%d/%s", t.Project, logTaskID, t.Execution, output.TestLogs.ID()))
 
 	keys, err := logService.GetChunkKeys(ctx, logNames)
 	if err != nil {
@@ -4575,7 +4590,7 @@ func (t *Task) moveLogsByNamesToBucket(ctx context.Context, settings *evergreen.
 					"task_id":   t.Id,
 					"execution": t.Execution,
 				})
-				if updateErr := t.setOutputBucketConfig(ctx, failedCfg); updateErr != nil {
+				if updateErr := t.setOutputBucketConfig(ctx, failedCfg, runInOldTaskCollection); updateErr != nil {
 					return errors.Wrap(moveErr, "moving logs to failed bucket")
 				}
 				return nil
@@ -4590,12 +4605,12 @@ func (t *Task) moveLogsByNamesToBucket(ctx context.Context, settings *evergreen.
 		return errors.Wrap(moveErr, "moving logs to failed bucket")
 	}
 
-	return errors.Wrapf(t.setOutputBucketConfig(ctx, failedCfg), "updating task output for task %s", t.Id)
+	return errors.Wrapf(t.setOutputBucketConfig(ctx, failedCfg, runInOldTaskCollection), "updating task output for task %s", t.Id)
 }
 
 // MoveTestAndTaskLogsToFailedBucket moves task + test logs to the failed-task bucket
 // using the provided source bucket config
-func (t *Task) MoveTestAndTaskLogsToFailedBucket(ctx context.Context, settings *evergreen.Settings, sourceBucketCfg evergreen.BucketConfig) error {
+func (t *Task) MoveTestAndTaskLogsToFailedBucket(ctx context.Context, settings *evergreen.Settings, sourceBucketCfg evergreen.BucketConfig, runInOldTaskCollection bool) error {
 	if t.UsesLongRetentionBucket(settings) {
 		return nil
 	}
@@ -4604,7 +4619,7 @@ func (t *Task) MoveTestAndTaskLogsToFailedBucket(ctx context.Context, settings *
 		return nil
 	}
 
-	return t.moveLogsByNamesToBucket(ctx, settings, output, &sourceBucketCfg)
+	return t.moveLogsByNamesToBucket(ctx, settings, output, &sourceBucketCfg, runInOldTaskCollection)
 }
 
 // RevertBucketConfigToSource updates the task's DB bucket config back to sourceBucketCfg.
@@ -4612,7 +4627,7 @@ func (t *Task) RevertBucketConfigToSource(ctx context.Context, sourceBucketCfg e
 	if t.TaskOutputInfo == nil {
 		return nil
 	}
-	return t.setOutputBucketConfig(ctx, sourceBucketCfg)
+	return t.setOutputBucketConfig(ctx, sourceBucketCfg, false)
 }
 
 // RevertBucketConfigToSourceIfLogsExist checks whether the task's log files are still in sourceBucketCfg.

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -1363,7 +1363,7 @@ func (h *hostAgentEndTask) Run(ctx context.Context) gimlet.Responder {
 			t.TaskOutputInfo.TaskLogs.BucketConfig = failedCfg
 			t.TaskOutputInfo.TestLogs.BucketConfig = failedCfg
 		}
-		j := units.NewMoveLogsToFailedBucketJob(h.env, t.Id, utility.RoundPartOfMinute(0).Format(units.TSFormat), sourceBucketCfg, units.MoveLogsTriggerTaskEnd)
+		j := units.NewMoveLogsToFailedBucketJob(h.env, t.Id, utility.RoundPartOfMinute(0).Format(units.TSFormat), sourceBucketCfg, units.MoveLogsTriggerTaskEnd, false)
 		if err := amboy.EnqueueUniqueJob(ctx, h.env.RemoteQueue(), j); err != nil {
 			grip.Error(ctx, message.WrapError(err, message.Fields{
 				"message": "could not enqueue job to move logs to failed bucket",

--- a/units/crons.go
+++ b/units/crons.go
@@ -947,7 +947,16 @@ const retryFailedLogMoveLogTaskIDCap = 200
 // PopulateRetryFailedLogMoveJobs finds failed tasks whose logs are still in the regular
 // bucket (move job failed or never ran) and enqueues one move-logs-to-failed-bucket job per task.
 // Caps enqueued jobs per run to avoid S3 rate limiting; newest failures are prioritized.
-func PopulateRetryFailedLogMoveJobs(env evergreen.Environment, runInOldTaskCollection bool) amboy.QueueOperation {
+func PopulateRetryFailedLogMoveJobs(env evergreen.Environment) amboy.QueueOperation {
+	return populateRetryFailedLogMoveJobs(env, false)
+}
+
+// PopulateRetryFailedLogMoveJobsForOldTasks is like PopulateRetryFailedLogMoveJobs but queries the old tasks collection.
+func PopulateRetryFailedLogMoveJobsForOldTasks(env evergreen.Environment) amboy.QueueOperation {
+	return populateRetryFailedLogMoveJobs(env, true)
+}
+
+func populateRetryFailedLogMoveJobs(env evergreen.Environment, runInOldTaskCollection bool) amboy.QueueOperation {
 	return func(ctx context.Context, queue amboy.Queue) error {
 		settings := env.Settings()
 		failedBucketCfg := settings.Buckets.LogBucketFailedTasks

--- a/units/crons.go
+++ b/units/crons.go
@@ -947,7 +947,7 @@ const retryFailedLogMoveLogTaskIDCap = 200
 // PopulateRetryFailedLogMoveJobs finds failed tasks whose logs are still in the regular
 // bucket (move job failed or never ran) and enqueues one move-logs-to-failed-bucket job per task.
 // Caps enqueued jobs per run to avoid S3 rate limiting; newest failures are prioritized.
-func PopulateRetryFailedLogMoveJobs(env evergreen.Environment) amboy.QueueOperation {
+func PopulateRetryFailedLogMoveJobs(env evergreen.Environment, runInOldTaskCollection bool) amboy.QueueOperation {
 	return func(ctx context.Context, queue amboy.Queue) error {
 		settings := env.Settings()
 		failedBucketCfg := settings.Buckets.LogBucketFailedTasks
@@ -989,7 +989,13 @@ func PopulateRetryFailedLogMoveJobs(env evergreen.Environment) amboy.QueueOperat
 		).Sort([]string{"-" + task.FinishTimeKey}).Limit(queryLimit)
 		findCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), retryFailedLogMoveFindTimeout)
 		defer cancel()
-		tasks, err := task.FindAll(findCtx, query)
+		var tasks []task.Task
+		var err error
+		if runInOldTaskCollection {
+			tasks, err = task.FindAllOld(findCtx, query)
+		} else {
+			tasks, err = task.FindAll(findCtx, query)
+		}
 		if err != nil {
 			grip.Error(ctx, message.WrapError(err, message.Fields{
 				"message":          "retry failed log move jobs: finding candidate tasks failed",
@@ -1015,14 +1021,15 @@ func PopulateRetryFailedLogMoveJobs(env evergreen.Environment) amboy.QueueOperat
 
 		if len(toRetry) == 0 {
 			grip.Info(ctx, message.Fields{
-				"message":                 "retry failed log move jobs",
-				"tasks_found":             0,
-				"tasks_queried":           len(tasks),
-				"task_ids_all_candidates": []string{},
-				"task_ids_attempt":        []string{},
-				"lookback_months":         lookbackMonths,
-				"max_jobs_per_run":        maxJobs,
-				"query_limit":             queryLimit,
+				"message":                    "retry failed log move jobs",
+				"run_in_old_task_collection": runInOldTaskCollection,
+				"tasks_found":                0,
+				"tasks_queried":              len(tasks),
+				"task_ids_all_candidates":    []string{},
+				"task_ids_attempt":           []string{},
+				"lookback_months":            lookbackMonths,
+				"max_jobs_per_run":           maxJobs,
+				"query_limit":                queryLimit,
 			})
 			return nil
 		}
@@ -1049,7 +1056,7 @@ func PopulateRetryFailedLogMoveJobs(env evergreen.Environment) amboy.QueueOperat
 			}
 			taskIDsAttempted = append(taskIDsAttempted, t.Id)
 			sourceCfg := output.TaskLogs.BucketConfig
-			catcher.Wrapf(amboy.EnqueueUniqueJob(ctx, queue, NewMoveLogsToFailedBucketJob(env, t.Id, ts, sourceCfg, MoveLogsTriggerHourlyRetry)), "enqueueing move logs job for task '%s'", t.Id)
+			catcher.Wrapf(amboy.EnqueueUniqueJob(ctx, queue, NewMoveLogsToFailedBucketJob(env, t.Id, ts, sourceCfg, MoveLogsTriggerHourlyRetry, runInOldTaskCollection)), "enqueueing move logs job for task '%s'", t.Id)
 		}
 
 		// Truncate copies of taskIDsAllCandidates and taskIDsAttempted to retryFailedLogMoveLogTaskIDCap
@@ -1070,6 +1077,7 @@ func PopulateRetryFailedLogMoveJobs(env evergreen.Environment) amboy.QueueOperat
 		err = catcher.Resolve()
 		fields := message.Fields{
 			"message":                        "retry failed log move jobs",
+			"run_in_old_task_collection":     runInOldTaskCollection,
 			"tasks_found":                    tasksFound,
 			"tasks_queried":                  len(tasks),
 			"task_ids_all_candidates":        logCandidates,

--- a/units/crons_remote_hour.go
+++ b/units/crons_remote_hour.go
@@ -45,10 +45,9 @@ func (j *cronsRemoteHourJob) Run(ctx context.Context) {
 		j.env = evergreen.GetEnvironment()
 	}
 
-	runInOldTaskCollection := true
 	ops := []amboy.QueueOperation{
-		PopulateRetryFailedLogMoveJobs(j.env, runInOldTaskCollection),
-		PopulateRetryFailedLogMoveJobs(j.env, !runInOldTaskCollection),
+		PopulateRetryFailedLogMoveJobsForOldTasks(j.env),
+		PopulateRetryFailedLogMoveJobs(j.env),
 		PopulateCacheHistoricalTaskDataJob(2),
 		PopulateTaskHostExpirationExtendJob(),
 		PopulateSpawnhostExpirationCheckJob(),

--- a/units/crons_remote_hour.go
+++ b/units/crons_remote_hour.go
@@ -45,8 +45,10 @@ func (j *cronsRemoteHourJob) Run(ctx context.Context) {
 		j.env = evergreen.GetEnvironment()
 	}
 
+	runInOldTaskCollection := true
 	ops := []amboy.QueueOperation{
-		PopulateRetryFailedLogMoveJobs(j.env),
+		PopulateRetryFailedLogMoveJobs(j.env, runInOldTaskCollection),
+		PopulateRetryFailedLogMoveJobs(j.env, !runInOldTaskCollection),
 		PopulateCacheHistoricalTaskDataJob(2),
 		PopulateTaskHostExpirationExtendJob(),
 		PopulateSpawnhostExpirationCheckJob(),

--- a/units/move_logs_to_failed_bucket.go
+++ b/units/move_logs_to_failed_bucket.go
@@ -41,6 +41,8 @@ type moveLogsToFailedBucketJob struct {
 	// Trigger records why the job was enqueued.
 	Trigger string        `bson:"trigger,omitempty"`
 	Timeout time.Duration `bson:"timeout,omitempty"`
+	// RunInOldTaskCollection uses old_tasks for lookup and updates instead of tasks.
+	RunInOldTaskCollection bool `bson:"run_in_old_task_collection,omitempty" json:"run_in_old_task_collection,omitempty"`
 
 	env evergreen.Environment
 }
@@ -58,13 +60,14 @@ func makeMoveLogsToFailedBucketJob() *moveLogsToFailedBucketJob {
 }
 
 // NewMoveLogsToFailedBucketJob creates a job that moves a task's logs to the failed bucket.
-// Pass an optional timeout as the last argument to override the default (e.g. NewMoveLogsToFailedBucketJob(env, taskID, ts, sourceCfg, 60*time.Minute)).
-func NewMoveLogsToFailedBucketJob(env evergreen.Environment, taskID, ts string, sourceBucketCfg evergreen.BucketConfig, trigger string, timeout ...time.Duration) amboy.Job {
+// Pass an optional timeout as the last argument to override the default (e.g. NewMoveLogsToFailedBucketJob(env, taskID, ts, sourceCfg, trigger, false, 60*time.Minute)).
+func NewMoveLogsToFailedBucketJob(env evergreen.Environment, taskID, ts string, sourceBucketCfg evergreen.BucketConfig, trigger string, runInOldTaskCollection bool, timeout ...time.Duration) amboy.Job {
 	j := makeMoveLogsToFailedBucketJob()
 	j.env = env
 	j.TaskID = taskID
 	j.SourceBucketCfg = sourceBucketCfg
 	j.Trigger = trigger
+	j.RunInOldTaskCollection = runInOldTaskCollection
 	if len(timeout) > 0 {
 		j.Timeout = timeout[0]
 	}
@@ -103,7 +106,13 @@ func (j *moveLogsToFailedBucketJob) Run(ctx context.Context) {
 	if j.Timeout > 0 {
 		timeout = j.Timeout
 	}
-	t, err := task.FindOneId(ctx, j.TaskID)
+	var t *task.Task
+	var err error
+	if j.RunInOldTaskCollection {
+		t, err = task.FindOneOldId(ctx, j.TaskID)
+	} else {
+		t, err = task.FindOneId(ctx, j.TaskID)
+	}
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "finding task '%s'", j.TaskID))
 		return
@@ -118,7 +127,7 @@ func (j *moveLogsToFailedBucketJob) Run(ctx context.Context) {
 	// Use the source bucket config captured when the job was created rather than the one on
 	// the task config because that has already been updated to the failed bucket so that future
 	// logs are written there directly.
-	if err := t.MoveTestAndTaskLogsToFailedBucket(fetchContext, j.env.Settings(), j.SourceBucketCfg); err != nil {
+	if err := t.MoveTestAndTaskLogsToFailedBucket(fetchContext, j.env.Settings(), j.SourceBucketCfg, j.RunInOldTaskCollection); err != nil {
 		grip.Error(ctx, message.WrapError(err, message.Fields{
 			"message":   "moving logs to failed bucket",
 			"task_id":   t.Id,

--- a/units/move_logs_to_failed_bucket.go
+++ b/units/move_logs_to_failed_bucket.go
@@ -25,7 +25,7 @@ const (
 // MoveLogsTriggerTaskEnd is used when the app server enqueues after a failed task ends (agent path).
 const MoveLogsTriggerTaskEnd = "task_end"
 
-// MoveLogsTriggerHourlyRetry is used by PopulateRetryFailedLogMoveJobs (hourly remote cron).
+// MoveLogsTriggerHourlyRetry is used by PopulateRetryFailedLogMoveJobs and PopulateRetryFailedLogMoveJobsForOldTasks (hourly remote cron).
 const MoveLogsTriggerHourlyRetry = "hourly_retry_failed_log_move"
 
 func init() {

--- a/units/move_logs_to_failed_bucket_test.go
+++ b/units/move_logs_to_failed_bucket_test.go
@@ -25,6 +25,21 @@ func TestNewMoveLogsToFailedBucketJob(t *testing.T) {
 		assert.Equal(t, "task-123", moveJob.TaskID)
 		assert.Equal(t, MoveLogsTriggerTaskEnd, moveJob.Trigger)
 		assert.Equal(t, sourceCfg, moveJob.SourceBucketCfg)
+		assert.False(t, moveJob.RunInOldTaskCollection)
+		assert.Zero(t, moveJob.Timeout)
+		assert.Equal(t, fetchTimeout, job.TimeInfo().MaxTime)
+	})
+
+	t.Run("RunInOldTaskCollection", func(t *testing.T) {
+		job := NewMoveLogsToFailedBucketJob(env, "task-old-789", "2025-01-16", sourceCfg, MoveLogsTriggerHourlyRetry, true)
+		require.NotNil(t, job)
+
+		moveJob, ok := job.(*moveLogsToFailedBucketJob)
+		require.True(t, ok)
+		assert.Equal(t, "task-old-789", moveJob.TaskID)
+		assert.Equal(t, MoveLogsTriggerHourlyRetry, moveJob.Trigger)
+		assert.Equal(t, sourceCfg, moveJob.SourceBucketCfg)
+		assert.True(t, moveJob.RunInOldTaskCollection)
 		assert.Zero(t, moveJob.Timeout)
 		assert.Equal(t, fetchTimeout, job.TimeInfo().MaxTime)
 	})
@@ -37,6 +52,21 @@ func TestNewMoveLogsToFailedBucketJob(t *testing.T) {
 		moveJob, ok := job.(*moveLogsToFailedBucketJob)
 		require.True(t, ok)
 		assert.Equal(t, "task-456", moveJob.TaskID)
+		assert.False(t, moveJob.RunInOldTaskCollection)
+		assert.Equal(t, customTimeout, moveJob.Timeout)
+		assert.Equal(t, customTimeout, job.TimeInfo().MaxTime)
+	})
+
+	t.Run("CustomTimeoutRunInOldTaskCollection", func(t *testing.T) {
+		customTimeout := 60 * time.Minute
+		job := NewMoveLogsToFailedBucketJob(env, "task-old-999", "2025-01-16", sourceCfg, MoveLogsTriggerHourlyRetry, true, customTimeout)
+		require.NotNil(t, job)
+
+		moveJob, ok := job.(*moveLogsToFailedBucketJob)
+		require.True(t, ok)
+		assert.Equal(t, "task-old-999", moveJob.TaskID)
+		assert.Equal(t, MoveLogsTriggerHourlyRetry, moveJob.Trigger)
+		assert.True(t, moveJob.RunInOldTaskCollection)
 		assert.Equal(t, customTimeout, moveJob.Timeout)
 		assert.Equal(t, customTimeout, job.TimeInfo().MaxTime)
 	})

--- a/units/move_logs_to_failed_bucket_test.go
+++ b/units/move_logs_to_failed_bucket_test.go
@@ -17,7 +17,7 @@ func TestNewMoveLogsToFailedBucketJob(t *testing.T) {
 	sourceCfg := evergreen.BucketConfig{Name: "test-source-bucket", Type: "s3"}
 
 	t.Run("DefaultTimeout", func(t *testing.T) {
-		job := NewMoveLogsToFailedBucketJob(env, "task-123", "2025-01-16", sourceCfg, MoveLogsTriggerTaskEnd)
+		job := NewMoveLogsToFailedBucketJob(env, "task-123", "2025-01-16", sourceCfg, MoveLogsTriggerTaskEnd, false)
 		require.NotNil(t, job)
 
 		moveJob, ok := job.(*moveLogsToFailedBucketJob)
@@ -31,7 +31,7 @@ func TestNewMoveLogsToFailedBucketJob(t *testing.T) {
 
 	t.Run("CustomTimeout", func(t *testing.T) {
 		customTimeout := 60 * time.Minute
-		job := NewMoveLogsToFailedBucketJob(env, "task-456", "2025-01-16", sourceCfg, MoveLogsTriggerTaskEnd, customTimeout)
+		job := NewMoveLogsToFailedBucketJob(env, "task-456", "2025-01-16", sourceCfg, MoveLogsTriggerTaskEnd, false, customTimeout)
 		require.NotNil(t, job)
 
 		moveJob, ok := job.(*moveLogsToFailedBucketJob)


### PR DESCRIPTION
[DEVPROD-32192](https://jira.mongodb.org/browse/DEVPROD-32192)

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Before this, if a failed task that failed to move its logs is restarted before the hourly cron job can find it and move it, the logs will remain in the success bucket. This fixes that by adding a job that runs the move for tasks in the old collection as well. 

### Testing
[Tested it on staging](https://mongodb.splunkcloud.com/en-US/app/search/search?earliest=1779285598&latest=1779285608.001&q=search%20index%3Devergreen-staging%20lookback_months%7C%20spath%20message%20%7C%20search%20message%3D%22retry%20failed%20log%20move%20jobs%22&display.page.search.mode=fast&dispatch.sample_ratio=1&display.general.type=events&display.page.search.tab=events&workload_pool=&sid=1779286544.276427) by pointing two executions of a task to the success buckets and ensuring both are picket up. 


