### PR TITLE
DEVPROD-32850 Correctly identify task groups for single task distros

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1855,7 +1855,7 @@ func (h *Host) ClearRunningAndSetLastTask(ctx context.Context, t *task.Task) err
 	h.LastGroup = t.TaskGroup
 	h.LastBuildVariant = t.BuildVariant
 	h.LastVersion = t.Version
-	h.LastProject = t.Version
+	h.LastProject = t.Project
 	h.LastTaskCompletedTime = now
 
 	return nil

--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -482,17 +482,21 @@ func assignNextAvailableTask(ctx context.Context, env evergreen.Environment, tas
 		}
 
 		// If the current task group is finished we leave the task on the queue, and indicate the current group needs to be torn down.
-		if details.TaskGroup != "" && details.TaskGroup != nextTask.TaskGroup {
+		// isTaskGroupNewToHost only fires when the next task is itself in a task group, so the standalone-next-task case is checked explicitly.
+		if details.TaskGroup != "" && (nextTask.TaskGroup == "" || isTaskGroupNewToHost(currentHost, nextTask)) {
 			grip.Debug(ctx, message.Fields{
-				"message":              "next task is a standalone task or part of a different task group; not updating running task group task, because current task group needs to be torn down",
-				"current_task_group":   details.TaskGroup,
-				"task_distro_id":       nextTask.DistroId,
-				"task_id":              nextTask.Id,
-				"next_task_group":      nextTask.TaskGroup,
-				"task_build_variant":   nextTask.BuildVariant,
-				"task_version":         nextTask.Version,
-				"task_project":         nextTask.Project,
-				"task_group_max_hosts": nextTask.TaskGroupMaxHosts,
+				"message":               "next task is a standalone task or part of a different task group instance; not updating running task group task, because current task group needs to be torn down",
+				"current_task_group":    details.TaskGroup,
+				"current_build_variant": currentHost.LastBuildVariant,
+				"current_project":       currentHost.LastProject,
+				"current_version":       currentHost.LastVersion,
+				"task_distro_id":        nextTask.DistroId,
+				"task_id":               nextTask.Id,
+				"next_task_group":       nextTask.TaskGroup,
+				"task_build_variant":    nextTask.BuildVariant,
+				"task_version":          nextTask.Version,
+				"task_project":          nextTask.Project,
+				"task_group_max_hosts":  nextTask.TaskGroupMaxHosts,
 			})
 			return nil, true, nil
 		}

--- a/rest/route/host_agent_test.go
+++ b/rest/route/host_agent_test.go
@@ -1499,6 +1499,28 @@ func TestAssignNextAvailableTask(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, "", h.RunningTask)
 		},
+		"a host that just finished a same-named task group from a different version should teardown": func(ctx context.Context, t *testing.T, env *mock.Environment, d data) {
+			d.Host1.LastTask = "previous-task"
+			d.Host1.LastGroup = d.Tg1Task1.TaskGroup
+			d.Host1.LastBuildVariant = d.Tg1Task1.BuildVariant
+			d.Host1.LastProject = d.Tg1Task1.Project
+			d.Host1.LastVersion = "different-version"
+			details := &apimodels.GetNextTaskDetails{
+				TaskGroup: d.Tg1Task1.TaskGroup,
+			}
+			t1, shouldTeardown, err := assignNextAvailableTask(ctx, env, d.Tq1, model.NewTaskDispatchService(time.Minute), d.Host1, details)
+			require.NoError(t, err)
+			assert.Nil(t, t1)
+			assert.True(t, shouldTeardown)
+
+			tq, err := model.LoadTaskQueue(t.Context(), d.Distro1.Id)
+			require.NoError(t, err)
+			assert.Equal(t, 2, tq.Length())
+
+			h, err := host.FindOneId(ctx, d.Host1.Id)
+			require.NoError(t, err)
+			assert.Equal(t, "", h.RunningTask)
+		},
 		"a dispatched task should not be updated in the host": func(ctx context.Context, t *testing.T, env *mock.Environment, d data) {
 			require.NoError(t, task.UpdateOne(ctx, bson.M{"_id": d.Task3.Id},
 				bson.M{"$set": bson.M{"status": evergreen.TaskStarted}}))


### PR DESCRIPTION
DEVPROD-32850


### Description
next task group check was returning true when the next task had the same task group name but from a different version. so now, we check the bv, version, and project so even if the task's name is the same, it will still correctly see that they are differen tasks for the single task hosts.

### Testing
added unit test that failed without my changes but now passes