### PR TITLE
DEVPROD-35064 Resolve task group blocks for generated tasks in debug hosts

### DIFF
--- a/agent/taskexec/local_executor.go
+++ b/agent/taskexec/local_executor.go
@@ -687,6 +687,10 @@ func (e *LocalExecutor) PrepareTask(ctx context.Context, taskName, variantName s
 	e.debugState.SelectedTask = taskName
 	e.logger.Infof(ctx, "Preparing task: %s", taskName)
 
+	if variantName == "" && e.taskConfig.Task.BuildVariant != "" {
+		variantName = e.taskConfig.Task.BuildVariant
+	}
+
 	var tg *model.TaskGroup
 	if variantName != "" {
 		bv := e.project.FindBuildVariant(variantName)
@@ -703,6 +707,10 @@ func (e *LocalExecutor) PrepareTask(ctx context.Context, taskName, variantName s
 		e.taskConfig.Expansions.Put("build_variant", variantName)
 		e.taskConfig.Expansions.Update(bv.Expansions)
 		e.logger.Infof(ctx, "Applied expansions from build variant: %s", variantName)
+	}
+
+	if tg == nil && e.taskConfig.Task.TaskGroup != "" {
+		tg = e.project.FindTaskGroup(e.taskConfig.Task.TaskGroup)
 	}
 
 	// Build command blocks array. If the task belongs to a task group, use

--- a/agent/taskexec/local_executor_test.go
+++ b/agent/taskexec/local_executor_test.go
@@ -455,6 +455,65 @@ buildvariants:
 		assert.Equal(t, command.TeardownTaskBlock, executor.commandBlocks[2].blockType)
 	})
 
+	t.Run("TaskGroupResolvedFromFetchedTaskWhenNoVariantProvided", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		yamlFile := filepath.Join(tmpDir, "test.yml")
+		yamlContent := `
+tasks:
+  - name: generated-task
+    commands:
+      - command: subprocess.exec
+        params:
+          command: make test
+pre:
+  - command: shell.exec
+    params:
+      script: echo "pre"
+post:
+  - command: shell.exec
+    params:
+      script: echo "post"
+task_groups:
+  - name: generated-group
+    setup_group:
+      - command: git.get_project
+    setup_task:
+      - command: shell.exec
+        params:
+          script: echo "setup task"
+    teardown_task:
+      - command: attach.xunit_results
+    tasks:
+      - generated-task
+buildvariants:
+  - name: enterprise-rhel-80-64-bit
+    tasks:
+      - name: generated-group
+`
+		err := os.WriteFile(yamlFile, []byte(yamlContent), 0644)
+		require.NoError(t, err)
+
+		executor, err := NewLocalExecutor(t.Context(), LocalExecutorOptions{})
+		require.NoError(t, err)
+
+		_, err = executor.LoadProject(yamlFile)
+		require.NoError(t, err)
+
+		executor.taskConfig.Task.BuildVariant = "enterprise-rhel-80-64-bit"
+		executor.taskConfig.Task.TaskGroup = "generated-group"
+
+		err = executor.PrepareTask(t.Context(), "generated-task", "")
+		require.NoError(t, err)
+		assert.Equal(t, "generated-task", executor.debugState.SelectedTask)
+		assert.Equal(t, "enterprise-rhel-80-64-bit", executor.debugState.SelectedVariant)
+
+		require.Len(t, executor.commandBlocks, 4)
+		assert.Equal(t, command.SetupGroupBlock, executor.commandBlocks[0].blockType)
+		assert.Equal(t, command.SetupTaskBlock, executor.commandBlocks[1].blockType)
+		assert.Equal(t, command.MainTaskBlock, executor.commandBlocks[2].blockType)
+		assert.Equal(t, command.TeardownTaskBlock, executor.commandBlocks[3].blockType)
+	})
+
 	t.Run("TaskGroupValidatesOnVariant", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		yamlFile := filepath.Join(tmpDir, "test.yml")

--- a/agent/taskexec/local_executor_test.go
+++ b/agent/taskexec/local_executor_test.go
@@ -514,6 +514,54 @@ buildvariants:
 		assert.Equal(t, command.TeardownTaskBlock, executor.commandBlocks[3].blockType)
 	})
 
+	t.Run("TaskGroupResolvedFromTaskWhenVariantLookupFails", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		yamlFile := filepath.Join(tmpDir, "test.yml")
+		yamlContent := `
+tasks:
+  - name: generated-task
+    commands:
+      - command: subprocess.exec
+        params:
+          command: make test
+pre:
+  - command: shell.exec
+    params:
+      script: echo "pre"
+task_groups:
+  - name: generated-group
+    setup_group:
+      - command: git.get_project
+    teardown_task:
+      - command: attach.xunit_results
+    tasks:
+      - generated-task
+buildvariants:
+  - name: some-variant
+    tasks:
+      - name: generated-task
+`
+		err := os.WriteFile(yamlFile, []byte(yamlContent), 0644)
+		require.NoError(t, err)
+
+		executor, err := NewLocalExecutor(t.Context(), LocalExecutorOptions{})
+		require.NoError(t, err)
+
+		_, err = executor.LoadProject(yamlFile)
+		require.NoError(t, err)
+
+		executor.taskConfig.Task.BuildVariant = "some-variant"
+		executor.taskConfig.Task.TaskGroup = "generated-group"
+
+		err = executor.PrepareTask(t.Context(), "generated-task", "")
+		require.NoError(t, err)
+
+		require.Len(t, executor.commandBlocks, 3)
+		assert.Equal(t, command.SetupGroupBlock, executor.commandBlocks[0].blockType)
+		assert.Equal(t, command.MainTaskBlock, executor.commandBlocks[1].blockType)
+		assert.Equal(t, command.TeardownTaskBlock, executor.commandBlocks[2].blockType)
+	})
+
 	t.Run("TaskGroupValidatesOnVariant", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		yamlFile := filepath.Join(tmpDir, "test.yml")

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -366,7 +366,7 @@ fi
 echo "Debug daemon started successfully."
 
 evergreen debug load "%s"
-evergreen debug select "%s"
+evergreen debug select "%s" --variant "%s"
 evergreen debug run-until %s
 
 if [ $? -eq 0 ]; then
@@ -374,7 +374,7 @@ if [ $? -eq 0 ]; then
 else
   echo "ERROR: Debug setup script failed during execution."
 fi
-`, configPath, t.DisplayName, stepNum, stepNum), nil
+`, configPath, t.DisplayName, t.BuildVariant, stepNum, stepNum), nil
 }
 
 func CheckInstanceTypeValid(ctx context.Context, d distro.Distro, requestedType string, allowedTypes []string) error {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-06-15"
+	AgentVersion = "2026-06-15a"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-35064

### Description

`debug list-steps` for a generated task that belongs to a task group shows pre/post blocks rather than the group's setup & teardown.

Solution is to infer the variant / task group from the task it's not provided by the user. Also updated the setup script to explicitly pass in the variant name.

### Testing
Added a new unit test.
