### PR TITLE
DEVPROD-30660 Support inline module paths in evergreen patch

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-05-07a"
+	ClientVersion = "2026-05-20"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -109,6 +109,12 @@ Note that `set-module` command will not work for module includes and this flag m
 evergreen patch --include-modules
 ```
 
+To specify module paths inline, use `--include-module`:
+
+```bash
+evergreen patch --include-module my_module=/path/to/my_module
+```
+
 ## Test Selection
 
 To run a patch with [test selection enabled](../Project-Configuration/Project-and-Distro-Settings#test_selection_settings) in a subset of those tasks, you can use the `--test-selection-include-variants`/`--tsv` and `--test-selection-include-tasks`/`--tst` flags. Those will specify a regexp subset of the variants/tasks that run in the patch where test selection will be enabled. You can also specify `--test-selection-exclude-variants` and `--test-selection-exclude-tasks` to define regexp variants/tasks where test selection should _not_ run (exclusion takes precedence over inclusion).
@@ -267,7 +273,17 @@ Finalizing a patch actually creates and schedules and tasks. Before this the pat
 evergreen patch --include-modules
 ```
 
-This will attempt to add changes for each module that your project supports. This flag will prompt you to provide your local absolute path to the module, and it will be stored in your evergreen.yml file. For example:
+This will attempt to add changes for each module that your project supports. This flag will prompt you to provide your local absolute path to the module, and it will be stored in your evergreen.yml file.
+
+To specify module paths directly on the command line without modifying your config, use the `--include-module` flag:
+
+```bash
+evergreen patch --include-module my_module=/path/to/my_module --include-module other_module=/path/to/other
+```
+
+This may be useful when working with multiple clones of the same module or when using automated tooling. It overrides any configured module paths that are set in your ~/.evergreen.yml.
+
+The stored config format looks like:
 
 ```yaml
 projects:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -109,7 +109,7 @@ Note that `set-module` command will not work for module includes and this flag m
 evergreen patch --include-modules
 ```
 
-To specify module paths inline, use `--include-module`:
+To specify module paths inline (overriding any configured paths for that invocation), use `--include-module`:
 
 ```bash
 evergreen patch --include-module my_module=/path/to/my_module

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -264,7 +264,7 @@ func Patch() cli.Command {
 				modulePathCache[moduleName] = modulePath
 			}
 			if params.IncludeModules {
-				if !outputJSON {
+				if !outputJSON && len(params.IncludeModuleOverrides) == 0 {
 					fmt.Fprint(os.Stderr, "Using --include-modules will apply module configuration changes to the patch "+
 						"regardless of whether you include each module's code changes.\nTo avoid this, "+
 						"use the set-module command to set modules individually instead.\n")

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -264,7 +264,7 @@ func Patch() cli.Command {
 				modulePathCache[moduleName] = modulePath
 			}
 			if params.IncludeModules {
-				if !outputJSON && len(params.IncludeModuleOverrides) == 0 {
+				if !outputJSON {
 					fmt.Fprint(os.Stderr, "Using --include-modules will apply module configuration changes to the patch "+
 						"regardless of whether you include each module's code changes.\nTo avoid this, "+
 						"use the set-module command to set modules individually instead.\n")

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -28,6 +28,7 @@ const (
 	repeatFailedDefinitionFlag           = "repeat-failed"
 	repeatPatchIdFlag                    = "repeat-patch"
 	includeModulesFlag                   = "include-modules"
+	includeModuleFlag                    = "include-module"
 	autoDescriptionFlag                  = "auto-description"
 	testSelectionIncludeVariantsFlagName = "test-selection-include-variants"
 	testSelectionIncludeTasksFlagName    = "test-selection-include-tasks"
@@ -116,6 +117,7 @@ func Patch() cli.Command {
 			mutuallyExclusiveArgs(false, preserveCommitsFlag, uncommittedChangesFlag),
 			mutuallyExclusiveArgs(false, repeatDefinitionFlag, repeatPatchIdFlag),
 			mutuallyExclusiveArgs(false, repeatPatchIdFlag, includeModulesFlag),
+			mutuallyExclusiveArgs(false, repeatPatchIdFlag, includeModuleFlag),
 		),
 		Aliases: []string{"create-patch", "submit-patch"},
 		Usage:   "submit a new patch to Evergreen",
@@ -123,6 +125,10 @@ func Patch() cli.Command {
 			cli.BoolFlag{
 				Name:  includeModulesFlag,
 				Usage: "if this boolean is set, Evergreen will include module diffs using changes from defined module paths",
+			},
+			cli.StringSliceFlag{
+				Name:  includeModuleFlag,
+				Usage: "specify a module as MODULE_NAME=PATH to override the module path for this invocation (repeatable); implicitly enables --include-modules",
 			},
 		),
 		Action: func(c *cli.Context) error {
@@ -174,6 +180,14 @@ func Patch() cli.Command {
 			params.Parameters, err = getParametersFromInput(paramsPairs)
 			if err != nil {
 				return err
+			}
+			includeModulePairs := c.StringSlice(includeModuleFlag)
+			params.IncludeModuleOverrides, err = parseModuleOverrides(includeModulePairs)
+			if err != nil {
+				return err
+			}
+			if len(params.IncludeModuleOverrides) > 0 {
+				params.IncludeModules = true
 			}
 
 			conf, err := NewClientSettings(confPath)
@@ -246,6 +260,9 @@ func Patch() cli.Command {
 			// Initialize module path cache in case these have already been set by the user. We use a cache here
 			// to avoid asking the user repeatedly for paths, in the case that they aren't writing them back to their configuration file.
 			modulePathCache := conf.getModulePathsForProject(params.Project)
+			for moduleName, modulePath := range params.IncludeModuleOverrides {
+				modulePathCache[moduleName] = modulePath
+			}
 			if params.IncludeModules {
 				if !outputJSON {
 					fmt.Fprint(os.Stderr, "Using --include-modules will apply module configuration changes to the patch "+
@@ -371,6 +388,26 @@ func getParametersFromInput(params []string) ([]patch.Parameter, error) {
 		key := pair[0]
 		val := strings.Join(pair[1:], "=")
 		res = append(res, patch.Parameter{Key: key, Value: val})
+	}
+	return res, catcher.Resolve()
+}
+
+func parseModuleOverrides(pairs []string) (map[string]string, error) {
+	res := map[string]string{}
+	catcher := grip.NewBasicCatcher()
+	for _, pair := range pairs {
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+			catcher.Errorf("could not parse module override '%s' in MODULE_NAME=PATH format", pair)
+			continue
+		}
+		moduleName := parts[0]
+		modulePath := parts[1]
+		if _, exists := res[moduleName]; exists {
+			catcher.Errorf("duplicate module override for '%s'", moduleName)
+			continue
+		}
+		res[moduleName] = modulePath
 	}
 	return res, catcher.Resolve()
 }

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -92,6 +92,7 @@ type patchParams struct {
 	GithubAuthor                       string
 	PatchAuthor                        string
 	IncludeModules                     bool
+	IncludeModuleOverrides             map[string]string
 	LocalModuleIncludes                []patch.LocalModuleInclude
 }
 

--- a/operations/patch_util_test.go
+++ b/operations/patch_util_test.go
@@ -627,4 +627,50 @@ func TestParseModuleOverrides(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "/path/with=equals/dsi", result["dsi"])
 	})
+
+	t.Run("EmptyInputReturnsEmptyMap", func(t *testing.T) {
+		result, err := parseModuleOverrides([]string{})
+		require.NoError(t, err)
+		assert.Empty(t, result)
+	})
+
+	t.Run("MissingSeparatorShouldError", func(t *testing.T) {
+		_, err := parseModuleOverrides([]string{"dsi"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "MODULE_NAME=PATH")
+	})
+
+	t.Run("EmptyModuleNameShouldError", func(t *testing.T) {
+		_, err := parseModuleOverrides([]string{"=/path/to/dsi"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "MODULE_NAME=PATH")
+	})
+
+	t.Run("EmptyPathShouldError", func(t *testing.T) {
+		_, err := parseModuleOverrides([]string{"dsi="})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "MODULE_NAME=PATH")
+	})
+
+	t.Run("DuplicateModuleShouldError", func(t *testing.T) {
+		_, err := parseModuleOverrides([]string{"dsi=/path/one", "dsi=/path/two"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "duplicate")
+	})
+}
+
+func TestGetModulePathUsesOverrideWithoutWritingConfig(t *testing.T) {
+	params := &patchParams{
+		Project:     "test-project",
+		SkipConfirm: false,
+	}
+	conf := &ClientSettings{}
+	modulePathCache := map[string]string{
+		"dsi": "/override/path/dsi",
+	}
+
+	path, err := params.getModulePath(t.Context(), conf, "dsi", modulePathCache)
+	require.NoError(t, err)
+	assert.Equal(t, "/override/path/dsi", path)
+	assert.Empty(t, conf.Projects)
 }

--- a/operations/patch_util_test.go
+++ b/operations/patch_util_test.go
@@ -568,4 +568,63 @@ include:
 			assert.Contains(t, []string{"file1.yml", "file2.yml"}, inc.FileName)
 		}
 	})
+
+	t.Run("CLIOverridePathTakesPrecedence", func(t *testing.T) {
+		originalDir := filepath.Join(tempDir, "original_module")
+		overrideDir := filepath.Join(tempDir, "override_module")
+		require.NoError(t, os.MkdirAll(originalDir, 0755))
+		require.NoError(t, os.MkdirAll(overrideDir, 0755))
+
+		require.NoError(t, os.WriteFile(filepath.Join(originalDir, "config.yml"), []byte("original"), 0644))
+		require.NoError(t, os.WriteFile(filepath.Join(overrideDir, "config.yml"), []byte("override"), 0644))
+
+		projectYAML := `
+include:
+  - filename: config.yml
+    module: mymodule
+`
+		projectFile := filepath.Join(tempDir, "project-override.yml")
+		require.NoError(t, os.WriteFile(projectFile, []byte(projectYAML), 0644))
+
+		params := &patchParams{
+			Project:     "test-project",
+			SkipConfirm: true,
+		}
+		conf := &ClientSettings{
+			Projects: []ClientProjectConf{
+				{
+					Name:        "test-project",
+					ModulePaths: map[string]string{"mymodule": originalDir},
+				},
+			},
+		}
+		modulePathCache := conf.getModulePathsForProject("test-project")
+		modulePathCache["mymodule"] = overrideDir
+
+		includes, err := getLocalModuleIncludes(t.Context(), params, conf, projectFile, "", modulePathCache)
+		require.NoError(t, err)
+		require.Len(t, includes, 1)
+		assert.Equal(t, "override", string(includes[0].FileContent))
+	})
+}
+
+func TestParseModuleOverrides(t *testing.T) {
+	t.Run("ValidSingleModule", func(t *testing.T) {
+		result, err := parseModuleOverrides([]string{"dsi=/path/to/dsi"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"dsi": "/path/to/dsi"}, result)
+	})
+
+	t.Run("ValidMultipleModules", func(t *testing.T) {
+		result, err := parseModuleOverrides([]string{"dsi=/path/to/dsi", "other=/path/to/other"})
+		require.NoError(t, err)
+		assert.Equal(t, "/path/to/dsi", result["dsi"])
+		assert.Equal(t, "/path/to/other", result["other"])
+	})
+
+	t.Run("PathContainingEquals", func(t *testing.T) {
+		result, err := parseModuleOverrides([]string{"dsi=/path/with=equals/dsi"})
+		require.NoError(t, err)
+		assert.Equal(t, "/path/with=equals/dsi", result["dsi"])
+	})
 }


### PR DESCRIPTION
DEVPROD-30660

### Description
Running `evergreen patch --include-modules` only reads module paths from the local client config in ~/.evergreen.yml. This means developers working across multiple clones of the same module have to update that path frequently in their client config.

This adds a new --include-module <name>=<path> flag that lets you specify module paths directly, and overrides whatever is in the config. It can be repeated for multiple modules.
### Testing
Built the CLI and creatdc a sandbox patch and verified it picked up the correct module diff:
```
commit-queue-sandbox % /Users/malikhadjri/GolandProjects/evergreen/clients/darwin_arm64/evergreen \
    -c ~/evergreen-staging.yml patch -u -p sandbox \
    --include-module trigger-sandbox=/Users/malikhadjri/GolandProjects/commit-queue-sandbox2 \
    --skip_confirm
Module 'trigger-sandbox' updated, base commit is '46d3726e3d177797a8faa15a4eee973ee641f5b1' (and will override the manifest).
no module path given
Patch successfully created.

         ID : 6a0dd021175a2e0007ee441d
    Project : sandbox
    Created : 2026-05-20 15:15:47.144 +0000 UTC
Description : main: trivial
      Build : https://evergreen-staging.corp.mongodb.com//patch/6a0dd021175a2e0007ee441d
     Status : created

```
The above created a patch with [this](https://spruce-staging.corp.mongodb.com/patch/6a0dd021175a2e0007ee441d/configure/changes) diff, which was expected

### Documentation
Updated docs
