### PR TITLE
DEVPROD-32223: Route artifact, version-display, and project-identifier reads to a secondary node

### DIFF
--- a/graphql/patch_resolver.go
+++ b/graphql/patch_resolver.go
@@ -215,7 +215,7 @@ func (r *patchResolver) PatchTriggerAliases(ctx context.Context, obj *restModel.
 			})
 		}
 
-		identifier, err := model.GetIdentifierForProject(ctx, alias.ChildProject)
+		identifier, err := model.GetIdentifierForProjectSecondary(ctx, alias.ChildProject)
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting project identifier for child project '%s' in alias '%s': %s", alias.ChildProject, alias.Alias, err.Error()))
 		}

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -268,7 +268,7 @@ func (r *queryResolver) DistroTaskQueue(ctx context.Context, distroID string) ([
 		apiTaskQueueItem := restModel.APITaskQueueItem{}
 
 		if _, ok := idToIdentifierMap[taskQueueItem.Project]; !ok {
-			identifier, err := model.GetIdentifierForProject(ctx, taskQueueItem.Project)
+			identifier, err := model.GetIdentifierForProjectSecondary(ctx, taskQueueItem.Project)
 			if err != nil {
 				return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting identifier for project '%s': %s", taskQueueItem.Project, err.Error()))
 			}

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -148,7 +148,7 @@ func presignFile(ctx context.Context, file File) (string, error) {
 }
 
 func GetAllArtifacts(ctx context.Context, tasks []TaskIDAndExecution) ([]File, error) {
-	artifacts, err := FindAll(ctx, ByTaskIdsAndExecutions(tasks))
+	artifacts, err := FindAllSecondary(ctx, ByTaskIdsAndExecutions(tasks))
 	if err != nil {
 		return nil, errors.Wrap(err, "finding artifact files for task")
 	}
@@ -157,7 +157,7 @@ func GetAllArtifacts(ctx context.Context, tasks []TaskIDAndExecution) ([]File, e
 		for _, t := range tasks {
 			taskIds = append(taskIds, t.TaskID)
 		}
-		artifacts, err = FindAll(ctx, ByTaskIds(taskIds))
+		artifacts, err = FindAllSecondary(ctx, ByTaskIds(taskIds))
 		if err != nil {
 			return nil, errors.Wrap(err, "finding artifact files for task without execution number")
 		}

--- a/model/artifact/db.go
+++ b/model/artifact/db.go
@@ -111,6 +111,15 @@ func FindAll(ctx context.Context, query db.Q) ([]Entry, error) {
 	return entries, err
 }
 
+// FindAllSecondary gets every Entry for the given query, reading from a secondary
+// node. Results may be replication-lagged, so use it only for display reads of
+// already-persisted artifacts, never in a read-after-write path.
+func FindAllSecondary(ctx context.Context, query db.Q) ([]Entry, error) {
+	entries := []Entry{}
+	err := db.FindAllQSecondary(ctx, Collection, query, &entries)
+	return entries, err
+}
+
 // UpdateFileLink updates the link for a single artifact file matching task ID, execution,
 // file name, and current link. Returns db.ErrNotFound if no file matched.
 func UpdateFileLink(ctx context.Context, taskID string, execution int, fileName, currentLink, newLink string) error {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1548,6 +1548,21 @@ func GetIdentifierForProject(ctx context.Context, id string) (string, error) {
 	return pRef.Identifier, nil
 }
 
+// GetIdentifierForProjectSecondary is the SecondaryPreferred sibling of
+// GetIdentifierForProject. It reads from a secondary node, so results may be
+// replication-lagged; use it only for display or serialization where a momentarily
+// stale identifier is acceptable, never in a read-after-write or ID-generation path.
+func GetIdentifierForProjectSecondary(ctx context.Context, id string) (string, error) {
+	pRef, err := findOneProjectRefQSecondary(ctx, byId(id).WithFields(ProjectRefIdentifierKey))
+	if err != nil {
+		return "", err
+	}
+	if pRef == nil {
+		return "", errors.Errorf("project '%s' does not exist", id)
+	}
+	return pRef.Identifier, nil
+}
+
 func CountProjectRefsWithIdentifier(ctx context.Context, identifier string) (int, error) {
 	return db.CountQ(ctx, ProjectRefCollection, byId(identifier))
 }

--- a/model/version.go
+++ b/model/version.go
@@ -680,7 +680,7 @@ func GetMostRecentWaterfallVersion(ctx context.Context, projectId string) (*Vers
 
 	res := []Version{}
 	env := evergreen.GetEnvironment()
-	cursor, err := env.DB().Collection(VersionCollection).Aggregate(ctx, pipeline)
+	cursor, err := env.SecondaryReadClient().Database(env.DB().Name()).Collection(VersionCollection).Aggregate(ctx, pipeline)
 	if err != nil {
 		return nil, errors.Wrap(err, "aggregating versions")
 	}
@@ -726,7 +726,7 @@ func GetPreviousPageCommitOrderNumber(ctx context.Context, projectId string, ord
 	res := []Version{}
 
 	env := evergreen.GetEnvironment()
-	cursor, err := env.DB().Collection(VersionCollection).Aggregate(ctx, pipeline)
+	cursor, err := env.SecondaryReadClient().Database(env.DB().Name()).Collection(VersionCollection).Aggregate(ctx, pipeline)
 	if err != nil {
 		return nil, errors.Wrap(err, "aggregating versions")
 	}
@@ -780,7 +780,7 @@ func GetMainlineCommitVersionsWithOptions(ctx context.Context, projectId string,
 
 	res := []Version{}
 	env := evergreen.GetEnvironment()
-	cursor, err := env.DB().Collection(VersionCollection).Aggregate(ctx, pipeline)
+	cursor, err := env.SecondaryReadClient().Database(env.DB().Name()).Collection(VersionCollection).Aggregate(ctx, pipeline)
 	if err != nil {
 		return nil, errors.Wrap(err, "aggregating versions")
 	}
@@ -933,7 +933,7 @@ func GetVersionsWithOptions(ctx context.Context, projectName string, opts GetVer
 
 	res := []Version{}
 
-	if err := db.Aggregate(ctx, VersionCollection, pipeline, &res); err != nil {
+	if err := db.AggregateSecondary(ctx, VersionCollection, pipeline, &res); err != nil {
 		return nil, errors.Wrap(err, "aggregating versions and builds")
 	}
 	return res, nil

--- a/rest/model/build.go
+++ b/rest/model/build.go
@@ -146,7 +146,7 @@ func (apiBuild *APIBuild) BuildFromService(ctx context.Context, v build.Build, p
 	}
 	apiBuild.Origin = utility.ToStringPtr(origin)
 	if v.Project != "" {
-		identifier, err := model.GetIdentifierForProject(ctx, v.Project)
+		identifier, err := model.GetIdentifierForProjectSecondary(ctx, v.Project)
 		if err == nil {
 			apiBuild.ProjectIdentifier = utility.ToStringPtr(identifier)
 		}

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -217,7 +217,7 @@ func (apiPatch *APIPatch) GetIdentifier(ctx context.Context) {
 		return
 	}
 	if utility.FromStringPtr(apiPatch.ProjectId) != "" {
-		identifier, err := model.GetIdentifierForProject(ctx, utility.FromStringPtr(apiPatch.ProjectId))
+		identifier, err := model.GetIdentifierForProjectSecondary(ctx, utility.FromStringPtr(apiPatch.ProjectId))
 
 		grip.ErrorWhen(ctx, !errors.Is(context.Canceled, err), message.WrapError(err, message.Fields{
 			"message":  "could not get identifier for project",

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -118,7 +118,7 @@ type APIPatchTriggerDefinition struct {
 
 func (t *APIPatchTriggerDefinition) BuildFromService(ctx context.Context, def patch.PatchTriggerDefinition) error {
 	t.ChildProjectId = utility.ToStringPtr(def.ChildProject) // we store the real ID in the child project field
-	identifier, err := model.GetIdentifierForProject(ctx, def.ChildProject)
+	identifier, err := model.GetIdentifierForProjectSecondary(ctx, def.ChildProject)
 	if err != nil {
 		return errors.Wrapf(err, "getting identifier for child project '%s'", def.ChildProject)
 	}

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -552,7 +552,7 @@ func (at *APITask) GetProjectIdentifier(ctx context.Context) {
 		return
 	}
 	if utility.FromStringPtr(at.ProjectId) != "" {
-		identifier, err := model.GetIdentifierForProject(ctx, utility.FromStringPtr(at.ProjectId))
+		identifier, err := model.GetIdentifierForProjectSecondary(ctx, utility.FromStringPtr(at.ProjectId))
 		if err == nil {
 			at.ProjectIdentifier = utility.ToStringPtr(identifier)
 		}
@@ -666,10 +666,10 @@ func (at *APITask) getArtifacts(ctx context.Context) error {
 			ets = append(ets, artifact.TaskIDAndExecution{TaskID: *t, Execution: at.Execution})
 		}
 		if len(ets) > 0 {
-			entries, err = artifact.FindAll(ctx, artifact.ByTaskIdsAndExecutions(ets))
+			entries, err = artifact.FindAllSecondary(ctx, artifact.ByTaskIdsAndExecutions(ets))
 		}
 	} else {
-		entries, err = artifact.FindAll(ctx, artifact.ByTaskIdAndExecution(utility.FromStringPtr(at.Id), at.Execution))
+		entries, err = artifact.FindAllSecondary(ctx, artifact.ByTaskIdAndExecution(utility.FromStringPtr(at.Id), at.Execution))
 	}
 	if err != nil {
 		return errors.Wrap(err, "retrieving artifacts")

--- a/rest/model/version.go
+++ b/rest/model/version.go
@@ -144,7 +144,7 @@ func (apiVersion *APIVersion) BuildFromService(ctx context.Context, v model.Vers
 	}
 
 	if v.Identifier != "" {
-		identifier, err := model.GetIdentifierForProject(ctx, v.Identifier)
+		identifier, err := model.GetIdentifierForProjectSecondary(ctx, v.Identifier)
 		if err == nil {
 			apiVersion.ProjectIdentifier = utility.ToStringPtr(identifier)
 		}

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -843,7 +843,7 @@ func (h *reportHighExecTimeoutHandler) Run(ctx context.Context) gimlet.Responder
 	t := MustHaveTask(ctx)
 	// Ignore errors because the project identifier is a nice-to-have for
 	// alerting.
-	projectIdentifier, _ := model.GetIdentifierForProject(ctx, t.Project)
+	projectIdentifier, _ := model.GetIdentifierForProjectSecondary(ctx, t.Project)
 
 	grip.Warning(ctx, message.Fields{
 		"message":                          "task dynamically set an unusually high exec timeout",

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -473,7 +473,7 @@ func (as *APIServer) listPatchModules(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	projectName := project.Identifier // this might be the ID, so use identifier if we can
-	identifier, _ := model.GetIdentifierForProject(r.Context(), project.Identifier)
+	identifier, _ := model.GetIdentifierForProjectSecondary(r.Context(), project.Identifier)
 	if identifier != "" {
 		projectName = identifier
 	}

--- a/service/rest_task.go
+++ b/service/rest_task.go
@@ -159,7 +159,7 @@ func (restapi restAPI) getTaskInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Copy over artifacts and binaries.
-	entries, err := artifact.FindAll(r.Context(), artifact.ByTaskId(srcTask.Id))
+	entries, err := artifact.FindAllSecondary(r.Context(), artifact.ByTaskId(srcTask.Id))
 	if err != nil {
 		msg := fmt.Sprintf("Error finding task '%s'", srcTask.Id)
 		grip.Errorf(r.Context(), "%v: %+v", msg, err)


### PR DESCRIPTION
DEVPROD-32223

### Summary
move more reads into secondary, primarily most of the project ref reads which will mostly go to secondary now.
this makes sense since project refs are read very heavily but are also written to pretty rarely (in comparison) 

### Testing

All existing tests pass
Staging behaves well 
https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/2ddpBy3vJDV
honeycomb validation that most project reads are now on secondary 