### PR TITLE
DEVPROD-36147: fix webhook redaction in project events

### DIFF
--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -21,8 +21,8 @@ const (
 	SubscriberTypeNone              = "none"
 	RunChildPatchSubscriberType     = "run-child-patch"
 
-	// WebhookAuthorizationHeader is the HTTP header key used to carry the
-	// webhook authorization token.
+	// WebhookAuthorizationHeader is the standard HTTP header key used for a
+	// webhook subscriber's authorization token.
 	WebhookAuthorizationHeader = "Authorization"
 
 	webhookRetryLimit    = 10

--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -21,6 +21,10 @@ const (
 	SubscriberTypeNone              = "none"
 	RunChildPatchSubscriberType     = "run-child-patch"
 
+	// WebhookAuthorizationHeader is the HTTP header key used to carry the
+	// webhook authorization token.
+	WebhookAuthorizationHeader = "Authorization"
+
 	webhookRetryLimit    = 10
 	webhookMinDelayLimit = 10000
 	webhookTimeoutLimit  = 30000

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -1068,7 +1068,7 @@ func (s *Subscription) saveWebhookAuthHeaderIfNeeded(ctx context.Context) error 
 		return nil
 	}
 
-	if authValue := webhookSub.GetHeader("Authorization"); authValue != "" {
+	if authValue := webhookSub.GetHeader(WebhookAuthorizationHeader); authValue != "" {
 		webhookSub.AuthorizationHeaderParameter = saveWebhookParameter(ctx, s.ID, getWebhookAuthParameterPath(s.ID), []byte(authValue))
 	} else if s.ID != "" {
 		// Authorization header was removed on update. Clean up the old PS entry if
@@ -1179,7 +1179,7 @@ func populateWebhookSecrets(ctx context.Context, subscriptions []Subscription) e
 				})
 				// Authorization header is already populated from the DB read — leave it as-is.
 			} else {
-				webhookSub.setHeader("Authorization", string(authValue))
+				webhookSub.setHeader(WebhookAuthorizationHeader, string(authValue))
 			}
 		}
 

--- a/model/event/subscriptions_test.go
+++ b/model/event/subscriptions_test.go
@@ -773,7 +773,7 @@ func (s *subscriptionsSuite) TestUpsertWebhookSavesAuthHeaderToParameterStore() 
 		URL:    "https://example.com/webhook",
 		Secret: []byte("my-secret"),
 		Headers: []WebhookHeader{
-			{Key: "Authorization", Value: "Bearer my-token"},
+			{Key: WebhookAuthorizationHeader, Value: "Bearer my-token"},
 			{Key: "X-Custom", Value: "custom-value"},
 		},
 	}
@@ -805,7 +805,7 @@ func (s *subscriptionsSuite) TestUpsertWebhookSavesAuthHeaderToParameterStore() 
 	s.Require().True(ok)
 	s.Require().NotNil(foundWebhook)
 	s.NotEmpty(foundWebhook.AuthorizationHeaderParameter, "authorization_header_parameter path should be stored in MongoDB")
-	s.Equal("Bearer my-token", foundWebhook.GetHeader("Authorization"), "Authorization header should be populated from Parameter Store on read")
+	s.Equal("Bearer my-token", foundWebhook.GetHeader(WebhookAuthorizationHeader), "Authorization header should be populated from Parameter Store on read")
 }
 
 func (s *subscriptionsSuite) TestUpsertWebhookWithoutAuthHeaderDoesNotCreateAuthParameter() {
@@ -839,7 +839,7 @@ func (s *subscriptionsSuite) TestFindSubscriptionByIDPopulatesAuthHeaderFromPara
 		URL:    "https://example.com/webhook",
 		Secret: []byte("my-secret"),
 		Headers: []WebhookHeader{
-			{Key: "Authorization", Value: "Bearer ps-token"},
+			{Key: WebhookAuthorizationHeader, Value: "Bearer ps-token"},
 		},
 	}
 	sub := Subscription{
@@ -863,7 +863,7 @@ func (s *subscriptionsSuite) TestFindSubscriptionByIDPopulatesAuthHeaderFromPara
 	foundWebhook, ok := found.Subscriber.Target.(*WebhookSubscriber)
 	s.Require().True(ok)
 	s.Require().NotNil(foundWebhook)
-	s.Equal("Bearer ps-token", foundWebhook.GetHeader("Authorization"))
+	s.Equal("Bearer ps-token", foundWebhook.GetHeader(WebhookAuthorizationHeader))
 	s.NotEmpty(foundWebhook.AuthorizationHeaderParameter)
 }
 
@@ -882,7 +882,7 @@ func (s *subscriptionsSuite) TestFindSubscriptionByIDFallsBackToMongoDBAuthHeade
 				URL:    "https://legacy.example.com",
 				Secret: []byte("legacy-secret"),
 				Headers: []WebhookHeader{
-					{Key: "Authorization", Value: "Bearer legacy-token"},
+					{Key: WebhookAuthorizationHeader, Value: "Bearer legacy-token"},
 				},
 			},
 		},
@@ -897,7 +897,7 @@ func (s *subscriptionsSuite) TestFindSubscriptionByIDFallsBackToMongoDBAuthHeade
 	foundWebhook, ok := found.Subscriber.Target.(*WebhookSubscriber)
 	s.Require().True(ok)
 	s.Require().NotNil(foundWebhook)
-	s.Equal("Bearer legacy-token", foundWebhook.GetHeader("Authorization"), "should fall back to MongoDB auth header")
+	s.Equal("Bearer legacy-token", foundWebhook.GetHeader(WebhookAuthorizationHeader), "should fall back to MongoDB auth header")
 	s.Empty(foundWebhook.AuthorizationHeaderParameter)
 }
 
@@ -906,7 +906,7 @@ func (s *subscriptionsSuite) TestRemoveSubscriptionDeletesAuthHeaderFromParamete
 		URL:    "https://example.com/webhook",
 		Secret: []byte("delete-me-secret"),
 		Headers: []WebhookHeader{
-			{Key: "Authorization", Value: "Bearer delete-me-token"},
+			{Key: WebhookAuthorizationHeader, Value: "Bearer delete-me-token"},
 		},
 	}
 	sub := Subscription{
@@ -942,7 +942,7 @@ func (s *subscriptionsSuite) TestUpsertWebhookDeletesAuthParameterWhenHeaderRemo
 		URL:    "https://example.com/webhook",
 		Secret: []byte("my-secret"),
 		Headers: []WebhookHeader{
-			{Key: "Authorization", Value: "Bearer original-token"},
+			{Key: WebhookAuthorizationHeader, Value: "Bearer original-token"},
 		},
 	}
 	sub := Subscription{
@@ -989,13 +989,13 @@ func TestSetHeader(t *testing.T) {
 	t.Run("UpdatesExistingKey", func(t *testing.T) {
 		ws := &WebhookSubscriber{
 			Headers: []WebhookHeader{
-				{Key: "Authorization", Value: "Bearer old-token"},
+				{Key: WebhookAuthorizationHeader, Value: "Bearer old-token"},
 				{Key: "X-Custom", Value: "custom"},
 			},
 		}
-		ws.setHeader("Authorization", "Bearer new-token")
+		ws.setHeader(WebhookAuthorizationHeader, "Bearer new-token")
 		require.Len(t, ws.Headers, 2)
-		assert.Equal(t, "Bearer new-token", ws.GetHeader("Authorization"))
+		assert.Equal(t, "Bearer new-token", ws.GetHeader(WebhookAuthorizationHeader))
 		assert.Equal(t, "custom", ws.GetHeader("X-Custom"))
 	})
 
@@ -1005,9 +1005,9 @@ func TestSetHeader(t *testing.T) {
 				{Key: "X-Custom", Value: "custom"},
 			},
 		}
-		ws.setHeader("Authorization", "Bearer new-token")
+		ws.setHeader(WebhookAuthorizationHeader, "Bearer new-token")
 		require.Len(t, ws.Headers, 2)
-		assert.Equal(t, "Bearer new-token", ws.GetHeader("Authorization"))
+		assert.Equal(t, "Bearer new-token", ws.GetHeader(WebhookAuthorizationHeader))
 	})
 }
 

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -239,7 +239,7 @@ func getModifiedWebhookFields(before, after []event.Subscription) (modifiedSecre
 		if !bytes.Equal(bws.Secret, aws.Secret) {
 			modifiedSecrets[id] = struct{}{}
 		}
-		if bws.GetHeader("Authorization") != aws.GetHeader("Authorization") {
+		if bws.GetHeader(event.WebhookAuthorizationHeader) != aws.GetHeader(event.WebhookAuthorizationHeader) {
 			modifiedAuthHeaders[id] = struct{}{}
 		}
 	}
@@ -277,7 +277,7 @@ func getRedactedSubscriptionsCopy(subscriptions []event.Subscription, modifiedSe
 			redacted.Secret = nil
 		}
 		for j := range redacted.Headers {
-			if redacted.Headers[j].Key == "Authorization" {
+			if redacted.Headers[j].Key == event.WebhookAuthorizationHeader {
 				if _, authHeaderModified := modifiedAuthHeaderIDs[result[i].ID]; authHeaderModified {
 					redacted.Headers[j].Value = placeholder
 				} else {

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -125,7 +125,8 @@ type ProjectChangeEvent struct {
 // RedactSecrets redacts project secrets from a project change event. Project
 // variables that are not changed are cleared and project variables that are
 // changed are replaced with redacted placeholders. Webhook secrets and
-// Authorization headers are always replaced with a redacted placeholder.
+// Authorization headers that changed are replaced with a redacted placeholder;
+// those that did not change are cleared.
 func (e *ProjectChangeEvent) RedactSecrets() {
 	modifiedVarKeys := e.getModifiedProjectVars()
 	e.Before.Vars.Vars = getRedactedVarsCopy(e.Before.Vars.Vars, modifiedVarKeys, evergreen.RedactedBeforeValue)
@@ -133,9 +134,9 @@ func (e *ProjectChangeEvent) RedactSecrets() {
 	isGHAppKeyModified := !bytes.Equal(e.Before.GitHubAppAuth.PrivateKey, e.After.GitHubAppAuth.PrivateKey)
 	e.Before.GitHubAppAuth = getRedactedGitHubAppCopy(e.Before.GitHubAppAuth, isGHAppKeyModified, evergreen.RedactedBeforeValue)
 	e.After.GitHubAppAuth = getRedactedGitHubAppCopy(e.After.GitHubAppAuth, isGHAppKeyModified, evergreen.RedactedAfterValue)
-	modifiedWebhooks := getModifiedWebhookSubscriberIDs(e.Before.Subscriptions, e.After.Subscriptions)
-	e.Before.Subscriptions = getRedactedSubscriptionsCopy(e.Before.Subscriptions, modifiedWebhooks, evergreen.RedactedBeforeValue)
-	e.After.Subscriptions = getRedactedSubscriptionsCopy(e.After.Subscriptions, modifiedWebhooks, evergreen.RedactedAfterValue)
+	modifiedSecrets, modifiedAuthHeaders := getModifiedWebhookFields(e.Before.Subscriptions, e.After.Subscriptions)
+	e.Before.Subscriptions = getRedactedSubscriptionsCopy(e.Before.Subscriptions, modifiedSecrets, modifiedAuthHeaders, evergreen.RedactedBeforeValue)
+	e.After.Subscriptions = getRedactedSubscriptionsCopy(e.After.Subscriptions, modifiedSecrets, modifiedAuthHeaders, evergreen.RedactedAfterValue)
 }
 
 // getModifiedProjectVars returns the set of project variables in the change
@@ -210,12 +211,15 @@ func getRedactedGitHubAppCopy(auth ProjectEventGitHubAppAuth, isGHAppKeyModified
 	return redactedAuth
 }
 
-// getModifiedWebhookSubscriberIDs returns the set of subscription IDs whose webhook secrets or Authorization headers changed.
-func getModifiedWebhookSubscriberIDs(before, after []event.Subscription) map[string]struct{} {
+// getModifiedWebhookFields returns two sets of subscription IDs: one for
+// webhooks whose webhook secret changed and one for webhooks whose
+// Authorization header changed.
+func getModifiedWebhookFields(before, after []event.Subscription) (modifiedSecrets, modifiedAuthHeaders map[string]struct{}) {
 	beforeByID := buildWebhookSubscribers(before)
 	afterByID := buildWebhookSubscribers(after)
 
-	modified := make(map[string]struct{})
+	modifiedSecrets = make(map[string]struct{})
+	modifiedAuthHeaders = make(map[string]struct{})
 	allIDs := make(map[string]struct{}, len(beforeByID)+len(afterByID))
 	for id := range beforeByID {
 		allIDs[id] = struct{}{}
@@ -226,17 +230,32 @@ func getModifiedWebhookSubscriberIDs(before, after []event.Subscription) map[str
 
 	for id := range allIDs {
 		bws, aws := beforeByID[id], afterByID[id]
-		if bws == nil || aws == nil || !bytes.Equal(bws.Secret, aws.Secret) || bws.GetHeader("Authorization") != aws.GetHeader("Authorization") {
-			modified[id] = struct{}{}
+		if bws == nil || aws == nil {
+			// The whole webhook was added or removed, so mark both fields as modified.
+			modifiedSecrets[id] = struct{}{}
+			modifiedAuthHeaders[id] = struct{}{}
+			continue
+		}
+		if !bytes.Equal(bws.Secret, aws.Secret) {
+			modifiedSecrets[id] = struct{}{}
+		}
+		if bws.GetHeader("Authorization") != aws.GetHeader("Authorization") {
+			modifiedAuthHeaders[id] = struct{}{}
 		}
 	}
-	return modified
+	return modifiedSecrets, modifiedAuthHeaders
 }
 
-// getRedactedSubscriptionsCopy returns a copy of the subscriptions with webhook secrets redacted.
-func getRedactedSubscriptionsCopy(subscriptions []event.Subscription, modifiedIDs map[string]struct{}, placeholder string) []event.Subscription {
+// getRedactedSubscriptionsCopy returns a copy of the subscriptions with webhook secrets and
+// Authorization headers redacted. For each webhook, secret fields that were
+// modified have their values replaced with the placeholder; secret fields that
+// did not change are cleared to indicate they exist but were not modified.
+// This intentionally makes a copy to avoid modifying the original
+// subscriptions, which may be shared by the actual project settings.
+func getRedactedSubscriptionsCopy(subscriptions []event.Subscription, modifiedSecretIDs, modifiedAuthHeaderIDs map[string]struct{}, placeholder string) []event.Subscription {
 	result := make([]event.Subscription, len(subscriptions))
 	copy(result, subscriptions)
+
 	for i := range result {
 		if result[i].Subscriber.Type != event.EvergreenWebhookSubscriberType {
 			continue
@@ -245,10 +264,28 @@ func getRedactedSubscriptionsCopy(subscriptions []event.Subscription, modifiedID
 		if !ok || ws == nil {
 			continue
 		}
+
 		redacted := *ws
 		redacted.Headers = make([]event.WebhookHeader, len(ws.Headers))
 		copy(redacted.Headers, ws.Headers)
-		redactWebhook(&redacted, placeholder)
+
+		if _, secretModified := modifiedSecretIDs[result[i].ID]; secretModified {
+			if len(redacted.Secret) > 0 {
+				redacted.Secret = []byte(placeholder)
+			}
+		} else {
+			redacted.Secret = nil
+		}
+		for j := range redacted.Headers {
+			if redacted.Headers[j].Key == "Authorization" {
+				if _, authHeaderModified := modifiedAuthHeaderIDs[result[i].ID]; authHeaderModified {
+					redacted.Headers[j].Value = placeholder
+				} else {
+					redacted.Headers[j].Value = ""
+				}
+			}
+		}
+
 		result[i].Subscriber.Target = &redacted
 	}
 	return result
@@ -266,18 +303,6 @@ func buildWebhookSubscribers(subscriptions []event.Subscription) map[string]*eve
 		}
 	}
 	return result
-}
-
-// redactWebhook replaces the webhook secret and Authorization header with the given placeholder.
-func redactWebhook(ws *event.WebhookSubscriber, placeholder string) {
-	if len(ws.Secret) > 0 {
-		ws.Secret = []byte(placeholder)
-	}
-	for i := range ws.Headers {
-		if ws.Headers[i].Key == "Authorization" {
-			ws.Headers[i].Value = placeholder
-		}
-	}
 }
 
 type ProjectChangeEvents []ProjectChangeEventEntry

--- a/model/project_event_test.go
+++ b/model/project_event_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -20,6 +22,10 @@ func TestProjectEventSuite(t *testing.T) {
 }
 
 func (s *ProjectEventSuite) SetupTest() {
+	s.Require().NoError(db.ClearCollections(event.EventCollection))
+}
+
+func (s *ProjectEventSuite) TearDownTest() {
 	s.Require().NoError(db.ClearCollections(event.EventCollection))
 }
 
@@ -173,225 +179,126 @@ func (s *ProjectEventSuite) TestModifyProjectEventRedactsAllVars() {
 }
 
 func (s *ProjectEventSuite) TestRedactSubscriptionSecrets() {
-	before := getMockProjectSettings()
-	before.Subscriptions = append(before.Subscriptions, event.Subscription{
-		ID:           "webhook-sub",
-		ResourceType: "project",
-		Owner:        "admin",
-		Subscriber: event.Subscriber{
-			Type: event.EvergreenWebhookSubscriberType,
-			Target: &event.WebhookSubscriber{
-				URL:    "https://example.com/hook",
-				Secret: []byte("old-secret"),
-				Headers: []event.WebhookHeader{
-					{Key: event.WebhookAuthorizationHeader, Value: "Bearer old-token"},
-					{Key: "Content-Type", Value: "application/json"},
-				},
-			},
+	tests := map[string]struct {
+		beforeSecret         []byte
+		afterSecret          []byte
+		beforeAuthValue      string
+		afterAuthValue       string
+		expectedBeforeSecret string
+		expectedAfterSecret  string
+		expectedBeforeAuth   string
+		expectedAfterAuth    string
+	}{
+		"SecretAndAuthHeaderModified": {
+			beforeSecret:         []byte("old-secret"),
+			afterSecret:          []byte("new-secret"),
+			beforeAuthValue:      "Bearer old-token",
+			afterAuthValue:       "Bearer new-token",
+			expectedBeforeSecret: evergreen.RedactedBeforeValue,
+			expectedAfterSecret:  evergreen.RedactedAfterValue,
+			expectedBeforeAuth:   evergreen.RedactedBeforeValue,
+			expectedAfterAuth:    evergreen.RedactedAfterValue,
 		},
-	})
-
-	after := getMockProjectSettings()
-	after.ProjectRef.Enabled = false
-	after.Subscriptions = append(after.Subscriptions, event.Subscription{
-		ID:           "webhook-sub",
-		ResourceType: "project",
-		Owner:        "admin",
-		Subscriber: event.Subscriber{
-			Type: event.EvergreenWebhookSubscriberType,
-			Target: &event.WebhookSubscriber{
-				URL:    "https://example.com/hook",
-				Secret: []byte("new-secret"),
-				Headers: []event.WebhookHeader{
-					{Key: event.WebhookAuthorizationHeader, Value: "Bearer new-token"},
-					{Key: "Content-Type", Value: "application/json"},
-				},
-			},
+		"NeitherSecretNorAuthHeaderModified": {
+			beforeSecret:    []byte("same-secret"),
+			afterSecret:     []byte("same-secret"),
+			beforeAuthValue: "Bearer same-token",
+			afterAuthValue:  "Bearer same-token",
 		},
-	})
-
-	s.Require().NoError(LogProjectModified(s.T().Context(), projectId, username, &before, &after))
-
-	projectEvents, err := MostRecentProjectEvents(s.T().Context(), projectId, 5)
-	s.Require().NoError(err)
-	s.Require().Len(projectEvents, 1)
-
-	eventData, ok := projectEvents[0].Data.(*ProjectChangeEvent)
-	s.Require().True(ok)
-	s.Require().NotNil(eventData)
-
-	checkRedacted := func(settingsEvent ProjectSettingsEvent, expectedRedactedValue string) {
-		var foundWebhook bool
-		for _, sub := range settingsEvent.Subscriptions {
-			if sub.Subscriber.Type != event.EvergreenWebhookSubscriberType {
-				continue
-			}
-			foundWebhook = true
-			webhookSub, ok := sub.Subscriber.Target.(*event.WebhookSubscriber)
-			s.Require().True(ok)
-			s.Require().NotNil(webhookSub)
-			s.Equal(expectedRedactedValue, string(webhookSub.Secret), "webhook secret should be redacted with placeholder")
-			for _, header := range webhookSub.Headers {
-				if header.Key == event.WebhookAuthorizationHeader {
-					s.Equal(expectedRedactedValue, header.Value, "Authorization header should be redacted with placeholder")
-				}
-				if header.Key == "Content-Type" {
-					s.Equal("application/json", header.Value, "non-auth headers should not be redacted")
-				}
-			}
-		}
-		s.True(foundWebhook, "should have found webhook subscription")
+		"OnlyAuthHeaderModified": {
+			beforeSecret:       []byte("same-secret"),
+			afterSecret:        []byte("same-secret"),
+			beforeAuthValue:    "Bearer old-token",
+			afterAuthValue:     "Bearer new-token",
+			expectedBeforeAuth: evergreen.RedactedBeforeValue,
+			expectedAfterAuth:  evergreen.RedactedAfterValue,
+		},
+		"OnlySecretModified": {
+			beforeSecret:         []byte("old-secret"),
+			afterSecret:          []byte("new-secret"),
+			beforeAuthValue:      "Bearer same-token",
+			afterAuthValue:       "Bearer same-token",
+			expectedBeforeSecret: evergreen.RedactedBeforeValue,
+			expectedAfterSecret:  evergreen.RedactedAfterValue,
+		},
 	}
-	checkRedacted(eventData.Before, evergreen.RedactedBeforeValue)
-	checkRedacted(eventData.After, evergreen.RedactedAfterValue)
-}
+	for name, tc := range tests {
+		s.T().Run(name, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(event.EventCollection))
+			t.Cleanup(func() { require.NoError(t, db.ClearCollections(event.EventCollection)) })
 
-func (s *ProjectEventSuite) TestRedactSubscriptionSecretsUnmodified() {
-	before := getMockProjectSettings()
-	before.Subscriptions = append(before.Subscriptions, event.Subscription{
-		ID:           "webhook-sub",
-		ResourceType: "project",
-		Owner:        "admin",
-		Subscriber: event.Subscriber{
-			Type: event.EvergreenWebhookSubscriberType,
-			Target: &event.WebhookSubscriber{
-				URL:    "https://example.com/hook",
-				Secret: []byte("same-secret"),
-				Headers: []event.WebhookHeader{
-					{Key: event.WebhookAuthorizationHeader, Value: "Bearer same-token"},
-					{Key: "Content-Type", Value: "application/json"},
+			before := getMockProjectSettings()
+			before.Subscriptions = append(before.Subscriptions, event.Subscription{
+				ID:           "webhook-sub",
+				ResourceType: "project",
+				Owner:        "admin",
+				Subscriber: event.Subscriber{
+					Type: event.EvergreenWebhookSubscriberType,
+					Target: &event.WebhookSubscriber{
+						URL:    "https://example.com/hook",
+						Secret: tc.beforeSecret,
+						Headers: []event.WebhookHeader{
+							{Key: event.WebhookAuthorizationHeader, Value: tc.beforeAuthValue},
+							{Key: "Content-Type", Value: "application/json"},
+						},
+					},
 				},
-			},
-		},
-	})
-
-	after := getMockProjectSettings()
-	after.ProjectRef.Enabled = false
-	after.Subscriptions = append(after.Subscriptions, event.Subscription{
-		ID:           "webhook-sub",
-		ResourceType: "project",
-		Owner:        "admin",
-		Subscriber: event.Subscriber{
-			Type: event.EvergreenWebhookSubscriberType,
-			Target: &event.WebhookSubscriber{
-				URL:    "https://example.com/hook",
-				Secret: []byte("same-secret"),
-				Headers: []event.WebhookHeader{
-					{Key: event.WebhookAuthorizationHeader, Value: "Bearer same-token"},
-					{Key: "Content-Type", Value: "application/json"},
+			})
+			after := getMockProjectSettings()
+			after.ProjectRef.Enabled = false
+			after.Subscriptions = append(after.Subscriptions, event.Subscription{
+				ID:           "webhook-sub",
+				ResourceType: "project",
+				Owner:        "admin",
+				Subscriber: event.Subscriber{
+					Type: event.EvergreenWebhookSubscriberType,
+					Target: &event.WebhookSubscriber{
+						URL:    "https://example.com/hook",
+						Secret: tc.afterSecret,
+						Headers: []event.WebhookHeader{
+							{Key: event.WebhookAuthorizationHeader, Value: tc.afterAuthValue},
+							{Key: "Content-Type", Value: "application/json"},
+						},
+					},
 				},
-			},
-		},
-	})
+			})
 
-	s.Require().NoError(LogProjectModified(s.T().Context(), projectId, username, &before, &after))
+			require.NoError(t, LogProjectModified(t.Context(), projectId, username, &before, &after))
 
-	projectEvents, err := MostRecentProjectEvents(s.T().Context(), projectId, 5)
-	s.Require().NoError(err)
-	s.Require().Len(projectEvents, 1)
+			projectEvents, err := MostRecentProjectEvents(t.Context(), projectId, 5)
+			require.NoError(t, err)
+			require.Len(t, projectEvents, 1)
 
-	eventData, ok := projectEvents[0].Data.(*ProjectChangeEvent)
-	s.Require().True(ok)
-	s.Require().NotNil(eventData)
+			eventData, ok := projectEvents[0].Data.(*ProjectChangeEvent)
+			require.True(t, ok)
+			require.NotNil(t, eventData)
 
-	checkCleared := func(settingsEvent ProjectSettingsEvent) {
-		var foundWebhook bool
-		for _, sub := range settingsEvent.Subscriptions {
-			if sub.Subscriber.Type != event.EvergreenWebhookSubscriberType {
-				continue
-			}
-			foundWebhook = true
-			webhookSub, ok := sub.Subscriber.Target.(*event.WebhookSubscriber)
-			s.Require().True(ok)
-			s.Require().NotNil(webhookSub)
-			s.Empty(webhookSub.Secret, "unmodified webhook secret should be cleared")
-			for _, header := range webhookSub.Headers {
-				if header.Key == event.WebhookAuthorizationHeader {
-					s.Empty(header.Value, "unmodified Authorization header should be cleared")
+			checkWebhook := func(settingsEvent ProjectSettingsEvent, expectedSecret, expectedAuth string) {
+				var foundWebhook bool
+				for _, sub := range settingsEvent.Subscriptions {
+					if sub.Subscriber.Type != event.EvergreenWebhookSubscriberType {
+						continue
+					}
+					foundWebhook = true
+					webhookSub, ok := sub.Subscriber.Target.(*event.WebhookSubscriber)
+					require.True(t, ok)
+					require.NotNil(t, webhookSub)
+					assert.Equal(t, expectedSecret, string(webhookSub.Secret))
+					for _, header := range webhookSub.Headers {
+						if header.Key == event.WebhookAuthorizationHeader {
+							assert.Equal(t, expectedAuth, header.Value)
+						}
+						if header.Key == "Content-Type" {
+							assert.Equal(t, "application/json", header.Value)
+						}
+					}
 				}
-				if header.Key == "Content-Type" {
-					s.Equal("application/json", header.Value, "non-auth headers should not be affected")
-				}
+				assert.True(t, foundWebhook, "should have found webhook subscription")
 			}
-		}
-		s.True(foundWebhook, "should have found webhook subscription")
+			checkWebhook(eventData.Before, tc.expectedBeforeSecret, tc.expectedBeforeAuth)
+			checkWebhook(eventData.After, tc.expectedAfterSecret, tc.expectedAfterAuth)
+		})
 	}
-	checkCleared(eventData.Before)
-	checkCleared(eventData.After)
-}
-
-func (s *ProjectEventSuite) TestRedactSubscriptionSecretsPartiallyModified() {
-	before := getMockProjectSettings()
-	before.Subscriptions = append(before.Subscriptions, event.Subscription{
-		ID:           "webhook-sub",
-		ResourceType: "project",
-		Owner:        "admin",
-		Subscriber: event.Subscriber{
-			Type: event.EvergreenWebhookSubscriberType,
-			Target: &event.WebhookSubscriber{
-				URL:    "https://example.com/hook",
-				Secret: []byte("same-secret"),
-				Headers: []event.WebhookHeader{
-					{Key: event.WebhookAuthorizationHeader, Value: "Bearer old-token"},
-					{Key: "Content-Type", Value: "application/json"},
-				},
-			},
-		},
-	})
-
-	after := getMockProjectSettings()
-	after.ProjectRef.Enabled = false
-	after.Subscriptions = append(after.Subscriptions, event.Subscription{
-		ID:           "webhook-sub",
-		ResourceType: "project",
-		Owner:        "admin",
-		Subscriber: event.Subscriber{
-			Type: event.EvergreenWebhookSubscriberType,
-			Target: &event.WebhookSubscriber{
-				URL:    "https://example.com/hook",
-				Secret: []byte("same-secret"),
-				Headers: []event.WebhookHeader{
-					{Key: event.WebhookAuthorizationHeader, Value: "Bearer new-token"},
-					{Key: "Content-Type", Value: "application/json"},
-				},
-			},
-		},
-	})
-
-	s.Require().NoError(LogProjectModified(s.T().Context(), projectId, username, &before, &after))
-
-	projectEvents, err := MostRecentProjectEvents(s.T().Context(), projectId, 5)
-	s.Require().NoError(err)
-	s.Require().Len(projectEvents, 1)
-
-	eventData, ok := projectEvents[0].Data.(*ProjectChangeEvent)
-	s.Require().True(ok)
-	s.Require().NotNil(eventData)
-
-	checkWebhook := func(settingsEvent ProjectSettingsEvent, expectedAuthValue string) {
-		var foundWebhook bool
-		for _, sub := range settingsEvent.Subscriptions {
-			if sub.Subscriber.Type != event.EvergreenWebhookSubscriberType {
-				continue
-			}
-			foundWebhook = true
-			webhookSub, ok := sub.Subscriber.Target.(*event.WebhookSubscriber)
-			s.Require().True(ok)
-			s.Require().NotNil(webhookSub)
-			s.Empty(webhookSub.Secret, "unmodified secret should be cleared even when auth header changed")
-			for _, header := range webhookSub.Headers {
-				if header.Key == event.WebhookAuthorizationHeader {
-					s.Equal(expectedAuthValue, header.Value, "modified Authorization header should be redacted")
-				}
-				if header.Key == "Content-Type" {
-					s.Equal("application/json", header.Value, "non-auth headers should not be affected")
-				}
-			}
-		}
-		s.True(foundWebhook, "should have found webhook subscription")
-	}
-	checkWebhook(eventData.Before, evergreen.RedactedBeforeValue)
-	checkWebhook(eventData.After, evergreen.RedactedAfterValue)
 }
 
 func (s *ProjectEventSuite) TestModifyProjectNonEvent() {

--- a/model/project_event_test.go
+++ b/model/project_event_test.go
@@ -184,7 +184,7 @@ func (s *ProjectEventSuite) TestRedactSubscriptionSecrets() {
 				URL:    "https://example.com/hook",
 				Secret: []byte("old-secret"),
 				Headers: []event.WebhookHeader{
-					{Key: "Authorization", Value: "Bearer old-token"},
+					{Key: event.WebhookAuthorizationHeader, Value: "Bearer old-token"},
 					{Key: "Content-Type", Value: "application/json"},
 				},
 			},
@@ -203,7 +203,7 @@ func (s *ProjectEventSuite) TestRedactSubscriptionSecrets() {
 				URL:    "https://example.com/hook",
 				Secret: []byte("new-secret"),
 				Headers: []event.WebhookHeader{
-					{Key: "Authorization", Value: "Bearer new-token"},
+					{Key: event.WebhookAuthorizationHeader, Value: "Bearer new-token"},
 					{Key: "Content-Type", Value: "application/json"},
 				},
 			},
@@ -232,7 +232,7 @@ func (s *ProjectEventSuite) TestRedactSubscriptionSecrets() {
 			s.Require().NotNil(webhookSub)
 			s.Equal(expectedRedactedValue, string(webhookSub.Secret), "webhook secret should be redacted with placeholder")
 			for _, header := range webhookSub.Headers {
-				if header.Key == "Authorization" {
+				if header.Key == event.WebhookAuthorizationHeader {
 					s.Equal(expectedRedactedValue, header.Value, "Authorization header should be redacted with placeholder")
 				}
 				if header.Key == "Content-Type" {
@@ -258,7 +258,7 @@ func (s *ProjectEventSuite) TestRedactSubscriptionSecretsUnmodified() {
 				URL:    "https://example.com/hook",
 				Secret: []byte("same-secret"),
 				Headers: []event.WebhookHeader{
-					{Key: "Authorization", Value: "Bearer same-token"},
+					{Key: event.WebhookAuthorizationHeader, Value: "Bearer same-token"},
 					{Key: "Content-Type", Value: "application/json"},
 				},
 			},
@@ -277,7 +277,7 @@ func (s *ProjectEventSuite) TestRedactSubscriptionSecretsUnmodified() {
 				URL:    "https://example.com/hook",
 				Secret: []byte("same-secret"),
 				Headers: []event.WebhookHeader{
-					{Key: "Authorization", Value: "Bearer same-token"},
+					{Key: event.WebhookAuthorizationHeader, Value: "Bearer same-token"},
 					{Key: "Content-Type", Value: "application/json"},
 				},
 			},
@@ -306,7 +306,7 @@ func (s *ProjectEventSuite) TestRedactSubscriptionSecretsUnmodified() {
 			s.Require().NotNil(webhookSub)
 			s.Empty(webhookSub.Secret, "unmodified webhook secret should be cleared")
 			for _, header := range webhookSub.Headers {
-				if header.Key == "Authorization" {
+				if header.Key == event.WebhookAuthorizationHeader {
 					s.Empty(header.Value, "unmodified Authorization header should be cleared")
 				}
 				if header.Key == "Content-Type" {
@@ -332,7 +332,7 @@ func (s *ProjectEventSuite) TestRedactSubscriptionSecretsPartiallyModified() {
 				URL:    "https://example.com/hook",
 				Secret: []byte("same-secret"),
 				Headers: []event.WebhookHeader{
-					{Key: "Authorization", Value: "Bearer old-token"},
+					{Key: event.WebhookAuthorizationHeader, Value: "Bearer old-token"},
 					{Key: "Content-Type", Value: "application/json"},
 				},
 			},
@@ -351,7 +351,7 @@ func (s *ProjectEventSuite) TestRedactSubscriptionSecretsPartiallyModified() {
 				URL:    "https://example.com/hook",
 				Secret: []byte("same-secret"),
 				Headers: []event.WebhookHeader{
-					{Key: "Authorization", Value: "Bearer new-token"},
+					{Key: event.WebhookAuthorizationHeader, Value: "Bearer new-token"},
 					{Key: "Content-Type", Value: "application/json"},
 				},
 			},
@@ -380,7 +380,7 @@ func (s *ProjectEventSuite) TestRedactSubscriptionSecretsPartiallyModified() {
 			s.Require().NotNil(webhookSub)
 			s.Empty(webhookSub.Secret, "unmodified secret should be cleared even when auth header changed")
 			for _, header := range webhookSub.Headers {
-				if header.Key == "Authorization" {
+				if header.Key == event.WebhookAuthorizationHeader {
 					s.Equal(expectedAuthValue, header.Value, "modified Authorization header should be redacted")
 				}
 				if header.Key == "Content-Type" {

--- a/model/project_event_test.go
+++ b/model/project_event_test.go
@@ -294,7 +294,7 @@ func (s *ProjectEventSuite) TestRedactSubscriptionSecretsUnmodified() {
 	s.Require().True(ok)
 	s.Require().NotNil(eventData)
 
-	checkRedacted := func(settingsEvent ProjectSettingsEvent, expectedRedactedValue string) {
+	checkCleared := func(settingsEvent ProjectSettingsEvent) {
 		var foundWebhook bool
 		for _, sub := range settingsEvent.Subscriptions {
 			if sub.Subscriber.Type != event.EvergreenWebhookSubscriberType {
@@ -304,17 +304,94 @@ func (s *ProjectEventSuite) TestRedactSubscriptionSecretsUnmodified() {
 			webhookSub, ok := sub.Subscriber.Target.(*event.WebhookSubscriber)
 			s.Require().True(ok)
 			s.Require().NotNil(webhookSub)
-			s.Equal(expectedRedactedValue, string(webhookSub.Secret), "unmodified webhook secret should be redacted")
+			s.Empty(webhookSub.Secret, "unmodified webhook secret should be cleared")
 			for _, header := range webhookSub.Headers {
 				if header.Key == "Authorization" {
-					s.Equal(expectedRedactedValue, header.Value, "unmodified Authorization header should be redacted")
+					s.Empty(header.Value, "unmodified Authorization header should be cleared")
+				}
+				if header.Key == "Content-Type" {
+					s.Equal("application/json", header.Value, "non-auth headers should not be affected")
 				}
 			}
 		}
 		s.True(foundWebhook, "should have found webhook subscription")
 	}
-	checkRedacted(eventData.Before, evergreen.RedactedBeforeValue)
-	checkRedacted(eventData.After, evergreen.RedactedAfterValue)
+	checkCleared(eventData.Before)
+	checkCleared(eventData.After)
+}
+
+func (s *ProjectEventSuite) TestRedactSubscriptionSecretsPartiallyModified() {
+	before := getMockProjectSettings()
+	before.Subscriptions = append(before.Subscriptions, event.Subscription{
+		ID:           "webhook-sub",
+		ResourceType: "project",
+		Owner:        "admin",
+		Subscriber: event.Subscriber{
+			Type: event.EvergreenWebhookSubscriberType,
+			Target: &event.WebhookSubscriber{
+				URL:    "https://example.com/hook",
+				Secret: []byte("same-secret"),
+				Headers: []event.WebhookHeader{
+					{Key: "Authorization", Value: "Bearer old-token"},
+					{Key: "Content-Type", Value: "application/json"},
+				},
+			},
+		},
+	})
+
+	after := getMockProjectSettings()
+	after.ProjectRef.Enabled = false
+	after.Subscriptions = append(after.Subscriptions, event.Subscription{
+		ID:           "webhook-sub",
+		ResourceType: "project",
+		Owner:        "admin",
+		Subscriber: event.Subscriber{
+			Type: event.EvergreenWebhookSubscriberType,
+			Target: &event.WebhookSubscriber{
+				URL:    "https://example.com/hook",
+				Secret: []byte("same-secret"),
+				Headers: []event.WebhookHeader{
+					{Key: "Authorization", Value: "Bearer new-token"},
+					{Key: "Content-Type", Value: "application/json"},
+				},
+			},
+		},
+	})
+
+	s.Require().NoError(LogProjectModified(s.T().Context(), projectId, username, &before, &after))
+
+	projectEvents, err := MostRecentProjectEvents(s.T().Context(), projectId, 5)
+	s.Require().NoError(err)
+	s.Require().Len(projectEvents, 1)
+
+	eventData, ok := projectEvents[0].Data.(*ProjectChangeEvent)
+	s.Require().True(ok)
+	s.Require().NotNil(eventData)
+
+	checkWebhook := func(settingsEvent ProjectSettingsEvent, expectedAuthValue string) {
+		var foundWebhook bool
+		for _, sub := range settingsEvent.Subscriptions {
+			if sub.Subscriber.Type != event.EvergreenWebhookSubscriberType {
+				continue
+			}
+			foundWebhook = true
+			webhookSub, ok := sub.Subscriber.Target.(*event.WebhookSubscriber)
+			s.Require().True(ok)
+			s.Require().NotNil(webhookSub)
+			s.Empty(webhookSub.Secret, "unmodified secret should be cleared even when auth header changed")
+			for _, header := range webhookSub.Headers {
+				if header.Key == "Authorization" {
+					s.Equal(expectedAuthValue, header.Value, "modified Authorization header should be redacted")
+				}
+				if header.Key == "Content-Type" {
+					s.Equal("application/json", header.Value, "non-auth headers should not be affected")
+				}
+			}
+		}
+		s.True(foundWebhook, "should have found webhook subscription")
+	}
+	checkWebhook(eventData.Before, evergreen.RedactedBeforeValue)
+	checkWebhook(eventData.After, evergreen.RedactedAfterValue)
 }
 
 func (s *ProjectEventSuite) TestModifyProjectNonEvent() {

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -623,8 +623,8 @@ func unredactWebhookSubscription(unredactedPreviousSubscriptions []event.Subscri
 	unredactedNewHeaders := []restModel.APIWebhookHeader{}
 	for _, redactedHeader := range redactedNewWebhookSubscription.Headers {
 		// If the header is the Authorization header and set to redacted, replace it with the unredacted value.
-		if utility.FromStringPtr(redactedHeader.Key) == "Authorization" && utility.FromStringPtr(redactedHeader.Value) == evergreen.RedactedValue {
-			redactedHeader.Value = utility.ToStringPtr(unredactedPreviousWebhookSubscription.GetHeader("Authorization"))
+		if utility.FromStringPtr(redactedHeader.Key) == event.WebhookAuthorizationHeader && utility.FromStringPtr(redactedHeader.Value) == evergreen.RedactedValue {
+			redactedHeader.Value = utility.ToStringPtr(unredactedPreviousWebhookSubscription.GetHeader(event.WebhookAuthorizationHeader))
 		}
 		unredactedNewHeaders = append(unredactedNewHeaders, redactedHeader)
 	}

--- a/rest/data/project_settings_test.go
+++ b/rest/data/project_settings_test.go
@@ -714,7 +714,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 							Value: utility.ToStringPtr("A new value"),
 						},
 						{
-							Key:   utility.ToStringPtr("Authorization"),
+							Key:   utility.ToStringPtr(event.WebhookAuthorizationHeader),
 							Value: utility.ToStringPtr(evergreen.RedactedValue), // This is testing that the webhook stays redacted.
 						},
 					},
@@ -767,7 +767,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 							Value: utility.ToStringPtr("A new value"),
 						},
 						{
-							Key:   utility.ToStringPtr("Authorization"),
+							Key:   utility.ToStringPtr(event.WebhookAuthorizationHeader),
 							Value: utility.ToStringPtr("a_different_secret"),
 						},
 					},
@@ -1213,7 +1213,7 @@ func TestSaveProjectSettingsForSection(t *testing.T) {
 							Value: "Value",
 						},
 						{
-							Key:   "Authorization",
+							Key:   event.WebhookAuthorizationHeader,
 							Value: "a_very_super_secret",
 						},
 					},

--- a/rest/model/subscriber.go
+++ b/rest/model/subscriber.go
@@ -304,7 +304,7 @@ func (s *APIWebhookSubscriber) ToService() event.WebhookSubscriber {
 
 func (s *APIWebhookHeader) BuildFromService(h event.WebhookHeader) {
 	s.Key = &h.Key
-	if h.Key == "Authorization" {
+	if h.Key == event.WebhookAuthorizationHeader {
 		s.Value = utility.ToStringPtr(evergreen.RedactedValue)
 	} else {
 		s.Value = &h.Value

--- a/units/webhook_secret_migration.go
+++ b/units/webhook_secret_migration.go
@@ -132,7 +132,7 @@ func (j *webhookSecretMigrationJob) Run(ctx context.Context) {
 		})
 	}
 
-	if authValue := webhookSub.GetHeader("Authorization"); authValue != "" && webhookSub.AuthorizationHeaderParameter == "" {
+	if authValue := webhookSub.GetHeader(event.WebhookAuthorizationHeader); authValue != "" && webhookSub.AuthorizationHeaderParameter == "" {
 		paramPath := event.GetWebhookAuthParameterPath(j.SubscriptionID)
 		param, err := paramMgr.Put(ctx, paramPath, authValue)
 		if err != nil {
@@ -175,7 +175,7 @@ var unmigratedWebhookQuery = bson.D{
 		},
 		bson.D{
 			{Key: "subscriber.target.headers", Value: bson.D{{Key: "$elemMatch", Value: bson.D{
-				{Key: "key", Value: "Authorization"},
+				{Key: "key", Value: event.WebhookAuthorizationHeader},
 				{Key: "value", Value: bson.D{{Key: "$ne", Value: ""}}},
 			}}}},
 			{Key: "subscriber.target.authorization_header_parameter", Value: bson.D{{Key: "$exists", Value: false}}},
@@ -334,10 +334,10 @@ func (j *webhookSecretCleanupJob) Run(ctx context.Context) {
 		})
 	}
 
-	if authValue := webhookSub.GetHeader("Authorization"); authValue != "" && webhookSub.AuthorizationHeaderParameter != "" {
+	if authValue := webhookSub.GetHeader(event.WebhookAuthorizationHeader); authValue != "" && webhookSub.AuthorizationHeaderParameter != "" {
 		if err := db.Update(ctx, event.SubscriptionsCollection,
 			bson.D{{Key: "_id", Value: j.SubscriptionID}},
-			bson.D{{Key: "$pull", Value: bson.D{{Key: "subscriber.target.headers", Value: bson.D{{Key: "key", Value: "Authorization"}}}}}},
+			bson.D{{Key: "$pull", Value: bson.D{{Key: "subscriber.target.headers", Value: bson.D{{Key: "key", Value: event.WebhookAuthorizationHeader}}}}}},
 		); err != nil {
 			j.AddError(errors.Wrapf(err, "removing Authorization header from MongoDB for subscription '%s'", j.SubscriptionID))
 			return
@@ -363,7 +363,7 @@ var migratedWebhookQuery = bson.D{
 		},
 		bson.D{
 			{Key: "subscriber.target.headers", Value: bson.D{{Key: "$elemMatch", Value: bson.D{
-				{Key: "key", Value: "Authorization"},
+				{Key: "key", Value: event.WebhookAuthorizationHeader},
 				{Key: "value", Value: bson.D{{Key: "$ne", Value: ""}}},
 			}}}},
 			{Key: "subscriber.target.authorization_header_parameter", Value: bson.D{{Key: "$exists", Value: true}, {Key: "$ne", Value: ""}}},


### PR DESCRIPTION
DEVPROD-36147

### Description
Fix a couple small issues with how webhook secrets are redacted in project events:
* If the webhook secret/Authorization header is not modified, clear it to indicate that there was no change (this is consistent with project vars behavior). Before, it would always replace any non-empty string with `{REDACTED_BEFORE}` and `{REDACTED_AFTER}`.
* Distinguish between when the webhook secret vs. Authorization header is modified. Before this, it assumed that if one of the two was modified, then both were modified.

I'd like to fix these before running the migration to scrub webhook secrets from the project event logs because if we don't fix it now, the data will be corrupted forever after the migration.

### Testing

* Added unit tests.
* Tested in personal staging to verify that the event diff data in the DB and the UI look as expected.

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
