### PR TITLE
DEVPROD-32221 Add new suggested indexes

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -247,7 +247,7 @@ func IdleEphemeralGroupedByDistroID(ctx context.Context, env evergreen.Environme
 		},
 	}
 
-	cur, err := env.DB().Collection(Collection).Aggregate(ctx, pipeline, options.Aggregate().SetHint(StartedByStatusIndex))
+	cur, err := env.DB().Collection(Collection).Aggregate(ctx, pipeline, options.Aggregate().SetHint(StartedByCreationTimeIndex))
 	if err != nil {
 		return nil, errors.Wrap(err, "grouping idle hosts by distro ID")
 	}

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2423,6 +2423,24 @@ var StartedByStatusIndex = bson.D{
 	},
 }
 
+// StartedByCreationTimeIndex is the started_by_1_creation_time_1 partial index (active task
+// hosts only). IdleEphemeralGroupedByDistroID hints this so its sort by creation_time is served
+// by the index, avoiding a blocking in-memory sort that spills to disk under load. status is
+// deliberately NOT a key field: the query matches status with an $or (running/starting), and a
+// range field between the started_by equality prefix and the creation_time sort key defeats the
+// index sort. Keeping creation_time directly after started_by lets the index provide the order,
+// with status (and the other predicates) applied as residual filters within the partial set.
+var StartedByCreationTimeIndex = bson.D{
+	{
+		Key:   StartedByKey,
+		Value: 1,
+	},
+	{
+		Key:   CreateTimeKey,
+		Value: 1,
+	},
+}
+
 // DistroIdStatusIndex is the distro_id_1_status_1 index.
 var DistroIdStatusIndex = bson.D{
 	{

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2423,13 +2423,10 @@ var StartedByStatusIndex = bson.D{
 	},
 }
 
-// StartedByCreationTimeIndex is the started_by_1_creation_time_1 partial index (active task
-// hosts only). IdleEphemeralGroupedByDistroID hints this so its sort by creation_time is served
-// by the index, avoiding a blocking in-memory sort that spills to disk under load. status is
-// deliberately NOT a key field: the query matches status with an $or (running/starting), and a
-// range field between the started_by equality prefix and the creation_time sort key defeats the
-// index sort. Keeping creation_time directly after started_by lets the index provide the order,
-// with status (and the other predicates) applied as residual filters within the partial set.
+// StartedByCreationTimeIndex is the started_by_1_creation_time_1 index, hinted by
+// IdleEphemeralGroupedByDistroID so its sort by creation_time is served by the index rather than a
+// blocking in-memory sort. status is intentionally omitted: it's matched with an $or, so keying it
+// between started_by and creation_time would break the index sort.
 var StartedByCreationTimeIndex = bson.D{
 	{
 		Key:   StartedByKey,

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -2052,7 +2052,7 @@ func TestInactiveHostCountPipeline(t *testing.T) {
 
 func setupIdleHostQueryIndex(t *testing.T) {
 	require.NoError(t, db.EnsureIndex(Collection, mongo.IndexModel{
-		Keys: StartedByStatusIndex,
+		Keys: StartedByCreationTimeIndex,
 	}))
 }
 

--- a/units/host_monitoring_idle_termination_test.go
+++ b/units/host_monitoring_idle_termination_test.go
@@ -52,7 +52,7 @@ func numIdleHostsFound(ctx context.Context, env evergreen.Environment, t *testin
 func testFlaggingIdleHostsSetupTest(t *testing.T) {
 	require.NoError(t, db.DropCollections(host.Collection, distro.Collection, task.Collection), "dropping collections")
 	require.NoError(t, modelUtil.AddTestIndexes(host.Collection, true, true, host.RunningTaskKey), "adding running_task_1 index")
-	require.NoError(t, modelUtil.AddTestIndexes(host.Collection, false, false, host.StartedByKey, host.StatusKey), "adding started_by_1_status_1 index")
+	require.NoError(t, modelUtil.AddTestIndexes(host.Collection, false, false, host.StartedByKey, host.CreateTimeKey), "adding started_by_1_creation_time_1 index")
 }
 
 // testFlaggingIdleHostsTeardownTest resets the relevant DB collections after a
@@ -868,7 +868,7 @@ func TestPopulateIdleHostJobsCalculations(t *testing.T) {
 	assert.NoError(env.Configure(ctx))
 
 	require.NoError(t, db.EnsureIndex(host.Collection, mongo.IndexModel{
-		Keys: host.StartedByStatusIndex,
+		Keys: host.StartedByCreationTimeIndex,
 	}))
 
 	distro1 := distro.Distro{


### PR DESCRIPTION
DEVPROD-32221


### Description

added partial indexes: 

    { started_by: 1, creation_time: 1 },
    { partialFilterExpression: { started_by: "mci", status: { $in: ["running", "starting"] } } }) 

    { started_by: 1, status: 1, host_type: 1 },
    {  partialFilterExpression: { started_by: "mci",
        status: { $in: ["building","building-failed","starting","provisioning","provision failed","running","stopping","stopped","decommissioned","quarantined"] } } })

These indexes will help with these two queries 
creation time: https://github.com/evergreen-ci/evergreen/blob/308afa85b07a236a30fe4d6f01d84e32376f2060/model/host/db.go#L219
host type: https://github.com/evergreen-ci/evergreen/blob/308afa85b07a236a30fe4d6f01d84e32376f2060/model/host/db.go#L290

Only the first one needs a hint but the other one uses it automatically
(using explain on queries) 

### Testing
added indexes on staging 
tested they work 
tested they are faster and skips sort stage 
