### PR TITLE
Add Go module caching to self-tests CI pipeline

### DIFF
--- a/makefile
+++ b/makefile
@@ -246,9 +246,11 @@ phony += lint build test coverage coverage-html list-tests
 # start module management targets
 mod-tidy:
 	$(gobin) mod tidy
+mod-download:
+	$(gobin) mod download
 verify-mod-tidy:
 	$(gobin) run cmd/verify-mod-tidy/verify-mod-tidy.go -goBin="$(gobin)"
-phony += mod-tidy verify-mod-tidy
+phony += mod-tidy mod-download verify-mod-tidy
 # end module management targets
 
 # convenience targets for runing tests and coverage tasks on a

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -193,6 +193,7 @@ functions:
         bucket: mciuploads
         remote_path: evergreen/self-tests/go-mod-cache
         key_files:
+          - evergreen/go.mod
           - evergreen/go.sum
         key_expansions:
           - ${distro_arch}
@@ -220,6 +221,7 @@ functions:
         bucket: mciuploads
         remote_path: evergreen/self-tests/go-mod-cache
         key_files:
+          - evergreen/go.mod
           - evergreen/go.sum
         key_expansions:
           - ${distro_arch}

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -185,20 +185,46 @@ functions:
         directory: evergreen
         token: ${github_token}
         shallow_clone: true
+    - command: cache.restore
+      type: setup
+      params:
+        name: go-modules
+        role_arn: ${assume_role_arn}
+        bucket: mciuploads
+        remote_path: evergreen/self-tests/go-mod-cache
+        key_files:
+          - evergreen/go.sum
+        key_expansions:
+          - ${distro_arch}
     - command: shell.exec
       type: setup
       params:
         working_dir: evergreen
-        include_expansions_in_env: ["GOROOT", "github_token"]
+        include_expansions_in_env: ["GOROOT", "github_token", "go_modules_cache_hit"]
         shell: bash
         script: |
-          # Downloading modules is flaky in the ubuntu1604-arm64 distros, because the TCP connection is sometimes reset
-          # by the peer for unknown reasons (this does not happen in other distros). Retry the module download multiple
-          # times to reduce the flakiness.
-          for i in {1..5}; do
-            make mod-tidy
-            [[ $? -eq 0 ]] && break;
-          done
+          # On a cache miss, download the modules into the module cache so cache.save can upload it below. Downloading
+          # modules is flaky in the ubuntu1604-arm64 distros, because the TCP connection is sometimes reset by the peer
+          # for unknown reasons (this does not happen in other distros). Retry the module download multiple times to
+          # reduce the flakiness.
+          if [ "$go_modules_cache_hit" != "true" ]; then
+            for i in {1..5}; do
+              make mod-download && break
+            done
+          fi
+    - command: cache.save
+      type: setup
+      params:
+        name: go-modules
+        role_arn: ${assume_role_arn}
+        bucket: mciuploads
+        remote_path: evergreen/self-tests/go-mod-cache
+        key_files:
+          - evergreen/go.sum
+        key_expansions:
+          - ${distro_arch}
+        paths:
+          - evergreen/bin/.mod-cache
 
   assume-role:
     command: ec2.assume_role


### PR DESCRIPTION
DEVPROD-34359

### Description

Implement Go module caching in the self-tests CI pipeline. Move `make mod-tidy` to `verify-mod-tidy` task, and instead use new `make mod-download` for downloading modules.

For the first tasks, before the cache is warmed, [downloading](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen-agent/trace/35XQb7ZpQHw?fields[]=s_name&fields[]=s_serviceName&span=5ee88d5e7347f5eb) modules takes 18 seconds. With a warm cache, [restoring](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen-agent/trace/vUuFPiy74xB?fields[]=s_name&fields[]=s_serviceName&span=2a63e0d358c4b2aa) the cache takes 7 seconds.

### References

- [Claude Code on the web session](https://claude.ai/code/session_01YR19ryfCjTuFQ2Es3ZZGmk)