### PR TITLE
DEVPROD-33516: productionize cross-file YAML anchors

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-06-16a"
+	ClientVersion = "2026-06-17"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -355,9 +355,9 @@ include:
     module: module_name
 ```
 
-#### YAML Anchors (Beta)
+#### YAML Anchors
 
-YAML anchors (`&name`) and aliases (`*name`) are supported within a single file and across include files. Cross-file anchor support is in beta and requires passing `--yaml-anchors` to `evergreen validate` or `evergreen evaluate`.
+YAML anchors (`&name`) and aliases (`*name`) are supported within a single file and across include files.
 
 An anchor defined in the main config file or in an earlier include file can be referenced as an alias in any later include file. Files are processed in the order they are listed in `include`, so an alias can only refer to an anchor that was defined in a file that appears earlier in the list (or in the main config file).
 

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -682,7 +682,7 @@ func TestMakePatchedConfigRenamed(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, projectData)
 
-	intermediateProject, err := createIntermediateProject(projectData, false, nil)
+	intermediateProject, err := createIntermediateProject(projectData, false, &anchorEntries{})
 	assert.NoError(t, err)
 	assert.NotNil(t, intermediateProject)
 	require.Len(t, intermediateProject.BuildVariants, 1)

--- a/model/project_matrix_test.go
+++ b/model/project_matrix_test.go
@@ -41,7 +41,7 @@ buildvariants:
       set:
         tags: "gotcha_boy"
 `
-			p, err := createIntermediateProject([]byte(axes), true, nil)
+			p, err := createIntermediateProject([]byte(axes), true, &anchorEntries{})
 			So(err, ShouldBeNil)
 			axis := p.Axes[0]
 			So(axis.Id, ShouldEqual, "os")
@@ -77,7 +77,7 @@ buildvariants:
     - blue
     - green
 `
-			p, err := createIntermediateProject([]byte(simple), false, nil)
+			p, err := createIntermediateProject([]byte(simple), false, &anchorEntries{})
 			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
 			m1 := *p.BuildVariants[0].Matrix
@@ -108,7 +108,7 @@ buildvariants:
 - name: "single_variant"
   tasks: "*"
 `
-			p, err := createIntermediateProject([]byte(simple), false, nil)
+			p, err := createIntermediateProject([]byte(simple), false, &anchorEntries{})
 			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
 			m1 := *p.BuildVariants[0].Matrix

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -723,12 +723,9 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, pro
 	defer span.End()
 
 	unmarshalStrict := false
-	var anchorRegistry *anchorEntries
+	anchorRegistry := &anchorEntries{}
 	if opts != nil {
 		unmarshalStrict = opts.UnmarshalStrict
-		if opts.EnableYAMLAnchors {
-			anchorRegistry = &anchorEntries{}
-		}
 	}
 	intermediateProject, err := createIntermediateProject(data, unmarshalStrict, anchorRegistry)
 	if err != nil {
@@ -1133,8 +1130,6 @@ type GetProjectOpts struct {
 	// LocalIncludeDir is the base directory for resolving relative include
 	// file paths when ReadFileFrom is ReadFromLocal.
 	LocalIncludeDir string
-	// EnableYAMLAnchors opts into cross-file YAML anchor and alias support.
-	EnableYAMLAnchors bool
 }
 
 type PatchOpts struct {
@@ -1373,35 +1368,9 @@ func GetProjectFromFile(ctx context.Context, opts GetProjectOpts) (ProjectInfo, 
 // createIntermediateProject marshals the supplied YAML into our intermediate project representation
 // (i.e. before selectors or matrix logic has been evaluated).
 // If unmarshalStrict is true, use the strict version of unmarshalling.
-// When anchorRegistry is non-nil, cross-file anchor support is enabled: existing anchors are prepended so the
-// parser can resolve cross-file aliases, and any new anchor definitions are appended to the registry for future files.
+// Existing anchors in anchorRegistry are prepended so the parser can resolve cross-file aliases,
+// and any new anchor definitions are appended to the registry for future files.
 func createIntermediateProject(parseBytes []byte, unmarshalStrict bool, anchorRegistry *anchorEntries) (*ParserProject, error) {
-	p := ParserProject{}
-
-	if anchorRegistry == nil {
-		if unmarshalStrict {
-			strictProjectWithVariables := struct {
-				ParserProject       `yaml:"pp,inline"`
-				ProjectConfigFields `yaml:"pc,inline"`
-				// Variables is only used to suppress yaml unmarshalling errors related
-				// to a non-existent variables field.
-				Variables any `yaml:"variables,omitempty" bson:"-"`
-			}{}
-			if err := util.UnmarshalYAMLStrictWithFallback(parseBytes, &strictProjectWithVariables); err != nil {
-				return nil, errors.Wrap(err, "unmarshalling parser project from YAML")
-			}
-			p = strictProjectWithVariables.ParserProject
-		} else {
-			if err := util.UnmarshalYAMLWithFallback(parseBytes, &p); err != nil {
-				return nil, errors.Wrap(err, "unmarshalling parser project from YAML")
-			}
-		}
-		if p.Functions == nil {
-			p.Functions = map[string]*YAMLCommandSet{}
-		}
-		return &p, nil
-	}
-
 	// Prepend accumulated anchors as a preamble so the parser can resolve cross-file aliases.
 	if len(*anchorRegistry) > 0 {
 		preamble, err := buildAnchorPreamble(anchorRegistry)

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -64,7 +64,7 @@ tasks:
     status: "failed"
     patch_optional: true
 `
-			p, err := createIntermediateProject([]byte(simple), false, nil)
+			p, err := createIntermediateProject([]byte(simple), false, &anchorEntries{})
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(p.Tasks[2].DependsOn[0].TaskSelector.Name, ShouldEqual, "compile")
@@ -81,7 +81,7 @@ tasks:
 - name: task1
   depends_on: task0
 `
-			p, err := createIntermediateProject([]byte(single), false, nil)
+			p, err := createIntermediateProject([]byte(single), false, &anchorEntries{})
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(p.Tasks[2].DependsOn[0].TaskSelector.Name, ShouldEqual, "task0")
@@ -93,7 +93,7 @@ tasks:
 - name: "compile"
   depends_on: ""
 `
-				p, err := createIntermediateProject([]byte(nameless), false, nil)
+				p, err := createIntermediateProject([]byte(nameless), false, &anchorEntries{})
 				So(p, ShouldBeNil)
 				So(err, ShouldNotBeNil)
 			})
@@ -105,7 +105,7 @@ tasks:
   - name: "task1"
   - status: "failed" #this has no task attached
 `
-				p, err := createIntermediateProject([]byte(nameless), false, nil)
+				p, err := createIntermediateProject([]byte(nameless), false, &anchorEntries{})
 				So(p, ShouldBeNil)
 				So(err, ShouldNotBeNil)
 			})
@@ -114,7 +114,7 @@ tasks:
 tasks:
 - name: "compile"
 `
-				p, err := createIntermediateProject([]byte(nameless), false, nil)
+				p, err := createIntermediateProject([]byte(nameless), false, &anchorEntries{})
 				So(p, ShouldNotBeNil)
 				So(err, ShouldBeNil)
 			})
@@ -143,7 +143,7 @@ buildvariants:
     stepback: false
     priority: 77
 `
-			p, err := createIntermediateProject([]byte(simple), false, nil)
+			p, err := createIntermediateProject([]byte(simple), false, &anchorEntries{})
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			bv := p.BuildVariants[0]
@@ -167,7 +167,7 @@ buildvariants:
   - name: "t2"
     depends_on: "t3"
 `
-			p, err := createIntermediateProject([]byte(simple), false, nil)
+			p, err := createIntermediateProject([]byte(simple), false, &anchorEntries{})
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			bv := p.BuildVariants[0]
@@ -185,7 +185,7 @@ buildvariants:
   tasks:
     name: "t1"
 `
-			p, err := createIntermediateProject([]byte(simple), false, nil)
+			p, err := createIntermediateProject([]byte(simple), false, &anchorEntries{})
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
@@ -209,7 +209,7 @@ buildvariants:
   run_on: "distro1"
   tasks: "*"
 `
-			p, err := createIntermediateProject([]byte(single), false, nil)
+			p, err := createIntermediateProject([]byte(single), false, &anchorEntries{})
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(len(p.Ignore), ShouldEqual, 1)
@@ -230,7 +230,7 @@ buildvariants:
   - name: "t1"
     run_on: "test"
 `
-			p, err := createIntermediateProject([]byte(single), false, nil)
+			p, err := createIntermediateProject([]byte(single), false, &anchorEntries{})
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(p.BuildVariants[0].Tasks[0].RunOn[0], ShouldEqual, "test")
@@ -245,7 +245,7 @@ buildvariants:
     run_on: "test"
     distros: "asdasdasd"
 `
-			p, err := createIntermediateProject([]byte(single), false, nil)
+			p, err := createIntermediateProject([]byte(single), false, &anchorEntries{})
 			So(p, ShouldBeNil)
 			So(err, ShouldNotBeNil)
 		})
@@ -257,7 +257,7 @@ buildvariants:
   - name: "t1"
     commit_queue_merge: true
 `
-			p, err := createIntermediateProject([]byte(single), false, nil)
+			p, err := createIntermediateProject([]byte(single), false, &anchorEntries{})
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			bv := p.BuildVariants[0]
@@ -280,7 +280,7 @@ buildvariants:
   - name: "t1"
     activate: true
 `
-	p, err := createIntermediateProject([]byte(yml), false, nil)
+	p, err := createIntermediateProject([]byte(yml), false, &anchorEntries{})
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
 	bv := p.BuildVariants[0]
@@ -1023,7 +1023,7 @@ tasks:
 - name: execTask3
 - name: execTask4
 `
-	p, err := createIntermediateProject([]byte(yml), false, nil)
+	p, err := createIntermediateProject([]byte(yml), false, &anchorEntries{})
 
 	// check that display tasks in bv1 parsed correctly
 	assert.NoError(err)
@@ -1052,7 +1052,7 @@ parameters:
 - key: buggy
   value: driver
 `
-	p, err := createIntermediateProject([]byte(yml), false, nil)
+	p, err := createIntermediateProject([]byte(yml), false, &anchorEntries{})
 	assert.NoError(t, err)
 	require.Len(t, p.Parameters, 2)
 	assert.Equal(t, "iter_count", p.Parameters[0].Key)
@@ -1361,7 +1361,7 @@ tasks:
 - name: execTask4
   tags: [ "even" ]
 `
-	pp, err := createIntermediateProject([]byte(tagYml), false, nil)
+	pp, err := createIntermediateProject([]byte(tagYml), false, &anchorEntries{})
 	assert.NotNil(pp)
 	assert.NoError(err)
 	require.Len(pp.BuildVariants[0].DisplayTasks, 2)
@@ -2149,7 +2149,7 @@ buildvariants:
 }
 
 func checkProjectPersists(ctx context.Context, t *testing.T, env evergreen.Environment, yml []byte, ppStorageMethod evergreen.ParserProjectStorageMethod) {
-	pp, err := createIntermediateProject(yml, false, nil)
+	pp, err := createIntermediateProject(yml, false, &anchorEntries{})
 	assert.NoError(t, err)
 	pp.Id = "my-project"
 	pp.Identifier = utility.ToStringPtr("old-project-identifier")
@@ -2172,7 +2172,7 @@ func checkProjectPersists(ctx context.Context, t *testing.T, env evergreen.Envir
 	assert.True(t, bytes.Equal(newYaml, yamlToCompare))
 
 	// ensure that updating with the re-parsed project doesn't error
-	pp, err = createIntermediateProject(newYaml, false, nil)
+	pp, err = createIntermediateProject(newYaml, false, &anchorEntries{})
 	assert.NoError(t, err)
 	pp.Id = "my-project"
 	pp.Identifier = utility.ToStringPtr("new-project-identifier")
@@ -2199,7 +2199,7 @@ func TestParserProjectRoundtrip(t *testing.T) {
 	yml, err := os.ReadFile(filepath)
 	assert.NoError(t, err)
 
-	original, err := createIntermediateProject(yml, false, nil)
+	original, err := createIntermediateProject(yml, false, &anchorEntries{})
 	assert.NoError(t, err)
 
 	// to and from yaml
@@ -2823,10 +2823,10 @@ ignore:
   - ".github/*"
 `
 
-	p1, err := createIntermediateProject([]byte(mainYaml), false, nil)
+	p1, err := createIntermediateProject([]byte(mainYaml), false, &anchorEntries{})
 	assert.NoError(t, err)
 	assert.NotNil(t, p1)
-	p2, err := createIntermediateProject([]byte(smallYaml), false, nil)
+	p2, err := createIntermediateProject([]byte(smallYaml), false, &anchorEntries{})
 	assert.NoError(t, err)
 	assert.NotNil(t, p2)
 	err = p1.mergeMultipleParserProjects(p2)
@@ -2872,13 +2872,13 @@ buildvariants:
       - name: task3
 `
 
-	p1, err := createIntermediateProject([]byte(mainYaml), false, nil)
+	p1, err := createIntermediateProject([]byte(mainYaml), false, &anchorEntries{})
 	assert.NoError(t, err)
 	assert.NotNil(t, p1)
-	p2, err := createIntermediateProject([]byte(succeed), false, nil)
+	p2, err := createIntermediateProject([]byte(succeed), false, &anchorEntries{})
 	assert.NoError(t, err)
 	assert.NotNil(t, p2)
-	p3, err := createIntermediateProject([]byte(fail), false, nil)
+	p3, err := createIntermediateProject([]byte(fail), false, &anchorEntries{})
 	assert.NoError(t, err)
 	assert.NotNil(t, p3)
 	err = p1.mergeMultipleParserProjects(p2)
@@ -3387,7 +3387,7 @@ tasks:
 - name: task2
   commands: *common-commands
 `
-	p, err := createIntermediateProject([]byte(yml), false, nil)
+	p, err := createIntermediateProject([]byte(yml), false, &anchorEntries{})
 	require.NoError(t, err)
 	require.NotNil(t, p)
 	require.Len(t, p.Tasks, 2)
@@ -3415,7 +3415,7 @@ tasks:
       os: linux
       arch: amd64
 `
-	p, err := createIntermediateProject([]byte(yml), false, nil)
+	p, err := createIntermediateProject([]byte(yml), false, &anchorEntries{})
 	require.NoError(t, err)
 	require.NotNil(t, p)
 	require.Len(t, p.Tasks, 1)
@@ -3436,12 +3436,10 @@ func moduleIncludeOpts(includes ...patch.LocalModuleInclude) *GetProjectOpts {
 	return &GetProjectOpts{LocalModuleIncludes: includes}
 }
 
-// anchorModuleIncludeOpts is like moduleIncludeOpts but also enables cross-file
-// YAML anchor support, which is required for cross-file alias tests.
+// anchorModuleIncludeOpts returns opts for cross-file anchor tests. Cross-file
+// anchor support is always-on, so this is equivalent to moduleIncludeOpts.
 func anchorModuleIncludeOpts(includes ...patch.LocalModuleInclude) *GetProjectOpts {
-	opts := moduleIncludeOpts(includes...)
-	opts.EnableYAMLAnchors = true
-	return opts
+	return moduleIncludeOpts(includes...)
 }
 
 // mainYAMLWithModuleIncludes builds a minimal main YAML that declares one
@@ -3907,4 +3905,119 @@ tasks:
 	assert.Equal(t, "shell.exec", cmd.Command)
 	assert.Equal(t, "./run.sh", cmd.Params["script"])
 	assert.Equal(t, "src", cmd.Params["working_dir"])
+}
+
+// TestAnchorInFunctionsDefinition verifies that anchors defined inside a
+// functions block in the main file can be aliased in an include file.
+func TestAnchorInFunctionsDefinition(t *testing.T) {
+	mainYAML := mainYAMLWithModuleIncludes(`
+functions:
+  setup: &setup-cmds
+    command: shell.exec
+    params:
+      script: ./setup.sh
+`, "include.yml")
+
+	includeYAML := `
+tasks:
+- name: use-setup
+  commands:
+  - *setup-cmds
+`
+	proj := &Project{}
+	_, err := LoadProjectInto(t.Context(), []byte(mainYAML),
+		moduleIncludeOpts(moduleInclude("include.yml", includeYAML)), "proj", proj)
+	require.NoError(t, err)
+	require.Len(t, proj.Tasks, 1)
+	assert.Equal(t, "use-setup", proj.Tasks[0].Name)
+	require.Len(t, proj.Tasks[0].Commands, 1)
+	assert.Equal(t, "shell.exec", proj.Tasks[0].Commands[0].Command)
+}
+
+// TestAliasInMainReferencingIncludeAnchorShouldError documents that anchors
+// defined in an include file cannot be aliased in the main file, because the
+// main file is parsed before any includes are processed.
+func TestAliasInMainReferencingIncludeAnchorShouldError(t *testing.T) {
+	mainYAML := mainYAMLWithModuleIncludes(`
+tasks:
+- name: main-task
+  commands:
+  - *from-include
+`, "include.yml")
+
+	includeYAML := `
+tasks:
+- name: include-task
+  commands:
+  - &from-include
+    command: shell.exec
+`
+	proj := &Project{}
+	_, err := LoadProjectInto(t.Context(), []byte(mainYAML),
+		moduleIncludeOpts(moduleInclude("include.yml", includeYAML)), "proj", proj)
+	require.Error(t, err)
+}
+
+// TestWithinSingleFileNoIncludes confirms that single-file projects with
+// anchors continue to work exactly as before (no regressions from always-on).
+func TestWithinSingleFileNoIncludes(t *testing.T) {
+	yml := `
+tasks:
+- name: base
+  commands:
+  - &cmd
+    command: shell.exec
+    params:
+      script: ./run.sh
+- name: derived
+  commands:
+  - *cmd
+`
+	proj := &Project{}
+	_, err := LoadProjectInto(t.Context(), []byte(yml), nil, "proj", proj)
+	require.NoError(t, err)
+
+	byName := map[string]ProjectTask{}
+	for _, task := range proj.Tasks {
+		byName[task.Name] = task
+	}
+	require.Contains(t, byName, "derived")
+	require.Len(t, byName["derived"].Commands, 1)
+	assert.Equal(t, "shell.exec", byName["derived"].Commands[0].Command)
+}
+
+// BenchmarkLoadProjectWithCrossFileAnchors measures end-to-end project loading
+// with cross-file anchors across several include files.
+func BenchmarkLoadProjectWithCrossFileAnchors(b *testing.B) {
+	const numIncludes = 10
+	includes := make([]patch.LocalModuleInclude, 0, numIncludes)
+	filenames := make([]string, 0, numIncludes)
+	for i := 0; i < numIncludes; i++ {
+		fn := fmt.Sprintf("inc%d.yml", i)
+		filenames = append(filenames, fn)
+		content := fmt.Sprintf(`
+tasks:
+- name: task-%d
+  commands:
+  - *common-setup
+`, i)
+		includes = append(includes, moduleInclude(fn, content))
+	}
+	mainYAML := mainYAMLWithModuleIncludes(`
+tasks:
+- name: setup
+  commands:
+  - &common-setup
+    command: shell.exec
+    params:
+      script: ./setup.sh
+`, filenames...)
+	opts := moduleIncludeOpts(includes...)
+
+	b.ResetTimer()
+	for range b.N {
+		proj := &Project{}
+		_, err := LoadProjectInto(b.Context(), []byte(mainYAML), opts, "proj", proj)
+		require.NoError(b, err)
+	}
 }

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1548,7 +1548,7 @@ tasks:
   depends_on:
     - name: dist-test
 `
-	intermediate, err := createIntermediateProject([]byte(projYml), false, nil)
+	intermediate, err := createIntermediateProject([]byte(projYml), false, &anchorEntries{})
 	s.NoError(err)
 	marshaled, err := yaml.Marshal(intermediate)
 	s.NoError(err)

--- a/operations/evaluate.go
+++ b/operations/evaluate.go
@@ -14,10 +14,9 @@ import (
 
 func Evaluate() cli.Command {
 	const (
-		taskFlagName        = "tasks"
-		variantsFlagName    = "variants"
-		diffableFlagName    = "diffable"
-		yamlAnchorsFlagName = "yaml-anchors"
+		taskFlagName     = "tasks"
+		variantsFlagName = "variants"
+		diffableFlagName = "diffable"
 	)
 
 	return cli.Command{
@@ -40,10 +39,6 @@ func Evaluate() cli.Command {
 				Name:  joinFlagNames(localModulesFlagName, "lm"),
 				Usage: "specify local modules for included files as MODULE_NAME=PATH pairs",
 			},
-			cli.BoolFlag{
-				Name:  yamlAnchorsFlagName,
-				Usage: "(BETA) enable cross-file YAML anchors in included files",
-			},
 		),
 		Before: mergeBeforeFuncs(requirePathFlag),
 		Action: func(c *cli.Context) error {
@@ -65,9 +60,8 @@ func Evaluate() cli.Command {
 			p := &model.Project{}
 			ctx := context.Background()
 			opts := &model.GetProjectOpts{
-				LocalModules:      localModuleMap,
-				ReadFileFrom:      model.ReadFromLocal,
-				EnableYAMLAnchors: c.Bool(yamlAnchorsFlagName),
+				LocalModules: localModuleMap,
+				ReadFileFrom: model.ReadFromLocal,
 			}
 			_, err = model.LoadProjectInto(ctx, configBytes, opts, "", p)
 			if err != nil {

--- a/operations/validate.go
+++ b/operations/validate.go
@@ -18,8 +18,6 @@ import (
 )
 
 func Validate() cli.Command {
-	const yamlAnchorsFlagName = "yaml-anchors"
-
 	return cli.Command{
 		Name:  "validate",
 		Usage: "verify that an evergreen project config is valid",
@@ -35,9 +33,6 @@ func Validate() cli.Command {
 		}, cli.StringFlag{
 			Name:  joinFlagNames(projectFlagName, "p"),
 			Usage: "specify project identifier in order to run validation requiring project settings",
-		}, cli.BoolFlag{
-			Name:  yamlAnchorsFlagName,
-			Usage: "(BETA) enable cross-file YAML anchors in included files",
 		}),
 		Before: mergeBeforeFuncs(autoUpdateCLI, setPlainLogger, requirePathFlag),
 		Action: func(c *cli.Context) error {
@@ -49,7 +44,6 @@ func Validate() cli.Command {
 			quiet := c.Bool(quietFlagName)
 			errorOnWarnings := c.Bool(errorOnWarningsFlagName)
 			projectID := c.String(projectFlagName)
-			enableAnchors := c.Bool(yamlAnchorsFlagName)
 			localModulePaths := c.StringSlice(localModulesFlagName)
 			localModuleMap, err := getLocalModulesFromInput(localModulePaths)
 			if err != nil {
@@ -81,12 +75,12 @@ func Validate() cli.Command {
 				}
 				catcher := grip.NewSimpleCatcher()
 				for _, file := range files {
-					catcher.Add(validateFile(conf, filepath.Join(path, file.Name()), quiet, errorOnWarnings, enableAnchors, localModuleMap, projectID))
+					catcher.Add(validateFile(conf, filepath.Join(path, file.Name()), quiet, errorOnWarnings, localModuleMap, projectID))
 				}
 				return catcher.Resolve()
 			}
 
-			return validateFile(conf, path, quiet, errorOnWarnings, enableAnchors, localModuleMap, projectID)
+			return validateFile(conf, path, quiet, errorOnWarnings, localModuleMap, projectID)
 		},
 	}
 }
@@ -104,8 +98,8 @@ func getLocalModulesFromInput(localModulePaths []string) (map[string]string, err
 	return moduleMap, catcher.Resolve()
 }
 
-func validateFile(conf *ClientSettings, path string, quiet, errorOnWarnings, enableAnchors bool, localModuleMap map[string]string, projectID string) error {
-	projectYaml, err := loadProjectYAML(path, quiet, errorOnWarnings, enableAnchors, localModuleMap, projectID)
+func validateFile(conf *ClientSettings, path string, quiet, errorOnWarnings bool, localModuleMap map[string]string, projectID string) error {
+	projectYaml, err := loadProjectYAML(path, quiet, errorOnWarnings, localModuleMap, projectID)
 	if err != nil {
 		return err
 	}
@@ -114,7 +108,7 @@ func validateFile(conf *ClientSettings, path string, quiet, errorOnWarnings, ena
 
 // loadProjectYAML reads and parses the project config file, performs local validation,
 // and returns the marshalled YAML bytes for remote validation.
-func loadProjectYAML(path string, quiet, errorOnWarnings, enableAnchors bool, localModuleMap map[string]string, projectID string) ([]byte, error) {
+func loadProjectYAML(path string, quiet, errorOnWarnings bool, localModuleMap map[string]string, projectID string) ([]byte, error) {
 	confFile, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "reading file '%s'", path)
@@ -122,9 +116,8 @@ func loadProjectYAML(path string, quiet, errorOnWarnings, enableAnchors bool, lo
 	project := &model.Project{}
 	ctx := context.Background()
 	opts := &model.GetProjectOpts{
-		LocalModules:      localModuleMap,
-		ReadFileFrom:      model.ReadFromLocal,
-		EnableYAMLAnchors: enableAnchors,
+		LocalModules: localModuleMap,
+		ReadFileFrom: model.ReadFromLocal,
 	}
 	if !quiet {
 		opts.UnmarshalStrict = true

--- a/operations/validate_test.go
+++ b/operations/validate_test.go
@@ -169,7 +169,7 @@ func TestValidateFile(t *testing.T) {
 				path = filepath.Join(t.TempDir(), "project.yml")
 				require.NoError(t, os.WriteFile(path, sampleYAML, 0644))
 			}
-			err := validateFile(&ClientSettings{}, path, testCase.quiet, testCase.errorOnWarnings, false, nil, "")
+			err := validateFile(&ClientSettings{}, path, testCase.quiet, testCase.errorOnWarnings, nil, "")
 
 			if testCase.expectErr != "" {
 				assert.ErrorContains(t, err, testCase.expectErr)
@@ -212,7 +212,7 @@ func TestLoadProjectYAML(t *testing.T) {
 				path = filepath.Join(t.TempDir(), "project.yml")
 				require.NoError(t, os.WriteFile(path, content, 0644))
 			}
-			projectYaml, err := loadProjectYAML(path, false, false, false, nil, "")
+			projectYaml, err := loadProjectYAML(path, false, false, nil, "")
 
 			if testCase.expectErr != "" {
 				assert.ErrorContains(t, err, testCase.expectErr)


### PR DESCRIPTION
DEVPROD-33516

## Summary

- Removes the `--yaml-anchors` beta flag from `evergreen validate` and `evergreen evaluate`; cross-file anchor support is now always-on
- Removes `EnableYAMLAnchors bool` from `GetProjectOpts` and the nil-registry legacy branch from `createIntermediateProject`
- Adds tests covering: anchors in `functions:` blocks, unsupported reverse-direction aliasing, single-file regression, and a benchmark across 10 include files
- Updates docs to remove "Beta" label and `--yaml-anchors` prerequisite language

## Test plan

- [ ] All existing anchor tests pass: `TestCollectAnchors`, `TestBuildAnchorPreamble`, `TestWithinFileAnchor`, `TestBasicCrossFileAnchor`, `TestAnchorInEarlierInclude`, `TestAnchorInLaterIncludeFileShouldError`, `TestDuplicateAnchorNameAcrossFilesLastWriteWins`, `TestAnchorWithNestedAlias`, `TestPreambleKeyStrippedFromParserProject`, `TestStrictModeWithCrossFileAnchor`, `TestNoAnchorsInIncludeFiles`, `TestAnchorOnComplexType`, `TestComplexAnchorAliasExpansion`
- [ ] New tests pass: `TestAnchorInFunctionsDefinition`, `TestAliasInMainReferencingIncludeAnchorShouldError`, `TestWithinSingleFileNoIncludes`
- [ ] `make lint-model` passes
- [ ] `evergreen validate` and `evergreen evaluate` no longer accept `--yaml-anchors` flag