### PR TITLE
DEVPROD-27416 Fix insecure random number generation for RDP passwords

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"crypto/rand"
 	"math"
-	"math/rand"
+	"math/big"
 	"net"
 	"path/filepath"
 	"regexp"
@@ -543,12 +544,16 @@ func (h *Host) SetupServiceUserCommands(ctx context.Context) (string, error) {
 
 const passwordCharset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890"
 
-func generatePassword(length int) string {
+func generatePassword(length int) (string, error) {
 	b := make([]byte, length)
 	for i := range b {
-		b[i] = passwordCharset[rand.Int()%len(passwordCharset)]
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(passwordCharset))))
+		if err != nil {
+			return "", errors.Wrap(err, "generating secure random number")
+		}
+		b[i] = passwordCharset[n.Int64()]
 	}
-	return string(b)
+	return string(b), nil
 }
 
 // CreateServicePassword creates the password for the host's service user.
@@ -556,7 +561,11 @@ func (h *Host) CreateServicePassword(ctx context.Context) error {
 	var password string
 	var valid bool
 	for i := 0; i < 1000; i++ {
-		password = generatePassword(12)
+		var err error
+		password, err = generatePassword(12)
+		if err != nil {
+			return errors.Wrap(err, "generating service password")
+		}
 		if valid = ValidateRDPPassword(password); valid {
 			break
 		}

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -2,9 +2,9 @@ package host
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
-	"crypto/rand"
 	"math"
 	"math/big"
 	"net"


### PR DESCRIPTION
DEVPROD-27416

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Password generation for Windows host RDP access uses math/rand, making generated passwords potentially predictable. If an attacker knows the approximate time a host was created, they may be able to use that time window to brute-force different seed values and predict the generated password. To fix this, we instead use crypto/rand, which does not use a deterministic algorithm or seed value. 

### Testing
pre-existing `TestCreateServicePassword` test in test-model-host

A proof of concept script is attached to the ticket. It demonstrates three things:

1. In the math/rand implementation, knowing the seed allows the password to be reconstructed
2. In this implementation, knowing the host creation time (potentially observable from the host tag) allows an attacker to brute-force seed values within a small time window and predict the generated password
3. In the crypto/rand implementation, there is no seed value and the password cannot be reproduced
