### PR TITLE
DEVPROD-33503: Allow quarantining passing tests and non-patch variants

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1406,13 +1406,6 @@ func canBuildVariantEnableTestSelection(bvName string, creationInfo TaskCreation
 	if !creationInfo.ProjectRef.IsTestSelectionAllowed() {
 		return false
 	}
-	if !evergreen.IsPatchRequester(creationInfo.Version.Requester) {
-		// Test selection is only available for patches for now. Will eventually
-		// be available for other requesters, but this acts as a temporary
-		// safety guard to prevent an experimental feature from affecting
-		// non-patch versions.
-		return false
-	}
 
 	isTestSelectionDefaultEnabled := creationInfo.ProjectRef.IsTestSelectionDefaultEnabled()
 	isTestSelectionIncludeSet := len(creationInfo.TestSelectionParams.IncludeBuildVariants) > 0 || len(creationInfo.TestSelectionParams.IncludeTasks) > 0

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -3265,7 +3265,7 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 		}
 		assert.False(t, canBuildVariantEnableTestSelection("bv1", creationInfo))
 	})
-	t.Run("ReturnsFalseForNonPatchVersion", func(t *testing.T) {
+	t.Run("ReturnsTrueForNonPatchVersion", func(t *testing.T) {
 		creationInfo := TaskCreationInfo{
 			ProjectRef: &ProjectRef{
 				TestSelection: TestSelectionSettings{
@@ -3280,7 +3280,7 @@ func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 				IncludeBuildVariants: []*regexp.Regexp{regexp.MustCompile("bv1")},
 			},
 		}
-		assert.False(t, canBuildVariantEnableTestSelection("bv1", creationInfo))
+		assert.True(t, canBuildVariantEnableTestSelection("bv1", creationInfo))
 	})
 	t.Run("ReturnsTrueIfTestSelectionDefaultEnabled", func(t *testing.T) {
 		creationInfo := TaskCreationInfo{


### PR DESCRIPTION
DEVPROD-33503

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Removes the patch-only guard inside canBuildVariantEnableTestSelection (added in DEVPROD-22987) so test selection, and also manual test quarantine, can run on non-patch variants. 

### Screenshots
https://github.com/user-attachments/assets/595858f1-ff1f-4daf-ba53-2c0de1755477

### Testing
* Smoke tested locally
* Added tests

### UI PR
https://github.com/evergreen-ci/ui/pull/1683

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
