### PR TITLE
DEVPROD-20246:  Add EC2/EBS cost attributes to task.completed span

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2024,6 +2024,13 @@ func buildTaskCompletedSpanAttributes(t *task.Task) []attribute.KeyValue {
 		attrs = append(attrs, attribute.Int64(evergreen.TaskDurationMsOtelAttribute,
 			t.FinishTime.Sub(t.StartTime).Milliseconds()))
 	}
+	if !t.TaskCost.IsZero() {
+		attrs = append(attrs,
+			attribute.Float64(evergreen.TaskAdjustedCostOtelAttribute, t.TaskCost.AdjustedEC2Cost),
+			attribute.Float64(evergreen.TaskEBSAdjustedThroughputCostOtelAttribute, t.TaskCost.AdjustedEBSThroughputCost),
+			attribute.Float64(evergreen.TaskEBSAdjustedStorageCostOtelAttribute, t.TaskCost.AdjustedEBSStorageCost),
+		)
+	}
 	return attrs
 }
 

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db/mgo/bson"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/cost"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -6769,4 +6770,41 @@ func TestBuildTaskCompletedSpanAttributesConditionalFields(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildTaskCompletedSpanAttributesCostFields(t *testing.T) {
+	t.Run("NonZeroCostProducesCostAttrs", func(t *testing.T) {
+		t1 := task.Task{
+			TaskCost: cost.Cost{
+				AdjustedEC2Cost:           1.23,
+				AdjustedEBSThroughputCost: 0.45,
+				AdjustedEBSStorageCost:    0.67,
+			},
+		}
+		attrs := buildTaskCompletedSpanAttributes(&t1)
+
+		ec2Val, hasEC2 := findAttr(attrs, evergreen.TaskAdjustedCostOtelAttribute)
+		require.True(t, hasEC2)
+		assert.Equal(t, 1.23, ec2Val.AsFloat64())
+
+		ebsThroughputVal, hasEBSThroughput := findAttr(attrs, evergreen.TaskEBSAdjustedThroughputCostOtelAttribute)
+		require.True(t, hasEBSThroughput)
+		assert.Equal(t, 0.45, ebsThroughputVal.AsFloat64())
+
+		ebsStorageVal, hasEBSStorage := findAttr(attrs, evergreen.TaskEBSAdjustedStorageCostOtelAttribute)
+		require.True(t, hasEBSStorage)
+		assert.Equal(t, 0.67, ebsStorageVal.AsFloat64())
+	})
+
+	t.Run("ZeroCostOmitsCostAttrs", func(t *testing.T) {
+		t1 := task.Task{}
+		attrs := buildTaskCompletedSpanAttributes(&t1)
+
+		_, hasEC2 := findAttr(attrs, evergreen.TaskAdjustedCostOtelAttribute)
+		assert.False(t, hasEC2)
+		_, hasEBSThroughput := findAttr(attrs, evergreen.TaskEBSAdjustedThroughputCostOtelAttribute)
+		assert.False(t, hasEBSThroughput)
+		_, hasEBSStorage := findAttr(attrs, evergreen.TaskEBSAdjustedStorageCostOtelAttribute)
+		assert.False(t, hasEBSStorage)
+	})
 }


### PR DESCRIPTION
DEVPROD-20246

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

 When a task completes with non-zero cost data, emit the EC2 and EBS cost
  values as attributes on the `task.completed` OpenTelemetry span.
### Testing

Added a test and[ tested in staging](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/7t6rBWWtg1t?omitMissingValues=)


<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
