### PR TITLE
DEVPROD-27187 Prevent createHostJob from un-decommissioning hosts

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -2069,6 +2069,15 @@ func (h *Host) MarkReachable(ctx context.Context) error {
 		return nil
 	}
 
+	if utility.StringSliceContains(evergreen.DownHostStatus, h.Status) {
+		grip.Info(ctx, message.Fields{
+			"message": "not marking host as reachable because it is in a down status",
+			"host_id": h.Id,
+			"status":  h.Status,
+		})
+		return nil
+	}
+
 	return h.setStatusAndFields(ctx, evergreen.HostRunning, nil, nil, nil, evergreen.User, "host marked reachable")
 }
 

--- a/units/host_monitoring_check.go
+++ b/units/host_monitoring_check.go
@@ -165,6 +165,18 @@ func handleExternallyTerminatedHost(ctx context.Context, id string, env evergree
 
 	switch cloudInfo.Status {
 	case cloud.StatusRunning:
+		if utility.StringSliceContains(evergreen.DownHostStatus, h.Status) {
+			// The host is intentionally being taken down; the cloud instance
+			// being alive is transient and the termination job will clean it up.
+			grip.Info(ctx, message.Fields{
+				"op_id":   id,
+				"message": "not updating status of down host that is still running in the cloud",
+				"status":  h.Status,
+				"host_id": h.Id,
+				"distro":  h.Distro.Id,
+			})
+			return false, nil
+		}
 		userDataProvisioning := h.Distro.BootstrapSettings.Method == distro.BootstrapMethodUserData && h.Status == evergreen.HostStarting
 		if h.Status != evergreen.HostRunning && !userDataProvisioning {
 			grip.Info(ctx, message.Fields{

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -497,6 +497,34 @@ func (j *createHostJob) spawnAndReplaceHost(ctx context.Context, cloudMgr cloud.
 // the real host already exists. If both of those fail, it will attempt to
 // terminate the cloud host.
 func (j *createHostJob) tryHostReplacement(ctx context.Context, cloudMgr cloud.Manager) (replaced bool, err error) {
+	// Re-read the intent host to check if it was decommissioned while waiting
+	// for the cloud provider to create the instance. If so, terminate the new
+	// instance rather than registering it as a starting host.
+	intentHost, err := host.FindOneId(ctx, j.HostID)
+	if err != nil {
+		return false, errors.Wrapf(err, "re-reading intent host '%s'", j.HostID)
+	}
+	if intentHost != nil && utility.StringSliceContains(evergreen.DownHostStatus, intentHost.Status) {
+		grip.Info(ctx, message.Fields{
+			"message":        "not registering spawned host because intent host is already down",
+			"host_id":        j.host.Id,
+			"intent_host_id": j.HostID,
+			"status":         intentHost.Status,
+			"job":            j.ID(),
+		})
+		terminateCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		grip.Error(ctx, message.WrapError(cloudMgr.TerminateInstance(terminateCtx, j.host, evergreen.User, "intent host was already down when cloud host was ready to register"), message.Fields{
+			"message":        "could not terminate cloud host spawned for down intent host",
+			"host_id":        j.host.Id,
+			"intent_host_id": j.HostID,
+			"distro":         j.host.Distro.Id,
+			"provider":       j.host.Provider,
+			"job":            j.ID(),
+		}))
+		return false, nil
+	}
+
 	if err = host.UnsafeReplace(ctx, j.env, j.HostID, j.host); err == nil {
 		return true, nil
 	}

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -498,34 +498,29 @@ func (j *createHostJob) spawnAndReplaceHost(ctx context.Context, cloudMgr cloud.
 // terminate the cloud host.
 func (j *createHostJob) tryHostReplacement(ctx context.Context, cloudMgr cloud.Manager) (replaced bool, err error) {
 	// Re-read the intent host to check if it was decommissioned while waiting
-	// for the cloud provider to create the instance. If so, terminate the new
-	// instance rather than registering it as a starting host.
+	// for the cloud provider to create the instance. If so, propagate the down
+	// status onto the spawned host so it gets recorded in the DB with its real
+	// instance ID (for traceability and billing) but is immediately picked up
+	// by FindHostsToTerminate rather than running tasks.
 	intentHost, err := host.FindOneId(ctx, j.HostID)
 	if err != nil {
 		return false, errors.Wrapf(err, "re-reading intent host '%s'", j.HostID)
 	}
 	if intentHost != nil && utility.StringSliceContains(evergreen.DownHostStatus, intentHost.Status) {
 		grip.Info(ctx, message.Fields{
-			"message":        "not registering spawned host because intent host is already down",
+			"message":        "recording spawned host as down because intent host was already down",
 			"host_id":        j.host.Id,
 			"intent_host_id": j.HostID,
 			"status":         intentHost.Status,
 			"job":            j.ID(),
 		})
-		terminateCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
-		defer cancel()
-		grip.Error(ctx, message.WrapError(cloudMgr.TerminateInstance(terminateCtx, j.host, evergreen.User, "intent host was already down when cloud host was ready to register"), message.Fields{
-			"message":        "could not terminate cloud host spawned for down intent host",
-			"host_id":        j.host.Id,
-			"intent_host_id": j.HostID,
-			"distro":         j.host.Distro.Id,
-			"provider":       j.host.Provider,
-			"job":            j.ID(),
-		}))
-		return false, nil
+		j.host.Status = intentHost.Status
 	}
 
 	if err = host.UnsafeReplace(ctx, j.env, j.HostID, j.host); err == nil {
+		if utility.StringSliceContains(evergreen.DownHostStatus, j.host.Status) {
+			return false, nil
+		}
 		return true, nil
 	}
 


### PR DESCRIPTION
DEVPROD-27187

### Description

Fixes a race in `createHostJob` where an EC2 instance could be created and registered as a `starting` host after the intent host had been decommissioned for taking too long; this causes an issue for analytics since they're referencing the first "terminated" job as when the host was terminated". 

### Testing
Difficult to test given that it depends on a race, but verified that tryHostReplacement doesn't change the status if its already down.
