### PR TITLE
DEVPROD-33393 attribute sagebot PRs to actual author

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -15,14 +15,14 @@ const (
 	// User is the generic user representing the Evergreen application as a
 	// whole entity. If there's a more specific user performing an operation,
 	// prefer to use that instead.
-	User            = "mci"
-	GithubPatchUser = "github_pull_request"
-	GithubMergeUser = "github_merge_queue"
+	User              = "mci"
+	GithubPatchUser   = "github_pull_request"
+	GithubMergeUser   = "github_merge_queue"
+	PeriodicBuildUser = "periodic_build_user"
+	ParentPatchUser   = "parent_patch"
 	// GitHubSageBotLogin is the GitHub login for mongodb-sage-bot, which sets
 	// the PR assignee as the intended human author of the PR.
 	GitHubSageBotLogin = "mongodb-sage-bot[bot]"
-	PeriodicBuildUser  = "periodic_build_user"
-	ParentPatchUser    = "parent_patch"
 
 	HostRunning       = "running"
 	HostTerminated    = "terminated"

--- a/globals.go
+++ b/globals.go
@@ -15,11 +15,14 @@ const (
 	// User is the generic user representing the Evergreen application as a
 	// whole entity. If there's a more specific user performing an operation,
 	// prefer to use that instead.
-	User              = "mci"
-	GithubPatchUser   = "github_pull_request"
-	GithubMergeUser   = "github_merge_queue"
-	PeriodicBuildUser = "periodic_build_user"
-	ParentPatchUser   = "parent_patch"
+	User            = "mci"
+	GithubPatchUser = "github_pull_request"
+	GithubMergeUser = "github_merge_queue"
+	// GitHubSageBotLogin is the GitHub login for mongodb-sage-bot, which sets
+	// the PR assignee as the intended human author of the PR.
+	GitHubSageBotLogin = "mongodb-sage-bot[bot]"
+	PeriodicBuildUser  = "periodic_build_user"
+	ParentPatchUser    = "parent_patch"
 
 	HostRunning       = "running"
 	HostTerminated    = "terminated"

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -156,7 +156,7 @@ func NewGithubIntent(ctx context.Context, msgDeliveryID, patchOwner, calledBy, a
 	// mongodb-sage-bot sets the PR assignee as the intended human author, so
 	// use the assignee's identity for attribution instead.
 	ownerUID := int(pr.User.GetID())
-	if pr.User.GetLogin() == evergreen.GitHubSageBotLogin && pr.GetAssignee().GetLogin() != "" {
+	if patchOwner == evergreen.GitHubSageBotLogin && pr.GetAssignee().GetLogin() != "" {
 		patchOwner = pr.GetAssignee().GetLogin()
 		ownerUID = int(pr.GetAssignee().GetID())
 	}

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -156,9 +156,11 @@ func NewGithubIntent(ctx context.Context, msgDeliveryID, patchOwner, calledBy, a
 	// mongodb-sage-bot sets the PR assignee as the intended human author, so
 	// use the assignee's identity for attribution instead.
 	ownerUID := int(pr.User.GetID())
-	if patchOwner == evergreen.GitHubSageBotLogin && pr.GetAssignee().GetLogin() != "" {
-		patchOwner = pr.GetAssignee().GetLogin()
-		ownerUID = int(pr.GetAssignee().GetID())
+	assigneeLogin := pr.GetAssignee().GetLogin()
+	assigneeUID := int(pr.GetAssignee().GetID())
+	if patchOwner == evergreen.GitHubSageBotLogin && assigneeLogin != "" && assigneeUID != 0 {
+		patchOwner = assigneeLogin
+		ownerUID = assigneeUID
 	}
 	if alias == "" {
 		alias = evergreen.GithubPRAlias

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -153,6 +153,13 @@ func NewGithubIntent(ctx context.Context, msgDeliveryID, patchOwner, calledBy, a
 	if patchOwner == "" {
 		patchOwner = pr.User.GetLogin()
 	}
+	// mongodb-sage-bot sets the PR assignee as the intended human author, so
+	// use the assignee's identity for attribution instead.
+	ownerUID := int(pr.User.GetID())
+	if pr.User.GetLogin() == evergreen.GitHubSageBotLogin && pr.GetAssignee().GetLogin() != "" {
+		patchOwner = pr.GetAssignee().GetLogin()
+		ownerUID = int(pr.GetAssignee().GetID())
+	}
 	if alias == "" {
 		alias = evergreen.GithubPRAlias
 	}
@@ -172,7 +179,7 @@ func NewGithubIntent(ctx context.Context, msgDeliveryID, patchOwner, calledBy, a
 		HeadBranch:    pr.Head.GetRef(),
 		PRNumber:      pr.GetNumber(),
 		User:          patchOwner,
-		UID:           int(pr.User.GetID()),
+		UID:           ownerUID,
 		HeadHash:      pr.Head.GetSHA(),
 		BaseHash:      pr.Base.GetSHA(),
 		MergeBase:     mergeBase,

--- a/model/patch/github_test.go
+++ b/model/patch/github_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/utility"
+	"github.com/google/go-github/v70/github"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -137,6 +138,38 @@ func (s *GithubSuite) TestNewGithubIntent() {
 	ghIntent, ok = intent.(*githubIntent)
 	s.True(ok)
 	s.Equal(patchId, ghIntent.RepeatPatchId)
+}
+
+func (s *GithubSuite) TestNewGithubIntentSageBotUsesAssignee() {
+	assigneeLogin := "real-human"
+	var assigneeID int64 = 9999
+	pr := testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, evergreen.GitHubSageBotLogin, s.title)
+	pr.Assignee = &github.User{
+		Login: github.String(assigneeLogin),
+		ID:    github.Int64(assigneeID),
+	}
+
+	intent, err := NewGithubIntent(s.T().Context(), "sagebot-1", "", "", "", "", pr)
+	s.Require().NoError(err)
+	s.Require().NotNil(intent)
+
+	ghIntent, ok := intent.(*githubIntent)
+	s.Require().True(ok)
+	s.Equal(assigneeLogin, ghIntent.User)
+	s.Equal(int(assigneeID), ghIntent.UID)
+}
+
+func (s *GithubSuite) TestNewGithubIntentSageBotNoAssigneeUsesBot() {
+	pr := testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, evergreen.GitHubSageBotLogin, s.title)
+
+	intent, err := NewGithubIntent(s.T().Context(), "sagebot-2", "", "", "", "", pr)
+	s.Require().NoError(err)
+	s.Require().NotNil(intent)
+
+	ghIntent, ok := intent.(*githubIntent)
+	s.Require().True(ok)
+	s.Equal(evergreen.GitHubSageBotLogin, ghIntent.User)
+	s.Equal(1234, ghIntent.UID)
 }
 
 func (s *GithubSuite) TestInsert() {


### PR DESCRIPTION
DEVPROD-33393

### Description
When mongodb-sage-bot[bot] opens a pull request, use the PR assignee's login and GitHub UID for patch attribution instead of the bot's identity. (Verified with grip statement that assignee login is what we'd expect; in the case that multiple assignees are granted, which isn't an expected case, the first assignee will be returned and so marked as the owner, which I think is fine)

### Testing

Added a couple of unit tests; not sure if I can trigger sage bot to open a PR on staging? But I might just check in on a sage bot authored PR after deploying.

