### PR TITLE
DEVPROD-34455: Add Backwards compatibility for project

### DIFF
--- a/rest/model/select.go
+++ b/rest/model/select.go
@@ -1,5 +1,7 @@
 package model
 
+import "encoding/json"
+
 // SelectTestsRequest represents a request to return a filtered set of tests to
 // run. It deliberately includes information that could be looked up in the
 // database in order to bypass database lookups. This allows Evergreen to pass
@@ -19,4 +21,23 @@ type SelectTestsRequest struct {
 	Tests []string `json:"tests"`
 	// Strategies is the optional list of test selection strategies to use.
 	Strategies []string `json:"strategies"`
+}
+
+// UnmarshalJSON accepts either "project_id" (preferred) or "project" (legacy)
+// for the Project field. evergreen.py <=3.15.0 sends "project" on the wire,
+// and resmoke pins that library, so we need to keep accepting it until those
+// callers migrate.
+func (s *SelectTestsRequest) UnmarshalJSON(data []byte) error {
+	type alias SelectTestsRequest
+	aux := struct {
+		LegacyProject string `json:"project"`
+		*alias
+	}{alias: (*alias)(s)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if s.Project == "" {
+		s.Project = aux.LegacyProject
+	}
+	return nil
 }

--- a/rest/route/select_test.go
+++ b/rest/route/select_test.go
@@ -130,3 +130,49 @@ func TestSelectTestsRouteUserAuth(t *testing.T) {
 	assert.True(t, called, "next handler should run for a user-authenticated request")
 	assert.Equal(t, http.StatusOK, rw.Code, "middleware should not short-circuit user-authenticated requests")
 }
+
+// Unauthenticated requests (no user in context, no task auth headers) must be
+// rejected — the new middleware should fall through to the task auth
+// middleware, which returns 401 when there's no task ID/secret either.
+func TestSelectTestsRouteUnauthenticated(t *testing.T) {
+	body := []byte(`{
+		"project_id": "my-project",
+		"requester": "patch",
+		"build_variant": "variant",
+		"task_id": "my-task-1234",
+		"task_name": "my-task",
+		"tests": ["test1"]
+	}`)
+	req, err := http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(body))
+	require.NoError(t, err)
+
+	rw := httptest.NewRecorder()
+	called := false
+	NewUserOrTaskAuthOnlyMiddleware().ServeHTTP(rw, req, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	assert.False(t, called, "next handler should not run for unauthenticated requests")
+	assert.Equal(t, http.StatusUnauthorized, rw.Code, "unauthenticated requests should be rejected with 401")
+}
+
+func TestSelectTestsHandlerAcceptsLegacyProjectKey(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
+	j := []byte(`{
+		"project": "my-project",
+		"requester": "patch",
+		"build_variant": "variant",
+		"task_id": "my-task-1234",
+		"task_name": "my-task",
+		"tests": ["test1"]
+	}`)
+	req, _ := http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(j))
+	sth := makeSelectTestsHandler(env)
+	require.NoError(t, sth.Parse(ctx, req), "request should parse with legacy 'project' key")
+}

--- a/rest/route/select_test.go
+++ b/rest/route/select_test.go
@@ -131,9 +131,7 @@ func TestSelectTestsRouteUserAuth(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rw.Code, "middleware should not short-circuit user-authenticated requests")
 }
 
-// Unauthenticated requests (no user in context, no task auth headers) must be
-// rejected — the new middleware should fall through to the task auth
-// middleware, which returns 401 when there's no task ID/secret either.
+// Unauthenticated requests should be rejected with 401.
 func TestSelectTestsRouteUnauthenticated(t *testing.T) {
 	body := []byte(`{
 		"project_id": "my-project",

--- a/smoke/internal/endpoint/smoke_test.go
+++ b/smoke/internal/endpoint/smoke_test.go
@@ -1,8 +1,10 @@
 package endpoint
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -62,6 +64,39 @@ func TestSmokeEndpoints(t *testing.T) {
 	for url, expected := range td.API {
 		makeSmokeGetRequestAndCheck(ctx, t, params, client, "/api"+url, expected)
 	}
+
+	grip.Info(ctx, "Testing /select/tests POST with user auth")
+	checkSelectTestsUserAuth(ctx, t, params, client)
+}
+
+// checkSelectTestsUserAuth POSTs to /rest/v2/select/tests as an authenticated
+// user. Regression guard for DEVPROD-34146: before that fix, this route was
+// wrapped with a middleware that rejected user-auth requests with
+// 400 "task ID is required" because it required {task_id} as a URL path var
+// that this route does not have.
+func checkSelectTestsUserAuth(ctx context.Context, t *testing.T, params smokeTestParams, client *http.Client) {
+	body := []byte(`{"project_id":"smoke","build_variant":"variant","requester":"patch","task_id":"smoke-task","task_name":"smoke-task","tests":["foo"]}`)
+	url := params.AppServerURL + "/rest/v2/select/tests"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set(evergreen.APIUserHeader, params.Username)
+	req.Header.Set(evergreen.APIKeyHeader, params.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// The fix is to never return the auth middleware's
+	// 400 "task ID is required" for this route. Downstream errors (e.g. TSS
+	// unreachable) are fine for smoke purposes — we only guard the
+	// middleware-level regression.
+	assert.NotEqual(t, http.StatusBadRequest, resp.StatusCode,
+		"user-authenticated POST to /select/tests should not get a 400; body %q", string(respBody))
+	assert.NotContains(t, string(respBody), "task ID is required",
+		"response should not contain the old middleware's 'task ID is required'; got status %d body %q", resp.StatusCode, string(respBody))
 }
 
 type smokeTestParams struct {

--- a/smoke/internal/endpoint/smoke_test.go
+++ b/smoke/internal/endpoint/smoke_test.go
@@ -1,10 +1,8 @@
 package endpoint
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -64,39 +62,6 @@ func TestSmokeEndpoints(t *testing.T) {
 	for url, expected := range td.API {
 		makeSmokeGetRequestAndCheck(ctx, t, params, client, "/api"+url, expected)
 	}
-
-	grip.Info(ctx, "Testing /select/tests POST with user auth")
-	checkSelectTestsUserAuth(ctx, t, params, client)
-}
-
-// checkSelectTestsUserAuth POSTs to /rest/v2/select/tests as an authenticated
-// user. Regression guard for DEVPROD-34146: before that fix, this route was
-// wrapped with a middleware that rejected user-auth requests with
-// 400 "task ID is required" because it required {task_id} as a URL path var
-// that this route does not have.
-func checkSelectTestsUserAuth(ctx context.Context, t *testing.T, params smokeTestParams, client *http.Client) {
-	body := []byte(`{"project_id":"smoke","build_variant":"variant","requester":"patch","task_id":"smoke-task","task_name":"smoke-task","tests":["foo"]}`)
-	url := params.AppServerURL + "/rest/v2/select/tests"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	require.NoError(t, err)
-	req.Header.Set(evergreen.APIUserHeader, params.Username)
-	req.Header.Set(evergreen.APIKeyHeader, params.APIKey)
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := client.Do(req)
-	require.NoError(t, err)
-	defer resp.Body.Close()
-	respBody, err := io.ReadAll(resp.Body)
-	require.NoError(t, err)
-
-	// The fix is to never return the auth middleware's
-	// 400 "task ID is required" for this route. Downstream errors (e.g. TSS
-	// unreachable) are fine for smoke purposes — we only guard the
-	// middleware-level regression.
-	assert.NotEqual(t, http.StatusBadRequest, resp.StatusCode,
-		"user-authenticated POST to /select/tests should not get a 400; body %q", string(respBody))
-	assert.NotContains(t, string(respBody), "task ID is required",
-		"response should not contain the old middleware's 'task ID is required'; got status %d body %q", resp.StatusCode, string(respBody))
 }
 
 type smokeTestParams struct {


### PR DESCRIPTION
DEVPROD-34455

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
`/select/test` API is being called with a mis of `project_id` as well as `project` for the same field. For example, the evergreen python package turns [project_id into project](https://github.com/evergreen-ci/evergreen.py/blob/main/src/evergreen/api.py#L1635-L1659) In an effort to unblock this work adding backwards compat until we can create a better fix for this across all the callers.

### Testing
* Added tests