### PR TITLE
DEVPROD-30379: add max time/retries for merge queue metrics

### DIFF
--- a/units/merge_queue_metrics.go
+++ b/units/merge_queue_metrics.go
@@ -46,7 +46,8 @@ func NewMergeQueueMetricsJob() amboy.Job {
 	const maxAttempts = 3
 	const maxTime = time.Minute
 
-	j.SetEnqueueScopes(mergeQueueMetricsJobName)
+	j.SetScopes([]string{mergeQueueMetricsJobName})
+	j.SetEnqueueAllScopes(true)
 	j.SetTimeInfo(amboy.JobTimeInfo{
 		MaxTime: maxTime,
 	})
@@ -71,7 +72,7 @@ func (j *mergeQueueMetricsJob) Run(ctx context.Context) {
 			"message": "error finding projects with merge queue enabled",
 			"job_id":  j.ID(),
 		}))
-		j.AddError(errors.Wrap(err, "finding projects with merge queue enabled"))
+		j.AddRetryableError(errors.Wrap(err, "finding projects with merge queue enabled"))
 		return
 	}
 
@@ -82,7 +83,7 @@ func (j *mergeQueueMetricsJob) Run(ctx context.Context) {
 				"project_id": projectRef.Id,
 				"job":        j.ID(),
 			}))
-			j.AddError(err)
+			j.AddRetryableError(err)
 		}
 	}
 }
@@ -126,7 +127,7 @@ func (j *mergeQueueMetricsJob) emitMetricsForProject(ctx context.Context, projec
 				"repo":        key.repo,
 				"base_branch": key.baseBranch,
 			}))
-			j.AddError(err)
+			j.AddRetryableError(err)
 		}
 	}
 

--- a/units/merge_queue_metrics.go
+++ b/units/merge_queue_metrics.go
@@ -42,6 +42,19 @@ func NewMergeQueueMetricsJob() amboy.Job {
 		},
 	}
 	j.SetID(fmt.Sprintf("%s.%s", mergeQueueMetricsJobName, utility.RoundPartOfHour(5).Format(TSFormat)))
+
+	const maxAttempts = 3
+	const maxTime = time.Minute
+
+	j.SetEnqueueScopes(mergeQueueMetricsJobName)
+	j.SetTimeInfo(amboy.JobTimeInfo{
+		MaxTime: maxTime,
+	})
+	j.UpdateRetryInfo(amboy.JobRetryOptions{
+		Retryable:   utility.TruePtr(),
+		MaxAttempts: utility.ToIntPtr(maxAttempts),
+	})
+
 	return j
 }
 


### PR DESCRIPTION
DEVPROD-30379

### Description

The original issue was that the merge queue metrics job missed a run because the DB was having temporary issues. There's not a lot the job itself can do about that, so I added max time/retries so that it can try again sooner, rather than wait another 5 mins to be re-enqueued.

Re the performance of the job, it seems like the job is already quite efficient because it makes fairly small/targeted queries with reasonable indexes, so the merge queue metrics job wouldn't be a huge source of slowness/load itself.

### Testing
Tested in personal staging with a fake error to confirm that the job retried.