### PR TITLE
DEVPROD-40889: Support partial + sparse clone in git.get_project

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -64,6 +64,28 @@ type gitFetchProject struct {
 	ShallowClone bool `mapstructure:"shallow_clone"`
 	CloneDepth   int  `mapstructure:"clone_depth"`
 
+	// Filter passes git clone's --filter (partial clone). The most common value is
+	// "blob:none", which omits all file content from the initial clone and lazily
+	// fetches blobs on demand. Combined with SparseCheckoutPaths it lets a task
+	// check out only the files it needs instead of the whole working tree.
+	Filter string `plugin:"expand" mapstructure:"filter"`
+
+	// SparseCheckoutPaths restricts the working tree to the listed paths via
+	// git sparse-checkout (no-cone mode). The clone is done with --no-checkout,
+	// the sparse set is applied, and only then is the revision checked out, so
+	// only the matching paths land on disk.
+	//
+	// Only takes effect when Filter is also set (a sparse checkout without a
+	// partial-clone filter still downloads every blob, so it would save nothing);
+	// with an empty Filter these paths are ignored and a normal full clone runs.
+	// This lets a shared command leave these set and toggle the behavior with the
+	// (expandable) Filter alone.
+	//
+	// Entries are gitignore-style patterns, NOT plain paths: an unanchored entry
+	// like "README.md" matches that name in every directory. To select one
+	// specific file, anchor it with a leading slash, e.g. "/scripts/foo.sh".
+	SparseCheckoutPaths []string `plugin:"expand" mapstructure:"sparse_checkout_paths"`
+
 	RecurseSubmodules bool `mapstructure:"recurse_submodules"`
 
 	CommitterName string `mapstructure:"committer_name"`
@@ -76,14 +98,16 @@ type gitFetchProject struct {
 }
 
 type cloneOpts struct {
-	owner             string
-	repo              string
-	branch            string
-	dir               string
-	token             string
-	recurseSubmodules bool
-	useVerbose        bool
-	cloneDepth        int
+	owner               string
+	repo                string
+	branch              string
+	dir                 string
+	token               string
+	recurseSubmodules   bool
+	useVerbose          bool
+	cloneDepth          int
+	filter              string
+	sparseCheckoutPaths []string
 }
 
 func (opts cloneOpts) validate() error {
@@ -135,6 +159,15 @@ func (opts cloneOpts) getCloneCommand() ([]string, error) {
 		return nil, errors.Wrap(err, "invalid clone command options")
 	}
 
+	// The filter is the master switch for the sparse partial clone. A sparse
+	// checkout without a partial-clone filter still downloads every blob, so it
+	// would save nothing; treat an empty filter as "feature off" and ignore the
+	// sparse paths. This lets callers leave sparse_checkout_paths set on a shared
+	// command and toggle the whole behavior with the (expandable) filter alone.
+	if opts.filter == "" {
+		opts.sparseCheckoutPaths = nil
+	}
+
 	gitURL := thirdparty.FormGitURLForApp(opts.owner, opts.repo, opts.token)
 
 	clone := fmt.Sprintf("git clone %s '%s'", gitURL, opts.dir)
@@ -148,17 +181,47 @@ func (opts cloneOpts) getCloneCommand() ([]string, error) {
 	if opts.cloneDepth > 0 {
 		clone = fmt.Sprintf("%s --depth %d", clone, opts.cloneDepth)
 	}
+	if opts.filter != "" {
+		clone = fmt.Sprintf("%s --filter='%s'", clone, opts.filter)
+	}
+	if len(opts.sparseCheckoutPaths) > 0 {
+		// --sparse initializes a sparse-checkout (we widen it below) and
+		// --no-checkout defers populating the tree until after the sparse set is
+		// narrowed, so the default sparse contents are never materialized.
+		clone = fmt.Sprintf("%s --sparse --no-checkout", clone)
+	}
 	if opts.branch != "" {
 		clone = fmt.Sprintf("%s --branch '%s'", clone, opts.branch)
 	}
 
-	return []string{
+	cmds := []string{
 		"set +o xtrace",
 		fmt.Sprintf(`echo %s`, strconv.Quote(clone)),
 		clone,
 		"set -o xtrace",
 		fmt.Sprintf("cd %s", opts.dir),
-	}, nil
+	}
+
+	if len(opts.sparseCheckoutPaths) > 0 {
+		// no-cone mode treats the entries as gitignore-style patterns (see the
+		// SparseCheckoutPaths field doc on anchoring). The subsequent
+		// checkout/reset (added by the caller) populates only the matching paths.
+		sparse := fmt.Sprintf("git sparse-checkout set --no-cone %s",
+			strings.Join(quoteAll(opts.sparseCheckoutPaths), " "))
+		cmds = append(cmds, sparse)
+	}
+
+	return cmds, nil
+}
+
+// quoteAll single-quotes each path so paths containing shell metacharacters are
+// passed to git literally.
+func quoteAll(paths []string) []string {
+	quoted := make([]string, len(paths))
+	for i, p := range paths {
+		quoted[i] = fmt.Sprintf("'%s'", p)
+	}
+	return quoted
 }
 
 // getCloneCommandForWikiModule runs a plain git clone to opts.dir. GitHub
@@ -326,12 +389,14 @@ func (c *gitFetchProject) buildModuleCloneCommand(conf *internal.TaskConfig, opt
 func (c *gitFetchProject) opts(ctx context.Context, cloneToken string, logger client.LoggerProducer, conf *internal.TaskConfig) (cloneOpts, error) {
 	shallowCloneEnabled := conf.Distro == nil || !conf.Distro.DisableShallowClone
 	opts := cloneOpts{
-		owner:             conf.ProjectRef.Owner,
-		repo:              conf.ProjectRef.Repo,
-		branch:            conf.ProjectRef.Branch,
-		dir:               c.Directory,
-		token:             cloneToken,
-		recurseSubmodules: c.RecurseSubmodules,
+		owner:               conf.ProjectRef.Owner,
+		repo:                conf.ProjectRef.Repo,
+		branch:              conf.ProjectRef.Branch,
+		dir:                 c.Directory,
+		token:               cloneToken,
+		recurseSubmodules:   c.RecurseSubmodules,
+		filter:              c.Filter,
+		sparseCheckoutPaths: c.SparseCheckoutPaths,
 	}
 
 	cloneDepth := c.CloneDepth

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -64,22 +64,13 @@ type gitFetchProject struct {
 	ShallowClone bool `mapstructure:"shallow_clone"`
 	CloneDepth   int  `mapstructure:"clone_depth"`
 
-	// Filter passes git clone's --filter (partial clone). The most common value is
-	// "blob:none", which omits all file content from the initial clone and lazily
-	// fetches blobs on demand. Combined with SparseCheckoutPaths it lets a task
-	// check out only the files it needs instead of the whole working tree.
+	// Filter passes git clone's --filter (partial clone), e.g. "blob:none" to
+	// omit file content from the initial clone and fetch blobs lazily on demand.
 	Filter string `plugin:"expand" mapstructure:"filter"`
 
 	// SparseCheckoutPaths restricts the working tree to the listed paths via
-	// git sparse-checkout (no-cone mode). The clone is done with --no-checkout,
-	// the sparse set is applied, and only then is the revision checked out, so
-	// only the matching paths land on disk.
-	//
-	// Only takes effect when Filter is also set (a sparse checkout without a
-	// partial-clone filter still downloads every blob, so it would save nothing);
-	// with an empty Filter these paths are ignored and a normal full clone runs.
-	// This lets a shared command leave these set and toggle the behavior with the
-	// (expandable) Filter alone.
+	// git sparse-checkout (no-cone mode). Only takes effect when Filter is set;
+	// otherwise the paths are ignored and a normal full clone runs.
 	//
 	// Entries are gitignore-style patterns, NOT plain paths: an unanchored entry
 	// like "README.md" matches that name in every directory. To select one
@@ -159,11 +150,8 @@ func (opts cloneOpts) getCloneCommand() ([]string, error) {
 		return nil, errors.Wrap(err, "invalid clone command options")
 	}
 
-	// The filter is the master switch for the sparse partial clone. A sparse
-	// checkout without a partial-clone filter still downloads every blob, so it
-	// would save nothing; treat an empty filter as "feature off" and ignore the
-	// sparse paths. This lets callers leave sparse_checkout_paths set on a shared
-	// command and toggle the whole behavior with the (expandable) filter alone.
+	// A sparse checkout without a partial-clone filter still downloads every
+	// blob, so an empty filter means the sparse paths are ignored.
 	if opts.filter == "" {
 		opts.sparseCheckoutPaths = nil
 	}
@@ -182,12 +170,11 @@ func (opts cloneOpts) getCloneCommand() ([]string, error) {
 		clone = fmt.Sprintf("%s --depth %d", clone, opts.cloneDepth)
 	}
 	if opts.filter != "" {
-		clone = fmt.Sprintf("%s --filter=%s", clone, shellQuote(opts.filter))
+		clone = fmt.Sprintf("%s --filter=%s", clone, util.ShellQuote(opts.filter))
 	}
 	if len(opts.sparseCheckoutPaths) > 0 {
-		// --sparse initializes a sparse-checkout (we widen it below) and
 		// --no-checkout defers populating the tree until after the sparse set is
-		// narrowed, so the default sparse contents are never materialized.
+		// applied below, so the default sparse contents are never materialized.
 		clone = fmt.Sprintf("%s --sparse --no-checkout", clone)
 	}
 	if opts.branch != "" {
@@ -204,30 +191,17 @@ func (opts cloneOpts) getCloneCommand() ([]string, error) {
 
 	if len(opts.sparseCheckoutPaths) > 0 {
 		// no-cone mode treats the entries as gitignore-style patterns (see the
-		// SparseCheckoutPaths field doc on anchoring). The subsequent
-		// checkout/reset (added by the caller) populates only the matching paths.
+		// SparseCheckoutPaths field doc on anchoring).
+		quotedPaths := make([]string, len(opts.sparseCheckoutPaths))
+		for i, p := range opts.sparseCheckoutPaths {
+			quotedPaths[i] = util.ShellQuote(p)
+		}
 		sparse := fmt.Sprintf("git sparse-checkout set --no-cone %s",
-			strings.Join(quoteAll(opts.sparseCheckoutPaths), " "))
+			strings.Join(quotedPaths, " "))
 		cmds = append(cmds, sparse)
 	}
 
 	return cmds, nil
-}
-
-// quoteAll single-quotes each path so paths containing shell metacharacters are
-// passed to git literally.
-func quoteAll(paths []string) []string {
-	quoted := make([]string, len(paths))
-	for i, p := range paths {
-		quoted[i] = shellQuote(p)
-	}
-	return quoted
-}
-
-// shellQuote single-quotes s so the shell passes it to git literally, escaping
-// any embedded single quotes.
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // getCloneCommandForWikiModule runs a plain git clone to opts.dir. GitHub

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -182,7 +182,7 @@ func (opts cloneOpts) getCloneCommand() ([]string, error) {
 		clone = fmt.Sprintf("%s --depth %d", clone, opts.cloneDepth)
 	}
 	if opts.filter != "" {
-		clone = fmt.Sprintf("%s --filter='%s'", clone, opts.filter)
+		clone = fmt.Sprintf("%s --filter=%s", clone, shellQuote(opts.filter))
 	}
 	if len(opts.sparseCheckoutPaths) > 0 {
 		// --sparse initializes a sparse-checkout (we widen it below) and
@@ -219,9 +219,15 @@ func (opts cloneOpts) getCloneCommand() ([]string, error) {
 func quoteAll(paths []string) []string {
 	quoted := make([]string, len(paths))
 	for i, p := range paths {
-		quoted[i] = fmt.Sprintf("'%s'", p)
+		quoted[i] = shellQuote(p)
 	}
 	return quoted
+}
+
+// shellQuote single-quotes s so the shell passes it to git literally, escaping
+// any embedded single quotes.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 // getCloneCommandForWikiModule runs a plain git clone to opts.dir. GitHub

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -190,8 +190,8 @@ func (opts cloneOpts) getCloneCommand() ([]string, error) {
 	}
 
 	if len(opts.sparseCheckoutPaths) > 0 {
-		// no-cone mode treats the entries as gitignore-style patterns (see the
-		// SparseCheckoutPaths field doc on anchoring).
+		// no-cone mode (git 2.35+) treats the entries as gitignore-style
+		// patterns (see the SparseCheckoutPaths field doc on anchoring).
 		quotedPaths := make([]string, len(opts.sparseCheckoutPaths))
 		for i, p := range opts.sparseCheckoutPaths {
 			quotedPaths[i] = util.ShellQuote(p)
@@ -977,6 +977,9 @@ func (c *gitFetchProject) applyPatch(ctx context.Context, logger client.LoggerPr
 			SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorSender(level.Error, logger.Task().GetSender())
 
 		if err = cmd.Run(ctx); err != nil {
+			if patchPart.ModuleName == "" && c.Filter != "" && len(c.SparseCheckoutPaths) > 0 {
+				return errors.Wrap(err, "applying patch in a sparse checkout (a patch that touches files outside sparse_checkout_paths cannot be applied)")
+			}
 			return errors.WithStack(err)
 		}
 	}

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -284,6 +284,58 @@ func (s *GitGetProjectSuite) TestBuildSourceCommandCloneDepth() {
 	s.Contains(combined, "git log HEAD..")
 }
 
+func (s *GitGetProjectSuite) TestBuildSourceCommandSparseCheckout() {
+	c := &gitFetchProject{
+		Directory: "dir",
+	}
+	conf := s.taskConfig2
+
+	opts := cloneOpts{
+		token:               projectGitHubToken,
+		owner:               conf.ProjectRef.Owner,
+		repo:                conf.ProjectRef.Repo,
+		branch:              conf.ProjectRef.Branch,
+		dir:                 c.Directory,
+		filter:              "blob:none",
+		sparseCheckoutPaths: []string{"scripts/a.sh", "scripts/b.sh"},
+	}
+	cmds, err := c.buildSourceCloneCommand(conf, opts)
+	s.Require().NoError(err)
+	combined := strings.Join(cmds, " ")
+	// The clone is partial (blob-filtered) and does not check out the working
+	// tree until the sparse set is applied.
+	s.Contains(combined, "--filter='blob:none'")
+	s.Contains(combined, "--sparse --no-checkout")
+	// The sparse set is narrowed before the revision is materialized, so only the
+	// listed paths land on disk.
+	s.Contains(combined, "git sparse-checkout set --no-cone 'scripts/a.sh' 'scripts/b.sh'")
+	s.True(utility.StringSliceContainsOrderedPrefixSubset(cmds, []string{
+		"git sparse-checkout set --no-cone 'scripts/a.sh' 'scripts/b.sh'",
+		"git reset --hard ",
+		"git log --oneline -n 10",
+	}), cmds)
+}
+
+func (s *GitGetProjectSuite) TestSparseCheckoutIgnoredWithoutFilter() {
+	// The filter is the master switch: sparse_checkout_paths set with no filter
+	// is a no-op (a sparse checkout without a partial-clone filter saves nothing),
+	// so the clone is a plain full clone.
+	opts := cloneOpts{
+		owner:               "evergreen-ci",
+		repo:                "sample",
+		dir:                 "dir",
+		token:               projectGitHubToken,
+		sparseCheckoutPaths: []string{"scripts/a.sh"},
+	}
+	cmds, err := opts.getCloneCommand()
+	s.Require().NoError(err)
+	s.Require().Len(cmds, 5)
+	combined := strings.Join(cmds, " ")
+	s.NotContains(combined, "--sparse")
+	s.NotContains(combined, "--no-checkout")
+	s.NotContains(combined, "sparse-checkout")
+}
+
 func (s *GitGetProjectSuite) TestGitPlugin() {
 	conf := s.taskConfig1
 	logger, err := s.comm.GetLoggerProducer(s.ctx, &conf.Task, nil)
@@ -518,6 +570,20 @@ func (s *GitGetProjectSuite) TestGetCloneCommand() {
 	s.True(utility.ContainsOrderedSubset(cmds, []string{
 		fmt.Sprintf("echo \"git clone https://x-access-token:%s@github.com/evergreen-ci/sample.git 'dir' --branch 'main'\"", projectGitHubToken),
 		fmt.Sprintf("git clone https://x-access-token:%s@github.com/evergreen-ci/sample.git 'dir' --branch 'main'", projectGitHubToken),
+	}), cmds)
+
+	// a partial, sparse clone filters blobs, defers checkout, and appends a
+	// sparse-checkout step that narrows the working tree to the listed paths
+	opts.filter = "blob:none"
+	opts.sparseCheckoutPaths = []string{"scripts/a.sh", "scripts/b.sh"}
+	cmds, err = opts.getCloneCommand()
+	s.NoError(err)
+	s.Require().Len(cmds, 6)
+	s.True(utility.ContainsOrderedSubset(cmds, []string{
+		fmt.Sprintf("git clone https://x-access-token:%s@github.com/evergreen-ci/sample.git 'dir' --filter='blob:none' --sparse --no-checkout --branch 'main'", projectGitHubToken),
+		"set -o xtrace",
+		"cd dir",
+		"git sparse-checkout set --no-cone 'scripts/a.sh' 'scripts/b.sh'",
 	}), cmds)
 }
 

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -286,6 +286,58 @@ func (s *GitGetProjectSuite) TestBuildSourceCommandCloneDepth() {
 	s.Contains(combined, "git log HEAD..")
 }
 
+func (s *GitGetProjectSuite) TestBuildSourceCommandSparseCheckout() {
+	c := &gitFetchProject{
+		Directory: "dir",
+	}
+	conf := s.taskConfig2
+
+	opts := cloneOpts{
+		token:               projectGitHubToken,
+		owner:               conf.ProjectRef.Owner,
+		repo:                conf.ProjectRef.Repo,
+		branch:              conf.ProjectRef.Branch,
+		dir:                 c.Directory,
+		filter:              "blob:none",
+		sparseCheckoutPaths: []string{"scripts/a.sh", "scripts/b.sh"},
+	}
+	cmds, err := c.buildSourceCloneCommand(conf, opts)
+	s.Require().NoError(err)
+	combined := strings.Join(cmds, " ")
+	// The clone is partial (blob-filtered) and does not check out the working
+	// tree until the sparse set is applied.
+	s.Contains(combined, "--filter='blob:none'")
+	s.Contains(combined, "--sparse --no-checkout")
+	// The sparse set is narrowed before the revision is materialized, so only the
+	// listed paths land on disk.
+	s.Contains(combined, "git sparse-checkout set --no-cone 'scripts/a.sh' 'scripts/b.sh'")
+	s.True(utility.StringSliceContainsOrderedPrefixSubset(cmds, []string{
+		"git sparse-checkout set --no-cone 'scripts/a.sh' 'scripts/b.sh'",
+		"git reset --hard ",
+		"git log --oneline -n 10",
+	}), cmds)
+}
+
+func (s *GitGetProjectSuite) TestSparseCheckoutIgnoredWithoutFilter() {
+	// The filter is the master switch: sparse_checkout_paths set with no filter
+	// is a no-op (a sparse checkout without a partial-clone filter saves nothing),
+	// so the clone is a plain full clone.
+	opts := cloneOpts{
+		owner:               "evergreen-ci",
+		repo:                "sample",
+		dir:                 "dir",
+		token:               projectGitHubToken,
+		sparseCheckoutPaths: []string{"scripts/a.sh"},
+	}
+	cmds, err := opts.getCloneCommand()
+	s.Require().NoError(err)
+	s.Require().Len(cmds, 5)
+	combined := strings.Join(cmds, " ")
+	s.NotContains(combined, "--sparse")
+	s.NotContains(combined, "--no-checkout")
+	s.NotContains(combined, "sparse-checkout")
+}
+
 func (s *GitGetProjectSuite) TestGitPlugin() {
 	conf := s.taskConfig1
 	logger, err := s.comm.GetLoggerProducer(s.ctx, &conf.Task, nil)
@@ -543,6 +595,20 @@ func (s *GitGetProjectSuite) TestGetCloneCommand() {
 	s.True(utility.ContainsOrderedSubset(cmds, []string{
 		fmt.Sprintf("echo \"git clone https://x-access-token:%s@github.com/evergreen-ci/sample.git 'dir' --branch 'main'\"", projectGitHubToken),
 		fmt.Sprintf("git clone https://x-access-token:%s@github.com/evergreen-ci/sample.git 'dir' --branch 'main'", projectGitHubToken),
+	}), cmds)
+
+	// a partial, sparse clone filters blobs, defers checkout, and appends a
+	// sparse-checkout step that narrows the working tree to the listed paths
+	opts.filter = "blob:none"
+	opts.sparseCheckoutPaths = []string{"scripts/a.sh", "scripts/b.sh"}
+	cmds, err = opts.getCloneCommand()
+	s.NoError(err)
+	s.Require().Len(cmds, 6)
+	s.True(utility.ContainsOrderedSubset(cmds, []string{
+		fmt.Sprintf("git clone https://x-access-token:%s@github.com/evergreen-ci/sample.git 'dir' --filter='blob:none' --sparse --no-checkout --branch 'main'", projectGitHubToken),
+		"set -o xtrace",
+		"cd dir",
+		"git sparse-checkout set --no-cone 'scripts/a.sh' 'scripts/b.sh'",
 	}), cmds)
 }
 

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -610,6 +610,13 @@ func (s *GitGetProjectSuite) TestGetCloneCommand() {
 		"cd dir",
 		"git sparse-checkout set --no-cone 'scripts/a.sh' 'scripts/b.sh'",
 	}), cmds)
+
+	// embedded single quotes are escaped so the shell passes them to git
+	// literally
+	opts.sparseCheckoutPaths = []string{"scripts/it's.sh"}
+	cmds, err = opts.getCloneCommand()
+	s.NoError(err)
+	s.Contains(strings.Join(cmds, " "), `git sparse-checkout set --no-cone 'scripts/it'\''s.sh'`)
 }
 
 func (s *GitGetProjectSuite) TestBuildSourceCommand() {

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-08-18"
+	AgentVersion = "2026-08-19"
 )
 
 const (

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -956,6 +956,19 @@ Parameters:
   patch builds, Evergreen will `git fetch --unshallow` if the base
   commit is older than `<clone_depth>` commits. `clone_depth` takes precedence over `shallow_clone`.
 - `shallow_clone`: Sets `clone_depth` to 100, if not already set.
+- `filter`: Clone with `git clone --filter=<filter>` (a partial clone). The
+  most common value is `blob:none`, which omits all file content from the
+  initial clone and lazily fetches blobs on demand. Combine with
+  `sparse_checkout_paths` to check out only the files a task needs.
+- `sparse_checkout_paths`: Restrict the working tree to the listed paths via
+  `git sparse-checkout` (no-cone mode). The clone is done with `--no-checkout`,
+  the sparse set is applied, and only then is the revision checked out, so only
+  the matching paths land on disk. Only takes effect when `filter` is also set;
+  with an empty `filter` these paths are ignored and a normal full clone runs, so
+  the behavior can be toggled with `filter` alone. Entries are gitignore-style
+  patterns, not plain paths: an unanchored entry like `README.md` matches that
+  name in every directory, so anchor a single file with a leading slash, e.g.
+  `/scripts/foo.sh`.
 - `recurse_submodules`: automatically initialize and update each
   submodule in the repository, including any nested submodules.
 

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -976,6 +976,7 @@ Parameters:
   on files outside the sparse set. Combining `filter` with `clone_depth` is
   supported, but the `git fetch --unshallow` fallback for older base commits
   requires a distro git new enough to unshallow a partial clone.
+
 - `recurse_submodules`: automatically initialize and update each
   submodule in the repository, including any nested submodules.
 

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -969,6 +969,13 @@ Parameters:
   patterns, not plain paths: an unanchored entry like `README.md` matches that
   name in every directory, so anchor a single file with a leading slash, e.g.
   `/scripts/foo.sh`.
+
+  Both `filter` and `sparse_checkout_paths` apply only to the source clone;
+  module and wiki clones are unaffected. Do not enable them on variants that
+  also run patch builds: Evergreen applies patches with `git apply`, which fails
+  on files outside the sparse set. Combining `filter` with `clone_depth` is
+  supported, but the `git fetch --unshallow` fallback for older base commits
+  requires a distro git new enough to unshallow a partial clone.
 - `recurse_submodules`: automatically initialize and update each
   submodule in the repository, including any nested submodules.
 

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -971,9 +971,12 @@ Parameters:
   `/scripts/foo.sh`.
 
   Both `filter` and `sparse_checkout_paths` apply only to the source clone;
-  module and wiki clones are unaffected. Do not enable them on variants that
-  also run patch builds: Evergreen applies patches with `git apply`, which fails
-  on files outside the sparse set. Combining `filter` with `clone_depth` is
+  module and wiki clones are unaffected. `sparse_checkout_paths` requires a
+  distro git of 2.35 or newer (for `git sparse-checkout set --no-cone`). Patch
+  builds whose diffs only touch files inside `sparse_checkout_paths` work
+  normally, but a patch that touches anything outside the sparse set fails to
+  apply: Evergreen applies patches with `git apply`, which errors on files
+  missing from the working tree. Combining `filter` with `clone_depth` is
   supported, but the `git fetch --unshallow` fallback for older base commits
   requires a distro git new enough to unshallow a partial clone.
 


### PR DESCRIPTION
DEVPROD-40889

### Description

Add two optional params to `git.get_project` so a task can check out only the files it needs instead of the whole working tree:

* `filter`: passes `git clone --filter` (partial clone), e.g. `blob:none` to omit file content and fetch blobs lazily.
* `sparse_checkout_paths`: restricts the working tree via `git sparse-checkout` (no-cone). Only takes effect when `filter` is set — a sparse checkout without a partial-clone filter still downloads every blob — which lets a shared command leave the paths set and toggle the whole behavior with the (expandable) `filter` alone.

Tasks that set neither param get byte-identical clone commands to before. Only the source clone is affected; module and wiki clones are unchanged.

Motivation: Atlas (10gen/mms) has ~196 per-team integration-test "result" tasks that, on a first run, only download streamed results and `attach.xunit_results` them — they run no build and need just a few checked-in scripts, yet each clones the whole ~80k-file repo (~15s of pure waste per task). A blob-filtered sparse clone of those scripts cuts that to ~1-2s.

### Testing

* Added unit coverage for the generated commands: a partial, sparse clone filters blobs, defers checkout, and appends a `git sparse-checkout set --no-cone` step with shell-quoted paths (`TestBuildSourceCommandSparseCheckout`), and `sparse_checkout_paths` without `filter` is a no-op producing the old command sequence (`TestSparseCheckoutIgnoredWithoutFilter`).
* The existing, unchanged `TestGetCloneCommand` cases confirm the output is byte-identical when the new params are unset.

### Documentation

Updated `docs/Project-Configuration/Project-Commands.md` with the new params and their limitations: unsuitable for patch builds whose diffs touch files outside the sparse set (`git apply` fails), and the `clone_depth` unshallow fallback needs a distro git new enough to unshallow a partial clone.
