### PR TITLE
DEVPROD-35981: Put the retryFailedLogMove job behind a flag

### DIFF
--- a/config_db.go
+++ b/config_db.go
@@ -97,6 +97,7 @@ var (
 	podDiagnosticsDisabledKey             = bsonutil.MustHaveTag(ServiceFlags{}, "PodDiagnosticsDisabled")
 	webhookSecretMigrationEnabledKey      = bsonutil.MustHaveTag(ServiceFlags{}, "WebhookSecretMigrationEnabled")
 	webhookSecretCleanupEnabledKey        = bsonutil.MustHaveTag(ServiceFlags{}, "WebhookSecretCleanupEnabled")
+	retryFailedLogMoveEnabledKey          = bsonutil.MustHaveTag(ServiceFlags{}, "RetryFailedLogMoveEnabled")
 	secondaryReadsDisabledKey             = bsonutil.MustHaveTag(ServiceFlags{}, "SecondaryReadsDisabled")
 	backgroundCommandFailureEnabledKey    = bsonutil.MustHaveTag(ServiceFlags{}, "BackgroundCommandFailureEnabled")
 	apiRateLimiterDisabledKey             = bsonutil.MustHaveTag(ServiceFlags{}, "APIRateLimiterDisabled")

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -45,6 +45,7 @@ type ServiceFlags struct {
 	PodDiagnosticsDisabled             bool `bson:"pod_diagnostics_disabled" json:"pod_diagnostics_disabled"`
 	WebhookSecretMigrationEnabled      bool `bson:"webhook_secret_migration_enabled" json:"webhook_secret_migration_enabled"`
 	WebhookSecretCleanupEnabled        bool `bson:"webhook_secret_cleanup_enabled" json:"webhook_secret_cleanup_enabled"`
+	RetryFailedLogMoveEnabled          bool `bson:"retry_failed_log_move_enabled" json:"retry_failed_log_move_enabled"`
 
 	// Notification Flags
 	EventProcessingDisabled      bool `bson:"event_processing_disabled" json:"event_processing_disabled"`
@@ -111,6 +112,7 @@ func (c *ServiceFlags) Set(ctx context.Context) error {
 			podDiagnosticsDisabledKey:             c.PodDiagnosticsDisabled,
 			webhookSecretMigrationEnabledKey:      c.WebhookSecretMigrationEnabled,
 			webhookSecretCleanupEnabledKey:        c.WebhookSecretCleanupEnabled,
+			retryFailedLogMoveEnabledKey:          c.RetryFailedLogMoveEnabled,
 			secondaryReadsDisabledKey:             c.SecondaryReadsDisabled,
 			backgroundCommandFailureEnabledKey:    c.BackgroundCommandFailureEnabled,
 			apiRateLimiterDisabledKey:             c.APIRateLimiterDisabled,

--- a/graphql/tests/mutation/setServiceFlags/results.json
+++ b/graphql/tests/mutation/setServiceFlags/results.json
@@ -56,6 +56,7 @@
             { "name": "pod_diagnostics_disabled", "enabled": false },
             { "name": "webhook_secret_migration_enabled", "enabled": false },
             { "name": "webhook_secret_cleanup_enabled", "enabled": false },
+            { "name": "retry_failed_log_move_enabled", "enabled": false },
             { "name": "event_processing_disabled", "enabled": false },
             { "name": "jira_notifications_disabled", "enabled": false },
             { "name": "slack_notifications_disabled", "enabled": false },

--- a/graphql/tests/query/adminSettings/results.json
+++ b/graphql/tests/query/adminSettings/results.json
@@ -621,6 +621,7 @@
               { "name": "pod_diagnostics_disabled", "enabled": false },
               { "name": "webhook_secret_migration_enabled", "enabled": false },
               { "name": "webhook_secret_cleanup_enabled", "enabled": false },
+              { "name": "retry_failed_log_move_enabled", "enabled": false },
               { "name": "event_processing_disabled", "enabled": false },
               { "name": "jira_notifications_disabled", "enabled": false },
               { "name": "slack_notifications_disabled", "enabled": false },

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2119,6 +2119,7 @@ type APIServiceFlags struct {
 	PodDiagnosticsDisabled             bool `json:"pod_diagnostics_disabled"`
 	WebhookSecretMigrationEnabled      bool `json:"webhook_secret_migration_enabled"`
 	WebhookSecretCleanupEnabled        bool `json:"webhook_secret_cleanup_enabled"`
+	RetryFailedLogMoveEnabled          bool `json:"retry_failed_log_move_enabled"`
 
 	// Notifications Flags
 	EventProcessingDisabled      bool `json:"event_processing_disabled"`
@@ -2582,6 +2583,7 @@ func (as *APIServiceFlags) BuildFromService(h any) error {
 		as.PodDiagnosticsDisabled = v.PodDiagnosticsDisabled
 		as.WebhookSecretMigrationEnabled = v.WebhookSecretMigrationEnabled
 		as.WebhookSecretCleanupEnabled = v.WebhookSecretCleanupEnabled
+		as.RetryFailedLogMoveEnabled = v.RetryFailedLogMoveEnabled
 		as.BackgroundCommandFailureEnabled = v.BackgroundCommandFailureEnabled
 		as.APIRateLimiterDisabled = v.APIRateLimiterDisabled
 		as.GraphQLComplexityLimiterDisabled = v.GraphQLComplexityLimiterDisabled
@@ -2635,6 +2637,7 @@ func (as *APIServiceFlags) ToService() (any, error) {
 		PodDiagnosticsDisabled:             as.PodDiagnosticsDisabled,
 		WebhookSecretMigrationEnabled:      as.WebhookSecretMigrationEnabled,
 		WebhookSecretCleanupEnabled:        as.WebhookSecretCleanupEnabled,
+		RetryFailedLogMoveEnabled:          as.RetryFailedLogMoveEnabled,
 		BackgroundCommandFailureEnabled:    as.BackgroundCommandFailureEnabled,
 		APIRateLimiterDisabled:             as.APIRateLimiterDisabled,
 		GraphQLComplexityLimiterDisabled:   as.GraphQLComplexityLimiterDisabled,

--- a/units/crons.go
+++ b/units/crons.go
@@ -958,6 +958,19 @@ func PopulateRetryFailedLogMoveJobsForOldTasks(env evergreen.Environment) amboy.
 
 func populateRetryFailedLogMoveJobs(env evergreen.Environment, runInOldTaskCollection bool) amboy.QueueOperation {
 	return func(ctx context.Context, queue amboy.Queue) error {
+		flags, err := evergreen.GetServiceFlags(ctx)
+		if err != nil {
+			return errors.Wrap(err, "getting service flags")
+		}
+		if !flags.RetryFailedLogMoveEnabled {
+			grip.InfoWhen(ctx, sometimes.Percent(evergreen.DegradedLoggingPercent), message.Fields{
+				"message": "retry failed log move is disabled",
+				"impact":  "skipping hourly retry of failed log moves to failed bucket",
+				"mode":    "degraded",
+			})
+			return nil
+		}
+
 		settings := env.Settings()
 		failedBucketCfg := settings.Buckets.LogBucketFailedTasks
 		if failedBucketCfg.Name == "" {
@@ -999,7 +1012,6 @@ func populateRetryFailedLogMoveJobs(env evergreen.Environment, runInOldTaskColle
 		findCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), retryFailedLogMoveFindTimeout)
 		defer cancel()
 		var tasks []task.Task
-		var err error
 		if runInOldTaskCollection {
 			tasks, err = task.FindAllOld(findCtx, query)
 		} else {


### PR DESCRIPTION
DEVPROD-35981

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

This is needed so it can be turned off when there is high pressure on the db, especially since this query is long running and needs some work to speed it up

### Testing

Verified `TestAtomicGQLQueries/serviceFlags` passes.

### Documentation

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
