### PR TITLE
DEVPROD-31904 Skip AWS lifecycle rule fetch for accounts without access

### DIFF
--- a/config_cost.go
+++ b/config_cost.go
@@ -153,6 +153,12 @@ func IsInDevProdOwnedAccountList(accountID string, list []string) bool {
 	})
 }
 
+// IsAccountWithoutLifecycleRules reports whether the account ID is in the list of accounts
+// for which we do not have access to fetch S3 lifecycle rules.
+func IsAccountWithoutLifecycleRules(accountID string, accountsWithoutLifecycleRules []string) bool {
+	return IsInDevProdOwnedAccountList(accountID, accountsWithoutLifecycleRules)
+}
+
 // IsDevprodOwnedArtifactIAMRole reports whether an IAM role ARN belongs to an account in the list
 // of devprod owned account IDs.
 func IsDevprodOwnedArtifactIAMRole(awsRoleARN string, devprodOwnedAWSAccountIDs []string) bool {

--- a/model/s3lifecycle/s3_lifecycle.go
+++ b/model/s3lifecycle/s3_lifecycle.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/pail"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/anser/bsonutil"
@@ -38,6 +39,7 @@ var (
 	FilterPrefixKey            = bsonutil.MustHaveTag(S3LifecycleRuleDoc{}, "FilterPrefix")
 	BucketTypeKey              = bsonutil.MustHaveTag(S3LifecycleRuleDoc{}, "BucketType")
 	RegionKey                  = bsonutil.MustHaveTag(S3LifecycleRuleDoc{}, "Region")
+	AWSAccountIDKey            = bsonutil.MustHaveTag(S3LifecycleRuleDoc{}, "AWSAccountID")
 	AdminBucketCategoryKey     = bsonutil.MustHaveTag(S3LifecycleRuleDoc{}, "AdminBucketCategory")
 	ProjectAssociationsKey     = bsonutil.MustHaveTag(S3LifecycleRuleDoc{}, "ProjectAssociations")
 	RuleIDKey                  = bsonutil.MustHaveTag(S3LifecycleRuleDoc{}, "RuleID")
@@ -106,9 +108,29 @@ type S3LifecycleClient interface {
 }
 
 // DiscoverAndCacheProjectBucket checks if we have lifecycle rules cached for a bucket and fetches them if not.
-// It returns true if rules were successfully cached (discovery succeeded), false if already cached or discovery failed.
+// It returns true if rules were successfully cached (discovery succeeded), false if already cached, if the
+// bucket's account is in accountsWithoutLifecycleRules, or if discovery failed.
 // This is best-effort - errors are logged but not returned to avoid failing file uploads.
-func DiscoverAndCacheProjectBucket(ctx context.Context, bucketName, region string, roleARN *string, externalID *string, projectID string, client S3LifecycleClient) bool {
+func DiscoverAndCacheProjectBucket(ctx context.Context, bucketName, region string, roleARN *string, externalID *string, projectID string, accountsWithoutLifecycleRules []string, client cloud.S3LifecycleClient) bool {
+	// Derive the AWS account ID from the role ARN so we can check it against the skip list.
+	var awsAccountID string
+	if roleARN != nil {
+		if id, ok := util.AWSAccountIDFromIAMARN(*roleARN); ok {
+			awsAccountID = id
+		}
+	}
+
+	if awsAccountID != "" && evergreen.IsAccountWithoutLifecycleRules(awsAccountID, accountsWithoutLifecycleRules) {
+		grip.Info(ctx, message.Fields{
+			"message":    "skipping lifecycle rule discovery for bucket in account without lifecycle rules access",
+			"bucket":     bucketName,
+			"account_id": awsAccountID,
+			"project":    projectID,
+		})
+		return false
+	}
+
+
 	existingRules, err := FindAllRulesForBucket(ctx, bucketName)
 	if err != nil {
 		grip.Warning(ctx, message.WrapError(err, message.Fields{
@@ -144,6 +166,7 @@ func DiscoverAndCacheProjectBucket(ctx context.Context, bucketName, region strin
 			FilterPrefix:            awsRule.Prefix,
 			BucketType:              BucketTypeUserSpecified,
 			Region:                  region,
+			AWSAccountID:            awsAccountID,
 			RuleID:                  awsRule.ID,
 			RuleStatus:              awsRule.Status,
 			ExpirationDays:          utility.ConvertInt32PtrToIntPtr(awsRule.ExpirationDays),
@@ -193,6 +216,9 @@ type S3LifecycleRuleDoc struct {
 	FilterPrefix string `bson:"filter_prefix" json:"filter_prefix"` // Empty string applies to all objects (default rule)
 	BucketType   string `bson:"bucket_type" json:"bucket_type"`
 	Region       string `bson:"region" json:"region"`
+	// AWSAccountID is the 12-digit AWS account ID that owns this bucket, derived from the IAM role ARN used
+	// during discovery. Empty for buckets that use key+secret authentication.
+	AWSAccountID string `bson:"aws_account_id,omitempty" json:"aws_account_id,omitempty"`
 
 	AdminBucketCategory string   `bson:"admin_bucket_category,omitempty" json:"admin_bucket_category,omitempty"`
 	ProjectAssociations []string `bson:"project_associations" json:"project_associations"`
@@ -231,6 +257,7 @@ func (s *S3LifecycleRuleDoc) Upsert(ctx context.Context) error {
 		FilterPrefixKey:            s.FilterPrefix,
 		BucketTypeKey:              s.BucketType,
 		RegionKey:                  s.Region,
+		AWSAccountIDKey:            s.AWSAccountID,
 		AdminBucketCategoryKey:     s.AdminBucketCategory,
 		ProjectAssociationsKey:     s.ProjectAssociations,
 		RuleIDKey:                  s.RuleID,

--- a/model/s3lifecycle/s3_lifecycle.go
+++ b/model/s3lifecycle/s3_lifecycle.go
@@ -111,7 +111,7 @@ type S3LifecycleClient interface {
 // It returns true if rules were successfully cached (discovery succeeded), false if already cached, if the
 // bucket's account is in accountsWithoutLifecycleRules, or if discovery failed.
 // This is best-effort - errors are logged but not returned to avoid failing file uploads.
-func DiscoverAndCacheProjectBucket(ctx context.Context, bucketName, region string, roleARN *string, externalID *string, projectID string, accountsWithoutLifecycleRules []string, client cloud.S3LifecycleClient) bool {
+func DiscoverAndCacheProjectBucket(ctx context.Context, bucketName, region string, roleARN *string, externalID *string, projectID string, accountsWithoutLifecycleRules []string, client S3LifecycleClient) bool {
 	// Derive the AWS account ID from the role ARN so we can check it against the skip list.
 	var awsAccountID string
 	if roleARN != nil {
@@ -129,7 +129,6 @@ func DiscoverAndCacheProjectBucket(ctx context.Context, bucketName, region strin
 		})
 		return false
 	}
-
 
 	existingRules, err := FindAllRulesForBucket(ctx, bucketName)
 	if err != nil {

--- a/model/s3lifecycle/s3_lifecycle_test.go
+++ b/model/s3lifecycle/s3_lifecycle_test.go
@@ -275,11 +275,13 @@ func TestDiscoverAdminManagedBuckets(t *testing.T) {
 
 // mockS3LifecycleClient is a mock implementation of cloud.S3LifecycleClient for testing.
 type mockS3LifecycleClient struct {
-	rules []pail.LifecycleRule
-	err   error
+	rules     []pail.LifecycleRule
+	err       error
+	callCount int
 }
 
 func (m *mockS3LifecycleClient) GetBucketLifecycleConfiguration(ctx context.Context, bucket, region string, roleARN *string, externalID *string) ([]pail.LifecycleRule, error) {
+	m.callCount++
 	if m.err != nil {
 		return nil, m.err
 	}
@@ -290,6 +292,7 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 	t.Run("NewBucket", func(t *testing.T) {
 		require.NoError(t, db.Clear(Collection))
 
+		roleARN := "arn:aws:iam::111111111111:role/my-role"
 		mockClient := &mockS3LifecycleClient{
 			rules: []pail.LifecycleRule{
 				{
@@ -307,7 +310,7 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 			},
 		}
 
-		discovered := DiscoverAndCacheProjectBucket(t.Context(), "test-bucket", "us-east-1", nil, nil, "test-project", mockClient)
+		discovered := DiscoverAndCacheProjectBucket(t.Context(), "test-bucket", "us-east-1", &roleARN, nil, "test-project", nil, mockClient)
 		assert.True(t, discovered, "should trigger discovery for new bucket")
 
 		rules, err := FindAllRulesForBucket(t.Context(), "test-bucket")
@@ -321,12 +324,14 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 		assert.Equal(t, BucketTypeUserSpecified, sandboxRule.BucketType)
 		assert.Equal(t, []string{"test-project"}, sandboxRule.ProjectAssociations)
 		assert.Equal(t, 30, *sandboxRule.ExpirationDays)
+		assert.Equal(t, "111111111111", sandboxRule.AWSAccountID)
 
 		defaultRule, err := FindByBucketAndPrefix(t.Context(), "test-bucket", "")
 		require.NoError(t, err)
 		require.NotNil(t, defaultRule)
 		assert.Equal(t, "test-bucket#", defaultRule.ID)
 		assert.Equal(t, 90, *defaultRule.ExpirationDays)
+		assert.Equal(t, "111111111111", defaultRule.AWSAccountID)
 	})
 
 	t.Run("AlreadyCached", func(t *testing.T) {
@@ -347,7 +352,7 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 			rules: []pail.LifecycleRule{{ID: "should-not-be-called"}},
 		}
 
-		discovered := DiscoverAndCacheProjectBucket(t.Context(), "cached-bucket", "us-east-1", nil, nil, "test-project", mockClient)
+		discovered := DiscoverAndCacheProjectBucket(t.Context(), "cached-bucket", "us-east-1", nil, nil, "test-project", nil, mockClient)
 		assert.False(t, discovered, "should skip discovery for cached bucket")
 
 		rules, err := FindAllRulesForBucket(t.Context(), "cached-bucket")
@@ -363,8 +368,8 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 			err: errors.New("AWS API error"),
 		}
 
-		discovered := DiscoverAndCacheProjectBucket(t.Context(), "error-bucket", "us-east-1", nil, nil, "test-project", mockClient)
-		assert.True(t, discovered, "should return true even if AWS call fails")
+		discovered := DiscoverAndCacheProjectBucket(t.Context(), "error-bucket", "us-east-1", nil, nil, "test-project", nil, mockClient)
+		assert.False(t, discovered, "should return false when AWS call fails")
 
 		rules, err := FindAllRulesForBucket(t.Context(), "error-bucket")
 		require.NoError(t, err)
@@ -378,11 +383,54 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 			rules: []pail.LifecycleRule{},
 		}
 
-		discovered := DiscoverAndCacheProjectBucket(t.Context(), "empty-bucket", "us-east-1", nil, nil, "test-project", mockClient)
+		discovered := DiscoverAndCacheProjectBucket(t.Context(), "empty-bucket", "us-east-1", nil, nil, "test-project", nil, mockClient)
 		assert.True(t, discovered, "should trigger discovery even if no rules returned")
 
 		rules, err := FindAllRulesForBucket(t.Context(), "empty-bucket")
 		require.NoError(t, err)
 		assert.Len(t, rules, 0)
+	})
+
+	t.Run("AccountWithoutLifecycleRulesAccess", func(t *testing.T) {
+		require.NoError(t, db.Clear(Collection))
+
+		roleARN := "arn:aws:iam::999999999999:role/my-role"
+		accountsWithoutLifecycleRules := []string{"999999999999"}
+		mockClient := &mockS3LifecycleClient{
+			rules: []pail.LifecycleRule{{ID: "should-not-be-called"}},
+		}
+
+		discovered := DiscoverAndCacheProjectBucket(t.Context(), "restricted-bucket", "us-east-1", &roleARN, nil, "test-project", accountsWithoutLifecycleRules, mockClient)
+		assert.False(t, discovered, "should skip discovery for buckets in accounts without lifecycle rules access")
+
+		rules, err := FindAllRulesForBucket(t.Context(), "restricted-bucket")
+		require.NoError(t, err)
+		assert.Empty(t, rules, "no rules should be cached for restricted account")
+		assert.Zero(t, mockClient.callCount, "should not have called AWS")
+	})
+
+	t.Run("NoRoleARNSkipsAccountCheck", func(t *testing.T) {
+		require.NoError(t, db.Clear(Collection))
+
+		accountsWithoutLifecycleRules := []string{"999999999999"}
+		mockClient := &mockS3LifecycleClient{
+			rules: []pail.LifecycleRule{
+				{
+					ID:             "rule1",
+					Prefix:         "",
+					Status:         "Enabled",
+					ExpirationDays: ptr(int32(30)),
+				},
+			},
+		}
+
+		// Without a role ARN we cannot determine the account ID, so discovery should proceed.
+		discovered := DiscoverAndCacheProjectBucket(t.Context(), "key-secret-bucket", "us-east-1", nil, nil, "test-project", accountsWithoutLifecycleRules, mockClient)
+		assert.True(t, discovered, "should proceed with discovery when no role ARN is present")
+
+		rules, err := FindAllRulesForBucket(t.Context(), "key-secret-bucket")
+		require.NoError(t, err)
+		assert.Len(t, rules, 1)
+		assert.Empty(t, rules[0].AWSAccountID, "account ID should be empty for key+secret auth buckets")
 	})
 }

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -688,6 +688,14 @@ func discoverAndCacheBucketLifecycleRules(ctx context.Context, t *task.Task, fil
 		}
 	}
 
+	costConfig := &evergreen.CostConfig{}
+	if err := costConfig.Get(ctx); err != nil {
+		grip.Warning(ctx, message.WrapError(err, message.Fields{
+			"message": "getting cost config for lifecycle rule discovery, proceeding without account skip list",
+			"task_id": t.Id,
+		}))
+	}
+
 	cachedBuckets := []string{}
 	for bucketName, file := range bucketsToDiscover {
 		region := evergreen.DefaultS3Region
@@ -702,7 +710,7 @@ func discoverAndCacheBucketLifecycleRules(ctx context.Context, t *task.Task, fil
 			externalID = &file.ExternalID
 		}
 
-		wasCached := s3lifecycle.DiscoverAndCacheProjectBucket(ctx, bucketName, region, roleARN, externalID, t.Project, cloud.NewS3LifecycleClient())
+		wasCached := s3lifecycle.DiscoverAndCacheProjectBucket(ctx, bucketName, region, roleARN, externalID, t.Project, costConfig.S3Cost.Storage.ArtifactAWSAccountsWithoutLifecycleRules, cloud.NewS3LifecycleClient())
 		if wasCached {
 			cachedBuckets = append(cachedBuckets, bucketName)
 		}

--- a/units/s3_lifecycle_sync_project_buckets.go
+++ b/units/s3_lifecycle_sync_project_buckets.go
@@ -69,6 +69,12 @@ func (j *s3LifecycleSyncProjectBucketsJob) Run(ctx context.Context) {
 		return
 	}
 
+	costConfig := evergreen.CostConfig{}
+	if err := costConfig.Get(ctx); err != nil {
+		j.AddError(errors.Wrap(err, "getting cost config"))
+		return
+	}
+
 	// Get distinct list of user-specified buckets from collection.
 	bucketNames, err := s3lifecycle.FindDistinctBucketNames(ctx, s3lifecycle.BucketTypeUserSpecified)
 	if err != nil {
@@ -90,7 +96,7 @@ func (j *s3LifecycleSyncProjectBucketsJob) Run(ctx context.Context) {
 	var failedBuckets []string
 
 	for _, bucketName := range bucketNames {
-		if err := j.syncBucket(ctx, client, bucketName); err != nil {
+		if err := j.syncBucket(ctx, client, bucketName, costConfig.S3Cost.Storage.ArtifactAWSAccountsWithoutLifecycleRules); err != nil {
 			grip.Error(ctx, message.WrapError(err, message.Fields{
 				"message": "failed to sync bucket",
 				"bucket":  bucketName,
@@ -116,8 +122,8 @@ func (j *s3LifecycleSyncProjectBucketsJob) Run(ctx context.Context) {
 	grip.Info(ctx, msg)
 }
 
-func (j *s3LifecycleSyncProjectBucketsJob) syncBucket(ctx context.Context, client cloud.S3LifecycleClient, bucketName string) error {
-	// Get existing rules to extract region (all rules for same bucket have same region).
+func (j *s3LifecycleSyncProjectBucketsJob) syncBucket(ctx context.Context, client cloud.S3LifecycleClient, bucketName string, accountsWithoutLifecycleRules []string) error {
+	// Get existing rules to extract region and account ID (all rules for same bucket share these).
 	existingRules, err := s3lifecycle.FindAllRulesForBucket(ctx, bucketName)
 	if err != nil {
 		return errors.Wrapf(err, "finding existing rules for bucket '%s'", bucketName)
@@ -128,6 +134,20 @@ func (j *s3LifecycleSyncProjectBucketsJob) syncBucket(ctx context.Context, clien
 			"message": "no existing rules found for bucket, skipping sync",
 			"bucket":  bucketName,
 			"job_id":  j.ID(),
+		})
+		return nil
+	}
+
+	// Skip sync for buckets belonging to accounts where we don't have lifecycle rule access.
+	// AWSAccountID is populated during discovery for role-based auth buckets. Buckets using
+	// key+secret auth or those discovered before this field was added will have an empty
+	// AWSAccountID and are always synced.
+	if awsAccountID := existingRules[0].AWSAccountID; awsAccountID != "" && evergreen.IsAccountWithoutLifecycleRules(awsAccountID, accountsWithoutLifecycleRules) {
+		grip.Info(ctx, message.Fields{
+			"message":    "skipping lifecycle rule sync for bucket in account without lifecycle rules access",
+			"bucket":     bucketName,
+			"account_id": awsAccountID,
+			"job_id":     j.ID(),
 		})
 		return nil
 	}
@@ -223,7 +243,7 @@ func (j *s3LifecycleSyncProjectBucketsJob) syncBucket(ctx context.Context, clien
 }
 
 // convertPailRuleToDoc converts a pail.LifecycleRule to S3LifecycleRuleDoc.
-// Preserves ProjectAssociations from existing rules if available.
+// Preserves ProjectAssociations and AWSAccountID from existing rules if available.
 func convertPailRuleToDoc(bucketName, region string, awsRule pail.LifecycleRule, existingRules []s3lifecycle.S3LifecycleRuleDoc) *s3lifecycle.S3LifecycleRuleDoc {
 	doc := &s3lifecycle.S3LifecycleRuleDoc{
 		BucketName:              bucketName,
@@ -240,10 +260,11 @@ func convertPailRuleToDoc(bucketName, region string, awsRule pail.LifecycleRule,
 		SyncError:               "", // Clear any previous error on successful sync
 	}
 
-	// Preserve ProjectAssociations from existing rule if it exists.
+	// Preserve ProjectAssociations and AWSAccountID from the matching existing rule.
 	for _, existingRule := range existingRules {
 		if existingRule.FilterPrefix == awsRule.Prefix {
 			doc.ProjectAssociations = existingRule.ProjectAssociations
+			doc.AWSAccountID = existingRule.AWSAccountID
 			break
 		}
 	}

--- a/units/s3_lifecycle_sync_project_buckets_test.go
+++ b/units/s3_lifecycle_sync_project_buckets_test.go
@@ -96,10 +96,12 @@ func TestConvertPailRuleToDoc(t *testing.T) {
 		{
 			FilterPrefix:        "sandbox/",
 			ProjectAssociations: []string{"project1", "project2"},
+			AWSAccountID:        "111111111111",
 		},
 		{
 			FilterPrefix:        "other/",
 			ProjectAssociations: []string{"project3"},
+			AWSAccountID:        "111111111111",
 		},
 	}
 
@@ -120,8 +122,9 @@ func TestConvertPailRuleToDoc(t *testing.T) {
 	assert.Len(t, doc.Transitions, 2)
 	assert.Equal(t, "", doc.SyncError)
 
-	// ProjectAssociations should be preserved from existing rule.
+	// ProjectAssociations and AWSAccountID should be preserved from existing rule.
 	assert.Equal(t, []string{"project1", "project2"}, doc.ProjectAssociations)
+	assert.Equal(t, "111111111111", doc.AWSAccountID)
 }
 
 func TestConvertPailRuleToDocWithoutExisting(t *testing.T) {
@@ -139,14 +142,16 @@ func TestConvertPailRuleToDocWithoutExisting(t *testing.T) {
 		{
 			FilterPrefix:        "other/",
 			ProjectAssociations: []string{"project1"},
+			AWSAccountID:        "222222222222",
 		},
 	}
 
 	doc := convertPailRuleToDoc(bucketName, region, awsRule, existingRules)
 
 	assert.Equal(t, "logs/", doc.FilterPrefix)
-	// ProjectAssociations should be nil since no matching existing rule.
+	// ProjectAssociations and AWSAccountID should be empty since no matching existing rule.
 	assert.Nil(t, doc.ProjectAssociations)
+	assert.Empty(t, doc.AWSAccountID)
 }
 
 func TestConvertPailTransitions(t *testing.T) {
@@ -267,7 +272,7 @@ func TestSyncBucket(t *testing.T) {
 	}
 
 	job := makeS3LifecycleSyncProjectBucketsJob()
-	err := job.syncBucket(ctx, mockClient, "test-bucket")
+	err := job.syncBucket(ctx, mockClient, "test-bucket", nil)
 	require.NoError(t, err)
 
 	// Verify sandbox/ rule was updated.
@@ -311,11 +316,102 @@ func TestSyncBucketWithNoExistingRules(t *testing.T) {
 	}
 
 	job := makeS3LifecycleSyncProjectBucketsJob()
-	err := job.syncBucket(ctx, mockClient, "test-bucket")
+	err := job.syncBucket(ctx, mockClient, "test-bucket", nil)
 	require.NoError(t, err)
 
 	// No error, but also no sync should happen since there are no existing rules.
 	logsRule, err := s3lifecycle.FindByBucketAndPrefix(ctx, "test-bucket", "logs/")
 	require.NoError(t, err)
 	assert.Nil(t, logsRule)
+}
+
+// TestSyncBucketAWSAccountIDPreserved verifies that AWSAccountID set during discovery is not
+// zeroed out by a subsequent sync run. This is the regression guard for the bug where
+// convertPailRuleToDoc did not carry AWSAccountID forward from the existing rule.
+func TestSyncBucketAWSAccountIDPreserved(t *testing.T) {
+	require.NoError(t, db.Clear(s3lifecycle.Collection))
+	t.Cleanup(func() {
+		require.NoError(t, db.Clear(s3lifecycle.Collection))
+	})
+
+	// Seed a rule that has AWSAccountID set (as would happen after initial discovery).
+	existing := &s3lifecycle.S3LifecycleRuleDoc{
+		BucketName:          "my-bucket",
+		FilterPrefix:        "sandbox/",
+		BucketType:          s3lifecycle.BucketTypeUserSpecified,
+		Region:              "us-east-1",
+		AWSAccountID:        "111111111111",
+		RuleID:              "original-rule",
+		RuleStatus:          "Enabled",
+		ExpirationDays:      utility.ToIntPtr(30),
+		ProjectAssociations: []string{"project1"},
+		LastSyncedAt:        time.Now().Add(-24 * time.Hour),
+	}
+	require.NoError(t, existing.Upsert(t.Context()))
+
+	mockClient := &mockS3LifecycleClient{
+		rules: map[string][]pail.LifecycleRule{
+			"my-bucket": {
+				{
+					ID:             "updated-rule",
+					Prefix:         "sandbox/",
+					Status:         "Enabled",
+					ExpirationDays: utility.ToInt32Ptr(60),
+				},
+			},
+		},
+	}
+
+	job := makeS3LifecycleSyncProjectBucketsJob()
+	// Account is not in the restricted list, so the sync should proceed.
+	err := job.syncBucket(t.Context(), mockClient, "my-bucket", nil)
+	require.NoError(t, err)
+
+	// The rule should be updated with the new AWS data AND the AWSAccountID must be preserved.
+	rule, err := s3lifecycle.FindByBucketAndPrefix(t.Context(), "my-bucket", "sandbox/")
+	require.NoError(t, err)
+	require.NotNil(t, rule)
+	assert.Equal(t, "updated-rule", rule.RuleID, "rule should be updated from AWS")
+	assert.Equal(t, 60, *rule.ExpirationDays, "expiration should reflect new AWS value")
+	assert.Equal(t, "111111111111", rule.AWSAccountID, "AWSAccountID must survive the sync")
+	assert.Equal(t, []string{"project1"}, rule.ProjectAssociations, "ProjectAssociations must survive the sync")
+}
+
+// TestSyncBucketSkipsAccountWithoutLifecycleRulesAccess verifies that syncBucket skips the AWS
+// call when the bucket's stored AWSAccountID is in the restricted list.
+func TestSyncBucketSkipsAccountWithoutLifecycleRulesAccess(t *testing.T) {
+	require.NoError(t, db.Clear(s3lifecycle.Collection))
+	t.Cleanup(func() {
+		require.NoError(t, db.Clear(s3lifecycle.Collection))
+	})
+
+	// Seed an existing rule whose account is in the skip list.
+	existingRule := &s3lifecycle.S3LifecycleRuleDoc{
+		BucketName:   "restricted-bucket",
+		FilterPrefix: "",
+		BucketType:   s3lifecycle.BucketTypeUserSpecified,
+		Region:       "us-east-1",
+		AWSAccountID: "999999999999",
+		RuleID:       "old-rule",
+		RuleStatus:   "Enabled",
+		LastSyncedAt: time.Now().Add(-24 * time.Hour),
+	}
+	require.NoError(t, existingRule.Upsert(t.Context()))
+
+	mockClient := &mockS3LifecycleClient{
+		rules: map[string][]pail.LifecycleRule{
+			"restricted-bucket": {{ID: "should-not-be-called"}},
+		},
+	}
+
+	accountsWithoutLifecycleRules := []string{"999999999999"}
+	job := makeS3LifecycleSyncProjectBucketsJob()
+	err := job.syncBucket(t.Context(), mockClient, "restricted-bucket", accountsWithoutLifecycleRules)
+	require.NoError(t, err)
+
+	// The existing rule should be unchanged, confirming no AWS call was made.
+	rule, err := s3lifecycle.FindByBucketAndPrefix(t.Context(), "restricted-bucket", "")
+	require.NoError(t, err)
+	require.NotNil(t, rule)
+	assert.Equal(t, "old-rule", rule.RuleID, "rule should be unchanged when sync is skipped")
 }


### PR DESCRIPTION
DEVPROD-31904

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
There are some accounts that we won't have access to fetch lifecycle rule for. Instead of trying and erroring, we should skip fetching and default immediately. This will also keep our logs clean so we can alert when something hits this unexpectedly. 

### Testing
Added tests 

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
