### PR TITLE
DEVPROD-33241 Fix single-host task group host counting

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -492,8 +492,8 @@ func allHostsSpawnedByFinishedBuilds(ctx context.Context) ([]Host, error) {
 	return Aggregate(ctx, pipeline)
 }
 
-// ByTaskSpec returns a query that finds all running hosts that are running a
-// task with the given group, buildvariant, project, and version.
+// ByTaskSpec returns a query that finds all running hosts currently assigned to
+// or idle between tasks with the given group, buildvariant, project, and version.
 func ByTaskSpec(group, buildVariant, project, version string) bson.M {
 	return bson.M{
 		StatusKey: bson.M{"$in": []string{evergreen.HostStarting, evergreen.HostRunning}},
@@ -506,18 +506,19 @@ func ByTaskSpec(group, buildVariant, project, version string) bson.M {
 				RunningTaskVersionKey:      version,
 			},
 			{
-				LTCTaskKey:    bson.M{"$exists": "true"},
-				LTCGroupKey:   group,
-				LTCBVKey:      buildVariant,
-				LTCProjectKey: project,
-				LTCVersionKey: version,
+				RunningTaskKey: bson.M{"$exists": false},
+				LTCTaskKey:     bson.M{"$exists": "true"},
+				LTCGroupKey:    group,
+				LTCBVKey:       buildVariant,
+				LTCProjectKey:  project,
+				LTCVersionKey:  version,
 			},
 		},
 	}
 }
 
-// NumHostsByTaskSpec returns the number of running hosts that are running a task with
-// the given group, buildvariant, project, and version.
+// NumHostsByTaskSpec returns the number of running hosts currently assigned to
+// or idle between tasks with the given group, buildvariant, project, and version.
 func NumHostsByTaskSpec(ctx context.Context, group, buildVariant, project, version string) (int, error) {
 	if group == "" || buildVariant == "" || project == "" || version == "" {
 		return 0, errors.Errorf("all arguments must be non-empty strings: (group is '%s', build variant is '%s', "+

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -1040,6 +1040,24 @@ func TestNumHostsByTaskSpec(t *testing.T) {
 		assert.Equal(t, 1, count)
 	})
 
+	t.Run("BusyHostRunningTaskGroupCounts", func(t *testing.T) {
+		require.NoError(t, db.Clear(Collection))
+		h := Host{
+			Id:                      "busy_with_task_group",
+			Status:                  evergreen.HostRunning,
+			RunningTask:             "current_task",
+			RunningTaskGroup:        group,
+			RunningTaskBuildVariant: buildVariant,
+			RunningTaskProject:      project,
+			RunningTaskVersion:      version,
+		}
+		require.NoError(t, h.Insert(t.Context()))
+
+		count, err := NumHostsByTaskSpec(t.Context(), group, buildVariant, project, version)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	})
+
 	t.Run("BusyHostRunningUnrelatedTaskDoesNotCount", func(t *testing.T) {
 		require.NoError(t, db.Clear(Collection))
 		h := Host{

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -1014,6 +1014,52 @@ func TestUpdateHostRunningTask(t *testing.T) {
 	})
 }
 
+func TestNumHostsByTaskSpec(t *testing.T) {
+	const (
+		group        = "task_group"
+		buildVariant = "build_variant"
+		project      = "project"
+		version      = "version"
+	)
+
+	t.Run("IdleHostBetweenTaskGroupTasksCounts", func(t *testing.T) {
+		require.NoError(t, db.Clear(Collection))
+		h := Host{
+			Id:               "idle_between_task_group_tasks",
+			Status:           evergreen.HostRunning,
+			LastTask:         "previous_task",
+			LastGroup:        group,
+			LastBuildVariant: buildVariant,
+			LastProject:      project,
+			LastVersion:      version,
+		}
+		require.NoError(t, h.Insert(t.Context()))
+
+		count, err := NumHostsByTaskSpec(t.Context(), group, buildVariant, project, version)
+		require.NoError(t, err)
+		assert.Equal(t, 1, count)
+	})
+
+	t.Run("BusyHostRunningUnrelatedTaskDoesNotCount", func(t *testing.T) {
+		require.NoError(t, db.Clear(Collection))
+		h := Host{
+			Id:               "busy_with_stale_task_group",
+			Status:           evergreen.HostRunning,
+			RunningTask:      "unrelated_task",
+			LastTask:         "previous_task",
+			LastGroup:        group,
+			LastBuildVariant: buildVariant,
+			LastProject:      project,
+			LastVersion:      version,
+		}
+		require.NoError(t, h.Insert(t.Context()))
+
+		count, err := NumHostsByTaskSpec(t.Context(), group, buildVariant, project, version)
+		require.NoError(t, err)
+		assert.Zero(t, count)
+	})
+}
+
 func TestUpsert(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
DEVPROD-33241

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->

Our query was mistakenly over-counting tasks assigned to a task group under very specific circumstances. This PR makes them count correctly.

### Testing

The unit tests I added emulate the data that was causing this bug. I did some testing on staging, but it's hard to emulate the exact conditions.