### PR TITLE
DEVPROD-35238 - Change Error in admin all configs to warning for missing Version Path

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-06-16"
+	ClientVersion = "2026-06-16a"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/admin_all_configs.go
+++ b/operations/admin_all_configs.go
@@ -95,7 +95,7 @@ func fetchAndWriteConfigs(ctx context.Context, c *legacyClient, projects []model
 				continue
 			}
 			if len(versions) == 0 {
-				catcher.Errorf("WARNING: project '%s' has no versions", p.Identifier)
+				grip.Warningf(ctx, "project '%s' has no versions; skipping", p.Identifier)
 				continue
 			}
 			config, err = c.GetConfig(versions[0])


### PR DESCRIPTION
DEVPROD-35238

### Description

Changes the error reported to a warning for the missing-version path in fetchAndWriteConfigs. With `catcher.Errorf`, the script exits non-zero if any project has no versions. This is a valid state for newly created projects. Changing to `grip.Warningf` allows the script to continue and skip those projects.

### Testing
Ran the script and now we see the script continue