### PR TITLE
DEVPROD-29984 Batch generate tasks estimation queries during patch scheduling

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -751,6 +751,18 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 		generatorIsGithubCheck = generateTask.IsGithubCheck
 	}
 
+	// Fetch generate tasks estimations for all generator tasks.
+	var generatorDisplayNames []string
+	for _, t := range tasksToCreate {
+		if creationInfo.Project.IsGenerateTask(t.Name) {
+			generatorDisplayNames = append(generatorDisplayNames, t.Name)
+		}
+	}
+	generateTaskEstimations, err := task.GetBatchedGenerateTasksEstimations(ctx, creationInfo.Project.Identifier, creationInfo.BuildVariant.Name, generatorDisplayNames)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting batched generate tasks estimations")
+	}
+
 	// create all the actual tasks
 	taskMap := make(map[string]*task.Task)
 	for _, t := range tasksToCreate {
@@ -759,6 +771,7 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 		if err != nil {
 			return nil, errors.Wrapf(err, "creating task '%s'", id)
 		}
+		newTask.SetGenerateTasksEstimationsFromMap(generateTaskEstimations)
 
 		projectTask := creationInfo.Project.FindProjectTask(t.Name)
 		if projectTask != nil {
@@ -1089,10 +1102,6 @@ func createOneTask(ctx context.Context, id string, creationInfo TaskCreationInfo
 	}
 
 	t.DisplayStatusCache = t.DetermineDisplayStatus()
-
-	if err := t.SetGenerateTasksEstimations(ctx); err != nil {
-		return nil, errors.Wrap(err, "setting generate tasks estimations")
-	}
 
 	if buildVarTask.CreateCheckRun != nil {
 		t.CheckRunPath = utility.ToStringPtr(buildVarTask.CreateCheckRun.PathToOutputs)

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -760,7 +760,12 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 	}
 	generateTaskEstimations, err := task.GetBatchedGenerateTasksEstimations(ctx, creationInfo.Project.Identifier, creationInfo.BuildVariant.Name, generatorDisplayNames)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting batched generate tasks estimations")
+		grip.Warning(ctx, message.WrapError(err, message.Fields{
+			"message": "getting batched generate tasks estimations",
+			"project": creationInfo.Project.Identifier,
+			"variant": creationInfo.BuildVariant.Name,
+		}))
+		generateTaskEstimations = map[string]task.GenerateTasksEstimation{}
 	}
 
 	// create all the actual tasks

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2990,15 +2990,21 @@ func FindGeneratedTasksFromID(ctx context.Context, generatorID string) ([]Genera
 }
 
 type generateTasksEstimationsResults struct {
+	DisplayName        string  `bson:"_id"`
 	EstimatedCreated   float64 `bson:"est_created"`
 	EstimatedActivated float64 `bson:"est_activated"`
 }
 
-func getGenerateTasksEstimation(ctx context.Context, project, buildVariant, displayName string, lookBackTime time.Duration) ([]generateTasksEstimationsResults, error) {
+func getBatchedGenerateTasksEstimations(ctx context.Context, project, buildVariant string, displayNames []string, lookBackTime time.Duration) ([]generateTasksEstimationsResults, error) {
+	if len(displayNames) == 0 {
+		return nil, nil
+	}
 	match := bson.M{
-		ProjectKey:        project,
-		BuildVariantKey:   buildVariant,
-		DisplayNameKey:    displayName,
+		ProjectKey:      project,
+		BuildVariantKey: buildVariant,
+		DisplayNameKey: bson.M{
+			"$in": displayNames,
+		},
 		GeneratedTasksKey: true,
 		StatusKey:         evergreen.TaskSucceeded,
 		StartTimeKey: bson.M{

--- a/model/task/generate_tasks_estimations.go
+++ b/model/task/generate_tasks_estimations.go
@@ -13,15 +13,16 @@ const (
 	lookBackTime = 7 * 24 * time.Hour // one week
 )
 
-type generateTasksEstimation struct {
+// GenerateTasksEstimation holds estimation results for a single generator task.
+type GenerateTasksEstimation struct {
 	EstimatedNumGeneratedTasks          int
 	EstimatedNumActivatedGeneratedTasks int
 }
 
 // GetBatchedGenerateTasksEstimations returns a map of estimations for multiple generator tasks, where keys
 // are each task's display name.
-func GetBatchedGenerateTasksEstimations(ctx context.Context, project, buildVariant string, displayNames []string) (map[string]generateTasksEstimation, error) {
-	result := make(map[string]generateTasksEstimation, len(displayNames))
+func GetBatchedGenerateTasksEstimations(ctx context.Context, project, buildVariant string, displayNames []string) (map[string]GenerateTasksEstimation, error) {
+	result := make(map[string]GenerateTasksEstimation, len(displayNames))
 	if len(displayNames) == 0 {
 		return result, nil
 	}
@@ -32,7 +33,7 @@ func GetBatchedGenerateTasksEstimations(ctx context.Context, project, buildVaria
 	}
 
 	for _, r := range results {
-		result[r.DisplayName] = generateTasksEstimation{
+		result[r.DisplayName] = GenerateTasksEstimation{
 			EstimatedNumGeneratedTasks:          int(math.Round(r.EstimatedCreated)),
 			EstimatedNumActivatedGeneratedTasks: int(math.Round(r.EstimatedActivated)),
 		}
@@ -42,7 +43,7 @@ func GetBatchedGenerateTasksEstimations(ctx context.Context, project, buildVaria
 }
 
 // SetGenerateTasksEstimationsFromMap applies generate.tasks estimation results to a task.
-func (t *Task) SetGenerateTasksEstimationsFromMap(estimations map[string]generateTasksEstimation) {
+func (t *Task) SetGenerateTasksEstimationsFromMap(estimations map[string]GenerateTasksEstimation) {
 	if !t.GenerateTask {
 		return
 	}

--- a/model/task/generate_tasks_estimations.go
+++ b/model/task/generate_tasks_estimations.go
@@ -13,30 +13,46 @@ const (
 	lookBackTime = 7 * 24 * time.Hour // one week
 )
 
-// SetGenerateTasksEstimations calculates and caches the estimated number of tasks that this task will generate.
-// To be called only in task creation.
-func (t *Task) SetGenerateTasksEstimations(ctx context.Context) error {
-	// Do not run if the task is not a generator.
-	if !t.GenerateTask {
-		return nil
+type generateTasksEstimation struct {
+	EstimatedNumGeneratedTasks          int
+	EstimatedNumActivatedGeneratedTasks int
+}
+
+// GetBatchedGenerateTasksEstimations returns a map of estimations for multiple generator tasks, where keys
+// are each task's display name.
+func GetBatchedGenerateTasksEstimations(ctx context.Context, project, buildVariant string, displayNames []string) (map[string]generateTasksEstimation, error) {
+	result := make(map[string]generateTasksEstimation, len(displayNames))
+	if len(displayNames) == 0 {
+		return result, nil
 	}
 
-	results, err := getGenerateTasksEstimation(ctx, t.Project, t.BuildVariant, t.DisplayName, lookBackTime)
+	results, err := getBatchedGenerateTasksEstimations(ctx, project, buildVariant, displayNames, lookBackTime)
 	if err != nil {
-		return errors.Wrap(err, "getting generate tasks estimation")
+		return nil, errors.Wrap(err, "getting generate tasks estimations")
 	}
 
-	if len(results) == 0 {
+	for _, r := range results {
+		result[r.DisplayName] = generateTasksEstimation{
+			EstimatedNumGeneratedTasks:          int(math.Round(r.EstimatedCreated)),
+			EstimatedNumActivatedGeneratedTasks: int(math.Round(r.EstimatedActivated)),
+		}
+	}
+
+	return result, nil
+}
+
+// SetGenerateTasksEstimationsFromMap applies generate.tasks estimation results to a task.
+func (t *Task) SetGenerateTasksEstimationsFromMap(estimations map[string]generateTasksEstimation) {
+	if !t.GenerateTask {
+		return
+	}
+	est, ok := estimations[t.DisplayName]
+	if !ok {
 		t.EstimatedNumGeneratedTasks = utility.ToIntPtr(0)
 		t.EstimatedNumActivatedGeneratedTasks = utility.ToIntPtr(0)
-
-		return nil
-	} else if len(results) > 1 {
-		return errors.Errorf("expected 1 result from generate tasks estimations aggregation but got %d", len(results))
+		return
 	}
 
-	t.EstimatedNumGeneratedTasks = utility.ToIntPtr(int(math.Round(results[0].EstimatedCreated)))
-	t.EstimatedNumActivatedGeneratedTasks = utility.ToIntPtr(int(math.Round(results[0].EstimatedActivated)))
-
-	return nil
+	t.EstimatedNumGeneratedTasks = utility.ToIntPtr(est.EstimatedNumGeneratedTasks)
+	t.EstimatedNumActivatedGeneratedTasks = utility.ToIntPtr(est.EstimatedNumActivatedGeneratedTasks)
 }

--- a/model/task/generate_tasks_estimations_test.go
+++ b/model/task/generate_tasks_estimations_test.go
@@ -9,11 +9,13 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-func TestGenerateTasksEstimations(t *testing.T) {
+func TestGenerateTasksEstimationsOnlyIncludesSucceeded(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
 	assert.NoError(db.ClearCollections(Collection))
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -26,61 +28,37 @@ func TestGenerateTasksEstimations(t *testing.T) {
 	project := "proj"
 	displayName := "display_name"
 
-	t1 := Task{
+	assert.NoError((&Task{
 		Id:                         "t1",
 		DisplayName:                displayName,
 		BuildVariant:               bv,
 		Project:                    project,
 		Status:                     evergreen.TaskFailed,
-		Requester:                  evergreen.RepotrackerVersionRequester,
 		NumGeneratedTasks:          1,
 		NumActivatedGeneratedTasks: 11,
-		StartTime:                  time.Now().Add(-1 * 10 * time.Hour),
-		FinishTime:                 time.Now().Add(-1 * 9 * time.Hour),
+		StartTime:                  time.Now().Add(-10 * time.Hour),
+		FinishTime:                 time.Now().Add(-9 * time.Hour),
 		GeneratedTasks:             true,
-	}
-	assert.NoError(t1.Insert(t.Context()))
-	t2 := Task{
+	}).Insert(t.Context()))
+
+	assert.NoError((&Task{
 		Id:                         "t2",
 		DisplayName:                displayName,
 		BuildVariant:               bv,
 		Project:                    project,
 		Status:                     evergreen.TaskSucceeded,
-		Requester:                  evergreen.GithubPRRequester,
 		NumGeneratedTasks:          2,
 		NumActivatedGeneratedTasks: 20,
-		StartTime:                  time.Now().Add(-1 * 20 * time.Hour),
-		FinishTime:                 time.Now().Add(-1 * 19 * time.Hour),
+		StartTime:                  time.Now().Add(-20 * time.Hour),
+		FinishTime:                 time.Now().Add(-19 * time.Hour),
 		GeneratedTasks:             true,
-	}
-	assert.NoError(t2.Insert(t.Context()))
-	t3 := Task{
-		Id:                         "t3",
-		DisplayName:                displayName,
-		BuildVariant:               bv,
-		Project:                    project,
-		Status:                     evergreen.TaskFailed,
-		Requester:                  evergreen.PatchVersionRequester,
-		NumGeneratedTasks:          3,
-		NumActivatedGeneratedTasks: 30,
-		StartTime:                  time.Now().Add(-1 * 30 * time.Hour),
-		FinishTime:                 time.Now().Add(-1 * 29 * time.Hour),
-		GeneratedTasks:             true,
-	}
-	assert.NoError(t3.Insert(t.Context()))
-	t4 := Task{
-		GenerateTask: true,
-		Id:           "t4",
-		DisplayName:  displayName,
-		BuildVariant: bv,
-		Project:      project,
-	}
-	assert.NoError(t4.Insert(t.Context()))
+	}).Insert(t.Context()))
 
-	err = t4.SetGenerateTasksEstimations(ctx)
-	assert.NoError(err)
-	assert.Equal(2, utility.FromIntPtr(t4.EstimatedNumGeneratedTasks))
-	assert.Equal(20, utility.FromIntPtr(t4.EstimatedNumActivatedGeneratedTasks))
+	results, err := GetBatchedGenerateTasksEstimations(ctx, project, bv, []string{displayName})
+	require.NoError(err)
+	require.Contains(results, displayName)
+	assert.Equal(2, results[displayName].EstimatedNumGeneratedTasks)
+	assert.Equal(20, results[displayName].EstimatedNumActivatedGeneratedTasks)
 }
 
 func TestGenerateTasksEstimationsNoPreviousTasks(t *testing.T) {
@@ -93,39 +71,132 @@ func TestGenerateTasksEstimationsNoPreviousTasks(t *testing.T) {
 	_, err := evergreen.GetEnvironment().DB().Collection(Collection).Indexes().CreateOne(ctx, mongo.IndexModel{Keys: TaskHistoricalDataIndex})
 	assert.NoError(err)
 
-	t1 := Task{
-		Id:           "t1",
+	results, err := GetBatchedGenerateTasksEstimations(ctx, "project", "bv", []string{"new task with no history"})
+	assert.NoError(err)
+	assert.NotContains(results, "new task with no history")
+
+	task := Task{
 		DisplayName:  "new task with no history",
-		BuildVariant: "bv",
-		Project:      "project",
 		GenerateTask: true,
 	}
-	assert.NoError(t1.Insert(t.Context()))
-
-	err = t1.SetGenerateTasksEstimations(ctx)
-	assert.NoError(err)
-	assert.Equal(0, utility.FromIntPtr(t1.EstimatedNumGeneratedTasks))
-	assert.Equal(0, utility.FromIntPtr(t1.EstimatedNumActivatedGeneratedTasks))
+	task.SetGenerateTasksEstimationsFromMap(results)
+	assert.Equal(0, utility.FromIntPtr(task.EstimatedNumGeneratedTasks))
+	assert.Equal(0, utility.FromIntPtr(task.EstimatedNumActivatedGeneratedTasks))
 }
 
-func TestGenerateTasksEstimationsDoesNotRun(t *testing.T) {
+func TestGetBatchedGenerateTasksEstimations(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
 	assert.NoError(db.ClearCollections(Collection))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	t1 := Task{
-		Id:           "t1",
-		DisplayName:  "not generate task",
-		BuildVariant: "bv",
-		Project:      "project",
-		GenerateTask: false,
-	}
-	assert.NoError(t1.Insert(t.Context()))
-
-	err := t1.SetGenerateTasksEstimations(ctx)
+	_, err := evergreen.GetEnvironment().DB().Collection(Collection).Indexes().CreateOne(ctx, mongo.IndexModel{Keys: TaskHistoricalDataIndex})
 	assert.NoError(err)
-	assert.Nil(t1.EstimatedNumGeneratedTasks)
-	assert.Nil(t1.EstimatedNumActivatedGeneratedTasks)
+
+	bv := "bv"
+	project := "proj"
+
+	assert.NoError((&Task{
+		Id:                         "h1",
+		DisplayName:                "gen_a",
+		BuildVariant:               bv,
+		Project:                    project,
+		Status:                     evergreen.TaskSucceeded,
+		NumGeneratedTasks:          10,
+		NumActivatedGeneratedTasks: 8,
+		StartTime:                  time.Now().Add(-20 * time.Hour),
+		FinishTime:                 time.Now().Add(-19 * time.Hour),
+		GeneratedTasks:             true,
+	}).Insert(t.Context()))
+	assert.NoError((&Task{
+		Id:                         "h2",
+		DisplayName:                "gen_a",
+		BuildVariant:               bv,
+		Project:                    project,
+		Status:                     evergreen.TaskSucceeded,
+		NumGeneratedTasks:          20,
+		NumActivatedGeneratedTasks: 16,
+		StartTime:                  time.Now().Add(-10 * time.Hour),
+		FinishTime:                 time.Now().Add(-9 * time.Hour),
+		GeneratedTasks:             true,
+	}).Insert(t.Context()))
+
+	assert.NoError((&Task{
+		Id:                         "h3",
+		DisplayName:                "gen_b",
+		BuildVariant:               bv,
+		Project:                    project,
+		Status:                     evergreen.TaskSucceeded,
+		NumGeneratedTasks:          6,
+		NumActivatedGeneratedTasks: 4,
+		StartTime:                  time.Now().Add(-5 * time.Hour),
+		FinishTime:                 time.Now().Add(-4 * time.Hour),
+		GeneratedTasks:             true,
+	}).Insert(t.Context()))
+
+	assert.NoError((&Task{
+		Id:                         "h4",
+		DisplayName:                "gen_b",
+		BuildVariant:               bv,
+		Project:                    project,
+		Status:                     evergreen.TaskFailed,
+		NumGeneratedTasks:          100,
+		NumActivatedGeneratedTasks: 100,
+		StartTime:                  time.Now().Add(-3 * time.Hour),
+		FinishTime:                 time.Now().Add(-2 * time.Hour),
+		GeneratedTasks:             true,
+	}).Insert(t.Context()))
+
+	results, err := GetBatchedGenerateTasksEstimations(ctx, project, bv, []string{"gen_a", "gen_b", "gen_c"})
+	require.NoError(err)
+
+	require.Contains(results, "gen_a")
+	assert.Equal(15, results["gen_a"].EstimatedNumGeneratedTasks)
+	assert.Equal(12, results["gen_a"].EstimatedNumActivatedGeneratedTasks)
+
+	require.Contains(results, "gen_b")
+	assert.Equal(6, results["gen_b"].EstimatedNumGeneratedTasks)
+	assert.Equal(4, results["gen_b"].EstimatedNumActivatedGeneratedTasks)
+
+	assert.NotContains(results, "gen_c")
+}
+
+func TestGetBatchedGenerateTasksEstimationsEmpty(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	results, err := GetBatchedGenerateTasksEstimations(ctx, "proj", "bv", []string{})
+	assert.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestSetGenerateTasksEstimationsFromMap(t *testing.T) {
+	estimations := map[string]generateTasksEstimation{
+		"gen_a": {
+			EstimatedNumGeneratedTasks:          15,
+			EstimatedNumActivatedGeneratedTasks: 12,
+		},
+	}
+
+	t.Run("GeneratorTaskWithMatchingEntry", func(t *testing.T) {
+		task := Task{
+			DisplayName:  "gen_a",
+			GenerateTask: true,
+		}
+		task.SetGenerateTasksEstimationsFromMap(estimations)
+		assert.Equal(t, 15, utility.FromIntPtr(task.EstimatedNumGeneratedTasks))
+		assert.Equal(t, 12, utility.FromIntPtr(task.EstimatedNumActivatedGeneratedTasks))
+	})
+
+	t.Run("GeneratorTaskWithNoEntry", func(t *testing.T) {
+		task := Task{
+			DisplayName:  "gen_unknown",
+			GenerateTask: true,
+		}
+		task.SetGenerateTasksEstimationsFromMap(estimations)
+		assert.Equal(t, 0, utility.FromIntPtr(task.EstimatedNumGeneratedTasks))
+		assert.Equal(t, 0, utility.FromIntPtr(task.EstimatedNumActivatedGeneratedTasks))
+	})
 }

--- a/model/task/generate_tasks_estimations_test.go
+++ b/model/task/generate_tasks_estimations_test.go
@@ -173,7 +173,7 @@ func TestGetBatchedGenerateTasksEstimationsEmpty(t *testing.T) {
 }
 
 func TestSetGenerateTasksEstimationsFromMap(t *testing.T) {
-	estimations := map[string]generateTasksEstimation{
+	estimations := map[string]GenerateTasksEstimation{
 		"gen_a": {
 			EstimatedNumGeneratedTasks:          15,
 			EstimatedNumActivatedGeneratedTasks: 12,


### PR DESCRIPTION
DEVPROD-29984


### Description
Individually querying tasks for estimated generated count is expensive and slows down operations like `SchedulePatch`. We can instead batch estimation queries for an entire variant into a single aggregation using `$in` on the display name field, which should reduce DB round trips from O(N) to O(1) per variant.

### Testing
Added unit tests for the batched query function.

### Post merge verification
I will be looking at SchedulePatch latency in [honeycomb](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen/result/gpizQoZL1C8) and will be hoping to see an improvement in the p99 and p90 latencies