### PR TITLE
DEVPROD-34882: protect agent process from OOM kills on Linux

### DIFF
--- a/agent/util/subtree_unix.go
+++ b/agent/util/subtree_unix.go
@@ -280,5 +280,8 @@ func SetOOMScoreAdj(adj int) error {
 	if runtime.GOOS != "linux" {
 		return nil
 	}
+	if adj < -1000 || adj > 1000 {
+		return errors.Errorf("OOM score adjustment %d is out of range [-1000, 1000]", adj)
+	}
 	return os.WriteFile("/proc/self/oom_score_adj", []byte(strconv.Itoa(adj)), 0)
 }

--- a/agent/util/subtree_unix.go
+++ b/agent/util/subtree_unix.go
@@ -273,3 +273,12 @@ func SetNice(pid, nice int) error {
 	// 0 refers to the current process.
 	return syscall.Setpriority(syscall.PRIO_PROCESS, pid, nice)
 }
+
+// SetOOMScoreAdj writes adj to /proc/self/oom_score_adj, which is added to
+// the kernel's OOM badness score when selecting a kill target.
+func SetOOMScoreAdj(adj int) error {
+	if runtime.GOOS != "linux" {
+		return nil
+	}
+	return os.WriteFile("/proc/self/oom_score_adj", []byte(strconv.Itoa(adj)), 0)
+}

--- a/agent/util/subtree_windows.go
+++ b/agent/util/subtree_windows.go
@@ -378,3 +378,8 @@ func GetNice(int) (int, error) {
 func SetNice(int, int) error {
 	return nil
 }
+
+// SetOOMScoreAdj is a no-op on Windows (Linux-only).
+func SetOOMScoreAdj(int) error {
+	return nil
+}

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-06-09"
+	AgentVersion = "2026-06-11"
 )
 
 const (

--- a/operations/agent.go
+++ b/operations/agent.go
@@ -202,6 +202,12 @@ func Agent() cli.Command {
 			grip.Warning(ctx, message.WrapError(setNiceAllThreads(agentutil.AgentNice), message.Fields{
 				"message": "could not set nice on agent process and all of its threads, some threads may proceed with default nice",
 			}))
+			// -900 puts the agent 900 points below any subprocess running at the
+			// default oom_score_adj of 0, so subprocesses are always preferred
+			// OOM targets while the agent remains eligible as a last resort.
+			grip.Warning(ctx, message.WrapError(agentutil.SetOOMScoreAdj(-900), message.Fields{
+				"message": "could not set oom_score_adj on agent process, agent may be targeted by the OOM killer",
+			}))
 
 			err = agt.Start(ctx)
 			if err != nil {


### PR DESCRIPTION
DEVPROD-34882

### Description
While investigating DEVPROD-34169, I noticed that there is nothing preventing the agent process itself from being OOM killed in an OOM cascade. We should set /proc/self/oom_score_adj at agent startup for Linux so that the OOM killer skips the agent regardless when there is memory pressure. 