### PR TITLE
DEVPROD-33913: Fix CLI authentication for agentic use

### DIFF
--- a/config.go
+++ b/config.go
@@ -33,7 +33,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-05-21"
+	ClientVersion = "2026-05-27a"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/flags.go
+++ b/operations/flags.go
@@ -19,6 +19,7 @@ const (
 	limitFlagName           = "limit"
 	localModulesFlagName    = "local_modules"
 	moduleFlagName          = "module"
+	noBrowserFlagName       = "no-browser"
 	overwriteConfFlagName   = "overwrite"
 	parameterFlagName       = "param"
 	patchAliasFlagName      = "alias"

--- a/operations/login.go
+++ b/operations/login.go
@@ -11,6 +11,12 @@ func Login() cli.Command {
 	return cli.Command{
 		Name:  "login",
 		Usage: "authenticate the CLI with evergreen",
+		Flags: []cli.Flag{
+			cli.BoolFlag{
+				Name:  noBrowserFlagName,
+				Usage: "authenticate without opening a browser. Saves it to your configuration file",
+			},
+		},
 		Action: func(c *cli.Context) error {
 			if _, err := login(c); err != nil {
 				return errors.Wrap(err, "logging in")
@@ -30,6 +36,12 @@ func login(c *cli.Context) (*ClientSettings, error) {
 	conf, err := NewClientSettings(confPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "loading configuration")
+	}
+	if c.Bool(noBrowserFlagName) {
+		conf.OAuth.DoNotUseBrowser = true
+		if err := conf.Write(""); err != nil {
+			return nil, errors.Wrap(err, "saving configuration")
+		}
 	}
 
 	if err = conf.SetOAuthToken(ctx); err != nil {

--- a/operations/model.go
+++ b/operations/model.go
@@ -683,7 +683,7 @@ func (s *ClientSettings) getOAuthToken(ctx context.Context) (*oauth2.Token, stri
 func (s *ClientSettings) SetOAuthToken(ctx context.Context) error {
 	token, path, err := s.getOAuthToken(ctx)
 	if err != nil {
-		return errors.Wrap(err, "getting OAuth token")
+		return errors.Wrap(err, "getting OAuth token; if your device cannot use the browser, try running 'evergreen login --no-browser'")
 	}
 
 	s.OAuth.AccessToken = token.AccessToken

--- a/operations/model.go
+++ b/operations/model.go
@@ -683,19 +683,7 @@ func (s *ClientSettings) getOAuthToken(ctx context.Context) (*oauth2.Token, stri
 func (s *ClientSettings) SetOAuthToken(ctx context.Context) error {
 	token, path, err := s.getOAuthToken(ctx)
 	if err != nil {
-		// The auth library caches tokens in a file. Sometimes, the tokens are expired and
-		// we need to remove the file to get a new token.
-		if path != "" {
-			if delErr := os.RemoveAll(path); delErr != nil {
-				grip.Warning(ctx, errors.Wrapf(delErr, "removing OAuth token file at '%s'", path))
-			}
-			token, path, err = s.getOAuthToken(ctx)
-			if err != nil {
-				return errors.Wrap(err, "getting OAuth token after removing token file")
-			}
-		} else {
-			return errors.Wrap(err, "getting OAuth token")
-		}
+		return errors.Wrap(err, "getting OAuth token")
 	}
 
 	s.OAuth.AccessToken = token.AccessToken

--- a/operations/model.go
+++ b/operations/model.go
@@ -683,7 +683,11 @@ func (s *ClientSettings) getOAuthToken(ctx context.Context) (*oauth2.Token, stri
 func (s *ClientSettings) SetOAuthToken(ctx context.Context) error {
 	token, path, err := s.getOAuthToken(ctx)
 	if err != nil {
-		return errors.Wrap(err, "getting OAuth token; if your device cannot use the browser, try running 'evergreen login --no-browser'")
+		// `getOAuthToken` has many fallbacks and retries internally
+		// so reaching this point typically means:
+		// 1. The user's device cannot use the browser and needs to use the device code flow.
+		// 2. The token lock file is stuck in a bad state and needs to be deleted.
+		return errors.Wrap(err, "getting OAuth token; if your device cannot use the browser, try running 'evergreen login --no-browser'. if you've ran this command before, delete the oauth.token_file_path from your configuration file and it's corresponding lock file (same path but with an appended .lock extension) and try again.")
 	}
 
 	s.OAuth.AccessToken = token.AccessToken

--- a/rest/client/client_test.go
+++ b/rest/client/client_test.go
@@ -2,10 +2,12 @@ package client
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,5 +67,78 @@ func TestRemoveStaleOAuthLockFile(t *testing.T) {
 
 	t.Run("NoErrorWhenFileDoesNotExist", func(t *testing.T) {
 		assert.NoError(t, removeStaleOAuthLockFile("/nonexistent/path"))
+	})
+}
+
+func TestWaitForOAuthLockRelease(t *testing.T) {
+	t.Run("MissingLockShouldReturnImmediately", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		lockFilePath := filepath.Join(tmpDir, "token.json.lock")
+
+		err := waitForOAuthLockRelease(t.Context(), lockFilePath, time.Second)
+		require.NoError(t, err)
+	})
+
+	t.Run("StaleLockShouldBeRemovedAndReturn", func(t *testing.T) {
+		cmd := exec.Command("true")
+		require.NoError(t, cmd.Run())
+
+		tmpDir := t.TempDir()
+		lockFilePath := filepath.Join(tmpDir, "token.json.lock")
+		require.NoError(t, os.WriteFile(lockFilePath, []byte(fmt.Sprintf("%d", cmd.Process.Pid)), 0600))
+
+		err := waitForOAuthLockRelease(t.Context(), lockFilePath, time.Second)
+		require.NoError(t, err)
+
+		_, statErr := os.Stat(lockFilePath)
+		assert.True(t, os.IsNotExist(statErr))
+	})
+
+	t.Run("ActiveLockShouldTimeout", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		lockFilePath := filepath.Join(tmpDir, "token.json.lock")
+		require.NoError(t, os.WriteFile(lockFilePath, []byte(fmt.Sprintf("%d", os.Getpid())), 0600))
+
+		start := time.Now()
+		err := waitForOAuthLockRelease(t.Context(), lockFilePath, 300*time.Millisecond)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "timed out")
+		assert.GreaterOrEqual(t, time.Since(start), 300*time.Millisecond)
+	})
+}
+
+func TestIsPortBindError(t *testing.T) {
+	t.Run("NilErrorShouldReturnFalse", func(t *testing.T) {
+		assert.False(t, isPortBindError(nil))
+	})
+
+	t.Run("PortBindErrorShouldReturnTrue", func(t *testing.T) {
+		assert.True(t, isPortBindError(fmt.Errorf("listen tcp 127.0.0.1:8888: bind: address already in use")))
+	})
+
+	t.Run("UnrelatedErrorShouldReturnFalse", func(t *testing.T) {
+		assert.False(t, isPortBindError(fmt.Errorf("refresh token expired")))
+	})
+}
+
+func TestCallbackPortAvailable(t *testing.T) {
+	t.Run("FreePortShouldReturnTrue", func(t *testing.T) {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		port := listener.Addr().(*net.TCPAddr).Port
+		require.NoError(t, listener.Close())
+
+		assert.True(t, callbackPortAvailable(fmt.Sprintf("%d", port)))
+	})
+
+	t.Run("UsedPortShouldReturnFalse", func(t *testing.T) {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		port := listener.Addr().(*net.TCPAddr).Port
+		t.Cleanup(func() {
+			assert.NoError(t, listener.Close())
+		})
+
+		assert.False(t, callbackPortAvailable(fmt.Sprintf("%d", port)))
 	})
 }

--- a/rest/client/client_test.go
+++ b/rest/client/client_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 	"os"
@@ -9,8 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kanopy-platform/kanopy-oidc-lib/pkg/dex"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 )
 
 func TestEvergreenCommunicatorConstructor(t *testing.T) {
@@ -118,6 +121,96 @@ func TestIsPortBindError(t *testing.T) {
 
 	t.Run("UnrelatedErrorShouldReturnFalse", func(t *testing.T) {
 		assert.False(t, isPortBindError(fmt.Errorf("refresh token expired")))
+	})
+}
+
+func TestIsOAuthLockClaimedError(t *testing.T) {
+	t.Run("NilErrorShouldReturnFalse", func(t *testing.T) {
+		assert.False(t, isOAuthLockClaimedError(nil))
+	})
+
+	t.Run("WrappedDexLockErrorShouldReturnTrue", func(t *testing.T) {
+		assert.True(t, isOAuthLockClaimedError(fmt.Errorf("lock claimed by process 123: %w", dex.ErrLockClaimed)))
+	})
+
+	t.Run("DexLockMessageShouldReturnTrue", func(t *testing.T) {
+		assert.True(t, isOAuthLockClaimedError(fmt.Errorf("lock claimed by process 123: lock file claimed by another process")))
+	})
+
+	t.Run("UnrelatedErrorShouldReturnFalse", func(t *testing.T) {
+		assert.False(t, isOAuthLockClaimedError(fmt.Errorf("refresh token expired")))
+	})
+}
+
+func TestRemoveInvalidOAuthTokenCacheIfUnlocked(t *testing.T) {
+	t.Run("MissingTokenShouldReturnImmediately", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tokenFilePath := filepath.Join(tmpDir, "token.json")
+
+		require.NoError(t, removeInvalidOAuthTokenCacheIfUnlocked(t.Context(), tokenFilePath, time.Second))
+	})
+
+	t.Run("ValidTokenShouldRemain", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tokenFilePath := filepath.Join(tmpDir, "token.json")
+		tokenData, err := json.Marshal(&oauth2.Token{
+			AccessToken:  "access",
+			RefreshToken: "refresh",
+			Expiry:       time.Now().Add(time.Hour),
+		})
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(tokenFilePath, tokenData, 0600))
+
+		require.NoError(t, removeInvalidOAuthTokenCacheIfUnlocked(t.Context(), tokenFilePath, time.Second))
+
+		_, err = os.Stat(tokenFilePath)
+		assert.NoError(t, err)
+	})
+
+	t.Run("InvalidTokenShouldBeRemoved", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tokenFilePath := filepath.Join(tmpDir, "token.json")
+		require.NoError(t, os.WriteFile(tokenFilePath, []byte("{"), 0600))
+
+		require.NoError(t, removeInvalidOAuthTokenCacheIfUnlocked(t.Context(), tokenFilePath, time.Second))
+
+		_, err := os.Stat(tokenFilePath)
+		assert.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("StaleLockShouldAllowInvalidTokenRemoval", func(t *testing.T) {
+		cmd := exec.Command("true")
+		require.NoError(t, cmd.Run())
+
+		tmpDir := t.TempDir()
+		tokenFilePath := filepath.Join(tmpDir, "token.json")
+		lockFilePath := tokenFilePath + ".lock"
+		require.NoError(t, os.WriteFile(tokenFilePath, []byte("{"), 0600))
+		require.NoError(t, os.WriteFile(lockFilePath, []byte(fmt.Sprintf("%d", cmd.Process.Pid)), 0600))
+
+		require.NoError(t, removeInvalidOAuthTokenCacheIfUnlocked(t.Context(), tokenFilePath, time.Second))
+
+		_, tokenErr := os.Stat(tokenFilePath)
+		assert.True(t, os.IsNotExist(tokenErr))
+		_, lockErr := os.Stat(lockFilePath)
+		assert.True(t, os.IsNotExist(lockErr))
+	})
+
+	t.Run("ActiveLockShouldNotRemoveInvalidToken", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		tokenFilePath := filepath.Join(tmpDir, "token.json")
+		lockFilePath := tokenFilePath + ".lock"
+		require.NoError(t, os.WriteFile(tokenFilePath, []byte("{"), 0600))
+		require.NoError(t, os.WriteFile(lockFilePath, []byte(fmt.Sprintf("%d", os.Getpid())), 0600))
+
+		err := removeInvalidOAuthTokenCacheIfUnlocked(t.Context(), tokenFilePath, 300*time.Millisecond)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "timed out")
+
+		_, tokenErr := os.Stat(tokenFilePath)
+		assert.NoError(t, tokenErr)
+		_, lockErr := os.Stat(lockFilePath)
+		assert.NoError(t, lockErr)
 	})
 }
 

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -40,7 +40,9 @@ var (
 		"claimed by another client",
 		"refresh token expired",
 	}
+)
 
+const (
 	oauthCallbackPort     = "8888"
 	oauthLockWaitTimeout  = 2 * time.Minute
 	oauthLockPollInterval = 200 * time.Millisecond

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -27,6 +28,7 @@ import (
 	"github.com/evergreen-ci/utility"
 	"github.com/kanopy-platform/kanopy-oidc-lib/pkg/dex"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
@@ -38,6 +40,17 @@ var (
 		"claimed by another client",
 		"refresh token expired",
 	}
+
+	oauthCallbackPort     = "8888"
+	oauthLockWaitTimeout  = 2 * time.Minute
+	oauthLockPollInterval = 200 * time.Millisecond
+)
+
+type oauthFlow int
+
+const (
+	oauthFlowAuthCode oauthFlow = iota
+	oauthFlowDevice
 )
 
 // CreateSpawnHost will insert an intent host into the DB that will be spawned later by the runner
@@ -1945,47 +1958,47 @@ func GetOAuthToken(ctx context.Context, doNotUseBrowser bool, opts ...dex.Client
 	ctx = oidc.ClientContext(ctx, httpClient)
 
 	loader := &dex.FileTokenLoader{}
-
-	opts = append(opts,
+	baseOpts := append([]dex.ClientOption{}, opts...)
+	baseOpts = append(baseOpts,
 		dex.WithContext(ctx),
 		dex.WithRefresh(),
 		dex.WithFallbackToStdOut(true),
-		dex.WithFlow("device"),
-		dex.WithNoBrowser(doNotUseBrowser),
 	)
+
+	flow := oauthFlowAuthCode
+	if doNotUseBrowser {
+		flow = oauthFlowDevice
+	} else if !callbackPortAvailable(oauthCallbackPort) {
+		grip.Notice(ctx, message.Fields{
+			"message": "OAuth callback port unavailable; using device code flow",
+			"port":    oauthCallbackPort,
+		})
+		flow = oauthFlowDevice
+	}
 
 	// The Dex client logs using logrus. The client doesn't
 	// have any way to turn off debug logs within it's API.
 	// We set the output to io.Discard to suppress debug logs.
 	logrus.SetOutput(io.Discard)
 
-	client, err := dex.NewClient(append(opts, dex.WithTokenLoader(loader))...)
-	if err != nil {
-		return nil, "", err
-	}
-	defer client.Close()
-
-	// Only remove the lock file if the owning process is dead, to avoid
-	// racing with a concurrent process that is actively refreshing.
-	tokenLockFilePath := client.TokenFilePath() + ".lock"
-	if err := removeStaleOAuthLockFile(tokenLockFilePath); err != nil {
-		grip.Warning(ctx, errors.Wrapf(err, "removing stale OAuth token lock file at '%s'", tokenLockFilePath))
+	token, tokenPath, err := requestOAuthToken(ctx, baseOpts, loader, flow)
+	if err == nil && token != nil && token.Expiry.After(time.Now()) {
+		return token, tokenPath, nil
 	}
 
-	// This attempt tries to get a token or refreshes using the refresh token.
-	token, err := client.Token()
-	// We have to explicitly check the expiry is valid because the OAuth
-	// library doesn't consider a token with a zero time expiry as expired.
-	if err == nil && token.Expiry.After(time.Now()) {
-		return token, client.TokenFilePath(), nil
+	if err != nil && flow == oauthFlowAuthCode && isPortBindError(err) {
+		grip.Notice(ctx, "OAuth auth-code flow failed due to a port conflict; falling back to device code flow")
+		flow = oauthFlowDevice
+		token, tokenPath, err = requestOAuthToken(ctx, baseOpts, loader, flow)
+		if err == nil && token != nil && token.Expiry.After(time.Now()) {
+			return token, tokenPath, nil
+		}
 	}
 
 	shouldRetry := false
 	if token != nil && token.Expiry.Before(time.Now()) {
-		// Retry if the token is expired.
 		shouldRetry = true
 	} else if err != nil {
-		// Otherwise, check the error to see if we should retry.
 		clientErrString := strings.ToLower(err.Error())
 		for _, retryIfFound := range oauthRetryErrors {
 			if strings.Contains(clientErrString, retryIfFound) {
@@ -1996,18 +2009,83 @@ func GetOAuthToken(ctx context.Context, doNotUseBrowser bool, opts ...dex.Client
 	}
 
 	if !shouldRetry {
-		return nil, client.TokenFilePath(), err
+		return nil, tokenPath, err
 	}
 
-	// This client prevents the Dex client from using the refresh token.
-	client, err = dex.NewClient(append(opts, dex.WithTokenLoader(&tokenLoaderWithoutRefresh{loader}))...)
+	token, tokenPath, err = requestOAuthToken(ctx, baseOpts, &tokenLoaderWithoutRefresh{loader}, flow)
+	return token, tokenPath, err
+}
+
+func requestOAuthToken(ctx context.Context, baseOpts []dex.ClientOption, loader dex.TokenLoader, flow oauthFlow) (*oauth2.Token, string, error) {
+	opts := append(append([]dex.ClientOption{}, baseOpts...), oauthFlowOptions(flow)...)
+	opts = append(opts, dex.WithTokenLoader(loader))
+
+	client, err := dex.NewClient(opts...)
 	if err != nil {
-		return nil, client.TokenFilePath(), err
+		return nil, "", err
 	}
 	defer client.Close()
 
-	token, err = client.Token()
-	return token, client.TokenFilePath(), err
+	tokenPath := client.TokenFilePath()
+	lockPath := tokenPath + ".lock"
+	if err := waitForOAuthLockRelease(ctx, lockPath, oauthLockWaitTimeout); err != nil {
+		return nil, tokenPath, err
+	}
+	if err := removeStaleOAuthLockFile(lockPath); err != nil {
+		grip.Warning(ctx, errors.Wrapf(err, "removing stale OAuth token lock file at '%s'", lockPath))
+	}
+
+	token, err := client.Token()
+	return token, tokenPath, err
+}
+
+func oauthFlowOptions(flow oauthFlow) []dex.ClientOption {
+	if flow == oauthFlowDevice {
+		return []dex.ClientOption{dex.WithFlow("device"), dex.WithNoBrowser(true)}
+	}
+	return []dex.ClientOption{dex.WithFlow("auth-code")}
+}
+
+func callbackPortAvailable(port string) bool {
+	listener, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", port))
+	if err != nil {
+		return false
+	}
+	return listener.Close() == nil
+}
+
+func isPortBindError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errString := strings.ToLower(err.Error())
+	return strings.Contains(errString, "address already in use") ||
+		strings.Contains(errString, "bind:") ||
+		strings.Contains(errString, "listen tcp")
+}
+
+func waitForOAuthLockRelease(ctx context.Context, lockFilePath string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if _, err := os.Stat(lockFilePath); os.IsNotExist(err) {
+			return nil
+		}
+		if err := removeStaleOAuthLockFile(lockFilePath); err != nil {
+			return err
+		}
+		if _, err := os.Stat(lockFilePath); os.IsNotExist(err) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(oauthLockPollInterval):
+		}
+	}
+	return errors.Errorf("timed out after %s waiting for OAuth token lock at '%s'", timeout, lockFilePath)
 }
 
 type tokenLoaderWithoutRefresh struct {

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -1958,8 +1958,7 @@ func GetOAuthToken(ctx context.Context, doNotUseBrowser bool, opts ...dex.Client
 	ctx = oidc.ClientContext(ctx, httpClient)
 
 	loader := &dex.FileTokenLoader{}
-	baseOpts := append([]dex.ClientOption{}, opts...)
-	baseOpts = append(baseOpts,
+	baseOpts := append(opts,
 		dex.WithContext(ctx),
 		dex.WithRefresh(),
 		dex.WithFallbackToStdOut(true),
@@ -1967,6 +1966,7 @@ func GetOAuthToken(ctx context.Context, doNotUseBrowser bool, opts ...dex.Client
 
 	flow := oauthFlowAuthCode
 	if doNotUseBrowser {
+		grip.Notice(ctx, "Using OAuth device flow because oauth.do_not_use_browser is true. You can set oauth.do_not_use_browser to false in your client configuration file to allow Evergreen to open a browser for a smoother login experience.")
 		flow = oauthFlowDevice
 	} else if !callbackPortAvailable(oauthCallbackPort) {
 		grip.Notice(ctx, message.Fields{
@@ -1989,6 +1989,13 @@ func GetOAuthToken(ctx context.Context, doNotUseBrowser bool, opts ...dex.Client
 	if err != nil && flow == oauthFlowAuthCode && isPortBindError(err) {
 		grip.Notice(ctx, "OAuth auth-code flow failed due to a port conflict; falling back to device code flow")
 		flow = oauthFlowDevice
+		token, tokenPath, err = requestOAuthToken(ctx, baseOpts, loader, flow)
+		if err == nil && token != nil && token.Expiry.After(time.Now()) {
+			return token, tokenPath, nil
+		}
+	}
+
+	if err != nil && isOAuthLockClaimedError(err) {
 		token, tokenPath, err = requestOAuthToken(ctx, baseOpts, loader, flow)
 		if err == nil && token != nil && token.Expiry.After(time.Now()) {
 			return token, tokenPath, nil
@@ -2027,12 +2034,8 @@ func requestOAuthToken(ctx context.Context, baseOpts []dex.ClientOption, loader 
 	defer client.Close()
 
 	tokenPath := client.TokenFilePath()
-	lockPath := tokenPath + ".lock"
-	if err := waitForOAuthLockRelease(ctx, lockPath, oauthLockWaitTimeout); err != nil {
+	if err := removeInvalidOAuthTokenCacheIfUnlocked(ctx, tokenPath, oauthLockWaitTimeout); err != nil {
 		return nil, tokenPath, err
-	}
-	if err := removeStaleOAuthLockFile(lockPath); err != nil {
-		grip.Warning(ctx, errors.Wrapf(err, "removing stale OAuth token lock file at '%s'", lockPath))
 	}
 
 	token, err := client.Token()
@@ -2062,6 +2065,38 @@ func isPortBindError(err error) bool {
 	return strings.Contains(errString, "address already in use") ||
 		strings.Contains(errString, "bind:") ||
 		strings.Contains(errString, "listen tcp")
+}
+
+func isOAuthLockClaimedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, dex.ErrLockClaimed) || strings.Contains(strings.ToLower(err.Error()), "lock claimed by process")
+}
+
+func removeInvalidOAuthTokenCacheIfUnlocked(ctx context.Context, tokenFilePath string, timeout time.Duration) error {
+	if tokenFilePath == "" {
+		return nil
+	}
+	lockPath := tokenFilePath + ".lock"
+	if err := waitForOAuthLockRelease(ctx, lockPath, timeout); err != nil {
+		return err
+	}
+	data, err := os.ReadFile(tokenFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.Wrapf(err, "reading OAuth token file at '%s'", tokenFilePath)
+	}
+	token := &oauth2.Token{}
+	if err := json.Unmarshal(data, token); err == nil {
+		return nil
+	}
+	if err := os.Remove(tokenFilePath); err != nil && !os.IsNotExist(err) {
+		return errors.Wrapf(err, "removing invalid OAuth token file at '%s'", tokenFilePath)
+	}
+	return nil
 }
 
 func waitForOAuthLockRelease(ctx context.Context, lockFilePath string, timeout time.Duration) error {


### PR DESCRIPTION
DEVPROD-33913

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->

This PR fixes two DX bumps when using the Evergreen CLI to authenticate:

1. Default to auth-code flow instead of device auth flow. Device auth can't be done effectively with agents, since it prints out to stdout a link. Auth-code automatically opens the browser for the user to authenticate. We originally defaulted to device code always because we couldn't trust old spawnhosts. It's been baked in to spawnhosts for a while now and we've gotten threads of old spawnhost running in to issues anyways because they had very old CLIs.
2. We were deleting the lock file erroneously which causes race conditions between processes, causing the refresh token to be invalidated and overwritten/consumed.

### Testing

<!--add a description of how you tested it-->

Ran the CLI locally against prod and staging. Added some unit tests.