### PR TITLE
DEVPROD-36045 Wrap FindAndTranslateProjectForVersion with a singleflight.Group

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -617,6 +617,7 @@ func FindAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.
 	// stored with the ID.
 	pp.Identifier = utility.ToStringPtr(v.Identifier)
 
+	// Coalesce concurrent translations for the same version into one compute.
 	key := versionTranslationKey(v.Id, preGeneration)
 	p, err := getOrComputeTranslation(key, func() (*Project, error) {
 		return TranslateProject(pp)

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -616,12 +616,15 @@ func FindAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.
 	// always has an identifier, but some old parser projects used to not be
 	// stored with the ID.
 	pp.Identifier = utility.ToStringPtr(v.Identifier)
-	var p *Project
-	p, err = TranslateProject(pp)
+
+	key := versionTranslationKey(v.Id, preGeneration)
+	p, err := getOrComputeTranslation(key, func() (*Project, error) {
+		return TranslateProject(pp)
+	})
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "translating parser project '%s'", v.Id)
 	}
-	return p, pp, err
+	return p, pp, nil
 }
 
 // LoadProjectInfoForVersion returns the project info for a version from its parser project.

--- a/model/project_translate_cache.go
+++ b/model/project_translate_cache.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"golang.org/x/sync/singleflight"
+)
+
+var translationGroupPtr atomic.Pointer[singleflight.Group]
+
+func init() {
+	translationGroupPtr.Store(&singleflight.Group{})
+}
+
+// getOrComputeTranslation coalesces concurrent calls for the same key into a
+// single compute via singleflight. Errors are not retained after the call
+// completes; the next caller will retry compute.
+func getOrComputeTranslation(key string, compute func() (*Project, error)) (*Project, error) {
+	v, err, _ := translationGroupPtr.Load().Do(key, func() (any, error) {
+		return compute()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.(*Project), nil
+}
+
+// versionTranslationKey returns the singleflight/cache key for a version-based translation.
+func versionTranslationKey(versionID string, preGeneration bool) string {
+	return fmt.Sprintf("v:%s:%v", versionID, preGeneration)
+}
+

--- a/model/project_translate_cache.go
+++ b/model/project_translate_cache.go
@@ -30,4 +30,3 @@ func getOrComputeTranslation(key string, compute func() (*Project, error)) (*Pro
 func versionTranslationKey(versionID string, preGeneration bool) string {
 	return fmt.Sprintf("v:%s:%v", versionID, preGeneration)
 }
-

--- a/model/project_translate_cache_test.go
+++ b/model/project_translate_cache_test.go
@@ -1,0 +1,125 @@
+package model
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/singleflight"
+)
+
+func resetTranslationCacheForTesting() {
+	translationGroupPtr.Store(&singleflight.Group{})
+}
+
+func TestGetOrComputeTranslation(t *testing.T) {
+	t.Run("SequentialCallsEachInvokeCompute", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		// Singleflight coalesces concurrent calls, not sequential ones.
+		var callCount int
+		compute := func() (*Project, error) {
+			callCount++
+			return &Project{Identifier: "test"}, nil
+		}
+
+		p1, err := getOrComputeTranslation("k", compute)
+		require.NoError(t, err)
+		p2, err := getOrComputeTranslation("k", compute)
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, callCount)
+		assert.Equal(t, "test", p1.Identifier)
+		assert.Equal(t, "test", p2.Identifier)
+	})
+
+	t.Run("CoalescesConcurrentCalls", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		var computeCount atomic.Int64
+		compute := func() (*Project, error) {
+			select {
+			case entered <- struct{}{}: // signal first entry
+			default:
+			}
+			<-release
+			computeCount.Add(1)
+			return &Project{Identifier: "coalesced"}, nil
+		}
+
+		const n = 5
+		projs := make([]*Project, n)
+		errs := make([]error, n)
+		var wg sync.WaitGroup
+		for i := range n {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				projs[i], errs[i] = getOrComputeTranslation("k", compute)
+			}(i)
+		}
+
+		<-entered                        // first goroutine is inside compute
+		time.Sleep(5 * time.Millisecond) // let remaining goroutines queue in singleflight
+		close(release)
+		wg.Wait()
+
+		assert.Equal(t, int64(1), computeCount.Load(), "concurrent calls should coalesce into one compute")
+		for i := range n {
+			require.NoError(t, errs[i])
+			assert.Equal(t, "coalesced", projs[i].Identifier)
+		}
+	})
+
+	t.Run("ErrorPropagatedToAllConcurrentWaiters", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		// All concurrent singleflight waiters receive the error when compute fails.
+		// The next sequential call must retry (singleflight does not cache errors).
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		var computeCount atomic.Int64
+		compute := func() (*Project, error) {
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			<-release
+			computeCount.Add(1)
+			return nil, errors.New("compute error")
+		}
+
+		const n = 5
+		errs := make([]error, n)
+		var wg sync.WaitGroup
+		for i := range n {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				_, errs[i] = getOrComputeTranslation("k", compute)
+			}(i)
+		}
+
+		<-entered
+		time.Sleep(5 * time.Millisecond)
+		close(release)
+		wg.Wait()
+
+		assert.Equal(t, int64(1), computeCount.Load(), "singleflight should coalesce concurrent failed computes")
+		for i := range n {
+			require.Error(t, errs[i])
+		}
+
+		// Error must not be cached — the next sequential call should retry.
+		p, err := getOrComputeTranslation("k", func() (*Project, error) {
+			return &Project{Identifier: "retry"}, nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "retry", p.Identifier)
+	})
+}
+

--- a/model/project_translate_cache_test.go
+++ b/model/project_translate_cache_test.go
@@ -122,4 +122,3 @@ func TestGetOrComputeTranslation(t *testing.T) {
 		assert.Equal(t, "retry", p.Identifier)
 	})
 }
-


### PR DESCRIPTION
DEVPROD-36045 

### Description

`FindAndTranslateProjectForVersion` is hit by many concurrent agent and UI requests. Multiple goroutines independently translate the same version, doing identical work and allocating separate copies of the result. 

This PR adds a singleflight group keyed on `(versionID, preGeneration)`. The first concurrent caller runs the translation and the rest wait and receive the same result.

 This is lower risk than the LRU cache (which is coming soon) so it doesn't need to be behind a feature flag, because unlike the cache, singleflight has no memory between completed calls. Once a request finishes, the result is discarded and the next caller always runs a fresh translation from the DB so we don't have to worry about stale data yet.

### Testing
Added unit tests. 
I also ran benchmarking that ran 50 concurrent callers with the same key. Without these changes it took 320 ms and with it it took 64 ms. It was 5 times faster per burst, with ~50× less CPU work. 

