### PR TITLE
DEVPROD-29442 Checkout PR branch directly for downstream project modules

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -908,18 +908,17 @@ func shouldSkipApplyingPatches(conf *internal.TaskConfig) bool {
 		return true
 	}
 	// Child patch with parent PR metadata: modules use pull/N/head; the stored diff must not be applied.
-	return conf.Task.ParentPatchID != "" && hasGithubPRPatchMetadata(conf.GithubPatchData)
-}
-
-func hasGithubPRPatchMetadata(gh thirdparty.GithubPatch) bool {
-	return gh.PRNumber != 0 && gh.HeadHash != ""
+	return conf.Task.ParentPatchID != "" && conf.GithubPatchData.PRNumber != 0
 }
 
 // moduleUsesGithubPRHeadCheckout reports whether a module clone should use the same
 // pull/N/head checkout as the main project for a GitHub PR task.
 func moduleUsesGithubPRHeadCheckout(conf *internal.TaskConfig, moduleOwner, moduleRepo string) bool {
+	if !evergreen.IsGithubPRRequester(conf.Task.Requester) && conf.Task.ParentPatchID == "" {
+		return false
+	}
 	gh := conf.GithubPatchData
-	if !hasGithubPRPatchMetadata(gh) {
+	if gh.PRNumber == 0 {
 		return false
 	}
 	moduleRepoKey := fmt.Sprintf("%s/%s", moduleOwner, moduleRepo)
@@ -930,7 +929,7 @@ func moduleUsesGithubPRHeadCheckout(conf *internal.TaskConfig, moduleOwner, modu
 }
 
 func isGitHub(conf *internal.TaskConfig) bool {
-	return hasGithubPRPatchMetadata(conf.GithubPatchData) || conf.GithubMergeData.HeadSHA != ""
+	return conf.GithubPatchData.PRNumber != 0
 }
 
 // parentRepoForGitHubAppToken returns the repository name to pass when resolving

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -293,7 +293,7 @@ func (c *gitFetchProject) buildModuleCloneCommand(conf *internal.TaskConfig, opt
 		return gitCommands, nil
 	}
 
-	if ref == "" && !isGitHubPRModulePatch(conf, modulePatch) {
+	if ref == "" && !moduleUsesGithubPRHeadCheckout(conf, opts.owner, opts.repo) {
 		return nil, errors.New("empty ref/branch to check out")
 	}
 
@@ -303,13 +303,13 @@ func (c *gitFetchProject) buildModuleCloneCommand(conf *internal.TaskConfig, opt
 	}
 	gitCommands = append(gitCommands, cloneCmd...)
 
-	if isGitHubPRModulePatch(conf, modulePatch) {
-		branchName := fmt.Sprintf("evg-merge-test-%s", utility.RandomString())
-		gitCommands = append(gitCommands,
-			fmt.Sprintf(`git fetch origin "pull/%s/merge:%s"`, modulePatch.PatchSet.Patch, branchName),
-			fmt.Sprintf("git checkout '%s'", branchName),
-			fmt.Sprintf("git reset --hard %s", modulePatch.Githash),
-		)
+	if moduleUsesGithubPRHeadCheckout(conf, opts.owner, opts.repo) {
+		branchName := fmt.Sprintf("evg-pr-test-%s", utility.RandomString())
+		gitCommands = append(gitCommands, []string{
+			fmt.Sprintf(`git fetch origin "pull/%d/head:%s"`, conf.GithubPatchData.PRNumber, branchName),
+			fmt.Sprintf(`git checkout "%s"`, branchName),
+			fmt.Sprintf("git reset --hard %s", conf.GithubPatchData.HeadHash),
+		}...)
 	} else {
 		gitCommands = append(gitCommands, fmt.Sprintf("git checkout '%s'", ref))
 	}
@@ -895,9 +895,21 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 	return nil
 }
 
-func isGitHubPRModulePatch(conf *internal.TaskConfig, modulePatch *patch.ModulePatch) bool {
-	patchProvided := (modulePatch != nil) && (modulePatch.PatchSet.Patch != "")
-	return isGitHub(conf) && patchProvided
+// moduleUsesGithubPRHeadCheckout reports whether a module clone should use the same
+// pull/N/head checkout as the main project for a GitHub PR task.
+func moduleUsesGithubPRHeadCheckout(conf *internal.TaskConfig, moduleOwner, moduleRepo string) bool {
+	if conf.Task.Requester != evergreen.GithubPRRequester {
+		return false
+	}
+	gh := conf.GithubPatchData
+	if gh.PRNumber == 0 || gh.HeadHash == "" {
+		return false
+	}
+	moduleRepoKey := fmt.Sprintf("%s/%s", moduleOwner, moduleRepo)
+
+	// Check if the module repo is the base or head repo.
+	return moduleRepoKey == fmt.Sprintf("%s/%s", gh.BaseOwner, gh.BaseRepo) ||
+		moduleRepoKey == fmt.Sprintf("%s/%s", gh.HeadOwner, gh.HeadRepo)
 }
 
 func isGitHub(conf *internal.TaskConfig) bool {

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -899,7 +899,10 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 // PR or merge-queue refs instead of the task revision. Child patches keep the child
 // project's mainline revision even when parent PR metadata is present for modules.
 func usesGitHubPRSourceCheckout(conf *internal.TaskConfig) bool {
-	return isGitHub(conf) && conf.Task.ParentPatchID == ""
+	if conf.Task.ParentPatchID != "" {
+		return false
+	}
+	return conf.GithubPatchData.PRNumber != 0 || conf.GithubMergeData.HeadSHA != ""
 }
 
 // shouldSkipApplyingPatches reports whether git apply should be skipped for this patch task.
@@ -926,10 +929,6 @@ func moduleUsesGithubPRHeadCheckout(conf *internal.TaskConfig, moduleOwner, modu
 	// Check if the module repo is the base or head repo.
 	return moduleRepoKey == fmt.Sprintf("%s/%s", gh.BaseOwner, gh.BaseRepo) ||
 		moduleRepoKey == fmt.Sprintf("%s/%s", gh.HeadOwner, gh.HeadRepo)
-}
-
-func isGitHub(conf *internal.TaskConfig) bool {
-	return conf.GithubPatchData.PRNumber != 0
 }
 
 // parentRepoForGitHubAppToken returns the repository name to pass when resolving

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -236,7 +236,7 @@ func (c *gitFetchProject) buildSourceCloneCommand(conf *internal.TaskConfig, opt
 	gitCommands = append(gitCommands, cloneCmd...)
 
 	// if there's a PR checkout the ref containing the changes
-	if isGitHub(conf) {
+	if usesGitHubPRSourceCheckout(conf) {
 		var suffix, localBranchName, remoteBranchName, commitToTest string
 		if conf.Task.Requester == evergreen.GithubPRRequester {
 			// Github creates a ref called refs/pull/[pr number]/head
@@ -711,7 +711,7 @@ func (c *gitFetchProject) fetch(ctx context.Context,
 	}
 
 	// Apply patches if this is a patch and we haven't already gotten the changes from a PR
-	if evergreen.IsPatchRequester(conf.Task.Requester) && !isGitHub(conf) {
+	if evergreen.IsPatchRequester(conf.Task.Requester) && !shouldSkipApplyingPatches(conf) {
 		if err = c.getPatchContents(ctx, comm, logger, conf, p); err != nil {
 			err = errors.Wrap(err, "getting patch contents")
 			logger.Task().Error(ctx, err.Error())
@@ -895,14 +895,31 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 	return nil
 }
 
+// usesGitHubPRSourceCheckout reports whether the main project checkout should use GitHub
+// PR or merge-queue refs instead of the task revision. Child patches keep the child
+// project's mainline revision even when parent PR metadata is present for modules.
+func usesGitHubPRSourceCheckout(conf *internal.TaskConfig) bool {
+	return isGitHub(conf) && conf.Task.ParentPatchID == ""
+}
+
+// shouldSkipApplyingPatches reports whether git apply should be skipped for this patch task.
+func shouldSkipApplyingPatches(conf *internal.TaskConfig) bool {
+	if usesGitHubPRSourceCheckout(conf) {
+		return true
+	}
+	// Child patch with parent PR metadata: modules use pull/N/head; the stored diff must not be applied.
+	return conf.Task.ParentPatchID != "" && hasGithubPRPatchMetadata(conf.GithubPatchData)
+}
+
+func hasGithubPRPatchMetadata(gh thirdparty.GithubPatch) bool {
+	return gh.PRNumber != 0 && gh.HeadHash != ""
+}
+
 // moduleUsesGithubPRHeadCheckout reports whether a module clone should use the same
 // pull/N/head checkout as the main project for a GitHub PR task.
 func moduleUsesGithubPRHeadCheckout(conf *internal.TaskConfig, moduleOwner, moduleRepo string) bool {
-	if conf.Task.Requester != evergreen.GithubPRRequester {
-		return false
-	}
 	gh := conf.GithubPatchData
-	if gh.PRNumber == 0 || gh.HeadHash == "" {
+	if !hasGithubPRPatchMetadata(gh) {
 		return false
 	}
 	moduleRepoKey := fmt.Sprintf("%s/%s", moduleOwner, moduleRepo)
@@ -913,7 +930,7 @@ func moduleUsesGithubPRHeadCheckout(conf *internal.TaskConfig, moduleOwner, modu
 }
 
 func isGitHub(conf *internal.TaskConfig) bool {
-	return conf.GithubPatchData.PRNumber != 0 || conf.GithubMergeData.HeadSHA != ""
+	return hasGithubPRPatchMetadata(conf.GithubPatchData) || conf.GithubMergeData.HeadSHA != ""
 }
 
 // parentRepoForGitHubAppToken returns the repository name to pass when resolving

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -680,19 +680,19 @@ func TestModuleUsesGithubPRHeadCheckout(t *testing.T) {
 	conf := &internal.TaskConfig{
 		Task: task.Task{Requester: evergreen.GithubPRRequester},
 		GithubPatchData: thirdparty.GithubPatch{
-			PRNumber:   42,
-			BaseOwner:  "evergreen-ci",
-			BaseRepo:   "evergreen",
-			HeadOwner:  "octocat",
-			HeadRepo:   "evergreen",
-			HeadHash:   "abc123",
+			PRNumber:  42,
+			BaseOwner: "evergreen-ci",
+			BaseRepo:  "evergreen",
+			HeadOwner: "octocat",
+			HeadRepo:  "evergreen",
+			HeadHash:  "abc123",
 		},
 	}
 	assert.True(t, moduleUsesGithubPRHeadCheckout(conf, "evergreen-ci", "evergreen"))
 	assert.True(t, moduleUsesGithubPRHeadCheckout(conf, "octocat", "evergreen"))
 	assert.False(t, moduleUsesGithubPRHeadCheckout(conf, "evergreen-ci", "sample"))
 	assert.False(t, moduleUsesGithubPRHeadCheckout(&internal.TaskConfig{
-		Task: task.Task{Requester: evergreen.PatchVersionRequester},
+		Task:            task.Task{Requester: evergreen.PatchVersionRequester},
 		GithubPatchData: conf.GithubPatchData,
 	}, "evergreen-ci", "evergreen"))
 }
@@ -702,12 +702,12 @@ func TestBuildModuleCloneCommandGithubPRHead(t *testing.T) {
 	conf := &internal.TaskConfig{
 		Task: task.Task{Requester: evergreen.GithubPRRequester},
 		GithubPatchData: thirdparty.GithubPatch{
-			PRNumber:   9001,
-			BaseOwner:  "evergreen-ci",
-			BaseRepo:   "evergreen",
-			HeadOwner:  "octocat",
-			HeadRepo:   "evergreen",
-			HeadHash:   "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+			PRNumber:  9001,
+			BaseOwner: "evergreen-ci",
+			BaseRepo:  "evergreen",
+			HeadOwner: "octocat",
+			HeadRepo:  "evergreen",
+			HeadHash:  "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
 		},
 	}
 	opts := cloneOpts{

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -696,6 +696,10 @@ func TestModuleUsesGithubPRHeadCheckout(t *testing.T) {
 		Task:            task.Task{Requester: evergreen.PatchVersionRequester, ParentPatchID: "parent-patch-id"},
 		GithubPatchData: conf.GithubPatchData,
 	}, "evergreen-ci", "evergreen"))
+	assert.False(t, moduleUsesGithubPRHeadCheckout(&internal.TaskConfig{
+		Task:            task.Task{Requester: evergreen.PatchVersionRequester},
+		GithubPatchData: conf.GithubPatchData,
+	}, "evergreen-ci", "evergreen"))
 }
 
 func TestUsesGitHubPRSourceCheckout(t *testing.T) {

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -718,6 +718,14 @@ func TestUsesGitHubPRSourceCheckout(t *testing.T) {
 	assert.False(t, shouldSkipApplyingPatches(&internal.TaskConfig{
 		Task: task.Task{Requester: evergreen.PatchVersionRequester},
 	}))
+	mqConf := &internal.TaskConfig{
+		Task: task.Task{Requester: evergreen.GithubMergeRequester},
+		GithubMergeData: thirdparty.GithubMergeGroup{
+			HeadSHA: "abc123",
+		},
+	}
+	assert.True(t, usesGitHubPRSourceCheckout(mqConf))
+	assert.Equal(t, 0, mqConf.GithubPatchData.PRNumber)
 }
 
 func TestBuildSourceCloneCommandChildPatchUsesTaskRevision(t *testing.T) {

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -691,10 +691,57 @@ func TestModuleUsesGithubPRHeadCheckout(t *testing.T) {
 	assert.True(t, moduleUsesGithubPRHeadCheckout(conf, "evergreen-ci", "evergreen"))
 	assert.True(t, moduleUsesGithubPRHeadCheckout(conf, "octocat", "evergreen"))
 	assert.False(t, moduleUsesGithubPRHeadCheckout(conf, "evergreen-ci", "sample"))
-	assert.False(t, moduleUsesGithubPRHeadCheckout(&internal.TaskConfig{
-		Task:            task.Task{Requester: evergreen.PatchVersionRequester},
+	// Child patches carry parent PR metadata but use PatchVersionRequester on the version.
+	assert.True(t, moduleUsesGithubPRHeadCheckout(&internal.TaskConfig{
+		Task:            task.Task{Requester: evergreen.PatchVersionRequester, ParentPatchID: "parent-patch-id"},
 		GithubPatchData: conf.GithubPatchData,
 	}, "evergreen-ci", "evergreen"))
+}
+
+func TestUsesGitHubPRSourceCheckout(t *testing.T) {
+	gh := thirdparty.GithubPatch{PRNumber: 42, HeadHash: "abc123"}
+	prConf := &internal.TaskConfig{
+		Task:            task.Task{Requester: evergreen.GithubPRRequester},
+		GithubPatchData: gh,
+	}
+	assert.True(t, usesGitHubPRSourceCheckout(prConf))
+	childConf := &internal.TaskConfig{
+		Task:            task.Task{Requester: evergreen.PatchVersionRequester, ParentPatchID: "parent"},
+		GithubPatchData: gh,
+	}
+	assert.False(t, usesGitHubPRSourceCheckout(childConf))
+	assert.True(t, shouldSkipApplyingPatches(childConf))
+	assert.False(t, shouldSkipApplyingPatches(&internal.TaskConfig{
+		Task: task.Task{Requester: evergreen.PatchVersionRequester},
+	}))
+}
+
+func TestBuildSourceCloneCommandChildPatchUsesTaskRevision(t *testing.T) {
+	c := &gitFetchProject{Directory: "dir", Token: projectGitHubToken}
+	conf := &internal.TaskConfig{
+		Task: task.Task{
+			Requester:     evergreen.PatchVersionRequester,
+			ParentPatchID: "parent-patch-id",
+			Revision:      "child-mainline-sha",
+		},
+		GithubPatchData: thirdparty.GithubPatch{
+			PRNumber: 9001,
+			HeadHash: "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+		},
+		ProjectRef: model.ProjectRef{Owner: "evergreen-ci", Repo: "evergreen", Branch: "main"},
+	}
+	opts := cloneOpts{
+		token:  projectGitHubToken,
+		branch: conf.ProjectRef.Branch,
+		owner:  conf.ProjectRef.Owner,
+		repo:   conf.ProjectRef.Repo,
+		dir:    c.Directory,
+	}
+	cmds, err := c.buildSourceCloneCommand(conf, opts)
+	require.NoError(t, err)
+	joined := strings.Join(cmds, "\n")
+	assert.Contains(t, joined, "git reset --hard child-mainline-sha")
+	assert.NotContains(t, joined, "pull/9001/head")
 }
 
 func TestBuildModuleCloneCommandGithubPRHead(t *testing.T) {

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -650,27 +650,78 @@ func (s *GitGetProjectSuite) TestBuildModuleCommand() {
 		fmt.Sprintf("git clone https://x-access-token:%s@github.com/evergreen-ci/sample.git 'module'", projectGitHubToken),
 	}), cmds)
 
-	conf = s.taskConfig4
-	// with merge test-commit checkout
-	module := &patch.ModulePatch{
-		ModuleName: "test-module",
-		Githash:    "1234abcd",
-		PatchSet: patch.PatchSet{
-			Patch: "1234",
-		},
-	}
-	cmds, err = c.buildModuleCloneCommand(conf, opts, "main", module)
+	conf = s.taskConfig3
+	opts.owner = "evergreen-ci"
+	opts.repo = "evergreen"
+	cmds, err = c.buildModuleCloneCommand(conf, opts, "main", nil)
 	s.NoError(err)
 	s.Require().Len(cmds, 10)
 	s.True(utility.StringSliceContainsOrderedPrefixSubset(cmds, []string{
 		"set -o xtrace",
 		"set -o errexit",
-		fmt.Sprintf("git clone https://x-access-token:%s@github.com/evergreen-ci/sample.git 'module'", projectGitHubToken),
+		fmt.Sprintf("git clone https://x-access-token:%s@github.com/evergreen-ci/evergreen.git 'module'", projectGitHubToken),
 		"cd module",
-		"git fetch origin \"pull/1234/merge:evg-merge-test-",
-		"git checkout 'evg-merge-test-",
-		"git reset --hard 1234abcd",
+		"git fetch origin \"pull/9001/head:evg-pr-test-",
+		"git checkout \"evg-pr-test-",
+		fmt.Sprintf("git reset --hard %s", conf.GithubPatchData.HeadHash),
 	}), cmds)
+
+	// A module in a different repo than the PR should use a normal ref checkout.
+	conf = s.taskConfig3
+	opts.owner = "evergreen-ci"
+	opts.repo = "sample"
+	cmds, err = c.buildModuleCloneCommand(conf, opts, "main", nil)
+	s.NoError(err)
+	s.Require().Len(cmds, 8)
+	s.Contains(cmds[len(cmds)-1], "git checkout 'main'")
+}
+
+func TestModuleUsesGithubPRHeadCheckout(t *testing.T) {
+	conf := &internal.TaskConfig{
+		Task: task.Task{Requester: evergreen.GithubPRRequester},
+		GithubPatchData: thirdparty.GithubPatch{
+			PRNumber:   42,
+			BaseOwner:  "evergreen-ci",
+			BaseRepo:   "evergreen",
+			HeadOwner:  "octocat",
+			HeadRepo:   "evergreen",
+			HeadHash:   "abc123",
+		},
+	}
+	assert.True(t, moduleUsesGithubPRHeadCheckout(conf, "evergreen-ci", "evergreen"))
+	assert.True(t, moduleUsesGithubPRHeadCheckout(conf, "octocat", "evergreen"))
+	assert.False(t, moduleUsesGithubPRHeadCheckout(conf, "evergreen-ci", "sample"))
+	assert.False(t, moduleUsesGithubPRHeadCheckout(&internal.TaskConfig{
+		Task: task.Task{Requester: evergreen.PatchVersionRequester},
+		GithubPatchData: conf.GithubPatchData,
+	}, "evergreen-ci", "evergreen"))
+}
+
+func TestBuildModuleCloneCommandGithubPRHead(t *testing.T) {
+	c := &gitFetchProject{Directory: "dir", Token: projectGitHubToken}
+	conf := &internal.TaskConfig{
+		Task: task.Task{Requester: evergreen.GithubPRRequester},
+		GithubPatchData: thirdparty.GithubPatch{
+			PRNumber:   9001,
+			BaseOwner:  "evergreen-ci",
+			BaseRepo:   "evergreen",
+			HeadOwner:  "octocat",
+			HeadRepo:   "evergreen",
+			HeadHash:   "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
+		},
+	}
+	opts := cloneOpts{
+		token: projectGitHubToken,
+		owner: "evergreen-ci",
+		repo:  "evergreen",
+		dir:   "module",
+	}
+	cmds, err := c.buildModuleCloneCommand(conf, opts, "", nil)
+	require.NoError(t, err)
+	joined := strings.Join(cmds, "\n")
+	assert.Contains(t, joined, `git fetch origin "pull/9001/head:evg-pr-test-`)
+	assert.Contains(t, joined, `git reset --hard 55ca6286e3e4f4fba5d0448333fa99fc5a404a73`)
+	assert.NotContains(t, joined, "/merge:")
 }
 
 func TestBuildModuleCloneCommandWiki(t *testing.T) {

--- a/config.go
+++ b/config.go
@@ -37,7 +37,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-05-18"
+	AgentVersion = "2026-05-20"
 )
 
 const (

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1227,6 +1227,10 @@ func (j *patchIntentProcessor) buildTriggerPatchDoc(ctx context.Context, patchDo
 		if parentPatch == nil {
 			return nil, nil, errors.Errorf("parent patch '%s' not found", patchDoc.Triggers.ParentPatch)
 		}
+		if parentPatch.IsGithubPRPatch() && intent.ParentAsModule != "" {
+			// Propagate PR metadata so the agent can check out pull/N/head for the module.
+			patchDoc.GithubPatchData = parentPatch.GithubPatchData
+		}
 		for _, p := range parentPatch.Patches {
 			if p.ModuleName == "" {
 				moduleName := intent.ParentAsModule
@@ -1236,11 +1240,16 @@ func (j *patchIntentProcessor) buildTriggerPatchDoc(ctx context.Context, patchDo
 					patchDoc.Githash = parentPatch.Githash
 					moduleName = ""
 				}
+				patchSet := p.PatchSet
+				if parentPatch.IsGithubPRPatch() && moduleName != "" {
+					// GitHub PR diffs are applied on the agent via pull/N/head, not git apply.
+					patchSet.Patch = ""
+				}
 				patchDoc.Patches = append(patchDoc.Patches, patch.ModulePatch{
 					// Apply the parent patch's changes if both child and parent are using the
 					// same repo/project/branch
 					ModuleName: moduleName,
-					PatchSet:   p.PatchSet,
+					PatchSet:   patchSet,
 					Githash:    parentPatch.Githash,
 				})
 				break

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1244,6 +1244,7 @@ func (j *patchIntentProcessor) buildTriggerPatchDoc(ctx context.Context, patchDo
 				if parentPatch.IsGithubPRPatch() && moduleName != "" {
 					// GitHub PR diffs are applied on the agent via pull/N/head, not git apply.
 					patchSet.Patch = ""
+					patchSet.PatchFileId = ""
 				}
 				patchDoc.Patches = append(patchDoc.Patches, patch.ModulePatch{
 					// Apply the parent patch's changes if both child and parent are using the

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1784,7 +1784,7 @@ tasks:
 		Patches: []patch.ModulePatch{{
 			Githash: s.hash,
 			PatchSet: patch.PatchSet{
-				Patch: "diff --git a/file b/file",
+				PatchFileId: "parent-patch-file-id",
 				Summary: []thirdparty.Summary{{
 					Name:      "file",
 					Additions: 1,
@@ -1821,6 +1821,7 @@ tasks:
 	s.Require().Len(childPatch.Patches, 1)
 	s.Equal("module1", childPatch.Patches[0].ModuleName)
 	s.Empty(childPatch.Patches[0].PatchSet.Patch)
+	s.Empty(childPatch.Patches[0].PatchSet.PatchFileId)
 	s.Require().Len(childPatch.Patches[0].PatchSet.Summary, 1)
 }
 

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1753,6 +1753,77 @@ tasks:
 	s.Equal("my-task", dbChildPatch.VariantsTasks[0].Tasks[0])
 }
 
+func (s *PatchIntentUnitsSuite) TestBuildTriggerPatchDocGithubPRParentModule() {
+	latestVersion := model.Version{
+		Id:         "childProj-pr-module-version",
+		Identifier: "childProj",
+		Requester:  evergreen.RepotrackerVersionRequester,
+	}
+	s.Require().NoError(latestVersion.Insert(s.ctx))
+
+	latestVersionParserProject := &model.ParserProject{}
+	s.Require().NoError(util.UnmarshalYAMLWithFallback([]byte(`
+buildvariants:
+- name: my-build-variant
+  display_name: my-build-variant
+  run_on:
+    - some-distro
+  tasks:
+    - my-task
+tasks:
+- name: my-task`), latestVersionParserProject))
+	latestVersionParserProject.Id = latestVersion.Id
+	s.Require().NoError(latestVersionParserProject.Insert(s.ctx))
+
+	parentPatch := &patch.Patch{
+		Id:              mgobson.NewObjectId(),
+		Project:         s.project,
+		Author:          evergreen.GithubPatchUser,
+		Githash:         s.hash,
+		GithubPatchData: s.githubPatchData,
+		Patches: []patch.ModulePatch{{
+			Githash: s.hash,
+			PatchSet: patch.PatchSet{
+				Patch: "diff --git a/file b/file",
+				Summary: []thirdparty.Summary{{
+					Name:      "file",
+					Additions: 1,
+				}},
+			},
+		}},
+	}
+	s.Require().NoError(parentPatch.Insert(s.ctx))
+
+	intent := patch.NewTriggerIntent(patch.TriggerIntentOptions{
+		ParentID:        parentPatch.Id.Hex(),
+		ParentProjectID: s.project,
+		ProjectID:       "childProj",
+		ParentAsModule:  "module1",
+		Requester:       evergreen.GithubPRRequester,
+		Author:          evergreen.ParentPatchUser,
+		Definitions: []patch.PatchTriggerDefinition{{
+			Alias:        "patch-alias",
+			ChildProject: "childProj",
+			TaskSpecifiers: []patch.TaskSpecifier{{
+				VariantRegex: "my-build-variant",
+				TaskRegex:    "my-task",
+			}},
+		}},
+	})
+
+	childPatch := intent.NewPatch()
+	j, ok := NewPatchIntentProcessor(s.env, mgobson.ObjectIdHex(intent.ID()), intent).(*patchIntentProcessor)
+	s.Require().True(ok)
+	_, _, err := j.buildTriggerPatchDoc(s.ctx, childPatch)
+	s.NoError(err)
+	s.Equal(s.githubPatchData.PRNumber, childPatch.GithubPatchData.PRNumber)
+	s.Equal(s.githubPatchData.HeadHash, childPatch.GithubPatchData.HeadHash)
+	s.Require().Len(childPatch.Patches, 1)
+	s.Equal("module1", childPatch.Patches[0].ModuleName)
+	s.Empty(childPatch.Patches[0].PatchSet.Patch)
+	s.Require().Len(childPatch.Patches[0].PatchSet.Summary, 1)
+}
+
 func (s *PatchIntentUnitsSuite) TestProcessTriggerAliasesWithAliasThatDoesNotMatchAnyVariantTasks() {
 	roleManager := s.env.RoleManager()
 	childProjScope := gimlet.Scope{


### PR DESCRIPTION
DEVPROD-29442

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Downstream projects that include the upstream project as a module and want to checkout the PR head (e.g. Pine for our project is this) currently do not handle binary files well. The current arch is:
- Evergreen downloads the PR data
- We store it in gridfs
- We download it on the agent
- We apply it on the agent while cloning
- Evergreen fails to clone ([example](https://spruce.corp.mongodb.com/version/69a9d919615577000720dc80/downstream-projects?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC))

This PR doesn't change our current system, since we currently expose the diff externally via our REST API. Instead, I just patched _how_ Evergreen clones. Now, instead of failing to clone, Evergreen will directly clone the PR head instead.

### Testing
Added unit tests. Deployed to staging and ran the example above.

Reran example and it failed on main ([task](https://spruce-staging.corp.mongodb.com/task/zackary_module_downstream_variant1_clone_patch_4ec5d156ca7c1c1988de27c03a40d309eb6b90d4_6a0dcfafc4e3fc0007285fb6_26_05_20_15_13_52/logs?execution=0)).

Passing with these changes ([task](https://spruce-staging.corp.mongodb.com/task/zackary_module_downstream_variant1_clone_patch_4ec5d156ca7c1c1988de27c03a40d309eb6b90d4_6a0df22b03292400074eb5f7_26_05_20_17_41_00/logs?execution=0)).

<!-- 
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models - If you're adding a field to the Task, Build, Version, or Patch structs, consider creating a
  DPIPE ticket to expose this in the data warehouse.

-->
