### PR TITLE
DEVPROD-33799 Add GraphQL complexity logging

### DIFF
--- a/graphql/http_handler.go
+++ b/graphql/http_handler.go
@@ -25,7 +25,8 @@ import (
 
 // Handler returns a gimlet http handler func used as the gql route handler
 func Handler(apiURL string, allowMutations bool) func(w http.ResponseWriter, r *http.Request) {
-	srv := handler.New(NewExecutableSchema(New(apiURL)))
+	schema := NewExecutableSchema(New(apiURL))
+	srv := handler.New(schema)
 
 	srv.AddTransport(transport.Websocket{
 		KeepAlivePingInterval: 10 * time.Second,
@@ -59,7 +60,7 @@ func Handler(apiURL string, allowMutations bool) func(w http.ResponseWriter, r *
 	))
 
 	// Log graphql requests to splunk
-	srv.Use(SplunkTracing{})
+	srv.Use(NewSplunkTracing(schema))
 
 	// Disable queries for service degradation
 	srv.Use(DisableQuery{})

--- a/graphql/http_handler.go
+++ b/graphql/http_handler.go
@@ -60,7 +60,7 @@ func Handler(apiURL string, allowMutations bool) func(w http.ResponseWriter, r *
 	))
 
 	// Log graphql requests to splunk
-	srv.Use(ComplexitySplunkTracing(schema))
+	srv.Use(MakeSplunkTracing(schema))
 
 	// Disable queries for service degradation
 	srv.Use(DisableQuery{})

--- a/graphql/http_handler.go
+++ b/graphql/http_handler.go
@@ -60,7 +60,7 @@ func Handler(apiURL string, allowMutations bool) func(w http.ResponseWriter, r *
 	))
 
 	// Log graphql requests to splunk
-	srv.Use(NewSplunkTracing(schema))
+	srv.Use(ComplexitySplunkTracing(schema))
 
 	// Disable queries for service degradation
 	srv.Use(DisableQuery{})

--- a/graphql/splunktracing.go
+++ b/graphql/splunktracing.go
@@ -20,7 +20,7 @@ type SplunkTracing struct {
 	schema graphql.ExecutableSchema
 }
 
-// NewSplunkTracing returns a SplunkTracing extension that computes query
+// ComplexitySplunkTracing returns a SplunkTracing extension that computes query
 // complexity scores for logging. The executable schema is required to resolve
 // per-field complexity weights during calculation.
 func ComplexitySplunkTracing(schema graphql.ExecutableSchema) SplunkTracing {

--- a/graphql/splunktracing.go
+++ b/graphql/splunktracing.go
@@ -20,10 +20,9 @@ type SplunkTracing struct {
 	schema graphql.ExecutableSchema
 }
 
-// ComplexitySplunkTracing returns a SplunkTracing extension that computes query
-// complexity scores for logging. The executable schema is required to resolve
-// per-field complexity weights during calculation.
-func ComplexitySplunkTracing(schema graphql.ExecutableSchema) SplunkTracing {
+// MakeSplunkTracing is a constructor for SplunkTracing that takes in the graphql schema as an argument.
+// The schema is used to calculate the complexity score of a query, which is then logged.
+func MakeSplunkTracing(schema graphql.ExecutableSchema) SplunkTracing {
 	return SplunkTracing{schema: schema}
 }
 
@@ -56,7 +55,7 @@ func (s SplunkTracing) InterceptResponse(ctx context.Context, next graphql.Respo
 	}
 
 	complexityScore := complexity.Calculate(ctx, s.schema, rc.Operation, rc.Variables)
-	trace.SpanFromContext(ctx).SetAttributes(attribute.Int("graphql.operation.complexity_score", complexityScore))
+	trace.SpanFromContext(ctx).SetAttributes(attribute.Int("gql.request.complexity_score", complexityScore))
 
 	defer func() {
 		usr := gimlet.GetUser(ctx)

--- a/graphql/splunktracing.go
+++ b/graphql/splunktracing.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"context"
 
+	"github.com/99designs/gqlgen/complexity"
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/gimlet"
@@ -15,7 +16,16 @@ import (
 // SplunkTracing is a graphql extension that adds splunk logging to graphql.
 // It is used to log the duration of a query and the user that made the request.
 // It does this by hooking into lifecycle events that gqlgen uses.
-type SplunkTracing struct{}
+type SplunkTracing struct {
+	schema graphql.ExecutableSchema
+}
+
+// NewSplunkTracing returns a SplunkTracing extension that computes query
+// complexity scores for logging. The executable schema is required to resolve
+// per-field complexity weights during calculation.
+func NewSplunkTracing(schema graphql.ExecutableSchema) SplunkTracing {
+	return SplunkTracing{schema: schema}
+}
 
 func (SplunkTracing) ExtensionName() string {
 	return "SplunkTracing"
@@ -25,7 +35,7 @@ func (SplunkTracing) Validate(graphql.ExecutableSchema) error {
 	return nil
 }
 
-func (SplunkTracing) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
+func (s SplunkTracing) InterceptResponse(ctx context.Context, next graphql.ResponseHandler) *graphql.Response {
 	if hasOperationContext := graphql.HasOperationContext(ctx); !hasOperationContext {
 		// There was an invalid operation context, so we can't do anything. This could be because the user made a
 		// malformed request to GraphQL.
@@ -45,6 +55,9 @@ func (SplunkTracing) InterceptResponse(ctx context.Context, next graphql.Respons
 		trace.SpanFromContext(ctx).SetAttributes(attribute.String(evergreen.GraphQLAIAgentOtelAttribute, aiAgent))
 	}
 
+	complexityScore := complexity.Calculate(ctx, s.schema, rc.Operation, rc.Variables)
+	trace.SpanFromContext(ctx).SetAttributes(attribute.Int("graphql.complexity_score", complexityScore))
+
 	defer func() {
 		usr := gimlet.GetUser(ctx)
 		end := graphql.Now()
@@ -52,16 +65,17 @@ func (SplunkTracing) InterceptResponse(ctx context.Context, next graphql.Respons
 		duration := end.Sub(start)
 		redactedRequestVariables := RedactFieldsInMap(rc.Variables, redactedFields)
 		fields := message.Fields{
-			"message":     "graphql.tracing",
-			"query":       rc.Operation.Name,
-			"operation":   rc.Operation.Operation,
-			"variables":   redactedRequestVariables,
-			"duration_ms": duration.Milliseconds(),
-			"request":     gimlet.GetRequestID(ctx),
-			"start":       start,
-			"end":         end,
-			"user":        usr.Username(),
-			"origin":      rc.Headers.Get("Origin"),
+			"message":          "graphql.tracing",
+			"query":            rc.Operation.Name,
+			"operation":        rc.Operation.Operation,
+			"variables":        redactedRequestVariables,
+			"duration_ms":      duration.Milliseconds(),
+			"complexity_score": complexityScore,
+			"request":          gimlet.GetRequestID(ctx),
+			"start":            start,
+			"end":              end,
+			"user":             usr.Username(),
+			"origin":           rc.Headers.Get("Origin"),
 		}
 		if aiAgent != "" {
 			fields["ai_agent"] = aiAgent

--- a/graphql/splunktracing.go
+++ b/graphql/splunktracing.go
@@ -23,7 +23,7 @@ type SplunkTracing struct {
 // NewSplunkTracing returns a SplunkTracing extension that computes query
 // complexity scores for logging. The executable schema is required to resolve
 // per-field complexity weights during calculation.
-func NewSplunkTracing(schema graphql.ExecutableSchema) SplunkTracing {
+func ComplexitySplunkTracing(schema graphql.ExecutableSchema) SplunkTracing {
 	return SplunkTracing{schema: schema}
 }
 

--- a/graphql/splunktracing.go
+++ b/graphql/splunktracing.go
@@ -56,7 +56,7 @@ func (s SplunkTracing) InterceptResponse(ctx context.Context, next graphql.Respo
 	}
 
 	complexityScore := complexity.Calculate(ctx, s.schema, rc.Operation, rc.Variables)
-	trace.SpanFromContext(ctx).SetAttributes(attribute.Int("graphql.complexity_score", complexityScore))
+	trace.SpanFromContext(ctx).SetAttributes(attribute.Int("graphql.operation.complexity_score", complexityScore))
 
 	defer func() {
 		usr := gimlet.GetUser(ctx)

--- a/graphql/splunktracing_test.go
+++ b/graphql/splunktracing_test.go
@@ -77,7 +77,7 @@ type capturedOutput struct {
 	spanAttrs map[string]any
 }
 
-func TestSplunkTracingComplexityScore(t *testing.T) {
+func TestGraphQLComplexityLogging(t *testing.T) {
 	schema := NewExecutableSchema(New(""))
 
 	parseOp := func(t *testing.T, queryStr string) *ast.OperationDefinition {

--- a/graphql/splunktracing_test.go
+++ b/graphql/splunktracing_test.go
@@ -106,7 +106,8 @@ func TestGraphQLComplexityLogging(t *testing.T) {
 		ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "test_user"})
 		ctx, span := tp.Tracer("test").Start(ctx, "test")
 
-		ComplexitySplunkTracing(schema).InterceptResponse(ctx, func(ctx context.Context) *graphql.Response {
+		splunkTracing := MakeSplunkTracing(schema)
+		splunkTracing.InterceptResponse(ctx, func(ctx context.Context) *graphql.Response {
 			return &graphql.Response{}
 		})
 		span.End()
@@ -134,8 +135,8 @@ func TestGraphQLComplexityLogging(t *testing.T) {
 
 	t.Run("OTelSpanHasComplexityScore", func(t *testing.T) {
 		out := runAndCapture(t, parseOp(t, userSettingsQuery))
-		val, ok := out.spanAttrs["graphql.operation.complexity_score"]
-		require.True(t, ok, "graphql.operation.complexity_score should be present as a span attribute")
+		val, ok := out.spanAttrs["gql.request.complexity_score"]
+		require.True(t, ok, "gql.request.complexity_score should be present as a span attribute")
 		score, ok := val.(int64)
 		require.True(t, ok)
 		assert.Greater(t, score, int64(0))
@@ -144,7 +145,7 @@ func TestGraphQLComplexityLogging(t *testing.T) {
 	t.Run("BothOutputsAgreeOnScore", func(t *testing.T) {
 		out := runAndCapture(t, parseOp(t, userSettingsQuery))
 		logScore := int64(out.logFields["complexity_score"].(int))
-		spanScore := out.spanAttrs["graphql.operation.complexity_score"].(int64)
+		spanScore := out.spanAttrs["gql.request.complexity_score"].(int64)
 		assert.Equal(t, logScore, spanScore)
 	})
 
@@ -152,6 +153,6 @@ func TestGraphQLComplexityLogging(t *testing.T) {
 		simple := runAndCapture(t, parseOp(t, userSettingsQuery))
 		complex := runAndCapture(t, parseOp(t, hostEventsQuery))
 		assert.Greater(t, complex.logFields["complexity_score"].(int), simple.logFields["complexity_score"].(int))
-		assert.Greater(t, complex.spanAttrs["graphql.operation.complexity_score"].(int64), simple.spanAttrs["graphql.operation.complexity_score"].(int64))
+		assert.Greater(t, complex.spanAttrs["gql.request.complexity_score"].(int64), simple.spanAttrs["gql.request.complexity_score"].(int64))
 	})
 }

--- a/graphql/splunktracing_test.go
+++ b/graphql/splunktracing_test.go
@@ -106,7 +106,7 @@ func TestGraphQLComplexityLogging(t *testing.T) {
 		ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "test_user"})
 		ctx, span := tp.Tracer("test").Start(ctx, "test")
 
-		NewSplunkTracing(schema).InterceptResponse(ctx, func(ctx context.Context) *graphql.Response {
+		ComplexitySplunkTracing(schema).InterceptResponse(ctx, func(ctx context.Context) *graphql.Response {
 			return &graphql.Response{}
 		})
 		span.End()

--- a/graphql/splunktracing_test.go
+++ b/graphql/splunktracing_test.go
@@ -134,8 +134,8 @@ func TestGraphQLComplexityLogging(t *testing.T) {
 
 	t.Run("OTelSpanHasComplexityScore", func(t *testing.T) {
 		out := runAndCapture(t, parseOp(t, userSettingsQuery))
-		val, ok := out.spanAttrs["graphql.complexity_score"]
-		require.True(t, ok, "graphql.complexity_score should be present as a span attribute")
+		val, ok := out.spanAttrs["graphql.operation.complexity_score"]
+		require.True(t, ok, "graphql.operation.complexity_score should be present as a span attribute")
 		score, ok := val.(int64)
 		require.True(t, ok)
 		assert.Greater(t, score, int64(0))
@@ -144,7 +144,7 @@ func TestGraphQLComplexityLogging(t *testing.T) {
 	t.Run("BothOutputsAgreeOnScore", func(t *testing.T) {
 		out := runAndCapture(t, parseOp(t, userSettingsQuery))
 		logScore := int64(out.logFields["complexity_score"].(int))
-		spanScore := out.spanAttrs["graphql.complexity_score"].(int64)
+		spanScore := out.spanAttrs["graphql.operation.complexity_score"].(int64)
 		assert.Equal(t, logScore, spanScore)
 	})
 
@@ -152,6 +152,6 @@ func TestGraphQLComplexityLogging(t *testing.T) {
 		simple := runAndCapture(t, parseOp(t, userSettingsQuery))
 		complex := runAndCapture(t, parseOp(t, hostEventsQuery))
 		assert.Greater(t, complex.logFields["complexity_score"].(int), simple.logFields["complexity_score"].(int))
-		assert.Greater(t, complex.spanAttrs["graphql.complexity_score"].(int64), simple.spanAttrs["graphql.complexity_score"].(int64))
+		assert.Greater(t, complex.spanAttrs["graphql.operation.complexity_score"].(int64), simple.spanAttrs["graphql.operation.complexity_score"].(int64))
 	})
 }

--- a/graphql/splunktracing_test.go
+++ b/graphql/splunktracing_test.go
@@ -1,0 +1,157 @@
+package graphql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/evergreen-ci/evergreen/model/user"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/send"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vektah/gqlparser/v2"
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/validator/rules"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// userSettingsQuery and hostEventsQuery are real queries taken from the
+// graphql/tests directory. They serve as a shallow and a deep query
+// respectively, so that the complexity score difference between them is
+// meaningful.
+const userSettingsQuery = `
+query {
+  user {
+    settings {
+      timezone
+      region
+      githubUser {
+        lastKnownAs
+      }
+      slackUsername
+      slackMemberId
+    }
+  }
+}`
+
+const hostEventsQuery = `
+query {
+  host(hostId: "i-0f81a2d39744003dd") {
+    events(opts: {}) {
+      eventLogEntries {
+        id
+        resourceType
+        processedAt
+        timestamp
+        eventType
+        data {
+          agentRevision
+          agentBuild
+          oldStatus
+          newStatus
+          logs
+          hostname
+          provisioningMethod
+          taskId
+          taskPid
+          taskStatus
+          execution
+          monitorOp
+          user
+          successful
+          duration
+        }
+        resourceId
+      }
+      count
+    }
+  }
+}`
+
+type capturedOutput struct {
+	logFields message.Fields
+	spanAttrs map[string]any
+}
+
+func TestSplunkTracingComplexityScore(t *testing.T) {
+	schema := NewExecutableSchema(New(""))
+
+	parseOp := func(t *testing.T, queryStr string) *ast.OperationDefinition {
+		doc, gqlErrs := gqlparser.LoadQueryWithRules(schema.Schema(), queryStr, rules.NewDefaultRules())
+		require.Empty(t, gqlErrs)
+		require.Len(t, doc.Operations, 1)
+		return doc.Operations[0]
+	}
+
+	// runAndCapture runs InterceptResponse with a recording OTel span and an
+	// internal grip sender, returning the logged Splunk fields and the span
+	// attributes so both outputs can be asserted.
+	runAndCapture := func(t *testing.T, op *ast.OperationDefinition) capturedOutput {
+		// Swap grip sender to capture log output.
+		defer func(s send.Sender) {
+			assert.NoError(t, grip.SetSender(s))
+		}(grip.GetSender())
+		sender := send.MakeInternalLogger()
+		require.NoError(t, grip.SetSender(sender))
+
+		// Build a recording tracer so span attributes can be inspected.
+		spanRecorder := tracetest.NewSpanRecorder()
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+		rc := &graphql.OperationContext{Operation: op}
+		ctx := graphql.WithOperationContext(t.Context(), rc)
+		ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "test_user"})
+		ctx, span := tp.Tracer("test").Start(ctx, "test")
+
+		NewSplunkTracing(schema).InterceptResponse(ctx, func(ctx context.Context) *graphql.Response {
+			return &graphql.Response{}
+		})
+		span.End()
+
+		require.True(t, sender.HasMessage())
+		fields, ok := sender.GetMessage().Message.Raw().(message.Fields)
+		require.True(t, ok)
+
+		ended := spanRecorder.Ended()
+		require.Len(t, ended, 1)
+		attrs := map[string]any{}
+		for _, kv := range ended[0].Attributes() {
+			attrs[string(kv.Key)] = kv.Value.AsInterface()
+		}
+
+		return capturedOutput{logFields: fields, spanAttrs: attrs}
+	}
+
+	t.Run("SplunkLogsComplexityScore", func(t *testing.T) {
+		out := runAndCapture(t, parseOp(t, userSettingsQuery))
+		score, ok := out.logFields["complexity_score"].(int)
+		require.True(t, ok, "complexity_score should be present in Splunk log fields as int")
+		assert.Greater(t, score, 0)
+	})
+
+	t.Run("OTelSpanHasComplexityScore", func(t *testing.T) {
+		out := runAndCapture(t, parseOp(t, userSettingsQuery))
+		val, ok := out.spanAttrs["graphql.complexity_score"]
+		require.True(t, ok, "graphql.complexity_score should be present as a span attribute")
+		score, ok := val.(int64)
+		require.True(t, ok)
+		assert.Greater(t, score, int64(0))
+	})
+
+	t.Run("BothOutputsAgreeOnScore", func(t *testing.T) {
+		out := runAndCapture(t, parseOp(t, userSettingsQuery))
+		logScore := int64(out.logFields["complexity_score"].(int))
+		spanScore := out.spanAttrs["graphql.complexity_score"].(int64)
+		assert.Equal(t, logScore, spanScore)
+	})
+
+	t.Run("DeeperQueryScoresHigher", func(t *testing.T) {
+		simple := runAndCapture(t, parseOp(t, userSettingsQuery))
+		complex := runAndCapture(t, parseOp(t, hostEventsQuery))
+		assert.Greater(t, complex.logFields["complexity_score"].(int), simple.logFields["complexity_score"].(int))
+		assert.Greater(t, complex.spanAttrs["graphql.complexity_score"].(int64), simple.spanAttrs["graphql.complexity_score"].(int64))
+	})
+}


### PR DESCRIPTION
DEVPROD-33799
<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Before API complexity limiting is implemented for GraphQL queries, we'll collect a few days of real production traffic data to better understand GraphQL query complexity and what looks like normal human behavior. The default complexity score (no custom complexity calculation) will be emitted to both the existing Splunk log line and as an OTel span attribute for analysis in Honeycomb. Within a few days, this analysis will allow a `GraphQLComplexityLimit` to be determined. 

Also added a few unit tests (`graphql/splunktracing_test.go`) to verify that complexity score is properly logged to both outputs, their scores match for the same query, and that deeper queries actually result in a higher complexity score being logged. 
<!--add description, context, thought process, etc-->

Currently, the OTel attribute is called `gql.request.complexity_score`, see [DEVPROD-34773](https://jira.mongodb.org/browse/DEVPROD-34773) follow up ticket for standardizing with UI and graphQL convention.

### Testing

- New unit tests (TestGraphQLComplexityLogging) with a real executable schema, see description above
- **(Local)** Navigated through Spruce, confirmed complexity_score appears on every graphql.tracing log line with values that vary by operation
- **(Staging)** Navigated through UI, confirmed that `complexity_score` is logged in both [Splunk](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22evergreen-staging%22%20complexity_score&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=&earliest=-2d%40d&latest=now&sid=1781028393.533746) and [Otel traces](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/eZ5x5JudeC4?tab=traces) visible on Honeycomb (example [one](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/eZ5x5JudeC4/trace/s4svUzWP3xz?fields[]=s_name&fields[]=s_serviceName&fields[]=c_graphql.complexity_score&source=query&span=26183e6e6fe700c7) and [two](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/eZ5x5JudeC4/trace/ezG4HgtNuwt?fields[]=s_name&fields[]=s_serviceName&fields[]=c_graphql.complexity_score&source=query&span=00bebd3c7f2c1194)), and that it varies across requests

<!--add a description of how you tested it-->
