### PR TITLE
DEVPROD-16801: Expose `displayName` for single task distros

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -68,6 +68,7 @@ type ResolverRoot interface {
 	Project() ProjectResolver
 	ProjectLite() ProjectLiteResolver
 	ProjectSettings() ProjectSettingsResolver
+	ProjectTasksPair() ProjectTasksPairResolver
 	ProjectVars() ProjectVarsResolver
 	Query() QueryResolver
 	RepoSettings() RepoSettingsResolver
@@ -1477,6 +1478,7 @@ type ComplexityRoot struct {
 	ProjectTasksPair struct {
 		AllowedBVs   func(childComplexity int) int
 		AllowedTasks func(childComplexity int) int
+		DisplayName  func(childComplexity int) int
 		ProjectID    func(childComplexity int) int
 	}
 
@@ -2622,6 +2624,9 @@ type ProjectSettingsResolver interface {
 
 	Subscriptions(ctx context.Context, obj *model.APIProjectSettings) ([]*model.APISubscription, error)
 	Vars(ctx context.Context, obj *model.APIProjectSettings) (*model.APIProjectVars, error)
+}
+type ProjectTasksPairResolver interface {
+	DisplayName(ctx context.Context, obj *model.APIProjectTasksPair) (string, error)
 }
 type ProjectVarsResolver interface {
 	AdminOnlyVars(ctx context.Context, obj *model.APIProjectVars) ([]string, error)
@@ -8806,6 +8811,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.ProjectTasksPair.AllowedTasks(childComplexity), true
+	case "ProjectTasksPair.displayName":
+		if e.complexity.ProjectTasksPair.DisplayName == nil {
+			break
+		}
+
+		return e.complexity.ProjectTasksPair.DisplayName(childComplexity), true
 	case "ProjectTasksPair.projectId":
 		if e.complexity.ProjectTasksPair.ProjectID == nil {
 			break
@@ -51260,6 +51271,35 @@ func (ec *executionContext) fieldContext_ProjectTasksPair_projectId(_ context.Co
 	return fc, nil
 }
 
+func (ec *executionContext) _ProjectTasksPair_displayName(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectTasksPair) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ProjectTasksPair_displayName,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.ProjectTasksPair().DisplayName(ctx, obj)
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ProjectTasksPair_displayName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ProjectTasksPair",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ProjectTasksPair_allowedTasks(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectTasksPair) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -58803,6 +58843,8 @@ func (ec *executionContext) fieldContext_SingleTaskDistroConfig_projectTasksPair
 			switch field.Name {
 			case "projectId":
 				return ec.fieldContext_ProjectTasksPair_projectId(ctx, field)
+			case "displayName":
+				return ec.fieldContext_ProjectTasksPair_displayName(ctx, field)
 			case "allowedTasks":
 				return ec.fieldContext_ProjectTasksPair_allowedTasks(ctx, field)
 			case "allowedBVs":
@@ -101109,17 +101151,53 @@ func (ec *executionContext) _ProjectTasksPair(ctx context.Context, sel ast.Selec
 		case "projectId":
 			out.Values[i] = ec._ProjectTasksPair_projectId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "displayName":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._ProjectTasksPair_displayName(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "allowedTasks":
 			out.Values[i] = ec._ProjectTasksPair_allowedTasks(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "allowedBVs":
 			out.Values[i] = ec._ProjectTasksPair_allowedBVs(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))

--- a/graphql/other_resolver.go
+++ b/graphql/other_resolver.go
@@ -2,13 +2,16 @@ package graphql
 
 import (
 	"context"
+	"fmt"
 	"sort"
 
-	"github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/evergreen/model"
+	restModel "github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/evergreen/util"
 )
 
 // CustomFields is the resolver for the customFields field.
-func (r *jiraNotificationsConfigResolver) CustomFields(ctx context.Context, obj *model.APIJIRANotificationsConfig) ([]*JiraNotificationsProjectEntry, error) {
+func (r *jiraNotificationsConfigResolver) CustomFields(ctx context.Context, obj *restModel.APIJIRANotificationsConfig) ([]*JiraNotificationsProjectEntry, error) {
 	if obj == nil || obj.CustomFields == nil {
 		return []*JiraNotificationsProjectEntry{}, nil
 	}
@@ -53,19 +56,40 @@ func (r *jiraNotificationsConfigResolver) CustomFields(ctx context.Context, obj 
 	return entries, nil
 }
 
+// DisplayName is the resolver for the displayName field.
+func (r *projectTasksPairResolver) DisplayName(ctx context.Context, obj *restModel.APIProjectTasksPair) (string, error) {
+	project, err := model.FindBranchProjectRef(ctx, obj.ProjectID)
+	if err != nil {
+		return "", InternalServerError.Send(ctx, fmt.Sprintf("finding project '%s': %s", obj.ProjectID, err.Error()))
+	}
+	if project != nil {
+		displayName := fmt.Sprintf("%s (Project)", util.CoalesceString(project.DisplayName, project.Identifier))
+		return displayName, nil
+	}
+	repo, err := model.FindOneRepoRef(ctx, obj.ProjectID)
+	if err != nil {
+		return "", InternalServerError.Send(ctx, fmt.Sprintf("finding repo '%s': %s", obj.ProjectID, err.Error()))
+	}
+	if repo != nil {
+		displayName := fmt.Sprintf("%s (Repo)", util.CoalesceString(repo.DisplayName, fmt.Sprintf("%s/%s", repo.Owner, repo.Repo)))
+		return displayName, nil
+	}
+	return "", InternalServerError.Send(ctx, fmt.Sprintf("no project or repo found with ID '%s'", obj.ProjectID))
+}
+
 // CustomFields is the resolver for the customFields field.
-func (r *jiraNotificationsConfigInputResolver) CustomFields(ctx context.Context, obj *model.APIJIRANotificationsConfig, data []*JiraNotificationsProjectEntryInput) error {
+func (r *jiraNotificationsConfigInputResolver) CustomFields(ctx context.Context, obj *restModel.APIJIRANotificationsConfig, data []*JiraNotificationsProjectEntryInput) error {
 	if obj == nil {
 		return nil
 	}
 
 	if obj.CustomFields == nil {
-		obj.CustomFields = make(map[string]model.APIJIRANotificationsProject)
+		obj.CustomFields = make(map[string]restModel.APIJIRANotificationsProject)
 	}
 
 	for _, entry := range data {
 		if entry != nil {
-			obj.CustomFields[entry.Project] = model.APIJIRANotificationsProject{
+			obj.CustomFields[entry.Project] = restModel.APIJIRANotificationsProject{
 				Fields:     entry.Fields,
 				Components: entry.Components,
 				Labels:     entry.Labels,
@@ -80,10 +104,14 @@ func (r *Resolver) JiraNotificationsConfig() JiraNotificationsConfigResolver {
 	return &jiraNotificationsConfigResolver{r}
 }
 
+// ProjectTasksPair returns ProjectTasksPairResolver implementation.
+func (r *Resolver) ProjectTasksPair() ProjectTasksPairResolver { return &projectTasksPairResolver{r} }
+
 // JiraNotificationsConfigInput returns JiraNotificationsConfigInputResolver implementation.
 func (r *Resolver) JiraNotificationsConfigInput() JiraNotificationsConfigInputResolver {
 	return &jiraNotificationsConfigInputResolver{r}
 }
 
 type jiraNotificationsConfigResolver struct{ *Resolver }
+type projectTasksPairResolver struct{ *Resolver }
 type jiraNotificationsConfigInputResolver struct{ *Resolver }

--- a/graphql/schema/types/adminSettings/other.graphql
+++ b/graphql/schema/types/adminSettings/other.graphql
@@ -162,9 +162,11 @@ input ProjectTasksPairInput {
 
 type ProjectTasksPair {
   projectId: String!
+  displayName: String!
   allowedTasks: [String!]!
   allowedBVs: [String!]!
 }
+
 input ReleaseModeConfigInput {
   distroMaxHostsFactor: Float
   targetTimeSecondsOverride: Int
@@ -217,39 +219,39 @@ type CostConfig {
 }
 
 input S3UploadCostConfigInput {
-    uploadCostDiscount: Float
+  uploadCostDiscount: Float
 }
 
 type S3UploadCostConfig {
-    uploadCostDiscount: Float
+  uploadCostDiscount: Float
 }
 
 input S3StorageCostConfigInput {
-    standardStorageCostDiscount: Float
-    iAStorageCostDiscount: Float
-    archiveStorageCostDiscount: Float
-    defaultMaxArtifactExpirationDays: Int
-    devprodOwnedAwsAccountIds: [String!]
-    artifactAwsAccountsWithoutLifecycleRules: [String!]
+  standardStorageCostDiscount: Float
+  iAStorageCostDiscount: Float
+  archiveStorageCostDiscount: Float
+  defaultMaxArtifactExpirationDays: Int
+  devprodOwnedAwsAccountIds: [String!]
+  artifactAwsAccountsWithoutLifecycleRules: [String!]
 }
 
 type S3StorageCostConfig {
-    standardStorageCostDiscount: Float
-    iAStorageCostDiscount: Float
-    archiveStorageCostDiscount: Float
-    defaultMaxArtifactExpirationDays: Int
-    devprodOwnedAwsAccountIds: [String!]
-    artifactAwsAccountsWithoutLifecycleRules: [String!]
+  standardStorageCostDiscount: Float
+  iAStorageCostDiscount: Float
+  archiveStorageCostDiscount: Float
+  defaultMaxArtifactExpirationDays: Int
+  devprodOwnedAwsAccountIds: [String!]
+  artifactAwsAccountsWithoutLifecycleRules: [String!]
 }
 
 input S3CostConfigInput {
-    upload: S3UploadCostConfigInput
-    storage: S3StorageCostConfigInput
+  upload: S3UploadCostConfigInput
+  storage: S3StorageCostConfigInput
 }
 
 type S3CostConfig {
-    upload: S3UploadCostConfig
-    storage: S3StorageCostConfig
+  upload: S3UploadCostConfig
+  storage: S3StorageCostConfig
 }
 
 input EBSCostConfigInput {

--- a/graphql/tests/query/adminSettings/data.json
+++ b/graphql/tests/query/adminSettings/data.json
@@ -304,6 +304,16 @@
           "project_id": "spruce",
           "allowed_tasks": ["lint", "storybook"],
           "allowed_bvs": null
+        },
+        {
+          "project_id": "evergreen_repo",
+          "allowed_tasks": ["check_codegen"],
+          "allowed_bvs": null
+        },
+        {
+          "project_id": "spruce_repo",
+          "allowed_tasks": ["check_codegen"],
+          "allowed_bvs": null
         }
       ]
     },
@@ -501,6 +511,37 @@
       "finance_formula": 0.777,
       "savings_plan_discount": 0.3,
       "on_demand_discount": 0.8
+    }
+  ],
+  "project_ref": [
+    {
+      "_id": "evergreen",
+      "display_name": "Evergreen",
+      "repo_ref_id": "evergreen_repo",
+      "owner_name": "evergreen-ci",
+      "repo_name": "evergreen"
+    },
+    {
+      "_id": "spruce",
+      "display_name": "",
+      "identifier": "spruce",
+      "repo_ref_id": "spruce_repo",
+      "owner_name": "evergreen-ci",
+      "repo_name": "spruce"
+    }
+  ],
+  "repo_ref": [
+    {
+      "_id": "evergreen_repo",
+      "display_name": "Evergreen Repo",
+      "owner_name": "evergreen-ci",
+      "repo_name": "evergreen"
+    },
+    {
+      "_id": "spruce_repo",
+      "display_name": "",
+      "owner_name": "evergreen-ci",
+      "repo_name": "spruce"
     }
   ]
 }

--- a/graphql/tests/query/adminSettings/queries/other.graphql
+++ b/graphql/tests/query/adminSettings/queries/other.graphql
@@ -13,6 +13,7 @@ query Other {
     singleTaskDistro {
       projectTasksPairs {
         projectId
+        displayName
         allowedTasks
         allowedBVs
       }

--- a/graphql/tests/query/adminSettings/results.json
+++ b/graphql/tests/query/adminSettings/results.json
@@ -352,12 +352,26 @@
               "projectTasksPairs": [
                 {
                   "projectId": "evergreen",
+                  "displayName": "Evergreen (Project)",
                   "allowedTasks": ["compile", "test"],
                   "allowedBVs": ["windows", "ubuntu1604"]
                 },
                 {
                   "projectId": "spruce",
+                  "displayName": "spruce (Project)",
                   "allowedTasks": ["lint", "storybook"],
+                  "allowedBVs": []
+                },
+                {
+                  "projectId": "evergreen_repo",
+                  "displayName": "Evergreen Repo (Repo)",
+                  "allowedTasks": ["check_codegen"],
+                  "allowedBVs": []
+                },
+                {
+                  "projectId": "spruce_repo",
+                  "displayName": "evergreen-ci/spruce (Repo)",
+                  "allowedTasks": ["check_codegen"],
                   "allowedBVs": []
                 }
               ]


### PR DESCRIPTION
DEVPROD-16801

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Adds a display name for single task distros, which is purely an aesthetic change to clarify what project/repos are being covered. There's only like 14 of them so I feel like a minimal approach would be ok for now.

<img width="1273" height="1194" alt="Screenshot 2026-05-29 at 1 21 26 PM" src="https://github.com/user-attachments/assets/5288fc70-5235-4e60-98bc-7c4e300399ac" />


### Testing
* add GraphQL tests