### PR TITLE
DEVPROD-34608: Fix host aggregation nil dereference

### DIFF
--- a/units/host_stats.go
+++ b/units/host_stats.go
@@ -123,6 +123,7 @@ func (j *hostStatsJob) Run(ctx context.Context) {
 	spawnStats, err := host.AggregateSpawnhostData(ctx)
 	if err != nil {
 		j.AddError(errors.Wrap(err, "aggregating spawn host data"))
+		return
 	}
 	debugHostCount, countErr := host.CountDebugSpawnhosts(ctx)
 	if countErr != nil {


### PR DESCRIPTION
DEVPROD-34608

### Description

return on host aggregation error instead of nil dereferencing  