### PR TITLE
DEVPROD-35926: Memoize tag selector criteria within a single translation run

### DIFF
--- a/model/project_selector.go
+++ b/model/project_selector.go
@@ -127,9 +127,10 @@ type tagged interface {
 
 // tagSelectorEvaluator evaluates selectors for arbitrary tagged items
 type tagSelectorEvaluator struct {
-	items  []tagged
-	byName map[string]tagged
-	byTag  map[string][]tagged
+	items          []tagged
+	byName         map[string]tagged
+	byTag          map[string][]tagged
+	criterionCache map[selectCriterion][]string
 }
 
 // newTagSelectorEvaluator returns a new taskSelectorEvaluator.
@@ -146,9 +147,10 @@ func newTagSelectorEvaluator(selectees []tagged) *tagSelectorEvaluator {
 		}
 	}
 	return &tagSelectorEvaluator{
-		items:  items,
-		byName: byName,
-		byTag:  byTag,
+		items:          items,
+		byName:         byName,
+		byTag:          byTag,
+		criterionCache: map[selectCriterion][]string{},
 	}
 }
 
@@ -184,39 +186,50 @@ func (tse *tagSelectorEvaluator) evalSelector(s Selector) ([]string, []string, e
 }
 
 // evalCriterion returns all names that fulfill a single selection criterion.
+// Results are memoized per evaluator instance; errors are never cached.
 func (tse *tagSelectorEvaluator) evalCriterion(sc selectCriterion) ([]string, error) {
-	switch {
-	case sc.Validate() != nil:
-		return nil, errors.Errorf("criterion '%v' is invalid: %v", sc, sc.Validate())
+	if err := sc.Validate(); err != nil {
+		return nil, errors.Errorf("criterion '%v' is invalid: %v", sc, err)
+	}
+	if names, ok := tse.criterionCache[sc]; ok {
+		return names, nil
+	}
+	names := tse.computeCriterion(sc)
+	tse.criterionCache[sc] = names
+	return names, nil
+}
 
+// computeCriterion performs the actual set computation for a validated criterion.
+func (tse *tagSelectorEvaluator) computeCriterion(sc selectCriterion) []string {
+	switch {
 	case sc.name == SelectAll: // special * case
 		names := make([]string, len(tse.items))
 		for i, item := range tse.items {
 			names[i] = item.name()
 		}
-		return names, nil
+		return names
 
 	case !sc.tagged && !sc.negated: // just a regular name
 		item := tse.byName[sc.name]
 		if item == nil {
-			return nil, nil
+			return nil
 		}
-		return []string{item.name()}, nil
+		return []string{item.name()}
 
 	case sc.tagged && !sc.negated: // expand a tag
 		taggedItems := tse.byTag[sc.name]
 		if len(taggedItems) == 0 {
-			return nil, nil
+			return nil
 		}
 		names := make([]string, len(taggedItems))
 		for i, item := range taggedItems {
 			names[i] = item.name()
 		}
-		return names, nil
+		return names
 
 	case !sc.tagged && sc.negated: // everything *but* a specific item
 		if tse.byName[sc.name] == nil {
-			return nil, nil
+			return nil
 		}
 		names := make([]string, 0, len(tse.items)-1)
 		for _, item := range tse.items {
@@ -224,12 +237,12 @@ func (tse *tagSelectorEvaluator) evalCriterion(sc selectCriterion) ([]string, er
 				names = append(names, item.name())
 			}
 		}
-		return names, nil
+		return names
 
 	case sc.tagged && sc.negated: // everything *but* a tag
 		items := tse.byTag[sc.name]
 		if len(items) == 0 {
-			return nil, nil
+			return nil
 		}
 		illegalItems := make(map[string]bool, len(items))
 		for _, item := range items {
@@ -243,7 +256,7 @@ func (tse *tagSelectorEvaluator) evalCriterion(sc selectCriterion) ([]string, er
 				names = append(names, item.name())
 			}
 		}
-		return names, nil
+		return names
 
 	default:
 		// protection for if we edit this switch block later

--- a/model/project_selector_test.go
+++ b/model/project_selector_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var materialTempAxes = []matrixAxis{
@@ -350,4 +352,25 @@ func TestVariantMatrixSelectorEvaluation(t *testing.T) {
 		})
 	})
 
+}
+
+func TestEvalCriterionMemoizationReturnsSameResults(t *testing.T) {
+	defs := []tagged{
+		testSelectee{Name: "red", Tags: []string{"primary", "warm"}},
+		testSelectee{Name: "blue", Tags: []string{"primary", "cool"}},
+		testSelectee{Name: "green", Tags: []string{"secondary", "cool"}},
+	}
+	tse := newTagSelectorEvaluator(defs)
+
+	sc := selectCriterion{name: "primary", tagged: true}
+	first, err := tse.evalCriterion(sc)
+	require.NoError(t, err)
+
+	second, err := tse.evalCriterion(sc)
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second, "repeated evalCriterion calls should return identical results")
+	cached, ok := tse.criterionCache[sc]
+	require.True(t, ok, "criterion should be in the cache after first evaluation")
+	assert.Equal(t, first, cached)
 }


### PR DESCRIPTION
DEVPROD-35926

### Description

Based on pprof data collected, evalCriterion was the #1 source of allocations during a spike in March 2026: 20.5% of all allocations (1.56 TB in a single heap snapshot). On a calm day (and after some other improvements we've made since) it is the #2 allocator at 7.9% (3.2 TB). 

During translation, each tag selector is broken into criteria and each criterion is evaluated to produce a list of matching task names. The expensive case is negation (e.g. !.arm64): it scans every task in the project and allocates a new list of results. Previously this happened once per build variant that referenced the criterion, so on a project with 100 variants all using the same !.arm64 selector, the same scan ran 100 times and allocated 100 identical lists.

This PR caches criterion results for the lifetime of a single translation. After the first evaluation, subsequent calls for the same criterion return the cached result with no allocation. Cached results are read-only, which is safe since all callers already copy or intersect them before modifying.

### Testing
Added TestEvalCriterionMemoizationReturnsSameResults, which asserts that repeated calls with the same criterion return identical results and that the entry is present in the cache afterward. The existing tests (TestBasicSelector, TestTaskSelectorEvaluation, TestVariantMatrixSelectorEvaluation) cover that the cached results are correct by running the same selector evaluation logic they always did.

Benchmarking ran on main and with this change shows that on a 50-variant, 200-task project where variants share selectors, there is a 20% reduction in allocations, 23% reduction in memory, and 33% reduction in time per translation call (1,226 → 982 allocs/op, 1.0 MB → 0.75 MB/op, ~812 µs → ~547 µs).


