### PR TITLE
DEVPROD-34455: Don't require URL task_id on /select/tests auth middleware 

### DIFF
--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -844,3 +844,24 @@ func (m *userOrTaskAuthMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Req
 
 	next(rw, r)
 }
+
+// NewUserOrTaskAuthOnlyMiddleware authenticates the request as either a user
+// or a task/host, with no further URL or permission checks. Use it for routes
+// that accept either auth type and don't need per-task gating.
+func NewUserOrTaskAuthOnlyMiddleware() gimlet.Middleware {
+	return &userOrTaskAuthOnlyMiddleware{
+		taskFallback: NewTaskAuthMiddleware(),
+	}
+}
+
+type userOrTaskAuthOnlyMiddleware struct {
+	taskFallback gimlet.Middleware
+}
+
+func (m *userOrTaskAuthOnlyMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	if gimlet.GetUser(r.Context()) == nil {
+		m.taskFallback.ServeHTTP(rw, r, next)
+		return
+	}
+	next(rw, r)
+}

--- a/rest/route/select_test.go
+++ b/rest/route/select_test.go
@@ -4,9 +4,13 @@ import (
 	"bytes"
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen/mock"
+	"github.com/evergreen-ci/evergreen/model/user"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -98,4 +102,31 @@ func TestSelectTestsHandler(t *testing.T) {
 	req, _ = http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(j))
 	sth = makeSelectTestsHandler(env)
 	require.Error(t, sth.Parse(ctx, req), "request should fail to parse when task name is missing")
+}
+
+// Regression guard: user-authenticated requests must reach the handler.
+// Previously NewUserOrTaskAuthMiddleware short-circuited them on a missing
+// {task_id} URL var that /select/tests doesn't have.
+func TestSelectTestsRouteUserAuth(t *testing.T) {
+	ctx := gimlet.AttachUser(context.Background(), &user.DBUser{Id: "test-user"})
+	body := []byte(`{
+		"project_id": "my-project",
+		"requester": "patch",
+		"build_variant": "variant",
+		"task_id": "my-task-1234",
+		"task_name": "my-task",
+		"tests": ["test1"]
+	}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/select/tests", bytes.NewBuffer(body))
+	require.NoError(t, err)
+
+	rw := httptest.NewRecorder()
+	called := false
+	NewUserOrTaskAuthOnlyMiddleware().ServeHTTP(rw, req, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	assert.True(t, called, "next handler should run for a user-authenticated request")
+	assert.Equal(t, http.StatusOK, rw.Code, "middleware should not short-circuit user-authenticated requests")
 }

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -34,6 +34,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	// Middleware
 	requireUser := gimlet.NewRequireAuthHandler()
 	requireUserOrTask := NewUserOrTaskAuthMiddleware()
+	requireUserOrTaskAuthOnly := NewUserOrTaskAuthOnlyMiddleware()
 	requireValidGithubPayload := NewGithubAuthMiddleware()
 	requireValidSNSPayload := NewSNSAuthMiddleware()
 	requireTask := NewTaskAuthMiddleware()
@@ -217,7 +218,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/permissions/users").Version(2).Get().Wrap(requireUser).RouteHandler(makeGetAllUsersPermissions(env.RoleManager()))
 	app.AddRoute("/roles").Version(2).Get().Wrap(requireUser).RouteHandler(acl.NewGetAllRolesHandler(env.RoleManager()))
 	app.AddRoute("/roles/{role_id}/users").Version(2).Get().Wrap(requireUser).RouteHandler(makeGetUsersWithRole())
-	app.AddRoute("/select/tests").Version(2).Post().Wrap(requireUserOrTask).RouteHandler(makeSelectTestsHandler(env))
+	app.AddRoute("/select/tests").Version(2).Post().Wrap(requireUserOrTaskAuthOnly).RouteHandler(makeSelectTestsHandler(env))
 	app.AddRoute("/status/cli_version").Version(2).Get().Wrap(requireUser).RouteHandler(makeFetchCLIVersionRoute(env))
 	app.AddRoute("/status/hosts/distros").Version(2).Get().Wrap(requireUser).RouteHandler(makeHostStatusByDistroRoute())
 	app.AddRoute("/status/notifications").Version(2).Get().Wrap(requireUser).RouteHandler(makeFetchNotifcationStatusRoute())


### PR DESCRIPTION
DEVPROD-34455

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Before there was a middleware requiring `task_id` in the API url for `GET /rest/v2/select/tests` like it was a task endpoint such as `GET /rest/v2/task/{task_id}`. This caused us to fail with a 4xx . We removed this check as task_id is expected in the body already, and it's not needed or grabbed from the url.


Parsley log failure from this behavior: 
<img width="1456" height="120" alt="Screenshot 2026-06-04 at 12 31 28 PM" src="https://github.com/user-attachments/assets/da1cd72a-904c-4488-9d5a-c8c5b3048ce4" />

Replicating the error locally:
<img width="797" height="351" alt="Screenshot 2026-06-04 at 1 27 48 PM" src="https://github.com/user-attachments/assets/397c32d3-2773-401c-b23d-e03436b3f525" />

### Testing
* Called locally using evergreen CLI's auth token
* Added tests
