### PR TITLE
DEVPROD-32222: Fix secondary task queue dispatcher refresh and dequeue collection

### DIFF
--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -400,6 +400,8 @@ func findTaskQueueForDistro(ctx context.Context, q taskQueueQuery) (*TaskQueue, 
 		val.Queue = nil
 	}
 	val.Distro = q.DistroID
+	// The aggregation above doesn't project DistroQueueInfo, so set the collection-routing flag from the queried collection.
+	val.DistroQueueInfo.SecondaryQueue = q.Collection == TaskSecondaryQueuesCollection
 
 	return val, nil
 }

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -476,7 +476,7 @@ outer:
 	// only no longer be present after the TTL has passed, and each app server
 	// has re-created its in-memory queue.
 
-	err := dequeue(ctx, taskId, tq.Distro)
+	err := dequeue(ctx, taskId, tq.Distro, tq.DistroQueueInfo.GetQueueCollection())
 	if adb.ResultsNotFound(err) {
 		return nil
 	}
@@ -484,12 +484,12 @@ outer:
 	return errors.WithStack(err)
 }
 
-func dequeue(ctx context.Context, taskId, distroId string) error {
+func dequeue(ctx context.Context, taskId, distroId, collection string) error {
 	itemKey := bsonutil.GetDottedKeyName(taskQueueQueueKey, taskQueueItemIdKey)
 
 	return errors.WithStack(db.Update(
 		ctx,
-		TaskQueuesCollection,
+		collection,
 		bson.M{
 			taskQueueDistroKey: distroId,
 			itemKey:            taskId,

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -29,6 +29,7 @@ const (
 type basicCachedDAGDispatcherImpl struct {
 	mu          sync.RWMutex
 	distroID    string
+	useAliases  bool // selects which task queue collection Refresh reloads from (secondary when true)
 	graph       *multi.DirectedGraph
 	sorted      []graph.Node
 	itemNodeMap map[string]graph.Node      // map[TaskQueueItem.Id]Node
@@ -55,8 +56,9 @@ type schedulableUnit struct {
 // newDistroTaskDAGDispatchService creates a basicCachedDAGDispatcherImpl from a slice of TaskQueueItems.
 func newDistroTaskDAGDispatchService(taskQueue TaskQueue, ttl time.Duration) (*basicCachedDAGDispatcherImpl, error) {
 	d := &basicCachedDAGDispatcherImpl{
-		distroID: taskQueue.Distro,
-		ttl:      ttl,
+		distroID:   taskQueue.Distro,
+		useAliases: taskQueue.DistroQueueInfo.SecondaryQueue,
+		ttl:        ttl,
 	}
 
 	if taskQueue.Length() != 0 {
@@ -80,7 +82,13 @@ func (d *basicCachedDAGDispatcherImpl) Refresh(ctx context.Context) error {
 		return nil
 	}
 
-	taskQueue, err := FindDistroTaskQueue(ctx, d.distroID)
+	var taskQueue TaskQueue
+	var err error
+	if d.useAliases {
+		taskQueue, err = FindDistroSecondaryTaskQueue(ctx, d.distroID)
+	} else {
+		taskQueue, err = FindDistroTaskQueue(ctx, d.distroID)
+	}
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/model/task_queue_test.go
+++ b/model/task_queue_test.go
@@ -107,7 +107,13 @@ func TestDequeueTaskUpdatesSecondaryQueueCollection(t *testing.T) {
 	}
 	require.NoError(t, tq.Save(t.Context()))
 
-	require.NoError(t, tq.DequeueTask(t.Context(), "t1"))
+	// Dequeue via the loader the dispatcher actually uses (an aggregation that doesn't
+	// populate DistroQueueInfo) rather than the hand-built struct, so collection routing
+	// is exercised for real.
+	loaded, err := LoadDistroSecondaryTaskQueue(t.Context(), distroID)
+	require.NoError(t, err)
+	require.NotNil(t, loaded)
+	require.NoError(t, loaded.DequeueTask(t.Context(), "t1"))
 
 	secondary, err := FindDistroSecondaryTaskQueue(t.Context(), distroID)
 	require.NoError(t, err)

--- a/model/task_queue_test.go
+++ b/model/task_queue_test.go
@@ -96,6 +96,56 @@ func TestDequeueTask(t *testing.T) {
 	})
 }
 
+func TestDequeueTaskUpdatesSecondaryQueueCollection(t *testing.T) {
+	require.NoError(t, db.ClearCollections(TaskQueuesCollection, TaskSecondaryQueuesCollection))
+	distroID := "d1"
+
+	tq := &TaskQueue{
+		Distro:          distroID,
+		Queue:           []TaskQueueItem{{Id: "t1"}, {Id: "t2"}},
+		DistroQueueInfo: DistroQueueInfo{SecondaryQueue: true},
+	}
+	require.NoError(t, tq.Save(t.Context()))
+
+	require.NoError(t, tq.DequeueTask(t.Context(), "t1"))
+
+	secondary, err := FindDistroSecondaryTaskQueue(t.Context(), distroID)
+	require.NoError(t, err)
+	require.Len(t, secondary.Queue, 2)
+	dispatched := map[string]bool{}
+	for _, item := range secondary.Queue {
+		dispatched[item.Id] = item.IsDispatched
+	}
+	assert.True(t, dispatched["t1"], "dequeued task should be marked dispatched in the secondary collection")
+	assert.False(t, dispatched["t2"])
+}
+
+func TestDAGDispatcherRefreshUsesSecondaryQueue(t *testing.T) {
+	require.NoError(t, db.ClearCollections(TaskQueuesCollection, TaskSecondaryQueuesCollection))
+	distroID := "d-alias-refresh"
+
+	// Seed different tasks into the primary and secondary queues for the same distro.
+	primary := &TaskQueue{Distro: distroID, Queue: []TaskQueueItem{{Id: "primary-task"}}}
+	require.NoError(t, primary.Save(t.Context()))
+	secondary := &TaskQueue{
+		Distro:          distroID,
+		Queue:           []TaskQueueItem{{Id: "secondary-task"}},
+		DistroQueueInfo: DistroQueueInfo{SecondaryQueue: true},
+	}
+	require.NoError(t, secondary.Save(t.Context()))
+
+	d, err := newDistroTaskDAGDispatchService(*secondary, time.Minute)
+	require.NoError(t, err)
+	d.lastUpdated = time.Now().Add(-time.Hour) // force a refresh past the TTL
+
+	require.NoError(t, d.Refresh(t.Context()))
+
+	_, hasSecondary := d.itemNodeMap["secondary-task"]
+	_, hasPrimary := d.itemNodeMap["primary-task"]
+	assert.True(t, hasSecondary, "alias dispatcher should reload from the secondary queue")
+	assert.False(t, hasPrimary, "alias dispatcher must not reload from the primary queue")
+}
+
 func TestClearTaskQueue(t *testing.T) {
 	assert := assert.New(t)
 	distro := "distro"


### PR DESCRIPTION
DEVPROD-32222

### Description
Two latent secondary-queue collection-identity bugs (today masked by the near-empty alias queue plus the atomic dispatch guard, but fatal under any real secondary-queue volume):

- **Refresh-from-primary:** the cached DAG dispatcher only knew its collection at seed time, so an alias dispatcher reloaded the primary `task_queues` on every post-TTL `Refresh`. Added a `useAliases` flag, set at the `ensureQueue` seam, and branched `Refresh` on it.
- **Dequeue-wrong-collection:** `dequeue` hardcoded `task_queues`, so dispatching a secondary-queue task set `dispatched` against a non-matching primary doc (swallowed as not-found, causing indefinite re-offers). Now routes through `DistroQueueInfo.GetQueueCollection()`.

### Testing
Two regression tests in `model/task_queue_test.go`, both verified failing without the fix: `TestDAGDispatcherRefreshUsesSecondaryQueue`, `TestDequeueTaskUpdatesSecondaryQueueCollection`. Existing `TestDequeueTask` unaffected.
