### PR TITLE
DEVPROD-32681: Support cloning mainline waterfall builds with per-variant task mappings

### DIFF
--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -786,10 +786,6 @@ func (j *patchIntentProcessor) setToPreviousPatchDefinition(ctx context.Context,
 // per-variant task mapping on patchDoc. Display-task wrappers are not reconstructed;
 // execution tasks are scheduled directly.
 func setToPreviousMainlineVersionDefinition(ctx context.Context, patchDoc *patch.Patch, versionId string) error {
-	grip.Debug(ctx, message.Fields{
-		"message":    "cloning mainline waterfall version via --repeat-patch",
-		"version_id": versionId,
-	})
 	activatedTasks, err := task.FindActivatedByVersionWithoutDisplay(ctx, versionId)
 	if err != nil {
 		return errors.Wrapf(err, "querying activated tasks for version '%s'", versionId)

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -751,6 +752,12 @@ func (j *patchIntentProcessor) setToPreviousPatchDefinition(ctx context.Context,
 		if reusePatch == nil {
 			return errors.Errorf("no previous patch available")
 		}
+	} else if !patch.IsValidId(patchId) {
+		// Mainline (waterfall) version IDs have no patch document; reconstruct VariantsTasks from activated tasks.
+		if failedOnly {
+			return errors.Errorf("repeating failed tasks from mainline version '%s' is not supported", patchId)
+		}
+		return setToPreviousMainlineVersionDefinition(ctx, patchDoc, patchId)
 	} else {
 		reusePatch, err = patch.FindOneId(ctx, patchId)
 		if err != nil {
@@ -772,6 +779,49 @@ func (j *patchIntentProcessor) setToPreviousPatchDefinition(ctx context.Context,
 		return errors.Wrapf(err, "filtering tasks for '%s'", patchId)
 	}
 
+	return nil
+}
+
+// setToPreviousMainlineVersionDefinition reproduces a mainline (waterfall) version's
+// per-variant task mapping on patchDoc. Display-task wrappers are not reconstructed;
+// execution tasks are scheduled directly.
+func setToPreviousMainlineVersionDefinition(ctx context.Context, patchDoc *patch.Patch, versionId string) error {
+	grip.Debug(ctx, message.Fields{
+		"message":    "cloning mainline waterfall version via --repeat-patch",
+		"version_id": versionId,
+	})
+	activatedTasks, err := task.FindActivatedByVersionWithoutDisplay(ctx, versionId)
+	if err != nil {
+		return errors.Wrapf(err, "querying activated tasks for version '%s'", versionId)
+	}
+	if len(activatedTasks) == 0 {
+		return errors.Errorf("no activated tasks found for version '%s'", versionId)
+	}
+
+	variantToTasks := map[string][]string{}
+	var allTasks []string
+	for _, t := range activatedTasks {
+		variantToTasks[t.BuildVariant] = append(variantToTasks[t.BuildVariant], t.DisplayName)
+		allTasks = append(allTasks, t.DisplayName)
+	}
+
+	buildVariants := make([]string, 0, len(variantToTasks))
+	for variant := range variantToTasks {
+		buildVariants = append(buildVariants, variant)
+	}
+	sort.Strings(buildVariants)
+	sort.Strings(allTasks)
+
+	variantsTasks := make([]patch.VariantTasks, 0, len(buildVariants))
+	for _, variant := range buildVariants {
+		tasks := variantToTasks[variant]
+		sort.Strings(tasks)
+		variantsTasks = append(variantsTasks, patch.VariantTasks{Variant: variant, Tasks: tasks})
+	}
+
+	patchDoc.Tasks = allTasks
+	patchDoc.BuildVariants = buildVariants
+	patchDoc.VariantsTasks = variantsTasks
 	return nil
 }
 

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -521,6 +521,26 @@ func (s *PatchIntentUnitsSuite) TestSetToPreviousPatchDefinition() {
 			s.Equal(currentPatchDoc.BuildVariants, reusePatchDoc.BuildVariants)
 			s.Equal([]string{"diffTask1"}, currentPatchDoc.Tasks)
 		},
+		"MainlineVersionIDBuildsPerVariantMapping": func(j *patchIntentProcessor, currentPatchDoc *patch.Patch) {
+			err := j.setToPreviousPatchDefinition(ctx, currentPatchDoc, &project, "v1", false)
+			s.NoError(err)
+
+			s.Equal([]string{"bv1", "bv2"}, currentPatchDoc.BuildVariants)
+			s.Equal([]string{"et1", "t1", "t2", "tgt1", "tgt2", "tgt4"}, currentPatchDoc.Tasks)
+			s.Require().Len(currentPatchDoc.VariantsTasks, 2)
+			s.Equal(patch.VariantTasks{Variant: "bv1", Tasks: []string{"t1", "t2", "tgt1", "tgt2", "tgt4"}}, currentPatchDoc.VariantsTasks[0])
+			s.Equal(patch.VariantTasks{Variant: "bv2", Tasks: []string{"et1"}}, currentPatchDoc.VariantsTasks[1])
+		},
+		"MainlineVersionIDWithFailedOnlyErrors": func(j *patchIntentProcessor, currentPatchDoc *patch.Patch) {
+			err := j.setToPreviousPatchDefinition(ctx, currentPatchDoc, &project, "v1", true)
+			s.Require().Error(err)
+			s.Contains(err.Error(), "not supported")
+		},
+		"MainlineVersionIDWithNoActivatedTasksErrors": func(j *patchIntentProcessor, currentPatchDoc *patch.Patch) {
+			err := j.setToPreviousPatchDefinition(ctx, currentPatchDoc, &project, "nonexistent_version", false)
+			s.Require().Error(err)
+			s.Contains(err.Error(), "no activated tasks found")
+		},
 	} {
 		s.NoError(db.ClearCollections(task.Collection))
 		t1 := task.Task{


### PR DESCRIPTION
DEVPROD-32681

### Description
This PR addresses a user ask to extend the managed multipatch service in signal-processing-service so they can clone mainline waterfall builds for performance comparison.

Previously the code only accepted patch IDs. For mainline version ids, the patch lookup returned nil and multipatch fell back to `patch-file --tasks XX --variants XX`. This  cross-multiplied tasks across variants 

Extended `setToPreviousPatchDefinition` so when we don't find a valid patch, we query the version's activated tasks and then grouped by build variants and populate the correct tasks

### Testing
Added test case coverage and staging patch passed