### PR TITLE
DEVPROD-33761 Wait times and scheduler overhead stats

### DIFF
--- a/units/stats_task.go
+++ b/units/stats_task.go
@@ -3,10 +3,12 @@ package units
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
@@ -80,4 +82,181 @@ func (j *taskStatsCollector) Run(ctx context.Context) {
 	}
 
 	j.logger.Info(ctx, task.GetResultCounts(tasks))
+
+	if len(tasks) == 0 {
+		return
+	}
+
+	for _, msg := range getWaitTimeMessages(tasks) {
+		j.logger.Info(ctx, msg)
+	}
+
+	requesterCounts := make(map[string]int, len(evergreen.AllRequesterTypes))
+	projectCounts := make(map[string]int)
+	for _, t := range tasks {
+		requesterCounts[t.Requester]++
+		projectCounts[t.Project]++
+	}
+
+	j.logger.Info(ctx, message.Fields{
+		"message":              "task stats by requester",
+		"stats":                "tasks-by-requester",
+		"gitter_request":       requesterCounts[evergreen.RepotrackerVersionRequester],
+		"patch_request":        requesterCounts[evergreen.PatchVersionRequester],
+		"github_pull_request":  requesterCounts[evergreen.GithubPRRequester],
+		"github_merge_request": requesterCounts[evergreen.GithubMergeRequester],
+		"trigger_request":      requesterCounts[evergreen.TriggerRequester],
+		"ad_hoc":               requesterCounts[evergreen.AdHocRequester],
+		"git_tag_request":      requesterCounts[evergreen.GitTagRequester],
+		"total":                len(tasks),
+	})
+
+	j.logger.Info(ctx, message.Fields{
+		"message":  "task stats by project",
+		"stats":    "tasks-by-project",
+		"projects": topNProjects(projectCounts, 10),
+		"total":    len(tasks),
+	})
+}
+
+type taskTimings struct {
+	waitSecs      float64
+	overheadRatio float64
+}
+
+const minDistroTasksForStats = 5
+
+// getWaitTimeMessages computes wait time percentiles and scheduler overhead
+// ratios for the given tasks, broken down globally and per-distro/per-requester.
+func getWaitTimeMessages(tasks []task.Task) []message.Fields {
+	var globalTimings []taskTimings
+	byDistro := make(map[string][]taskTimings)
+	byRequester := make(map[string][]taskTimings)
+
+	for _, t := range tasks {
+		if utility.IsZeroTime(t.StartTime) || utility.IsZeroTime(t.FinishTime) {
+			continue
+		}
+
+		submitTime := t.DependenciesMetTime
+		if utility.IsZeroTime(submitTime) {
+			submitTime = t.ScheduledTime
+		}
+		if utility.IsZeroTime(submitTime) {
+			continue
+		}
+
+		turnaround := t.FinishTime.Sub(submitTime)
+		waitTime := t.StartTime.Sub(submitTime)
+		if waitTime < 0 || turnaround <= 0 {
+			continue
+		}
+
+		timing := taskTimings{
+			waitSecs: waitTime.Seconds(),
+		}
+		// Overhead ratio is the fraction of total turnaround spent waiting rather than executing.
+		timing.overheadRatio = waitTime.Seconds() / turnaround.Seconds()
+
+		globalTimings = append(globalTimings, timing)
+		if t.DistroId != "" {
+			byDistro[t.DistroId] = append(byDistro[t.DistroId], timing)
+		}
+		if t.Requester != "" {
+			byRequester[t.Requester] = append(byRequester[t.Requester], timing)
+		}
+	}
+
+	var msgs []message.Fields
+
+	if len(globalTimings) > 0 {
+		msgs = append(msgs, makeWaitStatsMessage("", "", globalTimings))
+	}
+
+	distroStats := make(map[string]message.Fields)
+	for distro, timings := range byDistro {
+		if len(timings) < minDistroTasksForStats {
+			continue
+		}
+		distroStats[distro] = makeWaitStatsFields(timings)
+	}
+	if len(distroStats) > 0 {
+		msgs = append(msgs, message.Fields{
+			"message": "task queue wait stats by distro",
+			"stats":   "queue-wait-by-distro",
+			"distros": distroStats,
+		})
+	}
+
+	for requester, timings := range byRequester {
+		msgs = append(msgs, makeWaitStatsMessage("requester", requester, timings))
+	}
+
+	return msgs
+}
+
+func makeWaitStatsFields(timings []taskTimings) message.Fields {
+	waits := make([]float64, len(timings))
+	ratios := make([]float64, len(timings))
+	for i, t := range timings {
+		waits[i] = t.waitSecs
+		ratios[i] = t.overheadRatio
+	}
+	slices.Sort(waits)
+	slices.Sort(ratios)
+
+	return message.Fields{
+		"sample_size":        len(timings),
+		"p50_wait_seconds":   percentile(waits, 50),
+		"p90_wait_seconds":   percentile(waits, 90),
+		"p50_overhead_ratio": percentile(ratios, 50),
+		"p90_overhead_ratio": percentile(ratios, 90),
+	}
+}
+
+func makeWaitStatsMessage(groupKey, groupValue string, timings []taskTimings) message.Fields {
+	fields := makeWaitStatsFields(timings)
+
+	msg := "task queue wait stats"
+	if groupKey != "" {
+		msg = fmt.Sprintf("task queue wait stats by %s", groupKey)
+	}
+	fields["message"] = msg
+	fields["stats"] = "queue-wait"
+	if groupKey != "" {
+		fields[groupKey] = groupValue
+	}
+	return fields
+}
+
+func percentile(sorted []float64, pct float64) float64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := int(pct / 100 * float64(len(sorted)-1))
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+func topNProjects(counts map[string]int, n int) map[string]int {
+	type projectCount struct {
+		project string
+		count   int
+	}
+
+	sorted := make([]projectCount, 0, len(counts))
+	for p, c := range counts {
+		sorted = append(sorted, projectCount{project: p, count: c})
+	}
+	slices.SortFunc(sorted, func(a, b projectCount) int {
+		return b.count - a.count
+	})
+
+	result := make(map[string]int, min(n, len(sorted)))
+	for i := range min(n, len(sorted)) {
+		result[sorted[i].project] = sorted[i].count
+	}
+	return result
 }

--- a/units/stats_task.go
+++ b/units/stats_task.go
@@ -86,7 +86,10 @@ func (j *taskStatsCollector) Run(ctx context.Context) {
 	if len(tasks) == 0 {
 		return
 	}
+	j.logStats(ctx, tasks)
+}
 
+func (j *taskStatsCollector) logStats(ctx context.Context, tasks []task.Task) {
 	for _, msg := range getWaitTimeMessages(tasks) {
 		j.logger.Info(ctx, msg)
 	}

--- a/units/stats_test.go
+++ b/units/stats_test.go
@@ -3,12 +3,16 @@ package units
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/amboy/registry"
 	"github.com/mongodb/grip/logging"
+	"github.com/mongodb/grip/message"
 	"github.com/mongodb/grip/send"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -157,4 +161,134 @@ func (s *StatUnitsSuite) TestSysInfoCollector() {
 		s.True(m.Logged)
 		s.Contains(m.Message.String(), "cgo.calls", m.Message.String())
 	}
+}
+
+func TestGetWaitTimeMessagesOverheadRatio(t *testing.T) {
+	now := time.Now()
+	tasks := []task.Task{
+		{
+			ScheduledTime: now.Add(-10 * time.Minute),
+			StartTime:     now.Add(-5 * time.Minute),
+			FinishTime:    now,
+			DistroId:      "rhel80",
+			Requester:     "patch",
+		},
+	}
+
+	msgs := getWaitTimeMessages(tasks)
+	require.NotEmpty(t, msgs)
+
+	global := findMessage(t, msgs, "", "")
+	require.NotNil(t, global)
+	assert.Equal(t, 0.5, (*global)["p50_overhead_ratio"])
+	assert.Equal(t, 0.5, (*global)["p90_overhead_ratio"])
+}
+
+func TestGetWaitTimeMessagesGroupsByDistro(t *testing.T) {
+	now := time.Now()
+
+	var tasks []task.Task
+	for i := range minDistroTasksForStats {
+		tasks = append(tasks, task.Task{
+			ScheduledTime: now.Add(-10 * time.Minute),
+			StartTime:     now.Add(-time.Duration(5+i) * time.Minute),
+			FinishTime:    now,
+			DistroId:      "rhel80",
+			Requester:     "patch",
+		})
+	}
+
+	tasks = append(tasks, task.Task{
+		ScheduledTime: now.Add(-10 * time.Minute),
+		StartTime:     now.Add(-3 * time.Minute),
+		FinishTime:    now,
+		DistroId:      "ubuntu2204",
+		Requester:     "patch",
+	})
+
+	msgs := getWaitTimeMessages(tasks)
+
+	var distroMsg *message.Fields
+	for i := range msgs {
+		if msgs[i]["stats"] == "queue-wait-by-distro" {
+			distroMsg = &msgs[i]
+			break
+		}
+	}
+	require.NotNil(t, distroMsg)
+
+	distros, ok := (*distroMsg)["distros"].(map[string]message.Fields)
+	require.True(t, ok)
+	assert.Contains(t, distros, "rhel80")
+	assert.NotContains(t, distros, "ubuntu2204")
+	assert.Equal(t, minDistroTasksForStats, distros["rhel80"]["sample_size"])
+}
+
+func TestGetWaitTimeMessagesGroupsByRequester(t *testing.T) {
+	now := time.Now()
+	tasks := []task.Task{
+		{
+			ScheduledTime: now.Add(-10 * time.Minute),
+			StartTime:     now.Add(-5 * time.Minute),
+			FinishTime:    now,
+			DistroId:      "rhel80",
+			Requester:     "patch",
+		},
+		{
+			ScheduledTime: now.Add(-10 * time.Minute),
+			StartTime:     now.Add(-7 * time.Minute),
+			FinishTime:    now,
+			DistroId:      "rhel80",
+			Requester:     "gitter_request",
+		},
+	}
+
+	msgs := getWaitTimeMessages(tasks)
+
+	patch := findMessage(t, msgs, "requester", "patch")
+	require.NotNil(t, patch)
+	assert.Equal(t, 1, (*patch)["sample_size"])
+
+	gitter := findMessage(t, msgs, "requester", "gitter_request")
+	require.NotNil(t, gitter)
+	assert.Equal(t, 1, (*gitter)["sample_size"])
+	assert.Equal(t, 180.0, (*gitter)["p50_wait_seconds"])
+}
+
+func findMessage(t *testing.T, msgs []message.Fields, groupKey, groupValue string) *message.Fields {
+	t.Helper()
+	for i := range msgs {
+		if groupKey == "" {
+			if _, has := msgs[i]["distros"]; has {
+				continue
+			}
+			if _, has := msgs[i]["requester"]; has {
+				continue
+			}
+			return &msgs[i]
+		}
+		if msgs[i][groupKey] == groupValue {
+			return &msgs[i]
+		}
+	}
+	return nil
+}
+
+func TestTopNProjects(t *testing.T) {
+	t.Run("ReturnsTopN", func(t *testing.T) {
+		counts := map[string]int{
+			"project-a": 100,
+			"project-b": 50,
+			"project-c": 30,
+			"project-d": 20,
+			"project-e": 10,
+		}
+		result := topNProjects(counts, 3)
+		assert.Len(t, result, 3)
+		assert.Equal(t, 100, result["project-a"])
+		assert.Equal(t, 50, result["project-b"])
+		assert.Equal(t, 30, result["project-c"])
+		assert.NotContains(t, result, "project-d")
+		assert.NotContains(t, result, "project-e")
+	})
 }


### PR DESCRIPTION
DEVPROD-33761

### Description

Add queue wait time and scheduler overhead stats to the task stats collector job. For each batch of recently finished tasks, log percentile-based wait times (p50/p90) and the fraction of total turnaround time spent waiting vs. executing. Stats are broken down globally, per requester, and per distro. Also logging task counts by requester type and the top 10 projects by volume.

I only log distros with at least 5 tasks in the window to limit Splunk volume.

### Testing

Added some unit tests.