### PR TITLE
DEVPROD-33463 Add proof diagnostic route for comparing version manifests

### DIFF
--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -266,6 +266,10 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/versions/{version_id}/annotations").Version(2).Get().Wrap(requireUser, viewAnnotations).RouteHandler(makeFetchAnnotationsByVersion())
 	app.AddRoute("/versions/{version_id}/manifest").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetVersionManifest())
 
+	// This diagnostic route compares a version's manifest with its adjacent versions
+	// to show which project and module revisions changed.
+	app.AddRoute("/versions/{version_id}/manifest/proof").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetVersionManifestProof())
+
 	// Add an options method to every GET, POST request to handle pre-flight Options requests.
 	// These requests must not check for credentials and just validate whether a route exists
 	// And allows requests from a origin.

--- a/rest/route/version.go
+++ b/rest/route/version.go
@@ -524,9 +524,10 @@ type versionManifestProofGetHandler struct {
 }
 
 type versionManifestProofResponse struct {
-	Previous *versionManifestProofSnapshot `json:"previous"`
-	Current  *versionManifestProofSnapshot `json:"current"`
-	Next     *versionManifestProofSnapshot `json:"next"`
+	BeforePrevious *versionManifestProofVersion  `json:"before_previous"`
+	Previous       *versionManifestProofSnapshot `json:"previous"`
+	Current        *versionManifestProofSnapshot `json:"current"`
+	Next           *versionManifestProofSnapshot `json:"next"`
 }
 
 type versionManifestProofSnapshot struct {
@@ -541,6 +542,16 @@ type versionManifestProofSnapshot struct {
 	HasComparison          bool                         `json:"has_comparison"`
 	ManifestFound          bool                         `json:"manifest_found"`
 	Modules                []versionManifestProofModule `json:"modules"`
+}
+
+type versionManifestProofVersion struct {
+	VersionID       string    `json:"version_id"`
+	Project         string    `json:"project"`
+	Requester       string    `json:"requester"`
+	Order           int       `json:"order"`
+	CreateTime      time.Time `json:"create_time"`
+	IngestTime      time.Time `json:"ingest_time"`
+	ProjectRevision string    `json:"project_revision"`
 }
 
 type versionManifestProofModule struct {
@@ -628,7 +639,8 @@ func (h *versionManifestProofGetHandler) Run(ctx context.Context) gimlet.Respond
 	}
 
 	response := &versionManifestProofResponse{
-		Current: buildManifestProofSnapshot(current, currentManifest, previous, previousManifest),
+		BeforePrevious: buildManifestProofVersion(previousPrevious),
+		Current:        buildManifestProofSnapshot(current, currentManifest, previous, previousManifest),
 	}
 	if previous != nil {
 		response.Previous = buildManifestProofSnapshot(previous, previousManifest, previousPrevious, previousPreviousManifest)
@@ -665,6 +677,21 @@ func findManifestForProof(ctx context.Context, v *dbModel.Version) (*manifest.Ma
 		return nil, nil
 	}
 	return manifest.FindFromVersion(ctx, v.Id, v.Identifier, v.Revision, v.Requester)
+}
+
+func buildManifestProofVersion(v *dbModel.Version) *versionManifestProofVersion {
+	if v == nil {
+		return nil
+	}
+	return &versionManifestProofVersion{
+		VersionID:       v.Id,
+		Project:         v.Identifier,
+		Requester:       v.Requester,
+		Order:           v.RevisionOrderNumber,
+		CreateTime:      v.CreateTime,
+		IngestTime:      v.IngestTime,
+		ProjectRevision: v.Revision,
+	}
 }
 
 func buildManifestProofSnapshot(v *dbModel.Version, mfst *manifest.Manifest, comparisonVersion *dbModel.Version, comparisonManifest *manifest.Manifest) *versionManifestProofSnapshot {

--- a/rest/route/version.go
+++ b/rest/route/version.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 	"strconv"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -513,4 +515,200 @@ func (h *versionManifestGetHandler) Run(ctx context.Context) gimlet.Responder {
 	apiMfst := &restModel.APIManifest{}
 	apiMfst.BuildFromService(mfst)
 	return gimlet.NewJSONResponse(apiMfst)
+}
+
+// GET /rest/v2/versions/{version_id}/manifest/proof
+
+type versionManifestProofGetHandler struct {
+	versionId string
+}
+
+type versionManifestProofResponse struct {
+	Previous *versionManifestProofSnapshot `json:"previous"`
+	Current  *versionManifestProofSnapshot `json:"current"`
+	Next     *versionManifestProofSnapshot `json:"next"`
+}
+
+type versionManifestProofSnapshot struct {
+	VersionID              string                       `json:"version_id"`
+	Project                string                       `json:"project"`
+	Requester              string                       `json:"requester"`
+	Order                  int                          `json:"order"`
+	CreateTime             time.Time                    `json:"create_time"`
+	IngestTime             time.Time                    `json:"ingest_time"`
+	ProjectRevision        string                       `json:"project_revision"`
+	ProjectRevisionChanged bool                         `json:"project_revision_changed"`
+	HasComparison          bool                         `json:"has_comparison"`
+	ManifestFound          bool                         `json:"manifest_found"`
+	Modules                []versionManifestProofModule `json:"modules"`
+}
+
+type versionManifestProofModule struct {
+	restModel.APIManifestModule
+	Changed bool `json:"changed"`
+}
+
+func makeGetVersionManifestProof() gimlet.RouteHandler {
+	return &versionManifestProofGetHandler{}
+}
+
+// Factory creates an instance of the handler.
+//
+//	@Summary		Fetch version manifest proof by version ID
+//	@Description	Fetches previous/current/next version revisions and module pins for comparing manifest movement.
+//	@Tags			manifests
+//	@Router			/versions/{version_id}/manifest/proof [get]
+//	@Security		Api-User || Api-Key
+//	@Param			version_id	path		string	true	"version ID"
+//	@Success		200			{object}	versionManifestProofResponse
+func (h *versionManifestProofGetHandler) Factory() gimlet.RouteHandler {
+	return &versionManifestProofGetHandler{}
+}
+
+func (h *versionManifestProofGetHandler) Parse(ctx context.Context, r *http.Request) error {
+	h.versionId = gimlet.GetVars(r)["version_id"]
+	if h.versionId == "" {
+		return errors.New("missing version ID")
+	}
+	return nil
+}
+
+func (h *versionManifestProofGetHandler) Run(ctx context.Context) gimlet.Responder {
+	current, err := dbModel.VersionFindOneId(ctx, h.versionId)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding version '%s'", h.versionId))
+	}
+	if current == nil {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("version '%s' not found", h.versionId),
+		})
+	}
+
+	previous, err := findPreviousSystemVersion(ctx, current.Identifier, current.RevisionOrderNumber)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding previous version for version '%s'", h.versionId))
+	}
+	var previousPrevious *dbModel.Version
+	if previous != nil {
+		previousPrevious, err = findPreviousSystemVersion(ctx, previous.Identifier, previous.RevisionOrderNumber)
+		if err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding version before previous version '%s'", previous.Id))
+		}
+	}
+	next, err := findNextSystemVersion(ctx, current.Identifier, current.RevisionOrderNumber)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding next version for version '%s'", h.versionId))
+	}
+
+	currentManifest, err := findManifestForProof(ctx, current)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding manifest for version '%s'", current.Id))
+	}
+	var previousManifest *manifest.Manifest
+	if previous != nil {
+		previousManifest, err = findManifestForProof(ctx, previous)
+		if err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding manifest for previous version '%s'", previous.Id))
+		}
+	}
+	var previousPreviousManifest *manifest.Manifest
+	if previousPrevious != nil {
+		previousPreviousManifest, err = findManifestForProof(ctx, previousPrevious)
+		if err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding manifest for version before previous version '%s'", previousPrevious.Id))
+		}
+	}
+	var nextManifest *manifest.Manifest
+	if next != nil {
+		nextManifest, err = findManifestForProof(ctx, next)
+		if err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding manifest for next version '%s'", next.Id))
+		}
+	}
+
+	response := &versionManifestProofResponse{
+		Current: buildManifestProofSnapshot(current, currentManifest, previous, previousManifest),
+	}
+	if previous != nil {
+		response.Previous = buildManifestProofSnapshot(previous, previousManifest, previousPrevious, previousPreviousManifest)
+	}
+	if next != nil {
+		response.Next = buildManifestProofSnapshot(next, nextManifest, current, currentManifest)
+	}
+
+	return gimlet.NewJSONResponse(response)
+}
+
+func findPreviousSystemVersion(ctx context.Context, project string, order int) (*dbModel.Version, error) {
+	return findAdjacentSystemVersion(ctx, project, order, "$lt", "-"+dbModel.VersionRevisionOrderNumberKey)
+}
+
+func findNextSystemVersion(ctx context.Context, project string, order int) (*dbModel.Version, error) {
+	return findAdjacentSystemVersion(ctx, project, order, "$gt", dbModel.VersionRevisionOrderNumberKey)
+}
+
+func findAdjacentSystemVersion(ctx context.Context, project string, order int, comparisonOperator, sortKey string) (*dbModel.Version, error) {
+	return dbModel.VersionFindOne(ctx, db.Query(bson.M{
+		dbModel.VersionIdentifierKey: project,
+		dbModel.VersionRevisionOrderNumberKey: bson.M{
+			comparisonOperator: order,
+		},
+		dbModel.VersionRequesterKey: bson.M{
+			"$in": evergreen.SystemVersionRequesterTypes,
+		},
+	}).Sort([]string{sortKey}).WithoutFields(dbModel.VersionBuildVariantsKey))
+}
+
+func findManifestForProof(ctx context.Context, v *dbModel.Version) (*manifest.Manifest, error) {
+	if v == nil {
+		return nil, nil
+	}
+	return manifest.FindFromVersion(ctx, v.Id, v.Identifier, v.Revision, v.Requester)
+}
+
+func buildManifestProofSnapshot(v *dbModel.Version, mfst *manifest.Manifest, comparisonVersion *dbModel.Version, comparisonManifest *manifest.Manifest) *versionManifestProofSnapshot {
+	snapshot := &versionManifestProofSnapshot{
+		VersionID:       v.Id,
+		Project:         v.Identifier,
+		Requester:       v.Requester,
+		Order:           v.RevisionOrderNumber,
+		CreateTime:      v.CreateTime,
+		IngestTime:      v.IngestTime,
+		ProjectRevision: v.Revision,
+		HasComparison:   comparisonVersion != nil,
+		ManifestFound:   mfst != nil,
+		Modules:         []versionManifestProofModule{},
+	}
+	if comparisonVersion != nil {
+		snapshot.ProjectRevisionChanged = v.Revision != comparisonVersion.Revision
+	}
+	if mfst == nil {
+		return snapshot
+	}
+
+	moduleNames := make([]string, 0, len(mfst.Modules))
+	for moduleName := range mfst.Modules {
+		moduleNames = append(moduleNames, moduleName)
+	}
+	sort.Strings(moduleNames)
+
+	for _, moduleName := range moduleNames {
+		mfstModule := mfst.Modules[moduleName]
+		if mfstModule == nil {
+			continue
+		}
+		apiModule := restModel.APIManifestModule{}
+		apiModule.BuildFromService(moduleName, mfstModule)
+		proofModule := versionManifestProofModule{
+			APIManifestModule: apiModule,
+		}
+		if comparisonManifest != nil {
+			comparisonModule, ok := comparisonManifest.Modules[moduleName]
+			proofModule.Changed = !ok || comparisonModule == nil || comparisonModule.Revision != mfstModule.Revision
+		}
+		snapshot.Modules = append(snapshot.Modules, proofModule)
+	}
+
+	return snapshot
 }

--- a/rest/route/version.go
+++ b/rest/route/version.go
@@ -555,8 +555,13 @@ type versionManifestProofVersion struct {
 }
 
 type versionManifestProofModule struct {
-	restModel.APIManifestModule
-	Changed bool `json:"changed"`
+	Name     *string `json:"name"`
+	Owner    *string `json:"owner"`
+	Repo     *string `json:"repo"`
+	Branch   *string `json:"branch"`
+	Revision *string `json:"revision"`
+	URL      *string `json:"url"`
+	Changed  bool    `json:"changed"`
 }
 
 func makeGetVersionManifestProof() gimlet.RouteHandler {
@@ -725,10 +730,13 @@ func buildManifestProofSnapshot(v *dbModel.Version, mfst *manifest.Manifest, com
 		if mfstModule == nil {
 			continue
 		}
-		apiModule := restModel.APIManifestModule{}
-		apiModule.BuildFromService(moduleName, mfstModule)
 		proofModule := versionManifestProofModule{
-			APIManifestModule: apiModule,
+			Name:     utility.ToStringPtr(moduleName),
+			Branch:   utility.ToStringPtr(mfstModule.Branch),
+			Repo:     utility.ToStringPtr(mfstModule.Repo),
+			Revision: utility.ToStringPtr(mfstModule.Revision),
+			Owner:    utility.ToStringPtr(mfstModule.Owner),
+			URL:      utility.ToStringPtr(mfstModule.URL),
 		}
 		if comparisonManifest != nil {
 			comparisonModule, ok := comparisonManifest.Modules[moduleName]

--- a/rest/route/version_test.go
+++ b/rest/route/version_test.go
@@ -463,9 +463,15 @@ func TestGetVersionManifestProof(t *testing.T) {
 
 			proof, ok := res.Data().(*versionManifestProofResponse)
 			require.True(t, ok)
+			require.NotNil(t, proof.BeforePrevious)
 			require.NotNil(t, proof.Previous)
 			require.NotNil(t, proof.Current)
 			require.NotNil(t, proof.Next)
+
+			assert.Equal(t, previousPrevious.Id, proof.BeforePrevious.VersionID)
+			assert.Equal(t, previousPrevious.Requester, proof.BeforePrevious.Requester)
+			assert.Equal(t, previousPrevious.Revision, proof.BeforePrevious.ProjectRevision)
+			assert.Equal(t, previousPrevious.RevisionOrderNumber, proof.BeforePrevious.Order)
 
 			assert.Equal(t, previous.Id, proof.Previous.VersionID)
 			assert.True(t, proof.Previous.HasComparison)
@@ -504,6 +510,7 @@ func TestGetVersionManifestProof(t *testing.T) {
 
 			proof, ok := res.Data().(*versionManifestProofResponse)
 			require.True(t, ok)
+			assert.Nil(t, proof.BeforePrevious)
 			assert.Nil(t, proof.Previous)
 			assert.Nil(t, proof.Next)
 			require.NotNil(t, proof.Current)
@@ -527,6 +534,7 @@ func TestGetVersionManifestProof(t *testing.T) {
 
 			proof, ok := res.Data().(*versionManifestProofResponse)
 			require.True(t, ok)
+			assert.Nil(t, proof.BeforePrevious)
 			require.NotNil(t, proof.Previous)
 			require.NotNil(t, proof.Current)
 			assert.Nil(t, proof.Next)
@@ -553,6 +561,7 @@ func TestGetVersionManifestProof(t *testing.T) {
 
 			proof, ok := res.Data().(*versionManifestProofResponse)
 			require.True(t, ok)
+			assert.Nil(t, proof.BeforePrevious)
 			assert.Nil(t, proof.Previous)
 			assert.Nil(t, proof.Next)
 			require.NotNil(t, proof.Current)

--- a/rest/route/version_test.go
+++ b/rest/route/version_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -16,6 +17,8 @@ import (
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -438,4 +441,209 @@ func (s *VersionSuite) TestGetManifestForVersionErrorsForNonexistentVersion() {
 	res := handler.Run(ctx)
 	s.NotNil(res)
 	s.Equal(http.StatusNotFound, res.Status())
+}
+
+func TestGetVersionManifestProof(t *testing.T) {
+	for tName, tCase := range map[string]func(t *testing.T){
+		"WithAdjacentVersions": func(t *testing.T) {
+			projectID := "proof-adjacent-project"
+			previousPrevious := insertProofVersion(t, projectID, "proof-adjacent-previous-previous", "project-revision-1", 1)
+			previous := insertProofVersion(t, projectID, "proof-adjacent-previous", "project-revision-2", 2)
+			current := insertProofVersion(t, projectID, "proof-adjacent-current", "project-revision-2", 3)
+			next := insertProofVersion(t, projectID, "proof-adjacent-next", "project-revision-2", 4)
+			insertProofManifest(t, previousPrevious, "module-revision-1")
+			insertProofManifest(t, previous, "module-revision-1")
+			insertProofManifest(t, current, "module-revision-2")
+			insertProofManifest(t, next, "module-revision-3")
+
+			handler := &versionManifestProofGetHandler{versionId: current.Id}
+			res := handler.Run(t.Context())
+			require.NotNil(t, res)
+			require.Equal(t, http.StatusOK, res.Status(), res.Data())
+
+			proof, ok := res.Data().(*versionManifestProofResponse)
+			require.True(t, ok)
+			require.NotNil(t, proof.Previous)
+			require.NotNil(t, proof.Current)
+			require.NotNil(t, proof.Next)
+
+			assert.Equal(t, previous.Id, proof.Previous.VersionID)
+			assert.True(t, proof.Previous.HasComparison)
+			assert.True(t, proof.Previous.ManifestFound)
+			assert.True(t, proof.Previous.ProjectRevisionChanged)
+			require.Len(t, proof.Previous.Modules, 1)
+			assert.False(t, proof.Previous.Modules[0].Changed)
+
+			assert.Equal(t, current.Id, proof.Current.VersionID)
+			assert.True(t, proof.Current.HasComparison)
+			assert.True(t, proof.Current.ManifestFound)
+			assert.False(t, proof.Current.ProjectRevisionChanged)
+			currentModule := proofModuleByName(proof.Current.Modules, "module1")
+			require.NotNil(t, currentModule)
+			assert.True(t, currentModule.Changed)
+			assert.Equal(t, "module-revision-2", utility.FromStringPtr(currentModule.Revision))
+
+			assert.Equal(t, next.Id, proof.Next.VersionID)
+			assert.True(t, proof.Next.HasComparison)
+			assert.True(t, proof.Next.ManifestFound)
+			assert.False(t, proof.Next.ProjectRevisionChanged)
+			nextModule := proofModuleByName(proof.Next.Modules, "module1")
+			require.NotNil(t, nextModule)
+			assert.True(t, nextModule.Changed)
+			assert.Equal(t, "module-revision-3", utility.FromStringPtr(nextModule.Revision))
+		},
+		"WithOnlyCurrentVersion": func(t *testing.T) {
+			projectID := "proof-current-only-project"
+			current := insertProofVersion(t, projectID, "proof-current-only-current", "project-revision-1", 1)
+			insertProofManifest(t, current, "module-revision-1")
+
+			handler := &versionManifestProofGetHandler{versionId: current.Id}
+			res := handler.Run(t.Context())
+			require.NotNil(t, res)
+			require.Equal(t, http.StatusOK, res.Status(), res.Data())
+
+			proof, ok := res.Data().(*versionManifestProofResponse)
+			require.True(t, ok)
+			assert.Nil(t, proof.Previous)
+			assert.Nil(t, proof.Next)
+			require.NotNil(t, proof.Current)
+			assert.False(t, proof.Current.HasComparison)
+			assert.True(t, proof.Current.ManifestFound)
+			assert.False(t, proof.Current.ProjectRevisionChanged)
+			require.Len(t, proof.Current.Modules, 1)
+			assert.False(t, proof.Current.Modules[0].Changed)
+		},
+		"WithMissingPreviousPreviousAndNext": func(t *testing.T) {
+			projectID := "proof-missing-previous-previous-project"
+			previous := insertProofVersion(t, projectID, "proof-missing-previous-previous-previous", "project-revision-1", 1)
+			current := insertProofVersion(t, projectID, "proof-missing-previous-previous-current", "project-revision-2", 2)
+			insertProofManifest(t, previous, "module-revision-1")
+			insertProofManifest(t, current, "module-revision-2")
+
+			handler := &versionManifestProofGetHandler{versionId: current.Id}
+			res := handler.Run(t.Context())
+			require.NotNil(t, res)
+			require.Equal(t, http.StatusOK, res.Status(), res.Data())
+
+			proof, ok := res.Data().(*versionManifestProofResponse)
+			require.True(t, ok)
+			require.NotNil(t, proof.Previous)
+			require.NotNil(t, proof.Current)
+			assert.Nil(t, proof.Next)
+
+			assert.False(t, proof.Previous.HasComparison)
+			assert.False(t, proof.Previous.ProjectRevisionChanged)
+			require.Len(t, proof.Previous.Modules, 1)
+			assert.False(t, proof.Previous.Modules[0].Changed)
+
+			assert.True(t, proof.Current.HasComparison)
+			assert.True(t, proof.Current.ProjectRevisionChanged)
+			currentModule := proofModuleByName(proof.Current.Modules, "module1")
+			require.NotNil(t, currentModule)
+			assert.True(t, currentModule.Changed)
+		},
+		"ReturnsProjectDataWithoutCurrentManifest": func(t *testing.T) {
+			projectID := "proof-missing-current-manifest-project"
+			current := insertProofVersion(t, projectID, "proof-missing-current-manifest-current", "project-revision-1", 1)
+
+			handler := &versionManifestProofGetHandler{versionId: current.Id}
+			res := handler.Run(t.Context())
+			require.NotNil(t, res)
+			require.Equal(t, http.StatusOK, res.Status(), res.Data())
+
+			proof, ok := res.Data().(*versionManifestProofResponse)
+			require.True(t, ok)
+			assert.Nil(t, proof.Previous)
+			assert.Nil(t, proof.Next)
+			require.NotNil(t, proof.Current)
+			assert.Equal(t, current.Id, proof.Current.VersionID)
+			assert.Equal(t, current.Revision, proof.Current.ProjectRevision)
+			assert.False(t, proof.Current.ManifestFound)
+			assert.Empty(t, proof.Current.Modules)
+		},
+		"HandlesMissingNeighborManifest": func(t *testing.T) {
+			projectID := "proof-missing-neighbor-manifest-project"
+			previous := insertProofVersion(t, projectID, "proof-missing-neighbor-manifest-previous", "project-revision-1", 1)
+			current := insertProofVersion(t, projectID, "proof-missing-neighbor-manifest-current", "project-revision-2", 2)
+			insertProofManifest(t, current, "module-revision-1")
+
+			handler := &versionManifestProofGetHandler{versionId: current.Id}
+			res := handler.Run(t.Context())
+			require.NotNil(t, res)
+			require.Equal(t, http.StatusOK, res.Status(), res.Data())
+
+			proof, ok := res.Data().(*versionManifestProofResponse)
+			require.True(t, ok)
+			require.NotNil(t, proof.Previous)
+			require.NotNil(t, proof.Current)
+			assert.Equal(t, previous.Id, proof.Previous.VersionID)
+			assert.False(t, proof.Previous.ManifestFound)
+			assert.Empty(t, proof.Previous.Modules)
+			assert.True(t, proof.Current.HasComparison)
+			assert.True(t, proof.Current.ProjectRevisionChanged)
+			assert.True(t, proof.Current.ManifestFound)
+			require.Len(t, proof.Current.Modules, 1)
+			assert.False(t, proof.Current.Modules[0].Changed)
+		},
+		"ErrorsForNonexistentVersion": func(t *testing.T) {
+			handler := &versionManifestProofGetHandler{versionId: "proof-nonexistent-version"}
+
+			res := handler.Run(t.Context())
+			require.NotNil(t, res)
+			assert.Equal(t, http.StatusNotFound, res.Status())
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(serviceModel.VersionCollection, manifest.Collection))
+			tCase(t)
+		})
+	}
+}
+
+func insertProofVersion(t *testing.T, projectID, versionID, revision string, order int) serviceModel.Version {
+	t.Helper()
+	ts := time.Date(2026, time.June, 16, 12, order, 0, 0, time.UTC)
+	v := serviceModel.Version{
+		Id:                  versionID,
+		Identifier:          projectID,
+		Requester:           evergreen.RepotrackerVersionRequester,
+		Revision:            revision,
+		RevisionOrderNumber: order,
+		CreateTime:          ts,
+		IngestTime:          ts.Add(time.Second),
+	}
+	require.NoError(t, v.Insert(t.Context()))
+	return v
+}
+
+func insertProofManifest(t *testing.T, v serviceModel.Version, moduleRevision string) {
+	t.Helper()
+	mfst := manifest.Manifest{
+		Id:          v.Id,
+		Revision:    v.Revision,
+		ProjectName: v.Identifier,
+		Branch:      "main",
+		IsBase:      true,
+		Modules: map[string]*manifest.Module{
+			"module1": {
+				Branch:   "main",
+				Repo:     "module-repo",
+				Revision: moduleRevision,
+				Owner:    "module-owner",
+				URL:      "module-url",
+			},
+		},
+	}
+	exists, err := mfst.TryInsert(t.Context())
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func proofModuleByName(modules []versionManifestProofModule, name string) *versionManifestProofModule {
+	for i := range modules {
+		if utility.FromStringPtr(modules[i].Name) == name {
+			return &modules[i]
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
DEVPROD-33463

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->
This adds a diagnostic manifest proof route, that will be used for DEVPROD-33463 implementation.  The point of this route is provide users and myself with a quick way of checking the end-result of a version's manifest compared to its neighbors to verify if Evergreen is making the right selection.

### Testing

<!--add a description of how you tested it-->
Some unit tests that cover the common cases. I deployed to staging and got valid responses from the endpoint.

### Documentation

I added the openapi docs.

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
