### PR TITLE
DEVPROD-33350- Show correct total cost values for patches with child patches

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -548,6 +548,10 @@ models:
   Patch:
     model: github.com/evergreen-ci/evergreen/rest/model.APIPatch
     fields:
+      cost:
+        resolver: true
+      predictedCost:
+        resolver: true
       projectIdentifier:
         resolver: true
       includedLocalModules:

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -2609,6 +2609,8 @@ type PatchResolver interface {
 
 	Version(ctx context.Context, obj *model.APIPatch) (*model1.Version, error)
 	VersionFull(ctx context.Context, obj *model.APIPatch) (*model.APIVersion, error)
+	Cost(ctx context.Context, obj *model.APIPatch) (*cost.Cost, error)
+	PredictedCost(ctx context.Context, obj *model.APIPatch) (*cost.Cost, error)
 }
 type PatchesResolver interface {
 	FilteredPatchCount(ctx context.Context, obj *Patches) (int, error)
@@ -45957,7 +45959,7 @@ func (ec *executionContext) _Patch_cost(ctx context.Context, field graphql.Colle
 		field,
 		ec.fieldContext_Patch_cost,
 		func(ctx context.Context) (any, error) {
-			return obj.Cost, nil
+			return ec.resolvers.Patch().Cost(ctx, obj)
 		},
 		nil,
 		ec.marshalOCost2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋcostᚐCost,
@@ -45970,8 +45972,8 @@ func (ec *executionContext) fieldContext_Patch_cost(_ context.Context, field gra
 	fc = &graphql.FieldContext{
 		Object:     "Patch",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "total":
@@ -46006,7 +46008,7 @@ func (ec *executionContext) _Patch_predictedCost(ctx context.Context, field grap
 		field,
 		ec.fieldContext_Patch_predictedCost,
 		func(ctx context.Context) (any, error) {
-			return obj.PredictedCost, nil
+			return ec.resolvers.Patch().PredictedCost(ctx, obj)
 		},
 		nil,
 		ec.marshalOCost2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋcostᚐCost,
@@ -46019,8 +46021,8 @@ func (ec *executionContext) fieldContext_Patch_predictedCost(_ context.Context, 
 	fc = &graphql.FieldContext{
 		Object:     "Patch",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "total":
@@ -100230,9 +100232,71 @@ func (ec *executionContext) _Patch(ctx context.Context, sel ast.SelectionSet, ob
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "cost":
-			out.Values[i] = ec._Patch_cost(ctx, field, obj)
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Patch_cost(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "predictedCost":
-			out.Values[i] = ec._Patch_predictedCost(ctx, field, obj)
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Patch_predictedCost(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "invalidatedByUpstream":
 			out.Values[i] = ec._Patch_invalidatedByUpstream(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/graphql/patch_resolver.go
+++ b/graphql/patch_resolver.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/evergreen/graphql/loaders"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/cost"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
@@ -360,6 +361,28 @@ func (r *patchResolver) VersionFull(ctx context.Context, obj *restModel.APIPatch
 	apiVersion := restModel.APIVersion{}
 	apiVersion.BuildFromService(ctx, *v)
 	return &apiVersion, nil
+}
+
+// Cost returns the patch's cost with values rounded for display.
+func (r *patchResolver) Cost(ctx context.Context, obj *restModel.APIPatch) (*cost.Cost, error) {
+	if obj.Cost == nil {
+		return nil, nil
+	}
+	rounded := obj.Cost.RoundedBase()
+	rounded.ChildPatchesTotalCost = cost.RoundCost(obj.Cost.ChildPatchesTotalCost)
+	rounded.Total = cost.RoundCost(obj.Cost.AdjustedTotal() + obj.Cost.ChildPatchesTotalCost)
+	return &rounded, nil
+}
+
+// PredictedCost returns the patch's predicted cost with values rounded for display.
+func (r *patchResolver) PredictedCost(ctx context.Context, obj *restModel.APIPatch) (*cost.Cost, error) {
+	if obj.PredictedCost == nil {
+		return nil, nil
+	}
+	rounded := obj.PredictedCost.RoundedBase()
+	rounded.ChildPatchesTotalCost = cost.RoundCost(obj.PredictedCost.ChildPatchesTotalCost)
+	rounded.Total = cost.RoundCost(obj.PredictedCost.AdjustedTotal() + obj.PredictedCost.ChildPatchesTotalCost)
+	return &rounded, nil
 }
 
 // FilteredPatchCount is the resolver for the filteredPatchCount field.

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -28,7 +28,7 @@ func (r *costResolver) Total(ctx context.Context, obj *cost.Cost) (*float64, err
 	if obj == nil {
 		return nil, nil
 	}
-	return utility.ToFloat64Ptr(cost.RoundCost(obj.TotalAdjusted())), nil
+	return utility.ToFloat64Ptr(obj.Total), nil
 }
 
 // AbortInfo is the resolver for the abortInfo field.
@@ -751,15 +751,8 @@ func (r *taskResolver) TaskCost(ctx context.Context, obj *restModel.APITask) (*c
 	if obj.TaskCost == nil {
 		return nil, nil
 	}
-	rounded := cost.Cost{
-		AdjustedEC2Cost:               cost.RoundCost(obj.TaskCost.AdjustedEC2Cost),
-		AdjustedEBSThroughputCost:     cost.RoundCost(obj.TaskCost.AdjustedEBSThroughputCost),
-		AdjustedEBSStorageCost:        cost.RoundCost(obj.TaskCost.AdjustedEBSStorageCost),
-		AdjustedS3ArtifactPutCost:     cost.RoundCost(obj.TaskCost.AdjustedS3ArtifactPutCost),
-		AdjustedS3LogPutCost:          cost.RoundCost(obj.TaskCost.AdjustedS3LogPutCost),
-		AdjustedS3ArtifactStorageCost: cost.RoundCost(obj.TaskCost.AdjustedS3ArtifactStorageCost),
-		AdjustedS3LogStorageCost:      cost.RoundCost(obj.TaskCost.AdjustedS3LogStorageCost),
-	}
+	rounded := obj.TaskCost.RoundedBase()
+	rounded.Total = cost.RoundCost(obj.TaskCost.AdjustedTotal())
 	return &rounded, nil
 }
 

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -137,15 +137,8 @@ func (r *versionResolver) Cost(ctx context.Context, obj *restModel.APIVersion) (
 	if obj.Cost == nil {
 		return nil, nil
 	}
-	rounded := cost.Cost{
-		AdjustedEC2Cost:               cost.RoundCost(obj.Cost.AdjustedEC2Cost),
-		AdjustedEBSThroughputCost:     cost.RoundCost(obj.Cost.AdjustedEBSThroughputCost),
-		AdjustedEBSStorageCost:        cost.RoundCost(obj.Cost.AdjustedEBSStorageCost),
-		AdjustedS3ArtifactPutCost:     cost.RoundCost(obj.Cost.AdjustedS3ArtifactPutCost),
-		AdjustedS3LogPutCost:          cost.RoundCost(obj.Cost.AdjustedS3LogPutCost),
-		AdjustedS3ArtifactStorageCost: cost.RoundCost(obj.Cost.AdjustedS3ArtifactStorageCost),
-		AdjustedS3LogStorageCost:      cost.RoundCost(obj.Cost.AdjustedS3LogStorageCost),
-	}
+	rounded := obj.Cost.RoundedBase()
+	rounded.Total = cost.RoundCost(obj.Cost.AdjustedTotal())
 	return &rounded, nil
 }
 

--- a/model/cost/cost.go
+++ b/model/cost/cost.go
@@ -59,41 +59,50 @@ type Cost struct {
 	ChildPatchesTotalCost float64 `bson:"-" json:"child_patches_total_cost,omitempty"`
 }
 
-// TotalAdjusted returns the sum of every adjusted component in this value, excluding on-demand fields,
-// which are an alternate pricing view of the same usage.
-func (c Cost) TotalAdjusted() float64 {
+// AdjustedTotal returns the sum of the 7 base adjusted fields, excluding ChildPatchesTotalCost.
+func (c Cost) AdjustedTotal() float64 {
 	return c.AdjustedEC2Cost +
 		c.AdjustedEBSThroughputCost +
 		c.AdjustedEBSStorageCost +
 		c.AdjustedS3ArtifactPutCost +
 		c.AdjustedS3LogPutCost +
 		c.AdjustedS3ArtifactStorageCost +
-		c.AdjustedS3LogStorageCost +
-		c.ChildPatchesTotalCost
+		c.AdjustedS3LogStorageCost
 }
 
-// SumPerChildVersionAdjustedTotals sums actual and predicted adjusted costs for n children;
+// RoundedBase returns a new Cost with the 7 adjusted fields individually rounded.
+func (c Cost) RoundedBase() Cost {
+	return Cost{
+		AdjustedEC2Cost:               RoundCost(c.AdjustedEC2Cost),
+		AdjustedEBSThroughputCost:     RoundCost(c.AdjustedEBSThroughputCost),
+		AdjustedEBSStorageCost:        RoundCost(c.AdjustedEBSStorageCost),
+		AdjustedS3ArtifactPutCost:     RoundCost(c.AdjustedS3ArtifactPutCost),
+		AdjustedS3LogPutCost:          RoundCost(c.AdjustedS3LogPutCost),
+		AdjustedS3ArtifactStorageCost: RoundCost(c.AdjustedS3ArtifactStorageCost),
+		AdjustedS3LogStorageCost:      RoundCost(c.AdjustedS3LogStorageCost),
+	}
+}
+
+// SumPerChildVersionAdjustedTotals sums actual and predicted adjusted costs across n children.
 func SumPerChildVersionAdjustedTotals(n int, childAt func(int) (actual, predicted *Cost)) (sumActual, sumPred float64) {
 	for i := 0; i < n; i++ {
 		actual, predicted := childAt(i)
 		if actual != nil {
-			sumActual += actual.TotalAdjusted()
+			sumActual += actual.AdjustedTotal() + actual.ChildPatchesTotalCost
 		}
 		if predicted != nil {
-			sumPred += predicted.TotalAdjusted()
+			sumPred += predicted.AdjustedTotal() + predicted.ChildPatchesTotalCost
 		}
 	}
 	return
 }
 
-// RoundCost removes floating-point noise from a cost value. Values >= 0.01
-// are rounded to 2 decimal places; values < 0.01 are rounded to 2 significant
-// figures to preserve meaningful precision for very small costs.
+// RoundCost rounds v to 2 decimal places for values >= $0.10, or 2 significant figures below that threshold.
 func RoundCost(v float64) float64 {
 	if v == 0 {
 		return 0
 	}
-	if v >= 0.01 {
+	if v >= 0.10 {
 		return math.Round(v*100) / 100
 	}
 	magnitude := math.Floor(math.Log10(math.Abs(v)))

--- a/model/cost/cost_test.go
+++ b/model/cost/cost_test.go
@@ -37,7 +37,7 @@ func TestSumPerChildVersionAdjustedTotals(t *testing.T) {
 	})
 }
 
-func TestCostTotalAdjusted(t *testing.T) {
+func TestCostAdjustedTotal(t *testing.T) {
 	c := Cost{
 		AdjustedEC2Cost:               1,
 		AdjustedEBSThroughputCost:     2,
@@ -48,11 +48,12 @@ func TestCostTotalAdjusted(t *testing.T) {
 		AdjustedS3LogStorageCost:      0.4,
 		OnDemandEC2Cost:               100,
 	}
-	assert.InDelta(t, 8.0, c.TotalAdjusted(), 1e-9)
+	assert.InDelta(t, 8.0, c.AdjustedTotal(), 1e-9)
 
 	withChildren := c
 	withChildren.ChildPatchesTotalCost = 2
-	assert.InDelta(t, 10.0, withChildren.TotalAdjusted(), 1e-9)
+	assert.InDelta(t, 8.0, withChildren.AdjustedTotal(), 1e-9)
+	assert.InDelta(t, 10.0, withChildren.AdjustedTotal()+withChildren.ChildPatchesTotalCost, 1e-9)
 }
 
 func TestRoundCost(t *testing.T) {
@@ -69,8 +70,13 @@ func TestRoundCost(t *testing.T) {
 	t.Run("SmallValueRoundsUpToTwoSigFigs", func(t *testing.T) {
 		assert.Equal(t, 0.0058, RoundCost(0.005819905908980206))
 	})
-	t.Run("ValueAboveOneCentRoundsToTwoDecimalPlaces", func(t *testing.T) {
-		// Values >= 0.01 are rounded to 2 decimal places.
+	t.Run("ValueInSubDimeRangeRoundsToTwoSigFigs", func(t *testing.T) {
+		assert.Equal(t, 0.018, RoundCost(0.017745393484928533))
+	})
+	t.Run("ValueBetweenOneCentAndOneDimeRoundsToTwoSigFigs", func(t *testing.T) {
+		assert.Equal(t, 0.025, RoundCost(0.0249999))
+	})
+	t.Run("ValueAboveOneDimeRoundsToTwoDecimalPlaces", func(t *testing.T) {
 		assert.Equal(t, 1.23, RoundCost(1.2345678))
 	})
 }
@@ -132,7 +138,7 @@ func TestCostJSONIncludesEBSThroughputFieldsWhenZero(t *testing.T) {
 
 func TestCostJSONSerializesTotalWhenSet(t *testing.T) {
 	c := Cost{OnDemandEC2Cost: 1, AdjustedEC2Cost: 0.5}
-	c.Total = c.TotalAdjusted()
+	c.Total = c.AdjustedTotal()
 	data, err := json.Marshal(c)
 	require.NoError(t, err)
 	var m map[string]interface{}

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -343,12 +343,12 @@ func (apiPatch *APIPatch) populateCostFromVersion(ctx context.Context, versionID
 	}
 	if !v.Cost.IsZero() {
 		versionCost := v.Cost
-		versionCost.Total = versionCost.TotalAdjusted()
+		versionCost.Total = versionCost.AdjustedTotal()
 		apiPatch.Cost = &versionCost
 	}
 	if !v.PredictedCost.IsZero() {
 		predictedCost := v.PredictedCost
-		predictedCost.Total = predictedCost.TotalAdjusted()
+		predictedCost.Total = predictedCost.AdjustedTotal()
 		apiPatch.PredictedCost = &predictedCost
 	}
 	if !v.S3Usage.IsZero() {
@@ -417,7 +417,7 @@ func addChildPatchesCostToParent(apiPatch *APIPatch, childPatches []APIPatch) {
 			*dest = &cost.Cost{}
 		}
 		(*dest).ChildPatchesTotalCost = sum
-		(*dest).Total = (*dest).TotalAdjusted()
+		(*dest).Total = (*dest).AdjustedTotal() + (*dest).ChildPatchesTotalCost
 	}
 	merge(&apiPatch.Cost, actualSum)
 	merge(&apiPatch.PredictedCost, predictedSum)

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -410,14 +410,14 @@ func (at *APITask) buildTask(t *task.Task) error {
 
 	if !t.TaskCost.IsZero() {
 		taskCost := t.TaskCost
-		taskCost.Total = taskCost.TotalAdjusted()
+		taskCost.Total = taskCost.AdjustedTotal()
 		at.TaskCost = &taskCost
 	}
 
 	// Populate expected cost fields if they exist (not zero)
 	if !t.PredictedTaskCost.IsZero() {
 		predictedCost := t.PredictedTaskCost
-		predictedCost.Total = predictedCost.TotalAdjusted()
+		predictedCost.Total = predictedCost.AdjustedTotal()
 		at.PredictedTaskCost = &predictedCost
 	}
 

--- a/rest/model/version.go
+++ b/rest/model/version.go
@@ -152,12 +152,12 @@ func (apiVersion *APIVersion) BuildFromService(ctx context.Context, v model.Vers
 
 	if !v.Cost.IsZero() {
 		versionCost := v.Cost
-		versionCost.Total = versionCost.TotalAdjusted()
+		versionCost.Total = versionCost.AdjustedTotal()
 		apiVersion.Cost = &versionCost
 	}
 	if !v.PredictedCost.IsZero() {
 		predictedCost := v.PredictedCost
-		predictedCost.Total = predictedCost.TotalAdjusted()
+		predictedCost.Total = predictedCost.AdjustedTotal()
 		apiVersion.PredictedCost = &predictedCost
 	}
 	if !v.S3Usage.IsZero() {


### PR DESCRIPTION
DEVPROD-33350

### Description
This PR addresses a user reported bug for how we display costs on the UI.

2 issues are being addressed in this PR:
- When a patch has a child patch, the patch metadata info panel correctly shows the cost. But in the cost details modal. the child patch cost is not part of the total that is displayed. We now show the correct cost
- The child patch cost value is not correctly rounded. We are now rounding correctly

`Patch.cost` was missing `resolver: true` in `gqlgen.yml` --> due to this it bypassed the rounding layer that `Version.cost` and `Task.taskCost` already had. Created two resolvers in `graphql/patch_resolver.go` following the same pattern to round all cost fields and correctly include child patch cost in the total.

`TotalAdjusted()` was renamed to `AdjustedTotal()` and `ChildPatchesTotalCost` removed from its sum. Resolvers can compute the totals individually by adding child patch cost to the base compute. This math is done using unrounded values.

`RoundedBase()` is one place that is used for rounding across all three resolvers (version, task, patch) and deliberately excludes ChildPatchesTotalCost and Total, forcing callers to set those explicitly from unrounded sources.


### Testing
Testing in staging

[Evergreen-UI PR](https://github.com/evergreen-ci/ui/pull/1704)