### PR TITLE
DEVPROD-32660 Verify task project access when spawning hosts

### DIFF
--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -150,15 +150,24 @@ func (h *hostIDGetHandler) Run(ctx context.Context) gimlet.Responder {
 
 	var runningTask *task.Task
 	if foundHost.RunningTask != "" {
-		runningTask, err = task.FindOneIdAndExecution(ctx, foundHost.RunningTask, foundHost.RunningTaskExecution)
+		t, err := task.FindOneIdAndExecution(ctx, foundHost.RunningTask, foundHost.RunningTaskExecution)
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding host's running task '%s' execution '%d'", foundHost.RunningTask, foundHost.RunningTaskExecution))
 		}
-		if runningTask == nil {
+		if t == nil {
 			return gimlet.MakeJSONInternalErrorResponder(gimlet.ErrorResponse{
 				StatusCode: http.StatusNotFound,
 				Message:    fmt.Sprintf("host's running task '%s' execution '%d' not found", foundHost.RunningTask, foundHost.RunningTaskExecution),
 			})
+		}
+		u := MustHaveUser(ctx)
+		if u.HasPermission(ctx, gimlet.PermissionOpts{
+			Resource:      t.Project,
+			ResourceType:  evergreen.ProjectResourceType,
+			Permission:    evergreen.PermissionTasks,
+			RequiredLevel: evergreen.TasksView.Value,
+		}) {
+			runningTask = t
 		}
 	}
 	hostModel := &model.APIHost{}
@@ -287,12 +296,25 @@ func (hgh *hostGetHandler) Run(ctx context.Context) gimlet.Responder {
 		tasksById[t.Id] = t
 	}
 
+	u := MustHaveUser(ctx)
+	projectPermitted := make(map[string]bool)
+	for _, t := range tasks {
+		if _, checked := projectPermitted[t.Project]; !checked {
+			projectPermitted[t.Project] = u.HasPermission(ctx, gimlet.PermissionOpts{
+				Resource:      t.Project,
+				ResourceType:  evergreen.ProjectResourceType,
+				Permission:    evergreen.PermissionTasks,
+				RequiredLevel: evergreen.TasksView.Value,
+			})
+		}
+	}
+
 	for _, h := range hosts {
 		apiHost := &model.APIHost{}
 		var runningTask *task.Task
 		if h.RunningTask != "" {
 			t, ok := tasksById[h.RunningTask]
-			if ok {
+			if ok && projectPermitted[t.Project] {
 				runningTask = &t
 			}
 		}

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -296,16 +296,19 @@ func (hgh *hostGetHandler) Run(ctx context.Context) gimlet.Responder {
 		tasksById[t.Id] = t
 	}
 
-	u := MustHaveUser(ctx)
-	projectPermitted := make(map[string]bool)
-	for _, t := range tasks {
-		if _, checked := projectPermitted[t.Project]; !checked {
-			projectPermitted[t.Project] = u.HasPermission(ctx, gimlet.PermissionOpts{
-				Resource:      t.Project,
-				ResourceType:  evergreen.ProjectResourceType,
-				Permission:    evergreen.PermissionTasks,
-				RequiredLevel: evergreen.TasksView.Value,
-			})
+	var projectPermitted map[string]bool
+	if len(taskIds) > 0 {
+		u := MustHaveUser(ctx)
+		projectPermitted = make(map[string]bool)
+		for _, t := range tasks {
+			if _, checked := projectPermitted[t.Project]; !checked {
+				projectPermitted[t.Project] = u.HasPermission(ctx, gimlet.PermissionOpts{
+					Resource:      t.Project,
+					ResourceType:  evergreen.ProjectResourceType,
+					Permission:    evergreen.PermissionTasks,
+					RequiredLevel: evergreen.TasksView.Value,
+				})
+			}
 		}
 	}
 

--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -13,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
@@ -87,6 +88,27 @@ func (hph *hostPostHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 				StatusCode: http.StatusForbidden,
 				Message:    errors.Errorf("not authorized to spawn admin-only distro '%s'", hph.options.DistroID).Error(),
+			})
+		}
+	}
+
+	if hph.options.TaskID != "" {
+		projectID, err := task.FindProjectForTask(ctx, hph.options.TaskID)
+		if err != nil {
+			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+				StatusCode: http.StatusNotFound,
+				Message:    fmt.Sprintf("task '%s' not found", hph.options.TaskID),
+			})
+		}
+		if !user.HasPermission(ctx, gimlet.PermissionOpts{
+			Resource:      projectID,
+			ResourceType:  evergreen.ProjectResourceType,
+			Permission:    evergreen.PermissionTasks,
+			RequiredLevel: evergreen.TasksView.Value,
+		}) {
+			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+				StatusCode: http.StatusForbidden,
+				Message:    fmt.Sprintf("user '%s' does not have permission to view tasks in project '%s'", user.Id, projectID),
 			})
 		}
 	}

--- a/rest/route/host_spawn_test.go
+++ b/rest/route/host_spawn_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
@@ -40,6 +41,28 @@ func TestHostPostHandler(t *testing.T) {
 
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro){
 		"SpawnsHostForTask": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			tsk := &task.Task{
+				Id:      "task",
+				Project: "my-project",
+			}
+			require.NoError(t, tsk.Insert(ctx))
+
+			projectScope := gimlet.Scope{
+				ID:        "my_project_scope",
+				Name:      "my project scope",
+				Type:      evergreen.ProjectResourceType,
+				Resources: []string{"my-project"},
+			}
+			require.NoError(t, env.RoleManager().AddScope(ctx, projectScope))
+			taskViewRole := gimlet.Role{
+				ID:          "task_view_role",
+				Name:        "task view",
+				Scope:       projectScope.ID,
+				Permissions: map[string]int{evergreen.PermissionTasks: evergreen.TasksView.Value},
+			}
+			require.NoError(t, env.RoleManager().UpdateRole(ctx, taskViewRole))
+			require.NoError(t, u.AddRole(ctx, taskViewRole.ID))
+
 			rh.options.TaskID = "task"
 			rh.options.KeyName = "ssh-rsa YWJjZDEyMzQK"
 
@@ -246,11 +269,53 @@ func TestHostPostHandler(t *testing.T) {
 			require.NotZero(t, resp)
 			assert.NotEqual(t, http.StatusOK, resp.Status(), resp.Data())
 		},
+		"RejectsSpawnWithTaskFromUnauthorizedProject": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			tsk := &task.Task{
+				Id:      "secret-task",
+				Project: "secret-project",
+			}
+			require.NoError(t, tsk.Insert(ctx))
+
+			rh.options.TaskID = "secret-task"
+
+			resp := rh.Run(ctx)
+			require.NotZero(t, resp)
+			assert.Equal(t, http.StatusForbidden, resp.Status(), resp.Data())
+		},
+		"AllowsSpawnWithTaskFromAuthorizedProject": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			tsk := &task.Task{
+				Id:      "my-task",
+				Project: "my-project",
+			}
+			require.NoError(t, tsk.Insert(ctx))
+
+			projectScope := gimlet.Scope{
+				ID:        "my_project_scope",
+				Name:      "my project scope",
+				Type:      evergreen.ProjectResourceType,
+				Resources: []string{"my-project"},
+			}
+			require.NoError(t, env.RoleManager().AddScope(ctx, projectScope))
+			taskViewRole := gimlet.Role{
+				ID:          "task_view_role",
+				Name:        "task view",
+				Scope:       projectScope.ID,
+				Permissions: map[string]int{evergreen.PermissionTasks: evergreen.TasksView.Value},
+			}
+			require.NoError(t, env.RoleManager().UpdateRole(ctx, taskViewRole))
+			require.NoError(t, u.AddRole(ctx, taskViewRole.ID))
+
+			rh.options.TaskID = "my-task"
+
+			resp := rh.Run(ctx)
+			require.NotZero(t, resp)
+			assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
+		},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			ctx := t.Context()
 
-			require.NoError(t, db.ClearCollections(distro.Collection, host.Collection))
+			require.NoError(t, db.ClearCollections(distro.Collection, host.Collection, task.Collection))
 			env := &mock.Environment{}
 			assert.NoError(t, env.Configure(ctx))
 			env.EvergreenSettings.Spawnhost.SpawnHostsPerUser = 10

--- a/rest/route/host_spawn_test.go
+++ b/rest/route/host_spawn_test.go
@@ -315,7 +315,7 @@ func TestHostPostHandler(t *testing.T) {
 		t.Run(tName, func(t *testing.T) {
 			ctx := t.Context()
 
-			require.NoError(t, db.ClearCollections(distro.Collection, host.Collection, task.Collection))
+			require.NoError(t, db.ClearCollections(distro.Collection, host.Collection, task.Collection, user.Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
 			env := &mock.Environment{}
 			assert.NoError(t, env.Configure(ctx))
 			env.EvergreenSettings.Spawnhost.SpawnHostsPerUser = 10
@@ -350,6 +350,7 @@ func TestHostPostHandler(t *testing.T) {
 				Id:       "user",
 				Settings: user.UserSettings{Timezone: "Asia/Macau"},
 			}
+			require.NoError(t, u.Insert(ctx))
 			ctx = gimlet.AttachUser(ctx, u)
 
 			tCase(ctx, t, env, rh, u, d)


### PR DESCRIPTION
DEVPROD-32660


### Description

Spawning a host with a task ID now checks that the caller has task view permission on the appropriate project. Previously anybody could reference any task ID, which would allow them to get a GitHub token for that project, even if they didn't have the right permissions.

Also updated `GET /hosts` to redact running task details when the caller lacks permission to the project.

### Testing

Added unit tests.