### PR TITLE
DEVPROD-34767: Fix last-revision erroring on projects without modules

### DIFF
--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -1729,22 +1729,25 @@ func (c *communicatorImpl) GetManifestForVersion(ctx context.Context, versionID 
 		path:   fmt.Sprintf("versions/%s/manifest", versionID),
 	}
 	resp, err := c.retryRequest(ctx, info, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	// Manifests are optional for versions that don't use modules, so the route
+	// returns 404 when the version has no manifest (or doesn't exist). retryRequest
+	// surfaces non-2xx responses as an error, so the 404 must be checked before err
+	// to avoid treating a missing manifest as a failure.
+	if resp != nil && resp.StatusCode == http.StatusNotFound {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, errors.Wrapf(err, "sending request to get version manifest")
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return nil, util.RespError(resp, AuthError)
 	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		// Manifests are optional for versions that don't use modules, so the
-		// route can return 404 if the version does not exist or if the version
-		// has no manifest.
-		return nil, nil
 	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, util.RespError(resp, "getting version manifest")


### PR DESCRIPTION
DEVPROD-34767

### Description

`evergreen last-revision` fails with `404 version manifest not found` for any project that does not use modules (reported for `wiredtiger` in #ask-devprod). Projects without modules never have a version manifest, so the `versions/{id}/manifest` route returns 404 — which is expected, and is meant to be treated as "no modules."

`GetManifestForVersion` in rest/client/methods.go had a `StatusNotFound -> return nil, nil` branch for exactly this case, but it was unreachable: `retryRequest` surfaces non-2xx responses (including 404) as an error, and the `if err != nil` check returned first. So `last-revision` errored out instead of returning the matching revision with no modules.

The fix checks the 404 before the error and defers closing the response body on all paths (also fixing a latent body leak on the error path). The dead 404 handling was introduced alongside the feature in DEVPROD-20580 (#9294).

### Testing

existing tests pass
