### PR TITLE
DEVPROD-34398 Speed up units test suite and raise timeout

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -855,6 +855,7 @@ buildvariants:
       mongodb_url: https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu2204-8.0.0.tgz
       mongosh_url: https://downloads.mongodb.com/compass/mongosh-2.0.2-linux-x64.tgz
       notary_client_url: https://macos-notary-1628249594.s3.amazonaws.com/releases/client/v3.1.2/linux_amd64.zip
+      test_timeout: 15m
     tasks:
       - name: ".smoke"
       - name: ".test"

--- a/units/host_drawdown_test.go
+++ b/units/host_drawdown_test.go
@@ -33,9 +33,10 @@ func TestHostDrawdown(t *testing.T) {
 	ctx := testutil.TestSpan(t.Context(), t)
 
 	// Configuring the mock environment is expensive, so do it once and reuse it
-	// across subtests. The host collection is reset between subtests, and the
-	// drawdown job only reads/writes the database, so there is no shared state
-	// to leak through the environment.
+	// across subtests. The relevant DB collections (host, distro, task) are
+	// dropped between subtests (see testFlaggingIdleHostsSetupTest), and the
+	// drawdown job only reads/writes the database, so there is no test-relevant
+	// shared state to leak through the environment.
 	env := &mock.Environment{}
 	require.NoError(t, env.Configure(ctx))
 

--- a/units/host_drawdown_test.go
+++ b/units/host_drawdown_test.go
@@ -30,6 +30,15 @@ func numHostsDecommissionedForDrawdown(ctx context.Context, t *testing.T, env ev
 }
 
 func TestHostDrawdown(t *testing.T) {
+	ctx := testutil.TestSpan(t.Context(), t)
+
+	// Configuring the mock environment is expensive, so do it once and reuse it
+	// across subtests. The host collection is reset between subtests, and the
+	// drawdown job only reads/writes the database, so there is no shared state
+	// to leak through the environment.
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, d distro.Distro){
 		"DecommissionsHostsDownToCap": func(ctx context.Context, t *testing.T, env *mock.Environment, d distro.Distro) {
 			// insert a gaggle of hosts, some of which reference a host.Distro that doesn't exist in the distro collection
@@ -414,9 +423,7 @@ func TestHostDrawdown(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			ctx = testutil.TestSpan(ctx, t)
+			tctx := testutil.TestSpan(ctx, t)
 			testFlaggingIdleHostsSetupTest(t)
 
 			d := distro.Distro{
@@ -426,16 +433,14 @@ func TestHostDrawdown(t *testing.T) {
 					MinimumHosts: 0,
 				},
 			}
-			require.NoError(t, d.Insert(ctx))
+			require.NoError(t, d.Insert(tctx))
 			taskQueue := model.TaskQueue{
 				Distro: d.Id,
 				Queue:  []model.TaskQueueItem{},
 			}
-			require.NoError(t, taskQueue.Save(ctx))
-			env := &mock.Environment{}
-			require.NoError(t, env.Configure(ctx))
+			require.NoError(t, taskQueue.Save(tctx))
 
-			tCase(ctx, t, env, d)
+			tCase(tctx, t, env, d)
 		})
 	}
 }


### PR DESCRIPTION
DEVPROD-34398

### Description

The `units` test suite intermittently fails with `panic: test timed out` under the default 10m Go test timeout. This PR reduces the number of expensive `env.Configure` calls and increases the timeout.

An HTML explanation of this change: https://pages.monglify.aix.prod.corp.mongodb.com/p/coconut-jaguar-jasper