### PR TITLE
DEVPROD-32399 Prevent command injection in patch creation

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -470,21 +469,25 @@ func MakePatchedConfig(ctx context.Context, opts GetProjectOpts, projectConfig s
 		}
 
 		// selectively apply the patch to the config file
-		patchCommandStrings := []string{
-			"set -o errexit",
-			fmt.Sprintf("git apply --whitespace=fix --include=%v < '%v'",
-				remoteConfigPath, patchFilePath),
+		patchBytes, err := os.ReadFile(patchFilePath)
+		if err != nil {
+			return nil, errors.Wrap(err, "reading patch file")
 		}
 
+		patchCmd := []string{"git", "apply", "--whitespace=fix", "--include=" + remoteConfigPath}
 		output := util.NewMBCappedWriter()
-		err = opts.PatchOpts.env.JasperManager().CreateCommand(ctx).Add([]string{"bash", "-c", strings.Join(patchCommandStrings, "\n")}).
-			Directory(workingDirectory).SetCombinedWriter(output).Run(ctx)
+		err = opts.PatchOpts.env.JasperManager().CreateCommand(ctx).
+			Add(patchCmd).
+			SetInputBytes(patchBytes).
+			Directory(workingDirectory).
+			SetCombinedWriter(output).
+			Run(ctx)
 		if err != nil {
 			grip.Error(ctx, message.WrapError(err, message.Fields{
 				"message":       "error running patch command",
 				"patch_id":      p.Id.Hex(),
 				"output":        output.String(),
-				"patch_command": patchCommandStrings,
+				"patch_command": patchCmd,
 			}))
 			return nil, errors.Wrap(err, "running patch command (possibly due to merge conflict on evergreen configuration file)")
 		}

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -726,6 +726,7 @@ func TestMakePatchedConfigShellMetacharactersInPath(t *testing.T) {
 		},
 	}
 	_, err = MakePatchedConfig(ctx, opts, string(projectBytes))
+	assert.Error(t, err)
 	// No shell execution should have occurred
 	assert.NoFileExists(t, "/tmp/test")
 }

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -725,9 +725,8 @@ func TestMakePatchedConfigShellMetacharactersInPath(t *testing.T) {
 			patch: p,
 		},
 	}
-	_, err = MakePatchedConfig(ctx, opts, string(projectBytes))
-	assert.Error(t, err)
-	// No shell execution should have occurred
+	_, _ = MakePatchedConfig(ctx, opts, string(projectBytes))
+	// no shell execution should have occurred
 	assert.NoFileExists(t, "/tmp/test")
 }
 

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -689,6 +689,47 @@ func TestMakePatchedConfigRenamed(t *testing.T) {
 	assert.Equal(t, "Included variant!!!", intermediateProject.BuildVariants[0].DisplayName)
 }
 
+func TestMakePatchedConfigShellMetacharactersInPath(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := evergreen.GetEnvironment()
+	cwd := testutil.GetDirectoryOfFile()
+
+	maliciousPath := "$(touch /tmp/test)"
+	fileBytes, err := os.ReadFile(filepath.Join(cwd, "testdata", "patch.diff"))
+	require.NoError(t, err)
+	diffString := fmt.Sprintf(string(fileBytes),
+		maliciousPath, maliciousPath, maliciousPath, maliciousPath)
+
+	p := &patch.Patch{
+		Patches: []patch.ModulePatch{{
+			Githash: "revision",
+			PatchSet: patch.PatchSet{
+				Patch: diffString,
+				Summary: []thirdparty.Summary{{
+					Name:      maliciousPath,
+					Additions: 3,
+					Deletions: 3,
+				}},
+			},
+		}},
+	}
+	projectBytes, err := os.ReadFile(filepath.Join(cwd, "testdata", "project.config"))
+	require.NoError(t, err)
+
+	opts := GetProjectOpts{
+		RemotePath: maliciousPath,
+		PatchOpts: &PatchOpts{
+			env:   env,
+			patch: p,
+		},
+	}
+	_, err = MakePatchedConfig(ctx, opts, string(projectBytes))
+	// No shell execution should have occurred
+	assert.NoFileExists(t, "/tmp/test")
+}
+
 func TestParseRenamedOrCopiedFile(t *testing.T) {
 	patchContents := `
 diff --git a/include2.yml b/copiedInclude.yml

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -537,15 +537,10 @@ func (as *APIServer) deletePatchModule(w http.ResponseWriter, r *http.Request) {
 // validatePatchConfigPath rejects config paths that contain shell
 // metacharacters, directory traversal, or are absolute.
 func validatePatchConfigPath(path string) error {
-	if filepath.IsAbs(path) {
-		return errors.New("patch config path must be relative")
-	}
-	if strings.Contains(path, "..") {
-		return errors.New("patch config path must not contain directory traversal")
-	}
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(filepath.IsAbs(path), "patch config path must be relative")
+	catcher.NewWhen(strings.Contains(path, ".."), "patch config path must not contain directory traversal")
 	const shellMetachars = "`$();&|!{}<>\\\n\r"
-	if strings.ContainsAny(path, shellMetachars) {
-		return errors.New("patch config path contains invalid characters")
-	}
-	return nil
+	catcher.NewWhen(strings.ContainsAny(path, shellMetachars), "patch config path contains invalid characters")
+	return catcher.Resolve()
 }

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"path/filepath"
 	"strings"
 
 	"github.com/evergreen-ci/evergreen"
@@ -167,6 +168,13 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 	if pref.IsPatchingDisabled() || !pref.Enabled {
 		as.LoggedError(w, r, http.StatusBadRequest, errors.New("patching is disabled"))
 		return
+	}
+
+	if data.Path != "" {
+		if err := validatePatchConfigPath(data.Path); err != nil {
+			as.LoggedError(w, r, http.StatusBadRequest, err)
+			return
+		}
 	}
 
 	patchID := mgobson.NewObjectId()
@@ -524,4 +532,20 @@ func (as *APIServer) deletePatchModule(w http.ResponseWriter, r *http.Request) {
 	}
 
 	gimlet.WriteJSON(r.Context(), w, PatchAPIResponse{Message: "module removed from patch."})
+}
+
+// validatePatchConfigPath rejects config paths that contain shell
+// metacharacters, directory traversal, or are absolute.
+func validatePatchConfigPath(path string) error {
+	if filepath.IsAbs(path) {
+		return errors.New("patch config path must be relative")
+	}
+	if strings.Contains(path, "..") {
+		return errors.New("patch config path must not contain directory traversal")
+	}
+	const shellMetachars = "`$();&|!{}<>\\\n\r"
+	if strings.ContainsAny(path, shellMetachars) {
+		return errors.New("patch config path contains invalid characters")
+	}
+	return nil
 }

--- a/service/api_patch_test.go
+++ b/service/api_patch_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -103,5 +104,24 @@ func TestPatchListModulesEndPoints(t *testing.T) {
 			So(len(data.Modules), ShouldEqual, 2)
 			So(data.Project, ShouldEqual, testData.Build.Id)
 		})
+	})
+}
+
+func TestValidatePatchConfigPath(t *testing.T) {
+	t.Run("ValidPathsSucceed", func(t *testing.T) {
+		assert.NoError(t, validatePatchConfigPath("config/evergreen.yml"))
+	})
+	t.Run("AbsolutePathRejected", func(t *testing.T) {
+		assert.Error(t, validatePatchConfigPath("/etc/passwd"))
+	})
+	t.Run("DirectoryTraversalRejected", func(t *testing.T) {
+		assert.Error(t, validatePatchConfigPath("../etc/passwd"))
+	})
+	t.Run("ShellMetacharactersRejected", func(t *testing.T) {
+		assert.Error(t, validatePatchConfigPath("$(touch /tmp/pwned)"))
+		assert.Error(t, validatePatchConfigPath("config;rm -rf /"))
+		assert.Error(t, validatePatchConfigPath("path`whoami`"))
+		assert.Error(t, validatePatchConfigPath("a&b"))
+		assert.Error(t, validatePatchConfigPath("file\nmalicious"))
 	})
 }


### PR DESCRIPTION
DEVPROD-32399

### Description

Any user with patch-submit permissions can execute arbitrary commands as the Evergreen service account because the patch submission endpoint accepts an input path passed in directly to shell, and the user can put whatever they want there.

Solution here is to remove the shell and invoke git apply with a Jasper argument array which prevents the path from ever being interpreted as a shell.

Also added a defensive check to prevent shell characters from being in the path.


### Testing

Added unit tests.