### PR TITLE
DEVPROD-32943 Skip merge queue events for projects with it disabled

### DIFF
--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -554,13 +554,25 @@ func (gh *githubHookApi) handleMergeGroupChecksRequested(ctx context.Context, ev
 		"head_sha": event.GetMergeGroup().GetHeadSHA(),
 		"message":  "merge group received",
 	})
-	// Ensure that a project exists before creating an intent. Otherwise, intent creation will fail which will always yield an unactionable 'Evergreen error' posted to GitHub.
-	projectRefs, err := model.FindMergedEnabledProjectRefsByRepoAndBranch(ctx, org, repo, branch)
+	// Ensure that a project has merge queue enabled before creating an intent.
+	// Otherwise, intent processing emits an unactionable failing status to GitHub.
+	projectRef, err := model.FindOneProjectRefWithCommitQueueByOwnerRepoAndBranch(ctx, org, repo, branch)
 	if err != nil {
 		return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "finding project ref"))
 	}
-	if len(projectRefs) == 0 {
-		return gimlet.NewJSONInternalErrorResponse(errors.New("no matching project ref"))
+	if projectRef == nil {
+		grip.Info(ctx, message.Fields{
+			"source":   "GitHub hook",
+			"msg_id":   gh.msgID,
+			"event":    gh.eventType,
+			"org":      org,
+			"repo":     repo,
+			"branch":   branch,
+			"base_sha": event.GetMergeGroup().GetBaseSHA(),
+			"head_sha": event.GetMergeGroup().GetHeadSHA(),
+			"message":  "GitHub merge group ignored because Evergreen merge queue is not enabled",
+		})
+		return nil
 	}
 	if err := gh.AddIntentForGithubMerge(ctx, event); err != nil {
 		grip.Error(ctx, message.WrapError(err, message.Fields{

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -476,6 +476,7 @@ func TestHandleGitHubMergeGroup(t *testing.T) {
 	}
 	for testCase, test := range map[string]func(*testing.T){
 		"githubMergeQueueSelected": func(t *testing.T) {
+			p.CommitQueue.Enabled = utility.TruePtr()
 			require.NoError(t, p.Insert(t.Context()))
 			response := gh.handleMergeGroupChecksRequested(t.Context(), event)
 			// check for error returned by GitHub merge queue handler
@@ -483,12 +484,15 @@ func TestHandleGitHubMergeGroup(t *testing.T) {
 			assert.Contains(t, str, "message ID cannot be empty")
 			assert.NotContains(t, str, "200")
 		},
+		"githubMergeQueueDisabled": func(t *testing.T) {
+			p.CommitQueue.Enabled = utility.FalsePtr()
+			require.NoError(t, p.Insert(t.Context()))
+			response := gh.handleMergeGroupChecksRequested(t.Context(), event)
+			assert.Nil(t, response)
+		},
 		"nonexistentProject": func(t *testing.T) {
 			response := gh.handleMergeGroupChecksRequested(t.Context(), event)
-			// check for error returned by GitHub merge queue handler
-			str := fmt.Sprintf("%#v", response)
-			assert.Contains(t, str, "no matching project ref")
-			assert.NotContains(t, str, "200")
+			assert.Nil(t, response)
 		},
 	} {
 		require.NoError(t, db.ClearCollections(model.ProjectRefCollection))


### PR DESCRIPTION
DEVPROD-32943

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->

Small fix to skip sending merge queue statuses for projects with merge queue disabled (e.g. a project that uses Evergreen to test PRs but not the MQ).

### Testing

<!--add a description of how you tested it-->
Unit test