### PR TITLE
DEVPROD-31178 Harden legacy version and project routes

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -3297,6 +3297,14 @@ func (p *ProjectRef) CommitQueueIsOn() error {
 	return catcher.Resolve()
 }
 
+// RedactSecrets clears out sensitive fields.
+func (p *ProjectRef) RedactSecrets() {
+	p.BuildBaronSettings.BFSuggestionPassword = ""
+	p.BuildBaronSettings.BFSuggestionUsername = ""
+	p.TaskAnnotationSettings = evergreen.AnnotationsSettings{}
+	p.WorkstationConfig = WorkstationConfig{}
+}
+
 func GetProjectRefForTask(ctx context.Context, taskId string) (*ProjectRef, error) {
 	t, err := task.FindOneId(ctx, taskId)
 	if err != nil {

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -788,8 +788,6 @@ func (p *APIProjectRef) BuildPublicFields(ctx context.Context, projectRef model.
 
 	buildbaronConfig := APIBuildBaronSettings{}
 	buildbaronConfig.BuildFromService(projectRef.BuildBaronSettings)
-	buildbaronConfig.BFSuggestionPassword = nil
-	buildbaronConfig.BFSuggestionUsername = nil
 	p.BuildBaronSettings = buildbaronConfig
 
 	projectBanner := APIProjectBanner{}

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -788,6 +788,8 @@ func (p *APIProjectRef) BuildPublicFields(ctx context.Context, projectRef model.
 
 	buildbaronConfig := APIBuildBaronSettings{}
 	buildbaronConfig.BuildFromService(projectRef.BuildBaronSettings)
+	buildbaronConfig.BFSuggestionPassword = nil
+	buildbaronConfig.BFSuggestionUsername = nil
 	p.BuildBaronSettings = buildbaronConfig
 
 	projectBanner := APIProjectBanner{}

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -119,6 +119,8 @@ func (p *projectGetHandler) Run(ctx context.Context) gimlet.Responder {
 		if err = projectModel.BuildPublicFields(ctx, proj); err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "converting project '%s' to API model", proj.Id))
 		}
+		projectModel.BuildBaronSettings.BFSuggestionPassword = nil
+		projectModel.BuildBaronSettings.BFSuggestionUsername = nil
 		if err = resp.AddData(projectModel); err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "adding response data for project '%s'", utility.FromStringPtr(projectModel.Id)))
 		}

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -113,14 +113,13 @@ func (p *projectGetHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	projects = projects[:lastIndex]
-	for _, proj := range projects {
+	for i := range projects {
+		projects[i].RedactSecrets()
 		projectModel := &model.APIProjectRef{}
 		// Because this is route to accessible to non-admins, only return basic fields.
-		if err = projectModel.BuildPublicFields(ctx, proj); err != nil {
-			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "converting project '%s' to API model", proj.Id))
+		if err = projectModel.BuildPublicFields(ctx, projects[i]); err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "converting project '%s' to API model", projects[i].Id))
 		}
-		projectModel.BuildBaronSettings.BFSuggestionPassword = nil
-		projectModel.BuildBaronSettings.BFSuggestionUsername = nil
 		if err = resp.AddData(projectModel); err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "adding response data for project '%s'", utility.FromStringPtr(projectModel.Id)))
 		}

--- a/service/api.go
+++ b/service/api.go
@@ -162,6 +162,9 @@ func (as *APIServer) listProjects(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
+	for i := range allProjs {
+		allProjs[i].RedactSecrets()
+	}
 	gimlet.WriteJSON(r.Context(), w, allProjs)
 }
 

--- a/service/rest_version.go
+++ b/service/rest_version.go
@@ -386,6 +386,21 @@ func (restapi restAPI) modifyVersionInfo(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	if projCtx.ProjectRef == nil {
+		gimlet.WriteJSONResponse(r.Context(), w, http.StatusNotFound, responseError{Message: "project not found for version"})
+		return
+	}
+	opts := gimlet.PermissionOpts{
+		Resource:      projCtx.ProjectRef.Id,
+		ResourceType:  evergreen.ProjectResourceType,
+		Permission:    evergreen.PermissionTasks,
+		RequiredLevel: evergreen.TasksBasic.Value,
+	}
+	if !user.HasPermission(r.Context(), opts) {
+		gimlet.WriteJSONResponse(r.Context(), w, http.StatusUnauthorized, responseError{Message: "not authorized to modify this version"})
+		return
+	}
+
 	input := struct {
 		Activated *bool `json:"activated"`
 	}{}

--- a/service/rest_version_test.go
+++ b/service/rest_version_test.go
@@ -20,6 +20,7 @@ import (
 	modelutil "github.com/evergreen-ci/evergreen/model/testutil"
 	"github.com/evergreen-ci/evergreen/model/user"
 	serviceutil "github.com/evergreen-ci/evergreen/service/testutil"
+	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/require"
@@ -409,6 +410,9 @@ func TestGetVersionInfoViaRevision(t *testing.T) {
 }
 
 func TestActivateVersion(t *testing.T) {
+	testutil.DisablePermissionsForTests()
+	defer testutil.EnablePermissionsForTests()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	env := &mock.Environment{}
@@ -418,11 +422,18 @@ func TestActivateVersion(t *testing.T) {
 	require.NoError(t, err, "error setting up router")
 
 	Convey("When marking a particular version as active", t, func() {
-		require.NoError(t, db.ClearCollections(model.VersionCollection, build.Collection),
+		require.NoError(t, db.ClearCollections(model.VersionCollection, build.Collection, model.ProjectRefCollection),
 			"Error clearing collections")
 
 		versionId := "my-version"
 		projectName := "project_test"
+
+		pRef := &model.ProjectRef{
+			Id:         projectName,
+			Identifier: projectName,
+			Enabled:    true,
+		}
+		So(pRef.Insert(t.Context()), ShouldBeNil)
 
 		build := &build.Build{
 			Id:           "some-build-id",
@@ -536,6 +547,52 @@ func TestActivateVersion(t *testing.T) {
 			So(response.Code, ShouldEqual, http.StatusUnauthorized)
 		})
 	})
+}
+
+func TestActivateVersionUnauthorized(t *testing.T) {
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(t.Context()))
+	env.SetUserManager(serviceutil.MockUserManager{})
+	router, err := newAuthTestUIRouter(t.Context(), env)
+	require.NoError(t, err)
+
+	require.NoError(t, db.ClearCollections(model.VersionCollection, build.Collection, model.ProjectRefCollection))
+
+	projectName := "project_test"
+	versionId := "my-version"
+
+	pRef := &model.ProjectRef{
+		Id:         projectName,
+		Identifier: projectName,
+		Enabled:    true,
+	}
+	require.NoError(t, pRef.Insert(t.Context()))
+
+	b := &build.Build{
+		Id:           "some-build-id",
+		BuildVariant: "some-build-variant",
+	}
+	require.NoError(t, b.Insert(t.Context()))
+
+	v := &model.Version{
+		Id:         versionId,
+		Identifier: projectName,
+		BuildIds:   []string{b.Id},
+		Requester:  evergreen.RepotrackerVersionRequester,
+	}
+	require.NoError(t, v.Insert(t.Context()))
+
+	body, err := json.Marshal(map[string]any{"activated": true})
+	require.NoError(t, err)
+
+	request, err := http.NewRequest("PATCH", "/rest/v1/versions/"+versionId, bytes.NewReader(body))
+	require.NoError(t, err)
+	request.AddCookie(&http.Cookie{Name: evergreen.AuthTokenCookie, Value: "token"})
+
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	require.Equal(t, http.StatusUnauthorized, response.Code)
 }
 
 func TestGetVersionStatus(t *testing.T) {


### PR DESCRIPTION
DEVPROD-31178

### Description

Security improvements for the legacy modify version and get projects route.

Project route:
- Don't include BB or webhook secrets in the response

Version route:
- Verify the user has permission to modify the version's project (the REST v2 endpoint already enforces this)


### Testing

Added a unit test.
