### PR TITLE
DEVPROD-33122: Detach JIRA callback ctx from cancellation

### DIFF
--- a/model/notification/notification.go
+++ b/model/notification/notification.go
@@ -143,8 +143,13 @@ func (n *Notification) Composer(ctx context.Context) (message.Composer, error) {
 
 		payload.Project = jiraIssue.Project
 		payload.Type = jiraIssue.IssueType
+		// JIRA sends run on a background queue, so this callback fires from a
+		// different goroutine after the JIRA HTTP request returns, long after
+		// the caller's ctx has been canceled. Drop the cancellation so the
+		// event log insert below isn't aborted.
+		callbackCtx := context.WithoutCancel(ctx)
 		payload.Callback = func(issueKey string) {
-			event.LogJiraIssueCreated(ctx, n.Metadata.TaskID, n.Metadata.TaskExecution, issueKey, n.Metadata.CreatedBy)
+			event.LogJiraIssueCreated(callbackCtx, n.Metadata.TaskID, n.Metadata.TaskExecution, issueKey, n.Metadata.CreatedBy)
 		}
 
 		return message.MakeJiraMessage(payload), nil

--- a/model/notification/notification_test.go
+++ b/model/notification/notification_test.go
@@ -1,6 +1,7 @@
 package notification
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -14,6 +15,8 @@ import (
 	_ "github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mongodb/grip/message"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -297,6 +300,58 @@ func (s *notificationSuite) TestJIRAIssuePayload() {
 	s.NoError(err)
 	s.Require().NotNil(c)
 	s.True(c.Loggable())
+}
+
+func TestJIRAIssueCallbackLogsEventAfterCtxCancel(t *testing.T) {
+	require.NoError(t, db.ClearCollections(Collection, event.EventCollection))
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(Collection, event.EventCollection))
+	})
+
+	taskID := "task_jira_callback_ctx_cancel"
+	issueKey := "EVG-99999"
+	n := Notification{
+		ID: "jira-callback-ctx-cancel",
+		Subscriber: event.Subscriber{
+			Type: event.JIRAIssueSubscriberType,
+			Target: &event.JIRAIssueSubscriber{
+				Project:   "EVG",
+				IssueType: "Build Failure",
+			},
+		},
+		Payload: &message.JiraIssue{
+			Summary:     "title",
+			Description: "body",
+		},
+	}
+	n.SetTaskMetadata(taskID, 0, "admin.user")
+	require.NoError(t, InsertMany(t.Context(), n))
+
+	found, err := Find(t.Context(), n.ID)
+	require.NoError(t, err)
+	require.NotNil(t, found)
+
+	jobCtx, cancel := context.WithCancel(t.Context())
+	c, err := found.Composer(jobCtx)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	cancel()
+
+	raw, ok := c.Raw().(*message.JiraIssue)
+	require.True(t, ok)
+	require.NotNil(t, raw.Callback)
+	raw.Callback(issueKey)
+
+	events, err := event.Find(t.Context(), event.TaskEventsForId(taskID))
+	require.NoError(t, err)
+	require.Len(t, events, 1)
+	assert.Equal(t, event.TaskJiraAlertCreated, events[0].EventType)
+	assert.Equal(t, taskID, events[0].ResourceId)
+	data, ok := events[0].Data.(*event.TaskEventData)
+	require.True(t, ok)
+	assert.Equal(t, issueKey, data.JiraIssue)
+	assert.Equal(t, "admin.user", data.UserId)
 }
 
 func (s *notificationSuite) TestEmailPayload() {


### PR DESCRIPTION
## DEVPROD-33122

### Problem
When a JIRA ticket is filed via Build Baron, the `TASK_JIRA_ALERT_CREATED` task event is never written to the event log, even though the JIRA ticket is created successfully. So we have no record of who filed the ticket. The `userId` tracking added in DEVPROD-32042 never lands anywhere.

### Cause
1. Code calls `sender.Send` to file a JIRA ticket.
2. `sender.Send` queues the HTTP request on a background queue and returns immediately.
3. `EventSendJob.Run` returns. The amboy worker cancels the ctx it passed in.
4. Hundreds of ms later, the background queue actually runs the JIRA HTTP request.
5. JIRA responds. A callback fires to log `TASK_JIRA_ALERT_CREATED`.
6. The callback uses the ctx captured in step 1, which is now canceled. `db.Insert` returns `context canceled` and the event row is silently dropped.

### Fix
Use `context.WithoutCancel(ctx)` for the callback's context so the event log insert isn't aborted when the parent ctx is canceled.

### Test plan
- [x] New regression test `TestJIRAIssueCallbackLogsEventAfterCtxCancel` in `model/notification/notification_test.go`. Confirmed to **fail** without the fix (`inserting document: context canceled`, 0 events written) and **pass** with it.
- [] Will test on staging once it's free 