### PR TITLE
Fix warning logged as catcher error in admin all configs

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-06-16"
+	ClientVersion = "2026-06-16a"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/admin_all_configs.go
+++ b/operations/admin_all_configs.go
@@ -95,7 +95,7 @@ func fetchAndWriteConfigs(ctx context.Context, c *legacyClient, projects []model
 				continue
 			}
 			if len(versions) == 0 {
-				catcher.Errorf("WARNING: project '%s' has no versions", p.Identifier)
+				grip.Warningf(ctx, "project '%s' has no versions; skipping", p.Identifier)
 				continue
 			}
 			config, err = c.GetConfig(versions[0])


### PR DESCRIPTION
DEVPROD-34812

### Description

Fixes a regression introduced in #10318 which re-introduced `catcher.Errorf("WARNING: ...")` in `fetchAndWriteConfigs`. This causes the `validate-all-project-configs` command to exit non-zero when any project has no versions, breaking the `test-config-validation` CI task.

The fix restores the `grip.Warningf` behavior originally landed in #10314 (DEVPROD-34769).

### Testing

The `test-config-validation` CI task will pass once this merges.