### PR TITLE
DEVPROD-33785 Spawn host delivery & adoption stats

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3160,6 +3160,15 @@ func AggregateSpawnhostData(ctx context.Context) (*SpawnHostUsage, error) {
 	}, nil
 }
 
+// CountDebugSpawnhosts returns the number of active spawn hosts in debug mode.
+func CountDebugSpawnhosts(ctx context.Context) (int, error) {
+	return Count(ctx, bson.M{
+		UserHostKey: true,
+		StatusKey:   bson.M{"$in": evergreen.UpHostStatus},
+		IsDebugKey:  true,
+	})
+}
+
 // CountSpawnhostsWithNoExpirationByUser returns a count of all hosts associated
 // with a given users that are considered up and should never expire.
 func CountSpawnhostsWithNoExpirationByUser(ctx context.Context, user string) (int, error) {

--- a/model/version.go
+++ b/model/version.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/go-github/v70/github"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -1108,13 +1109,37 @@ func getManifestModule(ctx context.Context, projectRef *ProjectRef, module Modul
 func CreateManifest(ctx context.Context, v *Version, modules ModuleList, projectRef *ProjectRef) (*manifest.Manifest, error) {
 	newManifest, err := constructManifest(ctx, v, projectRef, modules)
 	if err != nil {
+		grip.Error(ctx, message.WrapError(err, message.Fields{
+			"message":     "constructing manifest",
+			"source":      "manifest-creation",
+			"version_id":  v.Id,
+			"project_id":  projectRef.Id,
+			"num_modules": len(modules),
+		}))
 		return nil, errors.Wrap(err, "constructing manifest")
 	}
 	if newManifest == nil {
 		return nil, nil
 	}
 	_, err = newManifest.TryInsert(ctx)
-	return newManifest, errors.Wrap(err, "inserting manifest")
+	if err != nil {
+		grip.Error(ctx, message.WrapError(err, message.Fields{
+			"message":     "inserting manifest",
+			"source":      "manifest-creation",
+			"version_id":  v.Id,
+			"project_id":  projectRef.Id,
+			"num_modules": len(newManifest.Modules),
+		}))
+		return newManifest, errors.Wrap(err, "inserting manifest")
+	}
+	grip.Info(ctx, message.Fields{
+		"message":     "successfully created manifest",
+		"source":      "manifest-creation",
+		"version_id":  v.Id,
+		"project_id":  projectRef.Id,
+		"num_modules": len(newManifest.Modules),
+	})
+	return newManifest, nil
 }
 
 type VersionsByCreateTime []Version

--- a/units/host_stats.go
+++ b/units/host_stats.go
@@ -119,4 +119,29 @@ func (j *hostStatsJob) Run(ctx context.Context) {
 		"message": "virtual workstations",
 		"stats":   count,
 	})
+
+	spawnStats, err := host.AggregateSpawnhostData(ctx)
+	if err != nil {
+		j.AddError(errors.Wrap(err, "aggregating spawn host data"))
+	}
+	debugHostCount, countErr := host.CountDebugSpawnhosts(ctx)
+	if countErr != nil {
+		j.AddError(errors.Wrap(countErr, "counting debug spawn hosts"))
+		return
+	}
+	j.logger.Info(ctx, message.Fields{
+		"message":                 "spawn host usage stats",
+		"stats":                   "spawn-hosts",
+		"total_hosts":             spawnStats.TotalHosts,
+		"total_stopped_hosts":     spawnStats.TotalStoppedHosts,
+		"total_unexpirable_hosts": spawnStats.TotalUnexpirableHosts,
+		"num_users_with_hosts":    spawnStats.NumUsersWithHosts,
+		"total_volumes":           spawnStats.TotalVolumes,
+		"total_volume_size":       spawnStats.TotalVolumeSize,
+		"num_users_with_volumes":  spawnStats.NumUsersWithVolumes,
+		"instance_types":          spawnStats.InstanceTypes,
+		"debug_hosts":             debugHostCount,
+		"non_debug_hosts":         spawnStats.TotalHosts - debugHostCount,
+	})
+
 }

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -837,6 +837,12 @@ func processTriggerAliases(ctx context.Context, p *patch.Patch, projectRef *mode
 		})
 
 		if err := triggerIntent.Insert(ctx); err != nil {
+			grip.Error(ctx, message.WrapError(err, message.Fields{
+				"message":            "inserting trigger intent for child patch",
+				"source":             "patch-trigger",
+				"parent_patch_id":    p.Id.Hex(),
+				"downstream_project": group.project,
+			}))
 			return errors.Wrap(err, "inserting trigger intent")
 		}
 
@@ -846,6 +852,14 @@ func processTriggerAliases(ctx context.Context, p *patch.Patch, projectRef *mode
 	if err := p.SetChildPatches(ctx); err != nil {
 		return errors.Wrap(err, "setting child patch IDs")
 	}
+	grip.Info(ctx, message.Fields{
+		"message":           "created downstream patch trigger intents",
+		"source":            "patch-trigger",
+		"parent_patch_id":   p.Id.Hex(),
+		"parent_project_id": p.Project,
+		"child_patch_ids":   p.Triggers.ChildPatches,
+		"num_children":      len(p.Triggers.ChildPatches),
+	})
 
 	for _, intent := range triggerIntents {
 		triggerIntent, ok := intent.(*patch.TriggerIntent)
@@ -859,6 +873,12 @@ func processTriggerAliases(ctx context.Context, p *patch.Patch, projectRef *mode
 			// we need the child patch intents to exist when the parent patch is finalized.
 			job.Run(ctx)
 			if err := job.Error(); err != nil {
+				grip.Error(ctx, message.WrapError(err, message.Fields{
+					"message":         "processing child patch",
+					"source":          "patch-trigger",
+					"parent_patch_id": p.Id.Hex(),
+					"child_patch_id":  intent.ID(),
+				}))
 				return errors.Wrap(err, "processing child patch")
 			}
 		} else {


### PR DESCRIPTION
DEVPROD-33785

### Description
Updated our host stats job to continuously log relevant spawn host health and usage stats to allow dashboard creations for spawn host related metrics defined under the Evergreen section [here](https://docs.google.com/document/d/1JjDwRV6CnQ-g_7bb7srQqfs9oe2g8Hl41sIHtHj3fIw/edit?tab=t.0#heading=h.6t9nsdzj4hw)

Also added some extra logs to help track multi-repo versions including patch triggers and modules.
### Testing
Existing tests