### PR TITLE
DEVPROD-33719 Add rate limiting service flags

### DIFF
--- a/config_db.go
+++ b/config_db.go
@@ -97,6 +97,8 @@ var (
 	podDiagnosticsDisabledKey             = bsonutil.MustHaveTag(ServiceFlags{}, "PodDiagnosticsDisabled")
 	secondaryReadsDisabledKey             = bsonutil.MustHaveTag(ServiceFlags{}, "SecondaryReadsDisabled")
 	backgroundCommandFailureEnabledKey    = bsonutil.MustHaveTag(ServiceFlags{}, "BackgroundCommandFailureEnabled")
+	apiRateLimiterDisabledKey             = bsonutil.MustHaveTag(ServiceFlags{}, "APIRateLimiterDisabled")
+	graphqlComplexityLimiterDisabledKey   = bsonutil.MustHaveTag(ServiceFlags{}, "GraphQLComplexityLimiterDisabled")
 
 	// DiagnosticsConfig keys
 	diagnosticsS3BucketNameKey = bsonutil.MustHaveTag(DiagnosticsConfig{}, "S3BucketName")

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -54,6 +54,10 @@ type ServiceFlags struct {
 	SecondaryReadsDisabled       bool `bson:"secondary_reads_disabled" json:"secondary_reads_disabled"`
 
 	BackgroundCommandFailureEnabled bool `bson:"background_command_failure_enabled" json:"background_command_failure_enabled"`
+
+	// Rate Limiting Flags
+	APIRateLimiterDisabled           bool `bson:"api_rate_limiter_disabled" json:"api_rate_limiter_disabled"`
+	GraphQLComplexityLimiterDisabled bool `bson:"graphql_complexity_limiter_disabled" json:"graphql_complexity_limiter_disabled"`
 }
 
 func (c *ServiceFlags) SectionId() string { return "service_flags" }
@@ -105,6 +109,8 @@ func (c *ServiceFlags) Set(ctx context.Context) error {
 			podDiagnosticsDisabledKey:             c.PodDiagnosticsDisabled,
 			secondaryReadsDisabledKey:             c.SecondaryReadsDisabled,
 			backgroundCommandFailureEnabledKey:    c.BackgroundCommandFailureEnabled,
+			apiRateLimiterDisabledKey:             c.APIRateLimiterDisabled,
+			graphqlComplexityLimiterDisabledKey:   c.GraphQLComplexityLimiterDisabled,
 		}}), "updating config section '%s'", c.SectionId(),
 	)
 }

--- a/graphql/tests/mutation/setServiceFlags/results.json
+++ b/graphql/tests/mutation/setServiceFlags/results.json
@@ -61,7 +61,9 @@
             { "name": "webhook_notifications_disabled", "enabled": false },
             { "name": "github_status_api_disabled", "enabled": false },
             { "name": "secondary_reads_disabled", "enabled": false },
-            { "name": "background_command_failure_enabled", "enabled": false }
+            { "name": "background_command_failure_enabled", "enabled": false },
+            { "name": "api_rate_limiter_disabled", "enabled": false },
+            { "name": "graphql_complexity_limiter_disabled", "enabled": false }
           ]
         }
       }

--- a/graphql/tests/query/adminSettings/results.json
+++ b/graphql/tests/query/adminSettings/results.json
@@ -614,7 +614,9 @@
               { "name": "webhook_notifications_disabled", "enabled": false },
               { "name": "github_status_api_disabled", "enabled": false },
               { "name": "secondary_reads_disabled", "enabled": false },
-              { "name": "background_command_failure_enabled", "enabled": false }
+              { "name": "background_command_failure_enabled", "enabled": false },
+              { "name": "api_rate_limiter_disabled", "enabled": false },
+              { "name": "graphql_complexity_limiter_disabled", "enabled": false }
             ]
           }
         }

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2079,6 +2079,10 @@ type APIServiceFlags struct {
 	SecondaryReadsDisabled       bool `json:"secondary_reads_disabled"`
 
 	BackgroundCommandFailureEnabled bool `json:"background_command_failure_enabled"`
+
+	// Rate Limiting Flags
+	APIRateLimiterDisabled           bool `json:"api_rate_limiter_disabled"`
+	GraphQLComplexityLimiterDisabled bool `json:"graphql_complexity_limiter_disabled"`
 }
 
 type APIProjectTasksPair struct {
@@ -2526,6 +2530,8 @@ func (as *APIServiceFlags) BuildFromService(h any) error {
 		as.UseMergeQueuePathFilteringDisabled = v.UseMergeQueuePathFilteringDisabled
 		as.PodDiagnosticsDisabled = v.PodDiagnosticsDisabled
 		as.BackgroundCommandFailureEnabled = v.BackgroundCommandFailureEnabled
+		as.APIRateLimiterDisabled = v.APIRateLimiterDisabled
+		as.GraphQLComplexityLimiterDisabled = v.GraphQLComplexityLimiterDisabled
 	default:
 		return errors.Errorf("programmatic error: expected service flags config but got type %T", h)
 	}
@@ -2575,6 +2581,8 @@ func (as *APIServiceFlags) ToService() (any, error) {
 		PSLoggingDisabled:                  as.PSLoggingDisabled,
 		PodDiagnosticsDisabled:             as.PodDiagnosticsDisabled,
 		BackgroundCommandFailureEnabled:    as.BackgroundCommandFailureEnabled,
+		APIRateLimiterDisabled:             as.APIRateLimiterDisabled,
+		GraphQLComplexityLimiterDisabled:   as.GraphQLComplexityLimiterDisabled,
 	}, nil
 }
 


### PR DESCRIPTION
DEVPROD-33719

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->
Added two operator-toggleable kill switches so misconfigured rate and complexity limits can be dropped into log-only mode without a deploy if real traffic starts getting blocked. 

### Testing

<!--add a description of how you tested it-->
Verified that flags propagate on Spruce locally and toggling them changes values in db accordingly. No other functionality to test yet.