### PR TITLE
DEVPROD-33799 Add GraphQL complexity logging

### DIFF
--- a/graphql/http_handler.go
+++ b/graphql/http_handler.go
@@ -60,7 +60,7 @@ func Handler(apiURL string, allowMutations bool) func(w http.ResponseWriter, r *
 	))
 
 	// Log graphql requests to splunk
-	srv.Use(NewSplunkTracing(schema))
+	srv.Use(ComplexitySplunkTracing(schema))
 
 	// Disable queries for service degradation
 	srv.Use(DisableQuery{})

--- a/graphql/splunktracing.go
+++ b/graphql/splunktracing.go
@@ -23,7 +23,7 @@ type SplunkTracing struct {
 // NewSplunkTracing returns a SplunkTracing extension that computes query
 // complexity scores for logging. The executable schema is required to resolve
 // per-field complexity weights during calculation.
-func NewSplunkTracing(schema graphql.ExecutableSchema) SplunkTracing {
+func ComplexitySplunkTracing(schema graphql.ExecutableSchema) SplunkTracing {
 	return SplunkTracing{schema: schema}
 }
 

--- a/graphql/splunktracing_test.go
+++ b/graphql/splunktracing_test.go
@@ -106,7 +106,7 @@ func TestGraphQLComplexityLogging(t *testing.T) {
 		ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "test_user"})
 		ctx, span := tp.Tracer("test").Start(ctx, "test")
 
-		NewSplunkTracing(schema).InterceptResponse(ctx, func(ctx context.Context) *graphql.Response {
+		ComplexitySplunkTracing(schema).InterceptResponse(ctx, func(ctx context.Context) *graphql.Response {
 			return &graphql.Response{}
 		})
 		span.End()


### PR DESCRIPTION
DEVPROD-33799
<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Before API complexity limiting is implemented for GraphQL queries, we'll collect a few days of real production traffic data to better understand GraphQL query complexity and what looks like normal human behavior. The default complexity score (no custom complexity calculation) will be emitted to both the existing Splunk log line and as an OTel span attribute for analysis in Honeycomb. Within a few days, this analysis will allow a `GraphQLComplexityLimit` to be determined. 

Also added a few unit tests (`graphql/splunktracing_test.go`) to verify that complexity score is properly logged to both outputs, their scores match for the same query, and that deeper queries actually result in a higher complexity score being logged. 
<!--add description, context, thought process, etc-->

### Testing

- New unit tests (TestGraphQLComplexityLogging) with a real executable schema, see description above
- **(Local)** Navigated through Spruce, confirmed complexity_score appears on every graphql.tracing log line with values that vary by operation
- **(Staging)** Navigated through UI, confirmed that `complexity_score` is logged in both Splunk and Otel traces visible on Honeycomb, and that it varies across requests

<!--add a description of how you tested it-->
