### PR TITLE
DEVPROD-32904: Treat access-denied as a cache miss and stop retrying client errors in cache commands

### DIFF
--- a/agent/command/cache_restore.go
+++ b/agent/command/cache_restore.go
@@ -160,13 +160,11 @@ func classifyCacheDownloadErr(err error) cacheDownloadOutcome {
 		return cacheDownloadMiss
 	}
 	var apiErr smithy.APIError
-	if errors.As(err, &apiErr) {
-		if apiErr.ErrorCode() == "AccessDenied" {
-			return cacheDownloadMaybeMiss
-		}
-		if apiErr.ErrorFault() == smithy.FaultClient {
-			return cacheDownloadFatal
-		}
+	if errors.As(err, &apiErr) && apiErr.ErrorCode() == "AccessDenied" {
+		return cacheDownloadMaybeMiss
+	}
+	if isS3ClientError(err) {
+		return cacheDownloadFatal
 	}
 	return cacheDownloadRetry
 }

--- a/agent/command/cache_restore.go
+++ b/agent/command/cache_restore.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/aws/smithy-go"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
@@ -78,17 +79,28 @@ func (c *cacheRestore) Execute(ctx context.Context, comm client.Communicator, lo
 	}()
 
 	// Download directly rather than checking Exists first: a missing object
-	// surfaces as a key-not-found error, which is a terminal cache miss, so we
-	// avoid an extra S3 round-trip.
+	// surfaces as a terminal cache miss, so we avoid an extra S3 round-trip (and
+	// a HEAD request would face the same 403/404 ambiguity handled below).
 	miss := false
 	downloadDesc := fmt.Sprintf("download cache object '%s'", remoteKey)
 	err = retryS3Op(ctx, logger.Task(), downloadDesc, func() (bool, error) {
 		downloadErr := c.bucket.Download(ctx, remoteKey, localPath)
-		if pail.IsKeyNotFoundError(downloadErr) {
-			miss = true
+		if downloadErr == nil {
 			return false, nil
 		}
-		return downloadErr != nil, downloadErr
+		switch classifyCacheDownloadErr(downloadErr) {
+		case cacheDownloadMaybeMiss:
+			logger.Task().Warningf(ctx, "cache.restore: got access-denied downloading '%s/%s', treating as a cache miss; if a cache was expected here, verify the credentials grant s3:GetObject on this path.", c.Bucket, remoteKey)
+			miss = true
+			return false, nil
+		case cacheDownloadMiss:
+			miss = true
+			return false, nil
+		case cacheDownloadFatal:
+			return false, downloadErr
+		default:
+			return true, downloadErr
+		}
 	})
 	if err != nil {
 		return errors.Wrapf(err, "downloading cache object '%s'", remoteKey)
@@ -118,6 +130,45 @@ func (c *cacheRestore) Execute(ctx context.Context, comm client.Communicator, lo
 	logger.Task().Infof(ctx, "cache.restore: cache hit for key '%s', extracted into '%s'.", key, conf.WorkDir)
 	setCacheHit(conf, c.CacheName, true)
 	return nil
+}
+
+// cacheDownloadOutcome classifies a cache object download error so the retry
+// loop can decide whether to retry, treat it as a miss, or fail.
+type cacheDownloadOutcome int
+
+const (
+	// cacheDownloadRetry is a transient error worth retrying.
+	cacheDownloadRetry cacheDownloadOutcome = iota
+	// cacheDownloadFatal is a non-retryable error that should fail the command.
+	cacheDownloadFatal
+	// cacheDownloadMiss means the object is absent, a normal cache miss.
+	cacheDownloadMiss
+	// cacheDownloadMaybeMiss is an access-denied response. It's treated as a
+	// miss but warned about, since it may instead be a permission
+	// misconfiguration (see classifyCacheDownloadErr).
+	cacheDownloadMaybeMiss
+)
+
+// classifyCacheDownloadErr decides how cache.restore should react to a non-nil
+// download error. A 404 NoSuchKey is a clean miss, but S3 only returns it when
+// the credentials hold bucket-wide s3:ListBucket; caches scoped to a bucket
+// sub-path typically lack that, so S3 masks a missing object as a 403
+// AccessDenied, which is treated as a (warned) miss. Other client (4xx) errors
+// won't succeed on retry and are fatal; everything else is retried.
+func classifyCacheDownloadErr(err error) cacheDownloadOutcome {
+	if pail.IsKeyNotFoundError(err) {
+		return cacheDownloadMiss
+	}
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		if apiErr.ErrorCode() == "AccessDenied" {
+			return cacheDownloadMaybeMiss
+		}
+		if apiErr.ErrorFault() == smithy.FaultClient {
+			return cacheDownloadFatal
+		}
+	}
+	return cacheDownloadRetry
 }
 
 func (c *cacheRestore) extract(ctx context.Context, archivePath, dest string) error {

--- a/agent/command/cache_restore_test.go
+++ b/agent/command/cache_restore_test.go
@@ -3,6 +3,9 @@ package command
 import (
 	"testing"
 
+	"github.com/aws/smithy-go"
+	"github.com/evergreen-ci/pail"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -96,4 +99,47 @@ func TestCacheRestoreParseParams(t *testing.T) {
 		c := &cacheRestore{}
 		require.NoError(t, c.ParseParams(params))
 	})
+}
+
+func TestClassifyCacheDownloadErr(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		err      error
+		expected cacheDownloadOutcome
+	}{
+		{
+			name:     "KeyNotFoundIsMiss",
+			err:      pail.NewKeyNotFoundError("no such key"),
+			expected: cacheDownloadMiss,
+		},
+		{
+			name:     "AccessDeniedIsMaybeMiss",
+			err:      &smithy.GenericAPIError{Code: "AccessDenied", Fault: smithy.FaultClient},
+			expected: cacheDownloadMaybeMiss,
+		},
+		{
+			name:     "WrappedAccessDeniedIsMaybeMiss",
+			err:      errors.Wrap(&smithy.GenericAPIError{Code: "AccessDenied", Fault: smithy.FaultClient}, "downloading"),
+			expected: cacheDownloadMaybeMiss,
+		},
+		{
+			name:     "OtherClientErrorIsFatal",
+			err:      &smithy.GenericAPIError{Code: "InvalidRequest", Fault: smithy.FaultClient},
+			expected: cacheDownloadFatal,
+		},
+		{
+			name:     "ServerErrorIsRetried",
+			err:      &smithy.GenericAPIError{Code: "InternalError", Fault: smithy.FaultServer},
+			expected: cacheDownloadRetry,
+		},
+		{
+			name:     "NonAPIErrorIsRetried",
+			err:      errors.New("connection reset by peer"),
+			expected: cacheDownloadRetry,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, classifyCacheDownloadErr(tc.err))
+		})
+	}
 }

--- a/agent/command/cache_save.go
+++ b/agent/command/cache_save.go
@@ -100,6 +100,9 @@ func (c *cacheSave) Execute(ctx context.Context, comm client.Communicator, logge
 	uploadDesc := fmt.Sprintf("upload cache object '%s'", remoteKey)
 	err = retryS3Op(ctx, logger.Task(), uploadDesc, func() (bool, error) {
 		uploadErr := c.bucket.Upload(ctx, remoteKey, localPath)
+		if uploadErr == nil {
+			return false, nil
+		}
 		// Skip-existing semantics: S3 reports PreconditionFailed when the
 		// object already exists and IfNotExists is set on the request. That is
 		// not an error for caching, it just means another task saved first.
@@ -108,7 +111,12 @@ func (c *cacheSave) Execute(ctx context.Context, comm client.Communicator, logge
 			alreadyExists = true
 			return false, nil
 		}
-		return uploadErr != nil, uploadErr
+		// Other client errors (4xx) won't succeed on retry, so fail fast rather
+		// than burning the full retry budget.
+		if isS3ClientError(uploadErr) {
+			return false, uploadErr
+		}
+		return true, uploadErr
 	})
 	if err != nil {
 		return errors.Wrapf(err, "uploading cache object '%s'", remoteKey)

--- a/agent/command/cache_util.go
+++ b/agent/command/cache_util.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/smithy-go"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
@@ -219,6 +220,14 @@ func retryS3Op(ctx context.Context, logger grip.Journaler, description string, o
 		MinDelay:    s3OpSleep,
 		MaxDelay:    s3OpRetryMaxSleep,
 	})
+}
+
+// isS3ClientError reports whether err is an S3 API error caused by a client
+// (4xx) fault. Such errors won't succeed on retry, so callers should treat them
+// as terminal rather than burning the retry budget.
+func isS3ClientError(err error) bool {
+	var apiErr smithy.APIError
+	return errors.As(err, &apiErr) && apiErr.ErrorFault() == smithy.FaultClient
 }
 
 // setCacheHit records whether a cache was hit in the cache-hit expansion that

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-06-01"
+	AgentVersion = "2026-06-02"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-32904

### Description

`cache.restore` only recognized a `404 NoSuchKey` as a cache miss. S3 returns that status only when the credentials hold bucket-wide `s3:ListBucket`. Caches scoped to a bucket sub-path lack that permission (appropriately, since it's bucket-level), so S3 masks a missing object as a `403 AccessDenied`. The original code treated the 403 as a retryable error, so a normal cache miss used the full retry budget and then **failed the task** instead of being recorded as a benign miss.

This PR:

- **`cache.restore`**: classifies the download error. A `404 NoSuchKey` is still a clean miss; a `403 AccessDenied` is now treated as a cache miss too (with a warning, since it could also be a genuine `s3:GetObject` misconfiguration); other 4xx client errors fail fast instead of retrying.
- **`cache.save`**: applied the mirror-image fix — a 4xx client error (other than the existing benign `PreconditionFailed` skip-existing case) now fails fast rather than using the retry budget. A failed save remains fatal; it just no longer retries pointlessly.

### Testing

- Added `TestClassifyCacheDownloadErr` covering key-not-found, access-denied (incl. wrapped), other 4xx (fatal), 5xx (retry), and non-API (retry) cases.

### Documentation

None, this is a bug fix.

### References

- [Claude Code on the web session](https://claude.ai/code/session_01MkoH3Vs8MAS1G8GqwEfHuD)
- [Slack conversation about s3:ListBucket](https://mongodb.slack.com/archives/C69UXN1CP/p1780425279788979)