### PR TITLE
DEVPROD-36042 add logging for large concurrent parser project task stats

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -3107,14 +3107,20 @@ func GetPendingGenerateTasks(ctx context.Context) (int, error) {
 	}
 }
 
-// CountLargeParserProjectTasks counts the number of tasks running with parser projects stored in s3.
-func CountLargeParserProjectTasks(ctx context.Context) (int, error) {
-	return Count(ctx, db.Query(bson.M{
+// runningLargeParserProjectTasksQuery returns a query matching tasks that are
+// currently running with parser projects stored in S3.
+func runningLargeParserProjectTasksQuery() bson.M {
+	return bson.M{
 		StatusKey: bson.M{
 			"$in": evergreen.TaskInProgressStatuses,
 		},
 		CachedProjectStorageMethodKey: evergreen.ProjectStorageMethodS3,
-	}))
+	}
+}
+
+// CountLargeParserProjectTasks counts the number of tasks running with parser projects stored in s3.
+func CountLargeParserProjectTasks(ctx context.Context) (int, error) {
+	return Count(ctx, db.Query(runningLargeParserProjectTasksQuery()))
 }
 
 // LargeParserProjectTaskStats contains the running task count for a single project
@@ -3129,12 +3135,7 @@ type LargeParserProjectTaskStats struct {
 func GetLargeParserProjectTaskStats(ctx context.Context) ([]LargeParserProjectTaskStats, error) {
 	pipeline := []bson.M{
 		{
-			"$match": bson.M{
-				StatusKey: bson.M{
-					"$in": evergreen.TaskInProgressStatuses,
-				},
-				CachedProjectStorageMethodKey: evergreen.ProjectStorageMethodS3,
-			},
+			"$match": runningLargeParserProjectTasksQuery(),
 		},
 		{
 			"$group": bson.M{

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -3143,7 +3143,7 @@ type LargeParserProjectTaskStats struct {
 
 // GetLargeParserProjectTaskStats returns per-project counts of tasks currently
 // running with S3-stored parser projects.
-func GetLargeParserProjectTaskStats(ctx context.Context) ([]LargeParserProjectTaskStats, error) {
+func GetLargeParserProjectTaskStats(ctx context.Context, env evergreen.Environment) ([]LargeParserProjectTaskStats, error) {
 	pipeline := []bson.M{
 		{
 			"$match": runningLargeParserProjectTasksQuery(),
@@ -3156,7 +3156,7 @@ func GetLargeParserProjectTaskStats(ctx context.Context) ([]LargeParserProjectTa
 		},
 	}
 
-	coll := evergreen.GetEnvironment().DB().Collection(Collection)
+	coll := env.DB().Collection(Collection)
 	dbCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	cursor, err := coll.Aggregate(dbCtx, pipeline)

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -3117,15 +3117,16 @@ func CountLargeParserProjectTasks(ctx context.Context) (int, error) {
 	}))
 }
 
-// LargeParserProjectTaskStats contains stats about tasks running with parser projects stored in S3.
+// LargeParserProjectTaskStats contains the running task count for a single project
+// with parser projects stored in S3.
 type LargeParserProjectTaskStats struct {
-	RunningVersions int `bson:"running_large_parser_project_versions"`
-	RunningTasks    int `bson:"running_large_parser_project_tasks"`
+	Project      string `bson:"_id"`
+	RunningTasks int    `bson:"running_tasks"`
 }
 
-// GetLargeParserProjectTaskStats returns a snapshot of how many tasks and
-// distinct versions with S3-stored parser projects are currently running.
-func GetLargeParserProjectTaskStats(ctx context.Context) (*LargeParserProjectTaskStats, error) {
+// GetLargeParserProjectTaskStats returns per-project counts of tasks currently
+// running with S3-stored parser projects.
+func GetLargeParserProjectTaskStats(ctx context.Context) ([]LargeParserProjectTaskStats, error) {
 	pipeline := []bson.M{
 		{
 			"$match": bson.M{
@@ -3137,22 +3138,8 @@ func GetLargeParserProjectTaskStats(ctx context.Context) (*LargeParserProjectTas
 		},
 		{
 			"$group": bson.M{
-				"_id":                       fmt.Sprintf("$%s", VersionKey),
-				"running_tasks_for_version": bson.M{"$sum": 1},
-			},
-		},
-		{
-			"$group": bson.M{
-				"_id":                                   nil,
-				"running_large_parser_project_versions": bson.M{"$sum": 1},
-				"running_large_parser_project_tasks":    bson.M{"$sum": "$running_tasks_for_version"},
-			},
-		},
-		{
-			"$project": bson.M{
-				"_id":                                   0,
-				"running_large_parser_project_versions": 1,
-				"running_large_parser_project_tasks":    1,
+				"_id":           fmt.Sprintf("$%s", ProjectKey),
+				"running_tasks": bson.M{"$sum": 1},
 			},
 		},
 	}
@@ -3168,11 +3155,7 @@ func GetLargeParserProjectTaskStats(ctx context.Context) (*LargeParserProjectTas
 	if err = cursor.All(dbCtx, &results); err != nil {
 		return nil, errors.Wrap(err, "iterating large parser project task stats")
 	}
-
-	if len(results) == 0 {
-		return &LargeParserProjectTaskStats{}, nil
-	}
-	return &results[0], nil
+	return results, nil
 }
 
 // GetLatestTaskFromImage retrieves the latest task from all the distros corresponding to the imageID.

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -3117,6 +3117,64 @@ func CountLargeParserProjectTasks(ctx context.Context) (int, error) {
 	}))
 }
 
+// LargeParserProjectTaskStats contains stats about tasks running with parser projects stored in S3.
+type LargeParserProjectTaskStats struct {
+	RunningVersions int `bson:"running_large_parser_project_versions"`
+	RunningTasks    int `bson:"running_large_parser_project_tasks"`
+}
+
+// GetLargeParserProjectTaskStats returns a snapshot of how many tasks and
+// distinct versions with S3-stored parser projects are currently running.
+func GetLargeParserProjectTaskStats(ctx context.Context) (*LargeParserProjectTaskStats, error) {
+	pipeline := []bson.M{
+		{
+			"$match": bson.M{
+				StatusKey: bson.M{
+					"$in": evergreen.TaskInProgressStatuses,
+				},
+				CachedProjectStorageMethodKey: evergreen.ProjectStorageMethodS3,
+			},
+		},
+		{
+			"$group": bson.M{
+				"_id":                       fmt.Sprintf("$%s", VersionKey),
+				"running_tasks_for_version": bson.M{"$sum": 1},
+			},
+		},
+		{
+			"$group": bson.M{
+				"_id":                                   nil,
+				"running_large_parser_project_versions": bson.M{"$sum": 1},
+				"running_large_parser_project_tasks":    bson.M{"$sum": "$running_tasks_for_version"},
+			},
+		},
+		{
+			"$project": bson.M{
+				"_id":                                   0,
+				"running_large_parser_project_versions": 1,
+				"running_large_parser_project_tasks":    1,
+			},
+		},
+	}
+
+	coll := evergreen.GetEnvironment().DB().Collection(Collection)
+	dbCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	cursor, err := coll.Aggregate(dbCtx, pipeline)
+	if err != nil {
+		return nil, errors.Wrap(err, "aggregating large parser project task stats")
+	}
+	var results []LargeParserProjectTaskStats
+	if err = cursor.All(dbCtx, &results); err != nil {
+		return nil, errors.Wrap(err, "iterating large parser project task stats")
+	}
+
+	if len(results) == 0 {
+		return &LargeParserProjectTaskStats{}, nil
+	}
+	return &results[0], nil
+}
+
 // GetLatestTaskFromImage retrieves the latest task from all the distros corresponding to the imageID.
 func GetLatestTaskFromImage(ctx context.Context, imageID string) (*Task, error) {
 	distros, err := distro.GetDistrosForImage(ctx, imageID)

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -2329,7 +2329,7 @@ func TestGetLargeParserProjectTaskStats(t *testing.T) {
 	t.Run("NoRunningTasks", func(t *testing.T) {
 		require.NoError(t, db.ClearCollections(Collection))
 
-		stats, err := GetLargeParserProjectTaskStats(t.Context())
+		stats, err := GetLargeParserProjectTaskStats(t.Context(), evergreen.GetEnvironment())
 		require.NoError(t, err)
 		assert.Empty(t, stats)
 	})
@@ -2346,7 +2346,7 @@ func TestGetLargeParserProjectTaskStats(t *testing.T) {
 		}
 		require.NoError(t, db.InsertMany(t.Context(), Collection, tasks[0], tasks[1], tasks[2], tasks[3]))
 
-		stats, err := GetLargeParserProjectTaskStats(t.Context())
+		stats, err := GetLargeParserProjectTaskStats(t.Context(), evergreen.GetEnvironment())
 		require.NoError(t, err)
 		require.Len(t, stats, 1)
 		assert.Equal(t, "proj-a", stats[0].Project)
@@ -2362,7 +2362,7 @@ func TestGetLargeParserProjectTaskStats(t *testing.T) {
 		}
 		require.NoError(t, db.InsertMany(t.Context(), Collection, tasks[0], tasks[1], tasks[2]))
 
-		stats, err := GetLargeParserProjectTaskStats(t.Context())
+		stats, err := GetLargeParserProjectTaskStats(t.Context(), evergreen.GetEnvironment())
 		require.NoError(t, err)
 		require.Len(t, stats, 2)
 		byProject := map[string]int{}

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -2331,40 +2331,45 @@ func TestGetLargeParserProjectTaskStats(t *testing.T) {
 
 		stats, err := GetLargeParserProjectTaskStats(t.Context())
 		require.NoError(t, err)
-		assert.Equal(t, 0, stats.RunningTasks)
-		assert.Equal(t, 0, stats.RunningVersions)
+		assert.Empty(t, stats)
 	})
 	t.Run("CountsStartedAndDispatchedS3Tasks", func(t *testing.T) {
 		require.NoError(t, db.ClearCollections(Collection))
 
 		tasks := []Task{
-			{Id: "started-s3", Status: evergreen.TaskStarted, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Version: "v1"},
-			{Id: "dispatched-s3", Status: evergreen.TaskDispatched, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Version: "v1"},
+			{Id: "started-s3", Status: evergreen.TaskStarted, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Project: "proj-a"},
+			{Id: "dispatched-s3", Status: evergreen.TaskDispatched, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Project: "proj-a"},
 			// Should not count: wrong status.
-			{Id: "failed-s3", Status: evergreen.TaskFailed, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Version: "v1"},
+			{Id: "failed-s3", Status: evergreen.TaskFailed, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Project: "proj-a"},
 			// Should not count: not S3.
-			{Id: "started-db", Status: evergreen.TaskStarted, CachedProjectStorageMethod: evergreen.ProjectStorageMethodDB, Version: "v1"},
+			{Id: "started-db", Status: evergreen.TaskStarted, CachedProjectStorageMethod: evergreen.ProjectStorageMethodDB, Project: "proj-a"},
 		}
 		require.NoError(t, db.InsertMany(t.Context(), Collection, tasks[0], tasks[1], tasks[2], tasks[3]))
 
 		stats, err := GetLargeParserProjectTaskStats(t.Context())
 		require.NoError(t, err)
-		assert.Equal(t, 2, stats.RunningTasks)
-		assert.Equal(t, 1, stats.RunningVersions)
+		require.Len(t, stats, 1)
+		assert.Equal(t, "proj-a", stats[0].Project)
+		assert.Equal(t, 2, stats[0].RunningTasks)
 	})
-	t.Run("CountsDistinctVersionsSeparately", func(t *testing.T) {
+	t.Run("ReturnsPerProjectCounts", func(t *testing.T) {
 		require.NoError(t, db.ClearCollections(Collection))
 
 		tasks := []Task{
-			{Id: "t1", Status: evergreen.TaskStarted, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Version: "v1"},
-			{Id: "t2", Status: evergreen.TaskStarted, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Version: "v1"},
-			{Id: "t3", Status: evergreen.TaskStarted, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Version: "v2"},
+			{Id: "t1", Status: evergreen.TaskStarted, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Project: "proj-a"},
+			{Id: "t2", Status: evergreen.TaskStarted, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Project: "proj-a"},
+			{Id: "t3", Status: evergreen.TaskStarted, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Project: "proj-b"},
 		}
 		require.NoError(t, db.InsertMany(t.Context(), Collection, tasks[0], tasks[1], tasks[2]))
 
 		stats, err := GetLargeParserProjectTaskStats(t.Context())
 		require.NoError(t, err)
-		assert.Equal(t, 3, stats.RunningTasks)
-		assert.Equal(t, 2, stats.RunningVersions)
+		require.Len(t, stats, 2)
+		byProject := map[string]int{}
+		for _, s := range stats {
+			byProject[s.Project] = s.RunningTasks
+		}
+		assert.Equal(t, 2, byProject["proj-a"])
+		assert.Equal(t, 1, byProject["proj-b"])
 	})
 }

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -2320,3 +2320,51 @@ func TestGetLatestTaskFromImage(t *testing.T) {
 	require.NotNil(t, latestTask)
 	assert.Equal(t, "t2", latestTask.Id)
 }
+
+func TestGetLargeParserProjectTaskStats(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(Collection))
+	}()
+
+	t.Run("NoRunningTasks", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(Collection))
+
+		stats, err := GetLargeParserProjectTaskStats(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, 0, stats.RunningTasks)
+		assert.Equal(t, 0, stats.RunningVersions)
+	})
+	t.Run("CountsStartedAndDispatchedS3Tasks", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(Collection))
+
+		tasks := []Task{
+			{Id: "started-s3", Status: evergreen.TaskStarted, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Version: "v1"},
+			{Id: "dispatched-s3", Status: evergreen.TaskDispatched, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Version: "v1"},
+			// Should not count: wrong status.
+			{Id: "failed-s3", Status: evergreen.TaskFailed, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Version: "v1"},
+			// Should not count: not S3.
+			{Id: "started-db", Status: evergreen.TaskStarted, CachedProjectStorageMethod: evergreen.ProjectStorageMethodDB, Version: "v1"},
+		}
+		require.NoError(t, db.InsertMany(t.Context(), Collection, tasks[0], tasks[1], tasks[2], tasks[3]))
+
+		stats, err := GetLargeParserProjectTaskStats(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, 2, stats.RunningTasks)
+		assert.Equal(t, 1, stats.RunningVersions)
+	})
+	t.Run("CountsDistinctVersionsSeparately", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(Collection))
+
+		tasks := []Task{
+			{Id: "t1", Status: evergreen.TaskStarted, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Version: "v1"},
+			{Id: "t2", Status: evergreen.TaskStarted, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Version: "v1"},
+			{Id: "t3", Status: evergreen.TaskStarted, CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3, Version: "v2"},
+		}
+		require.NoError(t, db.InsertMany(t.Context(), Collection, tasks[0], tasks[1], tasks[2]))
+
+		stats, err := GetLargeParserProjectTaskStats(t.Context())
+		require.NoError(t, err)
+		assert.Equal(t, 3, stats.RunningTasks)
+		assert.Equal(t, 2, stats.RunningVersions)
+	})
+}

--- a/model/task_queue_service_dependency.go
+++ b/model/task_queue_service_dependency.go
@@ -547,7 +547,7 @@ func (d *basicCachedDAGDispatcherImpl) setTaskGroup(taskGroupUnit schedulableUni
 // on how many concurrent large parser project tasks can be running. The first returned parameter indicates whether FindNextTask should
 // return on an error, and the second indicates whether FindNextTask should skip this task and continue its loop.
 func checkMaxConcurrentLargeParserProjectTasks(ctx context.Context, settings *evergreen.Settings, nextTaskFromDB *task.Task, distroId string) (bool, bool) {
-	maxConcurrentLargeParserProjTasks := getMaxConcurrentLargeParserProjTasks(settings)
+	maxConcurrentLargeParserProjTasks := GetMaxConcurrentLargeParserProjTasks(settings)
 	if maxConcurrentLargeParserProjTasks <= 0 {
 		return false, false
 	}
@@ -602,7 +602,9 @@ func checkMaxConcurrentLargeParserProjectTasks(ctx context.Context, settings *ev
 	return false, false
 }
 
-func getMaxConcurrentLargeParserProjTasks(settings *evergreen.Settings) int {
+// GetMaxConcurrentLargeParserProjTasks returns the configured limit for
+// concurrent large parser project tasks, accounting for degraded mode.
+func GetMaxConcurrentLargeParserProjTasks(settings *evergreen.Settings) int {
 	isDegradedMode := !settings.ServiceFlags.CPUDegradedModeDisabled
 	maxConcurrentLargeParserProjTasks := settings.TaskLimits.MaxConcurrentLargeParserProjectTasks
 	if isDegradedMode {

--- a/units/crons.go
+++ b/units/crons.go
@@ -1243,6 +1243,14 @@ func PopulateUnexpirableSpawnHostStatsJob() amboy.QueueOperation {
 	}
 }
 
+// PopulateLargeParserProjectTaskStatsJob populates a job to log stats about
+// running tasks with S3-stored parser projects.
+func PopulateLargeParserProjectTaskStatsJob() amboy.QueueOperation {
+	return func(ctx context.Context, queue amboy.Queue) error {
+		return amboy.EnqueueUniqueJob(ctx, queue, NewLargeParserProjectTaskStatsJob(utility.RoundPartOfHour(5).Format(TSFormat)))
+	}
+}
+
 func sleepSchedulerJobs(ctx context.Context, env evergreen.Environment, ts time.Time) ([]amboy.Job, error) {
 	return []amboy.Job{NewSleepSchedulerJob(env, ts.Format(TSFormat))}, nil
 }

--- a/units/crons_remote_five_minute.go
+++ b/units/crons_remote_five_minute.go
@@ -57,6 +57,7 @@ func (j *cronsRemoteFiveMinuteJob) Run(ctx context.Context) {
 		PopulateWebhookSecretMigrationJobs(),
 		// Cleanup runs after migration is verified complete in prod. Enable by setting WebhookSecretCleanupEnabled=true.
 		PopulateWebhookSecretCleanupJobs(),
+		PopulateLargeParserProjectTaskStatsJob(),
 	}
 
 	queue := j.env.RemoteQueue()

--- a/units/large_parser_project_task_stats.go
+++ b/units/large_parser_project_task_stats.go
@@ -65,7 +65,7 @@ func (j *largeParserProjectTaskStatsJob) Run(ctx context.Context) {
 		j.env = evergreen.GetEnvironment()
 	}
 
-	statsByProject, err := task.GetLargeParserProjectTaskStats(ctx)
+	statsByProject, err := task.GetLargeParserProjectTaskStats(ctx, j.env)
 	if err != nil {
 		j.AddRetryableError(errors.Wrap(err, "getting large parser project task stats"))
 		return

--- a/units/large_parser_project_task_stats.go
+++ b/units/large_parser_project_task_stats.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
@@ -17,7 +18,7 @@ import (
 
 const (
 	largeParserProjectTaskStatsJobName        = "large-parser-project-task-stats"
-	largeParserProjectTaskStatsJobMaxAttempts = 10
+	largeParserProjectTaskStatsJobMaxAttempts = 1
 )
 
 func init() {
@@ -79,10 +80,10 @@ func (j *largeParserProjectTaskStatsJob) Run(ctx context.Context) {
 
 	settings := j.env.Settings()
 	grip.Info(ctx, message.Fields{
-		"job_id":                                 j.ID(),
-		"message":                                "large parser project task stats",
-		"num_running_large_parser_project_tasks": totalTasks,
-		"num_by_project":                         tasksByProject,
-		"max_concurrent_large_parser_project_tasks": settings.TaskLimits.MaxConcurrentLargeParserProjectTasks,
+		"message":                            "large parser project task stats",
+		"job_id":                             j.ID(),
+		"running_large_parser_project_tasks": totalTasks,
+		"tasks_by_project":                   tasksByProject,
+		"max_concurrent_large_parser_project_tasks": model.GetMaxConcurrentLargeParserProjTasks(settings),
 	})
 }

--- a/units/large_parser_project_task_stats.go
+++ b/units/large_parser_project_task_stats.go
@@ -1,0 +1,88 @@
+package units
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
+)
+
+const (
+	largeParserProjectTaskStatsJobName        = "large-parser-project-task-stats"
+	largeParserProjectTaskStatsJobMaxAttempts = 10
+)
+
+func init() {
+	registry.AddJobType(largeParserProjectTaskStatsJobName, func() amboy.Job {
+		return makeLargeParserProjectTaskStatsJob()
+	})
+}
+
+type largeParserProjectTaskStatsJob struct {
+	job.Base `bson:"metadata" json:"metadata" yaml:"metadata"`
+	env      evergreen.Environment
+}
+
+func makeLargeParserProjectTaskStatsJob() *largeParserProjectTaskStatsJob {
+	j := &largeParserProjectTaskStatsJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    largeParserProjectTaskStatsJobName,
+				Version: 0,
+			},
+		},
+	}
+	return j
+}
+
+// NewLargeParserProjectTaskStatsJob returns a job to log the current count of
+// running tasks with S3-stored parser projects alongside the configured limit.
+func NewLargeParserProjectTaskStatsJob(ts string) amboy.Job {
+	j := makeLargeParserProjectTaskStatsJob()
+	j.SetID(fmt.Sprintf("%s.%s", largeParserProjectTaskStatsJobName, ts))
+	j.SetScopes([]string{largeParserProjectTaskStatsJobName})
+	j.SetEnqueueAllScopes(true)
+	j.UpdateRetryInfo(amboy.JobRetryOptions{
+		Retryable:   utility.TruePtr(),
+		MaxAttempts: utility.ToIntPtr(largeParserProjectTaskStatsJobMaxAttempts),
+	})
+	return j
+}
+
+func (j *largeParserProjectTaskStatsJob) Run(ctx context.Context) {
+	defer j.MarkComplete()
+
+	if j.env == nil {
+		j.env = evergreen.GetEnvironment()
+	}
+
+	statsByProject, err := task.GetLargeParserProjectTaskStats(ctx)
+	if err != nil {
+		j.AddRetryableError(errors.Wrap(err, "getting large parser project task stats"))
+		return
+	}
+
+	var totalTasks int
+	tasksByProject := make(map[string]int, len(statsByProject))
+	for _, s := range statsByProject {
+		totalTasks += s.RunningTasks
+		tasksByProject[s.Project] = s.RunningTasks
+	}
+
+	settings := j.env.Settings()
+	grip.Info(ctx, message.Fields{
+		"job_id":                                 j.ID(),
+		"message":                                "large parser project task stats",
+		"num_running_large_parser_project_tasks": totalTasks,
+		"num_by_project":                         tasksByProject,
+		"max_concurrent_large_parser_project_tasks": settings.TaskLimits.MaxConcurrentLargeParserProjectTasks,
+	})
+}


### PR DESCRIPTION
[DEVPROD-36042](https://jira.mongodb.org/browse/DEVPROD-36042)

Description
Logs how many things are running that are stored in S3 (since that's what we use for our "large project" count), what projects they're in, and what our limit is. I figure we might want a more dynamic splunk query / graph where we show where we are relative to the limit or who to ask for help or something. (Might also help remind us to bounce if we need to)

Testing
Added a unit test for the aggregation.