### PR TITLE
DEVPROD-33572: Allowing display task's tests to be quarantined 

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"57bd248d-dc0d-404a-adfa-176364c10c4d","pid":13029,"acquiredAt":1779810483699}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"57bd248d-dc0d-404a-adfa-176364c10c4d","pid":13029,"acquiredAt":1779810483699}

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -858,12 +858,10 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 
 	addSingleHostTaskGroupDependencies(taskMap, creationInfo.Project, execTable)
 
-	// Determine which newly-created tasks should use test selection.
-	// Note that this will only consider test selection for newly-created tasks,
-	// not existing tasks. If a task already existed and is now being regrouped
-	// under a new display task, its test selection state will not be
-	// re-evaluated to avoid changing the behavior of the task.
-	if err := setTestSelectionEnabledForTasks(taskMap, displayTaskIDsToNames, creationInfo); err != nil {
+	// Set test-selection state on newly-created execution tasks and propagate
+	// to display tasks. tasks contains only display tasks here; execution
+	// tasks are appended below. Pre-existing tasks are not re-evaluated.
+	if err := setTestSelectionEnabledForTasks(taskMap, tasks, displayTaskIDsToNames, creationInfo); err != nil {
 		return nil, errors.Wrap(err, "setting test selection enabled for newly-created tasks")
 	}
 
@@ -1134,14 +1132,26 @@ func createOneTask(ctx context.Context, id string, creationInfo TaskCreationInfo
 }
 
 // setTestSelectionEnabledForTasks sets the test selection enabled state for
-// the given tasks.
-func setTestSelectionEnabledForTasks(tasks map[string]*task.Task, displayTaskIDsToNames map[string]string, creationInfo TaskCreationInfo) error {
-	for _, t := range tasks {
+// the given execution tasks, and propagates the result to each display task:
+// a display task is considered enabled if any of its execution tasks are.
+// Only newly-created execution tasks (those present in execTasks) contribute
+// to the display task's state; pre-existing execution tasks are not
+// re-evaluated, matching the policy applied to execution tasks themselves.
+func setTestSelectionEnabledForTasks(execTasks map[string]*task.Task, displayTasks []*task.Task, displayTaskIDsToNames map[string]string, creationInfo TaskCreationInfo) error {
+	for _, t := range execTasks {
 		enabled, err := isTestSelectionEnabledForTask(t, displayTaskIDsToNames, creationInfo)
 		if err != nil {
 			return errors.Wrapf(err, "checking if test selection is enabled for task '%s'", t.Id)
 		}
 		t.TestSelectionEnabled = enabled
+	}
+	for _, dt := range displayTasks {
+		for _, execTaskID := range dt.ExecutionTasks {
+			if execTask, ok := execTasks[execTaskID]; ok && execTask.TestSelectionEnabled {
+				dt.TestSelectionEnabled = true
+				break
+			}
+		}
 	}
 	return nil
 }

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -3377,3 +3377,51 @@ func TestIsTestSelectionEnabledForTask(t *testing.T) {
 		})
 	}
 }
+
+func TestSetTestSelectionEnabledForTasks(t *testing.T) {
+	creationInfo := TaskCreationInfo{
+		TestSelectionParams: TestSelectionParams{
+			CanBuildVariantEnableTestSelection: true,
+		},
+	}
+	displayTaskIDsToNames := map[string]string{"dt_id": "dt"}
+
+	t.Run("DisplayTaskEnabledWhenAnyExecutionTaskEnabled", func(t *testing.T) {
+		execTasks := map[string]*task.Task{
+			"exec1": {Id: "exec1", DisplayName: "exec1"},
+			"exec2": {Id: "exec2", DisplayName: "exec2"},
+		}
+		dt := &task.Task{Id: "dt_id", DisplayName: "dt", DisplayOnly: true, ExecutionTasks: []string{"exec1", "exec2"}}
+		ci := creationInfo
+		ci.TestSelectionParams.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("exec1")}
+
+		require.NoError(t, setTestSelectionEnabledForTasks(execTasks, []*task.Task{dt}, displayTaskIDsToNames, ci))
+		assert.True(t, execTasks["exec1"].TestSelectionEnabled)
+		assert.False(t, execTasks["exec2"].TestSelectionEnabled)
+		assert.True(t, dt.TestSelectionEnabled, "display task should be enabled when any execution task is")
+	})
+
+	t.Run("DisplayTaskDisabledWhenAllExecutionTasksDisabled", func(t *testing.T) {
+		execTasks := map[string]*task.Task{
+			"exec1": {Id: "exec1", DisplayName: "exec1"},
+			"exec2": {Id: "exec2", DisplayName: "exec2"},
+		}
+		dt := &task.Task{Id: "dt_id", DisplayName: "dt", DisplayOnly: true, ExecutionTasks: []string{"exec1", "exec2"}}
+		ci := creationInfo
+		ci.TestSelectionParams.IncludeTasks = []*regexp.Regexp{regexp.MustCompile("no_match")}
+
+		require.NoError(t, setTestSelectionEnabledForTasks(execTasks, []*task.Task{dt}, displayTaskIDsToNames, ci))
+		assert.False(t, dt.TestSelectionEnabled)
+	})
+
+	t.Run("DisplayTaskIgnoresExecutionTasksNotInMap", func(t *testing.T) {
+		// A display task's ExecutionTasks may reference pre-existing exec tasks
+		// not present in execTasks; the helper should leave the display task
+		// disabled rather than treating missing entries as enabled.
+		execTasks := map[string]*task.Task{}
+		dt := &task.Task{Id: "dt_id", DisplayName: "dt", DisplayOnly: true, ExecutionTasks: []string{"missing_exec"}}
+
+		require.NoError(t, setTestSelectionEnabledForTasks(execTasks, []*task.Task{dt}, displayTaskIDsToNames, creationInfo))
+		assert.False(t, dt.TestSelectionEnabled)
+	})
+}

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -932,7 +932,9 @@ func TestAddNewPatch(t *testing.T) {
 	assert.Equal("task1", dbTasks[1].DisplayName)
 	assert.Equal("task2", dbTasks[2].DisplayName)
 	assert.Equal("task3", dbTasks[3].DisplayName)
-	assert.False(dbTasks[0].TestSelectionEnabled)
+	// displaytask1 contains task1 and task2 (both TSS-enabled), so the
+	// display task is also considered enabled.
+	assert.True(dbTasks[0].TestSelectionEnabled)
 	assert.True(dbTasks[1].TestSelectionEnabled)
 	assert.True(dbTasks[2].TestSelectionEnabled)
 	assert.False(dbTasks[3].TestSelectionEnabled)

--- a/rest/data/select.go
+++ b/rest/data/select.go
@@ -11,6 +11,8 @@ import (
 	"github.com/evergreen-ci/evergreen/rest/model"
 	testselection "github.com/evergreen-ci/test-selection-client"
 	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -130,14 +132,19 @@ func GetTestsQuarantineStatus(ctx context.Context, projectID, bvName, taskName s
 }
 
 // DecorateQuarantineStatus populates IsManuallyQuarantined on each test result
-// in place. No-ops when test selection is disabled. Display tasks fan out to
-// their execution tasks because TSS keys quarantine state by execution task name.
+// in place. No-ops when test selection is disabled. Display tasks always fan
+// out to their execution tasks; the display task's TestSelectionEnabled flag
+// is treated as a hint because it can be stale relative to its execution
+// tasks, so the fan-out re-checks each execution task's state directly.
 func DecorateQuarantineStatus(ctx context.Context, t *task.Task, results []testresult.TestResult) error {
-	if !t.TestSelectionEnabled || len(results) == 0 {
+	if len(results) == 0 {
 		return nil
 	}
 	if t.DisplayOnly {
 		return decorateDisplayTaskQuarantineStatus(ctx, results)
+	}
+	if !t.TestSelectionEnabled {
+		return nil
 	}
 	testNames := make([]string, 0, len(results))
 	for _, r := range results {
@@ -176,6 +183,20 @@ func decorateDisplayTaskQuarantineStatus(ctx context.Context, results []testresu
 	if err != nil {
 		return errors.Wrap(err, "fetching execution tasks")
 	}
+	foundExecTaskIDs := make(map[string]bool, len(execTasks))
+	for _, execTask := range execTasks {
+		foundExecTaskIDs[execTask.Id] = true
+	}
+	var missingExecTaskIDs []string
+	for _, id := range execTaskIDs {
+		if !foundExecTaskIDs[id] {
+			missingExecTaskIDs = append(missingExecTaskIDs, id)
+		}
+	}
+	grip.WarningWhen(ctx, len(missingExecTaskIDs) > 0, message.Fields{
+		"message":               "execution tasks not found when decorating display task quarantine status; their test results will be left undecorated",
+		"missing_exec_task_ids": missingExecTaskIDs,
+	})
 	for _, execTask := range execTasks {
 		if !execTask.TestSelectionEnabled {
 			continue

--- a/rest/data/select.go
+++ b/rest/data/select.go
@@ -141,7 +141,7 @@ func DecorateQuarantineStatus(ctx context.Context, t *task.Task, results []testr
 		return nil
 	}
 	if t.DisplayOnly {
-		return decorateDisplayTaskQuarantineStatus(ctx, results)
+		return decorateDisplayTaskQuarantineStatus(ctx, t.Id, results)
 	}
 	if !t.TestSelectionEnabled {
 		return nil
@@ -164,7 +164,7 @@ func DecorateQuarantineStatus(ctx context.Context, t *task.Task, results []testr
 // and fetches quarantine status once per execution task. Execution tasks
 // without test selection enabled, and tests whose execution task can't be
 // loaded, are left with the default IsManuallyQuarantined value.
-func decorateDisplayTaskQuarantineStatus(ctx context.Context, results []testresult.TestResult) error {
+func decorateDisplayTaskQuarantineStatus(ctx context.Context, displayTaskID string, results []testresult.TestResult) error {
 	resultIndicesByExecTaskID := map[string][]int{}
 	for i, r := range results {
 		if r.TaskID == "" {
@@ -195,8 +195,12 @@ func decorateDisplayTaskQuarantineStatus(ctx context.Context, results []testresu
 	}
 	grip.WarningWhen(ctx, len(missingExecTaskIDs) > 0, message.Fields{
 		"message":               "execution tasks not found when decorating display task quarantine status; their test results will be left undecorated",
+		"display_task_id":       displayTaskID,
 		"missing_exec_task_ids": missingExecTaskIDs,
 	})
+	// TODO: issue these GetTestsQuarantineStatus calls concurrently with a
+	// bounded semaphore to reduce latency on display tasks with many execution
+	// tasks.
 	for _, execTask := range execTasks {
 		if !execTask.TestSelectionEnabled {
 			continue

--- a/rest/data/select.go
+++ b/rest/data/select.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/evergreen/rest/model"
@@ -129,11 +130,14 @@ func GetTestsQuarantineStatus(ctx context.Context, projectID, bvName, taskName s
 }
 
 // DecorateQuarantineStatus populates IsManuallyQuarantined on each test result
-// in place. No-ops on display tasks and on tasks without test selection
-// enabled.
+// in place. No-ops when test selection is disabled. Display tasks fan out to
+// their execution tasks because TSS keys quarantine state by execution task name.
 func DecorateQuarantineStatus(ctx context.Context, t *task.Task, results []testresult.TestResult) error {
-	if !t.TestSelectionEnabled || t.DisplayOnly || len(results) == 0 {
+	if !t.TestSelectionEnabled || len(results) == 0 {
 		return nil
+	}
+	if t.DisplayOnly {
+		return decorateDisplayTaskQuarantineStatus(ctx, results)
 	}
 	testNames := make([]string, 0, len(results))
 	for _, r := range results {
@@ -145,6 +149,49 @@ func DecorateQuarantineStatus(ctx context.Context, t *task.Task, results []testr
 	}
 	for i := range results {
 		results[i].IsManuallyQuarantined = statuses[results[i].GetDisplayTestName()]
+	}
+	return nil
+}
+
+// decorateDisplayTaskQuarantineStatus groups results by their execution task ID
+// and fetches quarantine status once per execution task. Execution tasks
+// without test selection enabled, and tests whose execution task can't be
+// loaded, are left with the default IsManuallyQuarantined value.
+func decorateDisplayTaskQuarantineStatus(ctx context.Context, results []testresult.TestResult) error {
+	resultIndicesByExecTaskID := map[string][]int{}
+	for i, r := range results {
+		if r.TaskID == "" {
+			continue
+		}
+		resultIndicesByExecTaskID[r.TaskID] = append(resultIndicesByExecTaskID[r.TaskID], i)
+	}
+	if len(resultIndicesByExecTaskID) == 0 {
+		return nil
+	}
+	execTaskIDs := make([]string, 0, len(resultIndicesByExecTaskID))
+	for id := range resultIndicesByExecTaskID {
+		execTaskIDs = append(execTaskIDs, id)
+	}
+	execTasks, err := task.FindAll(ctx, db.Query(task.ByIds(execTaskIDs)))
+	if err != nil {
+		return errors.Wrap(err, "fetching execution tasks")
+	}
+	for _, execTask := range execTasks {
+		if !execTask.TestSelectionEnabled {
+			continue
+		}
+		indices := resultIndicesByExecTaskID[execTask.Id]
+		testNames := make([]string, 0, len(indices))
+		for _, i := range indices {
+			testNames = append(testNames, results[i].GetDisplayTestName())
+		}
+		statuses, err := GetTestsQuarantineStatus(ctx, execTask.Project, execTask.BuildVariant, execTask.DisplayName, testNames)
+		if err != nil {
+			return errors.Wrapf(err, "fetching test quarantine statuses for execution task '%s'", execTask.Id)
+		}
+		for _, i := range indices {
+			results[i].IsManuallyQuarantined = statuses[results[i].GetDisplayTestName()]
+		}
 	}
 	return nil
 }

--- a/rest/data/select_test.go
+++ b/rest/data/select_test.go
@@ -4,9 +4,13 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -130,5 +134,182 @@ func TestGetTestsQuarantineStatus(t *testing.T) {
 		_, err := GetTestsQuarantineStatus(t.Context(), projectID, bvName, taskName, []string{"test_a"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "forwarding request to test selection service")
+	})
+}
+
+func TestDecorateQuarantineStatus(t *testing.T) {
+	setTSSURL := func(t *testing.T, url string) {
+		original := evergreen.GetEnvironment().Settings().TestSelection.URL
+		evergreen.GetEnvironment().Settings().TestSelection.URL = url
+		t.Cleanup(func() {
+			evergreen.GetEnvironment().Settings().TestSelection.URL = original
+		})
+	}
+
+	// statusServer returns a TSS server that resolves quarantine state from a
+	// per-task-name map. Path segment matching keeps each execution task's
+	// response isolated.
+	statusServer := func(t *testing.T, statesByTaskName map[string]map[string]string) *httptest.Server {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			var taskName string
+			for name := range statesByTaskName {
+				if strings.Contains(r.URL.Path, "/"+name+"/") {
+					taskName = name
+					break
+				}
+			}
+			body := map[string]map[string]any{}
+			for testName, state := range statesByTaskName[taskName] {
+				body[testName] = map[string]any{"state": state}
+			}
+			require.NoError(t, json.NewEncoder(w).Encode(body))
+		}))
+		t.Cleanup(srv.Close)
+		return srv
+	}
+
+	t.Run("NoOpWhenTestSelectionDisabled", func(t *testing.T) {
+		parent := &task.Task{
+			Id:                   "exec_task",
+			Project:              "p",
+			BuildVariant:         "bv",
+			DisplayName:          "exec_task",
+			TestSelectionEnabled: false,
+		}
+		results := []testresult.TestResult{{TaskID: "exec_task", TestName: "TestFoo"}}
+		require.NoError(t, DecorateQuarantineStatus(t.Context(), parent, results))
+		assert.False(t, results[0].IsManuallyQuarantined)
+	})
+
+	t.Run("NoOpWhenResultsEmpty", func(t *testing.T) {
+		parent := &task.Task{
+			Id:                   "exec_task",
+			TestSelectionEnabled: true,
+		}
+		require.NoError(t, DecorateQuarantineStatus(t.Context(), parent, nil))
+	})
+
+	t.Run("ExecutionTaskUsesParentTaskFields", func(t *testing.T) {
+		srv := statusServer(t, map[string]map[string]string{
+			"exec_task": {"TestFoo": "manually_quarantined", "TestBar": "stable"},
+		})
+		setTSSURL(t, srv.URL)
+
+		parent := &task.Task{
+			Id:                   "exec_task",
+			Project:              "p",
+			BuildVariant:         "bv",
+			DisplayName:          "exec_task",
+			TestSelectionEnabled: true,
+		}
+		results := []testresult.TestResult{
+			{TaskID: "exec_task", TestName: "TestFoo"},
+			{TaskID: "exec_task", TestName: "TestBar"},
+		}
+		require.NoError(t, DecorateQuarantineStatus(t.Context(), parent, results))
+		assert.True(t, results[0].IsManuallyQuarantined)
+		assert.False(t, results[1].IsManuallyQuarantined)
+	})
+
+	t.Run("DisplayTaskFansOutAcrossExecutionTasks", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(task.Collection))
+		require.NoError(t, (&task.Task{
+			Id:                   "exec_a",
+			Project:              "p",
+			BuildVariant:         "bv",
+			DisplayName:          "task_a",
+			TestSelectionEnabled: true,
+		}).Insert(t.Context()))
+		require.NoError(t, (&task.Task{
+			Id:                   "exec_b",
+			Project:              "p",
+			BuildVariant:         "bv",
+			DisplayName:          "task_b",
+			TestSelectionEnabled: true,
+		}).Insert(t.Context()))
+
+		srv := statusServer(t, map[string]map[string]string{
+			"task_a": {"TestA1": "manually_quarantined"},
+			"task_b": {"TestB1": "stable", "TestB2": "manually_quarantined"},
+		})
+		setTSSURL(t, srv.URL)
+
+		display := &task.Task{
+			Id:                   "display_task",
+			Project:              "p",
+			BuildVariant:         "bv",
+			DisplayName:          "display_task",
+			DisplayOnly:          true,
+			ExecutionTasks:       []string{"exec_a", "exec_b"},
+			TestSelectionEnabled: true,
+		}
+		results := []testresult.TestResult{
+			{TaskID: "exec_a", TestName: "TestA1"},
+			{TaskID: "exec_b", TestName: "TestB1"},
+			{TaskID: "exec_b", TestName: "TestB2"},
+		}
+		require.NoError(t, DecorateQuarantineStatus(t.Context(), display, results))
+		assert.True(t, results[0].IsManuallyQuarantined, "TestA1 should be quarantined")
+		assert.False(t, results[1].IsManuallyQuarantined, "TestB1 should not be quarantined")
+		assert.True(t, results[2].IsManuallyQuarantined, "TestB2 should be quarantined")
+	})
+
+	t.Run("DisplayTaskSkipsExecutionTaskWithoutTestSelection", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(task.Collection))
+		require.NoError(t, (&task.Task{
+			Id:                   "exec_enabled",
+			Project:              "p",
+			BuildVariant:         "bv",
+			DisplayName:          "enabled",
+			TestSelectionEnabled: true,
+		}).Insert(t.Context()))
+		require.NoError(t, (&task.Task{
+			Id:                   "exec_disabled",
+			Project:              "p",
+			BuildVariant:         "bv",
+			DisplayName:          "disabled",
+			TestSelectionEnabled: false,
+		}).Insert(t.Context()))
+
+		srv := statusServer(t, map[string]map[string]string{
+			"enabled":  {"TestEnabled": "manually_quarantined"},
+			"disabled": {"TestDisabled": "manually_quarantined"},
+		})
+		setTSSURL(t, srv.URL)
+
+		display := &task.Task{
+			Id:                   "display_task",
+			DisplayOnly:          true,
+			ExecutionTasks:       []string{"exec_enabled", "exec_disabled"},
+			TestSelectionEnabled: true,
+		}
+		results := []testresult.TestResult{
+			{TaskID: "exec_enabled", TestName: "TestEnabled"},
+			{TaskID: "exec_disabled", TestName: "TestDisabled"},
+		}
+		require.NoError(t, DecorateQuarantineStatus(t.Context(), display, results))
+		assert.True(t, results[0].IsManuallyQuarantined)
+		assert.False(t, results[1].IsManuallyQuarantined, "TSS should not be queried for execution tasks without test selection enabled")
+	})
+
+	t.Run("DisplayTaskWithMissingExecutionTaskDoesNotError", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(task.Collection))
+		// No execution tasks inserted.
+
+		srv := statusServer(t, map[string]map[string]string{})
+		setTSSURL(t, srv.URL)
+
+		display := &task.Task{
+			Id:                   "display_task",
+			DisplayOnly:          true,
+			ExecutionTasks:       []string{"missing_exec"},
+			TestSelectionEnabled: true,
+		}
+		results := []testresult.TestResult{
+			{TaskID: "missing_exec", TestName: "TestOrphan"},
+		}
+		require.NoError(t, DecorateQuarantineStatus(t.Context(), display, results))
+		assert.False(t, results[0].IsManuallyQuarantined)
 	})
 }

--- a/rest/data/select_test.go
+++ b/rest/data/select_test.go
@@ -312,4 +312,37 @@ func TestDecorateQuarantineStatus(t *testing.T) {
 		require.NoError(t, DecorateQuarantineStatus(t.Context(), display, results))
 		assert.False(t, results[0].IsManuallyQuarantined)
 	})
+
+	t.Run("DisplayTaskFansOutEvenWhenDisplayTaskTestSelectionDisabled", func(t *testing.T) {
+		// Covers the case where the display task's TestSelectionEnabled flag is
+		// stale (e.g. a new display task was created over a mix of new and
+		// pre-existing execution tasks, and only the pre-existing one had TSS
+		// enabled). The fan-out should still decorate based on each execution
+		// task's actual state.
+		require.NoError(t, db.ClearCollections(task.Collection))
+		require.NoError(t, (&task.Task{
+			Id:                   "exec_enabled",
+			Project:              "p",
+			BuildVariant:         "bv",
+			DisplayName:          "enabled",
+			TestSelectionEnabled: true,
+		}).Insert(t.Context()))
+
+		srv := statusServer(t, map[string]map[string]string{
+			"enabled": {"TestEnabled": "manually_quarantined"},
+		})
+		setTSSURL(t, srv.URL)
+
+		display := &task.Task{
+			Id:                   "display_task",
+			DisplayOnly:          true,
+			ExecutionTasks:       []string{"exec_enabled"},
+			TestSelectionEnabled: false,
+		}
+		results := []testresult.TestResult{
+			{TaskID: "exec_enabled", TestName: "TestEnabled"},
+		}
+		require.NoError(t, DecorateQuarantineStatus(t.Context(), display, results))
+		assert.True(t, results[0].IsManuallyQuarantined)
+	})
 }


### PR DESCRIPTION
DEVPROD-33572

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Works with [FE PR ](https://github.com/evergreen-ci/ui/pull/1669) to make display task's test quarantineable. 
`DecorateQuarantineStatus` now fans out per execution task for display tasks, and `setTestSelectionEnabledForTasks` propagates TSS-enabled state from execution tasks to their parent display task so the new path is actually reachable.

### Testing
* Added tests validating behavor
* Tested locally

### Screenshot
https://github.com/user-attachments/assets/4cce0491-abd2-41f2-8406-a843dc9a2356


### UI PR
https://github.com/evergreen-ci/ui/pull/1669