### PR TITLE
Bump pail to v0.0.0-20260603160329-d42d169cab98

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/evergreen-ci/birch v0.0.0-20250224221624-64f481f4b888
 	github.com/evergreen-ci/certdepot v0.0.0-20260326190252-5ab5e35f6cb7
 	github.com/evergreen-ci/gimlet v0.0.0-20260520162532-2cfc3356800c
-	github.com/evergreen-ci/pail v0.0.0-20260507160025-5cf2ef56c715
+	github.com/evergreen-ci/pail v0.0.0-20260603160329-d42d169cab98
 	github.com/evergreen-ci/poplar v0.0.0-20260330180450-c8cf511d1bd6
 	github.com/evergreen-ci/shrub v0.0.0-20251017154811-4d3ed1599154
 	github.com/evergreen-ci/utility v0.0.0-20260116164328-250718d590d2

--- a/go.sum
+++ b/go.sum
@@ -167,8 +167,8 @@ github.com/evergreen-ci/lru v0.0.0-20260326190734-0d627bf39810 h1:Q+MNMS3rHQw6bG
 github.com/evergreen-ci/lru v0.0.0-20260326190734-0d627bf39810/go.mod h1:A+sGkHeCogvvRBXUrF/Ghu5Gec6lyLtb1MKZN/xfWmI=
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035 h1:oVU/ni/sRq+GAogUMLa7LBGtvVHMVLbisuytxBC5KaY=
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035/go.mod h1:pvK7NM0ZC+sfTLuIiJN4BgM1S9S5Oo79PJReAFFph18=
-github.com/evergreen-ci/pail v0.0.0-20260507160025-5cf2ef56c715 h1:kPCrIdzDB+9t3ZxWiQdO2FL5Tt2fIkHxPeZc+SxI0K4=
-github.com/evergreen-ci/pail v0.0.0-20260507160025-5cf2ef56c715/go.mod h1:lj8oxBSqzEoapX1apBDy88B7wRjj27QQu9EXk2i3AOM=
+github.com/evergreen-ci/pail v0.0.0-20260603160329-d42d169cab98 h1:kMGvulzi5DKq0i/KMbtPYg4aRkqfF2utfP/xDzcDcpc=
+github.com/evergreen-ci/pail v0.0.0-20260603160329-d42d169cab98/go.mod h1:lj8oxBSqzEoapX1apBDy88B7wRjj27QQu9EXk2i3AOM=
 github.com/evergreen-ci/plank v0.0.0-20251203163536-53406252f581 h1:JOYnqPypLzZdjlFxS2ynWGKFPTrx0HAJwe6mi9P/lhk=
 github.com/evergreen-ci/plank v0.0.0-20251203163536-53406252f581/go.mod h1:visOo9VGGrTN+jNPSg56zhbCH81sSlMRnXpJCYb+kt4=
 github.com/evergreen-ci/poplar v0.0.0-20260330180450-c8cf511d1bd6 h1:leuRlgINHoR0/takPgoHYrfHt5mAtXcLdKdfQ0KVnyQ=


### PR DESCRIPTION


## Summary
- Bumps `github.com/evergreen-ci/pail` from `v0.0.0-20260507160025-5cf2ef56c715` to `v0.0.0-20260603160329-d42d169cab98`



