### PR TITLE
DEVPROD-35277: Add version-tagged span to FindAndTranslateProjectForVersion 

### DIFF
--- a/makefile
+++ b/makefile
@@ -338,7 +338,7 @@ gqlgen:
 	$(gobin) run cmd/gqlgen/generate_secret_fields.go
 
 govul-install:
-	$(gobin) install golang.org/x/vuln/cmd/govulncheck@latest
+	$(gobin) install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
 swaggo:
 	$(MAKE) swaggo-format swaggo-build swaggo-render

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -579,10 +579,20 @@ func FindAndTranslateProjectForPatch(ctx context.Context, settings *evergreen.Se
 	return FindAndTranslateProjectForVersion(ctx, settings, v, false)
 }
 
+// parserProjectPreGenerationOtelAttribute records whether a translation used the
+// pre-generation parser project copy.
+const parserProjectPreGenerationOtelAttribute = "evergreen.parser_project.pre_generation"
+
 // FindAndTranslateProjectForVersion translates a parser project for a version into a Project.
 // Also sets the project ID. If the preGeneration flag is true, this function will attempt to
 // fetch and translate the parser project from before it was modified by generate.tasks
 func FindAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.Settings, v *Version, preGeneration bool) (*Project, *ParserProject, error) {
+	ctx, span := tracer.Start(ctx, "FindAndTranslateProjectForVersion", trace.WithAttributes(
+		attribute.String(evergreen.VersionIDOtelAttribute, v.Id),
+		attribute.Bool(parserProjectPreGenerationOtelAttribute, preGeneration),
+	))
+	defer span.End()
+
 	var pp *ParserProject
 	var err error
 	if preGeneration {


### PR DESCRIPTION
DEVPROD-35277

### Description

Adds a span on `FindAndTranslateProjectForVersion` tagged with `evergreen.version.id` and a new `evergreen.parser_project.pre_generation` attribute. This will lets us query production traffic in Honeycomb grouped by version ID see repeat frequency and the concurrent-vs-sequential split, and decide whether just wrapping FindAndTranslateProjectForVersion with a singleflight.Group is enough or if an LRU cache is worth it as well. 

