### PR TITLE
DEVPROD-33786 Add missing merge queue and host stats to splunk

### DIFF
--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -549,6 +549,7 @@ func (gh *githubHookApi) handleMergeGroupChecksRequested(ctx context.Context, ev
 		"org":      org,
 		"repo":     repo,
 		"branch":   branch,
+		"sender":   event.GetSender().GetLogin(),
 		"base_sha": event.GetMergeGroup().GetBaseSHA(),
 		"head_sha": event.GetMergeGroup().GetHeadSHA(),
 		"message":  "merge group received",

--- a/trigger/process.go
+++ b/trigger/process.go
@@ -359,6 +359,7 @@ func TriggerDownstreamProjectsForPush(ctx context.Context, projectId string, eve
 		grip.Info(ctx, message.Fields{
 			"source":                           "GitHub hook",
 			"message":                          "triggered downstream versions for project push event",
+			"sender":                           event.GetSender().GetLogin(),
 			"upstream_commits":                 commits,
 			"upstream_project_id":              projectId,
 			"downstream_version_ids":           versionIds,

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -903,6 +903,7 @@ func processTriggerAliases(ctx context.Context, p *patch.Patch, projectRef *mode
 		"source":            "patch-trigger",
 		"parent_patch_id":   p.Id.Hex(),
 		"parent_project_id": p.Project,
+		"author":            p.Author,
 		"child_patch_ids":   p.Triggers.ChildPatches,
 		"num_children":      len(p.Triggers.ChildPatches),
 	})

--- a/units/provisioning_create_host.go
+++ b/units/provisioning_create_host.go
@@ -381,6 +381,7 @@ func (j *createHostJob) createHost(ctx context.Context) error {
 		"single_task_distro": j.host.Distro.SingleTaskDistro,
 		"provider":           j.host.Provider,
 		"subnet":             j.host.GetSubnetID(),
+		"started_by":         j.host.StartedBy,
 		"job":                j.ID(),
 		"runtime_secs":       time.Since(j.start).Seconds(),
 		"num_attempts":       j.RetryInfo().CurrentAttempt,


### PR DESCRIPTION
DEVPROD-33786

### Description
Addresses the following gaps in data that are currently missing from the [golden path dashboard](https://mongodb.splunkcloud.com/en-US/app/search/evergreen_product__operational_metrics?form.global_time.earliest=-24h%40h&form.global_time.latest=now&tab=layout_1) and were laid out in this [doc](https://docs.google.com/document/d/1JjDwRV6CnQ-g_7bb7srQqfs9oe2g8Hl41sIHtHj3fIw/edit?tab=t.0):

- Total task hosts spun up per day by requester type
- num of users interacting with patch triggers & project triggers
- num of users for the merge queue
### Testing

Existing tests.