### PR TITLE
DEVPROD-25481: Remove SlackSenderCheckEnabled feature flag

### DIFF
--- a/config_db.go
+++ b/config_db.go
@@ -95,7 +95,6 @@ var (
 	useMergeQueuePathFilteringDisabledKey = bsonutil.MustHaveTag(ServiceFlags{}, "UseMergeQueuePathFilteringDisabled")
 	psLoggingDisabledKey                  = bsonutil.MustHaveTag(ServiceFlags{}, "PSLoggingDisabled")
 	podDiagnosticsDisabledKey             = bsonutil.MustHaveTag(ServiceFlags{}, "PodDiagnosticsDisabled")
-	slackSenderCheckEnabledKey            = bsonutil.MustHaveTag(ServiceFlags{}, "SlackSenderCheckEnabled")
 
 	// DiagnosticsConfig keys
 	diagnosticsS3BucketNameKey = bsonutil.MustHaveTag(DiagnosticsConfig{}, "S3BucketName")

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -51,7 +51,6 @@ type ServiceFlags struct {
 	EmailNotificationsDisabled   bool `bson:"email_notifications_disabled" json:"email_notifications_disabled"`
 	WebhookNotificationsDisabled bool `bson:"webhook_notifications_disabled" json:"webhook_notifications_disabled"`
 	GithubStatusAPIDisabled      bool `bson:"github_status_api_disabled" json:"github_status_api_disabled"`
-	SlackSenderCheckEnabled      bool `bson:"slack_sender_check_enabled" json:"slack_sender_check_enabled"`
 }
 
 func (c *ServiceFlags) SectionId() string { return "service_flags" }
@@ -101,7 +100,6 @@ func (c *ServiceFlags) Set(ctx context.Context) error {
 			useMergeQueuePathFilteringDisabledKey: c.UseMergeQueuePathFilteringDisabled,
 			psLoggingDisabledKey:                  c.PSLoggingDisabled,
 			podDiagnosticsDisabledKey:             c.PodDiagnosticsDisabled,
-			slackSenderCheckEnabledKey:            c.SlackSenderCheckEnabled,
 		}}), "updating config section '%s'", c.SectionId(),
 	)
 }

--- a/graphql/tests/mutation/setServiceFlags/results.json
+++ b/graphql/tests/mutation/setServiceFlags/results.json
@@ -59,8 +59,7 @@
             { "name": "slack_notifications_disabled", "enabled": false },
             { "name": "email_notifications_disabled", "enabled": false },
             { "name": "webhook_notifications_disabled", "enabled": false },
-            { "name": "github_status_api_disabled", "enabled": false },
-            { "name": "slack_sender_check_enabled", "enabled": false }
+            { "name": "github_status_api_disabled", "enabled": false }
           ]
         }
       }

--- a/graphql/tests/query/adminSettings/results.json
+++ b/graphql/tests/query/adminSettings/results.json
@@ -598,8 +598,7 @@
               { "name": "slack_notifications_disabled", "enabled": false },
               { "name": "email_notifications_disabled", "enabled": false },
               { "name": "webhook_notifications_disabled", "enabled": false },
-              { "name": "github_status_api_disabled", "enabled": false },
-              { "name": "slack_sender_check_enabled", "enabled": false }
+              { "name": "github_status_api_disabled", "enabled": false }
             ]
           }
         }

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2076,7 +2076,6 @@ type APIServiceFlags struct {
 	EmailNotificationsDisabled   bool `json:"email_notifications_disabled"`
 	WebhookNotificationsDisabled bool `json:"webhook_notifications_disabled"`
 	GithubStatusAPIDisabled      bool `json:"github_status_api_disabled"`
-	SlackSenderCheckEnabled      bool `json:"slack_sender_check_enabled"`
 }
 
 type APIProjectTasksPair struct {
@@ -2522,7 +2521,6 @@ func (as *APIServiceFlags) BuildFromService(h any) error {
 		as.PSLoggingDisabled = v.PSLoggingDisabled
 		as.UseMergeQueuePathFilteringDisabled = v.UseMergeQueuePathFilteringDisabled
 		as.PodDiagnosticsDisabled = v.PodDiagnosticsDisabled
-		as.SlackSenderCheckEnabled = v.SlackSenderCheckEnabled
 	default:
 		return errors.Errorf("programmatic error: expected service flags config but got type %T", h)
 	}
@@ -2570,7 +2568,6 @@ func (as *APIServiceFlags) ToService() (any, error) {
 		UseMergeQueuePathFilteringDisabled: as.UseMergeQueuePathFilteringDisabled,
 		PSLoggingDisabled:                  as.PSLoggingDisabled,
 		PodDiagnosticsDisabled:             as.PodDiagnosticsDisabled,
-		SlackSenderCheckEnabled:            as.SlackSenderCheckEnabled,
 	}, nil
 }
 

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -540,19 +540,12 @@ func (m *sendNotificationMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.R
 		return
 	}
 
-	senderCheckEnabled := evergreen.GetEnvironment().Settings().ServiceFlags.SlackSenderCheckEnabled
 	grip.Debug(ctx, message.Fields{
-		"message":              "slack notification target does not match sender",
-		"sender":               u.Username(),
-		"target":               target,
-		"slack_username":       slackUsername,
-		"sender_check_enabled": senderCheckEnabled,
+		"message":        "slack notification target does not match sender",
+		"sender":         u.Username(),
+		"target":         target,
+		"slack_username": slackUsername,
 	})
-
-	if !senderCheckEnabled {
-		next(rw, r)
-		return
-	}
 
 	gimlet.WriteResponse(ctx, rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 		StatusCode: http.StatusUnauthorized,

--- a/rest/route/middleware_test.go
+++ b/rest/route/middleware_test.go
@@ -276,11 +276,7 @@ func TestSendNotificationMiddleware(t *testing.T) {
 	serveMiddleware(rw, r)
 	assert.Equal(t, http.StatusOK, rw.Code)
 
-	// Regular user sending to a different Slack username gets 401 (check enabled).
-	evergreen.GetEnvironment().Settings().ServiceFlags.SlackSenderCheckEnabled = true
-	t.Cleanup(func() {
-		evergreen.GetEnvironment().Settings().ServiceFlags.SlackSenderCheckEnabled = false
-	})
+	// Regular user sending to a different Slack username gets 401.
 	r = makeRequest("@someone.else")
 	ctx = gimlet.AttachUser(t.Context(), &user.DBUser{Id: "other.user", Settings: user.UserSettings{SlackUsername: "myslack"}})
 	r = r.WithContext(context.WithValue(ctx, RequestContext, &opCtx))
@@ -305,23 +301,6 @@ func TestSendNotificationMiddleware(t *testing.T) {
 	rw = httptest.NewRecorder()
 	serveMiddleware(rw, r)
 	assert.Equal(t, http.StatusUnauthorized, rw.Code)
-
-	// With the check disabled, a regular user sending to a different Slack username is allowed through.
-	evergreen.GetEnvironment().Settings().ServiceFlags.SlackSenderCheckEnabled = false
-	r = makeRequest("@someone.else")
-	ctx = gimlet.AttachUser(t.Context(), &user.DBUser{Id: "other.user", Settings: user.UserSettings{SlackUsername: "myslack"}})
-	r = r.WithContext(context.WithValue(ctx, RequestContext, &opCtx))
-	rw = httptest.NewRecorder()
-	serveMiddleware(rw, r)
-	assert.Equal(t, http.StatusOK, rw.Code)
-
-	// With the check disabled, a regular user with no Slack username set is allowed through.
-	r = makeRequest("@myslack")
-	ctx = gimlet.AttachUser(t.Context(), &user.DBUser{Id: "no.slack.user"})
-	r = r.WithContext(context.WithValue(ctx, RequestContext, &opCtx))
-	rw = httptest.NewRecorder()
-	serveMiddleware(rw, r)
-	assert.Equal(t, http.StatusOK, rw.Code)
 }
 
 func TestTaskAuthMiddleware(t *testing.T) {


### PR DESCRIPTION
DEVPROD-25481

### Description
The `SlackSenderCheckEnabled` service flag was introduced to gate enforcement of the Slack CLI (non-admin users may only send Slack notifications to themselves). The flag has been enabled in production, so we can remove it.

### Testing
Removed unneeded tests.