### PR TITLE
DEVPROD-34200: Fix BV path filtering for MQ versions

### DIFF
--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1481,7 +1481,8 @@ func (j *patchIntentProcessor) sendGitHubSuccessMessageForIgnoredVariants(ctx co
 // sendGitHubSuccessMessages sends a successful status to GitHub with the given message for all
 // Evergreen rules configured for the given project.
 func (j *patchIntentProcessor) sendGitHubSuccessMessages(ctx context.Context, patchDoc *patch.Patch, projectRef *model.ProjectRef) {
-	rules := j.getEvergreenRulesForStatuses(ctx, patchDoc.GithubPatchData.BaseOwner, projectRef.Repo, projectRef.Branch)
+	owner, repo, branch := j.gitHubStatusRuleTarget(patchDoc, projectRef)
+	rules := j.getEvergreenRulesForStatuses(ctx, owner, repo, branch)
 	for _, rule := range rules {
 		var update amboy.Job
 		if j.IntentType == patch.GithubIntentType {
@@ -1507,6 +1508,14 @@ func (j *patchIntentProcessor) sendGitHubSuccessMessages(ctx context.Context, pa
 		update.Run(ctx)
 		j.AddError(update.Error())
 	}
+}
+
+func (j *patchIntentProcessor) gitHubStatusRuleTarget(patchDoc *patch.Patch, projectRef *model.ProjectRef) (owner, repo, branch string) {
+	if j.IntentType == patch.GithubMergeIntentType {
+		return patchDoc.GithubMergeData.Org, patchDoc.GithubMergeData.Repo, patchDoc.GithubMergeData.BaseBranch
+	}
+
+	return patchDoc.GithubPatchData.BaseOwner, projectRef.Repo, projectRef.Branch
 }
 
 // getEvergreenRulesForStatuses returns the rules we want to send Evergreen statuses for.

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -2307,3 +2307,42 @@ func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 		})
 	}
 }
+
+func TestGitHubStatusRuleTarget(t *testing.T) {
+	projectRef := &model.ProjectRef{
+		Owner:  "project-owner",
+		Repo:   "project-repo",
+		Branch: "project-branch",
+	}
+
+	t.Run("MergeQueuePatchUsesMergeQueueRepository", func(t *testing.T) {
+		j := &patchIntentProcessor{IntentType: patch.GithubMergeIntentType}
+		patchDoc := &patch.Patch{
+			GithubMergeData: thirdparty.GithubMergeGroup{
+				Org:        "merge-owner",
+				Repo:       "merge-repo",
+				BaseBranch: "merge-base-branch",
+			},
+		}
+
+		owner, repo, branch := j.gitHubStatusRuleTarget(patchDoc, projectRef)
+		assert.Equal(t, "merge-owner", owner)
+		assert.Equal(t, "merge-repo", repo)
+		assert.Equal(t, "merge-base-branch", branch)
+	})
+
+	t.Run("GitHubPRPatchUsesExistingPRTarget", func(t *testing.T) {
+		j := &patchIntentProcessor{IntentType: patch.GithubIntentType}
+		patchDoc := &patch.Patch{
+			GithubPatchData: thirdparty.GithubPatch{
+				BaseOwner: "pr-owner",
+				BaseRepo:  "pr-repo",
+			},
+		}
+
+		owner, repo, branch := j.gitHubStatusRuleTarget(patchDoc, projectRef)
+		assert.Equal(t, "pr-owner", owner)
+		assert.Equal(t, "project-repo", repo)
+		assert.Equal(t, "project-branch", branch)
+	})
+}


### PR DESCRIPTION
DEVPROD-34200

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->

Merge queue versions DO NOT have patch data, they have merge queue data. This switches it over for those versions.


### Testing

<!--add a description of how you tested it-->

Unit tests and staging test:

#### Before

No patch was created, the evergreen status says success but the other statuses never resolve
<img width="1101" height="455" alt="Screenshot 2026-06-03 at 10 48 12 PM" src="https://github.com/user-attachments/assets/f04c62c5-3840-419d-b6ed-1bb0fc46da8c" />


#### After

No patch was created (correct), and the Evergreen statuses were resolved, the [PR was merged](https://github.com/evergreen-ci/github-merge-queue-sandbox/pull/228). You can also see in the history, it's the same PR as before.

<img width="1124" height="464" alt="Screenshot 2026-06-03 at 10 52 06 PM" src="https://github.com/user-attachments/assets/ab8b4c06-730b-4db8-bea0-603d26d767f6" />
