### PR TITLE
DEVPROD-30080 Add display status to agent honeycomb span

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1292,21 +1292,44 @@ func (a *Agent) finishTask(ctx context.Context, tc *taskContext, detail *apimode
 	}
 
 	span := trace.SpanFromContext(ctx)
-	span.SetAttributes(attribute.String(evergreen.TaskStatusOtelAttribute, detail.Status))
+	var taskData *task.Task
+	if tc.taskConfig != nil {
+		taskData = &tc.taskConfig.Task
+	}
+	span.SetAttributes(buildTaskEndSpanAttributes(taskData, detail)...)
 	if detail.Status != evergreen.TaskSucceeded {
 		span.SetStatus(codes.Error, fmt.Sprintf("failing status '%s'", detail.Status))
 	}
-	if detail.Type != "" {
-		span.SetAttributes(attribute.String(evergreen.TaskFailureTypeOtelAttribute, detail.Type))
-	}
-	if detail.FailingCommand != "" {
-		span.SetAttributes(attribute.String(evergreen.TaskFailingCommandOtelAttribute, detail.FailingCommand))
-	}
-	if detail.Description != "" {
-		span.SetAttributes(attribute.String(evergreen.TaskDescriptionOtelAttribute, detail.Description))
-	}
 
 	return resp, nil
+}
+
+func buildTaskEndSpanAttributes(t *task.Task, detail *apimodels.TaskEndDetail) []attribute.KeyValue {
+	if detail == nil {
+		return nil
+	}
+
+	attrs := []attribute.KeyValue{
+		attribute.String(evergreen.TaskStatusOtelAttribute, detail.Status),
+	}
+
+	if t != nil {
+		taskCopy := *t
+		taskCopy.Status = detail.Status
+		taskCopy.Details = *detail
+		attrs = append(attrs, attribute.String(evergreen.TaskDisplayStatusOtelAttribute, taskCopy.DetermineDisplayStatus()))
+	}
+	if detail.Type != "" {
+		attrs = append(attrs, attribute.String(evergreen.TaskFailureTypeOtelAttribute, detail.Type))
+	}
+	if detail.FailingCommand != "" {
+		attrs = append(attrs, attribute.String(evergreen.TaskFailingCommandOtelAttribute, detail.FailingCommand))
+	}
+	if detail.Description != "" {
+		attrs = append(attrs, attribute.String(evergreen.TaskDescriptionOtelAttribute, detail.Description))
+	}
+
+	return attrs
 }
 
 // bucketConfigsChanged returns true if either the task or test bucket config

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 func init() {
@@ -71,6 +72,36 @@ type AgentSuite struct {
 
 func TestAgentSuite(t *testing.T) {
 	suite.Run(t, new(AgentSuite))
+}
+
+func TestBuildTaskEndSpanAttributes(t *testing.T) {
+	t.Run("SystemUnresponsiveIncludesDisplayStatusAndStatusDetails", func(t *testing.T) {
+		detail := &apimodels.TaskEndDetail{
+			Status:      evergreen.TaskFailed,
+			Type:        evergreen.CommandTypeSystem,
+			Description: evergreen.TaskDescriptionHeartbeat,
+			TimedOut:    true,
+		}
+
+		attrs := taskEndSpanAttrMap(buildTaskEndSpanAttributes(&task.Task{}, detail))
+
+		assert.Equal(t, evergreen.TaskFailed, attrs[evergreen.TaskStatusOtelAttribute].AsString())
+		assert.Equal(t, evergreen.TaskSystemUnresponse, attrs[evergreen.TaskDisplayStatusOtelAttribute].AsString())
+		assert.Equal(t, evergreen.CommandTypeSystem, attrs[evergreen.TaskFailureTypeOtelAttribute].AsString())
+		assert.Equal(t, evergreen.TaskDescriptionHeartbeat, attrs[evergreen.TaskDescriptionOtelAttribute].AsString())
+	})
+
+	t.Run("NilDetailHasNoAttributes", func(t *testing.T) {
+		assert.Empty(t, buildTaskEndSpanAttributes(&task.Task{}, nil))
+	})
+}
+
+func taskEndSpanAttrMap(attrs []attribute.KeyValue) map[string]attribute.Value {
+	attrMap := map[string]attribute.Value{}
+	for _, attr := range attrs {
+		attrMap[string(attr.Key)] = attr.Value
+	}
+	return attrMap
 }
 
 func (s *AgentSuite) SetupSuite() {

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-06-17a"
+	AgentVersion = "2026-06-18"
 )
 
 const (

--- a/globals.go
+++ b/globals.go
@@ -498,6 +498,7 @@ const (
 	TaskNameOtelAttribute                       = "evergreen.task.name"
 	TaskExecutionOtelAttribute                  = "evergreen.task.execution"
 	TaskStatusOtelAttribute                     = "evergreen.task.status"
+	TaskDisplayStatusOtelAttribute              = "evergreen.task.display_status"
 	TaskFailureTypeOtelAttribute                = "evergreen.task.failure_type"
 	TaskFailingCommandOtelAttribute             = "evergreen.task.failing_command"
 	TaskDescriptionOtelAttribute                = "evergreen.task.description"


### PR DESCRIPTION
DEVPROD-30080

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->
Adds the display status to the agent honeycomb span. I did some code cleanup as well to compress the set attributes call to one

### Testing

<!--add a description of how you tested it-->
Unit tests.

Deployed to staging and got:

<img width="1176" height="290" alt="Screenshot 2026-06-18 at 4 21 29 PM" src="https://github.com/user-attachments/assets/c3669d9f-1b97-40ae-b429-bcec0c35885e" />
