### PR TITLE
 DEVPROD-34534  Tag task host EBS volumes with evergreen host name at creation time

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -486,10 +486,6 @@ func (m *ec2Manager) SpawnHost(ctx context.Context, h *host.Host) (*host.Host, e
 		"distro":        h.Distro.Id,
 	})
 
-	if err = tagHostIDOnVolumes(ctx, m.client, h); err != nil {
-		return nil, errors.Wrap(err, "tagging host ID on volumes")
-	}
-
 	return h, nil
 }
 
@@ -692,36 +688,6 @@ func extendExpireOnByDay(ctx context.Context, client AWSClient, h *host.Host) er
 	}
 
 	return errors.Wrap(h.BumpExpireOnTag(ctx, newExpireOn), "bumping expire-on tag in DB")
-}
-
-// tagHostIDOnVolumes tags the host's EBS volumes with its EC2 instance ID.
-func tagHostIDOnVolumes(ctx context.Context, client AWSClient, h *host.Host) error {
-	var devices []types.InstanceBlockDeviceMapping
-	if err := utility.Retry(ctx, func() (bool, error) {
-		var err error
-		devices, err = client.GetInstanceBlockDevices(ctx, h)
-		return err != nil, err
-	}, awsClientDefaultRetryOptions()); err != nil {
-		return errors.Wrap(err, "getting instance block devices")
-	}
-
-	volumeIDs := make([]string, 0, len(devices))
-	for _, device := range devices {
-		if device.Ebs != nil && device.Ebs.VolumeId != nil {
-			volumeIDs = append(volumeIDs, *device.Ebs.VolumeId)
-		}
-	}
-	if len(volumeIDs) == 0 {
-		return nil
-	}
-
-	_, err := client.CreateTags(ctx, &ec2.CreateTagsInput{
-		Resources: volumeIDs,
-		Tags: []types.Tag{
-			{Key: aws.String(evergreen.TagHostID), Value: aws.String(h.Id)},
-		},
-	})
-	return errors.Wrapf(err, "adding host-id tag to volumes for host '%s'", h.Id)
 }
 
 // ModifyHost modifies a spawn host according to the changes specified by a HostModifyOptions struct.
@@ -1284,6 +1250,12 @@ func (m *ec2Manager) CreateVolume(ctx context.Context, volume *host.Volume) (*ho
 	volumeTags := []types.Tag{
 		{Key: aws.String(evergreen.TagOwner), Value: aws.String(volume.CreatedBy)},
 		{Key: aws.String(evergreen.TagExpireOn), Value: aws.String(expireInDays(evergreen.SpawnHostExpireDays))},
+	}
+	if volume.Host != "" {
+		volumeTags = append(volumeTags, types.Tag{Key: aws.String(evergreen.TagHostName), Value: aws.String(volume.Host)})
+		// Clear before inserting so the DB field isn't left as the intent host tag;
+		// AddVolumeToHost sets volume.Host to the real host ID after attachment.
+		volume.Host = ""
 	}
 	input := &ec2.CreateVolumeInput{
 		AvailabilityZone: aws.String(volume.AvailabilityZone),

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -150,10 +150,6 @@ func (m *ec2FleetManager) SpawnHost(ctx context.Context, h *host.Host) (*host.Ho
 		"distro":        h.Distro.Id,
 	})
 
-	if err := tagHostIDOnVolumes(ctx, m.client, h); err != nil {
-		return nil, errors.Wrap(err, "tagging host ID on volumes")
-	}
-
 	return h, nil
 }
 

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -1542,6 +1542,42 @@ func (s *EC2Suite) TestCreateVolume() {
 	s.NoError(err)
 }
 
+func (s *EC2Suite) TestCreateVolumeWithHostTagAppliesHostNameTag() {
+	s.volume.Host = "ht_abc123"
+	_, err := s.onDemandManager.CreateVolume(s.ctx, s.volume)
+	s.NoError(err)
+
+	mock, ok := s.impl.client.(*awsClientMock)
+	s.Require().True(ok)
+
+	var hostNameTagValue string
+	for _, spec := range mock.CreateVolumeInput.TagSpecifications {
+		for _, tag := range spec.Tags {
+			if tag.Key != nil && *tag.Key == evergreen.TagHostName {
+				hostNameTagValue = *tag.Value
+			}
+		}
+	}
+	s.Equal("ht_abc123", hostNameTagValue)
+}
+
+func (s *EC2Suite) TestCreateVolumeWithoutHostTagOmitsHostNameTag() {
+	s.volume.Host = ""
+	_, err := s.onDemandManager.CreateVolume(s.ctx, s.volume)
+	s.NoError(err)
+
+	mock, ok := s.impl.client.(*awsClientMock)
+	s.Require().True(ok)
+
+	for _, spec := range mock.CreateVolumeInput.TagSpecifications {
+		for _, tag := range spec.Tags {
+			if tag.Key != nil {
+				s.NotEqual(evergreen.TagHostName, *tag.Key, "host-name tag should not be present when volume.Host is empty")
+			}
+		}
+	}
+}
+
 func (s *EC2Suite) TestDeleteVolume() {
 	s.NoError(s.volume.Insert(s.ctx))
 	s.NoError(s.onDemandManager.DeleteVolume(s.ctx, s.volume))

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -176,6 +176,7 @@ func makeTags(intentHost *host.Host) []host.Tag {
 		{Key: evergreen.TagExpireOn, Value: expireOn, CanBeModified: false},
 		{Key: evergreen.TagAllowRemoteAccess, Value: "true", CanBeModified: false},
 		{Key: evergreen.TagIsDebug, Value: fmt.Sprintf("%t", intentHost.IsDebug), CanBeModified: false},
+		{Key: evergreen.TagHostName, Value: intentHost.Tag, CanBeModified: false},
 	}
 
 	if intentHost.UserHost {

--- a/cloud/ec2_util_test.go
+++ b/cloud/ec2_util_test.go
@@ -361,6 +361,23 @@ func TestReleaseIPAddressForHost(t *testing.T) {
 	}
 }
 
+func TestMakeTagsIncludesHostNameTag(t *testing.T) {
+	h := &host.Host{
+		Id:  "i-abc123",
+		Tag: "ht_abc123",
+	}
+	tags := makeTags(h)
+
+	var hostNameTagValue string
+	for _, tag := range tags {
+		if tag.Key == evergreen.TagHostName {
+			hostNameTagValue = tag.Value
+			break
+		}
+	}
+	assert.Equal(t, h.Tag, hostNameTagValue, "host-name tag should be set to the evergreen intent host ID (h.Tag), not the EC2 instance ID")
+}
+
 func TestDeleteHostPersistentDNSName(t *testing.T) {
 	defer func() {
 		assert.NoError(t, db.ClearCollections(host.Collection))

--- a/globals.go
+++ b/globals.go
@@ -292,7 +292,7 @@ const (
 	TagExpireOn          = "expire-on"
 	TagAllowRemoteAccess = "AllowRemoteAccess"
 	TagIsDebug           = "IsDebug"
-	TagHostID            = "host-id"
+	TagHostName          = "host-name"
 	TagTaskID            = "task-id"
 	TagTaskExecution     = "task-execution"
 	TagBuildID           = "build-id"

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -654,6 +654,7 @@ func attachVolume(ctx context.Context, env evergreen.Environment, h *host.Host) 
 				IOPS:             cloud.Gp2EquivalentIOPSForGp3(int32(h.HomeVolumeSize)),
 				Throughput:       cloud.Gp2EquivalentThroughputForGp3(int32(h.HomeVolumeSize)),
 				HomeVolume:       true,
+				Host:             h.Tag,
 			})
 			if err != nil {
 				return errors.Wrapf(err, "creating new volume for host '%s'", h.Id)

--- a/units/provisioning_setup_host_test.go
+++ b/units/provisioning_setup_host_test.go
@@ -4,9 +4,52 @@ import (
 	"context"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/mock"
+	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+
+func TestAttachVolumePassesHostTagToCreateVolume(t *testing.T) {
+	require.NoError(t, db.ClearCollections(host.Collection, host.VolumesCollection))
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(host.Collection, host.VolumesCollection))
+	})
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(t.Context()))
+
+	h := &host.Host{
+		Id:  "i-ec2-instance-id",
+		Tag: "ht_intent_id",
+		Distro: distro.Distro{
+			Arch:     "linux/amd64",
+			Provider: evergreen.ProviderNameMock,
+			BootstrapSettings: distro.BootstrapSettings{
+				Communication: distro.CommunicationMethodSSH,
+			},
+		},
+		HomeVolumeSize: 10,
+		Zone:           "us-east-1a",
+	}
+	require.NoError(t, h.Insert(t.Context()))
+
+	// AttachVolume fails because the mock instance isn't registered, so SetHost
+	// never runs and the volume retains the Host value set at creation.
+	err := attachVolume(t.Context(), env, h)
+	require.Error(t, err)
+	require.NotEmpty(t, h.HomeVolumeID, "volume must have been created before the attach error")
+
+	volume, err := host.FindVolumeByID(t.Context(), h.HomeVolumeID)
+	require.NoError(t, err)
+	require.NotNil(t, volume)
+	assert.Equal(t, h.Tag, volume.Host, "CreateVolume should be called with Host set to the evergreen intent host ID (h.Tag)")
+}
 
 func TestGetMostRecentlyAddedDevice(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/units/provisioning_setup_host_test.go
+++ b/units/provisioning_setup_host_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-
 func TestAttachVolumePassesHostTagToCreateVolume(t *testing.T) {
 	require.NoError(t, db.ClearCollections(host.Collection, host.VolumesCollection))
 	t.Cleanup(func() {


### PR DESCRIPTION
 DEVPROD-34534

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Previously, EBS volumes for task hosts were tagged with `host-id = <EC2 instance ID>` in a post-launch API call (`tagHostIDOnVolumes`), which had a race window and missed volumes created during provisioning, Now the evergreen intent host ID is applied atomically at volume creation which should give us better accuracy. 

### Testing

Added tests 



<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
