### PR TITLE
DEVPROD-34975 Gitignore Claude Code local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ evergreen
 # Agent related files
 CLAUDE.local.md
 .claude/scheduled_tasks.lock
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
## Summary
DEVPROD-34975

Adds two Claude Code-generated local files to `.gitignore` alongside the existing agent-related entries:
- `.claude/settings.local.json` — personal settings overrides
- `.claude/worktrees/` — ephemeral worktree session state

## Testing
N/A — `.gitignore` only change.