### PR TITLE
DEVPROD-33316 Unify handleTimeoutAndOOM on detail.Status as source of truth

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -572,7 +572,8 @@ func (a *Agent) handleSetupError(ctx context.Context, tc *taskContext, err error
 	catcher.Wrap(err, "handling setup error")
 	tc.logger.Execution().Error(ctx, err)
 	grip.Infof(ctx, "Task complete: '%s'.", tc.task.ID)
-	shouldExit, err := a.handleTaskResponse(ctx, tc, evergreen.TaskSystemFailed, err.Error())
+	detail := a.endTaskResponse(ctx, tc, evergreen.TaskSystemFailed, err.Error())
+	shouldExit, err := a.handleTaskResponse(ctx, tc, detail)
 	catcher.Wrap(err, "handling task response")
 	return tc, shouldExit, catcher.Resolve()
 }
@@ -737,7 +738,8 @@ func (a *Agent) runTask(ctx context.Context, tcInput *taskContext, nt *apimodels
 	go a.startHeartbeat(tskCtx, preAndMainCancel, tc)
 
 	status := a.runPreAndMain(preAndMainCtx, tc)
-	shouldExit, err = a.handleTaskResponse(tskCtx, tc, status, "")
+	detail := a.endTaskResponse(tskCtx, tc, status, "")
+	shouldExit, err = a.handleTaskResponse(tskCtx, tc, detail)
 	return tc, shouldExit, err
 }
 
@@ -1132,8 +1134,8 @@ func (a *Agent) runTeardownGroupCommands(ctx context.Context, tc *taskContext) {
 	}
 }
 
-func (a *Agent) handleTaskResponse(ctx context.Context, tc *taskContext, status string, systemFailureDescription string) (bool, error) {
-	resp, err := a.finishTask(ctx, tc, status, systemFailureDescription)
+func (a *Agent) handleTaskResponse(ctx context.Context, tc *taskContext, detail *apimodels.TaskEndDetail) (bool, error) {
+	resp, err := a.finishTask(ctx, tc, detail)
 	if err != nil {
 		return false, errors.Wrap(err, "marking task complete")
 	}
@@ -1178,8 +1180,7 @@ func (a *Agent) handleTimeoutAndOOM(ctx context.Context, tc *taskContext, detail
 
 // finishTask finishes up a running task. It runs any post-task command blocks
 // such as timeout and post, then sends the final end task response.
-func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, systemFailureDescription string) (*apimodels.EndTaskResponse, error) {
-	detail := a.endTaskResponse(ctx, tc, status, systemFailureDescription)
+func (a *Agent) finishTask(ctx context.Context, tc *taskContext, detail *apimodels.TaskEndDetail) (*apimodels.EndTaskResponse, error) {
 	if detail.TimedOut {
 		a.runDefaultTimeoutHandler(ctx, tc, detail)
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1147,14 +1147,12 @@ func (a *Agent) handleTaskResponse(ctx context.Context, tc *taskContext, status 
 	return false, errors.WithStack(err)
 }
 
-func (a *Agent) handleTimeoutAndOOM(ctx context.Context, tc *taskContext, detail *apimodels.TaskEndDetail, status string) {
+func (a *Agent) handleTimeoutAndOOM(ctx context.Context, tc *taskContext, detail *apimodels.TaskEndDetail) {
 	if tc.hadTimedOut() && ctx.Err() == nil {
-		status = evergreen.TaskFailed
 		a.runTaskTimeoutCommands(ctx, tc)
 	}
 
-	// Check both statuses, as this may have changed via user endpoint or etc.
-	if tc.oomTrackerEnabled(a.opts.CloudProvider) && (detail.Status == evergreen.TaskFailed || status == evergreen.TaskFailed) {
+	if tc.oomTrackerEnabled(a.opts.CloudProvider) && (detail.Status == evergreen.TaskFailed || tc.hadTimedOut()) {
 		startTime := time.Now()
 		oomCtx, oomCancel := context.WithTimeout(ctx, 10*time.Second)
 		defer oomCancel()
@@ -1187,7 +1185,7 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, 
 	}
 	switch detail.Status {
 	case evergreen.TaskSucceeded:
-		a.handleTimeoutAndOOM(ctx, tc, detail, status)
+		a.handleTimeoutAndOOM(ctx, tc, detail)
 
 		tc.logger.Task().Info(ctx, "Task completed - SUCCESS.")
 		if err := a.runPostOrTeardownTaskCommands(ctx, tc); err != nil {
@@ -1200,7 +1198,7 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, status string, 
 		updateEndTaskFailureDetailsForTestResults(ctx, tc, detail)
 
 	case evergreen.TaskFailed:
-		a.handleTimeoutAndOOM(ctx, tc, detail, status)
+		a.handleTimeoutAndOOM(ctx, tc, detail)
 
 		tc.logger.Task().Info(ctx, "Task completed - FAILURE.")
 		// If the post commands error, ignore the error. runCommandsInBlock

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1150,11 +1150,14 @@ func (a *Agent) handleTaskResponse(ctx context.Context, tc *taskContext, detail 
 }
 
 func (a *Agent) handleTimeoutAndOOM(ctx context.Context, tc *taskContext, detail *apimodels.TaskEndDetail) {
-	if tc.hadTimedOut() && ctx.Err() == nil {
+	if detail.TimedOut && ctx.Err() == nil {
 		a.runTaskTimeoutCommands(ctx, tc)
 	}
 
-	if tc.oomTrackerEnabled(a.opts.CloudProvider) && (detail.Status == evergreen.TaskFailed || tc.hadTimedOut()) {
+	// The OOM check follows the final reported status, so if a user endpoint
+	// overrode a failed task to succeeded, the check is intentionally skipped
+	// unless the task timed out.
+	if tc.oomTrackerEnabled(a.opts.CloudProvider) && (detail.Status == evergreen.TaskFailed || detail.TimedOut) {
 		startTime := time.Now()
 		oomCtx, oomCancel := context.WithTimeout(ctx, 10*time.Second)
 		defer oomCancel()

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -314,7 +314,8 @@ func (s *AgentSuite) TestFinishTaskWithNormalCompletedTask() {
 	s.mockCommunicator.EndTaskResponse = &apimodels.EndTaskResponse{}
 
 	for _, status := range evergreen.TaskCompletedStatuses {
-		resp, err := s.a.finishTask(s.ctx, s.tc, status, "")
+		detail := s.a.endTaskResponse(s.ctx, s.tc, status, "")
+		resp, err := s.a.finishTask(s.ctx, s.tc, detail)
 		s.Equal(&apimodels.EndTaskResponse{}, resp)
 		s.NoError(err)
 		s.NoError(s.tc.logger.Close())
@@ -328,7 +329,8 @@ func (s *AgentSuite) TestFinishTaskWithAbnormallyCompletedTask() {
 	s.mockCommunicator.EndTaskResponse = &apimodels.EndTaskResponse{}
 
 	const status = evergreen.TaskSystemFailed
-	resp, err := s.a.finishTask(s.ctx, s.tc, status, "")
+	detail := s.a.endTaskResponse(s.ctx, s.tc, status, "")
+	resp, err := s.a.finishTask(s.ctx, s.tc, detail)
 	s.Equal(&apimodels.EndTaskResponse{}, resp)
 	s.NoError(err)
 
@@ -347,7 +349,8 @@ func (s *AgentSuite) TestFinishTaskWithAbnormallyCompletedTask() {
 
 func (s *AgentSuite) TestFinishTaskEndTaskError() {
 	s.mockCommunicator.EndTaskShouldFail = true
-	resp, err := s.a.finishTask(s.ctx, s.tc, evergreen.TaskSucceeded, "")
+	detail := s.a.endTaskResponse(s.ctx, s.tc, evergreen.TaskSucceeded, "")
+	resp, err := s.a.finishTask(s.ctx, s.tc, detail)
 	s.Nil(resp)
 	s.Error(err)
 }
@@ -1529,7 +1532,8 @@ func (s *AgentSuite) TestOOMTrackerRunsForSuccessStatusWithFailedDetailStatus() 
 	// while the originally computed status is still successful.
 	s.tc.setUserEndTaskResponse(&triggerEndTaskResp{Status: evergreen.TaskFailed})
 
-	_, err := s.a.finishTask(s.ctx, s.tc, evergreen.TaskSucceeded, "")
+	detail := s.a.endTaskResponse(s.ctx, s.tc, evergreen.TaskSucceeded, "")
+	_, err := s.a.finishTask(s.ctx, s.tc, detail)
 	s.NoError(err)
 	s.Require().NotNil(s.mockCommunicator.EndTaskResult.Detail.OOMTracker)
 	s.True(s.mockCommunicator.EndTaskResult.Detail.OOMTracker.Detected)
@@ -1552,7 +1556,8 @@ func (s *AgentSuite) TestOOMTrackerRunsForTimedOutTaskWithSucceededStatus() {
 	// an OOM kill even when the task is ultimately marked as succeeded.
 	s.tc.setTimedOut(true, globals.ExecTimeout)
 
-	_, err := s.a.finishTask(s.ctx, s.tc, evergreen.TaskSucceeded, "")
+	detail := s.a.endTaskResponse(s.ctx, s.tc, evergreen.TaskSucceeded, "")
+	_, err := s.a.finishTask(s.ctx, s.tc, detail)
 	s.NoError(err)
 	s.Require().NotNil(s.mockCommunicator.EndTaskResult.Detail.OOMTracker)
 	s.True(s.mockCommunicator.EndTaskResult.Detail.OOMTracker.Detected)
@@ -1575,7 +1580,8 @@ func (s *AgentSuite) TestOOMTrackerSkippedWhenUserOverridesToSucceeded() {
 	// not run.
 	s.tc.setUserEndTaskResponse(&triggerEndTaskResp{Status: evergreen.TaskSucceeded})
 
-	_, err := s.a.finishTask(s.ctx, s.tc, evergreen.TaskFailed, "")
+	detail := s.a.endTaskResponse(s.ctx, s.tc, evergreen.TaskFailed, "")
+	_, err := s.a.finishTask(s.ctx, s.tc, detail)
 	s.NoError(err)
 	s.Nil(s.mockCommunicator.EndTaskResult.Detail.OOMTracker)
 }
@@ -1593,7 +1599,8 @@ func (s *AgentSuite) TestOOMTrackerRunsForFailedStatusWithNoUserOverride() {
 	}
 	// No user override: agent-computed failure should trigger the OOM check.
 	// This is the positive companion to TestOOMTrackerSkippedWhenUserOverridesToSucceeded.
-	_, err := s.a.finishTask(s.ctx, s.tc, evergreen.TaskFailed, "")
+	detail := s.a.endTaskResponse(s.ctx, s.tc, evergreen.TaskFailed, "")
+	_, err := s.a.finishTask(s.ctx, s.tc, detail)
 	s.NoError(err)
 	s.Require().NotNil(s.mockCommunicator.EndTaskResult.Detail.OOMTracker)
 	s.True(s.mockCommunicator.EndTaskResult.Detail.OOMTracker.Detected)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1536,6 +1536,70 @@ func (s *AgentSuite) TestOOMTrackerRunsForSuccessStatusWithFailedDetailStatus() 
 	s.Equal(pids, s.mockCommunicator.EndTaskResult.Detail.OOMTracker.Pids)
 }
 
+func (s *AgentSuite) TestOOMTrackerRunsForTimedOutTaskWithSucceededStatus() {
+	s.mockCommunicator.EndTaskResponse = &apimodels.EndTaskResponse{}
+	s.a.opts.CloudProvider = "provider"
+	s.tc.taskConfig.Project.OomTracker = true
+
+	pids := []int{1, 2, 3}
+	lines := []string{"line 1", "line 2", "line 3"}
+	s.tc.oomTracker = &mock.OOMTracker{
+		Lines: lines,
+		PIDs:  pids,
+	}
+	// Task timed out but the final status is still succeeded (e.g. a non-failing
+	// timeout phase). The OOM check must still run because a timeout can indicate
+	// an OOM kill even when the task is ultimately marked as succeeded.
+	s.tc.setTimedOut(true, globals.ExecTimeout)
+
+	_, err := s.a.finishTask(s.ctx, s.tc, evergreen.TaskSucceeded, "")
+	s.NoError(err)
+	s.Require().NotNil(s.mockCommunicator.EndTaskResult.Detail.OOMTracker)
+	s.True(s.mockCommunicator.EndTaskResult.Detail.OOMTracker.Detected)
+	s.Equal(pids, s.mockCommunicator.EndTaskResult.Detail.OOMTracker.Pids)
+}
+
+func (s *AgentSuite) TestOOMTrackerSkippedWhenUserOverridesToSucceeded() {
+	s.mockCommunicator.EndTaskResponse = &apimodels.EndTaskResponse{}
+	s.a.opts.CloudProvider = "provider"
+	s.tc.taskConfig.Project.OomTracker = true
+
+	pids := []int{1, 2, 3}
+	lines := []string{"line 1", "line 2", "line 3"}
+	s.tc.oomTracker = &mock.OOMTracker{
+		Lines: lines,
+		PIDs:  pids,
+	}
+	// Agent computed a failure, but the user HTTP endpoint explicitly overrode
+	// the status to succeeded. The OOM check should respect the final status and
+	// not run.
+	s.tc.setUserEndTaskResponse(&triggerEndTaskResp{Status: evergreen.TaskSucceeded})
+
+	_, err := s.a.finishTask(s.ctx, s.tc, evergreen.TaskFailed, "")
+	s.NoError(err)
+	s.Nil(s.mockCommunicator.EndTaskResult.Detail.OOMTracker)
+}
+
+func (s *AgentSuite) TestOOMTrackerRunsForFailedStatusWithNoUserOverride() {
+	s.mockCommunicator.EndTaskResponse = &apimodels.EndTaskResponse{}
+	s.a.opts.CloudProvider = "provider"
+	s.tc.taskConfig.Project.OomTracker = true
+
+	pids := []int{1, 2, 3}
+	lines := []string{"line 1", "line 2", "line 3"}
+	s.tc.oomTracker = &mock.OOMTracker{
+		Lines: lines,
+		PIDs:  pids,
+	}
+	// No user override: agent-computed failure should trigger the OOM check.
+	// This is the positive companion to TestOOMTrackerSkippedWhenUserOverridesToSucceeded.
+	_, err := s.a.finishTask(s.ctx, s.tc, evergreen.TaskFailed, "")
+	s.NoError(err)
+	s.Require().NotNil(s.mockCommunicator.EndTaskResult.Detail.OOMTracker)
+	s.True(s.mockCommunicator.EndTaskResult.Detail.OOMTracker.Detected)
+	s.Equal(pids, s.mockCommunicator.EndTaskResult.Detail.OOMTracker.Pids)
+}
+
 func (s *AgentSuite) TestFinishPrevTaskWithoutTaskGroup() {
 	const buildID = "build_id"
 	const versionID = "not_a_task_group_version"

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-06-03"
+	AgentVersion = "2026-06-08"
 )
 
 const (

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-06-08"
+	AgentVersion = "2026-06-09"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-33316

### Description

`finishTask` threads two representations of task status through `handleTimeoutAndOOM`: the agent-computed `status string` parameter (from `runPreAndMain`) and `detail.Status` (the final value sent to the app server, which may be overridden by the user HTTP endpoint). 

The OOM check predicate consulted both, which could cause it to run against stale agent-computed state when the user had overridden the status. This was fixed in 65096c5c0aa7942a8d07ddc3975942c5bf80f587 by checking both statuses.

This refactor drop the `status string` parameter from `handleTimeoutAndOOM` entirely and unifies on `detail.Status` as the source of truth.

### Testing

Added three new unit tests to `agent/agent_test.go`:

- `TestOOMTrackerRunsForTimedOutTaskWithSucceededStatus` — timeout with succeeded final status still triggers OOM check (exercises the `|| tc.hadTimedOut()` branch).
- `TestOOMTrackerSkippedWhenUserOverridesToSucceeded` — agent-computed failure overridden to succeeded via HTTP endpoint skips OOM check (documents the new intended behavior).
- `TestOOMTrackerRunsForFailedStatusWithNoUserOverride` — plain failed task with no override runs OOM check (positive companion to the above).

### Documentation

No documentation changes needed.