### PR TITLE
DEVPROD-32825 Add project setting to disable waterfall

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1619,6 +1619,7 @@ type ComplexityRoot struct {
 		TestSelection                      func(childComplexity int) int
 		Triggers                           func(childComplexity int) int
 		VersionControlEnabled              func(childComplexity int) int
+		WaterfallDisabled                  func(childComplexity int) int
 		WorkstationConfig                  func(childComplexity int) int
 	}
 
@@ -9679,6 +9680,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.RepoRef.VersionControlEnabled(childComplexity), true
+	case "RepoRef.waterfallDisabled":
+		if e.complexity.RepoRef.WaterfallDisabled == nil {
+			break
+		}
+
+		return e.complexity.RepoRef.WaterfallDisabled(childComplexity), true
 	case "RepoRef.workstationConfig":
 		if e.complexity.RepoRef.WorkstationConfig == nil {
 			break
@@ -29803,6 +29810,8 @@ func (ec *executionContext) fieldContext_GroupedProjects_repo(_ context.Context,
 				return ec.fieldContext_RepoRef_disabledStatsCache(ctx, field)
 			case "dispatchingDisabled":
 				return ec.fieldContext_RepoRef_dispatchingDisabled(ctx, field)
+			case "waterfallDisabled":
+				return ec.fieldContext_RepoRef_waterfallDisabled(ctx, field)
 			case "displayName":
 				return ec.fieldContext_RepoRef_displayName(ctx, field)
 			case "enabled":
@@ -55663,6 +55672,35 @@ func (ec *executionContext) fieldContext_RepoRef_dispatchingDisabled(_ context.C
 	return fc, nil
 }
 
+func (ec *executionContext) _RepoRef_waterfallDisabled(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectRef) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_RepoRef_waterfallDisabled,
+		func(ctx context.Context) (any, error) {
+			return obj.WaterfallDisabled, nil
+		},
+		nil,
+		ec.marshalNBoolean2ᚖbool,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_RepoRef_waterfallDisabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RepoRef",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _RepoRef_displayName(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectRef) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -56940,6 +56978,8 @@ func (ec *executionContext) fieldContext_RepoSettings_projectRef(_ context.Conte
 				return ec.fieldContext_RepoRef_disabledStatsCache(ctx, field)
 			case "dispatchingDisabled":
 				return ec.fieldContext_RepoRef_dispatchingDisabled(ctx, field)
+			case "waterfallDisabled":
+				return ec.fieldContext_RepoRef_waterfallDisabled(ctx, field)
 			case "displayName":
 				return ec.fieldContext_RepoRef_displayName(ctx, field)
 			case "enabled":
@@ -86907,7 +86947,7 @@ func (ec *executionContext) unmarshalInputRepoRefInput(ctx context.Context, obj 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "admins", "batchTime", "buildBaronSettings", "commitQueue", "deactivatePrevious", "disabledStatsCache", "dispatchingDisabled", "displayName", "enabled", "externalLinks", "githubChecksEnabled", "githubDynamicTokenPermissionGroups", "githubPermissionGroupByRequester", "githubPRTriggerAliases", "githubMQTriggerAliases", "gitTagAuthorizedTeams", "gitTagAuthorizedUsers", "gitTagVersionsEnabled", "manualPrTestingEnabled", "notifyOnBuildFailure", "oldestAllowedMergeBase", "owner", "parsleyFilters", "patchingDisabled", "patchTriggerAliases", "perfEnabled", "periodicBuilds", "prTestingEnabled", "remotePath", "repo", "repotrackerDisabled", "restricted", "runEveryMainlineCommit", "spawnHostScriptPath", "debugSpawnHostsDisabled", "stepbackDisabled", "stepbackBisect", "taskAnnotationSettings", "testSelection", "triggers", "versionControlEnabled", "workstationConfig"}
+	fieldsInOrder := [...]string{"id", "admins", "batchTime", "buildBaronSettings", "commitQueue", "deactivatePrevious", "disabledStatsCache", "dispatchingDisabled", "waterfallDisabled", "displayName", "enabled", "externalLinks", "githubChecksEnabled", "githubDynamicTokenPermissionGroups", "githubPermissionGroupByRequester", "githubPRTriggerAliases", "githubMQTriggerAliases", "gitTagAuthorizedTeams", "gitTagAuthorizedUsers", "gitTagVersionsEnabled", "manualPrTestingEnabled", "notifyOnBuildFailure", "oldestAllowedMergeBase", "owner", "parsleyFilters", "patchingDisabled", "patchTriggerAliases", "perfEnabled", "periodicBuilds", "prTestingEnabled", "remotePath", "repo", "repotrackerDisabled", "restricted", "runEveryMainlineCommit", "spawnHostScriptPath", "debugSpawnHostsDisabled", "stepbackDisabled", "stepbackBisect", "taskAnnotationSettings", "testSelection", "triggers", "versionControlEnabled", "workstationConfig"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -86970,6 +87010,13 @@ func (ec *executionContext) unmarshalInputRepoRefInput(ctx context.Context, obj 
 				return it, err
 			}
 			it.DispatchingDisabled = data
+		case "waterfallDisabled":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("waterfallDisabled"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.WaterfallDisabled = data
 		case "displayName":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("displayName"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
@@ -103166,6 +103213,11 @@ func (ec *executionContext) _RepoRef(ctx context.Context, sel ast.SelectionSet, 
 			}
 		case "dispatchingDisabled":
 			out.Values[i] = ec._RepoRef_dispatchingDisabled(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "waterfallDisabled":
+			out.Values[i] = ec._RepoRef_waterfallDisabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1374,6 +1374,7 @@ type ComplexityRoot struct {
 		TestSelection                      func(childComplexity int) int
 		Triggers                           func(childComplexity int) int
 		VersionControlEnabled              func(childComplexity int) int
+		WaterfallDisabled                  func(childComplexity int) int
 		WorkstationConfig                  func(childComplexity int) int
 	}
 
@@ -1466,6 +1467,7 @@ type ComplexityRoot struct {
 		StepbackBisect          func(childComplexity int) int
 		StepbackDisabled        func(childComplexity int) int
 		VersionControlEnabled   func(childComplexity int) int
+		WaterfallDisabled       func(childComplexity int) int
 	}
 
 	ProjectPermissions struct {
@@ -8365,6 +8367,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Project.VersionControlEnabled(childComplexity), true
+	case "Project.waterfallDisabled":
+		if e.complexity.Project.WaterfallDisabled == nil {
+			break
+		}
+
+		return e.complexity.Project.WaterfallDisabled(childComplexity), true
 	case "Project.workstationConfig":
 		if e.complexity.Project.WorkstationConfig == nil {
 			break
@@ -8781,6 +8789,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.ProjectLite.VersionControlEnabled(childComplexity), true
+	case "ProjectLite.waterfallDisabled":
+		if e.complexity.ProjectLite.WaterfallDisabled == nil {
+			break
+		}
+
+		return e.complexity.ProjectLite.WaterfallDisabled(childComplexity), true
 
 	case "ProjectPermissions.edit":
 		if e.complexity.ProjectPermissions.Edit == nil {
@@ -29658,6 +29672,8 @@ func (ec *executionContext) fieldContext_GroupedProjects_projects(_ context.Cont
 				return ec.fieldContext_Project_disabledStatsCache(ctx, field)
 			case "dispatchingDisabled":
 				return ec.fieldContext_Project_dispatchingDisabled(ctx, field)
+			case "waterfallDisabled":
+				return ec.fieldContext_Project_waterfallDisabled(ctx, field)
 			case "displayName":
 				return ec.fieldContext_Project_displayName(ctx, field)
 			case "enabled":
@@ -37795,6 +37811,8 @@ func (ec *executionContext) fieldContext_Mutation_attachProjectToNewRepo(ctx con
 				return ec.fieldContext_Project_disabledStatsCache(ctx, field)
 			case "dispatchingDisabled":
 				return ec.fieldContext_Project_dispatchingDisabled(ctx, field)
+			case "waterfallDisabled":
+				return ec.fieldContext_Project_waterfallDisabled(ctx, field)
 			case "displayName":
 				return ec.fieldContext_Project_displayName(ctx, field)
 			case "enabled":
@@ -37942,6 +37960,8 @@ func (ec *executionContext) fieldContext_Mutation_attachProjectToRepo(ctx contex
 				return ec.fieldContext_Project_disabledStatsCache(ctx, field)
 			case "dispatchingDisabled":
 				return ec.fieldContext_Project_dispatchingDisabled(ctx, field)
+			case "waterfallDisabled":
+				return ec.fieldContext_Project_waterfallDisabled(ctx, field)
 			case "displayName":
 				return ec.fieldContext_Project_displayName(ctx, field)
 			case "enabled":
@@ -38089,6 +38109,8 @@ func (ec *executionContext) fieldContext_Mutation_createProject(ctx context.Cont
 				return ec.fieldContext_Project_disabledStatsCache(ctx, field)
 			case "dispatchingDisabled":
 				return ec.fieldContext_Project_dispatchingDisabled(ctx, field)
+			case "waterfallDisabled":
+				return ec.fieldContext_Project_waterfallDisabled(ctx, field)
 			case "displayName":
 				return ec.fieldContext_Project_displayName(ctx, field)
 			case "enabled":
@@ -38236,6 +38258,8 @@ func (ec *executionContext) fieldContext_Mutation_copyProject(ctx context.Contex
 				return ec.fieldContext_Project_disabledStatsCache(ctx, field)
 			case "dispatchingDisabled":
 				return ec.fieldContext_Project_dispatchingDisabled(ctx, field)
+			case "waterfallDisabled":
+				return ec.fieldContext_Project_waterfallDisabled(ctx, field)
 			case "displayName":
 				return ec.fieldContext_Project_displayName(ctx, field)
 			case "enabled":
@@ -38551,6 +38575,8 @@ func (ec *executionContext) fieldContext_Mutation_detachProjectFromRepo(ctx cont
 				return ec.fieldContext_Project_disabledStatsCache(ctx, field)
 			case "dispatchingDisabled":
 				return ec.fieldContext_Project_dispatchingDisabled(ctx, field)
+			case "waterfallDisabled":
+				return ec.fieldContext_Project_waterfallDisabled(ctx, field)
 			case "displayName":
 				return ec.fieldContext_Project_displayName(ctx, field)
 			case "enabled":
@@ -41191,6 +41217,8 @@ func (ec *executionContext) fieldContext_Mutation_addFavoriteProject(ctx context
 				return ec.fieldContext_Project_disabledStatsCache(ctx, field)
 			case "dispatchingDisabled":
 				return ec.fieldContext_Project_dispatchingDisabled(ctx, field)
+			case "waterfallDisabled":
+				return ec.fieldContext_Project_waterfallDisabled(ctx, field)
 			case "displayName":
 				return ec.fieldContext_Project_displayName(ctx, field)
 			case "enabled":
@@ -41488,6 +41516,8 @@ func (ec *executionContext) fieldContext_Mutation_removeFavoriteProject(ctx cont
 				return ec.fieldContext_Project_disabledStatsCache(ctx, field)
 			case "dispatchingDisabled":
 				return ec.fieldContext_Project_dispatchingDisabled(ctx, field)
+			case "waterfallDisabled":
+				return ec.fieldContext_Project_waterfallDisabled(ctx, field)
 			case "displayName":
 				return ec.fieldContext_Project_displayName(ctx, field)
 			case "enabled":
@@ -45063,6 +45093,8 @@ func (ec *executionContext) fieldContext_Patch_projectMetadata(_ context.Context
 				return ec.fieldContext_Project_disabledStatsCache(ctx, field)
 			case "dispatchingDisabled":
 				return ec.fieldContext_Project_dispatchingDisabled(ctx, field)
+			case "waterfallDisabled":
+				return ec.fieldContext_Project_waterfallDisabled(ctx, field)
 			case "displayName":
 				return ec.fieldContext_Project_displayName(ctx, field)
 			case "enabled":
@@ -47567,6 +47599,35 @@ func (ec *executionContext) fieldContext_Project_dispatchingDisabled(_ context.C
 	return fc, nil
 }
 
+func (ec *executionContext) _Project_waterfallDisabled(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectRef) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Project_waterfallDisabled,
+		func(ctx context.Context) (any, error) {
+			return obj.WaterfallDisabled, nil
+		},
+		nil,
+		ec.marshalOBoolean2ᚖbool,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_Project_waterfallDisabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Project",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Project_displayName(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectRef) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -49715,6 +49776,8 @@ func (ec *executionContext) fieldContext_ProjectEventSettings_projectRef(_ conte
 				return ec.fieldContext_Project_disabledStatsCache(ctx, field)
 			case "dispatchingDisabled":
 				return ec.fieldContext_Project_dispatchingDisabled(ctx, field)
+			case "waterfallDisabled":
+				return ec.fieldContext_Project_waterfallDisabled(ctx, field)
 			case "displayName":
 				return ec.fieldContext_Project_displayName(ctx, field)
 			case "enabled":
@@ -50178,6 +50241,35 @@ func (ec *executionContext) _ProjectLite_dispatchingDisabled(ctx context.Context
 }
 
 func (ec *executionContext) fieldContext_ProjectLite_dispatchingDisabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ProjectLite",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _ProjectLite_waterfallDisabled(ctx context.Context, field graphql.CollectedField, obj *model1.ProjectRef) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ProjectLite_waterfallDisabled,
+		func(ctx context.Context) (any, error) {
+			return obj.WaterfallDisabled, nil
+		},
+		nil,
+		ec.marshalOBoolean2ᚖbool,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_ProjectLite_waterfallDisabled(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "ProjectLite",
 		Field:      field,
@@ -51292,6 +51384,8 @@ func (ec *executionContext) fieldContext_ProjectSettings_projectRef(_ context.Co
 				return ec.fieldContext_Project_disabledStatsCache(ctx, field)
 			case "dispatchingDisabled":
 				return ec.fieldContext_Project_dispatchingDisabled(ctx, field)
+			case "waterfallDisabled":
+				return ec.fieldContext_Project_waterfallDisabled(ctx, field)
 			case "displayName":
 				return ec.fieldContext_Project_displayName(ctx, field)
 			case "enabled":
@@ -53066,6 +53160,8 @@ func (ec *executionContext) fieldContext_Query_project(ctx context.Context, fiel
 				return ec.fieldContext_Project_disabledStatsCache(ctx, field)
 			case "dispatchingDisabled":
 				return ec.fieldContext_Project_dispatchingDisabled(ctx, field)
+			case "waterfallDisabled":
+				return ec.fieldContext_Project_waterfallDisabled(ctx, field)
 			case "displayName":
 				return ec.fieldContext_Project_displayName(ctx, field)
 			case "enabled":
@@ -65485,6 +65581,8 @@ func (ec *executionContext) fieldContext_Task_project(_ context.Context, field g
 				return ec.fieldContext_Project_disabledStatsCache(ctx, field)
 			case "dispatchingDisabled":
 				return ec.fieldContext_Project_dispatchingDisabled(ctx, field)
+			case "waterfallDisabled":
+				return ec.fieldContext_Project_waterfallDisabled(ctx, field)
 			case "displayName":
 				return ec.fieldContext_Project_displayName(ctx, field)
 			case "enabled":
@@ -75025,6 +75123,8 @@ func (ec *executionContext) fieldContext_Version_projectMetadata(_ context.Conte
 				return ec.fieldContext_Project_disabledStatsCache(ctx, field)
 			case "dispatchingDisabled":
 				return ec.fieldContext_Project_dispatchingDisabled(ctx, field)
+			case "waterfallDisabled":
+				return ec.fieldContext_Project_waterfallDisabled(ctx, field)
 			case "displayName":
 				return ec.fieldContext_Project_displayName(ctx, field)
 			case "enabled":
@@ -76086,6 +76186,8 @@ func (ec *executionContext) fieldContext_VersionLite_project(_ context.Context, 
 				return ec.fieldContext_ProjectLite_disabledStatsCache(ctx, field)
 			case "dispatchingDisabled":
 				return ec.fieldContext_ProjectLite_dispatchingDisabled(ctx, field)
+			case "waterfallDisabled":
+				return ec.fieldContext_ProjectLite_waterfallDisabled(ctx, field)
 			case "displayName":
 				return ec.fieldContext_ProjectLite_displayName(ctx, field)
 			case "enabled":
@@ -85904,7 +86006,7 @@ func (ec *executionContext) unmarshalInputProjectInput(ctx context.Context, obj 
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "admins", "banner", "batchTime", "branch", "buildBaronSettings", "commitQueue", "deactivatePrevious", "debugSpawnHostsDisabled", "disabledStatsCache", "dispatchingDisabled", "displayName", "enabled", "externalLinks", "githubChecksEnabled", "githubDynamicTokenPermissionGroups", "githubPermissionGroupByRequester", "githubPRTriggerAliases", "githubMQTriggerAliases", "gitTagAuthorizedTeams", "gitTagAuthorizedUsers", "gitTagVersionsEnabled", "identifier", "manualPrTestingEnabled", "notifyOnBuildFailure", "oldestAllowedMergeBase", "owner", "parsleyFilters", "patchingDisabled", "patchTriggerAliases", "perfEnabled", "periodicBuilds", "projectHealthView", "prTestingEnabled", "remotePath", "repo", "repotrackerDisabled", "restricted", "runEveryMainlineCommit", "spawnHostScriptPath", "stepbackDisabled", "stepbackBisect", "taskAnnotationSettings", "testSelection", "triggers", "versionControlEnabled", "workstationConfig"}
+	fieldsInOrder := [...]string{"id", "admins", "banner", "batchTime", "branch", "buildBaronSettings", "commitQueue", "deactivatePrevious", "debugSpawnHostsDisabled", "disabledStatsCache", "dispatchingDisabled", "waterfallDisabled", "displayName", "enabled", "externalLinks", "githubChecksEnabled", "githubDynamicTokenPermissionGroups", "githubPermissionGroupByRequester", "githubPRTriggerAliases", "githubMQTriggerAliases", "gitTagAuthorizedTeams", "gitTagAuthorizedUsers", "gitTagVersionsEnabled", "identifier", "manualPrTestingEnabled", "notifyOnBuildFailure", "oldestAllowedMergeBase", "owner", "parsleyFilters", "patchingDisabled", "patchTriggerAliases", "perfEnabled", "periodicBuilds", "projectHealthView", "prTestingEnabled", "remotePath", "repo", "repotrackerDisabled", "restricted", "runEveryMainlineCommit", "spawnHostScriptPath", "stepbackDisabled", "stepbackBisect", "taskAnnotationSettings", "testSelection", "triggers", "versionControlEnabled", "workstationConfig"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -85988,6 +86090,13 @@ func (ec *executionContext) unmarshalInputProjectInput(ctx context.Context, obj 
 				return it, err
 			}
 			it.DispatchingDisabled = data
+		case "waterfallDisabled":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("waterfallDisabled"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.WaterfallDisabled = data
 		case "displayName":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("displayName"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
@@ -100563,6 +100672,8 @@ func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, 
 			out.Values[i] = ec._Project_disabledStatsCache(ctx, field, obj)
 		case "dispatchingDisabled":
 			out.Values[i] = ec._Project_dispatchingDisabled(ctx, field, obj)
+		case "waterfallDisabled":
+			out.Values[i] = ec._Project_waterfallDisabled(ctx, field, obj)
 		case "displayName":
 			out.Values[i] = ec._Project_displayName(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -101166,6 +101277,8 @@ func (ec *executionContext) _ProjectLite(ctx context.Context, sel ast.SelectionS
 			out.Values[i] = ec._ProjectLite_disabledStatsCache(ctx, field, obj)
 		case "dispatchingDisabled":
 			out.Values[i] = ec._ProjectLite_dispatchingDisabled(ctx, field, obj)
+		case "waterfallDisabled":
+			out.Values[i] = ec._ProjectLite_waterfallDisabled(ctx, field, obj)
 		case "displayName":
 			out.Values[i] = ec._ProjectLite_displayName(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/graphql/schema/types/project.graphql
+++ b/graphql/schema/types/project.graphql
@@ -251,6 +251,7 @@ type Project {
   debugSpawnHostsDisabled: Boolean
   disabledStatsCache: Boolean
   dispatchingDisabled: Boolean
+  waterfallDisabled: Boolean
   displayName: String!
   enabled: Boolean
   externalLinks: [ExternalLink!]
@@ -356,6 +357,7 @@ type ProjectLite {
   debugSpawnHostsDisabled: Boolean
   disabledStatsCache: Boolean
   dispatchingDisabled: Boolean
+  waterfallDisabled: Boolean
   displayName: String!
   enabled: Boolean
   githubChecksEnabled: Boolean

--- a/graphql/schema/types/project_settings.graphql
+++ b/graphql/schema/types/project_settings.graphql
@@ -49,6 +49,7 @@ input ProjectInput {
   debugSpawnHostsDisabled: Boolean
   disabledStatsCache: Boolean
   dispatchingDisabled: Boolean
+  waterfallDisabled: Boolean
   displayName: String
   enabled: Boolean
   externalLinks: [ExternalLinkInput!]

--- a/graphql/schema/types/repo_ref.graphql
+++ b/graphql/schema/types/repo_ref.graphql
@@ -8,6 +8,7 @@ input RepoRefInput {
   deactivatePrevious: Boolean
   disabledStatsCache: Boolean
   dispatchingDisabled: Boolean
+  waterfallDisabled: Boolean
   displayName: String
   enabled: Boolean
   externalLinks: [ExternalLinkInput!]
@@ -60,6 +61,7 @@ type RepoRef {
   deactivatePrevious: Boolean!
   disabledStatsCache: Boolean!
   dispatchingDisabled: Boolean!
+  waterfallDisabled: Boolean!
   displayName: String!
   enabled: Boolean!
   githubChecksEnabled: Boolean!

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -564,8 +564,8 @@ func (p *ProjectRef) IsDispatchingDisabled() bool {
 	return utility.FromBoolPtr(p.DispatchingDisabled)
 }
 
-func (p *ProjectRef) IsWaterfallDisabled() bool {
-	return utility.FromBoolPtr(p.WaterfallDisabled)
+func (p *ProjectRef) IsWaterfallEnabled() bool {
+	return !utility.FromBoolPtr(p.WaterfallDisabled)
 }
 
 func (p *ProjectRef) IsPRTestingEnabled() bool {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -57,6 +57,7 @@ type ProjectRef struct {
 	PatchingDisabled       *bool               `bson:"patching_disabled,omitempty" json:"patching_disabled,omitempty"`
 	RepotrackerDisabled    *bool               `bson:"repotracker_disabled,omitempty" json:"repotracker_disabled,omitempty" yaml:"repotracker_disabled"`
 	DispatchingDisabled    *bool               `bson:"dispatching_disabled,omitempty" json:"dispatching_disabled,omitempty" yaml:"dispatching_disabled"`
+	WaterfallDisabled      *bool               `bson:"waterfall_disabled,omitempty" json:"waterfall_disabled,omitempty" yaml:"waterfall_disabled"`
 	StepbackDisabled       *bool               `bson:"stepback_disabled,omitempty" json:"stepback_disabled,omitempty" yaml:"stepback_disabled"`
 	StepbackBisect         *bool               `bson:"stepback_bisect,omitempty" json:"stepback_bisect,omitempty" yaml:"stepback_bisect"`
 	VersionControlEnabled  *bool               `bson:"version_control_enabled,omitempty" json:"version_control_enabled,omitempty" yaml:"version_control_enabled"`
@@ -515,6 +516,7 @@ var (
 	projectRefCommitQueueKey                        = bsonutil.MustHaveTag(ProjectRef{}, "CommitQueue")
 	projectRefPatchingDisabledKey                   = bsonutil.MustHaveTag(ProjectRef{}, "PatchingDisabled")
 	projectRefDispatchingDisabledKey                = bsonutil.MustHaveTag(ProjectRef{}, "DispatchingDisabled")
+	projectRefWaterfallDisabledKey                  = bsonutil.MustHaveTag(ProjectRef{}, "WaterfallDisabled")
 	projectRefStepbackDisabledKey                   = bsonutil.MustHaveTag(ProjectRef{}, "StepbackDisabled")
 	projectRefStepbackBisectKey                     = bsonutil.MustHaveTag(ProjectRef{}, "StepbackBisect")
 	projectRefVersionControlEnabledKey              = bsonutil.MustHaveTag(ProjectRef{}, "VersionControlEnabled")
@@ -560,6 +562,10 @@ func (p *ProjectRef) IsRepotrackerDisabled() bool {
 
 func (p *ProjectRef) IsDispatchingDisabled() bool {
 	return utility.FromBoolPtr(p.DispatchingDisabled)
+}
+
+func (p *ProjectRef) IsWaterfallDisabled() bool {
+	return utility.FromBoolPtr(p.WaterfallDisabled)
 }
 
 func (p *ProjectRef) IsPRTestingEnabled() bool {
@@ -2246,6 +2252,7 @@ func SaveProjectPageForSection(ctx context.Context, projectId string, p *Project
 			ProjectRefRemotePathKey:              p.RemotePath,
 			projectRefSpawnHostScriptPathKey:     p.SpawnHostScriptPath,
 			projectRefDispatchingDisabledKey:     p.DispatchingDisabled,
+			projectRefWaterfallDisabledKey:       p.WaterfallDisabled,
 			projectRefStepbackDisabledKey:        p.StepbackDisabled,
 			projectRefStepbackBisectKey:          p.StepbackBisect,
 			projectRefVersionControlEnabledKey:   p.VersionControlEnabled,

--- a/model/version_activation.go
+++ b/model/version_activation.go
@@ -17,7 +17,7 @@ const (
 )
 
 func DoProjectActivation(ctx context.Context, projectRef *ProjectRef, ts time.Time) ([]string, error) {
-	if projectRef.IsWaterfallDisabled() {
+	if !projectRef.IsWaterfallEnabled() {
 		return nil, nil
 	}
 	if projectRef.RunEveryMainlineCommit {

--- a/model/version_activation.go
+++ b/model/version_activation.go
@@ -17,6 +17,9 @@ const (
 )
 
 func DoProjectActivation(ctx context.Context, projectRef *ProjectRef, ts time.Time) ([]string, error) {
+	if projectRef.IsWaterfallDisabled() {
+		return nil, nil
+	}
 	if projectRef.RunEveryMainlineCommit {
 		return activateEveryRecentMainlineCommitForProject(ctx, projectRef, ts)
 	}

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -554,6 +554,8 @@ type APIProjectRef struct {
 	RepotrackerError *APIRepositoryErrorDetails `json:"repotracker_error"`
 	// Disable task dispatching.
 	DispatchingDisabled *bool `json:"dispatching_disabled"`
+	// Disable automatic task activation on the waterfall.
+	WaterfallDisabled *bool `json:"waterfall_disabled"`
 	// Disable stepback.
 	StepbackDisabled *bool `json:"stepback_disabled"`
 	// Enable debug spawn host functionality.
@@ -649,6 +651,7 @@ func (p *APIProjectRef) ToService() (*model.ProjectRef, error) {
 		PatchingDisabled:                 utility.BoolPtrCopy(p.PatchingDisabled),
 		RepotrackerDisabled:              utility.BoolPtrCopy(p.RepotrackerDisabled),
 		DispatchingDisabled:              utility.BoolPtrCopy(p.DispatchingDisabled),
+		WaterfallDisabled:                utility.BoolPtrCopy(p.WaterfallDisabled),
 		StepbackDisabled:                 utility.BoolPtrCopy(p.StepbackDisabled),
 		StepbackBisect:                   utility.BoolPtrCopy(p.StepbackBisect),
 		VersionControlEnabled:            utility.BoolPtrCopy(p.VersionControlEnabled),
@@ -757,6 +760,7 @@ func (p *APIProjectRef) BuildPublicFields(ctx context.Context, projectRef model.
 	p.PatchingDisabled = utility.BoolPtrCopy(projectRef.PatchingDisabled)
 	p.RepotrackerDisabled = utility.BoolPtrCopy(projectRef.RepotrackerDisabled)
 	p.DispatchingDisabled = utility.BoolPtrCopy(projectRef.DispatchingDisabled)
+	p.WaterfallDisabled = utility.BoolPtrCopy(projectRef.WaterfallDisabled)
 	p.StepbackDisabled = utility.BoolPtrCopy(projectRef.StepbackDisabled)
 	p.StepbackBisect = utility.BoolPtrCopy(projectRef.StepbackBisect)
 	p.VersionControlEnabled = utility.BoolPtrCopy(projectRef.VersionControlEnabled)

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -1490,7 +1490,7 @@ func (gh *githubHookApi) createVersionForTag(ctx context.Context, pRef model.Pro
 		Revision:   revision,
 		GitTag:     tag,
 		RemotePath: remotePath,
-		Activate:   !pRef.IsWaterfallDisabled(),
+		Activate:   pRef.IsWaterfallEnabled(),
 	}
 	var projectInfo model.ProjectInfo
 	if remotePath != "" {

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -1490,7 +1490,7 @@ func (gh *githubHookApi) createVersionForTag(ctx context.Context, pRef model.Pro
 		Revision:   revision,
 		GitTag:     tag,
 		RemotePath: remotePath,
-		Activate:   true,
+		Activate:   !pRef.IsWaterfallDisabled(),
 	}
 	var projectInfo model.ProjectInfo
 	if remotePath != "" {

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -108,7 +108,7 @@ func (j *periodicBuildJob) Run(ctx context.Context) {
 
 	metadata := model.VersionMetadata{
 		IsAdHoc:         true,
-		Activate:        !j.project.IsWaterfallDisabled(),
+		Activate:        j.project.IsWaterfallEnabled(),
 		Message:         definition.Message,
 		PeriodicBuildID: definition.ID,
 		Alias:           definition.Alias,

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -108,7 +108,7 @@ func (j *periodicBuildJob) Run(ctx context.Context) {
 
 	metadata := model.VersionMetadata{
 		IsAdHoc:         true,
-		Activate:        true,
+		Activate:        !j.project.IsWaterfallDisabled(),
 		Message:         definition.Message,
 		PeriodicBuildID: definition.ID,
 		Alias:           definition.Alias,


### PR DESCRIPTION
DEVPROD-32825

### Description
Adds a new waterfallDisabled project setting that prevents automatic task activation on the waterfall while still allowing the repotracker to create versions and tasks. Commits will still appear on the waterfall but will be unscheduled, but can be manually scheduled.
### Testing
Existing tests and verified in sandbox staging.

### Documentation
Will add docs once UI side PR is approved