### PR TITLE
DEVPROD-34996: Complete UserLite type

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -100,7 +100,7 @@ models:
   BannerTheme:
     model: github.com/evergreen-ci/evergreen.BannerTheme
   BetaFeatures:
-    model: github.com/evergreen-ci/evergreen/rest/model.APIBetaFeatures
+    model: github.com/evergreen-ci/evergreen.BetaFeatures
   BetaFeaturesInput:
     model: github.com/evergreen-ci/evergreen/rest/model.APIBetaFeatures
   BooleanMap:
@@ -542,7 +542,7 @@ models:
   ParserProjectS3ConfigInput:
     model: github.com/evergreen-ci/evergreen/rest/model.APIParserProjectS3Config
   ParsleyFilter:
-    model: github.com/evergreen-ci/evergreen/rest/model.APIParsleyFilter
+    model: github.com/evergreen-ci/evergreen/model/parsley.Filter
   ParsleyFilterInput:
     model: github.com/evergreen-ci/evergreen/rest/model.APIParsleyFilter
   Patch:

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -22,6 +22,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/model/parsley"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/model"
@@ -71,6 +72,7 @@ type ResolverRoot interface {
 	ProjectTasksPair() ProjectTasksPairResolver
 	ProjectVars() ProjectVarsResolver
 	Query() QueryResolver
+	RepoRef() RepoRefResolver
 	RepoSettings() RepoSettingsResolver
 	SleepSchedule() SleepScheduleResolver
 	SpruceConfig() SpruceConfigResolver
@@ -78,7 +80,9 @@ type ResolverRoot interface {
 	Task() TaskResolver
 	TaskLogs() TaskLogsResolver
 	TicketFields() TicketFieldsResolver
+	UIConfig() UIConfigResolver
 	User() UserResolver
+	UserLite() UserLiteResolver
 	Version() VersionResolver
 	VersionLite() VersionLiteResolver
 	Volume() VolumeResolver
@@ -1229,6 +1233,7 @@ type ComplexityRoot struct {
 		Tasks                 func(childComplexity int) int
 		Time                  func(childComplexity int) int
 		User                  func(childComplexity int) int
+		UserLite              func(childComplexity int) int
 		Variants              func(childComplexity int) int
 		VariantsTasks         func(childComplexity int) int
 		Version               func(childComplexity int) int
@@ -1536,6 +1541,7 @@ type ComplexityRoot struct {
 		TaskTestSample           func(childComplexity int, versionID string, taskIds []string, filters []*TestFilter) int
 		User                     func(childComplexity int, userID *string) int
 		UserConfig               func(childComplexity int) int
+		UserLite                 func(childComplexity int, userID *string) int
 		VariantQuarantineStatus  func(childComplexity int, projectIdentifier string, buildVariant string) int
 		Version                  func(childComplexity int, versionID string) int
 		ViewableProjectRefs      func(childComplexity int) int
@@ -2267,9 +2273,17 @@ type ComplexityRoot struct {
 	}
 
 	UserLite struct {
-		DispName     func(childComplexity int) int
-		EmailAddress func(childComplexity int) int
-		Id           func(childComplexity int) int
+		BetaFeatures              func(childComplexity int) int
+		DispName                  func(childComplexity int) int
+		EmailAddress              func(childComplexity int) int
+		HasTokenExchangePending   func(childComplexity int) int
+		Id                        func(childComplexity int) int
+		ParsleyFilters            func(childComplexity int) int
+		Patches                   func(childComplexity int, patchesInput PatchesInput) int
+		Permissions               func(childComplexity int) int
+		Settings                  func(childComplexity int) int
+		Subscriptions             func(childComplexity int) int
+		TokenAccessTokenExpiresAt func(childComplexity int) int
 	}
 
 	UserServiceFlags struct {
@@ -2342,6 +2356,7 @@ type ComplexityRoot struct {
 		Tasks                    func(childComplexity int, options TaskFilterOptions) int
 		UpstreamProject          func(childComplexity int) int
 		User                     func(childComplexity int) int
+		UserLite                 func(childComplexity int) int
 		VersionTiming            func(childComplexity int) int
 		Warnings                 func(childComplexity int) int
 		WaterfallBuilds          func(childComplexity int) int
@@ -2606,6 +2621,7 @@ type PatchResolver interface {
 	TaskStatuses(ctx context.Context, obj *model.APIPatch) ([]string, error)
 	Time(ctx context.Context, obj *model.APIPatch) (*PatchTime, error)
 	User(ctx context.Context, obj *model.APIPatch) (*model.APIDBUser, error)
+	UserLite(ctx context.Context, obj *model.APIPatch) (*user.DBUser, error)
 
 	Version(ctx context.Context, obj *model.APIPatch) (*model1.Version, error)
 	VersionFull(ctx context.Context, obj *model.APIPatch) (*model.APIVersion, error)
@@ -2627,6 +2643,7 @@ type PermissionsResolver interface {
 type ProjectResolver interface {
 	IsFavorite(ctx context.Context, obj *model.APIProjectRef) (bool, error)
 
+	ParsleyFilters(ctx context.Context, obj *model.APIProjectRef) ([]*parsley.Filter, error)
 	Patches(ctx context.Context, obj *model.APIProjectRef, patchesInput PatchesInput) (*Patches, error)
 }
 type ProjectLiteResolver interface {
@@ -2684,6 +2701,7 @@ type QueryResolver interface {
 	VariantQuarantineStatus(ctx context.Context, projectIdentifier string, buildVariant string) (*model.APIVariantQuarantineStatus, error)
 	MyPublicKeys(ctx context.Context) ([]*model.APIPubKey, error)
 	User(ctx context.Context, userID *string) (*model.APIDBUser, error)
+	UserLite(ctx context.Context, userID *string) (*user.DBUser, error)
 	UserConfig(ctx context.Context) (*UserConfig, error)
 	BuildVariantsForTaskName(ctx context.Context, projectIdentifier string, taskName string) ([]*task.BuildVariantTuple, error)
 	MainlineCommits(ctx context.Context, options MainlineCommitsOptions, buildVariantOptions *BuildVariantOptions) (*MainlineCommits, error)
@@ -2695,6 +2713,9 @@ type QueryResolver interface {
 	Version(ctx context.Context, versionID string) (*model.APIVersion, error)
 	Image(ctx context.Context, imageID string) (*model.APIImage, error)
 	Images(ctx context.Context) ([]string, error)
+}
+type RepoRefResolver interface {
+	ParsleyFilters(ctx context.Context, obj *model.APIProjectRef) ([]*parsley.Filter, error)
 }
 type RepoSettingsResolver interface {
 	Aliases(ctx context.Context, obj *model.APIProjectSettings) ([]*model.APIProjectAlias, error)
@@ -2800,11 +2821,26 @@ type TicketFieldsResolver interface {
 
 	ResolutionName(ctx context.Context, obj *thirdparty.TicketFields) (*string, error)
 }
+type UIConfigResolver interface {
+	BetaFeatures(ctx context.Context, obj *model.APIUIConfig) (*evergreen.BetaFeatures, error)
+}
 type UserResolver interface {
+	BetaFeatures(ctx context.Context, obj *model.APIDBUser) (*evergreen.BetaFeatures, error)
+
+	ParsleyFilters(ctx context.Context, obj *model.APIDBUser) ([]*parsley.Filter, error)
 	Patches(ctx context.Context, obj *model.APIDBUser, patchesInput PatchesInput) (*Patches, error)
 	Permissions(ctx context.Context, obj *model.APIDBUser) (*Permissions, error)
 
 	Subscriptions(ctx context.Context, obj *model.APIDBUser) ([]*model.APISubscription, error)
+}
+type UserLiteResolver interface {
+	HasTokenExchangePending(ctx context.Context, obj *user.DBUser) (bool, error)
+
+	Patches(ctx context.Context, obj *user.DBUser, patchesInput PatchesInput) (*Patches, error)
+	Permissions(ctx context.Context, obj *user.DBUser) (*Permissions, error)
+	Settings(ctx context.Context, obj *user.DBUser) (*model.APIUserSettings, error)
+	Subscriptions(ctx context.Context, obj *user.DBUser) ([]*model.APISubscription, error)
+	TokenAccessTokenExpiresAt(ctx context.Context, obj *user.DBUser) (*time.Time, error)
 }
 type VersionResolver interface {
 	BaseVersion(ctx context.Context, obj *model.APIVersion) (*model.APIVersion, error)
@@ -2834,6 +2870,7 @@ type VersionResolver interface {
 	TaskStatusStats(ctx context.Context, obj *model.APIVersion, options BuildVariantOptions) (*task.TaskStats, error)
 	UpstreamProject(ctx context.Context, obj *model.APIVersion) (*UpstreamProject, error)
 	User(ctx context.Context, obj *model.APIVersion) (*model.APIDBUser, error)
+	UserLite(ctx context.Context, obj *model.APIVersion) (*user.DBUser, error)
 	VersionTiming(ctx context.Context, obj *model.APIVersion) (*VersionTiming, error)
 	Warnings(ctx context.Context, obj *model.APIVersion) ([]string, error)
 	WaterfallBuilds(ctx context.Context, obj *model.APIVersion) ([]*model1.WaterfallBuild, error)
@@ -7719,6 +7756,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Patch.User(childComplexity), true
+	case "Patch.userLite":
+		if e.complexity.Patch.UserLite == nil {
+			break
+		}
+
+		return e.complexity.Patch.UserLite(childComplexity), true
 	case "Patch.variants":
 		if e.complexity.Patch.Variants == nil {
 			break
@@ -9306,6 +9349,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Query.UserConfig(childComplexity), true
+	case "Query.userLite":
+		if e.complexity.Query.UserLite == nil {
+			break
+		}
+
+		args, err := ec.field_Query_userLite_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.UserLite(childComplexity, args["userId"].(*string)), true
 	case "Query.variantQuarantineStatus":
 		if e.complexity.Query.VariantQuarantineStatus == nil {
 			break
@@ -12306,6 +12360,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.UserConfig.User(childComplexity), true
 
+	case "UserLite.betaFeatures":
+		if e.complexity.UserLite.BetaFeatures == nil {
+			break
+		}
+
+		return e.complexity.UserLite.BetaFeatures(childComplexity), true
 	case "UserLite.displayName":
 		if e.complexity.UserLite.DispName == nil {
 			break
@@ -12318,12 +12378,59 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.UserLite.EmailAddress(childComplexity), true
+	case "UserLite.hasTokenExchangePending":
+		if e.complexity.UserLite.HasTokenExchangePending == nil {
+			break
+		}
+
+		return e.complexity.UserLite.HasTokenExchangePending(childComplexity), true
 	case "UserLite.id":
 		if e.complexity.UserLite.Id == nil {
 			break
 		}
 
 		return e.complexity.UserLite.Id(childComplexity), true
+	case "UserLite.parsleyFilters":
+		if e.complexity.UserLite.ParsleyFilters == nil {
+			break
+		}
+
+		return e.complexity.UserLite.ParsleyFilters(childComplexity), true
+	case "UserLite.patches":
+		if e.complexity.UserLite.Patches == nil {
+			break
+		}
+
+		args, err := ec.field_UserLite_patches_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.UserLite.Patches(childComplexity, args["patchesInput"].(PatchesInput)), true
+	case "UserLite.permissions":
+		if e.complexity.UserLite.Permissions == nil {
+			break
+		}
+
+		return e.complexity.UserLite.Permissions(childComplexity), true
+	case "UserLite.settings":
+		if e.complexity.UserLite.Settings == nil {
+			break
+		}
+
+		return e.complexity.UserLite.Settings(childComplexity), true
+	case "UserLite.subscriptions":
+		if e.complexity.UserLite.Subscriptions == nil {
+			break
+		}
+
+		return e.complexity.UserLite.Subscriptions(childComplexity), true
+	case "UserLite.tokenAccessTokenExpiresAt":
+		if e.complexity.UserLite.TokenAccessTokenExpiresAt == nil {
+			break
+		}
+
+		return e.complexity.UserLite.TokenAccessTokenExpiresAt(childComplexity), true
 
 	case "UserServiceFlags.debugSpawnHostDisabled":
 		if e.complexity.UserServiceFlags.DebugSpawnHostDisabled == nil {
@@ -12696,6 +12803,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Version.User(childComplexity), true
+	case "Version.userLite":
+		if e.complexity.Version.UserLite == nil {
+			break
+		}
+
+		return e.complexity.Version.UserLite(childComplexity), true
 	case "Version.versionTiming":
 		if e.complexity.Version.VersionTiming == nil {
 			break
@@ -17067,6 +17180,17 @@ func (ec *executionContext) field_Query_task_argsTaskID(
 	}
 }
 
+func (ec *executionContext) field_Query_userLite_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "userId", ec.unmarshalOString2ᚖstring)
+	if err != nil {
+		return nil, err
+	}
+	args["userId"] = arg0
+	return args, nil
+}
+
 func (ec *executionContext) field_Query_user_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -17226,6 +17350,17 @@ func (ec *executionContext) field_Task_tests_args(ctx context.Context, rawArgs m
 		return nil, err
 	}
 	args["opts"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_UserLite_patches_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "patchesInput", ec.unmarshalNPatchesInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPatchesInput)
+	if err != nil {
+		return nil, err
+	}
+	args["patchesInput"] = arg0
 	return args, nil
 }
 
@@ -22330,7 +22465,7 @@ func (ec *executionContext) fieldContext_AuthUser_email(_ context.Context, field
 	return fc, nil
 }
 
-func (ec *executionContext) _BetaFeatures_spruceWaterfallEnabled(ctx context.Context, field graphql.CollectedField, obj *model.APIBetaFeatures) (ret graphql.Marshaler) {
+func (ec *executionContext) _BetaFeatures_spruceWaterfallEnabled(ctx context.Context, field graphql.CollectedField, obj *evergreen.BetaFeatures) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -35927,6 +36062,8 @@ func (ec *executionContext) fieldContext_MainlineCommitVersion_rolledUpVersions(
 				return ec.fieldContext_Version_upstreamProject(ctx, field)
 			case "user":
 				return ec.fieldContext_Version_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Version_userLite(ctx, field)
 			case "versionTiming":
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
@@ -36044,6 +36181,8 @@ func (ec *executionContext) fieldContext_MainlineCommitVersion_version(_ context
 				return ec.fieldContext_Version_upstreamProject(ctx, field)
 			case "user":
 				return ec.fieldContext_Version_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Version_userLite(ctx, field)
 			case "versionTiming":
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
@@ -37556,6 +37695,8 @@ func (ec *executionContext) fieldContext_Mutation_setPatchVisibility(ctx context
 				return ec.fieldContext_Patch_time(ctx, field)
 			case "user":
 				return ec.fieldContext_Patch_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Patch_userLite(ctx, field)
 			case "variants":
 				return ec.fieldContext_Patch_variants(ctx, field)
 			case "variantsTasks":
@@ -37675,6 +37816,8 @@ func (ec *executionContext) fieldContext_Mutation_schedulePatch(ctx context.Cont
 				return ec.fieldContext_Patch_time(ctx, field)
 			case "user":
 				return ec.fieldContext_Patch_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Patch_userLite(ctx, field)
 			case "variants":
 				return ec.fieldContext_Patch_variants(ctx, field)
 			case "variantsTasks":
@@ -42492,6 +42635,8 @@ func (ec *executionContext) fieldContext_Mutation_restartVersions(ctx context.Co
 				return ec.fieldContext_Version_upstreamProject(ctx, field)
 			case "user":
 				return ec.fieldContext_Version_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Version_userLite(ctx, field)
 			case "versionTiming":
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
@@ -44367,7 +44512,7 @@ func (ec *executionContext) fieldContext_ParserProjectS3Config_generatedJSONPref
 	return fc, nil
 }
 
-func (ec *executionContext) _ParsleyFilter_caseSensitive(ctx context.Context, field graphql.CollectedField, obj *model.APIParsleyFilter) (ret graphql.Marshaler) {
+func (ec *executionContext) _ParsleyFilter_caseSensitive(ctx context.Context, field graphql.CollectedField, obj *parsley.Filter) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -44377,7 +44522,7 @@ func (ec *executionContext) _ParsleyFilter_caseSensitive(ctx context.Context, fi
 			return obj.CaseSensitive, nil
 		},
 		nil,
-		ec.marshalNBoolean2ᚖbool,
+		ec.marshalNBoolean2bool,
 		true,
 		true,
 	)
@@ -44396,7 +44541,7 @@ func (ec *executionContext) fieldContext_ParsleyFilter_caseSensitive(_ context.C
 	return fc, nil
 }
 
-func (ec *executionContext) _ParsleyFilter_description(ctx context.Context, field graphql.CollectedField, obj *model.APIParsleyFilter) (ret graphql.Marshaler) {
+func (ec *executionContext) _ParsleyFilter_description(ctx context.Context, field graphql.CollectedField, obj *parsley.Filter) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -44406,7 +44551,7 @@ func (ec *executionContext) _ParsleyFilter_description(ctx context.Context, fiel
 			return obj.Description, nil
 		},
 		nil,
-		ec.marshalNString2ᚖstring,
+		ec.marshalNString2string,
 		true,
 		true,
 	)
@@ -44425,7 +44570,7 @@ func (ec *executionContext) fieldContext_ParsleyFilter_description(_ context.Con
 	return fc, nil
 }
 
-func (ec *executionContext) _ParsleyFilter_exactMatch(ctx context.Context, field graphql.CollectedField, obj *model.APIParsleyFilter) (ret graphql.Marshaler) {
+func (ec *executionContext) _ParsleyFilter_exactMatch(ctx context.Context, field graphql.CollectedField, obj *parsley.Filter) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -44435,7 +44580,7 @@ func (ec *executionContext) _ParsleyFilter_exactMatch(ctx context.Context, field
 			return obj.ExactMatch, nil
 		},
 		nil,
-		ec.marshalNBoolean2ᚖbool,
+		ec.marshalNBoolean2bool,
 		true,
 		true,
 	)
@@ -44454,7 +44599,7 @@ func (ec *executionContext) fieldContext_ParsleyFilter_exactMatch(_ context.Cont
 	return fc, nil
 }
 
-func (ec *executionContext) _ParsleyFilter_expression(ctx context.Context, field graphql.CollectedField, obj *model.APIParsleyFilter) (ret graphql.Marshaler) {
+func (ec *executionContext) _ParsleyFilter_expression(ctx context.Context, field graphql.CollectedField, obj *parsley.Filter) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -44464,7 +44609,7 @@ func (ec *executionContext) _ParsleyFilter_expression(ctx context.Context, field
 			return obj.Expression, nil
 		},
 		nil,
-		ec.marshalNString2ᚖstring,
+		ec.marshalNString2string,
 		true,
 		true,
 	)
@@ -44790,6 +44935,8 @@ func (ec *executionContext) fieldContext_Patch_childPatches(_ context.Context, f
 				return ec.fieldContext_Patch_time(ctx, field)
 			case "user":
 				return ec.fieldContext_Patch_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Patch_userLite(ctx, field)
 			case "variants":
 				return ec.fieldContext_Patch_variants(ctx, field)
 			case "variantsTasks":
@@ -45698,6 +45845,59 @@ func (ec *executionContext) fieldContext_Patch_user(_ context.Context, field gra
 	return fc, nil
 }
 
+func (ec *executionContext) _Patch_userLite(ctx context.Context, field graphql.CollectedField, obj *model.APIPatch) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Patch_userLite,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Patch().UserLite(ctx, obj)
+		},
+		nil,
+		ec.marshalNUserLite2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋuserᚐDBUser,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Patch_userLite(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Patch",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "betaFeatures":
+				return ec.fieldContext_UserLite_betaFeatures(ctx, field)
+			case "displayName":
+				return ec.fieldContext_UserLite_displayName(ctx, field)
+			case "emailAddress":
+				return ec.fieldContext_UserLite_emailAddress(ctx, field)
+			case "hasTokenExchangePending":
+				return ec.fieldContext_UserLite_hasTokenExchangePending(ctx, field)
+			case "id":
+				return ec.fieldContext_UserLite_id(ctx, field)
+			case "parsleyFilters":
+				return ec.fieldContext_UserLite_parsleyFilters(ctx, field)
+			case "patches":
+				return ec.fieldContext_UserLite_patches(ctx, field)
+			case "permissions":
+				return ec.fieldContext_UserLite_permissions(ctx, field)
+			case "settings":
+				return ec.fieldContext_UserLite_settings(ctx, field)
+			case "subscriptions":
+				return ec.fieldContext_UserLite_subscriptions(ctx, field)
+			case "tokenAccessTokenExpiresAt":
+				return ec.fieldContext_UserLite_tokenAccessTokenExpiresAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UserLite", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Patch_variants(ctx context.Context, field graphql.CollectedField, obj *model.APIPatch) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -45939,6 +46139,8 @@ func (ec *executionContext) fieldContext_Patch_versionFull(_ context.Context, fi
 				return ec.fieldContext_Version_upstreamProject(ctx, field)
 			case "user":
 				return ec.fieldContext_Version_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Version_userLite(ctx, field)
 			case "versionTiming":
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
@@ -46659,6 +46861,8 @@ func (ec *executionContext) fieldContext_Patches_patches(_ context.Context, fiel
 				return ec.fieldContext_Patch_time(ctx, field)
 			case "user":
 				return ec.fieldContext_Patch_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Patch_userLite(ctx, field)
 			case "variants":
 				return ec.fieldContext_Patch_variants(ctx, field)
 			case "variantsTasks":
@@ -48477,10 +48681,10 @@ func (ec *executionContext) _Project_parsleyFilters(ctx context.Context, field g
 		field,
 		ec.fieldContext_Project_parsleyFilters,
 		func(ctx context.Context) (any, error) {
-			return obj.ParsleyFilters, nil
+			return ec.resolvers.Project().ParsleyFilters(ctx, obj)
 		},
 		nil,
-		ec.marshalOParsleyFilter2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIParsleyFilterᚄ,
+		ec.marshalOParsleyFilter2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋparsleyᚐFilterᚄ,
 		true,
 		false,
 	)
@@ -48490,8 +48694,8 @@ func (ec *executionContext) fieldContext_Project_parsleyFilters(_ context.Contex
 	fc = &graphql.FieldContext{
 		Object:     "Project",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "caseSensitive":
@@ -53320,6 +53524,8 @@ func (ec *executionContext) fieldContext_Query_patch(ctx context.Context, field 
 				return ec.fieldContext_Patch_time(ctx, field)
 			case "user":
 				return ec.fieldContext_Patch_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Patch_userLite(ctx, field)
 			case "variants":
 				return ec.fieldContext_Patch_variants(ctx, field)
 			case "variantsTasks":
@@ -54722,6 +54928,71 @@ func (ec *executionContext) fieldContext_Query_user(ctx context.Context, field g
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_userLite(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Query_userLite,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Query().UserLite(ctx, fc.Args["userId"].(*string))
+		},
+		nil,
+		ec.marshalNUserLite2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋuserᚐDBUser,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Query_userLite(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "betaFeatures":
+				return ec.fieldContext_UserLite_betaFeatures(ctx, field)
+			case "displayName":
+				return ec.fieldContext_UserLite_displayName(ctx, field)
+			case "emailAddress":
+				return ec.fieldContext_UserLite_emailAddress(ctx, field)
+			case "hasTokenExchangePending":
+				return ec.fieldContext_UserLite_hasTokenExchangePending(ctx, field)
+			case "id":
+				return ec.fieldContext_UserLite_id(ctx, field)
+			case "parsleyFilters":
+				return ec.fieldContext_UserLite_parsleyFilters(ctx, field)
+			case "patches":
+				return ec.fieldContext_UserLite_patches(ctx, field)
+			case "permissions":
+				return ec.fieldContext_UserLite_permissions(ctx, field)
+			case "settings":
+				return ec.fieldContext_UserLite_settings(ctx, field)
+			case "subscriptions":
+				return ec.fieldContext_UserLite_subscriptions(ctx, field)
+			case "tokenAccessTokenExpiresAt":
+				return ec.fieldContext_UserLite_tokenAccessTokenExpiresAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UserLite", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_userLite_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_userConfig(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -55191,6 +55462,8 @@ func (ec *executionContext) fieldContext_Query_version(ctx context.Context, fiel
 				return ec.fieldContext_Version_upstreamProject(ctx, field)
 			case "user":
 				return ec.fieldContext_Version_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Version_userLite(ctx, field)
 			case "versionTiming":
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
@@ -56411,10 +56684,10 @@ func (ec *executionContext) _RepoRef_parsleyFilters(ctx context.Context, field g
 		field,
 		ec.fieldContext_RepoRef_parsleyFilters,
 		func(ctx context.Context) (any, error) {
-			return obj.ParsleyFilters, nil
+			return ec.resolvers.RepoRef().ParsleyFilters(ctx, obj)
 		},
 		nil,
-		ec.marshalOParsleyFilter2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIParsleyFilterᚄ,
+		ec.marshalOParsleyFilter2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋparsleyᚐFilterᚄ,
 		true,
 		false,
 	)
@@ -56424,8 +56697,8 @@ func (ec *executionContext) fieldContext_RepoRef_parsleyFilters(_ context.Contex
 	fc = &graphql.FieldContext{
 		Object:     "RepoRef",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "caseSensitive":
@@ -64879,6 +65152,8 @@ func (ec *executionContext) fieldContext_Task_patch(_ context.Context, field gra
 				return ec.fieldContext_Patch_time(ctx, field)
 			case "user":
 				return ec.fieldContext_Patch_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Patch_userLite(ctx, field)
 			case "variants":
 				return ec.fieldContext_Patch_variants(ctx, field)
 			case "variantsTasks":
@@ -66829,6 +67104,8 @@ func (ec *executionContext) fieldContext_Task_versionMetadata(_ context.Context,
 				return ec.fieldContext_Version_upstreamProject(ctx, field)
 			case "user":
 				return ec.fieldContext_Version_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Version_userLite(ctx, field)
 			case "versionTiming":
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
@@ -71969,10 +72246,10 @@ func (ec *executionContext) _UIConfig_betaFeatures(ctx context.Context, field gr
 		field,
 		ec.fieldContext_UIConfig_betaFeatures,
 		func(ctx context.Context) (any, error) {
-			return obj.BetaFeatures, nil
+			return ec.resolvers.UIConfig().BetaFeatures(ctx, obj)
 		},
 		nil,
-		ec.marshalNBetaFeatures2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIBetaFeatures,
+		ec.marshalNBetaFeatures2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚐBetaFeatures,
 		true,
 		true,
 	)
@@ -71982,8 +72259,8 @@ func (ec *executionContext) fieldContext_UIConfig_betaFeatures(_ context.Context
 	fc = &graphql.FieldContext{
 		Object:     "UIConfig",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "spruceWaterfallEnabled":
@@ -72408,7 +72685,7 @@ func (ec *executionContext) _UpdateBetaFeaturesPayload_betaFeatures(ctx context.
 			return obj.BetaFeatures, nil
 		},
 		nil,
-		ec.marshalOBetaFeatures2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIBetaFeatures,
+		ec.marshalOBetaFeatures2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚐBetaFeatures,
 		true,
 		false,
 	)
@@ -72951,6 +73228,8 @@ func (ec *executionContext) fieldContext_UpstreamProject_version(_ context.Conte
 				return ec.fieldContext_Version_upstreamProject(ctx, field)
 			case "user":
 				return ec.fieldContext_Version_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Version_userLite(ctx, field)
 			case "versionTiming":
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
@@ -73000,10 +73279,10 @@ func (ec *executionContext) _User_betaFeatures(ctx context.Context, field graphq
 		field,
 		ec.fieldContext_User_betaFeatures,
 		func(ctx context.Context) (any, error) {
-			return obj.BetaFeatures, nil
+			return ec.resolvers.User().BetaFeatures(ctx, obj)
 		},
 		nil,
-		ec.marshalOBetaFeatures2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIBetaFeatures,
+		ec.marshalOBetaFeatures2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚐBetaFeatures,
 		true,
 		false,
 	)
@@ -73013,8 +73292,8 @@ func (ec *executionContext) fieldContext_User_betaFeatures(_ context.Context, fi
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "spruceWaterfallEnabled":
@@ -73120,10 +73399,10 @@ func (ec *executionContext) _User_parsleyFilters(ctx context.Context, field grap
 		field,
 		ec.fieldContext_User_parsleyFilters,
 		func(ctx context.Context) (any, error) {
-			return obj.ParsleyFilters, nil
+			return ec.resolvers.User().ParsleyFilters(ctx, obj)
 		},
 		nil,
-		ec.marshalOParsleyFilter2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIParsleyFilterᚄ,
+		ec.marshalOParsleyFilter2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋparsleyᚐFilterᚄ,
 		true,
 		false,
 	)
@@ -73133,8 +73412,8 @@ func (ec *executionContext) fieldContext_User_parsleyFilters(_ context.Context, 
 	fc = &graphql.FieldContext{
 		Object:     "User",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "caseSensitive":
@@ -73601,6 +73880,39 @@ func (ec *executionContext) fieldContext_UserConfig_oauth_connector_id(_ context
 	return fc, nil
 }
 
+func (ec *executionContext) _UserLite_betaFeatures(ctx context.Context, field graphql.CollectedField, obj *user.DBUser) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_UserLite_betaFeatures,
+		func(ctx context.Context) (any, error) {
+			return obj.BetaFeatures, nil
+		},
+		nil,
+		ec.marshalOBetaFeatures2githubᚗcomᚋevergreenᚑciᚋevergreenᚐBetaFeatures,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_UserLite_betaFeatures(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserLite",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "spruceWaterfallEnabled":
+				return ec.fieldContext_BetaFeatures_spruceWaterfallEnabled(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type BetaFeatures", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UserLite_displayName(ctx context.Context, field graphql.CollectedField, obj *user.DBUser) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -73659,6 +73971,35 @@ func (ec *executionContext) fieldContext_UserLite_emailAddress(_ context.Context
 	return fc, nil
 }
 
+func (ec *executionContext) _UserLite_hasTokenExchangePending(ctx context.Context, field graphql.CollectedField, obj *user.DBUser) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_UserLite_hasTokenExchangePending,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.UserLite().HasTokenExchangePending(ctx, obj)
+		},
+		nil,
+		ec.marshalNBoolean2bool,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_UserLite_hasTokenExchangePending(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserLite",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _UserLite_id(ctx context.Context, field graphql.CollectedField, obj *user.DBUser) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -73683,6 +74024,262 @@ func (ec *executionContext) fieldContext_UserLite_id(_ context.Context, field gr
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserLite_parsleyFilters(ctx context.Context, field graphql.CollectedField, obj *user.DBUser) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_UserLite_parsleyFilters,
+		func(ctx context.Context) (any, error) {
+			return obj.ParsleyFilters, nil
+		},
+		nil,
+		ec.marshalOParsleyFilter2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋparsleyᚐFilterᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_UserLite_parsleyFilters(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserLite",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "caseSensitive":
+				return ec.fieldContext_ParsleyFilter_caseSensitive(ctx, field)
+			case "description":
+				return ec.fieldContext_ParsleyFilter_description(ctx, field)
+			case "exactMatch":
+				return ec.fieldContext_ParsleyFilter_exactMatch(ctx, field)
+			case "expression":
+				return ec.fieldContext_ParsleyFilter_expression(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ParsleyFilter", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserLite_patches(ctx context.Context, field graphql.CollectedField, obj *user.DBUser) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_UserLite_patches,
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.UserLite().Patches(ctx, obj, fc.Args["patchesInput"].(PatchesInput))
+		},
+		nil,
+		ec.marshalOPatches2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPatches,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_UserLite_patches(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserLite",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "filteredPatchCount":
+				return ec.fieldContext_Patches_filteredPatchCount(ctx, field)
+			case "patches":
+				return ec.fieldContext_Patches_patches(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Patches", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_UserLite_patches_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserLite_permissions(ctx context.Context, field graphql.CollectedField, obj *user.DBUser) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_UserLite_permissions,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.UserLite().Permissions(ctx, obj)
+		},
+		nil,
+		ec.marshalOPermissions2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPermissions,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_UserLite_permissions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserLite",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "canCreateDistro":
+				return ec.fieldContext_Permissions_canCreateDistro(ctx, field)
+			case "canCreateProject":
+				return ec.fieldContext_Permissions_canCreateProject(ctx, field)
+			case "canEditAdminSettings":
+				return ec.fieldContext_Permissions_canEditAdminSettings(ctx, field)
+			case "distroPermissions":
+				return ec.fieldContext_Permissions_distroPermissions(ctx, field)
+			case "projectPermissions":
+				return ec.fieldContext_Permissions_projectPermissions(ctx, field)
+			case "repoPermissions":
+				return ec.fieldContext_Permissions_repoPermissions(ctx, field)
+			case "userId":
+				return ec.fieldContext_Permissions_userId(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type Permissions", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserLite_settings(ctx context.Context, field graphql.CollectedField, obj *user.DBUser) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_UserLite_settings,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.UserLite().Settings(ctx, obj)
+		},
+		nil,
+		ec.marshalOUserSettings2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIUserSettings,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_UserLite_settings(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserLite",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "githubUser":
+				return ec.fieldContext_UserSettings_githubUser(ctx, field)
+			case "notifications":
+				return ec.fieldContext_UserSettings_notifications(ctx, field)
+			case "region":
+				return ec.fieldContext_UserSettings_region(ctx, field)
+			case "slackUsername":
+				return ec.fieldContext_UserSettings_slackUsername(ctx, field)
+			case "slackMemberId":
+				return ec.fieldContext_UserSettings_slackMemberId(ctx, field)
+			case "timezone":
+				return ec.fieldContext_UserSettings_timezone(ctx, field)
+			case "useSpruceOptions":
+				return ec.fieldContext_UserSettings_useSpruceOptions(ctx, field)
+			case "dateFormat":
+				return ec.fieldContext_UserSettings_dateFormat(ctx, field)
+			case "timeFormat":
+				return ec.fieldContext_UserSettings_timeFormat(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UserSettings", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserLite_subscriptions(ctx context.Context, field graphql.CollectedField, obj *user.DBUser) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_UserLite_subscriptions,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.UserLite().Subscriptions(ctx, obj)
+		},
+		nil,
+		ec.marshalOGeneralSubscription2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPISubscriptionᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_UserLite_subscriptions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserLite",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_GeneralSubscription_id(ctx, field)
+			case "ownerType":
+				return ec.fieldContext_GeneralSubscription_ownerType(ctx, field)
+			case "regexSelectors":
+				return ec.fieldContext_GeneralSubscription_regexSelectors(ctx, field)
+			case "resourceType":
+				return ec.fieldContext_GeneralSubscription_resourceType(ctx, field)
+			case "selectors":
+				return ec.fieldContext_GeneralSubscription_selectors(ctx, field)
+			case "subscriber":
+				return ec.fieldContext_GeneralSubscription_subscriber(ctx, field)
+			case "trigger":
+				return ec.fieldContext_GeneralSubscription_trigger(ctx, field)
+			case "triggerData":
+				return ec.fieldContext_GeneralSubscription_triggerData(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type GeneralSubscription", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _UserLite_tokenAccessTokenExpiresAt(ctx context.Context, field graphql.CollectedField, obj *user.DBUser) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_UserLite_tokenAccessTokenExpiresAt,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.UserLite().TokenAccessTokenExpiresAt(ctx, obj)
+		},
+		nil,
+		ec.marshalOTime2ᚖtimeᚐTime,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_UserLite_tokenAccessTokenExpiresAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "UserLite",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Time does not have child fields")
 		},
 	}
 	return fc, nil
@@ -74439,6 +75036,8 @@ func (ec *executionContext) fieldContext_Version_baseVersion(_ context.Context, 
 				return ec.fieldContext_Version_upstreamProject(ctx, field)
 			case "user":
 				return ec.fieldContext_Version_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Version_userLite(ctx, field)
 			case "versionTiming":
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
@@ -74683,6 +75282,8 @@ func (ec *executionContext) fieldContext_Version_childVersions(_ context.Context
 				return ec.fieldContext_Version_upstreamProject(ctx, field)
 			case "user":
 				return ec.fieldContext_Version_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Version_userLite(ctx, field)
 			case "versionTiming":
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
@@ -75252,6 +75853,8 @@ func (ec *executionContext) fieldContext_Version_patch(_ context.Context, field 
 				return ec.fieldContext_Patch_time(ctx, field)
 			case "user":
 				return ec.fieldContext_Patch_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Patch_userLite(ctx, field)
 			case "variants":
 				return ec.fieldContext_Patch_variants(ctx, field)
 			case "variantsTasks":
@@ -75426,6 +76029,8 @@ func (ec *executionContext) fieldContext_Version_previousVersion(_ context.Conte
 				return ec.fieldContext_Version_upstreamProject(ctx, field)
 			case "user":
 				return ec.fieldContext_Version_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Version_userLite(ctx, field)
 			case "versionTiming":
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
@@ -76040,6 +76645,59 @@ func (ec *executionContext) fieldContext_Version_user(_ context.Context, field g
 				return ec.fieldContext_User_userId(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type User", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Version_userLite(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Version_userLite,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Version().UserLite(ctx, obj)
+		},
+		nil,
+		ec.marshalNUserLite2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋuserᚐDBUser,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_Version_userLite(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Version",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "betaFeatures":
+				return ec.fieldContext_UserLite_betaFeatures(ctx, field)
+			case "displayName":
+				return ec.fieldContext_UserLite_displayName(ctx, field)
+			case "emailAddress":
+				return ec.fieldContext_UserLite_emailAddress(ctx, field)
+			case "hasTokenExchangePending":
+				return ec.fieldContext_UserLite_hasTokenExchangePending(ctx, field)
+			case "id":
+				return ec.fieldContext_UserLite_id(ctx, field)
+			case "parsleyFilters":
+				return ec.fieldContext_UserLite_parsleyFilters(ctx, field)
+			case "patches":
+				return ec.fieldContext_UserLite_patches(ctx, field)
+			case "permissions":
+				return ec.fieldContext_UserLite_permissions(ctx, field)
+			case "settings":
+				return ec.fieldContext_UserLite_settings(ctx, field)
+			case "subscriptions":
+				return ec.fieldContext_UserLite_subscriptions(ctx, field)
+			case "tokenAccessTokenExpiresAt":
+				return ec.fieldContext_UserLite_tokenAccessTokenExpiresAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type UserLite", field.Name)
 		},
 	}
 	return fc, nil
@@ -76875,12 +77533,28 @@ func (ec *executionContext) fieldContext_VersionLite_user(_ context.Context, fie
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "betaFeatures":
+				return ec.fieldContext_UserLite_betaFeatures(ctx, field)
 			case "displayName":
 				return ec.fieldContext_UserLite_displayName(ctx, field)
 			case "emailAddress":
 				return ec.fieldContext_UserLite_emailAddress(ctx, field)
+			case "hasTokenExchangePending":
+				return ec.fieldContext_UserLite_hasTokenExchangePending(ctx, field)
 			case "id":
 				return ec.fieldContext_UserLite_id(ctx, field)
+			case "parsleyFilters":
+				return ec.fieldContext_UserLite_parsleyFilters(ctx, field)
+			case "patches":
+				return ec.fieldContext_UserLite_patches(ctx, field)
+			case "permissions":
+				return ec.fieldContext_UserLite_permissions(ctx, field)
+			case "settings":
+				return ec.fieldContext_UserLite_settings(ctx, field)
+			case "subscriptions":
+				return ec.fieldContext_UserLite_subscriptions(ctx, field)
+			case "tokenAccessTokenExpiresAt":
+				return ec.fieldContext_UserLite_tokenAccessTokenExpiresAt(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type UserLite", field.Name)
 		},
@@ -77785,6 +78459,8 @@ func (ec *executionContext) fieldContext_Waterfall_flattenedVersions(_ context.C
 				return ec.fieldContext_Version_upstreamProject(ctx, field)
 			case "user":
 				return ec.fieldContext_Version_user(ctx, field)
+			case "userLite":
+				return ec.fieldContext_Version_userLite(ctx, field)
 			case "versionTiming":
 				return ec.fieldContext_Version_versionTiming(ctx, field)
 			case "warnings":
@@ -92601,7 +93277,7 @@ func (ec *executionContext) _AuthUser(ctx context.Context, sel ast.SelectionSet,
 
 var betaFeaturesImplementors = []string{"BetaFeatures"}
 
-func (ec *executionContext) _BetaFeatures(ctx context.Context, sel ast.SelectionSet, obj *model.APIBetaFeatures) graphql.Marshaler {
+func (ec *executionContext) _BetaFeatures(ctx context.Context, sel ast.SelectionSet, obj *evergreen.BetaFeatures) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, betaFeaturesImplementors)
 
 	out := graphql.NewFieldSet(fields)
@@ -99536,7 +100212,7 @@ func (ec *executionContext) _ParserProjectS3Config(ctx context.Context, sel ast.
 
 var parsleyFilterImplementors = []string{"ParsleyFilter"}
 
-func (ec *executionContext) _ParsleyFilter(ctx context.Context, sel ast.SelectionSet, obj *model.APIParsleyFilter) graphql.Marshaler {
+func (ec *executionContext) _ParsleyFilter(ctx context.Context, sel ast.SelectionSet, obj *parsley.Filter) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, parsleyFilterImplementors)
 
 	out := graphql.NewFieldSet(fields)
@@ -100129,6 +100805,42 @@ func (ec *executionContext) _Patch(ctx context.Context, sel ast.SelectionSet, ob
 					}
 				}()
 				res = ec._Patch_user(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "userLite":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Patch_userLite(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -101241,7 +101953,38 @@ func (ec *executionContext) _Project(ctx context.Context, sel ast.SelectionSet, 
 				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "parsleyFilters":
-			out.Values[i] = ec._Project_parsleyFilters(ctx, field, obj)
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Project_parsleyFilters(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "patches":
 			field := field
 
@@ -103181,6 +103924,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "userLite":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_userLite(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "userConfig":
 			field := field
 
@@ -103630,67 +104395,67 @@ func (ec *executionContext) _RepoRef(ctx context.Context, sel ast.SelectionSet, 
 		case "id":
 			out.Values[i] = ec._RepoRef_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "admins":
 			out.Values[i] = ec._RepoRef_admins(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "batchTime":
 			out.Values[i] = ec._RepoRef_batchTime(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "buildBaronSettings":
 			out.Values[i] = ec._RepoRef_buildBaronSettings(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "commitQueue":
 			out.Values[i] = ec._RepoRef_commitQueue(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "deactivatePrevious":
 			out.Values[i] = ec._RepoRef_deactivatePrevious(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "disabledStatsCache":
 			out.Values[i] = ec._RepoRef_disabledStatsCache(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "dispatchingDisabled":
 			out.Values[i] = ec._RepoRef_dispatchingDisabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "waterfallDisabled":
 			out.Values[i] = ec._RepoRef_waterfallDisabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "displayName":
 			out.Values[i] = ec._RepoRef_displayName(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "enabled":
 			out.Values[i] = ec._RepoRef_enabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "githubChecksEnabled":
 			out.Values[i] = ec._RepoRef_githubChecksEnabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "githubDynamicTokenPermissionGroups":
 			out.Values[i] = ec._RepoRef_githubDynamicTokenPermissionGroups(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "githubPermissionGroupByRequester":
 			out.Values[i] = ec._RepoRef_githubPermissionGroupByRequester(ctx, field, obj)
@@ -103705,112 +104470,143 @@ func (ec *executionContext) _RepoRef(ctx context.Context, sel ast.SelectionSet, 
 		case "gitTagVersionsEnabled":
 			out.Values[i] = ec._RepoRef_gitTagVersionsEnabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "manualPrTestingEnabled":
 			out.Values[i] = ec._RepoRef_manualPrTestingEnabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "notifyOnBuildFailure":
 			out.Values[i] = ec._RepoRef_notifyOnBuildFailure(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "oldestAllowedMergeBase":
 			out.Values[i] = ec._RepoRef_oldestAllowedMergeBase(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "owner":
 			out.Values[i] = ec._RepoRef_owner(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "parsleyFilters":
-			out.Values[i] = ec._RepoRef_parsleyFilters(ctx, field, obj)
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._RepoRef_parsleyFilters(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "patchingDisabled":
 			out.Values[i] = ec._RepoRef_patchingDisabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "patchTriggerAliases":
 			out.Values[i] = ec._RepoRef_patchTriggerAliases(ctx, field, obj)
 		case "perfEnabled":
 			out.Values[i] = ec._RepoRef_perfEnabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "periodicBuilds":
 			out.Values[i] = ec._RepoRef_periodicBuilds(ctx, field, obj)
 		case "prTestingEnabled":
 			out.Values[i] = ec._RepoRef_prTestingEnabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "remotePath":
 			out.Values[i] = ec._RepoRef_remotePath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "repo":
 			out.Values[i] = ec._RepoRef_repo(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "repotrackerDisabled":
 			out.Values[i] = ec._RepoRef_repotrackerDisabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "restricted":
 			out.Values[i] = ec._RepoRef_restricted(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "runEveryMainlineCommit":
 			out.Values[i] = ec._RepoRef_runEveryMainlineCommit(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "spawnHostScriptPath":
 			out.Values[i] = ec._RepoRef_spawnHostScriptPath(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "debugSpawnHostsDisabled":
 			out.Values[i] = ec._RepoRef_debugSpawnHostsDisabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "stepbackDisabled":
 			out.Values[i] = ec._RepoRef_stepbackDisabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "stepbackBisect":
 			out.Values[i] = ec._RepoRef_stepbackBisect(ctx, field, obj)
 		case "taskAnnotationSettings":
 			out.Values[i] = ec._RepoRef_taskAnnotationSettings(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "testSelection":
 			out.Values[i] = ec._RepoRef_testSelection(ctx, field, obj)
 		case "triggers":
 			out.Values[i] = ec._RepoRef_triggers(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "versionControlEnabled":
 			out.Values[i] = ec._RepoRef_versionControlEnabled(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "workstationConfig":
 			out.Values[i] = ec._RepoRef_workstationConfig(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "externalLinks":
 			out.Values[i] = ec._RepoRef_externalLinks(ctx, field, obj)
@@ -109586,10 +110382,41 @@ func (ec *executionContext) _UIConfig(ctx context.Context, sel ast.SelectionSet,
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("UIConfig")
 		case "betaFeatures":
-			out.Values[i] = ec._UIConfig_betaFeatures(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UIConfig_betaFeatures(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
 			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "url":
 			out.Values[i] = ec._UIConfig_url(ctx, field, obj)
 		case "uiv2Url":
@@ -109603,17 +110430,17 @@ func (ec *executionContext) _UIConfig(ctx context.Context, sel ast.SelectionSet,
 		case "defaultProject":
 			out.Values[i] = ec._UIConfig_defaultProject(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "corsOrigins":
 			out.Values[i] = ec._UIConfig_corsOrigins(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "fileStreamingContentTypes":
 			out.Values[i] = ec._UIConfig_fileStreamingContentTypes(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "loginDomain":
 			out.Values[i] = ec._UIConfig_loginDomain(ctx, field, obj)
@@ -109805,7 +110632,38 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("User")
 		case "betaFeatures":
-			out.Values[i] = ec._User_betaFeatures(ctx, field, obj)
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_betaFeatures(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "displayName":
 			out.Values[i] = ec._User_displayName(ctx, field, obj)
 		case "emailAddress":
@@ -109816,7 +110674,38 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "parsleyFilters":
-			out.Values[i] = ec._User_parsleyFilters(ctx, field, obj)
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._User_parsleyFilters(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "patches":
 			field := field
 
@@ -110028,15 +110917,220 @@ func (ec *executionContext) _UserLite(ctx context.Context, sel ast.SelectionSet,
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("UserLite")
+		case "betaFeatures":
+			out.Values[i] = ec._UserLite_betaFeatures(ctx, field, obj)
 		case "displayName":
 			out.Values[i] = ec._UserLite_displayName(ctx, field, obj)
 		case "emailAddress":
 			out.Values[i] = ec._UserLite_emailAddress(ctx, field, obj)
+		case "hasTokenExchangePending":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UserLite_hasTokenExchangePending(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "id":
 			out.Values[i] = ec._UserLite_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
+		case "parsleyFilters":
+			out.Values[i] = ec._UserLite_parsleyFilters(ctx, field, obj)
+		case "patches":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UserLite_patches(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "permissions":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UserLite_permissions(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "settings":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UserLite_settings(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "subscriptions":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UserLite_subscriptions(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "tokenAccessTokenExpiresAt":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._UserLite_tokenAccessTokenExpiresAt(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -110965,6 +112059,42 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 					}
 				}()
 				res = ec._Version_user(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "userLite":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Version_userLite(ctx, field, obj)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -112815,8 +113945,18 @@ func (ec *executionContext) marshalNBannerTheme2githubᚗcomᚋevergreenᚑciᚋ
 	return res
 }
 
-func (ec *executionContext) marshalNBetaFeatures2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIBetaFeatures(ctx context.Context, sel ast.SelectionSet, v model.APIBetaFeatures) graphql.Marshaler {
+func (ec *executionContext) marshalNBetaFeatures2githubᚗcomᚋevergreenᚑciᚋevergreenᚐBetaFeatures(ctx context.Context, sel ast.SelectionSet, v evergreen.BetaFeatures) graphql.Marshaler {
 	return ec._BetaFeatures(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNBetaFeatures2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚐBetaFeatures(ctx context.Context, sel ast.SelectionSet, v *evergreen.BetaFeatures) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._BetaFeatures(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNBetaFeaturesInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIBetaFeatures(ctx context.Context, v any) (model.APIBetaFeatures, error) {
@@ -115901,8 +117041,18 @@ func (ec *executionContext) unmarshalNParameterInput2ᚖgithubᚗcomᚋevergreen
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNParsleyFilter2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIParsleyFilter(ctx context.Context, sel ast.SelectionSet, v model.APIParsleyFilter) graphql.Marshaler {
+func (ec *executionContext) marshalNParsleyFilter2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋparsleyᚐFilter(ctx context.Context, sel ast.SelectionSet, v parsley.Filter) graphql.Marshaler {
 	return ec._ParsleyFilter(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNParsleyFilter2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋparsleyᚐFilter(ctx context.Context, sel ast.SelectionSet, v *parsley.Filter) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._ParsleyFilter(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNParsleyFilterInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIParsleyFilter(ctx context.Context, v any) (model.APIParsleyFilter, error) {
@@ -118982,11 +120132,11 @@ func (ec *executionContext) marshalOBannerTheme2ᚖgithubᚗcomᚋevergreenᚑci
 	return res
 }
 
-func (ec *executionContext) marshalOBetaFeatures2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIBetaFeatures(ctx context.Context, sel ast.SelectionSet, v model.APIBetaFeatures) graphql.Marshaler {
+func (ec *executionContext) marshalOBetaFeatures2githubᚗcomᚋevergreenᚑciᚋevergreenᚐBetaFeatures(ctx context.Context, sel ast.SelectionSet, v evergreen.BetaFeatures) graphql.Marshaler {
 	return ec._BetaFeatures(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalOBetaFeatures2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIBetaFeatures(ctx context.Context, sel ast.SelectionSet, v *model.APIBetaFeatures) graphql.Marshaler {
+func (ec *executionContext) marshalOBetaFeatures2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚐBetaFeatures(ctx context.Context, sel ast.SelectionSet, v *evergreen.BetaFeatures) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
@@ -120822,7 +121972,7 @@ func (ec *executionContext) unmarshalOParserProjectS3ConfigInput2ᚖgithubᚗcom
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalOParsleyFilter2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIParsleyFilterᚄ(ctx context.Context, sel ast.SelectionSet, v []model.APIParsleyFilter) graphql.Marshaler {
+func (ec *executionContext) marshalOParsleyFilter2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋparsleyᚐFilterᚄ(ctx context.Context, sel ast.SelectionSet, v []parsley.Filter) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
@@ -120849,7 +121999,54 @@ func (ec *executionContext) marshalOParsleyFilter2ᚕgithubᚗcomᚋevergreenᚑ
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNParsleyFilter2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIParsleyFilter(ctx, sel, v[i])
+			ret[i] = ec.marshalNParsleyFilter2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋparsleyᚐFilter(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalOParsleyFilter2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋparsleyᚐFilterᚄ(ctx context.Context, sel ast.SelectionSet, v []*parsley.Filter) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNParsleyFilter2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋparsleyᚐFilter(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -122532,6 +123729,13 @@ func (ec *executionContext) marshalOUserConfig2ᚖgithubᚗcomᚋevergreenᚑci�
 
 func (ec *executionContext) marshalOUserSettings2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIUserSettings(ctx context.Context, sel ast.SelectionSet, v model.APIUserSettings) graphql.Marshaler {
 	return ec._UserSettings(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalOUserSettings2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIUserSettings(ctx context.Context, sel ast.SelectionSet, v *model.APIUserSettings) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._UserSettings(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalOUserSettingsInput2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIUserSettings(ctx context.Context, v any) (*model.APIUserSettings, error) {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/rest/model"
@@ -702,7 +703,7 @@ type UpdateBetaFeaturesInput struct {
 }
 
 type UpdateBetaFeaturesPayload struct {
-	BetaFeatures *model.APIBetaFeatures `json:"betaFeatures,omitempty"`
+	BetaFeatures *evergreen.BetaFeatures `json:"betaFeatures,omitempty"`
 }
 
 type UpdateSpawnHostStatusInput struct {

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -1415,8 +1415,7 @@ func (r *mutationResolver) UpdateBetaFeatures(ctx context.Context, opts UpdateBe
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("updating beta features for user '%s': %s", usr.Id, err.Error()))
 	}
 
-	betaFeatures := restModel.APIBetaFeatures{}
-	betaFeatures.BuildFromService(usr.BetaFeatures)
+	betaFeatures := usr.BetaFeatures
 	return &UpdateBetaFeaturesPayload{
 		BetaFeatures: &betaFeatures,
 	}, nil

--- a/graphql/patch_resolver.go
+++ b/graphql/patch_resolver.go
@@ -329,6 +329,31 @@ func (r *patchResolver) User(ctx context.Context, obj *restModel.APIPatch) (*res
 	return apiUser, nil
 }
 
+// UserLite is the resolver for the userLite field.
+func (r *patchResolver) UserLite(ctx context.Context, obj *restModel.APIPatch) (*user.DBUser, error) {
+	// If only id is requested, we can return it without a database call.
+	requestedFields := graphql.CollectAllFields(ctx)
+	if len(requestedFields) == 1 && requestedFields[0] == "id" {
+		return &user.DBUser{Id: utility.FromStringPtr(obj.Author)}, nil
+	}
+
+	authorId := utility.FromStringPtr(obj.Author)
+	currentUser := mustHaveUser(ctx)
+	if currentUser.Id == authorId {
+		return currentUser, nil
+	}
+
+	dbUser, err := loaders.GetUser(ctx, authorId)
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting user '%s': %s", authorId, err.Error()), err)
+	}
+	// This is most likely a service user, so just return their ID.
+	if dbUser == nil {
+		return &user.DBUser{Id: authorId}, nil
+	}
+	return dbUser, nil
+}
+
 // Version is the resolver for the version field.
 func (r *patchResolver) Version(ctx context.Context, obj *restModel.APIPatch) (*model.Version, error) {
 	versionID := utility.FromStringPtr(obj.Version)

--- a/graphql/project_resolver.go
+++ b/graphql/project_resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/parsley"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/utility"
 )
@@ -15,6 +16,11 @@ func (r *projectResolver) IsFavorite(ctx context.Context, obj *restModel.APIProj
 		return true, nil
 	}
 	return false, nil
+}
+
+// ParsleyFilters is the resolver for the parsleyFilters field.
+func (r *projectResolver) ParsleyFilters(ctx context.Context, obj *restModel.APIProjectRef) ([]*parsley.Filter, error) {
+	return apiParsleyFiltersToService(obj.ParsleyFilters), nil
 }
 
 // Patches is the resolver for the patches field.

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -767,6 +767,22 @@ func (r *queryResolver) User(ctx context.Context, userID *string) (*restModel.AP
 	return &apiUser, nil
 }
 
+// UserLite is the resolver for the userLite field.
+func (r *queryResolver) UserLite(ctx context.Context, userID *string) (*user.DBUser, error) {
+	usr := mustHaveUser(ctx)
+	if userID != nil {
+		dbUser, err := user.FindOneById(ctx, utility.FromStringPtr(userID))
+		if err != nil {
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching user '%s': %s", utility.FromStringPtr(userID), err.Error()))
+		}
+		if dbUser == nil {
+			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("user '%s' not found", utility.FromStringPtr(userID)))
+		}
+		return dbUser, nil
+	}
+	return usr, nil
+}
+
 // UserConfig is the resolver for the userConfig field.
 func (r *queryResolver) UserConfig(ctx context.Context) (*UserConfig, error) {
 	usr := mustHaveUser(ctx)

--- a/graphql/repo_ref_resolver.go
+++ b/graphql/repo_ref_resolver.go
@@ -1,0 +1,18 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/evergreen-ci/evergreen/model/parsley"
+	"github.com/evergreen-ci/evergreen/rest/model"
+)
+
+// ParsleyFilters is the resolver for the parsleyFilters field.
+func (r *repoRefResolver) ParsleyFilters(ctx context.Context, obj *model.APIProjectRef) ([]*parsley.Filter, error) {
+	return apiParsleyFiltersToService(obj.ParsleyFilters), nil
+}
+
+// RepoRef returns RepoRefResolver implementation.
+func (r *Resolver) RepoRef() RepoRefResolver { return &repoRefResolver{r} }
+
+type repoRefResolver struct{ *Resolver }

--- a/graphql/schema/query.graphql
+++ b/graphql/schema/query.graphql
@@ -80,6 +80,7 @@ type Query {
   # user
   myPublicKeys: [PublicKey!]!
   user(userId: String): User!
+  userLite(userId: String): UserLite!
   userConfig: UserConfig
 
   # mainline commits

--- a/graphql/schema/types/patch.graphql
+++ b/graphql/schema/types/patch.graphql
@@ -95,7 +95,8 @@ type Patch {
   tasks: [String!]!
   taskStatuses: [String!]!
   time: PatchTime
-  user: User!
+  user: User! @deprecated(reason: "Use userLite instead.")
+  userLite: UserLite!
   variants: [String!]!
   variantsTasks: [VariantTask!]!
   version: VersionLite

--- a/graphql/schema/types/user.graphql
+++ b/graphql/schema/types/user.graphql
@@ -173,10 +173,19 @@ type UseSpruceOptions {
 }
 
 """
-UserLite replaces User by sidestepping the APIUser field. It does not contain all fields at this time.
+UserLite replaces User by sidestepping the APIDBUser API model and binding directly to the
+service-layer user model. New clients should query UserLite instead of User.
 """
 type UserLite {
+  betaFeatures: BetaFeatures
   displayName: String
   emailAddress: String
+  hasTokenExchangePending: Boolean!
   id: String!
+  parsleyFilters: [ParsleyFilter!]
+  patches(patchesInput: PatchesInput!): Patches # user patches
+  permissions: Permissions
+  settings: UserSettings
+  subscriptions: [GeneralSubscription!]
+  tokenAccessTokenExpiresAt: Time
 }

--- a/graphql/schema/types/version.graphql
+++ b/graphql/schema/types/version.graphql
@@ -89,7 +89,8 @@ type Version {
   taskStatuses: [String!]!
   taskStatusStats(options: BuildVariantOptions!): TaskStats
   upstreamProject: UpstreamProject
-  user: User!
+  user: User! @deprecated(reason: "Use userLite instead.")
+  userLite: UserLite!
   versionTiming: VersionTiming
   warnings: [String!]!
   waterfallBuilds: [WaterfallBuild!]

--- a/graphql/tests/patch/user/data.json
+++ b/graphql/tests/patch/user/data.json
@@ -1,0 +1,37 @@
+{
+  "versions": [
+    {
+      "_id": "5dd2e89cd1fe07048e43bb9c",
+      "identifier": "spruce",
+      "r": "gitter_request",
+      "requester": "gitter_request",
+      "status": "failed"
+    }
+  ],
+  "patches": [
+    {
+      "_id": {
+        "$oid": "9e4ff3abe3c3317e352062e4"
+      },
+      "branch": "spruce",
+      "githash": "3b53f9b61226491cd31113c773d66e351957ed29",
+      "patch_number": 20,
+      "author": "trey.granderson",
+      "version": "5dd2e89cd1fe07048e43bb9c",
+      "status": "started"
+    }
+  ],
+  "users": [
+    {
+      "_id": "trey.granderson",
+      "display_name": "Trey Granderson",
+      "email": "trey.granderson@mongodb.com"
+    }
+  ],
+  "project_ref": [
+    {
+      "_id": "spruce",
+      "identifier": "spruce"
+    }
+  ]
+}

--- a/graphql/tests/patch/user/queries/user.graphql
+++ b/graphql/tests/patch/user/queries/user.graphql
@@ -1,0 +1,9 @@
+{
+  patch(patchId: "9e4ff3abe3c3317e352062e4") {
+    userLite {
+      id
+      displayName
+      emailAddress
+    }
+  }
+}

--- a/graphql/tests/patch/user/results.json
+++ b/graphql/tests/patch/user/results.json
@@ -1,0 +1,18 @@
+{
+  "tests": [
+    {
+      "query_file": "user.graphql",
+      "result": {
+        "data": {
+          "patch": {
+            "userLite": {
+              "id": "trey.granderson",
+              "displayName": "Trey Granderson",
+              "emailAddress": "trey.granderson@mongodb.com"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/graphql/tests/query/user/data.json
+++ b/graphql/tests/query/user/data.json
@@ -16,13 +16,24 @@
       "display_name": "Bob Smith",
       "first_name": "Bob",
       "last_name": "Smith",
+      "email": "bob.smith@mongodb.com",
       "settings": {
         "timezone": "America/New_York",
         "region": "us-west-1",
         "github_user": {
           "last_known_as": "bob_smith_1"
         }
-      }
+      },
+      "beta_features": {
+        "spruce_waterfall_enabled": true
+      },
+      "parsley_filters": [
+        {
+          "expression": "abc",
+          "exact_match": true,
+          "case_sensitive": true
+        }
+      ]
     }
   ]
 }

--- a/graphql/tests/query/user/queries/current_user.graphql
+++ b/graphql/tests/query/user/queries/current_user.graphql
@@ -1,0 +1,7 @@
+{
+  userLite {
+    id
+    displayName
+    emailAddress
+  }
+}

--- a/graphql/tests/query/user/queries/user_all_fields.graphql
+++ b/graphql/tests/query/user/queries/user_all_fields.graphql
@@ -1,0 +1,23 @@
+{
+  userLite(userId: "bob.smith") {
+    id
+    displayName
+    emailAddress
+    hasTokenExchangePending
+    betaFeatures {
+      spruceWaterfallEnabled
+    }
+    parsleyFilters {
+      expression
+      exactMatch
+      caseSensitive
+    }
+    settings {
+      timezone
+      region
+      githubUser {
+        lastKnownAs
+      }
+    }
+  }
+}

--- a/graphql/tests/query/user/queries/user_not_found.graphql
+++ b/graphql/tests/query/user/queries/user_not_found.graphql
@@ -1,0 +1,5 @@
+{
+  userLite(userId: "nonexistent-userid") {
+    id
+  }
+}

--- a/graphql/tests/query/user/results.json
+++ b/graphql/tests/query/user/results.json
@@ -38,6 +38,64 @@
         ],
         "data": null
       }
+    },
+    {
+      "query_file": "current_user.graphql",
+      "test_user_id": "regular_user",
+      "result": {
+        "data": {
+          "userLite": {
+            "id": "regular_user",
+            "displayName": "Regular User",
+            "emailAddress": "regular_user@mongodb.com"
+          }
+        }
+      }
+    },
+    {
+      "query_file": "user_all_fields.graphql",
+      "result": {
+        "data": {
+          "userLite": {
+            "id": "bob.smith",
+            "displayName": "Bob Smith",
+            "emailAddress": "bob.smith@mongodb.com",
+            "hasTokenExchangePending": false,
+            "betaFeatures": {
+              "spruceWaterfallEnabled": true
+            },
+            "parsleyFilters": [
+              {
+                "expression": "abc",
+                "exactMatch": true,
+                "caseSensitive": true
+              }
+            ],
+            "settings": {
+              "timezone": "America/New_York",
+              "region": "us-west-1",
+              "githubUser": {
+                "lastKnownAs": "bob_smith_1"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "user_not_found.graphql",
+      "result": {
+        "errors": [
+          {
+            "message": "user 'nonexistent-userid' not found",
+            "path": ["userLite"],
+            "extensions": {
+              "code": "RESOURCE_NOT_FOUND"
+            }
+          }
+        ],
+        "data": null
+      }
     }
   ]
 }

--- a/graphql/tests/version/user/data.json
+++ b/graphql/tests/version/user/data.json
@@ -1,0 +1,21 @@
+{
+  "versions": [
+    {
+      "_id": "5e4ff3abe3c3317e352062e4",
+      "identifier": "spruce",
+      "author": "Brian Samek",
+      "author_id": "brian.samek",
+      "author_email": "brian.samek@mongodb.com",
+      "status": "failed",
+      "order": 2567,
+      "r": "gitter_request",
+      "requester": "gitter_request"
+    }
+  ],
+  "project_ref": [
+    {
+      "_id": "spruce",
+      "identifier": "spruce"
+    }
+  ]
+}

--- a/graphql/tests/version/user/queries/user.graphql
+++ b/graphql/tests/version/user/queries/user.graphql
@@ -1,0 +1,9 @@
+{
+  version(versionId: "5e4ff3abe3c3317e352062e4") {
+    userLite {
+      id
+      displayName
+      emailAddress
+    }
+  }
+}

--- a/graphql/tests/version/user/results.json
+++ b/graphql/tests/version/user/results.json
@@ -1,0 +1,18 @@
+{
+  "tests": [
+    {
+      "query_file": "user.graphql",
+      "result": {
+        "data": {
+          "version": {
+            "userLite": {
+              "id": "brian.samek",
+              "displayName": "Brian Samek",
+              "emailAddress": "brian.samek@mongodb.com"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/graphql/user_helpers.go
+++ b/graphql/user_helpers.go
@@ -1,0 +1,49 @@
+package graphql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/evergreen-ci/evergreen/graphql/loaders"
+	"github.com/evergreen-ci/evergreen/model/user"
+)
+
+// getVersionAuthorDBUser returns a version author as a *user.DBUser. The id, displayName,
+// and emailAddress fields are served from the denormalized version document; requesting any
+// other field triggers a database fetch.
+func getVersionAuthorDBUser(ctx context.Context, authorID, authorName, authorEmail string) (*user.DBUser, error) {
+	fromVersion := &user.DBUser{
+		Id:           authorID,
+		DispName:     authorName,
+		EmailAddress: authorEmail,
+	}
+
+	requestedFields := graphql.CollectAllFields(ctx)
+	needsDBFetch := false
+	for _, field := range requestedFields {
+		if field != "id" && field != "displayName" && field != "emailAddress" {
+			needsDBFetch = true
+			break
+		}
+	}
+	if !needsDBFetch {
+		return fromVersion, nil
+	}
+
+	currentUser := mustHaveUser(ctx)
+	if currentUser.Id == authorID {
+		return currentUser, nil
+	}
+
+	dbUser, err := loaders.GetUser(ctx, authorID)
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting user '%s': %s", authorID, err.Error()), err)
+	}
+	// This is most likely a service or reaped user, so just return their info from the version.
+	if dbUser == nil {
+		return fromVersion, nil
+	}
+
+	return dbUser, nil
+}

--- a/graphql/user_resolver.go
+++ b/graphql/user_resolver.go
@@ -2,11 +2,26 @@ package graphql
 
 import (
 	"context"
+	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/event"
+	"github.com/evergreen-ci/evergreen/model/parsley"
+	"github.com/evergreen-ci/evergreen/model/user"
 	restModel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/utility"
 )
+
+// BetaFeatures is the resolver for the betaFeatures field.
+func (r *userResolver) BetaFeatures(ctx context.Context, obj *restModel.APIDBUser) (*evergreen.BetaFeatures, error) {
+	betaFeatures := obj.BetaFeatures.ToService()
+	return &betaFeatures, nil
+}
+
+// ParsleyFilters is the resolver for the parsleyFilters field.
+func (r *userResolver) ParsleyFilters(ctx context.Context, obj *restModel.APIDBUser) ([]*parsley.Filter, error) {
+	return apiParsleyFiltersToService(obj.ParsleyFilters), nil
+}
 
 // Patches is the resolver for the patches field.
 func (r *userResolver) Patches(ctx context.Context, obj *restModel.APIDBUser, patchesInput PatchesInput) (*Patches, error) {
@@ -24,6 +39,43 @@ func (r *userResolver) Subscriptions(ctx context.Context, obj *restModel.APIDBUs
 	return getAPISubscriptionsForOwner(ctx, utility.FromStringPtr(obj.UserID), event.OwnerTypePerson)
 }
 
+// HasTokenExchangePending is the resolver for the hasTokenExchangePending field.
+func (r *userLiteResolver) HasTokenExchangePending(ctx context.Context, obj *user.DBUser) (bool, error) {
+	return obj.TokenExchangeState != nil, nil
+}
+
+// Patches is the resolver for the patches field.
+func (r *userLiteResolver) Patches(ctx context.Context, obj *user.DBUser, patchesInput PatchesInput) (*Patches, error) {
+	// Return empty Patches - field resolvers will access patchesInput via Parent.Args
+	return &Patches{}, nil
+}
+
+// Permissions is the resolver for the permissions field.
+func (r *userLiteResolver) Permissions(ctx context.Context, obj *user.DBUser) (*Permissions, error) {
+	return &Permissions{UserID: obj.Id}, nil
+}
+
+// Settings is the resolver for the settings field.
+func (r *userLiteResolver) Settings(ctx context.Context, obj *user.DBUser) (*restModel.APIUserSettings, error) {
+	settings := restModel.APIUserSettings{}
+	settings.BuildFromService(obj.Settings)
+	return &settings, nil
+}
+
+// Subscriptions is the resolver for the subscriptions field.
+func (r *userLiteResolver) Subscriptions(ctx context.Context, obj *user.DBUser) ([]*restModel.APISubscription, error) {
+	return getAPISubscriptionsForOwner(ctx, obj.Id, event.OwnerTypePerson)
+}
+
+// TokenAccessTokenExpiresAt is the resolver for the tokenAccessTokenExpiresAt field.
+func (r *userLiteResolver) TokenAccessTokenExpiresAt(ctx context.Context, obj *user.DBUser) (*time.Time, error) {
+	if tok := obj.TokenExchangeToken; tok != nil && !tok.Expiry.IsZero() {
+		// Use UTC so GraphQL Time marshaling is stable across server local TZ (RFC3339 Z).
+		return restModel.ToTimePtr(tok.Expiry.UTC()), nil
+	}
+	return nil, nil
+}
+
 // Target is the resolver for the target field.
 func (r *subscriberInputResolver) Target(ctx context.Context, obj *restModel.APISubscriber, data string) error {
 	obj.Target = data
@@ -33,8 +85,12 @@ func (r *subscriberInputResolver) Target(ctx context.Context, obj *restModel.API
 // User returns UserResolver implementation.
 func (r *Resolver) User() UserResolver { return &userResolver{r} }
 
+// UserLite returns UserLiteResolver implementation.
+func (r *Resolver) UserLite() UserLiteResolver { return &userLiteResolver{r} }
+
 // SubscriberInput returns SubscriberInputResolver implementation.
 func (r *Resolver) SubscriberInput() SubscriberInputResolver { return &subscriberInputResolver{r} }
 
 type userResolver struct{ *Resolver }
+type userLiteResolver struct{ *Resolver }
 type subscriberInputResolver struct{ *Resolver }

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -23,6 +23,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/model/parsley"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/testresult"
@@ -1453,18 +1454,31 @@ func buildOptionsFromParentArgs(ctx context.Context, fc *graphql.FieldContext) (
 		opts.Requesters = []string{evergreen.GithubMergeRequester}
 	}
 
-	// Get the parent object to determine if this is a project or user query
-	// The parent.Parent should be either Project or User resolver
+	// Get the parent object to determine if this is a project or user query.
+	// The parent.Parent should be a Project, User, or UserLite resolver.
 	if fc.Parent.Parent != nil {
 		switch grandparent := fc.Parent.Parent.Result.(type) {
 		case *restModel.APIProjectRef:
 			opts.Project = grandparent.Id
 		case *restModel.APIDBUser:
 			opts.Author = grandparent.UserID
+		case *user.DBUser:
+			opts.Author = utility.ToStringPtr(grandparent.Id)
 		}
 	}
 
 	return opts, nil
+}
+
+// apiParsleyFiltersToService converts a list of APIParsleyFilters into the
+// service-layer parsley.Filter type used by the GraphQL ParsleyFilter type.
+func apiParsleyFiltersToService(filters []restModel.APIParsleyFilter) []*parsley.Filter {
+	res := make([]*parsley.Filter, 0, len(filters))
+	for _, f := range filters {
+		serviceFilter := f.ToService()
+		res = append(res, &serviceFilter)
+	}
+	return res
 }
 
 // getPrevTask finds a mainline task's previous run that matches the given statuses.

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -551,6 +551,11 @@ func (r *versionResolver) User(ctx context.Context, obj *restModel.APIVersion) (
 	return apiUser, nil
 }
 
+// UserLite is the resolver for the userLite field.
+func (r *versionResolver) UserLite(ctx context.Context, obj *restModel.APIVersion) (*user.DBUser, error) {
+	return getVersionAuthorDBUser(ctx, utility.FromStringPtr(obj.AuthorID), utility.FromStringPtr(obj.Author), utility.FromStringPtr(obj.AuthorEmail))
+}
+
 // VersionTiming is the resolver for the versionTiming field.
 func (r *versionResolver) VersionTiming(ctx context.Context, obj *restModel.APIVersion) (*VersionTiming, error) {
 	versionID := utility.FromStringPtr(obj.Id)
@@ -690,44 +695,7 @@ func (r *versionLiteResolver) TaskStatusStats(ctx context.Context, obj *model.Ve
 
 // User is the resolver for the user field.
 func (r *versionLiteResolver) User(ctx context.Context, obj *model.Version) (*user.DBUser, error) {
-	// id, displayName, and emailAddress are always returned from the version document.
-	// Other fields require a database call.
-	requestedFields := graphql.CollectAllFields(ctx)
-	needsDBFetch := false
-	for _, field := range requestedFields {
-		if field != "id" && field != "displayName" && field != "emailAddress" {
-			needsDBFetch = true
-			break
-		}
-	}
-
-	if !needsDBFetch {
-		return &user.DBUser{
-			Id:           obj.AuthorID,
-			DispName:     obj.Author,
-			EmailAddress: obj.AuthorEmail,
-		}, nil
-	}
-
-	currentUser := mustHaveUser(ctx)
-	if currentUser.Id == obj.AuthorID {
-		return currentUser, nil
-	}
-
-	dbUser, err := loaders.GetUser(ctx, obj.AuthorID)
-	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting user '%s': %s", obj.AuthorID, err.Error()), err)
-	}
-	// This is most likely a service user, so just return their info from version
-	if dbUser == nil {
-		return &user.DBUser{
-			Id:           obj.AuthorID,
-			DispName:     obj.Author,
-			EmailAddress: obj.AuthorEmail,
-		}, nil
-	}
-
-	return dbUser, nil
+	return getVersionAuthorDBUser(ctx, obj.AuthorID, obj.Author, obj.AuthorEmail)
 }
 
 // Version returns VersionResolver implementation.

--- a/graphql/web_resolver.go
+++ b/graphql/web_resolver.go
@@ -1,0 +1,19 @@
+package graphql
+
+import (
+	"context"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/rest/model"
+)
+
+// BetaFeatures is the resolver for the betaFeatures field.
+func (r *uIConfigResolver) BetaFeatures(ctx context.Context, obj *model.APIUIConfig) (*evergreen.BetaFeatures, error) {
+	betaFeatures := obj.BetaFeatures.ToService()
+	return &betaFeatures, nil
+}
+
+// UIConfig returns UIConfigResolver implementation.
+func (r *Resolver) UIConfig() UIConfigResolver { return &uIConfigResolver{r} }
+
+type uIConfigResolver struct{ *Resolver }


### PR DESCRIPTION
DEVPROD-34996

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Add all `User` fields to `UserLite` so use of `User` can be removed in the UI. We'll then rename `UserLite` to `User` to be fully separate from REST API routes.

Some new resolver files were created because structs within `UserLite` rely on API types. As such, these are just a transitional addition that will be removed.

### Testing
Update unit tests. Currently running `pnpm dev` locally to ensure this works before opening a UI PR!