### PR TITLE
DEVPROD-34606 Improve token redaction in debug run-all

### DIFF
--- a/agent/internal/redactor/redacting_sender_test.go
+++ b/agent/internal/redactor/redacting_sender_test.go
@@ -105,3 +105,37 @@ func TestRedactingSender(t *testing.T) {
 		})
 	}
 }
+
+func TestRedactingSenderPicksUpDynamicRedactions(t *testing.T) {
+	t.Run("WithoutPreloadPicksUpNewRedactions", func(t *testing.T) {
+		wrappedSender, err := send.NewInternalLogger("", send.LevelInfo{Threshold: level.Info, Default: level.Info})
+		require.NoError(t, err)
+
+		expansions := util.NewDynamicExpansions(map[string]string{})
+		s := NewRedactingSender(wrappedSender, RedactionOptions{
+			Expansions: expansions,
+		})
+
+		expansions.PutAndRedact("github_token", "ghp_secret123")
+
+		s.Send(context.Background(), message.NewDefaultMessage(level.Info, "token is ghp_secret123"))
+		assert.Equal(t, fmt.Sprintf("token is %s", fmt.Sprintf(redactedVariableTemplate, "github_token")), wrappedSender.GetMessage().Message.String())
+	})
+
+	t.Run("WithPreloadDoesNotPickUpNewRedactions", func(t *testing.T) {
+		wrappedSender, err := send.NewInternalLogger("", send.LevelInfo{Threshold: level.Info, Default: level.Info})
+		require.NoError(t, err)
+
+		expansions := util.NewDynamicExpansions(map[string]string{"existing_key": "existing_val"})
+		expansions.PutAndRedact("existing_key", "existing_val")
+		s := NewRedactingSender(wrappedSender, RedactionOptions{
+			Expansions:        expansions,
+			PreloadRedactions: true,
+		})
+
+		expansions.PutAndRedact("github_token", "ghp_secret123")
+
+		s.Send(context.Background(), message.NewDefaultMessage(level.Info, "token is ghp_secret123"))
+		assert.Equal(t, "token is ghp_secret123", wrappedSender.GetMessage().Message.String())
+	})
+}

--- a/agent/taskexec/local_executor.go
+++ b/agent/taskexec/local_executor.go
@@ -541,7 +541,6 @@ func (e *LocalExecutor) SetStreamWriter(sw *streamWriter) {
 		Expansions:         e.taskConfig.NewExpansions,
 		Redacted:           e.taskConfig.Redacted,
 		InternalRedactions: e.taskConfig.InternalRedactions,
-		PreloadRedactions:  true,
 	})
 
 	producer.setSender(redactedSender)

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-06-05a"
+	AgentVersion = "2026-06-08"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-34606

### Description

The streaming output from debug run-all needs to have its redaction list computed dynamically so tokens added mid execution are properly redacted.

### Testing

Verified manually in staging.