### PR TITLE
DEVPROD-33789 Update logs to enable notification health dashboard

### DIFF
--- a/units/github_status_api.go
+++ b/units/github_status_api.go
@@ -245,8 +245,13 @@ func (j *githubStatusUpdateJob) Run(ctx context.Context) {
 
 	j.sender.Send(ctx, c)
 	grip.Info(ctx, message.Fields{
-		"ticket":  thirdparty.GithubInvestigation,
-		"message": "called github status send",
-		"caller":  githubStatusUpdateJobName,
+		"ticket":      thirdparty.GithubInvestigation,
+		"message":     "called github status send",
+		"caller":      githubStatusUpdateJobName,
+		"owner":       status.Owner,
+		"repo":        status.Repo,
+		"ref":         status.Ref,
+		"update_type": j.UpdateType,
+		"patch_id":    j.FetchID,
 	})
 }

--- a/units/stats_notifications.go
+++ b/units/stats_notifications.go
@@ -73,6 +73,7 @@ func (j *notificationsStatsCollector) Run(ctx context.Context) {
 	}
 	if e != nil {
 		msg["last_processed_at"] = e.ProcessedAt
+		msg["processing_lag_seconds"] = time.Since(e.ProcessedAt).Seconds()
 	}
 
 	nUnprocessed, err := event.CountUnprocessedEvents(ctx)


### PR DESCRIPTION
DEVPROD-33789

### Description
Adding some extra Splunk logs that will be needed to make dashboards for the following Evergreen golden path metrics defined [here](https://docs.google.com/document/d/1JjDwRV6CnQ-g_7bb7srQqfs9oe2g8Hl41sIHtHj3fIw/edit?tab=t.0)

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-f07fbee9-7fff-0f63-5923-0b9cfc6d86a9"><div dir="ltr" style="margin-left:0pt;" align="center">
Metric type | Metric | Proposed platform | Golden Path | Metric Completed✅
-- | -- | -- | -- | --


</div></b>

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-c232e8ef-7fff-b885-2b15-cc0991f7c2ca"><div dir="ltr" style="margin-left:0pt;" align="center">
Operational | Are developers getting notified?Throughput and error vs. sent ratio per channel (slack, email, etc).Are notification pipelines stuck?E2e notification latency (time since last event was processed + count of unprocessed events) | Splunk | Allow users to receive timely notifications for host/version/build/task status updates and waterfall  success/runtime regressions. |  
-- | -- | -- | -- | --


</div></b>

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-f9e62973-7fff-2158-af3f-f214520e60de"><div dir="ltr" style="margin-left:0pt;" align="center">
Operational | Are developers getting notified?Throughput and error vs. sent ratio per channel (slack, email, etc).Are notification pipelines stuck?E2e notification latency (time since last event was processed + count of unprocessed events) | Splunk | Allow users to receive timely notifications for host/version/build/task status updates and waterfall  success/runtime regressions. |  
-- | -- | -- | -- | --


</div></b>

### Testing
Existing tests.