### PR TITLE
DEVPROD-34453 Propagate origin from request to outputted urls

### DIFF
--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -841,12 +841,17 @@ func (r *taskResolver) Tests(ctx context.Context, obj *restModel.APITask, opts *
 	}
 
 	apiResults := make([]*restModel.APITest, len(taskResults.Results))
+	settings := evergreen.GetEnvironment().Settings()
+	apiTestArgs := &restModel.APITestArgs{
+		EvergreenBaseURL: settings.Api.URL,
+		ParsleyLogURL:    settings.Ui.ParsleyUrl,
+	}
 	for i, t := range taskResults.Results {
 		apiTest := &restModel.APITest{}
-		if err = apiTest.BuildFromService(t.TaskID); err != nil {
+		if err = apiTest.BuildFromService(t.TaskID, nil); err != nil {
 			return nil, InternalServerError.Send(ctx, err.Error())
 		}
-		if err = apiTest.BuildFromService(&t); err != nil {
+		if err = apiTest.BuildFromService(&t, apiTestArgs); err != nil {
 			return nil, InternalServerError.Send(ctx, err.Error())
 		}
 

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1644,10 +1644,15 @@ func buildQuarantineMutationResponse(ctx context.Context, t *task.Task, testName
 	tr := taskResults.Results[0]
 	tr.IsManuallyQuarantined = isManuallyQuarantined
 	apiTest := &restModel.APITest{}
-	if err = apiTest.BuildFromService(tr.TaskID); err != nil {
+	settings := evergreen.GetEnvironment().Settings()
+	apiTestArgs := &restModel.APITestArgs{
+		EvergreenBaseURL: settings.Api.URL,
+		ParsleyLogURL:    settings.Ui.ParsleyUrl,
+	}
+	if err = apiTest.BuildFromService(tr.TaskID, nil); err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())
 	}
-	if err = apiTest.BuildFromService(&tr); err != nil {
+	if err = apiTest.BuildFromService(&tr, apiTestArgs); err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())
 	}
 	return apiTest, nil

--- a/model/testresult/testresult.go
+++ b/model/testresult/testresult.go
@@ -166,9 +166,7 @@ func (tr TestResult) Duration() time.Duration {
 // It is not advisable to set URL or URLRaw with the output of this function as
 // those fields are reserved for external logs and used to determine URL
 // generation for other log viewers.
-func (tr TestResult) GetLogURL(env evergreen.Environment, viewer evergreen.LogViewer) string {
-	root := env.Settings().Api.URL
-	parsleyURL := env.Settings().Ui.ParsleyUrl
+func (tr TestResult) GetLogURL(root, parsleyURL string, viewer evergreen.LogViewer) string {
 	deprecatedLogkeeperURLs := []string{"https://logkeeper.mongodb.org", "https://logkeeper2.build.10gen.cc"}
 
 	switch viewer {

--- a/model/testresult/testresult_test.go
+++ b/model/testresult/testresult_test.go
@@ -1,24 +1,15 @@
 package testresult
 
 import (
-	"context"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGetLogURL(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	settings := testutil.TestConfig()
-	require.NoError(t, db.Clear(evergreen.ConfigCollection))
-	settings.Ui.ParsleyUrl = "https://parsley.mongodb.org"
-	require.NoError(t, evergreen.UpdateConfig(ctx, settings))
+	evergreenBaseURL := "https://request.evergreen.example.com"
+	parsleyURL := "https://parsley.mongodb.org"
 
 	test1 := TestResult{
 		TaskID:   "task1",
@@ -37,10 +28,10 @@ func TestGetLogURL(t *testing.T) {
 		Status:   evergreen.TestFailedStatus,
 	}
 
-	url := test1.GetLogURL(evergreen.GetEnvironment(), evergreen.LogViewerRaw)
-	assert.Equal(t, url, "https://localhost:8443/rest/v2/tasks/task1/build/TestLogs/test1?execution=0&print_time=true")
-	url = test2.GetLogURL(evergreen.GetEnvironment(), evergreen.LogViewerHTML)
-	assert.Equal(t, url, "https://localhost:8443/test_log/task1/0?test_name=test2#L0")
-	url = test3.GetLogURL(evergreen.GetEnvironment(), evergreen.LogViewerParsley)
-	assert.Equal(t, url, "https://localhost:4173/test/task1/0/test3?shareLine=0")
+	url := test1.GetLogURL(evergreenBaseURL, parsleyURL, evergreen.LogViewerRaw)
+	assert.Equal(t, "https://request.evergreen.example.com/rest/v2/tasks/task1/build/TestLogs/test1?execution=0&print_time=true", url)
+	url = test2.GetLogURL(evergreenBaseURL, parsleyURL, evergreen.LogViewerHTML)
+	assert.Equal(t, "https://request.evergreen.example.com/test_log/task1/0?test_name=test2#L0", url)
+	url = test3.GetLogURL(evergreenBaseURL, parsleyURL, evergreen.LogViewerParsley)
+	assert.Equal(t, "https://parsley.mongodb.org/test/task1/0/test3?shareLine=0", url)
 }

--- a/rest/data/build_baron.go
+++ b/rest/data/build_baron.go
@@ -139,11 +139,12 @@ func makeJiraNotification(ctx context.Context, settings *evergreen.Settings, t *
 		return nil, errors.Wrap(err, "getting Jira mappings")
 	}
 	payload, err := trigger.JIRATaskPayload(ctx, trigger.JiraIssueParameters{
-		Project:  jiraOpts.project,
-		UiURL:    settings.Ui.Url,
-		UiV2URL:  settings.Ui.UIv2Url,
-		Mappings: mappings,
-		Task:     t,
+		Project:       jiraOpts.project,
+		UiURL:         settings.Ui.Url,
+		UiV2URL:       settings.Ui.UIv2Url,
+		ParsleyLogURL: settings.Ui.ParsleyUrl,
+		Mappings:      mappings,
+		Task:          t,
 	})
 	if err != nil {
 		return nil, err

--- a/rest/model/test.go
+++ b/rest/model/test.go
@@ -53,11 +53,24 @@ type TestLogs struct {
 	LogsToMerge []string `json:"logs_to_merge,omitempty"`
 }
 
-func (at *APITest) BuildFromService(st any) error {
-	env := evergreen.GetEnvironment()
+// APITestArgs contains values used to populate generated test log links.
+type APITestArgs struct {
+	EvergreenBaseURL string
+	ParsleyLogURL    string
+}
+
+func (at *APITest) BuildFromService(st any, args *APITestArgs) error {
+	buildArgs := APITestArgs{}
+	if args != nil {
+		buildArgs = *args
+	}
 
 	switch v := st.(type) {
 	case *testresult.TestResult:
+		if buildArgs.EvergreenBaseURL == "" {
+			return errors.New("evergreen base URL is required to build test log links")
+		}
+
 		at.ID = utility.ToStringPtr(v.TestName)
 		at.Execution = v.Execution
 		if v.GroupID != "" {
@@ -74,12 +87,12 @@ func (at *APITest) BuildFromService(st any) error {
 
 		at.TestFile = utility.ToStringPtr(v.GetDisplayTestName())
 		at.Logs = TestLogs{
-			URL:      utility.ToStringPtr(v.GetLogURL(env, evergreen.LogViewerHTML)),
-			URLRaw:   utility.ToStringPtr(v.GetLogURL(env, evergreen.LogViewerRaw)),
+			URL:      utility.ToStringPtr(v.GetLogURL(buildArgs.EvergreenBaseURL, buildArgs.ParsleyLogURL, evergreen.LogViewerHTML)),
+			URLRaw:   utility.ToStringPtr(v.GetLogURL(buildArgs.EvergreenBaseURL, buildArgs.ParsleyLogURL, evergreen.LogViewerRaw)),
 			LineNum:  v.LineNum,
 			TestName: utility.ToStringPtr(v.GetLogTestName()),
 		}
-		if parsleyURL := v.GetLogURL(env, evergreen.LogViewerParsley); parsleyURL != "" {
+		if parsleyURL := v.GetLogURL(buildArgs.EvergreenBaseURL, buildArgs.ParsleyLogURL, evergreen.LogViewerParsley); parsleyURL != "" {
 			at.Logs.URLParsley = utility.ToStringPtr(parsleyURL)
 		}
 		if v.LogInfo != nil {

--- a/rest/model/test_test.go
+++ b/rest/model/test_test.go
@@ -5,24 +5,18 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/testresult"
-	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTestBuildFromService(t *testing.T) {
-	ctx := t.Context()
-
-	settings := testutil.TestConfig()
-	require.NoError(t, db.Clear(evergreen.ConfigCollection))
-	settings.Ui.ParsleyUrl = "https://parsley.mongodb.org"
-	require.NoError(t, evergreen.UpdateConfig(ctx, settings))
-
-	env := evergreen.GetEnvironment()
+	args := &APITestArgs{
+		EvergreenBaseURL: "https://request.evergreen.example.com",
+		ParsleyLogURL:    "https://parsley.mongodb.org",
+	}
 	start := time.Now().Add(-10 * time.Minute)
 	end := time.Now()
 
@@ -50,9 +44,9 @@ func TestTestBuildFromService(t *testing.T) {
 					Status:    utility.ToStringPtr(input.Status),
 					TestFile:  utility.ToStringPtr(input.TestName),
 					Logs: TestLogs{
-						URL:        utility.ToStringPtr(input.GetLogURL(env, evergreen.LogViewerHTML)),
-						URLRaw:     utility.ToStringPtr(input.GetLogURL(env, evergreen.LogViewerRaw)),
-						URLParsley: utility.ToStringPtr(input.GetLogURL(env, evergreen.LogViewerParsley)),
+						URL:        utility.ToStringPtr(input.GetLogURL(args.EvergreenBaseURL, args.ParsleyLogURL, evergreen.LogViewerHTML)),
+						URLRaw:     utility.ToStringPtr(input.GetLogURL(args.EvergreenBaseURL, args.ParsleyLogURL, evergreen.LogViewerRaw)),
+						URLParsley: utility.ToStringPtr(input.GetLogURL(args.EvergreenBaseURL, args.ParsleyLogURL, evergreen.LogViewerParsley)),
 						LineNum:    input.LineNum,
 						TestName:   utility.ToStringPtr(input.GetLogTestName()),
 					},
@@ -92,9 +86,9 @@ func TestTestBuildFromService(t *testing.T) {
 					GroupID:   utility.ToStringPtr(input.GroupID),
 					Status:    utility.ToStringPtr(input.Status),
 					Logs: TestLogs{
-						URL:           utility.ToStringPtr(input.GetLogURL(env, evergreen.LogViewerHTML)),
-						URLRaw:        utility.ToStringPtr(input.GetLogURL(env, evergreen.LogViewerRaw)),
-						URLParsley:    utility.ToStringPtr(input.GetLogURL(env, evergreen.LogViewerParsley)),
+						URL:           utility.ToStringPtr(input.GetLogURL(args.EvergreenBaseURL, args.ParsleyLogURL, evergreen.LogViewerHTML)),
+						URLRaw:        utility.ToStringPtr(input.GetLogURL(args.EvergreenBaseURL, args.ParsleyLogURL, evergreen.LogViewerRaw)),
+						URLParsley:    utility.ToStringPtr(input.GetLogURL(args.EvergreenBaseURL, args.ParsleyLogURL, evergreen.LogViewerParsley)),
 						LineNum:       int(input.LogInfo.LineNum),
 						TestName:      utility.ToStringPtr(input.GetLogTestName()),
 						RenderingType: input.LogInfo.RenderingType,
@@ -144,9 +138,9 @@ func TestTestBuildFromService(t *testing.T) {
 					Status:    utility.ToStringPtr(input.Status),
 					TestFile:  utility.ToStringPtr(input.TestName),
 					Logs: TestLogs{
-						URL:           utility.ToStringPtr(input.GetLogURL(env, evergreen.LogViewerHTML)),
-						URLRaw:        utility.ToStringPtr(input.GetLogURL(env, evergreen.LogViewerRaw)),
-						URLParsley:    utility.ToStringPtr(input.GetLogURL(env, evergreen.LogViewerParsley)),
+						URL:           utility.ToStringPtr(input.GetLogURL(args.EvergreenBaseURL, args.ParsleyLogURL, evergreen.LogViewerHTML)),
+						URLRaw:        utility.ToStringPtr(input.GetLogURL(args.EvergreenBaseURL, args.ParsleyLogURL, evergreen.LogViewerRaw)),
+						URLParsley:    utility.ToStringPtr(input.GetLogURL(args.EvergreenBaseURL, args.ParsleyLogURL, evergreen.LogViewerParsley)),
 						LineNum:       int(input.LogInfo.LineNum),
 						TestName:      utility.ToStringPtr(input.GetLogTestName()),
 						RenderingType: input.LogInfo.RenderingType,
@@ -180,9 +174,9 @@ func TestTestBuildFromService(t *testing.T) {
 					Status:    utility.ToStringPtr(input.Status),
 					TestFile:  utility.ToStringPtr(input.TestName),
 					Logs: TestLogs{
-						URL:        utility.ToStringPtr(input.GetLogURL(env, evergreen.LogViewerHTML)),
-						URLRaw:     utility.ToStringPtr(input.GetLogURL(env, evergreen.LogViewerRaw)),
-						URLParsley: utility.ToStringPtr(input.GetLogURL(env, evergreen.LogViewerParsley)),
+						URL:        utility.ToStringPtr(input.GetLogURL(args.EvergreenBaseURL, args.ParsleyLogURL, evergreen.LogViewerHTML)),
+						URLRaw:     utility.ToStringPtr(input.GetLogURL(args.EvergreenBaseURL, args.ParsleyLogURL, evergreen.LogViewerRaw)),
+						URLParsley: utility.ToStringPtr(input.GetLogURL(args.EvergreenBaseURL, args.ParsleyLogURL, evergreen.LogViewerParsley)),
 						LineNum:    input.LineNum,
 						TestName:   utility.ToStringPtr(input.GetLogTestName()),
 					},
@@ -205,7 +199,7 @@ func TestTestBuildFromService(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			at := &APITest{}
 			input, output := test.io()
-			err := at.BuildFromService(input)
+			err := at.BuildFromService(input, args)
 
 			if test.hasErr {
 				assert.Error(t, err)
@@ -215,4 +209,19 @@ func TestTestBuildFromService(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("MissingEvergreenBaseURLShouldError", func(t *testing.T) {
+		at := &APITest{}
+		err := at.BuildFromService(&testresult.TestResult{TestName: "test_file"}, nil)
+		assert.Error(t, err)
+
+		err = at.BuildFromService(&testresult.TestResult{TestName: "test_file"}, &APITestArgs{})
+		assert.Error(t, err)
+	})
+
+	t.Run("TaskIDShouldAllowNilArgs", func(t *testing.T) {
+		at := &APITest{}
+		require.NoError(t, at.BuildFromService("task", nil))
+		assert.Equal(t, utility.ToStringPtr("task"), at.TaskID)
+	})
 }

--- a/rest/route/test.go
+++ b/rest/route/test.go
@@ -168,13 +168,14 @@ func (tgh *testGetHandler) buildResponse(ctx context.Context, results []testresu
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "setting response format"))
 	}
 
+	logURL := GetURL(ctx)
 	if key != "" {
 		err := resp.SetPages(&gimlet.ResponsePages{
 			Next: &gimlet.Page{
 				Relation:        "next",
 				LimitQueryParam: "limit",
 				KeyQueryParam:   "start_at",
-				BaseURL:         GetURL(ctx),
+				BaseURL:         logURL,
 				Key:             key,
 				Limit:           tgh.limit,
 			},
@@ -184,8 +185,12 @@ func (tgh *testGetHandler) buildResponse(ctx context.Context, results []testresu
 		}
 	}
 
+	args := &model.APITestArgs{
+		EvergreenBaseURL: logURL,
+		ParsleyLogURL:    tgh.env.Settings().Ui.ParsleyUrl,
+	}
 	for i, result := range results {
-		if err := tgh.addDataToResponse(resp, &result); err != nil {
+		if err := tgh.addDataToResponse(resp, &result, args); err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "adding test result at index %d", i))
 		}
 	}
@@ -193,15 +198,15 @@ func (tgh *testGetHandler) buildResponse(ctx context.Context, results []testresu
 	return resp
 }
 
-func (tgh *testGetHandler) addDataToResponse(resp gimlet.Responder, result any) error {
+func (tgh *testGetHandler) addDataToResponse(resp gimlet.Responder, result any, args *model.APITestArgs) error {
 	at := &model.APITest{}
-	if err := at.BuildFromService(tgh.taskID); err != nil {
+	if err := at.BuildFromService(tgh.taskID, nil); err != nil {
 		return gimlet.ErrorResponse{
 			Message:    errors.Wrap(err, "adding task ID to task API model").Error(),
 			StatusCode: http.StatusInternalServerError,
 		}
 	}
-	if err := at.BuildFromService(result); err != nil {
+	if err := at.BuildFromService(result, args); err != nil {
 		return gimlet.ErrorResponse{
 			Message:    errors.Wrap(err, "adding test result to task API model").Error(),
 			StatusCode: http.StatusInternalServerError,

--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -450,10 +450,11 @@ func makeCommonPayload(sub *event.Subscription, eventAttributes event.Attributes
 
 func getFailedTestsFromTemplate(t task.Task) ([]testresult.TestResult, error) {
 	results := []testresult.TestResult{}
+	settings := evergreen.GetEnvironment().Settings()
 	for i := range t.LocalTestResults {
 		if t.LocalTestResults[i].Status == evergreen.TestFailedStatus {
 			testResult := t.LocalTestResults[i]
-			testResult.LogURL = testResult.GetLogURL(evergreen.GetEnvironment(), evergreen.LogViewerHTML)
+			testResult.LogURL = testResult.GetLogURL(settings.Api.URL, settings.Ui.ParsleyUrl, evergreen.LogViewerHTML)
 			results = append(results, testResult)
 		}
 	}

--- a/trigger/payloads_test.go
+++ b/trigger/payloads_test.go
@@ -195,8 +195,8 @@ func (s *payloadSuite) TestGetFailedTestsFromTemplate() {
 	tr, err := getFailedTestsFromTemplate(t)
 	s.NoError(err)
 	s.Require().Len(tr, 2)
-	s.Equal(test2.GetLogURL(evergreen.GetEnvironment(), evergreen.LogViewerHTML), tr[0].LogURL)
-	s.Equal(test3.GetLogURL(evergreen.GetEnvironment(), evergreen.LogViewerHTML), tr[1].LogURL)
+	s.Equal(test2.GetLogURL(settings.Api.URL, settings.Ui.ParsleyUrl, evergreen.LogViewerHTML), tr[0].LogURL)
+	s.Equal(test3.GetLogURL(settings.Api.URL, settings.Ui.ParsleyUrl, evergreen.LogViewerHTML), tr[1].LogURL)
 }
 
 func TestTruncateString(t *testing.T) {

--- a/trigger/task.go
+++ b/trigger/task.go
@@ -925,28 +925,30 @@ func matchingFailureType(requested, actual string) bool {
 
 func (j *taskTriggers) makeJIRATaskPayload(ctx context.Context, subID, project, testNames string) (*message.JiraIssue, error) {
 	return JIRATaskPayload(ctx, JiraIssueParameters{
-		SubID:     subID,
-		Project:   project,
-		UiURL:     j.uiConfig.Url,
-		EventID:   j.event.ID,
-		TestNames: testNames,
-		Mappings:  j.jiraMappings,
-		Task:      j.task,
-		Host:      j.host,
+		SubID:         subID,
+		Project:       project,
+		UiURL:         j.uiConfig.Url,
+		ParsleyLogURL: j.uiConfig.ParsleyUrl,
+		EventID:       j.event.ID,
+		TestNames:     testNames,
+		Mappings:      j.jiraMappings,
+		Task:          j.task,
+		Host:          j.host,
 	})
 }
 
 // JiraIssueParameters specify a task payload.
 type JiraIssueParameters struct {
-	SubID     string
-	Project   string
-	UiURL     string
-	UiV2URL   string
-	EventID   string
-	TestNames string
-	Mappings  *evergreen.JIRANotificationsConfig
-	Task      *task.Task
-	Host      *host.Host
+	SubID         string
+	Project       string
+	UiURL         string
+	UiV2URL       string
+	ParsleyLogURL string
+	EventID       string
+	TestNames     string
+	Mappings      *evergreen.JIRANotificationsConfig
+	Task          *task.Task
+	Host          *host.Host
 }
 
 // JIRATaskPayload creates a Jira issue for a given task.
@@ -979,6 +981,7 @@ func JIRATaskPayload(ctx context.Context, params JiraIssueParameters) (*message.
 		Context:         ctx,
 		UIRoot:          params.UiURL,
 		UIv2Url:         params.UiV2URL,
+		ParsleyLogURL:   params.ParsleyLogURL,
 		SubscriptionID:  params.SubID,
 		EventID:         params.EventID,
 		Task:            params.Task,

--- a/trigger/task_jira.go
+++ b/trigger/task_jira.go
@@ -166,6 +166,7 @@ type jiraTemplateData struct {
 	Context            context.Context
 	UIRoot             string
 	UIv2Url            string
+	ParsleyLogURL      string
 	SubscriptionID     string
 	EventID            string
 	Task               *task.Task
@@ -371,10 +372,9 @@ func (j *jiraBuilder) getDescription() (string, error) {
 	tests := []jiraTestFailure{}
 	for _, test := range j.data.Task.LocalTestResults {
 		if test.Status == evergreen.TestFailedStatus {
-			env := evergreen.GetEnvironment()
-			url := test.GetLogURL(env, evergreen.LogViewerParsley)
+			url := test.GetLogURL(j.data.UIRoot, j.data.ParsleyLogURL, evergreen.LogViewerParsley)
 			if url == "" {
-				url = test.GetLogURL(env, evergreen.LogViewerHTML)
+				url = test.GetLogURL(j.data.UIRoot, j.data.ParsleyLogURL, evergreen.LogViewerHTML)
 			}
 
 			tests = append(tests, jiraTestFailure{

--- a/trigger/task_jira_test.go
+++ b/trigger/task_jira_test.go
@@ -251,7 +251,8 @@ func TestJiraDescription(t *testing.T) {
 	Convey("With a failed task context", t, func() {
 		j := jiraBuilder{
 			data: jiraTemplateData{
-				UIRoot: "http://evergreen.ui",
+				UIRoot:        "http://evergreen.ui",
+				ParsleyLogURL: "http://parsley.ui",
 				Project: &model.ProjectRef{
 					DisplayName: projectName,
 					Id:          projectId,
@@ -340,15 +341,15 @@ func TestJiraDescription(t *testing.T) {
 			So(tests, ShouldContain, "FunUnitTest")
 
 			So(len(logfiles), ShouldEqual, 2)
-			So(logfiles, ShouldContain, j.data.Task.LocalTestResults[0].GetLogURL(evergreen.GetEnvironment(), evergreen.LogViewerParsley))
-			So(logfiles, ShouldContain, j.data.Task.LocalTestResults[1].GetLogURL(evergreen.GetEnvironment(), evergreen.LogViewerParsley))
+			So(logfiles, ShouldContain, j.data.Task.LocalTestResults[0].GetLogURL(j.data.UIRoot, j.data.ParsleyLogURL, evergreen.LogViewerParsley))
+			So(logfiles, ShouldContain, j.data.Task.LocalTestResults[1].GetLogURL(j.data.UIRoot, j.data.ParsleyLogURL, evergreen.LogViewerParsley))
 
 			So(len(taskURLs), ShouldEqual, 1)
 			So(taskURLs, ShouldContain, "http://evergreen.ui/task/t1%21/0")
 		})
 
 		Convey("the description should be successfully generated - HTML Links for logs", func() {
-			evergreen.GetEnvironment().Settings().Ui.ParsleyUrl = ""
+			j.data.ParsleyLogURL = ""
 			d, err := j.getDescription()
 			So(err, ShouldBeNil)
 			So(d, ShouldNotEqual, "")
@@ -381,7 +382,7 @@ func TestJiraDescription(t *testing.T) {
 			})
 		})
 		Convey("the description should match the URL and logline regexes - HTML Links for logs", func() {
-			evergreen.GetEnvironment().Settings().Ui.ParsleyUrl = ""
+			j.data.ParsleyLogURL = ""
 			desc, err := j.getDescription()
 			So(err, ShouldBeNil)
 
@@ -411,8 +412,8 @@ func TestJiraDescription(t *testing.T) {
 			So(tests, ShouldContain, "FunUnitTest")
 
 			So(len(logfiles), ShouldEqual, 2)
-			So(logfiles, ShouldContain, j.data.Task.LocalTestResults[0].GetLogURL(evergreen.GetEnvironment(), evergreen.LogViewerHTML))
-			So(logfiles, ShouldContain, j.data.Task.LocalTestResults[1].GetLogURL(evergreen.GetEnvironment(), evergreen.LogViewerHTML))
+			So(logfiles, ShouldContain, j.data.Task.LocalTestResults[0].GetLogURL(j.data.UIRoot, j.data.ParsleyLogURL, evergreen.LogViewerHTML))
+			So(logfiles, ShouldContain, j.data.Task.LocalTestResults[1].GetLogURL(j.data.UIRoot, j.data.ParsleyLogURL, evergreen.LogViewerHTML))
 
 			So(len(taskURLs), ShouldEqual, 1)
 			So(taskURLs, ShouldContain, "http://evergreen.ui/task/t1%21/0")


### PR DESCRIPTION
DEVPROD-34453

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->

Previously in #10244, I made requests from corp produce corp urls, and non-corp produce non-corp urls. I covered a lot of locations, but I missed a couple. This PR covers some. It's a bit of a rewrite because I wanted to tackle relevant tech debt with it rather than doing the bare minimum.

### Testing

<!--add a description of how you tested it-->
Unit tests. Ran it and got the correct urls for tasks as well! I used [this evergreen.staging URL](https://evergreen.staging.corp.mongodb.com/rest/v2/tasks/evg_race_detector_test_model_manifest_99f735119d13d427ec05526947ac6ed452e70acb_26_06_04_02_54_34/tests) and [this evergreen-staging URL](https://evergreen-staging.corp.mongodb.com/rest/v2/tasks/evg_race_detector_test_model_manifest_99f735119d13d427ec05526947ac6ed452e70acb_26_06_04_02_54_34/tests) and deployed to staging.

Before hand, both used non-corp `evergreen-staging`. After, the use the same as the origin / incoming request used.