### PR TITLE
DEVPROD-34805 only take into account hosts without tasks

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2789,7 +2789,7 @@ func (hosts HostGroup) ProvisioningHosts() HostGroup {
 	out := HostGroup{}
 
 	for _, h := range hosts {
-		if utility.StringSliceContains(evergreen.ProvisioningHostStatus, h.Status) {
+		if utility.StringSliceContains(evergreen.ProvisioningHostStatus, h.Status) && h.RunningTask == "" {
 			out = append(out, h)
 		}
 	}

--- a/units/host_allocator.go
+++ b/units/host_allocator.go
@@ -176,7 +176,7 @@ func (j *hostAllocatorJob) Run(ctx context.Context) {
 				startingHostsWithNoTasks++
 			}
 		}
-		nHosts = distroQueueInfo.LengthWithDependenciesMet - len(existingHosts.ProvisioningSingleTaskHosts())
+		nHosts = distroQueueInfo.LengthWithDependenciesMet - startingHostsWithNoTasks
 	} else {
 		hostAllocator := scheduler.GetHostAllocator(config.Scheduler.HostAllocator)
 

--- a/units/host_allocator.go
+++ b/units/host_allocator.go
@@ -170,13 +170,7 @@ func (j *hostAllocatorJob) Run(ctx context.Context) {
 
 	if distro.SingleTaskDistro {
 		// Single tasks distros should spawn a host for each task available to run in the queue.
-		startingHostsWithNoTasks := 0
-		for _, h := range provisioningHosts {
-			if h.RunningTask == "" {
-				startingHostsWithNoTasks++
-			}
-		}
-		nHosts = distroQueueInfo.LengthWithDependenciesMet - startingHostsWithNoTasks
+		nHosts = distroQueueInfo.LengthWithDependenciesMet - len(provisioningHosts)
 	} else {
 		hostAllocator := scheduler.GetHostAllocator(config.Scheduler.HostAllocator)
 

--- a/units/host_allocator.go
+++ b/units/host_allocator.go
@@ -170,7 +170,13 @@ func (j *hostAllocatorJob) Run(ctx context.Context) {
 
 	if distro.SingleTaskDistro {
 		// Single tasks distros should spawn a host for each task available to run in the queue.
-		nHosts = distroQueueInfo.LengthWithDependenciesMet - len(provisioningHosts)
+		startingHostsWithNoTasks := 0
+		for _, h := range provisioningHosts {
+			if h.RunningTask == "" {
+				startingHostsWithNoTasks++
+			}
+		}
+		nHosts = distroQueueInfo.LengthWithDependenciesMet - len(existingHosts.ProvisioningSingleTaskHosts())
 	} else {
 		hostAllocator := scheduler.GetHostAllocator(config.Scheduler.HostAllocator)
 


### PR DESCRIPTION
DEVPROD-34805


### Description

we assumed that provisioning tasks with status "starting" would not have a task but it sometimes does

### Testing

checked on the DB that the running task is fielded even if status is starting