### PR TITLE
DEVPROD-35921: Build per-translation lookup maps once instead of per build variant

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1692,6 +1692,14 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 	var unmatchedSelectors []string
 	var unmatchedCriteria []string
 	var evalErrs, errs []error
+	tasksByName := map[string]parserTask{}
+	for _, t := range tasks {
+		tasksByName[t.Name] = t
+	}
+	tgMap := map[string]TaskGroup{}
+	for _, tg := range tgs {
+		tgMap[tg.Name] = tg
+	}
 	for _, pbv := range pbvs {
 		bv := BuildVariant{
 			DisplayName:        pbv.DisplayName,
@@ -1714,7 +1722,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 			Tags:               pbv.Tags,
 			Paths:              pbv.Paths,
 		}
-		bv.Tasks, unmatchedSelectors, unmatchedCriteria, errs = evaluateBVTasks(tse, tgse, vse, pbv, tasks)
+		bv.Tasks, unmatchedSelectors, unmatchedCriteria, errs = evaluateBVTasks(tse, tgse, vse, pbv, tasksByName)
 		if len(unmatchedSelectors) > 0 {
 			bv.TranslationWarnings = append(bv.TranslationWarnings, fmt.Sprintf("buildvariant '%s' has unmatched selector: '%s'", pbv.Name, strings.Join(unmatchedSelectors, "', '")))
 		}
@@ -1754,7 +1762,7 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 
 				var added []BuildVariantTaskUnit
 				pbv.Tasks = r.AddTasks
-				added, _, _, errs = evaluateBVTasks(tse, tgse, vse, pbv, tasks)
+				added, _, _, errs = evaluateBVTasks(tse, tgse, vse, pbv, tasksByName)
 				evalErrs = append(evalErrs, errs...)
 				// check for conflicting duplicates
 				for _, t := range added {
@@ -1771,10 +1779,6 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 			}
 		}
 
-		tgMap := map[string]TaskGroup{}
-		for _, tg := range tgs {
-			tgMap[tg.Name] = tg
-		}
 		dtse := newDisplayTaskSelectorEvaluator(bv, tasks, tgMap)
 
 		// check that display tasks contain real tasks that are not duplicated
@@ -1846,16 +1850,12 @@ func evaluateBuildVariants(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluato
 // match anything, the list of criteria that did not match any tasks, and
 // any errors encountered during evaluation.
 func evaluateBVTasks(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, vse *variantSelectorEvaluator,
-	pbv parserBV, tasks []parserTask) ([]BuildVariantTaskUnit, []string, []string, []error) {
+	pbv parserBV, tasksByName map[string]parserTask) ([]BuildVariantTaskUnit, []string, []string, []error) {
 	var evalErrs, errs []error
 	ts := []BuildVariantTaskUnit{}
 	unmatchedSelectors := []string{}
 	unmatchedCriteria := []string{}
 	taskUnitsByName := map[string]BuildVariantTaskUnit{}
-	tasksByName := map[string]parserTask{}
-	for _, t := range tasks {
-		tasksByName[t.Name] = t
-	}
 	for _, pbvt := range pbv.Tasks {
 		// Evaluate each task against both the task and task group selectors
 		// only error if both selectors error because each task should only be found

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -749,7 +749,11 @@ func parserTaskSelectorTaskEval(tse *taskSelectorEvaluator, tsge *tagSelectorEva
 	Convey(fmt.Sprintf("tasks [%v] should evaluate to [%v]",
 		strings.Join(names, ", "), strings.Join(exp, ", ")), func() {
 		pbv := parserBV{Name: "build-variant-wow", Tasks: tasks}
-		taskUnit, unmatchedSelectors, unmatchedCriteria, errs := evaluateBVTasks(tse, tsge, vse, pbv, taskDefs)
+		tasksByName := map[string]parserTask{}
+		for _, t := range taskDefs {
+			tasksByName[t.Name] = t
+		}
+		taskUnit, unmatchedSelectors, unmatchedCriteria, errs := evaluateBVTasks(tse, tsge, vse, pbv, tasksByName)
 		if expected != nil {
 			So(errs, ShouldBeNil)
 		} else {


### PR DESCRIPTION
DEVPROD-35921

### Description
During project translation, evaluateBVTasks rebuilt a tasksByName map on every call, and evaluateBuildVariants rebuilt a tgMap (task groups) on every loop iteration. Both inputs are constant for the entire translation, so this work was repeated unnecessarily for every build variant in the project.

Based on Pprof data collected, evaluateBVTasks is the single largest source of memory allocations both during a spike and on a normal day: 21% and 17% of all allocations in a production heap profile. High allocation rates force Go's garbage collector to run frequently, which consumes CPU.

This removes the unnecessary allocations and should help relieve some of the pressure.


### Testing
I edited the existing tests which verify correctness. I'm working on benchmarking to verify that it has the expected impact. 

Benchmarking on main versus with this change shows a 25% reduction in allocations and 16% reduction in memory per translation call on a 50-variant, 100-task project (21,663 → 16,321 allocs/op, 9.1 MB → 7.7 MB/op).
