### PR TITLE
DEVPROD-32959 Set up Redis at Evergreen Startup

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -31,10 +32,12 @@ import (
 	"github.com/mongodb/grip/send"
 	"github.com/mongodb/jasper"
 	"github.com/pkg/errors"
+	"github.com/redis/go-redis/v9"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/propagation"
@@ -206,6 +209,8 @@ type Environment interface {
 	// BuildVersion returns the ID of the Evergreen version that built the binary.
 	// Returns an empty string if the version ID isn't provided on startup.
 	BuildVersion() string
+	// RedisClient returns a Redis client for interacting with Redis.
+	RedisClient() *redis.Client
 }
 
 // NewEnvironment constructs an Environment instance and initializes all
@@ -291,6 +296,7 @@ func NewEnvironment(ctx context.Context, confPath, versionID, clientS3Bucket str
 	catcher.Add(e.setupRoleManager(ctx, tracer))
 	catcher.Add(e.initTracer(ctx, versionID != "", tracer))
 	catcher.Add(e.initSSH(ctx, tracer))
+	catcher.Add(e.initRedis(ctx, tracer))
 	catcher.Extend(e.initQueues(ctx, tracer))
 
 	if catcher.HasErrors() {
@@ -324,6 +330,7 @@ type envState struct {
 	userManagerInfo         UserManagerInfo
 	shutdownSequenceStarted bool
 	versionID               string
+	redisClient             *redis.Client
 }
 
 // UserManagerInfo lists properties of the UserManager regarding its support for
@@ -1079,6 +1086,57 @@ func (e *envState) initTracer(ctx context.Context, useInternalDNS bool, tracer t
 	})
 
 	return nil
+}
+
+func (e *envState) initRedis(ctx context.Context, tracer trace.Tracer) error {
+	_, span := tracer.Start(ctx, "InitRedis")
+	defer span.End()
+
+	// We do not have a local testing environment for redis.
+	if testing.Testing() {
+		return nil
+	}
+
+	// Send Redis setup errors to honeycomb to alert on.
+	recordFailure := func(err error) {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+
+	redisURL := os.Getenv("REDIS_URL")
+	if redisURL == "" {
+		recordFailure(errors.New("REDIS_URL not set in environment"))
+		return nil
+	}
+
+	opt, err := redis.ParseURL(redisURL)
+	if err != nil {
+		recordFailure(errors.Wrapf(err, "parsing Redis URL '%s'", redisURL))
+		return nil
+	}
+
+	if opt == nil {
+		recordFailure(errors.Errorf("parsed Redis options were nil for URL '%s'", redisURL))
+		return nil
+	}
+
+	e.redisClient = redis.NewClient(opt)
+	if e.redisClient == nil {
+		recordFailure(errors.New("creating Redis client returned nil"))
+		return nil
+	}
+
+	e.RegisterCloser("redis", false, func(_ context.Context) error {
+		return e.redisClient.Close()
+	})
+	return nil
+}
+
+func (e *envState) RedisClient() *redis.Client {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	return e.redisClient
 }
 
 // initSSH pulls all private keys from Secrets Manager and adds them to the ssh-agent daemon.

--- a/environment.go
+++ b/environment.go
@@ -209,7 +209,8 @@ type Environment interface {
 	// BuildVersion returns the ID of the Evergreen version that built the binary.
 	// Returns an empty string if the version ID isn't provided on startup.
 	BuildVersion() string
-	// RedisClient returns a Redis client for interacting with Redis.
+	// RedisClient returns the Redis client. May be nil if REDIS_URL is unset
+	// or invalid, in which case callers should skip Redis-backed paths.
 	RedisClient() *redis.Client
 }
 
@@ -296,8 +297,11 @@ func NewEnvironment(ctx context.Context, confPath, versionID, clientS3Bucket str
 	catcher.Add(e.setupRoleManager(ctx, tracer))
 	catcher.Add(e.initTracer(ctx, versionID != "", tracer))
 	catcher.Add(e.initSSH(ctx, tracer))
-	catcher.Add(e.initRedis(ctx, tracer))
 	catcher.Extend(e.initQueues(ctx, tracer))
+
+	// initRedis intentionally does not fail startup. Setup errors are recorded
+	// on its OTel span and surface as Honeycomb alerts.
+	e.initRedis(ctx, tracer)
 
 	if catcher.HasErrors() {
 		return nil, errors.WithStack(catcher.Resolve())
@@ -1088,13 +1092,16 @@ func (e *envState) initTracer(ctx context.Context, useInternalDNS bool, tracer t
 	return nil
 }
 
-func (e *envState) initRedis(ctx context.Context, tracer trace.Tracer) error {
+// initRedis initializes the Redis client from REDIS_URL. Setup failures are
+// recorded on the OTel span for Honeycomb alerting and are intentionally
+// non-fatal — Evergreen must continue to start even if Redis is unreachable.
+func (e *envState) initRedis(ctx context.Context, tracer trace.Tracer) {
 	_, span := tracer.Start(ctx, "InitRedis")
 	defer span.End()
 
 	// We do not have a local testing environment for redis.
 	if testing.Testing() {
-		return nil
+		return
 	}
 
 	// Send Redis setup errors to honeycomb to alert on.
@@ -1106,30 +1113,28 @@ func (e *envState) initRedis(ctx context.Context, tracer trace.Tracer) error {
 	redisURL := os.Getenv("REDIS_URL")
 	if redisURL == "" {
 		recordFailure(errors.New("REDIS_URL not set in environment"))
-		return nil
+		return
 	}
 
 	opt, err := redis.ParseURL(redisURL)
 	if err != nil {
 		recordFailure(errors.Wrapf(err, "parsing Redis URL '%s'", redisURL))
-		return nil
-	}
-
-	if opt == nil {
-		recordFailure(errors.Errorf("parsed Redis options were nil for URL '%s'", redisURL))
-		return nil
+		return
 	}
 
 	e.redisClient = redis.NewClient(opt)
-	if e.redisClient == nil {
-		recordFailure(errors.New("creating Redis client returned nil"))
-		return nil
+
+	// Pinging Redis to verify the connection because the NewClient method does not return nil or error.
+	// We set a timeout to avoid hanging indefinitely if Redis is unreachable.
+	pingCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := e.redisClient.Ping(pingCtx).Err(); err != nil {
+		recordFailure(errors.Wrap(err, "pinging Redis"))
 	}
 
 	e.RegisterCloser("redis", false, func(_ context.Context) error {
 		return e.redisClient.Close()
 	})
-	return nil
 }
 
 func (e *envState) RedisClient() *redis.Client {

--- a/go.mod
+++ b/go.mod
@@ -176,6 +176,7 @@ require (
 	github.com/kanopy-platform/kanopy-oidc-lib v0.1.3
 	github.com/mongodb/jasper v0.0.0-20260330133616-5411573646d1
 	github.com/parquet-go/parquet-go v0.29.0
+	github.com/redis/go-redis/v9 v9.19.0
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/sirupsen/logrus v1.9.4
 	github.com/vikstrous/dataloadgen v0.0.10
@@ -208,7 +209,6 @@ require (
 	github.com/okta/okta-jwt-verifier-golang/v2 v2.1.1 // indirect
 	github.com/parquet-go/bitpack v1.0.0 // indirect
 	github.com/parquet-go/jsonlite v1.0.0 // indirect
-	github.com/redis/go-redis/v9 v9.19.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/twpayne/go-geom v1.6.1 // indirect
 	github.com/urfave/cli/v3 v3.6.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -208,11 +208,13 @@ require (
 	github.com/okta/okta-jwt-verifier-golang/v2 v2.1.1 // indirect
 	github.com/parquet-go/bitpack v1.0.0 // indirect
 	github.com/parquet-go/jsonlite v1.0.0 // indirect
+	github.com/redis/go-redis/v9 v9.19.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/twpayne/go-geom v1.6.1 // indirect
 	github.com/urfave/cli/v3 v3.6.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.39.0 // indirect
+	go.uber.org/atomic v1.11.0 // indirect
 	gopkg.in/go-jose/go-jose.v2 v2.6.3 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -363,6 +363,8 @@ github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4
 github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/ravilushqa/otelgqlgen v0.19.0 h1:LbgdvOeZLW3y6qJoZHu2qd1srsB2aYRDiY8moPfmZkQ=
 github.com/ravilushqa/otelgqlgen v0.19.0/go.mod h1:89WViMNkh5tnf6PYQGDFQDyLdhpQSlDdQ2/lYkdnlHg=
+github.com/redis/go-redis/v9 v9.19.0 h1:XPVaaPSnG6RhYf7p+rmSa9zZfeVAnWsH5h3lxthOm/k=
+github.com/redis/go-redis/v9 v9.19.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
 github.com/robbiet480/go.sns v0.0.0-20210223081447-c7c9eb6836cb h1:0OJCKQDYBoiOW3Fn+dENmiGQXU8CmIUJqS+B1rZVNbU=
 github.com/robbiet480/go.sns v0.0.0-20210223081447-c7c9eb6836cb/go.mod h1:9CDhL7uDVy8vEVDNPJzxq89dPaPBWP6hxQcC8woBHus=
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
@@ -492,6 +494,8 @@ go.opentelemetry.io/proto/otlp v1.9.0 h1:l706jCMITVouPOqEnii2fIAuO3IVGBRPV5ICjce
 go.opentelemetry.io/proto/otlp v1.9.0/go.mod h1:xE+Cx5E/eEHw+ISFkwPLwCZefwVjY+pqKg1qcK03+/4=
 go.step.sm/crypto v0.31.0 h1:8ZG/BxC+0+LzPpk/764h5yubpG3GfxcRVR4E+Aye72g=
 go.step.sm/crypto v0.31.0/go.mod h1:Dv4lpkijKiZVkoc6zp+Xaw1xmy+voia1mykvbpQIvuc=
+go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
+go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
 go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/go.sum
+++ b/go.sum
@@ -96,6 +96,10 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bradleyfalzon/ghinstallation/v2 v2.17.0 h1:SmbUK/GxpAspRjSQbB6ARvH+ArzlNzTtHydNyXUQ6zg=
 github.com/bradleyfalzon/ghinstallation/v2 v2.17.0/go.mod h1:vuD/xvJT9Y+ZVZRv4HQ42cMyPFIYqpc7AbB4Gvt/DlY=
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -268,7 +272,10 @@ github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0
 github.com/klauspost/compress v1.11.4/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.18.3 h1:9PJRvfbmTabkOX8moIpXPbMMbYN60bWImDDU7L+/6zw=
 github.com/klauspost/compress v1.18.3/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
+github.com/klauspost/cpuid v1.2.0 h1:NMpwD2G9JSFOE1/TJjGSo5zG7Yb2bTe7eq1jH+irmeE=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
+github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
+github.com/klauspost/cpuid/v2 v2.2.10/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU=
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
@@ -456,6 +463,8 @@ github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfS
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
+github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 go.mongodb.org/mongo-driver v1.17.9 h1:IexDdCuuNJ3BHrELgBlyaH9p60JXAvdzWR128q+U5tU=
 go.mongodb.org/mongo-driver v1.17.9/go.mod h1:LlOhpH5NUEfhxcAwG0UEkMqwYcc4JU18gtCdGudk/tQ=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/mock/environment.go
+++ b/mock/environment.go
@@ -23,6 +23,7 @@ import (
 	"github.com/mongodb/grip/send"
 	"github.com/mongodb/jasper"
 	"github.com/pkg/errors"
+	"github.com/redis/go-redis/v9"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
@@ -52,6 +53,7 @@ type Environment struct {
 	Clients                 evergreen.ClientConfig
 	shutdownSequenceStarted bool
 	versionID               string
+	redisClient             *redis.Client
 }
 
 // Configure sets default values on the Environment, except for the user manager
@@ -275,6 +277,10 @@ func (e *Environment) CertificateDepot() certdepot.Depot {
 	defer e.mu.RUnlock()
 
 	return e.Depot
+}
+
+func (e *Environment) RedisClient() *redis.Client {
+	return nil
 }
 
 func (e *Environment) SetParameterManager(pm *parameterstore.ParameterManager) {

--- a/mock/environment.go
+++ b/mock/environment.go
@@ -53,7 +53,6 @@ type Environment struct {
 	Clients                 evergreen.ClientConfig
 	shutdownSequenceStarted bool
 	versionID               string
-	redisClient             *redis.Client
 }
 
 // Configure sets default values on the Environment, except for the user manager


### PR DESCRIPTION
DEVPROD-32959


### Description
set up redis at start up 
even if this errors, it does not affect evergreen startup 

### Testing
Deployed to staging and made sure that it was able to connect to the redis and save and get values 
checked on honeycomb that errors were able to be fielded and set up an alert 
https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/sgz3KbfDY2x?tab=traces
