### PR TITLE
DEVPROD-34881: Add panic recovery to resourceMonitor goroutine

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -732,7 +732,10 @@ func (a *Agent) runTask(ctx context.Context, tcInput *taskContext, nt *apimodels
 		defer shutdown(ctx)
 	}
 
-	go tc.resourceMonitor.start(tskCtx)
+	go func() {
+		defer recovery.LogStackTraceAndContinue("resource monitor")
+		tc.resourceMonitor.start(tskCtx)
+	}()
 
 	tc.setHeartbeatTimeout(heartbeatTimeoutOptions{})
 	preAndMainCtx, preAndMainCancel := context.WithCancel(tskCtx)

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-06-09"
+	AgentVersion = "2026-06-11"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-34881

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

While investigating DEVPROD-34169, I noticed that the resourceMonitor goroutine was the only goroutine launched during task execution without a `defer recovery` wrapper.

This is important because the resourceMonitor samples /proc/meminfo and /proc/stat every 15 seconds and when a large process is SIGKILLed, the kernel tears down its memory mappings abruptly. If the resourceMonitor reads /proc/meminfo in the middle of that teardown, gopsutil could encounter a transient or unexpected value and nil-dereference.


