### PR TITLE
DEVPROD-29864: Reduce MaxConcurrentCopies for task log S3 bucket to 5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/evergreen-ci/birch v0.0.0-20250224221624-64f481f4b888
 	github.com/evergreen-ci/certdepot v0.0.0-20260326190252-5ab5e35f6cb7
 	github.com/evergreen-ci/gimlet v0.0.0-20260520162532-2cfc3356800c
-	github.com/evergreen-ci/pail v0.0.0-20260615180627-332e25d14040
+	github.com/evergreen-ci/pail v0.0.0-20260618132147-c9bcc0488a7f
 	github.com/evergreen-ci/poplar v0.0.0-20260330180450-c8cf511d1bd6
 	github.com/evergreen-ci/shrub v0.0.0-20251017154811-4d3ed1599154
 	github.com/evergreen-ci/utility v0.0.0-20260116164328-250718d590d2

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/evergreen-ci/lru v0.0.0-20260326190734-0d627bf39810 h1:Q+MNMS3rHQw6bG
 github.com/evergreen-ci/lru v0.0.0-20260326190734-0d627bf39810/go.mod h1:A+sGkHeCogvvRBXUrF/Ghu5Gec6lyLtb1MKZN/xfWmI=
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035 h1:oVU/ni/sRq+GAogUMLa7LBGtvVHMVLbisuytxBC5KaY=
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035/go.mod h1:pvK7NM0ZC+sfTLuIiJN4BgM1S9S5Oo79PJReAFFph18=
-github.com/evergreen-ci/pail v0.0.0-20260615180627-332e25d14040 h1:CRCFT91RYkIqY0kkkZoBkaiN+zBRh5G32DvTgsqBpDA=
-github.com/evergreen-ci/pail v0.0.0-20260615180627-332e25d14040/go.mod h1:lj8oxBSqzEoapX1apBDy88B7wRjj27QQu9EXk2i3AOM=
+github.com/evergreen-ci/pail v0.0.0-20260618132147-c9bcc0488a7f h1:7pjExNZ0z+ZRVNJpZH0vlTa6/iBxZXiAyN5coZ8f7Ok=
+github.com/evergreen-ci/pail v0.0.0-20260618132147-c9bcc0488a7f/go.mod h1:lj8oxBSqzEoapX1apBDy88B7wRjj27QQu9EXk2i3AOM=
 github.com/evergreen-ci/plank v0.0.0-20251203163536-53406252f581 h1:JOYnqPypLzZdjlFxS2ynWGKFPTrx0HAJwe6mi9P/lhk=
 github.com/evergreen-ci/plank v0.0.0-20251203163536-53406252f581/go.mod h1:visOo9VGGrTN+jNPSg56zhbCH81sSlMRnXpJCYb+kt4=
 github.com/evergreen-ci/poplar v0.0.0-20260330180450-c8cf511d1bd6 h1:leuRlgINHoR0/takPgoHYrfHt5mAtXcLdKdfQ0KVnyQ=

--- a/model/task/util.go
+++ b/model/task/util.go
@@ -16,13 +16,14 @@ func newBucket(ctx context.Context, config evergreen.BucketConfig, creds aws.Cre
 	switch config.Type {
 	case evergreen.BucketTypeS3:
 		return pail.NewS3Bucket(ctx, pail.S3Options{
-			Name:         config.Name,
-			Credentials:  creds,
-			Region:       evergreen.DefaultEC2Region,
-			Permissions:  pail.S3PermissionsPrivate,
-			MaxRetries:   utility.ToIntPtr(10),
-			Compress:     true,
-			StorageClass: s3Types.StorageClassIntelligentTiering,
+			Name:                config.Name,
+			Credentials:         creds,
+			Region:              evergreen.DefaultEC2Region,
+			Permissions:         pail.S3PermissionsPrivate,
+			MaxRetries:          utility.ToIntPtr(10),
+			MaxConcurrentCopies: utility.ToIntPtr(5),
+			Compress:            true,
+			StorageClass:        s3Types.StorageClassIntelligentTiering,
 		})
 	case evergreen.BucketTypeGridFS:
 		client, err := mongo.Connect(ctx)


### PR DESCRIPTION
DEVPROD-29864

### Summary

- The default `MaxConcurrentCopies` for pail's `MoveObjects` is 20. With up to 50 concurrent `move-logs-to-failed-bucket` jobs, this produces up to 1000 simultaneous `CopyObject` requests per second against the same S3 bucket -- the primary driver of 503 SlowDown errors we've been seeing. 
- Pairs with evergreen-ci/pail#153, which ensures the 500ms delete pause fires for typical single-batch moves (< 1000 objects). I'll bump pail once that's merged. 

### Testing

Existing tests and will monitor honeycomb after. 