### PR TITLE
DEVPROD-35991: Remove compute-predicted-cost-for-week span

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -4428,14 +4428,6 @@ type CostPredictionResult struct {
 }
 
 func (t *Task) ComputePredictedCostForWeek(ctx context.Context) (CostPredictionResult, error) {
-	ctx, span := tracer.Start(ctx, "compute-predicted-cost-for-week")
-	defer span.End()
-	span.SetAttributes(
-		attribute.String(evergreen.ProjectIDOtelAttribute, t.Project),
-		attribute.String(evergreen.BuildNameOtelAttribute, t.BuildVariant),
-		attribute.String(evergreen.TaskNameOtelAttribute, t.DisplayName),
-	)
-
 	end := time.Now()
 	start := end.Add(-taskCompletionEstimateWindow)
 


### PR DESCRIPTION
DEVPROD-35991 followup

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->
This span was added [many times](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen/result/iPq66fNLNX9/trace/9Avw6BGecbw?fields[]=s_name&fields[]=s_serviceName&span=bce08f6b0fcfd9d8), causing the span queue to overflow. This yields a lot of orphan `finalize-patch` spans that aren't attached to `schedule-patch` ([example](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen/result/zjWCD4e7svX/trace/BQi1Dt92eA7?fields[]=s_name&fields[]=s_serviceName&span=2d309475272911a9) of schedule-patch missing finalize-patch). We also already save this count effectively as the [attribute](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/EVkzm6c7PVe/trace/u47FWQ6J6vz?fields[]=s_name&fields[]=s_serviceName&span=a496df21418f8551) `num_cost_prediction_groups`.

### Testing

<!--add a description of how you tested it-->
This isn't highly testable in staging, because in my initial PR `finalize-patch` always appeared within `schedule-patch`

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
