### PR TITLE
DEVPROD-33463 Track commit ingest time

### DIFF
--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2138,15 +2138,6 @@ func FindNonHiddenProjects(ctx context.Context, key string, limit int, sortDir i
 	return projectRefs, errors.Wrapf(err, "fetching projects starting at project '%s'", key)
 }
 
-// UpdateProjectRevision updates the given project's revision
-func UpdateProjectRevision(ctx context.Context, projectID, revision string) error {
-	if err := UpdateLastRevision(ctx, projectID, revision); err != nil {
-		return errors.Wrapf(err, "updating revision for project '%s'", projectID)
-	}
-
-	return nil
-}
-
 func FindHiddenProjectRefByOwnerRepoAndBranch(ctx context.Context, owner, repo, branch string) (*ProjectRef, error) {
 	// don't need to include undefined branches here since hidden projects explicitly define them
 	q := byOwnerRepoAndBranch(owner, repo, branch, false)

--- a/model/repository.go
+++ b/model/repository.go
@@ -6,16 +6,26 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/anser/bsonutil"
 	adb "github.com/mongodb/anser/db"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
-// Repository contains fields used to track projects.
+// Repository has 1 document per project and it tracks the last revision
+// that Evergreen ingested for the project.
 type Repository struct {
 	Project             string `bson:"_id"`
 	LastRevision        string `bson:"last_revision"`
 	RevisionOrderNumber int    `bson:"last_commit_number"`
+}
+
+// RepositoryRevision records when Evergreen ingested a project revision.
+type RepositoryRevision struct {
+	Project    string    `bson:"project"`
+	Revision   string    `bson:"revision"`
+	IngestTime time.Time `bson:"ingest_time"`
+	Order      int       `bson:"order"`
 }
 
 var (
@@ -23,10 +33,16 @@ var (
 	RepoProjectKey           = bsonutil.MustHaveTag(Repository{}, "Project")
 	RepoLastRevisionKey      = bsonutil.MustHaveTag(Repository{}, "LastRevision")
 	RepositoryOrderNumberKey = bsonutil.MustHaveTag(Repository{}, "RevisionOrderNumber")
+
+	RepositoryRevisionProjectKey    = bsonutil.MustHaveTag(RepositoryRevision{}, "Project")
+	RepositoryRevisionRevisionKey   = bsonutil.MustHaveTag(RepositoryRevision{}, "Revision")
+	RepositoryRevisionIngestTimeKey = bsonutil.MustHaveTag(RepositoryRevision{}, "IngestTime")
+	RepositoryRevisionOrderKey      = bsonutil.MustHaveTag(RepositoryRevision{}, "Order")
 )
 
 const (
-	RepositoriesCollection = "repo_revisions"
+	RepositoriesCollection               = "repo_revisions"
+	RepositoryRevisionsHistoryCollection = "repo_revision_history"
 )
 
 type Revision struct {
@@ -79,6 +95,46 @@ func UpdateLastRevision(ctx context.Context, projectId, revision string) error {
 			},
 		},
 	)
+}
+
+// UpsertRepositoryRevision records that Evergreen ingested a project revision.
+func UpsertRepositoryRevision(ctx context.Context, projectID, revision string, ingestTime time.Time, order int) error {
+	if utility.IsZeroTime(ingestTime) {
+		ingestTime = time.Now()
+	}
+	_, err := db.Upsert(
+		ctx,
+		RepositoryRevisionsHistoryCollection,
+		bson.M{
+			RepositoryRevisionProjectKey:  projectID,
+			RepositoryRevisionRevisionKey: revision,
+		},
+		bson.M{
+			"$set": bson.M{
+				RepositoryRevisionProjectKey:    projectID,
+				RepositoryRevisionRevisionKey:   revision,
+				RepositoryRevisionIngestTimeKey: ingestTime,
+				RepositoryRevisionOrderKey:      order,
+			},
+		},
+	)
+	return err
+}
+
+// FindLatestRepositoryRevisionByIngestTime finds the latest project revision Evergreen ingested at or before ingestTime.
+func FindLatestRepositoryRevisionByIngestTime(ctx context.Context, projectID string, ingestTime time.Time) (*RepositoryRevision, error) {
+	revision := &RepositoryRevision{}
+	q := db.Query(bson.M{
+		RepositoryRevisionProjectKey: projectID,
+		RepositoryRevisionIngestTimeKey: bson.M{
+			"$lte": ingestTime,
+		},
+	}).Sort([]string{"-" + RepositoryRevisionIngestTimeKey, "-" + RepositoryRevisionOrderKey})
+	err := db.FindOneQ(ctx, RepositoryRevisionsHistoryCollection, q, revision)
+	if adb.ResultsNotFound(err) {
+		return nil, nil
+	}
+	return revision, err
 }
 
 // GetNewRevisionOrderNumber gets a new revision order number for a project.

--- a/model/repository.go
+++ b/model/repository.go
@@ -110,7 +110,7 @@ func UpsertRepositoryRevision(ctx context.Context, projectID, revision string, i
 			RepositoryRevisionRevisionKey: revision,
 		},
 		bson.M{
-			"$set": bson.M{
+			"$setOnInsert": bson.M{
 				RepositoryRevisionProjectKey:    projectID,
 				RepositoryRevisionRevisionKey:   revision,
 				RepositoryRevisionIngestTimeKey: ingestTime,

--- a/model/repository_test.go
+++ b/model/repository_test.go
@@ -87,10 +87,12 @@ func TestFindLatestRepositoryRevisionByIngestTime(t *testing.T) {
 	require.NoError(t, UpsertRepositoryRevision(t.Context(), "proj", "r2", now.Add(time.Minute), 2))
 	require.NoError(t, UpsertRepositoryRevision(t.Context(), "proj", "r3", now.Add(3*time.Minute), 3))
 	require.NoError(t, UpsertRepositoryRevision(t.Context(), "other", "other-r1", now.Add(2*time.Minute), 1))
+	require.NoError(t, UpsertRepositoryRevision(t.Context(), "proj", "r2", now.Add(4*time.Minute), 4))
 
 	revision, err := FindLatestRepositoryRevisionByIngestTime(t.Context(), "proj", now.Add(2*time.Minute))
 	require.NoError(t, err)
 	require.NotNil(t, revision)
 	assert.Equal(t, "r2", revision.Revision)
 	assert.Equal(t, 2, revision.Order)
+	assert.WithinDuration(t, now.Add(time.Minute), revision.IngestTime, time.Millisecond)
 }

--- a/model/repository_test.go
+++ b/model/repository_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/evergreen-ci/evergreen/db"
 	. "github.com/smartystreets/goconvey/convey"
@@ -77,4 +78,19 @@ func TestUpdateLastRevision(t *testing.T) {
 			test(t, "my-project", "my-revision")
 		})
 	}
+}
+
+func TestFindLatestRepositoryRevisionByIngestTime(t *testing.T) {
+	require.NoError(t, db.ClearCollections(RepositoriesCollection, RepositoryRevisionsHistoryCollection))
+	now := time.Now()
+	require.NoError(t, UpsertRepositoryRevision(t.Context(), "proj", "r1", now, 1))
+	require.NoError(t, UpsertRepositoryRevision(t.Context(), "proj", "r2", now.Add(time.Minute), 2))
+	require.NoError(t, UpsertRepositoryRevision(t.Context(), "proj", "r3", now.Add(3*time.Minute), 3))
+	require.NoError(t, UpsertRepositoryRevision(t.Context(), "other", "other-r1", now.Add(2*time.Minute), 1))
+
+	revision, err := FindLatestRepositoryRevisionByIngestTime(t.Context(), "proj", now.Add(2*time.Minute))
+	require.NoError(t, err)
+	require.NotNil(t, revision)
+	assert.Equal(t, "r2", revision.Revision)
+	assert.Equal(t, 2, revision.Order)
 }

--- a/rest/data/repotracker.go
+++ b/rest/data/repotracker.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
@@ -102,11 +103,14 @@ func TriggerRepotracker(ctx context.Context, q amboy.Queue, msgID string, event 
 	unactionable := []string{}
 	failed := []string{}
 	catcher := grip.NewSimpleCatcher()
+	ingestTime := time.Now()
 	for i := range refs {
 		if !refs[i].Enabled || refs[i].IsRepotrackerDisabled() {
 			unactionable = append(unactionable, refs[i].Id)
 			continue
 		}
+
+		catcher.Wrapf(upsertRepositoryRevisionsFromPushEvent(ctx, refs[i].Id, event, ingestTime), "upserting repository revisions for project '%s'", refs[i].Id)
 
 		err = trigger.TriggerDownstreamProjectsForPush(ctx, refs[i].Id, event, trigger.TriggerDownstreamVersion)
 		catcher.Wrapf(err, "triggering downstream projects for push event for project '%s'", refs[i].Id)
@@ -160,6 +164,20 @@ func TriggerRepotracker(ctx context.Context, q amboy.Queue, msgID string, event 
 	}
 
 	return nil
+}
+
+// upsertRepositoryRevisionsFromPushEvent allows Evergreen to track when commits
+// are pushed to a repository. The pushed time (aka ingest time) is the source of truth
+// for the commit on the Evergreen side for decisions like which module commit to use.
+func upsertRepositoryRevisionsFromPushEvent(ctx context.Context, projectID string, event *github.PushEvent, ingestTime time.Time) error {
+	catcher := grip.NewBasicCatcher()
+	for i, commit := range event.Commits {
+		if commit.GetID() == "" {
+			continue
+		}
+		catcher.Wrapf(model.UpsertRepositoryRevision(ctx, projectID, commit.GetID(), ingestTime, i), "upserting revision '%s'", commit.GetID())
+	}
+	return catcher.Resolve()
 }
 
 func validatePushEvent(event *github.PushEvent) (string, error) {

--- a/rest/data/repotracker.go
+++ b/rest/data/repotracker.go
@@ -110,7 +110,16 @@ func TriggerRepotracker(ctx context.Context, q amboy.Queue, msgID string, event 
 			continue
 		}
 
-		catcher.Wrapf(upsertRepositoryRevisionsFromPushEvent(ctx, refs[i].Id, event, ingestTime), "upserting repository revisions for project '%s'", refs[i].Id)
+		err := upsertRepositoryRevisionsFromPushEvent(ctx, refs[i].Id, event, ingestTime)
+		grip.Error(ctx, message.WrapError(err, message.Fields{
+			"message":     "upserting repository revisions for project",
+			"project":     refs[i].Id,
+			"event":       event,
+			"ingest_time": ingestTime,
+			"refs":        refs[i],
+		}))
+		err = upsertRepositoryRevisionsFromPushEvent(ctx, refs[i].Id, event, ingestTime)
+		catcher.Wrapf(err, "upserting repository revisions for project '%s'", refs[i].Id)
 
 		err = trigger.TriggerDownstreamProjectsForPush(ctx, refs[i].Id, event, trigger.TriggerDownstreamVersion)
 		catcher.Wrapf(err, "triggering downstream projects for push event for project '%s'", refs[i].Id)

--- a/rest/data/repotracker.go
+++ b/rest/data/repotracker.go
@@ -118,8 +118,6 @@ func TriggerRepotracker(ctx context.Context, q amboy.Queue, msgID string, event 
 			"ingest_time": ingestTime,
 			"refs":        refs[i],
 		}))
-		err = upsertRepositoryRevisionsFromPushEvent(ctx, refs[i].Id, event, ingestTime)
-		catcher.Wrapf(err, "upserting repository revisions for project '%s'", refs[i].Id)
 
 		err = trigger.TriggerDownstreamProjectsForPush(ctx, refs[i].Id, event, trigger.TriggerDownstreamVersion)
 		catcher.Wrapf(err, "triggering downstream projects for push event for project '%s'", refs[i].Id)

--- a/rest/data/repotracker_test.go
+++ b/rest/data/repotracker_test.go
@@ -2,10 +2,15 @@ package data
 
 import (
 	"testing"
+	"time"
 
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/utility"
 	"github.com/google/go-github/v70/github"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidatePushEvent(t *testing.T) {
@@ -59,4 +64,24 @@ func TestValidatePushEvent(t *testing.T) {
 	branch, err = validatePushEvent(&event)
 	assert.NoError(err)
 	assert.Empty(branch)
+}
+
+func TestUpsertRepositoryRevisionsFromPushEvent(t *testing.T) {
+	require.NoError(t, db.ClearCollections(model.RepositoryRevisionsHistoryCollection))
+	ingestTime := time.Now()
+	event := &github.PushEvent{
+		Commits: []*github.HeadCommit{
+			{ID: utility.ToStringPtr("revision-1")},
+			{ID: utility.ToStringPtr("revision-2")},
+			{},
+		},
+	}
+
+	require.NoError(t, upsertRepositoryRevisionsFromPushEvent(t.Context(), "project", event, ingestTime))
+	revision, err := model.FindLatestRepositoryRevisionByIngestTime(t.Context(), "project", ingestTime)
+	require.NoError(t, err)
+	require.NotNil(t, revision)
+	assert.Equal(t, "revision-2", revision.Revision)
+	assert.WithinDuration(t, ingestTime, revision.IngestTime, time.Millisecond)
+	assert.Equal(t, 1, revision.Order)
 }

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -401,7 +401,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 
 	newRevision := utility.FromStringPtr(h.apiNewProjectRef.Revision)
 	if newRevision != "" {
-		if err = dbModel.UpdateProjectRevision(ctx, h.project, newRevision); err != nil {
+		if err = dbModel.UpdateLastRevision(ctx, h.project, newRevision); err != nil {
 			return gimlet.MakeJSONErrorResponder(err)
 		}
 		h.newProjectRef.RepotrackerError = &dbModel.RepositoryErrorDetails{


### PR DESCRIPTION
DEVPROD-33463

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->

This adds a new collection `repo_revision_history` that is a sibling to our existing `repo_revisions`. This new model is suppose to contain all the commits pushed to our tracked branches with their `ingested` time. In a future PR, we will be using `FindLatestRepositoryRevisionByIngestTime`. I included this function despite it not being used to make the review for the 2nd PR simplier, since it will be separate from this new collection. I wrote some comments to explain this in the code, please lmk if it isn't clear!

### Testing

<!--add a description of how you tested it-->
I added a unit test. The repotracker job will start upserting the revisions for use in a later PR and will have no impact functionally.