### PR TITLE
DEVPROD-34108 Move debug config to the distro work directory

### DIFF
--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -165,7 +165,7 @@ func CreateSpawnHost(ctx context.Context, so SpawnOptions, settings *evergreen.S
 		}
 	}
 	if so.IsDebug {
-		debugScript, err := getDebugSetupScript(ctx, so, settings, d.HomeDir())
+		debugScript, err := getDebugSetupScript(ctx, so, settings, d.WorkDir, d.HomeDir())
 		if err != nil {
 			return nil, errors.Wrap(err, "generating debug setup script")
 		}
@@ -237,9 +237,13 @@ func CreateSpawnHost(ctx context.Context, so SpawnOptions, settings *evergreen.S
 // getDebugSetupScript returns the debug setup script to use. The
 // admin-configured debug script always runs. If a step number is also
 // specified, the debug setup-phase script is appended after it.
-func getDebugSetupScript(ctx context.Context, so SpawnOptions, settings *evergreen.Settings, homeDir string) (string, error) {
+func getDebugSetupScript(ctx context.Context, so SpawnOptions, settings *evergreen.Settings, workDir, homeDir string) (string, error) {
 	script := settings.DebugSpawnHosts.SetupScript
-	configScript, configPath, err := generateConfigScript(ctx, so.ProvisionOptions.TaskId, settings, homeDir)
+	configBaseDir := workDir
+	if configBaseDir == "" {
+		configBaseDir = homeDir
+	}
+	configScript, configPath, err := generateConfigScript(ctx, so.ProvisionOptions.TaskId, settings, configBaseDir)
 	if err != nil {
 		return "", errors.Wrap(err, "generating config YAML script")
 	}

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -165,7 +165,7 @@ func CreateSpawnHost(ctx context.Context, so SpawnOptions, settings *evergreen.S
 		}
 	}
 	if so.IsDebug {
-		debugScript, err := getDebugSetupScript(ctx, so, settings, d.WorkDir, d.HomeDir())
+		debugScript, err := getDebugSetupScript(ctx, so, settings, d.WorkDir)
 		if err != nil {
 			return nil, errors.Wrap(err, "generating debug setup script")
 		}
@@ -237,12 +237,9 @@ func CreateSpawnHost(ctx context.Context, so SpawnOptions, settings *evergreen.S
 // getDebugSetupScript returns the debug setup script to use. The
 // admin-configured debug script always runs. If a step number is also
 // specified, the debug setup-phase script is appended after it.
-func getDebugSetupScript(ctx context.Context, so SpawnOptions, settings *evergreen.Settings, workDir, homeDir string) (string, error) {
+func getDebugSetupScript(ctx context.Context, so SpawnOptions, settings *evergreen.Settings, workDir string) (string, error) {
 	script := settings.DebugSpawnHosts.SetupScript
 	configBaseDir := workDir
-	if configBaseDir == "" {
-		configBaseDir = homeDir
-	}
 	configScript, configPath, err := generateConfigScript(ctx, so.ProvisionOptions.TaskId, settings, configBaseDir)
 	if err != nil {
 		return "", errors.Wrap(err, "generating config YAML script")

--- a/docs/Hosts/Debug-Spawn-Hosts.md
+++ b/docs/Hosts/Debug-Spawn-Hosts.md
@@ -49,10 +49,10 @@ Follow these steps to start a debugging session:
    evergreen debug daemon status
    ```
 
-2. **Load your project's configuration file.** This tells the debugger where to find your task definitions. The file is pre-loaded into the `~/debug_project_config/` directory on the spawn host.
+2. **Load your project's configuration file.** This tells the debugger where to find your task definitions. The file is pre-loaded into the `debug_project_config/` subdirectory of the distro's working directory on the spawn host (typically `/data/mci/debug_project_config/`).
 
    ```bash
-   evergreen debug load ~/debug_project_config/evergreen.yml
+   evergreen debug load /data/mci/debug_project_config/evergreen.yml
    ```
 
 3. **Select the task you want to debug.** Use the exact task name as it appears in your Evergreen configuration.
@@ -87,7 +87,7 @@ Your task failed at [step](#understanding-step-numbers) 5. Here's how to debug i
 
 ```bash
 # Load config and select your task
-evergreen debug load ~/debug_project_config/evergreen.yml
+evergreen debug load /data/mci/debug_project_config/evergreen.yml
 evergreen debug select my_failing_task
 
 # Execute up to the problem step
@@ -125,7 +125,7 @@ evergreen debug next
 If you know steps 1-3 work fine and want to debug step 4:
 
 ```bash
-evergreen debug load ~/debug_project_config/evergreen.yml
+evergreen debug load /data/mci/debug_project_config/evergreen.yml
 evergreen debug select my_task
 
 # Jump straight to step 4 and execute it
@@ -139,10 +139,10 @@ You can modify your `evergreen.yml` file and reload it between steps to test con
 
 ```bash
 # Edit your evergreen.yml file
-vim ~/debug_project_config/evergreen.yml
+vim /data/mci/debug_project_config/evergreen.yml
 
 # Reload the modified configuration
-evergreen debug load ~/debug_project_config/evergreen.yml
+evergreen debug load /data/mci/debug_project_config/evergreen.yml
 
 # Your task selection, step position, and custom expansions are all preserved
 # Continue debugging with the updated configuration
@@ -172,7 +172,7 @@ The hot reload preserves:
 Load a project configuration file. The path can be relative or absolute. Must be run before selecting a task.
 
 ```bash
-evergreen debug load ~/debug_project_config/evergreen.yml
+evergreen debug load /data/mci/debug_project_config/evergreen.yml
 evergreen debug load /home/user/project/evergreen.yml
 ```
 


### PR DESCRIPTION
DEVPROD-34108

### Description

Debug spawn hosts were placing the project config and all build output on the root volume, which is small in disk size. This caused some bazel builds to fail with "No space left on device" errors that didn't occur on the original task.

### Soution
Write the debug project config to the distro's work directory instead of the home directory. Since the debug daemon derives its working directory from the config path, this moves all build execution onto the large data volume where normal tasks run.

### Testing
Verified on a debug spawn host that builds now write to `/data/` instead of `/`.
### Documentation
Updated docs
