### PR TITLE
DEVPROD-31179 Improve middleware to avoid project_id query param override

### DIFF
--- a/rest/data/middleware.go
+++ b/rest/data/middleware.go
@@ -174,8 +174,24 @@ func BuildProjectParameterMapForGraphQL(args map[string]any) (map[string]string,
 // BuildProjectParameterMapForLegacy builds the parameters map that can be used as an input to GetProjectIdFromParams.
 // It is used by the legacy middleware.
 func BuildProjectParameterMapForLegacy(query url.Values, vars map[string]string) map[string]string {
+	// Derive the project from whatever object is in the path.
+	hasObjectIDInPath := util.CoalesceString(
+		vars["task_id"], vars[taskIdKey],
+		vars["build_id"], vars[buildIdKey],
+		vars["version_id"], vars[versionIdKey],
+		vars["patch_id"], vars[patchIdKey],
+		vars["log_id"],
+	) != ""
+
+	var projectIDValue string
+	if hasObjectIDInPath {
+		projectIDValue = util.CoalesceString(vars["project_id"], vars[projectIdKey])
+	} else {
+		projectIDValue = util.CoalesceStrings(append(query["project_id"], query[projectIdKey]...), vars["project_id"], vars[projectIdKey])
+	}
+
 	paramsMap := map[string]string{
-		projectIdKey: util.CoalesceStrings(append(query["project_id"], query[projectIdKey]...), vars["project_id"], vars[projectIdKey]),
+		projectIdKey: projectIDValue,
 		repoIdKey:    util.CoalesceStrings(append(query["repo_id"], query[repoIdKey]...), vars["repo_id"], vars[repoIdKey]),
 		versionIdKey: util.CoalesceStrings(append(query["version_id"], query[versionIdKey]...), vars["version_id"], vars[versionIdKey]),
 		patchIdKey:   util.CoalesceStrings(append(query["patch_id"], query[patchIdKey]...), vars["patch_id"], vars[patchIdKey]),

--- a/rest/data/middleware_test.go
+++ b/rest/data/middleware_test.go
@@ -3,6 +3,7 @@ package data
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen/db"
@@ -151,4 +152,46 @@ func TestGetProjectIdFromParams(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, http.StatusNotFound, statusCode)
 	require.Equal(t, "", projectId)
+}
+
+func TestBuildProjectParameterMapForLegacy(t *testing.T) {
+	t.Run("QueryProjectIDIgnoredWhenBuildIDInPath", func(t *testing.T) {
+		query := url.Values{"project_id": []string{"attacker_project"}}
+		vars := map[string]string{"build_id": "victim_build_id"}
+
+		paramsMap := BuildProjectParameterMapForLegacy(query, vars)
+
+		require.Empty(t, paramsMap[projectIdKey])
+		require.Equal(t, "victim_build_id", paramsMap[buildIdKey])
+	})
+
+	t.Run("QueryProjectIDIgnoredWhenTaskIDInPath", func(t *testing.T) {
+		query := url.Values{"project_id": []string{"attacker_project"}}
+		vars := map[string]string{"task_id": "victim_task_id"}
+
+		paramsMap := BuildProjectParameterMapForLegacy(query, vars)
+
+		require.Empty(t, paramsMap[projectIdKey])
+		require.Equal(t, "victim_task_id", paramsMap[taskIdKey])
+	})
+
+	t.Run("QueryProjectIDIgnoredWhenVersionIDInPath", func(t *testing.T) {
+		query := url.Values{"project_id": []string{"attacker_project"}}
+		vars := map[string]string{"version_id": "victim_version_id"}
+
+		paramsMap := BuildProjectParameterMapForLegacy(query, vars)
+
+		require.Empty(t, paramsMap[projectIdKey])
+		require.Equal(t, "victim_version_id", paramsMap[versionIdKey])
+	})
+
+	t.Run("QueryProjectIDIgnoredWhenPatchIDInPath", func(t *testing.T) {
+		query := url.Values{"project_id": []string{"attacker_project"}}
+		vars := map[string]string{"patch_id": "victim_patch_id"}
+
+		paramsMap := BuildProjectParameterMapForLegacy(query, vars)
+
+		require.Empty(t, paramsMap[projectIdKey])
+		require.Equal(t, "victim_patch_id", paramsMap[patchIdKey])
+	})
 }


### PR DESCRIPTION
DEVPROD-31179

### Description

A user with access to one project can supply ?project_id=my-project while targeting a task, build, or version belonging to a different project, bypassing the permission check entirely.

### Solution
Change `BuildProjectParameterMapForLegacy` to ignore query-supplied project_id whenever an e.g. (task, build, version, patch) is provided.

### Testing
Verified that supplying ?project_id=<accessible_project> on routes with a foreign task/build/version in the path now correctly returns 401 instead of allowing access. Added a unit test.
