### PR TITLE
DEVPROD-34618 Preserve symlinks in cache.save/cache.restore

### DIFF
--- a/agent/command/archive_tarball_create.go
+++ b/agent/command/archive_tarball_create.go
@@ -174,7 +174,15 @@ func (c *tarballCreate) makeArchive(ctx context.Context, logger grip.Journaler, 
 	}()
 
 	// Build the archive
-	out, err := buildArchive(ctx, tarWriter, c.SourceDir, pathsToAdd, c.ExcludeFiles, logger, verbose, false)
+	out, err := buildArchive(ctx, buildArchiveOptions{
+		tarWriter:        tarWriter,
+		rootPath:         c.SourceDir,
+		paths:            pathsToAdd,
+		excludes:         c.ExcludeFiles,
+		logger:           logger,
+		verbose:          verbose,
+		preserveSymlinks: false,
+	})
 
 	return out, errors.WithStack(err)
 }

--- a/agent/command/archive_tarball_create.go
+++ b/agent/command/archive_tarball_create.go
@@ -174,7 +174,7 @@ func (c *tarballCreate) makeArchive(ctx context.Context, logger grip.Journaler, 
 	}()
 
 	// Build the archive
-	out, err := buildArchive(ctx, tarWriter, c.SourceDir, pathsToAdd, c.ExcludeFiles, logger, verbose)
+	out, err := buildArchive(ctx, tarWriter, c.SourceDir, pathsToAdd, c.ExcludeFiles, logger, verbose, false)
 
 	return out, errors.WithStack(err)
 }

--- a/agent/command/archive_tarball_create_test.go
+++ b/agent/command/archive_tarball_create_test.go
@@ -209,7 +209,7 @@ func TestTarGzCommandMakeArchive(t *testing.T) {
 				defer f.Close()
 				defer gz.Close()
 
-				So(extractTarballArchive(t.Context(), tarReader, outputDir, []string{}), ShouldBeNil)
+				So(extractTarballArchive(t.Context(), tarReader, outputDir, []string{}, false), ShouldBeNil)
 				assert.DirExists(t, filepath.Join(outputDir, "dir1"))
 				assert.DirExists(t, filepath.Join(outputDir, "dir1", "dir2"))
 			})

--- a/agent/command/archive_tarball_extract.go
+++ b/agent/command/archive_tarball_extract.go
@@ -61,7 +61,7 @@ func (e *tarballExtract) Execute(ctx context.Context,
 		logger.Task().Notice(ctx, errors.Wrapf(archive.Close(), "closing file '%s'", archivePath))
 	}()
 
-	if err := extractTarball(ctx, archive, destinationPath, e.ExcludeFiles); err != nil {
+	if err := extractTarball(ctx, archive, destinationPath, e.ExcludeFiles, false); err != nil {
 		return errors.Wrapf(err, "extracting file '%s'", archivePath)
 	}
 

--- a/agent/command/archive_util.go
+++ b/agent/command/archive_util.go
@@ -173,7 +173,7 @@ FileLoop:
 				continue
 			}
 			hdr.Typeflag = tar.TypeSymlink
-			hdr.Linkname = strings.Replace(target, "\\", "/", -1)
+			hdr.Linkname = target
 			numFilesArchived++
 			if err := tarWriter.WriteHeader(hdr); err != nil {
 				return numFilesArchived, errors.Wrapf(err, "writing tarball header for symlink '%s'", intarball)

--- a/agent/command/archive_util.go
+++ b/agent/command/archive_util.go
@@ -304,7 +304,7 @@ tarReaderLoop:
 				rawLinkname := linkname
 				linkFiles = append(linkFiles, func() error {
 					if err := os.MkdirAll(filepath.Dir(namePath), 0755); err != nil {
-						return errors.WithStack(err)
+						return errors.Wrapf(err, "creating directory '%s'", filepath.Dir(namePath))
 					}
 					// Remove any existing entry so restoring into an
 					// already-populated tree (e.g. a second cache.restore in a
@@ -313,7 +313,7 @@ tarReaderLoop:
 					// deliberate: silently deleting a directory tree to make room
 					// for a symlink would be too destructive.
 					if err := os.Remove(namePath); err != nil && !os.IsNotExist(err) {
-						return errors.WithStack(err)
+						return errors.Wrapf(err, "removing existing entry '%s'", namePath)
 					}
 					return os.Symlink(rawLinkname, namePath)
 				})

--- a/agent/command/archive_util.go
+++ b/agent/command/archive_util.go
@@ -306,6 +306,15 @@ tarReaderLoop:
 					if err := os.MkdirAll(filepath.Dir(namePath), 0755); err != nil {
 						return errors.WithStack(err)
 					}
+					// Remove any existing entry so restoring into an
+					// already-populated tree (e.g. a second cache.restore in a
+					// task group) overwrites like regular-file extraction does,
+					// instead of failing with EEXIST. A non-recursive remove is
+					// deliberate: silently deleting a directory tree to make room
+					// for a symlink would be too destructive.
+					if err := os.Remove(namePath); err != nil && !os.IsNotExist(err) {
+						return errors.WithStack(err)
+					}
 					return os.Symlink(rawLinkname, namePath)
 				})
 			} else {

--- a/agent/command/archive_util.go
+++ b/agent/command/archive_util.go
@@ -59,14 +59,27 @@ func validateSymlinkTarget(linkname, linkPath, rootPath string) error {
 	return nil
 }
 
+// buildArchiveOptions configures how buildArchive writes files into the archive.
+type buildArchiveOptions struct {
+	tarWriter *tar.Writer
+	rootPath  string
+	paths     []archiveContentFile
+	excludes  []string
+	logger    grip.Journaler
+	verbose   bool
+	// preserveSymlinks archives symlinks as symlink entries (preserving their
+	// targets); otherwise they are dereferenced and the target's contents are
+	// stored at the symlink's path.
+	preserveSymlinks bool
+}
+
 // buildArchive reads the rootPath directory into the tar.Writer,
 // taking included and excluded strings into account.
 // Returns the number of files that were added to the archive.
-// When preserveSymlinks is true, symlinks are archived as symlink entries
-// (preserving their targets); otherwise they are dereferenced and the target's
-// contents are stored at the symlink's path.
-func buildArchive(ctx context.Context, tarWriter *tar.Writer, rootPath string, pathsToAdd []archiveContentFile,
-	excludes []string, logger grip.Journaler, verbose, preserveSymlinks bool) (int, error) {
+func buildArchive(ctx context.Context, opts buildArchiveOptions) (int, error) {
+	tarWriter, rootPath, logger := opts.tarWriter, opts.rootPath, opts.logger
+	pathsToAdd, excludes := opts.paths, opts.excludes
+	verbose, preserveSymlinks := opts.verbose, opts.preserveSymlinks
 
 	numFilesArchived := 0
 	processed := map[string]bool{}

--- a/agent/command/archive_util.go
+++ b/agent/command/archive_util.go
@@ -39,11 +39,34 @@ func validateRelativePath(filePath, rootPath string) error {
 	return nil
 }
 
+// validateSymlinkTarget verifies that following a symlink located at linkPath
+// whose raw target is linkname cannot resolve outside rootPath. A relative
+// target is resolved against the symlink's own directory (its real semantics);
+// an absolute target is rejected because it is host-specific and would point
+// outside the extracted tree.
+func validateSymlinkTarget(linkname, linkPath, rootPath string) error {
+	if filepath.IsAbs(linkname) {
+		return errors.New("symlink target is absolute")
+	}
+	resolved := filepath.Join(filepath.Dir(linkPath), linkname)
+	relpath, err := filepath.Rel(rootPath, resolved)
+	if err != nil {
+		return errors.Wrap(err, "getting relative path of symlink target")
+	}
+	if relpath == ".." || strings.HasPrefix(relpath, ".."+string(filepath.Separator)) {
+		return errors.New("symlink target resolves outside the root path")
+	}
+	return nil
+}
+
 // buildArchive reads the rootPath directory into the tar.Writer,
 // taking included and excluded strings into account.
-// Returns the number of files that were added to the archive
+// Returns the number of files that were added to the archive.
+// When preserveSymlinks is true, symlinks are archived as symlink entries
+// (preserving their targets); otherwise they are dereferenced and the target's
+// contents are stored at the symlink's path.
 func buildArchive(ctx context.Context, tarWriter *tar.Writer, rootPath string, pathsToAdd []archiveContentFile,
-	excludes []string, logger grip.Journaler, verbose bool) (int, error) {
+	excludes []string, logger grip.Journaler, verbose, preserveSymlinks bool) (int, error) {
 
 	numFilesArchived := 0
 	processed := map[string]bool{}
@@ -55,10 +78,11 @@ FileLoop:
 		}
 
 		var intarball string
-		// Tarring symlinks doesn't work reliably right now, so if the file is
-		// a symlink, leave intarball path intact but write from the file
-		// underlying the symlink.
-		if file.info.Mode()&os.ModeSymlink > 0 {
+		// When preserveSymlinks is false, tarring symlinks doesn't work reliably,
+		// so leave the intarball path intact but write from the file underlying
+		// the symlink. When preserveSymlinks is true, the symlink is left alone
+		// here and archived as a symlink entry below.
+		if file.info.Mode()&os.ModeSymlink > 0 && !preserveSymlinks {
 			symlinkPath, err := filepath.EvalSymlinks(file.path)
 			if err != nil {
 				logger.Warningf(ctx, "Could not follow symlink '%s', ignoring.", file.path)
@@ -125,6 +149,26 @@ FileLoop:
 			continue
 		}
 
+		if file.info.Mode()&os.ModeSymlink > 0 {
+			// Reachable only when preserveSymlinks is true; otherwise the block
+			// at the top of the loop rewrote file.info to the dereferenced target.
+			// os.Readlink preserves the raw (possibly relative or broken) target,
+			// which is what tools like NPM expect to find on restore.
+			target, err := os.Readlink(file.path)
+			if err != nil {
+				logger.Warningf(ctx, "Could not read symlink '%s', ignoring.", file.path)
+				continue
+			}
+			hdr.Typeflag = tar.TypeSymlink
+			hdr.Linkname = strings.Replace(target, "\\", "/", -1)
+			numFilesArchived++
+			if err := tarWriter.WriteHeader(hdr); err != nil {
+				return numFilesArchived, errors.Wrapf(err, "writing tarball header for symlink '%s'", intarball)
+			}
+			logger.Warning(ctx, errors.Wrap(tarWriter.Flush(), "flushing tar writer"))
+			continue
+		}
+
 		hdr.Size = file.info.Size()
 
 		numFilesArchived++
@@ -155,7 +199,7 @@ FileLoop:
 	return numFilesArchived, nil
 }
 
-func extractTarball(ctx context.Context, reader io.Reader, rootPath string, excludes []string) error {
+func extractTarball(ctx context.Context, reader io.Reader, rootPath string, excludes []string, preserveSymlinks bool) error {
 	// wrap the reader in a gzip reader and a tar reader
 	gzipReader, err := pgzip.NewReader(reader)
 	if err != nil {
@@ -163,7 +207,7 @@ func extractTarball(ctx context.Context, reader io.Reader, rootPath string, excl
 	}
 
 	tarReader := tar.NewReader(gzipReader)
-	err = extractTarballArchive(ctx, tarReader, rootPath, excludes)
+	err = extractTarballArchive(ctx, tarReader, rootPath, excludes, preserveSymlinks)
 	if err != nil {
 		return errors.Wrapf(err, "extracting path '%s'", rootPath)
 	}
@@ -171,8 +215,11 @@ func extractTarball(ctx context.Context, reader io.Reader, rootPath string, excl
 	return nil
 }
 
-// extractTarballArchive unpacks the tar.Reader into rootPath.
-func extractTarballArchive(ctx context.Context, tarReader *tar.Reader, rootPath string, excludes []string) error {
+// extractTarballArchive unpacks the tar.Reader into rootPath. When
+// preserveSymlinks is true, symlink entries are recreated with their original
+// (possibly relative) targets, validated to stay within rootPath; otherwise
+// symlink targets are interpreted relative to rootPath.
+func extractTarballArchive(ctx context.Context, tarReader *tar.Reader, rootPath string, excludes []string, preserveSymlinks bool) error {
 	// Link files and symlink files are extracted after all other files are extracted.
 	linkFiles := []func() error{}
 tarReaderLoop:
@@ -201,14 +248,23 @@ tarReaderLoop:
 		if err := validateRelativePath(name, rootPath); err != nil {
 			return errors.Wrapf(err, "artifact path name '%s' should be relative to the root path", name)
 		}
-		if linkname != "" {
-			if err := validateRelativePath(linkname, rootPath); err != nil {
-				return errors.Wrapf(err, "artifact path link name '%s' should be relative to the root path", linkname)
-			}
-		}
 
 		namePath := filepath.Join(rootPath, name)
 		linkNamePath := filepath.Join(rootPath, linkname)
+
+		if linkname != "" {
+			// A preserved symlink keeps its raw (possibly relative) target, which
+			// resolves against the symlink's own directory. Every other link
+			// (hard links, and symlinks when preservation is off) is interpreted
+			// relative to the root path.
+			if hdr.Typeflag == tar.TypeSymlink && preserveSymlinks {
+				if err := validateSymlinkTarget(linkname, namePath, rootPath); err != nil {
+					return errors.Wrapf(err, "validating symlink target '%s' for '%s'", linkname, name)
+				}
+			} else if err := validateRelativePath(linkname, rootPath); err != nil {
+				return errors.Wrapf(err, "artifact path link name '%s' should be relative to the root path", linkname)
+			}
+		}
 
 		for _, ignore := range excludes {
 			if match, _ := filepath.Match(ignore, name); match {
@@ -229,9 +285,21 @@ tarReaderLoop:
 			})
 		case tar.TypeSymlink:
 			// Tar entry for a symbolic link.
-			linkFiles = append(linkFiles, func() error {
-				return os.Symlink(linkNamePath, namePath)
-			})
+			if preserveSymlinks {
+				// Recreate the symlink with its raw target so relative links
+				// (e.g. an NPM node_modules/.bin entry) are preserved verbatim.
+				rawLinkname := linkname
+				linkFiles = append(linkFiles, func() error {
+					if err := os.MkdirAll(filepath.Dir(namePath), 0755); err != nil {
+						return errors.WithStack(err)
+					}
+					return os.Symlink(rawLinkname, namePath)
+				})
+			} else {
+				linkFiles = append(linkFiles, func() error {
+					return os.Symlink(linkNamePath, namePath)
+				})
+			}
 		case tar.TypeReg, tar.TypeRegA:
 			// Tar entry for a regular file.
 			// First, ensure the file's parent directory exists.

--- a/agent/command/archive_util_test.go
+++ b/agent/command/archive_util_test.go
@@ -384,6 +384,30 @@ func TestExtractTarballPreserveSymlinks(t *testing.T) {
 		assert.Equal(t, "#!/bin/sh\n", string(contents))
 	})
 
+	t.Run("ExistingSymlinkIsOverwritten", func(t *testing.T) {
+		srcDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "real.txt"), []byte("payload"), 0644))
+		require.NoError(t, os.Symlink("real.txt", filepath.Join(srcDir, "link.txt")))
+
+		archive := buildArchiveTo(t, srcDir)
+		f, err := os.Open(archive)
+		require.NoError(t, err)
+		t.Cleanup(func() { assert.NoError(t, f.Close()) })
+
+		destDir := t.TempDir()
+		require.NoError(t, extractTarball(ctx, f, destDir, nil, true))
+
+		// A second extraction into the already-populated tree must overwrite
+		// the existing symlink rather than fail with EEXIST.
+		_, err = f.Seek(0, io.SeekStart)
+		require.NoError(t, err)
+		require.NoError(t, extractTarball(ctx, f, destDir, nil, true))
+
+		target, err := os.Readlink(filepath.Join(destDir, "link.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "real.txt", target)
+	})
+
 	t.Run("EscapingSymlinkRejected", func(t *testing.T) {
 		srcDir := t.TempDir()
 		require.NoError(t, os.Symlink(filepath.Join("..", "..", "escape"), filepath.Join(srcDir, "evil")))

--- a/agent/command/archive_util_test.go
+++ b/agent/command/archive_util_test.go
@@ -328,6 +328,39 @@ func TestBuildArchivePreserveSymlinks(t *testing.T) {
 	})
 }
 
+func TestValidateSymlinkTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink preservation is not supported on Windows")
+	}
+	root := filepath.Join(string(filepath.Separator), "tmp", "root")
+	for _, tc := range []struct {
+		name     string
+		linkname string
+		linkPath string
+		valid    bool
+	}{
+		{name: "TargetInSameDirectoryAllowed", linkname: "real.txt", linkPath: filepath.Join(root, "link.txt"), valid: true},
+		{name: "TargetOfDotAllowed", linkname: ".", linkPath: filepath.Join(root, "link"), valid: true},
+		{name: "TargetTraversingWithinRootAllowed", linkname: "a/../b", linkPath: filepath.Join(root, "link"), valid: true},
+		{name: "TargetClimbingToRootFromSubdirAllowed", linkname: "../real.txt", linkPath: filepath.Join(root, "sub", "link"), valid: true},
+		// A name that merely starts with dots is not a traversal; the
+		// neighboring validateRelativePath would falsely reject this.
+		{name: "TargetNameStartingWithDotsAllowed", linkname: "..data", linkPath: filepath.Join(root, "link"), valid: true},
+		{name: "TargetOfParentRejected", linkname: "..", linkPath: filepath.Join(root, "link"), valid: false},
+		{name: "TargetEscapingRootRejected", linkname: "../../escape", linkPath: filepath.Join(root, "sub", "link"), valid: false},
+		{name: "AbsoluteTargetRejected", linkname: "/etc/passwd", linkPath: filepath.Join(root, "link"), valid: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateSymlinkTarget(tc.linkname, tc.linkPath, root)
+			if tc.valid {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
 func TestExtractTarballPreserveSymlinks(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink preservation is not supported on Windows")
@@ -406,6 +439,48 @@ func TestExtractTarballPreserveSymlinks(t *testing.T) {
 		target, err := os.Readlink(filepath.Join(destDir, "link.txt"))
 		require.NoError(t, err)
 		assert.Equal(t, "real.txt", target)
+	})
+
+	t.Run("ExistingRegularFileIsOverwritten", func(t *testing.T) {
+		srcDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "real.txt"), []byte("payload"), 0644))
+		require.NoError(t, os.Symlink("real.txt", filepath.Join(srcDir, "link.txt")))
+
+		archive := buildArchiveTo(t, srcDir)
+		f, err := os.Open(archive)
+		require.NoError(t, err)
+		t.Cleanup(func() { assert.NoError(t, f.Close()) })
+
+		destDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(destDir, "link.txt"), []byte("stale"), 0644))
+		require.NoError(t, extractTarball(ctx, f, destDir, nil, true))
+
+		target, err := os.Readlink(filepath.Join(destDir, "link.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "real.txt", target)
+	})
+
+	t.Run("ExistingNonEmptyDirectoryFailsExtraction", func(t *testing.T) {
+		// The remove before recreating a symlink is deliberately non-recursive:
+		// extraction must not silently delete a directory tree to make room.
+		srcDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "real.txt"), []byte("payload"), 0644))
+		require.NoError(t, os.Symlink("real.txt", filepath.Join(srcDir, "link.txt")))
+
+		archive := buildArchiveTo(t, srcDir)
+		f, err := os.Open(archive)
+		require.NoError(t, err)
+		t.Cleanup(func() { assert.NoError(t, f.Close()) })
+
+		destDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(destDir, "link.txt"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(destDir, "link.txt", "keep.txt"), []byte("keep"), 0644))
+
+		require.Error(t, extractTarball(ctx, f, destDir, nil, true))
+
+		kept, err := os.ReadFile(filepath.Join(destDir, "link.txt", "keep.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "keep", string(kept))
 	})
 
 	t.Run("EscapingSymlinkRejected", func(t *testing.T) {

--- a/agent/command/archive_util_test.go
+++ b/agent/command/archive_util_test.go
@@ -132,7 +132,7 @@ func TestArchiveExtract(t *testing.T) {
 		defer f.Close()
 		defer gz.Close()
 
-		err = extractTarballArchive(ctx, tarReader, outputDir, []string{})
+		err = extractTarballArchive(ctx, tarReader, outputDir, []string{}, false)
 		So(err, ShouldBeNil)
 
 		Convey("extracted data should match the archive contents", func() {
@@ -179,7 +179,7 @@ func TestBuildArchive(t *testing.T) {
 				pathsToAdd, _, err := findContentsToArchive(ctx, rootPath, includes, []string{})
 				require.NoError(t, err)
 				excludes := []string{"*.pdb"}
-				_, err = buildArchive(ctx, tarWriter, rootPath, pathsToAdd, excludes, logger, false)
+				_, err = buildArchive(ctx, tarWriter, rootPath, pathsToAdd, excludes, logger, false, false)
 				So(err, ShouldBeNil)
 			})
 		}
@@ -209,9 +209,176 @@ func TestBuildArchiveVerbose(t *testing.T) {
 	pathsToAdd, _, err := findContentsToArchive(ctx, rootPath, []string{"dir1/**"}, []string{})
 	require.NoError(t, err)
 
-	numFiles, err := buildArchive(ctx, tarWriter, rootPath, pathsToAdd, []string{"*.pdb"}, logger, true)
+	numFiles, err := buildArchive(ctx, tarWriter, rootPath, pathsToAdd, []string{"*.pdb"}, logger, true, false)
 	require.NoError(t, err)
 	assert.Greater(t, numFiles, 0)
+}
+
+// collectTarHeaders reads every entry from a gzipped tarball into a map keyed
+// by header name, so tests can assert on typeflags and link targets directly.
+func collectTarHeaders(t *testing.T, path string) map[string]*tar.Header {
+	f, gz, tarReader, err := tarGzReader(path)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, gz.Close())
+		assert.NoError(t, f.Close())
+	})
+
+	headers := map[string]*tar.Header{}
+	for {
+		hdr, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		headers[hdr.Name] = hdr
+	}
+	return headers
+}
+
+func TestBuildArchivePreserveSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink preservation is not supported on Windows")
+	}
+	logger := logging.NewGrip("test.archive")
+	ctx := t.Context()
+
+	// A directory with a regular file, a relative symlink to it, a symlink to a
+	// subdirectory, and a broken symlink.
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "real.txt"), []byte("hello"), 0644))
+	require.NoError(t, os.Symlink("real.txt", filepath.Join(srcDir, "link.txt")))
+	require.NoError(t, os.MkdirAll(filepath.Join(srcDir, "subdir"), 0755))
+	require.NoError(t, os.Symlink("subdir", filepath.Join(srcDir, "dirlink")))
+	require.NoError(t, os.Symlink("does-not-exist", filepath.Join(srcDir, "broken")))
+
+	contents, _, err := gatherCacheContents(srcDir, []string{"."})
+	require.NoError(t, err)
+
+	t.Run("PreservedAsSymlinkEntries", func(t *testing.T) {
+		target := filepath.Join(t.TempDir(), "preserve.tgz")
+		f, gz, tarWriter, err := tarGzWriter(target, false)
+		require.NoError(t, err)
+		_, err = buildArchive(ctx, tarWriter, srcDir, contents, nil, logger, false, true)
+		require.NoError(t, err)
+		require.NoError(t, tarWriter.Close())
+		require.NoError(t, gz.Close())
+		require.NoError(t, f.Close())
+
+		headers := collectTarHeaders(t, target)
+
+		require.Contains(t, headers, "link.txt")
+		assert.Equal(t, byte(tar.TypeSymlink), headers["link.txt"].Typeflag)
+		assert.Equal(t, "real.txt", headers["link.txt"].Linkname)
+
+		require.Contains(t, headers, "dirlink")
+		assert.Equal(t, byte(tar.TypeSymlink), headers["dirlink"].Typeflag)
+		assert.Equal(t, "subdir", headers["dirlink"].Linkname)
+
+		// A broken symlink is preserved verbatim, not dropped.
+		require.Contains(t, headers, "broken")
+		assert.Equal(t, byte(tar.TypeSymlink), headers["broken"].Typeflag)
+		assert.Equal(t, "does-not-exist", headers["broken"].Linkname)
+
+		require.Contains(t, headers, "real.txt")
+		assert.Equal(t, byte(tar.TypeReg), headers["real.txt"].Typeflag)
+	})
+
+	t.Run("DereferencedWhenDisabled", func(t *testing.T) {
+		target := filepath.Join(t.TempDir(), "deref.tgz")
+		f, gz, tarWriter, err := tarGzWriter(target, false)
+		require.NoError(t, err)
+		_, err = buildArchive(ctx, tarWriter, srcDir, contents, nil, logger, false, false)
+		require.NoError(t, err)
+		require.NoError(t, tarWriter.Close())
+		require.NoError(t, gz.Close())
+		require.NoError(t, f.Close())
+
+		headers := collectTarHeaders(t, target)
+
+		// The symlink to a regular file is stored as a regular file with the
+		// target's contents; the broken symlink is dropped entirely.
+		require.Contains(t, headers, "link.txt")
+		assert.Equal(t, byte(tar.TypeReg), headers["link.txt"].Typeflag)
+		assert.NotContains(t, headers, "broken")
+	})
+}
+
+func TestExtractTarballPreserveSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink preservation is not supported on Windows")
+	}
+	logger := logging.NewGrip("test.archive")
+	ctx := t.Context()
+
+	// buildArchiveTo writes the given source dir to a gzipped tarball, preserving
+	// symlinks, and returns its path.
+	buildArchiveTo := func(t *testing.T, srcDir string) string {
+		contents, _, err := gatherCacheContents(srcDir, []string{"."})
+		require.NoError(t, err)
+		target := filepath.Join(t.TempDir(), "archive.tgz")
+		f, gz, tarWriter, err := tarGzWriter(target, false)
+		require.NoError(t, err)
+		_, err = buildArchive(ctx, tarWriter, srcDir, contents, nil, logger, false, true)
+		require.NoError(t, err)
+		require.NoError(t, tarWriter.Close())
+		require.NoError(t, gz.Close())
+		require.NoError(t, f.Close())
+		return target
+	}
+
+	t.Run("RelativeSymlinkRoundTrips", func(t *testing.T) {
+		// Mirror an NPM-style layout: a binary under a nested dir and a relative
+		// symlink to it from a sibling .bin directory.
+		srcDir := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(srcDir, "typescript", "bin"), 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "typescript", "bin", "tsc"), []byte("#!/bin/sh\n"), 0755))
+		require.NoError(t, os.MkdirAll(filepath.Join(srcDir, ".bin"), 0755))
+		require.NoError(t, os.Symlink(filepath.Join("..", "typescript", "bin", "tsc"), filepath.Join(srcDir, ".bin", "tsc")))
+
+		archive := buildArchiveTo(t, srcDir)
+		f, err := os.Open(archive)
+		require.NoError(t, err)
+		t.Cleanup(func() { assert.NoError(t, f.Close()) })
+
+		destDir := t.TempDir()
+		require.NoError(t, extractTarball(ctx, f, destDir, nil, true))
+
+		link := filepath.Join(destDir, ".bin", "tsc")
+		target, err := os.Readlink(link)
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join("..", "typescript", "bin", "tsc"), target)
+		// The link resolves to the real file inside the extracted tree.
+		contents, err := os.ReadFile(link)
+		require.NoError(t, err)
+		assert.Equal(t, "#!/bin/sh\n", string(contents))
+	})
+
+	t.Run("EscapingSymlinkRejected", func(t *testing.T) {
+		srcDir := t.TempDir()
+		require.NoError(t, os.Symlink(filepath.Join("..", "..", "escape"), filepath.Join(srcDir, "evil")))
+		archive := buildArchiveTo(t, srcDir)
+		f, err := os.Open(archive)
+		require.NoError(t, err)
+		t.Cleanup(func() { assert.NoError(t, f.Close()) })
+
+		err = extractTarball(ctx, f, t.TempDir(), nil, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "outside the root path")
+	})
+
+	t.Run("AbsoluteSymlinkRejected", func(t *testing.T) {
+		srcDir := t.TempDir()
+		require.NoError(t, os.Symlink("/etc/passwd", filepath.Join(srcDir, "abs")))
+		archive := buildArchiveTo(t, srcDir)
+		f, err := os.Open(archive)
+		require.NoError(t, err)
+		t.Cleanup(func() { assert.NoError(t, f.Close()) })
+
+		err = extractTarball(ctx, f, t.TempDir(), nil, true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "absolute")
+	})
 }
 
 func TestBuildArchiveRoundTrip(t *testing.T) {
@@ -245,7 +412,7 @@ func TestBuildArchiveRoundTrip(t *testing.T) {
 				rootPath := filepath.Join(testDir, "testdata", "archive", "artifacts_in")
 				pathsToAdd, _, err := findContentsToArchive(ctx, rootPath, includes, []string{})
 				require.NoError(t, err)
-				found, err = buildArchive(ctx, tarWriter, rootPath, pathsToAdd, excludes, logger, false)
+				found, err = buildArchive(ctx, tarWriter, rootPath, pathsToAdd, excludes, logger, false, false)
 				So(err, ShouldBeNil)
 				So(found, ShouldEqual, 4)
 				So(tarWriter.Close(), ShouldBeNil)
@@ -255,7 +422,7 @@ func TestBuildArchiveRoundTrip(t *testing.T) {
 				outputDir := t.TempDir()
 				f2, gz2, tarReader, err := tarGzReader(outputFile.Name())
 				require.NoError(t, err)
-				err = extractTarballArchive(context.Background(), tarReader, outputDir, []string{})
+				err = extractTarballArchive(context.Background(), tarReader, outputDir, []string{}, false)
 				defer f2.Close()
 				defer gz2.Close()
 				So(err, ShouldBeNil)

--- a/agent/command/archive_util_test.go
+++ b/agent/command/archive_util_test.go
@@ -179,7 +179,13 @@ func TestBuildArchive(t *testing.T) {
 				pathsToAdd, _, err := findContentsToArchive(ctx, rootPath, includes, []string{})
 				require.NoError(t, err)
 				excludes := []string{"*.pdb"}
-				_, err = buildArchive(ctx, tarWriter, rootPath, pathsToAdd, excludes, logger, false, false)
+				_, err = buildArchive(ctx, buildArchiveOptions{
+					tarWriter: tarWriter,
+					rootPath:  rootPath,
+					paths:     pathsToAdd,
+					excludes:  excludes,
+					logger:    logger,
+				})
 				So(err, ShouldBeNil)
 			})
 		}
@@ -209,7 +215,14 @@ func TestBuildArchiveVerbose(t *testing.T) {
 	pathsToAdd, _, err := findContentsToArchive(ctx, rootPath, []string{"dir1/**"}, []string{})
 	require.NoError(t, err)
 
-	numFiles, err := buildArchive(ctx, tarWriter, rootPath, pathsToAdd, []string{"*.pdb"}, logger, true, false)
+	numFiles, err := buildArchive(ctx, buildArchiveOptions{
+		tarWriter: tarWriter,
+		rootPath:  rootPath,
+		paths:     pathsToAdd,
+		excludes:  []string{"*.pdb"},
+		logger:    logger,
+		verbose:   true,
+	})
 	require.NoError(t, err)
 	assert.Greater(t, numFiles, 0)
 }
@@ -259,7 +272,13 @@ func TestBuildArchivePreserveSymlinks(t *testing.T) {
 		target := filepath.Join(t.TempDir(), "preserve.tgz")
 		f, gz, tarWriter, err := tarGzWriter(target, false)
 		require.NoError(t, err)
-		_, err = buildArchive(ctx, tarWriter, srcDir, contents, nil, logger, false, true)
+		_, err = buildArchive(ctx, buildArchiveOptions{
+			tarWriter:        tarWriter,
+			rootPath:         srcDir,
+			paths:            contents,
+			logger:           logger,
+			preserveSymlinks: true,
+		})
 		require.NoError(t, err)
 		require.NoError(t, tarWriter.Close())
 		require.NoError(t, gz.Close())
@@ -288,7 +307,12 @@ func TestBuildArchivePreserveSymlinks(t *testing.T) {
 		target := filepath.Join(t.TempDir(), "deref.tgz")
 		f, gz, tarWriter, err := tarGzWriter(target, false)
 		require.NoError(t, err)
-		_, err = buildArchive(ctx, tarWriter, srcDir, contents, nil, logger, false, false)
+		_, err = buildArchive(ctx, buildArchiveOptions{
+			tarWriter: tarWriter,
+			rootPath:  srcDir,
+			paths:     contents,
+			logger:    logger,
+		})
 		require.NoError(t, err)
 		require.NoError(t, tarWriter.Close())
 		require.NoError(t, gz.Close())
@@ -319,7 +343,13 @@ func TestExtractTarballPreserveSymlinks(t *testing.T) {
 		target := filepath.Join(t.TempDir(), "archive.tgz")
 		f, gz, tarWriter, err := tarGzWriter(target, false)
 		require.NoError(t, err)
-		_, err = buildArchive(ctx, tarWriter, srcDir, contents, nil, logger, false, true)
+		_, err = buildArchive(ctx, buildArchiveOptions{
+			tarWriter:        tarWriter,
+			rootPath:         srcDir,
+			paths:            contents,
+			logger:           logger,
+			preserveSymlinks: true,
+		})
 		require.NoError(t, err)
 		require.NoError(t, tarWriter.Close())
 		require.NoError(t, gz.Close())
@@ -412,7 +442,13 @@ func TestBuildArchiveRoundTrip(t *testing.T) {
 				rootPath := filepath.Join(testDir, "testdata", "archive", "artifacts_in")
 				pathsToAdd, _, err := findContentsToArchive(ctx, rootPath, includes, []string{})
 				require.NoError(t, err)
-				found, err = buildArchive(ctx, tarWriter, rootPath, pathsToAdd, excludes, logger, false, false)
+				found, err = buildArchive(ctx, buildArchiveOptions{
+					tarWriter: tarWriter,
+					rootPath:  rootPath,
+					paths:     pathsToAdd,
+					excludes:  excludes,
+					logger:    logger,
+				})
 				So(err, ShouldBeNil)
 				So(found, ShouldEqual, 4)
 				So(tarWriter.Close(), ShouldBeNil)

--- a/agent/command/cache_restore.go
+++ b/agent/command/cache_restore.go
@@ -176,5 +176,5 @@ func (c *cacheRestore) extract(ctx context.Context, archivePath, dest string) er
 	}
 	defer f.Close()
 
-	return errors.Wrap(extractTarball(ctx, f, dest, []string{}), "extracting tarball")
+	return errors.Wrap(extractTarball(ctx, f, dest, []string{}, c.PreserveSymlinks), "extracting tarball")
 }

--- a/agent/command/cache_restore_test.go
+++ b/agent/command/cache_restore_test.go
@@ -91,6 +91,18 @@ func TestCacheRestoreParseParams(t *testing.T) {
 		assert.Equal(t, "mise_and_go_cache_hit", cacheHitExpansionName(c.CacheName))
 	})
 
+	t.Run("PreserveSymlinksDecodedAndDefaultsToFalse", func(t *testing.T) {
+		c := &cacheRestore{}
+		require.NoError(t, c.ParseParams(validParams()))
+		assert.False(t, c.PreserveSymlinks)
+
+		params := validParams()
+		params["preserve_symlinks"] = true
+		c = &cacheRestore{}
+		require.NoError(t, c.ParseParams(params))
+		assert.True(t, c.PreserveSymlinks)
+	})
+
 	t.Run("ExpandableNameDeferredToExpansion", func(t *testing.T) {
 		// A templated name passes parse-time validation; the resolved value is
 		// re-validated after expansions are applied.

--- a/agent/command/cache_save.go
+++ b/agent/command/cache_save.go
@@ -82,7 +82,7 @@ func (c *cacheSave) Execute(ctx context.Context, comm client.Communicator, logge
 	logger.Task().Infof(ctx, "cache.save: computed cache key '%s'.", key)
 	logger.Task().Infof(ctx, "cache.save: bundling paths %s into '%s'.", c.Paths, localPath)
 
-	if err := makeCacheArchive(ctx, conf.WorkDir, c.Paths, localPath, logger.Task()); err != nil {
+	if err := makeCacheArchive(ctx, conf.WorkDir, c.Paths, localPath, logger.Task(), c.PreserveSymlinks); err != nil {
 		return errors.Wrap(err, "creating cache archive")
 	}
 

--- a/agent/command/cache_save_test.go
+++ b/agent/command/cache_save_test.go
@@ -66,9 +66,9 @@ func TestCacheSaveRecomputedKeyMatchesRestore(t *testing.T) {
 	dir := t.TempDir()
 	keyFile := writeCacheKeyFile(t, dir, "go.sum", "checksum")
 
-	restoreKey, err := computeCacheKey([]string{keyFile}, []string{"my-project", "linux"})
+	restoreKey, err := computeCacheKey([]string{keyFile}, []string{"my-project", "linux"}, false)
 	require.NoError(t, err)
-	saveKey, err := computeCacheKey([]string{keyFile}, []string{"my-project", "linux"})
+	saveKey, err := computeCacheKey([]string{keyFile}, []string{"my-project", "linux"}, false)
 	require.NoError(t, err)
 	assert.Equal(t, restoreKey, saveKey)
 }

--- a/agent/command/cache_save_test.go
+++ b/agent/command/cache_save_test.go
@@ -57,6 +57,18 @@ func TestCacheSaveParseParams(t *testing.T) {
 		c := &cacheSave{}
 		require.Error(t, c.ParseParams(params))
 	})
+
+	t.Run("PreserveSymlinksDecodedAndDefaultsToFalse", func(t *testing.T) {
+		c := &cacheSave{}
+		require.NoError(t, c.ParseParams(validParams()))
+		assert.False(t, c.PreserveSymlinks)
+
+		params := validParams()
+		params["preserve_symlinks"] = true
+		c = &cacheSave{}
+		require.NoError(t, c.ParseParams(params))
+		assert.True(t, c.PreserveSymlinks)
+	})
 }
 
 // TestCacheSaveRecomputedKeyMatchesRestore verifies cache.save derives the same

--- a/agent/command/cache_util.go
+++ b/agent/command/cache_util.go
@@ -364,7 +364,13 @@ func makeCacheArchive(ctx context.Context, workDir string, paths []string, targe
 		logger.Error(ctx, f.Close())
 	}()
 
-	_, err = buildArchive(ctx, tarWriter, workDir, contents, nil, logger, false, preserveSymlinks)
+	_, err = buildArchive(ctx, buildArchiveOptions{
+		tarWriter:        tarWriter,
+		rootPath:         workDir,
+		paths:            contents,
+		logger:           logger,
+		preserveSymlinks: preserveSymlinks,
+	})
 	return errors.Wrap(err, "building cache archive")
 }
 

--- a/agent/command/cache_util.go
+++ b/agent/command/cache_util.go
@@ -290,8 +290,11 @@ func validateCacheCredentials(catcher grip.Catcher, roleARN, awsKey, awsSecret, 
 // differently from expansions ["a", "b"]. Nothing about the runtime environment
 // is folded in implicitly; callers include values like "${distro_id}" through
 // keyExpansions if they want that partitioning. The preserveSymlinks flag is
-// folded in as a trailing discriminator so symlink-aware caches occupy a
-// distinct key space from older dereferenced ones.
+// folded in only when enabled, so symlink-aware caches occupy a distinct key
+// space while keys computed before the option existed stay valid. This is
+// unambiguous because the encoding is self-delimiting: no flag-less input can
+// produce the same byte stream as another input plus the trailing
+// discriminator.
 func computeCacheKey(keyFiles, keyExpansions []string, preserveSymlinks bool) (string, error) {
 	h := sha256.New()
 	writeUint64 := func(n int) {
@@ -326,11 +329,9 @@ func computeCacheKey(keyFiles, keyExpansions []string, preserveSymlinks bool) (s
 		h.Write([]byte(value))
 	}
 
-	var preserveSymlinksByte byte
 	if preserveSymlinks {
-		preserveSymlinksByte = 1
+		h.Write([]byte{1})
 	}
-	h.Write([]byte{preserveSymlinksByte})
 
 	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/agent/command/cache_util.go
+++ b/agent/command/cache_util.go
@@ -62,6 +62,13 @@ type cacheCommon struct {
 	// is required so every cache makes an explicit invalidation choice.
 	KeyExpansions []string `mapstructure:"key_expansions" plugin:"expand"`
 
+	// PreserveSymlinks, when true, archives symlinks as symlinks (preserving
+	// their targets) instead of dereferencing them into regular files. It is
+	// folded into the cache key so symlink-aware caches never reuse older
+	// dereferenced ones, and so it must match between cache.save and
+	// cache.restore.
+	PreserveSymlinks bool `mapstructure:"preserve_symlinks"`
+
 	// AwsKey, AwsSecret, and AwsSessionToken are the user's credentials for
 	// authenticating interactions with S3.
 	AwsKey          string `mapstructure:"aws_key" plugin:"expand"`
@@ -146,7 +153,7 @@ func (c *cacheCommon) resolveCacheKey(conf *internal.TaskConfig) (string, error)
 	for i, keyFile := range c.KeyFiles {
 		keyFiles[i] = GetWorkingDirectory(conf, keyFile)
 	}
-	return computeCacheKey(keyFiles, c.KeyExpansions)
+	return computeCacheKey(keyFiles, c.KeyExpansions, c.PreserveSymlinks)
 }
 
 // remoteKey returns the S3 object key for a cache with the given content key.
@@ -282,8 +289,10 @@ func validateCacheCredentials(catcher grip.Catcher, roleARN, awsKey, awsSecret, 
 // inputs can't run together: a key file containing "a" plus expansion "b" hashes
 // differently from expansions ["a", "b"]. Nothing about the runtime environment
 // is folded in implicitly; callers include values like "${distro_id}" through
-// keyExpansions if they want that partitioning.
-func computeCacheKey(keyFiles, keyExpansions []string) (string, error) {
+// keyExpansions if they want that partitioning. The preserveSymlinks flag is
+// folded in as a trailing discriminator so symlink-aware caches occupy a
+// distinct key space from older dereferenced ones.
+func computeCacheKey(keyFiles, keyExpansions []string, preserveSymlinks bool) (string, error) {
 	h := sha256.New()
 	writeUint64 := func(n int) {
 		var buf [8]byte
@@ -316,6 +325,13 @@ func computeCacheKey(keyFiles, keyExpansions []string) (string, error) {
 		writeUint64(len(value))
 		h.Write([]byte(value))
 	}
+
+	var preserveSymlinksByte byte
+	if preserveSymlinks {
+		preserveSymlinksByte = 1
+	}
+	h.Write([]byte{preserveSymlinksByte})
+
 	return hex.EncodeToString(h.Sum(nil)), nil
 }
 
@@ -328,8 +344,10 @@ func cacheHitExpansionName(name string) string {
 
 // makeCacheArchive bundles paths (relative to workDir, or absolute) into a
 // gzipped tarball at target. It reuses the same archive helpers as
-// archive.targz_pack. A path that does not exist on disk is an error.
-func makeCacheArchive(ctx context.Context, workDir string, paths []string, target string, logger grip.Journaler) error {
+// archive.targz_pack. A path that does not exist on disk is an error. When
+// preserveSymlinks is true, symlinks are archived as symlinks rather than
+// dereferenced.
+func makeCacheArchive(ctx context.Context, workDir string, paths []string, target string, logger grip.Journaler, preserveSymlinks bool) error {
 	contents, totalSize, err := gatherCacheContents(workDir, paths)
 	if err != nil {
 		return err
@@ -346,7 +364,7 @@ func makeCacheArchive(ctx context.Context, workDir string, paths []string, targe
 		logger.Error(ctx, f.Close())
 	}()
 
-	_, err = buildArchive(ctx, tarWriter, workDir, contents, nil, logger, false)
+	_, err = buildArchive(ctx, tarWriter, workDir, contents, nil, logger, false, preserveSymlinks)
 	return errors.Wrap(err, "building cache archive")
 }
 

--- a/agent/command/cache_util_test.go
+++ b/agent/command/cache_util_test.go
@@ -79,6 +79,19 @@ func TestComputeCacheKey(t *testing.T) {
 		assert.NotEqual(t, withFile, withoutFile)
 	})
 
+	t.Run("KeyFormatIsStableAcrossReleases", func(t *testing.T) {
+		// These golden values pin the key encoding. If this test fails, the
+		// change invalidates every cache already stored under the old keys, so
+		// only update the constants if that one-time invalidation is intended.
+		goldenFile := writeCacheKeyFile(t, dir, "golden.txt", "golden")
+		without, err := computeCacheKey([]string{goldenFile}, []string{"linux"}, false)
+		require.NoError(t, err)
+		assert.Equal(t, "1d7273dbbd1c9e64bb8da4fe864248f156723956240f58a3ffaf7153fb1b09e8", without)
+		with, err := computeCacheKey([]string{goldenFile}, []string{"linux"}, true)
+		require.NoError(t, err)
+		assert.Equal(t, "945b01d04a1e8f38c6e0c031ea5b44324fae0a866466c8259058dd4a57fc9532", with)
+	})
+
 	t.Run("PreserveSymlinksChangesKey", func(t *testing.T) {
 		// Folding preserve_symlinks into the key partitions symlink-aware caches
 		// from older dereferenced ones with otherwise-identical inputs.

--- a/agent/command/cache_util_test.go
+++ b/agent/command/cache_util_test.go
@@ -3,6 +3,7 @@ package command
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/mongodb/grip/logging"
@@ -23,46 +24,46 @@ func TestComputeCacheKey(t *testing.T) {
 	fileB := writeCacheKeyFile(t, dir, "b.txt", "beta")
 
 	t.Run("IdenticalInputsProduceIdenticalKeys", func(t *testing.T) {
-		first, err := computeCacheKey([]string{fileA, fileB}, []string{"linux", "go1.21"})
+		first, err := computeCacheKey([]string{fileA, fileB}, []string{"linux", "go1.21"}, false)
 		require.NoError(t, err)
-		second, err := computeCacheKey([]string{fileA, fileB}, []string{"linux", "go1.21"})
+		second, err := computeCacheKey([]string{fileA, fileB}, []string{"linux", "go1.21"}, false)
 		require.NoError(t, err)
 		assert.Equal(t, first, second)
 	})
 
 	t.Run("ReorderingExpansionsChangesKey", func(t *testing.T) {
-		first, err := computeCacheKey(nil, []string{"linux", "go1.21"})
+		first, err := computeCacheKey(nil, []string{"linux", "go1.21"}, false)
 		require.NoError(t, err)
-		second, err := computeCacheKey(nil, []string{"go1.21", "linux"})
+		second, err := computeCacheKey(nil, []string{"go1.21", "linux"}, false)
 		require.NoError(t, err)
 		assert.NotEqual(t, first, second)
 	})
 
 	t.Run("ReorderingKeyFilesChangesKey", func(t *testing.T) {
-		first, err := computeCacheKey([]string{fileA, fileB}, []string{"linux"})
+		first, err := computeCacheKey([]string{fileA, fileB}, []string{"linux"}, false)
 		require.NoError(t, err)
-		second, err := computeCacheKey([]string{fileB, fileA}, []string{"linux"})
+		second, err := computeCacheKey([]string{fileB, fileA}, []string{"linux"}, false)
 		require.NoError(t, err)
 		assert.NotEqual(t, first, second)
 	})
 
 	t.Run("DifferentFileContentsChangeKey", func(t *testing.T) {
 		changed := writeCacheKeyFile(t, dir, "a.txt", "alpha-changed")
-		first, err := computeCacheKey([]string{fileB}, []string{"linux"})
+		first, err := computeCacheKey([]string{fileB}, []string{"linux"}, false)
 		require.NoError(t, err)
-		second, err := computeCacheKey([]string{changed}, []string{"linux"})
+		second, err := computeCacheKey([]string{changed}, []string{"linux"}, false)
 		require.NoError(t, err)
 		assert.NotEqual(t, first, second)
 	})
 
 	t.Run("NoKeyFilesIsValid", func(t *testing.T) {
-		key, err := computeCacheKey(nil, []string{"linux"})
+		key, err := computeCacheKey(nil, []string{"linux"}, false)
 		require.NoError(t, err)
 		assert.NotEmpty(t, key)
 	})
 
 	t.Run("MissingKeyFileErrors", func(t *testing.T) {
-		_, err := computeCacheKey([]string{filepath.Join(dir, "does-not-exist.txt")}, []string{"linux"})
+		_, err := computeCacheKey([]string{filepath.Join(dir, "does-not-exist.txt")}, []string{"linux"}, false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "does-not-exist.txt")
 	})
@@ -71,11 +72,21 @@ func TestComputeCacheKey(t *testing.T) {
 		// A key file containing "a" plus expansion "b" must not hash the same as
 		// expansions ["a", "b"], which a naive concatenation would conflate.
 		fileWithA := writeCacheKeyFile(t, dir, "collide.txt", "a")
-		withFile, err := computeCacheKey([]string{fileWithA}, []string{"b"})
+		withFile, err := computeCacheKey([]string{fileWithA}, []string{"b"}, false)
 		require.NoError(t, err)
-		withoutFile, err := computeCacheKey(nil, []string{"a", "b"})
+		withoutFile, err := computeCacheKey(nil, []string{"a", "b"}, false)
 		require.NoError(t, err)
 		assert.NotEqual(t, withFile, withoutFile)
+	})
+
+	t.Run("PreserveSymlinksChangesKey", func(t *testing.T) {
+		// Folding preserve_symlinks into the key partitions symlink-aware caches
+		// from older dereferenced ones with otherwise-identical inputs.
+		without, err := computeCacheKey([]string{fileA}, []string{"linux"}, false)
+		require.NoError(t, err)
+		with, err := computeCacheKey([]string{fileA}, []string{"linux"}, true)
+		require.NoError(t, err)
+		assert.NotEqual(t, without, with)
 	})
 }
 
@@ -95,13 +106,13 @@ func TestCacheArchiveRoundTrip(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(nested, "lib.txt"), []byte("library"), 0644))
 
 	archivePath := filepath.Join(t.TempDir(), "cache.tgz")
-	require.NoError(t, makeCacheArchive(ctx, srcDir, []string{"top.txt", "deps"}, archivePath, logger))
+	require.NoError(t, makeCacheArchive(ctx, srcDir, []string{"top.txt", "deps"}, archivePath, logger, false))
 
 	destDir := t.TempDir()
 	archive, err := os.Open(archivePath)
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, archive.Close()) })
-	require.NoError(t, extractTarball(ctx, archive, destDir, nil))
+	require.NoError(t, extractTarball(ctx, archive, destDir, nil, false))
 
 	top, err := os.ReadFile(filepath.Join(destDir, "top.txt"))
 	require.NoError(t, err)
@@ -112,12 +123,41 @@ func TestCacheArchiveRoundTrip(t *testing.T) {
 	assert.Equal(t, "library", string(lib))
 }
 
+func TestCacheArchiveRoundTripPreservesSymlinks(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink preservation is not supported on Windows")
+	}
+	logger := logging.MakeGrip(send.MakeInternalLogger())
+	ctx := t.Context()
+
+	srcDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "real.txt"), []byte("payload"), 0644))
+	require.NoError(t, os.Symlink("real.txt", filepath.Join(srcDir, "link.txt")))
+
+	archivePath := filepath.Join(t.TempDir(), "cache.tgz")
+	require.NoError(t, makeCacheArchive(ctx, srcDir, []string{"real.txt", "link.txt"}, archivePath, logger, true))
+
+	destDir := t.TempDir()
+	archive, err := os.Open(archivePath)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, archive.Close()) })
+	require.NoError(t, extractTarball(ctx, archive, destDir, nil, true))
+
+	info, err := os.Lstat(filepath.Join(destDir, "link.txt"))
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&os.ModeSymlink, "restored link.txt should still be a symlink")
+
+	target, err := os.Readlink(filepath.Join(destDir, "link.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "real.txt", target)
+}
+
 func TestMakeCacheArchiveMissingPathErrors(t *testing.T) {
 	logger := logging.MakeGrip(send.MakeInternalLogger())
 	srcDir := t.TempDir()
 	archivePath := filepath.Join(t.TempDir(), "cache.tgz")
 
-	err := makeCacheArchive(t.Context(), srcDir, []string{"missing-dir"}, archivePath, logger)
+	err := makeCacheArchive(t.Context(), srcDir, []string{"missing-dir"}, archivePath, logger, false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing-dir")
 }

--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -366,7 +366,7 @@ func (c *s3get) fetchAndExtractTarball(ctx context.Context, f *os.File) error {
 		return errors.Wrapf(err, "seeking to start of tgz file")
 	}
 
-	if err := extractTarball(ctx, f, c.ExtractTo, []string{}); err != nil {
+	if err := extractTarball(ctx, f, c.ExtractTo, []string{}, false); err != nil {
 		return errors.Wrapf(err, "extracting file '%s' from archive to destination '%s'", c.RemoteFile, c.ExtractTo)
 	}
 

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-06-03"
+	AgentVersion = "2026-06-09"
 )
 
 const (

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-06-03"
+	ClientVersion = "2026-06-08"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-06-08"
+	ClientVersion = "2026-06-03"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -426,6 +426,12 @@ Parameters:
 - `aws_key`, `aws_secret`, `aws_session_token`, `role_arn`, `region`:
   S3 credentials and region, with the same semantics as [`s3.put`](#s3put).
   Use either `role_arn` (recommended) or `aws_key` + `aws_secret`.
+- `preserve_symlinks`: optional boolean (default `false`). When `true`, symlinks
+  are restored as symlinks (preserving their targets) instead of being
+  dereferenced into regular files, which is required for tools like NPM that
+  expect `node_modules` symlinks. This value is folded into the cache key, so it
+  must match the `cache.save` that produced the cache, and symlink-aware caches
+  never reuse older dereferenced ones.
 
 The cache key is order-sensitive and contains nothing implicit: the OS,
 architecture, and distro are folded in only if you add them to `key_expansions`.
@@ -476,6 +482,11 @@ Parameters:
   must match so the key resolves to the same object.
 - `paths`: required list (at least one entry) of file or directory paths,
   relative to the working directory, to bundle into the tarball.
+- `preserve_symlinks`: optional boolean (default `false`). When `true`, symlinks
+  are archived as symlinks (preserving their targets) instead of being
+  dereferenced into regular files, which is required for tools like NPM that
+  expect `node_modules` symlinks. This value is folded into the cache key, so it
+  must match the `cache.restore` that reads the cache.
 
 A realistic restore-then-save flow wraps both commands in a function so they
 share parameters, using the cache-hit expansion to skip the expensive install

--- a/smoke/internal/testdata/project.yml
+++ b/smoke/internal/testdata/project.yml
@@ -293,6 +293,66 @@ tasks:
           args:
             - "-c"
             - 'test "$smoke_cache_cache_hit" = "true" && grep -q "cached-content-${revision}" cache-src/cached-file'
+      # preserve_symlinks round trip: a relative symlink must survive save and
+      # restore as a symlink rather than being dereferenced into a regular file.
+      - command: shell.exec
+        params:
+          script: |
+            set -o errexit
+            mkdir -p cache-symlink-src
+            echo "symlink-content-${revision}" > cache-symlink-src/real.txt
+            ln -s real.txt cache-symlink-src/link.txt
+      - command: cache.restore
+        display_name: "First symlink cache.restore (expected miss)"
+        params:
+          name: smoke-cache-symlink
+          aws_key: ${aws_key}
+          aws_secret: ${aws_secret}
+          aws_session_token: ${aws_token}
+          bucket: mciuploads
+          remote_path: evergreen/smoke/cache/${build_id}-${build_variant}
+          key_expansions:
+            - ${task_name}-${revision}
+          preserve_symlinks: true
+      - command: cache.save
+        display_name: "Symlink cache.save (expected upload)"
+        params:
+          name: smoke-cache-symlink
+          aws_key: ${aws_key}
+          aws_secret: ${aws_secret}
+          aws_session_token: ${aws_token}
+          bucket: mciuploads
+          remote_path: evergreen/smoke/cache/${build_id}-${build_variant}
+          key_expansions:
+            - ${task_name}-${revision}
+          preserve_symlinks: true
+          paths:
+            - cache-symlink-src
+      - command: shell.exec
+        display_name: "Remove symlink dir to prove restore re-fetches it"
+        params:
+          script: rm -rf cache-symlink-src
+      - command: cache.restore
+        display_name: "Second symlink cache.restore (expected hit)"
+        params:
+          name: smoke-cache-symlink
+          aws_key: ${aws_key}
+          aws_secret: ${aws_secret}
+          aws_session_token: ${aws_token}
+          bucket: mciuploads
+          remote_path: evergreen/smoke/cache/${build_id}-${build_variant}
+          key_expansions:
+            - ${task_name}-${revision}
+          preserve_symlinks: true
+      - command: subprocess.exec
+        display_name: "Assert symlink cache.restore preserved the symlink"
+        params:
+          binary: bash
+          include_expansions_in_env:
+            - smoke_cache_symlink_cache_hit
+          args:
+            - "-c"
+            - 'test "$smoke_cache_symlink_cache_hit" = "true" && test -L cache-symlink-src/link.txt && [ "$(readlink cache-symlink-src/link.txt)" = "real.txt" ]'
       - command: timeout.update
         params:
           timeout_secs: 2700


### PR DESCRIPTION
DEVPROD-34618

[HTML Walkthrough](https://pages.monglify.aix.prod.corp.mongodb.com/p/flamingo-prairie-onyx)

### Description

Adds a `preserve_symlinks` option to the `cache.save` and `cache.restore` commands so that symlinks within cached paths are archived as symlinks rather than dereferenced into copies of the underlying files. Tools like NPM rely on relative symlinks. The previous behavior dereferenced symlinks when building the cache archive, which broke those tools on restore.

### Testing

- Added/updated unit tests.
- Added a smoke test fixture exercising the option.

### Documentation

Updated `docs/Project-Configuration/Project-Commands.md` to document `preserve_symlinks`.
