### PR TITLE
DEVPROD-33790 Add spawn hosts by project stats

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3184,6 +3184,56 @@ func CountDebugSpawnhosts(ctx context.Context) (int, error) {
 	})
 }
 
+type spawnHostProjectCount struct {
+	Project string `bson:"project" json:"project"`
+	Count   int    `bson:"count" json:"count"`
+}
+
+// AggregateSpawnhostCountByProject returns the count of active spawn hosts
+// grouped by the project of the task they were created from.
+func AggregateSpawnhostCountByProject(ctx context.Context) ([]spawnHostProjectCount, error) {
+	const taskResult = "task_result"
+	taskIdKey := bsonutil.GetDottedKeyName(ProvisionOptionsKey, ProvisionOptionsTaskIdKey)
+	pipeline := []bson.M{
+		{"$match": bson.M{
+			UserHostKey: true,
+			StatusKey:   bson.M{"$in": evergreen.UpHostStatus},
+			taskIdKey:   bson.M{"$exists": true, "$ne": ""},
+		}},
+		{"$lookup": bson.M{
+			"from":         task.Collection,
+			"localField":   taskIdKey,
+			"foreignField": task.IdKey,
+			"as":           taskResult,
+		}},
+		{"$unwind": bson.M{
+			"path":                       "$" + taskResult,
+			"preserveNullAndEmptyArrays": false,
+		}},
+		{"$group": bson.M{
+			"_id":   "$" + bsonutil.GetDottedKeyName(taskResult, task.ProjectKey),
+			"count": bson.M{"$sum": 1},
+		}},
+		{"$project": bson.M{
+			"_id":     0,
+			"project": "$_id",
+			"count":   "$count",
+		}},
+		{"$sort": bson.M{"count": -1}},
+	}
+
+	cur, err := evergreen.GetEnvironment().DB().Collection(Collection).Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, errors.Wrap(err, "aggregating spawn host counts by project")
+	}
+	var results []spawnHostProjectCount
+	if err = cur.All(ctx, &results); err != nil {
+		return nil, errors.Wrap(err, "decoding spawn host counts by project")
+	}
+
+	return results, nil
+}
+
 // CountSpawnhostsWithNoExpirationByUser returns a count of all hosts associated
 // with a given users that are considered up and should never expire.
 func CountSpawnhostsWithNoExpirationByUser(ctx context.Context, user string) (int, error) {

--- a/model/host/stats_test.go
+++ b/model/host/stats_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/distro"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func insertTestDocuments(ctx context.Context) error {
@@ -146,4 +148,62 @@ func TestHostStatsByDistro(t *testing.T) {
 	sort.Slice(alt, func(i, j int) bool { return alt[i].Distro < alt[j].Distro })
 	sort.Slice(result, func(i, j int) bool { return result[i].Distro < result[j].Distro })
 	assert.Equal(alt, result)
+}
+
+func TestAggregateSpawnhostCountByProject(t *testing.T) {
+	require.NoError(t, db.ClearCollections(Collection, task.Collection))
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(Collection, task.Collection))
+	})
+
+	t.Run("MultipleProjectsReturnsSortedByCountDescending", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(Collection, task.Collection))
+
+		for _, tk := range []task.Task{
+			{Id: "task1", Project: "projectA"},
+			{Id: "task2", Project: "projectA"},
+			{Id: "task3", Project: "projectB"},
+		} {
+			require.NoError(t, tk.Insert(t.Context()))
+		}
+
+		for _, h := range []Host{
+			{Id: "h1", UserHost: true, Status: evergreen.HostRunning, ProvisionOptions: &ProvisionOptions{TaskId: "task1"}},
+			{Id: "h2", UserHost: true, Status: evergreen.HostRunning, ProvisionOptions: &ProvisionOptions{TaskId: "task2"}},
+			{Id: "h3", UserHost: true, Status: evergreen.HostStarting, ProvisionOptions: &ProvisionOptions{TaskId: "task3"}},
+		} {
+			require.NoError(t, h.Insert(t.Context()))
+		}
+
+		results, err := AggregateSpawnhostCountByProject(t.Context())
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+		assert.Equal(t, "projectA", results[0].Project)
+		assert.Equal(t, 2, results[0].Count)
+		assert.Equal(t, "projectB", results[1].Project)
+		assert.Equal(t, 1, results[1].Count)
+	})
+
+	t.Run("ExcludesNonSpawnHostsAndTerminatedHosts", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(Collection, task.Collection))
+
+		require.NoError(t, (&task.Task{Id: "task1", Project: "projectA"}).Insert(t.Context()))
+		require.NoError(t, (&task.Task{Id: "task2", Project: "projectB"}).Insert(t.Context()))
+		require.NoError(t, (&task.Task{Id: "task3", Project: "projectC"}).Insert(t.Context()))
+
+		for _, h := range []Host{
+			{Id: "h1", UserHost: false, Status: evergreen.HostRunning, ProvisionOptions: &ProvisionOptions{TaskId: "task1"}},
+			{Id: "h2", UserHost: true, Status: evergreen.HostTerminated, ProvisionOptions: &ProvisionOptions{TaskId: "task2"}},
+			{Id: "h3", UserHost: true, Status: evergreen.HostRunning, ProvisionOptions: &ProvisionOptions{TaskId: ""}},
+			{Id: "h4", UserHost: true, Status: evergreen.HostRunning, ProvisionOptions: &ProvisionOptions{TaskId: "task3"}},
+		} {
+			require.NoError(t, h.Insert(t.Context()))
+		}
+
+		results, err := AggregateSpawnhostCountByProject(t.Context())
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "projectC", results[0].Project)
+		assert.Equal(t, 1, results[0].Count)
+	})
 }

--- a/model/host/stats_test.go
+++ b/model/host/stats_test.go
@@ -195,7 +195,8 @@ func TestAggregateSpawnhostCountByProject(t *testing.T) {
 			{Id: "h1", UserHost: false, Status: evergreen.HostRunning, ProvisionOptions: &ProvisionOptions{TaskId: "task1"}},
 			{Id: "h2", UserHost: true, Status: evergreen.HostTerminated, ProvisionOptions: &ProvisionOptions{TaskId: "task2"}},
 			{Id: "h3", UserHost: true, Status: evergreen.HostRunning, ProvisionOptions: &ProvisionOptions{TaskId: ""}},
-			{Id: "h4", UserHost: true, Status: evergreen.HostRunning, ProvisionOptions: &ProvisionOptions{TaskId: "task3"}},
+			{Id: "h4", UserHost: true, Status: evergreen.HostRunning, ProvisionOptions: &ProvisionOptions{TaskId: "nonexistent_task"}},
+			{Id: "h5", UserHost: true, Status: evergreen.HostRunning, ProvisionOptions: &ProvisionOptions{TaskId: "task3"}},
 		} {
 			require.NoError(t, h.Insert(t.Context()))
 		}

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -813,6 +813,12 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 	if err != nil {
 		return nil, errors.Wrap(err, "finalizing patch")
 	}
+	grip.Info(ctx, message.Fields{
+		"message":   "successfully created version",
+		"version":   patchVersion.Id,
+		"project":   patchVersion.Identifier,
+		"requester": requester,
+	})
 
 	// Update aggregate costs after transaction commits. We use a goroutine with
 	// retry logic to handle MongoDB transaction propagation delays.

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -1144,11 +1144,12 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			return errors.Wrapf(err, "committing transaction for version '%s'", v.Id)
 		}
 		grip.Info(ctx, message.Fields{
-			"message": "successfully created version",
-			"version": v.Id,
-			"hash":    v.Revision,
-			"project": v.Identifier,
-			"runner":  RunnerName,
+			"message":   "successfully created version",
+			"version":   v.Id,
+			"hash":      v.Revision,
+			"project":   v.Identifier,
+			"requester": v.Requester,
+			"runner":    RunnerName,
 		})
 		return nil
 	}

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1719,6 +1719,12 @@ func PostCommentToPullRequest(ctx context.Context, owner, repo string, prNum int
 	if resp != nil && resp.StatusCode != http.StatusCreated || respComment == nil || respComment.ID == nil {
 		return errors.New("unexpected data from GitHub")
 	}
+	grip.Info(ctx, message.Fields{
+		"message": "posted PR comment",
+		"owner":   owner,
+		"repo":    repo,
+		"pr_num":  prNum,
+	})
 	return nil
 }
 

--- a/units/host_stats.go
+++ b/units/host_stats.go
@@ -145,4 +145,13 @@ func (j *hostStatsJob) Run(ctx context.Context) {
 		"non_debug_hosts":         spawnStats.TotalHosts - debugHostCount,
 	})
 
+	spawnHostsByProject, err := host.AggregateSpawnhostCountByProject(ctx)
+	if err != nil {
+		j.AddError(errors.Wrap(err, "aggregating spawn host counts by project"))
+	} else {
+		j.logger.Info(ctx, message.Fields{
+			"message":  "spawn hosts by project",
+			"projects": spawnHostsByProject,
+		})
+	}
 }


### PR DESCRIPTION
DEVPROD-33790

### Description
This was done to fulfill the following metric defined [here](https://docs.google.com/document/d/1JjDwRV6CnQ-g_7bb7srQqfs9oe2g8Hl41sIHtHj3fIw/edit?tab=t.0):
```
What does adoption of the golden path look like?
Include # of unique users and total active spawn hosts. Allow breakdown per project.
```
Also added a requester field to the waterfall version completion logs to enable filtering for periodic builds and triggers alongside mainline commits. Similarly, added a log to patch finalization with a requester field so we can track versions per day per requester, which is also required in the metrics doc.


### Splunk considerations
The modified host stats job runs every 30 minutes, so it should not meaningfully contribute to Splunk limits.

The new patch finalization log volume is also not likely to be significant (~10k patches / day relative to 150 million current splunk events / day)

### Testing
Added a unit test.