### PR TITLE
DEVPROD-33393 get assignee a different way from github event

### DIFF
--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -216,7 +216,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 				"pr_number": event.GetPullRequest().GetNumber(),
 				"hash":      event.GetPullRequest().GetHead().GetSHA(),
 				"user":      event.GetSender().GetLogin(),
-				"assignee":  event.GetAssignee().GetLogin(),
+				"assignee":  event.GetPullRequest().GetAssignee().GetLogin(),
 				"message":   "PR accepted, attempting to queue",
 			})
 


### PR DESCRIPTION
DEVPROD-33393
<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Assignee currently unpopulated, but I didn't realize there was another way to grab it, and this one seems more likely to work. (I want to deploy this to production because I _specifically_ want to see how this looks for PRs that sage bot opens.)