### PR TITLE
DEVPROD-34812: Fix all-configs skipping file write for projects sharing a YAML

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-06-10"
+	ClientVersion = "2026-06-10a"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/admin_all_configs.go
+++ b/operations/admin_all_configs.go
@@ -70,7 +70,9 @@ func fetchAndWriteConfigs(ctx context.Context, c *legacyClient, projects []model
 		Branch     string
 		ConfigFile string
 	}
-	configDownloaded := map[projectRepo]bool{}
+	// Maps a repo+config key to the downloaded YAML content so that projects sharing
+	// the same config file get their own output file without a redundant download.
+	configCache := map[projectRepo][]byte{}
 	for _, p := range projects {
 		if !p.Enabled && !includeDisabled {
 			continue
@@ -81,30 +83,30 @@ func fetchAndWriteConfigs(ctx context.Context, c *legacyClient, projects []model
 			Branch:     p.Branch,
 			ConfigFile: p.RemotePath,
 		}
-		if exists := configDownloaded[repo]; exists {
-			grip.Infof(ctx, "Configuration for project '%s' already downloaded", p.Identifier)
-			continue
-		}
-		grip.Infof(ctx, "Downloading configuration for '%s'", p.Identifier)
-		versions, err := c.GetRecentVersions(p.Id)
-		if err != nil {
-			catcher.Wrapf(err, "fetching recent versions for '%s'", p.Identifier)
-			continue
-		}
-		if len(versions) == 0 {
-			grip.Warningf(ctx, "project '%s' has no versions; skipping", p.Identifier)
-			continue
+		var config []byte
+		if cached, exists := configCache[repo]; exists {
+			grip.Infof(ctx, "Reusing already-downloaded configuration for project '%s'", p.Identifier)
+			config = cached
+		} else {
+			grip.Infof(ctx, "Downloading configuration for '%s'", p.Identifier)
+			versions, err := c.GetRecentVersions(p.Id)
+			if err != nil {
+				catcher.Wrapf(err, "fetching recent versions for '%s'", p.Identifier)
+				continue
+			}
+			if len(versions) == 0 {
+				catcher.Errorf("WARNING: project '%s' has no versions", p.Identifier)
+				continue
+			}
+			config, err = c.GetConfig(versions[0])
+			if err != nil {
+				catcher.Wrapf(err, "fetching config for project '%s', version '%s'", p.Identifier, versions[0])
+				continue
+			}
+			configCache[repo] = config
 		}
 
-		config, err := c.GetConfig(versions[0])
-		if err != nil {
-			catcher.Wrapf(err, "fetching config for project '%s', version '%s'", p.Identifier, versions[0])
-			continue
-		}
-		configDownloaded[repo] = true
-
-		err = os.WriteFile(filepath.Join(directory, p.Identifier+".yml"), config, 0644)
-		if err != nil {
+		if err := os.WriteFile(filepath.Join(directory, p.Identifier+".yml"), config, 0644); err != nil {
 			catcher.Wrapf(err, "writing configuration for project '%s'", p.Identifier)
 		}
 	}


### PR DESCRIPTION
DEVPROD-34812

### Summary
I discovered a bug with `evergreen admin all-configs` where it was logging "Configuration for project 'X' already downloaded" and skipping the `.yml` file write for any project that shares the same `owner/repo/branch/remote-path` as an earlier project in the list.
This is fixed by caching the downloaded bytes (instead of a `bool`) so duplicate-key projects still get their own output file without a redundant GitHub fetch.

### Testing
Tested manually against staging and added a test suite covering: unique projects, shared-YAML projects (the regression case), disabled-project skipping, `--include-disabled`, and no-versions error handling.