### PR TITLE
DEVPROD-33463 Add proof diagnostic history route for comparing version manifests

### DIFF
--- a/model/manifest/db.go
+++ b/model/manifest/db.go
@@ -36,6 +36,13 @@ func FindOne(ctx context.Context, query db.Q) (*Manifest, error) {
 	return m, err
 }
 
+// Find gets every Manifest matching the given query.
+func Find(ctx context.Context, query db.Q) ([]Manifest, error) {
+	manifests := []Manifest{}
+	err := db.FindAllQ(ctx, Collection, query, &manifests)
+	return manifests, err
+}
+
 // TryInsert writes the manifest to the database if possible.
 // If the document already exists, it returns true and the error
 // If it does not it will return false and the error
@@ -56,6 +63,11 @@ func (m *Manifest) Insert(ctx context.Context) error {
 // ById returns a query that contains an Id selector on the string, id.
 func ById(id string) db.Q {
 	return db.Query(bson.M{IdKey: id})
+}
+
+// ByIds creates a query that finds all manifests with the given ids.
+func ByIds(ids []string) db.Q {
+	return db.Query(bson.M{IdKey: bson.M{"$in": ids}})
 }
 
 func ByBaseProjectAndRevision(project, revision string) db.Q {

--- a/model/manifest/manifest_test.go
+++ b/model/manifest/manifest_test.go
@@ -118,3 +118,28 @@ func TestByBaseProjectAndRevision(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "m1", mfest.Id)
 }
+
+func TestFindByIds(t *testing.T) {
+	require.NoError(t, db.Clear(Collection))
+	mfests := []Manifest{
+		{Id: "m1", ProjectName: "evergreen", Revision: "abc"},
+		{Id: "m2", ProjectName: "evergreen", Revision: "def"},
+		{Id: "m3", ProjectName: "evergreen", Revision: "ghi"},
+	}
+	for _, mfest := range mfests {
+		_, err := mfest.TryInsert(t.Context())
+		require.NoError(t, err)
+	}
+
+	found, err := Find(t.Context(), ByIds([]string{"m1", "m3", "missing"}))
+	require.NoError(t, err)
+	require.Len(t, found, 2)
+
+	foundIDs := map[string]bool{}
+	for _, mfest := range found {
+		foundIDs[mfest.Id] = true
+	}
+	assert.True(t, foundIDs["m1"])
+	assert.True(t, foundIDs["m3"])
+	assert.False(t, foundIDs["m2"])
+}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -266,9 +266,9 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/versions/{version_id}/annotations").Version(2).Get().Wrap(requireUser, viewAnnotations).RouteHandler(makeFetchAnnotationsByVersion())
 	app.AddRoute("/versions/{version_id}/manifest").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetVersionManifest())
 
-	// This diagnostic route compares a version's manifest with its adjacent versions
-	// to show which project and module revisions changed.
+	// Diagnostic manifest proof routes compare project and module revision movement across system versions.
 	app.AddRoute("/versions/{version_id}/manifest/proof").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetVersionManifestProof())
+	app.AddRoute("/versions/{version_id}/manifest/proof/history").Version(2).Get().Wrap(requireUser, viewTasks).RouteHandler(makeGetVersionManifestProofHistory())
 
 	// Add an options method to every GET, POST request to handle pre-flight Options requests.
 	// These requests must not check for credentials and just validate whether a route exists

--- a/rest/route/version.go
+++ b/rest/route/version.go
@@ -673,6 +673,10 @@ type versionManifestProofHistoryItem struct {
 	Version                *versionManifestProofSnapshot `json:"version"`
 	OnlyOneRevisionChanged bool                          `json:"only_one_revision_changed"`
 	ChangedRevisionCount   int                           `json:"changed_revision_count"`
+	// ModulesChanged is true when a module was added or removed between this
+	// version and the previous one. Membership changes are reported separately
+	// and do not count toward ChangedRevisionCount.
+	ModulesChanged bool `json:"modules_changed"`
 }
 
 func makeGetVersionManifestProofHistory() gimlet.RouteHandler {
@@ -682,7 +686,7 @@ func makeGetVersionManifestProofHistory() gimlet.RouteHandler {
 // Factory creates an instance of the handler.
 //
 //	@Summary		Fetch version manifest proof history by version ID
-//	@Description	Checks whether each recent system version changed exactly one project or module revision. This is for projects that use modules with project triggers on all modules.
+//	@Description	Checks whether each recent system version changed exactly one project or module commit revision. Module add/remove is reported separately via modules_changed and does not count as a revision change. This is for projects that use modules with project triggers on all modules.
 //	@Tags			manifests
 //	@Router			/versions/{version_id}/manifest/proof/history [get]
 //	@Security		Api-User || Api-Key
@@ -750,11 +754,12 @@ func (h *versionManifestProofHistoryGetHandler) Run(ctx context.Context) gimlet.
 			comparisonManifest = manifests[comparisonVersion.Id]
 		}
 
-		changedRevisionCount := countChangedRevisionsForProof(&versions[i], manifests[versions[i].Id], comparisonVersion, comparisonManifest)
+		diff := compareProofRevisions(&versions[i], manifests[versions[i].Id], comparisonVersion, comparisonManifest)
 		response.Versions = append(response.Versions, versionManifestProofHistoryItem{
 			Version:                buildManifestProofSnapshot(&versions[i], manifests[versions[i].Id], comparisonVersion, comparisonManifest),
-			OnlyOneRevisionChanged: changedRevisionCount == 1,
-			ChangedRevisionCount:   changedRevisionCount,
+			OnlyOneRevisionChanged: diff.changedRevisionCount == 1,
+			ChangedRevisionCount:   diff.changedRevisionCount,
+			ModulesChanged:         diff.modulesChanged,
 		})
 	}
 
@@ -864,17 +869,26 @@ func buildManifestProofSnapshot(v *dbModel.Version, mfst *manifest.Manifest, com
 	return snapshot
 }
 
-func countChangedRevisionsForProof(v *dbModel.Version, mfst *manifest.Manifest, comparisonVersion *dbModel.Version, comparisonManifest *manifest.Manifest) int {
+type proofRevisionDiff struct {
+	changedRevisionCount int
+	modulesChanged       bool
+}
+
+// compareProofRevisions counts project/module commit revision changes between
+// two versions. A module appearing or disappearing sets modulesChanged but does
+// not increment changedRevisionCount; only shared modules with differing
+// revisions count as a commit change.
+func compareProofRevisions(v *dbModel.Version, mfst *manifest.Manifest, comparisonVersion *dbModel.Version, comparisonManifest *manifest.Manifest) proofRevisionDiff {
 	if v == nil || comparisonVersion == nil {
-		return 0
+		return proofRevisionDiff{}
 	}
 
-	count := 0
+	diff := proofRevisionDiff{}
 	if v.Revision != comparisonVersion.Revision {
-		count++
+		diff.changedRevisionCount++
 	}
 	if mfst == nil || comparisonManifest == nil {
-		return count
+		return diff
 	}
 
 	moduleNames := map[string]struct{}{}
@@ -892,10 +906,14 @@ func countChangedRevisionsForProof(v *dbModel.Version, mfst *manifest.Manifest, 
 	for moduleName := range moduleNames {
 		module := mfst.Modules[moduleName]
 		comparisonModule := comparisonManifest.Modules[moduleName]
-		if module == nil || comparisonModule == nil || module.Revision != comparisonModule.Revision {
-			count++
+		if module == nil || comparisonModule == nil {
+			diff.modulesChanged = true
+			continue
+		}
+		if module.Revision != comparisonModule.Revision {
+			diff.changedRevisionCount++
 		}
 	}
 
-	return count
+	return diff
 }

--- a/rest/route/version.go
+++ b/rest/route/version.go
@@ -21,6 +21,8 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 )
 
+const versionManifestProofHistoryLimit = 20
+
 ////////////////////////////////////////////////////////////////////////
 //
 // GET /rest/v2/versions/{version_id}
@@ -657,6 +659,104 @@ func (h *versionManifestProofGetHandler) Run(ctx context.Context) gimlet.Respond
 	return gimlet.NewJSONResponse(response)
 }
 
+// GET /rest/v2/versions/{version_id}/manifest/proof/history
+
+type versionManifestProofHistoryGetHandler struct {
+	versionId string
+}
+
+type versionManifestProofHistoryResponse struct {
+	Versions []versionManifestProofHistoryItem `json:"versions"`
+}
+
+type versionManifestProofHistoryItem struct {
+	Version                *versionManifestProofSnapshot `json:"version"`
+	OnlyOneRevisionChanged bool                          `json:"only_one_revision_changed"`
+	ChangedRevisionCount   int                           `json:"changed_revision_count"`
+}
+
+func makeGetVersionManifestProofHistory() gimlet.RouteHandler {
+	return &versionManifestProofHistoryGetHandler{}
+}
+
+// Factory creates an instance of the handler.
+//
+//	@Summary		Fetch version manifest proof history by version ID
+//	@Description	Checks whether each recent system version changed exactly one project or module revision. This is for projects that use modules with project triggers on all modules.
+//	@Tags			manifests
+//	@Router			/versions/{version_id}/manifest/proof/history [get]
+//	@Security		Api-User || Api-Key
+//	@Param			version_id	path		string	true	"version ID"
+//	@Success		200			{object}	versionManifestProofHistoryResponse
+func (h *versionManifestProofHistoryGetHandler) Factory() gimlet.RouteHandler {
+	return &versionManifestProofHistoryGetHandler{}
+}
+
+func (h *versionManifestProofHistoryGetHandler) Parse(ctx context.Context, r *http.Request) error {
+	h.versionId = gimlet.GetVars(r)["version_id"]
+	if h.versionId == "" {
+		return errors.New("missing version ID")
+	}
+	return nil
+}
+
+func (h *versionManifestProofHistoryGetHandler) Run(ctx context.Context) gimlet.Responder {
+	current, err := dbModel.VersionFindOneId(ctx, h.versionId)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding version '%s'", h.versionId))
+	}
+	if current == nil {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("version '%s' not found", h.versionId),
+		})
+	}
+
+	previousVersions, err := findSystemVersionHistory(ctx, current.Identifier, current.RevisionOrderNumber, versionManifestProofHistoryLimit)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding proof history versions for version '%s'", h.versionId))
+	}
+
+	versions := make([]dbModel.Version, 0, len(previousVersions)+1)
+	versions = append(versions, *current)
+	versions = append(versions, previousVersions...)
+
+	manifests := map[string]*manifest.Manifest{}
+	for i := range versions {
+		mfst, err := findManifestForProof(ctx, &versions[i])
+		if err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding manifest for proof history version '%s'", versions[i].Id))
+		}
+		manifests[versions[i].Id] = mfst
+	}
+
+	numVersionsToReturn := len(versions)
+	if numVersionsToReturn > versionManifestProofHistoryLimit {
+		numVersionsToReturn = versionManifestProofHistoryLimit
+	}
+
+	response := &versionManifestProofHistoryResponse{
+		Versions: []versionManifestProofHistoryItem{},
+	}
+	for i := 0; i < numVersionsToReturn; i++ {
+		var comparisonVersion *dbModel.Version
+		var comparisonManifest *manifest.Manifest
+		if i+1 < len(versions) {
+			comparisonVersion = &versions[i+1]
+			comparisonManifest = manifests[comparisonVersion.Id]
+		}
+
+		changedRevisionCount := countChangedRevisionsForProof(&versions[i], manifests[versions[i].Id], comparisonVersion, comparisonManifest)
+		response.Versions = append(response.Versions, versionManifestProofHistoryItem{
+			Version:                buildManifestProofSnapshot(&versions[i], manifests[versions[i].Id], comparisonVersion, comparisonManifest),
+			OnlyOneRevisionChanged: changedRevisionCount == 1,
+			ChangedRevisionCount:   changedRevisionCount,
+		})
+	}
+
+	return gimlet.NewJSONResponse(response)
+}
+
 func findPreviousSystemVersion(ctx context.Context, project string, order int) (*dbModel.Version, error) {
 	return findAdjacentSystemVersion(ctx, project, order, "$lt", "-"+dbModel.VersionRevisionOrderNumberKey)
 }
@@ -675,6 +775,18 @@ func findAdjacentSystemVersion(ctx context.Context, project string, order int, c
 			"$in": evergreen.SystemVersionRequesterTypes,
 		},
 	}).Sort([]string{sortKey}).WithoutFields(dbModel.VersionBuildVariantsKey))
+}
+
+func findSystemVersionHistory(ctx context.Context, project string, order, limit int) ([]dbModel.Version, error) {
+	return dbModel.VersionFind(ctx, db.Query(bson.M{
+		dbModel.VersionIdentifierKey: project,
+		dbModel.VersionRevisionOrderNumberKey: bson.M{
+			"$lt": order,
+		},
+		dbModel.VersionRequesterKey: bson.M{
+			"$in": evergreen.SystemVersionRequesterTypes,
+		},
+	}).Sort([]string{"-" + dbModel.VersionRevisionOrderNumberKey}).Limit(limit).WithoutFields(dbModel.VersionBuildVariantsKey))
 }
 
 func findManifestForProof(ctx context.Context, v *dbModel.Version) (*manifest.Manifest, error) {
@@ -746,4 +858,37 @@ func buildManifestProofSnapshot(v *dbModel.Version, mfst *manifest.Manifest, com
 	}
 
 	return snapshot
+}
+
+func countChangedRevisionsForProof(v *dbModel.Version, mfst *manifest.Manifest, comparisonVersion *dbModel.Version, comparisonManifest *manifest.Manifest) int {
+	if v == nil || comparisonVersion == nil || mfst == nil || comparisonManifest == nil {
+		return 0
+	}
+
+	count := 0
+	if v.Revision != comparisonVersion.Revision {
+		count++
+	}
+
+	moduleNames := map[string]struct{}{}
+	for moduleName, module := range mfst.Modules {
+		if module != nil {
+			moduleNames[moduleName] = struct{}{}
+		}
+	}
+	for moduleName, module := range comparisonManifest.Modules {
+		if module != nil {
+			moduleNames[moduleName] = struct{}{}
+		}
+	}
+
+	for moduleName := range moduleNames {
+		module := mfst.Modules[moduleName]
+		comparisonModule := comparisonManifest.Modules[moduleName]
+		if module == nil || comparisonModule == nil || module.Revision != comparisonModule.Revision {
+			count++
+		}
+	}
+
+	return count
 }

--- a/rest/route/version.go
+++ b/rest/route/version.go
@@ -721,13 +721,17 @@ func (h *versionManifestProofHistoryGetHandler) Run(ctx context.Context) gimlet.
 	versions = append(versions, *current)
 	versions = append(versions, previousVersions...)
 
-	manifests := map[string]*manifest.Manifest{}
+	manifestIDs := make([]string, 0, len(versions))
 	for i := range versions {
-		mfst, err := findManifestForProof(ctx, &versions[i])
-		if err != nil {
-			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding manifest for proof history version '%s'", versions[i].Id))
-		}
-		manifests[versions[i].Id] = mfst
+		manifestIDs = append(manifestIDs, versions[i].Id)
+	}
+	foundManifests, err := manifest.Find(ctx, manifest.ByIds(manifestIDs))
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding manifests for proof history version '%s'", h.versionId))
+	}
+	manifests := make(map[string]*manifest.Manifest, len(foundManifests))
+	for i := range foundManifests {
+		manifests[foundManifests[i].Id] = &foundManifests[i]
 	}
 
 	numVersionsToReturn := len(versions)

--- a/rest/route/version.go
+++ b/rest/route/version.go
@@ -675,8 +675,8 @@ type versionManifestProofHistoryItem struct {
 	ChangedRevisionCount   int                           `json:"changed_revision_count"`
 	// ModulesChanged is true when a module was added or removed between this
 	// version and the previous one. Membership changes are reported separately
-	// and do not count toward ChangedRevisionCount.
-	ModulesChanged bool `json:"modules_changed"`
+	// and do not count toward ChangedRevisionCount. Omitted when false.
+	ModulesChanged bool `json:"modules_changed,omitzero"`
 }
 
 func makeGetVersionManifestProofHistory() gimlet.RouteHandler {
@@ -686,7 +686,7 @@ func makeGetVersionManifestProofHistory() gimlet.RouteHandler {
 // Factory creates an instance of the handler.
 //
 //	@Summary		Fetch version manifest proof history by version ID
-//	@Description	Checks whether each recent system version changed exactly one project or module commit revision. Module add/remove is reported separately via modules_changed and does not count as a revision change. This is for projects that use modules with project triggers on all modules.
+//	@Description	Checks whether each recent system version changed exactly one project or module commit revision. Module add/remove is reported separately via modules_changed (omitted when false) and does not count as a revision change. This is for projects that use modules with project triggers on all modules.
 //	@Tags			manifests
 //	@Router			/versions/{version_id}/manifest/proof/history [get]
 //	@Security		Api-User || Api-Key

--- a/rest/route/version.go
+++ b/rest/route/version.go
@@ -861,13 +861,16 @@ func buildManifestProofSnapshot(v *dbModel.Version, mfst *manifest.Manifest, com
 }
 
 func countChangedRevisionsForProof(v *dbModel.Version, mfst *manifest.Manifest, comparisonVersion *dbModel.Version, comparisonManifest *manifest.Manifest) int {
-	if v == nil || comparisonVersion == nil || mfst == nil || comparisonManifest == nil {
+	if v == nil || comparisonVersion == nil {
 		return 0
 	}
 
 	count := 0
 	if v.Revision != comparisonVersion.Revision {
 		count++
+	}
+	if mfst == nil || comparisonManifest == nil {
+		return count
 	}
 
 	moduleNames := map[string]struct{}{}

--- a/rest/route/version_test.go
+++ b/rest/route/version_test.go
@@ -719,6 +719,23 @@ func TestGetVersionManifestProofHistory(t *testing.T) {
 			require.True(t, ok)
 			require.Len(t, history.Versions, 2)
 			assert.False(t, history.Versions[0].Version.ManifestFound)
+			assert.True(t, history.Versions[0].OnlyOneRevisionChanged)
+			assert.Equal(t, 1, history.Versions[0].ChangedRevisionCount)
+		},
+		"HandlesMissingManifestsWithoutProjectRevisionChange": func(t *testing.T) {
+			projectID := "proof-history-missing-manifest-no-change-project"
+			insertProofVersion(t, projectID, "proof-history-missing-manifest-no-change-previous", "project-revision-1", 1)
+			current := insertProofVersion(t, projectID, "proof-history-missing-manifest-no-change-current", "project-revision-1", 2)
+
+			handler := &versionManifestProofHistoryGetHandler{versionId: current.Id}
+			res := handler.Run(t.Context())
+			require.NotNil(t, res)
+			require.Equal(t, http.StatusOK, res.Status(), res.Data())
+
+			history, ok := res.Data().(*versionManifestProofHistoryResponse)
+			require.True(t, ok)
+			require.Len(t, history.Versions, 2)
+			assert.False(t, history.Versions[0].Version.ManifestFound)
 			assert.False(t, history.Versions[0].OnlyOneRevisionChanged)
 			assert.Equal(t, 0, history.Versions[0].ChangedRevisionCount)
 		},

--- a/rest/route/version_test.go
+++ b/rest/route/version_test.go
@@ -2,6 +2,7 @@ package route
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -609,13 +610,144 @@ func TestGetVersionManifestProof(t *testing.T) {
 	}
 }
 
+func TestGetVersionManifestProofHistory(t *testing.T) {
+	for tName, tCase := range map[string]func(t *testing.T){
+		"ReturnsVersionsNewestToOldestLimitedToTwenty": func(t *testing.T) {
+			projectID := "proof-history-limit-project"
+			versions := make([]serviceModel.Version, 0, 22)
+			for i := 1; i <= 22; i++ {
+				v := insertProofVersion(t, projectID, fmt.Sprintf("proof-history-limit-%d", i), fmt.Sprintf("project-revision-%d", i), i)
+				insertProofManifest(t, v, "module-revision")
+				versions = append(versions, v)
+			}
+
+			handler := &versionManifestProofHistoryGetHandler{versionId: versions[21].Id}
+			res := handler.Run(t.Context())
+			require.NotNil(t, res)
+			require.Equal(t, http.StatusOK, res.Status(), res.Data())
+
+			history, ok := res.Data().(*versionManifestProofHistoryResponse)
+			require.True(t, ok)
+			require.Len(t, history.Versions, versionManifestProofHistoryLimit)
+			assert.Equal(t, versions[21].Id, history.Versions[0].Version.VersionID)
+			assert.Equal(t, versions[2].Id, history.Versions[19].Version.VersionID)
+			assert.True(t, history.Versions[19].Version.HasComparison)
+			assert.True(t, history.Versions[19].OnlyOneRevisionChanged)
+			assert.Equal(t, 1, history.Versions[19].ChangedRevisionCount)
+		},
+		"CalculatesExactOneRevisionChanged": func(t *testing.T) {
+			projectID := "proof-history-changed-project"
+			base := insertProofVersion(t, projectID, "proof-history-changed-base", "project-revision-1", 1)
+			projectChanged := insertProofVersion(t, projectID, "proof-history-changed-project", "project-revision-2", 2)
+			moduleChanged := insertProofVersion(t, projectID, "proof-history-changed-module", "project-revision-2", 3)
+			projectAndModuleChanged := insertProofVersion(t, projectID, "proof-history-changed-project-and-module", "project-revision-3", 4)
+			unchanged := insertProofVersion(t, projectID, "proof-history-changed-unchanged", "project-revision-3", 5)
+			insertProofManifest(t, base, "module-revision-1")
+			insertProofManifest(t, projectChanged, "module-revision-1")
+			insertProofManifest(t, moduleChanged, "module-revision-2")
+			insertProofManifest(t, projectAndModuleChanged, "module-revision-3")
+			insertProofManifest(t, unchanged, "module-revision-3")
+
+			handler := &versionManifestProofHistoryGetHandler{versionId: unchanged.Id}
+			res := handler.Run(t.Context())
+			require.NotNil(t, res)
+			require.Equal(t, http.StatusOK, res.Status(), res.Data())
+
+			history, ok := res.Data().(*versionManifestProofHistoryResponse)
+			require.True(t, ok)
+			require.Len(t, history.Versions, 5)
+
+			unchangedItem := proofHistoryItemByID(history.Versions, unchanged.Id)
+			require.NotNil(t, unchangedItem)
+			assert.False(t, unchangedItem.OnlyOneRevisionChanged)
+			assert.Equal(t, 0, unchangedItem.ChangedRevisionCount)
+
+			projectAndModuleChangedItem := proofHistoryItemByID(history.Versions, projectAndModuleChanged.Id)
+			require.NotNil(t, projectAndModuleChangedItem)
+			assert.False(t, projectAndModuleChangedItem.OnlyOneRevisionChanged)
+			assert.Equal(t, 2, projectAndModuleChangedItem.ChangedRevisionCount)
+
+			moduleChangedItem := proofHistoryItemByID(history.Versions, moduleChanged.Id)
+			require.NotNil(t, moduleChangedItem)
+			assert.True(t, moduleChangedItem.OnlyOneRevisionChanged)
+			assert.Equal(t, 1, moduleChangedItem.ChangedRevisionCount)
+
+			projectChangedItem := proofHistoryItemByID(history.Versions, projectChanged.Id)
+			require.NotNil(t, projectChangedItem)
+			assert.True(t, projectChangedItem.OnlyOneRevisionChanged)
+			assert.Equal(t, 1, projectChangedItem.ChangedRevisionCount)
+
+			baseItem := proofHistoryItemByID(history.Versions, base.Id)
+			require.NotNil(t, baseItem)
+			assert.False(t, baseItem.OnlyOneRevisionChanged)
+			assert.Equal(t, 0, baseItem.ChangedRevisionCount)
+		},
+		"IgnoresNonSystemVersionsInHistory": func(t *testing.T) {
+			projectID := "proof-history-ignore-patch-project"
+			previous := insertProofVersion(t, projectID, "proof-history-ignore-patch-previous", "project-revision-1", 1)
+			patchVersion := insertProofVersionWithRequester(t, projectID, "proof-history-ignore-patch-patch", evergreen.PatchVersionRequester, "project-revision-2", 2)
+			current := insertProofVersion(t, projectID, "proof-history-ignore-patch-current", "project-revision-3", 3)
+			insertProofManifest(t, previous, "module-revision-1")
+			insertProofManifest(t, patchVersion, "module-revision-2")
+			insertProofManifest(t, current, "module-revision-1")
+
+			handler := &versionManifestProofHistoryGetHandler{versionId: current.Id}
+			res := handler.Run(t.Context())
+			require.NotNil(t, res)
+			require.Equal(t, http.StatusOK, res.Status(), res.Data())
+
+			history, ok := res.Data().(*versionManifestProofHistoryResponse)
+			require.True(t, ok)
+			require.Len(t, history.Versions, 2)
+			assert.Equal(t, current.Id, history.Versions[0].Version.VersionID)
+			assert.Equal(t, previous.Id, history.Versions[1].Version.VersionID)
+			assert.True(t, history.Versions[0].OnlyOneRevisionChanged)
+			assert.Equal(t, 1, history.Versions[0].ChangedRevisionCount)
+		},
+		"HandlesMissingManifests": func(t *testing.T) {
+			projectID := "proof-history-missing-manifest-project"
+			previous := insertProofVersion(t, projectID, "proof-history-missing-manifest-previous", "project-revision-1", 1)
+			current := insertProofVersion(t, projectID, "proof-history-missing-manifest-current", "project-revision-2", 2)
+			insertProofManifest(t, previous, "module-revision-1")
+
+			handler := &versionManifestProofHistoryGetHandler{versionId: current.Id}
+			res := handler.Run(t.Context())
+			require.NotNil(t, res)
+			require.Equal(t, http.StatusOK, res.Status(), res.Data())
+
+			history, ok := res.Data().(*versionManifestProofHistoryResponse)
+			require.True(t, ok)
+			require.Len(t, history.Versions, 2)
+			assert.False(t, history.Versions[0].Version.ManifestFound)
+			assert.False(t, history.Versions[0].OnlyOneRevisionChanged)
+			assert.Equal(t, 0, history.Versions[0].ChangedRevisionCount)
+		},
+		"ErrorsForNonexistentVersion": func(t *testing.T) {
+			handler := &versionManifestProofHistoryGetHandler{versionId: "proof-history-nonexistent-version"}
+
+			res := handler.Run(t.Context())
+			require.NotNil(t, res)
+			assert.Equal(t, http.StatusNotFound, res.Status())
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(serviceModel.VersionCollection, manifest.Collection))
+			tCase(t)
+		})
+	}
+}
+
 func insertProofVersion(t *testing.T, projectID, versionID, revision string, order int) serviceModel.Version {
+	return insertProofVersionWithRequester(t, projectID, versionID, evergreen.RepotrackerVersionRequester, revision, order)
+}
+
+func insertProofVersionWithRequester(t *testing.T, projectID, versionID, requester, revision string, order int) serviceModel.Version {
 	t.Helper()
 	ts := time.Date(2026, time.June, 16, 12, order, 0, 0, time.UTC)
 	v := serviceModel.Version{
 		Id:                  versionID,
 		Identifier:          projectID,
-		Requester:           evergreen.RepotrackerVersionRequester,
+		Requester:           requester,
 		Revision:            revision,
 		RevisionOrderNumber: order,
 		CreateTime:          ts,
@@ -652,6 +784,15 @@ func proofModuleByName(modules []versionManifestProofModule, name string) *versi
 	for i := range modules {
 		if utility.FromStringPtr(modules[i].Name) == name {
 			return &modules[i]
+		}
+	}
+	return nil
+}
+
+func proofHistoryItemByID(items []versionManifestProofHistoryItem, versionID string) *versionManifestProofHistoryItem {
+	for i := range items {
+		if items[i].Version.VersionID == versionID {
+			return &items[i]
 		}
 	}
 	return nil

--- a/rest/route/version_test.go
+++ b/rest/route/version_test.go
@@ -661,26 +661,80 @@ func TestGetVersionManifestProofHistory(t *testing.T) {
 			require.NotNil(t, unchangedItem)
 			assert.False(t, unchangedItem.OnlyOneRevisionChanged)
 			assert.Equal(t, 0, unchangedItem.ChangedRevisionCount)
+			assert.False(t, unchangedItem.ModulesChanged)
 
 			projectAndModuleChangedItem := proofHistoryItemByID(history.Versions, projectAndModuleChanged.Id)
 			require.NotNil(t, projectAndModuleChangedItem)
 			assert.False(t, projectAndModuleChangedItem.OnlyOneRevisionChanged)
 			assert.Equal(t, 2, projectAndModuleChangedItem.ChangedRevisionCount)
+			assert.False(t, projectAndModuleChangedItem.ModulesChanged)
 
 			moduleChangedItem := proofHistoryItemByID(history.Versions, moduleChanged.Id)
 			require.NotNil(t, moduleChangedItem)
 			assert.True(t, moduleChangedItem.OnlyOneRevisionChanged)
 			assert.Equal(t, 1, moduleChangedItem.ChangedRevisionCount)
+			assert.False(t, moduleChangedItem.ModulesChanged)
 
 			projectChangedItem := proofHistoryItemByID(history.Versions, projectChanged.Id)
 			require.NotNil(t, projectChangedItem)
 			assert.True(t, projectChangedItem.OnlyOneRevisionChanged)
 			assert.Equal(t, 1, projectChangedItem.ChangedRevisionCount)
+			assert.False(t, projectChangedItem.ModulesChanged)
 
 			baseItem := proofHistoryItemByID(history.Versions, base.Id)
 			require.NotNil(t, baseItem)
 			assert.False(t, baseItem.OnlyOneRevisionChanged)
 			assert.Equal(t, 0, baseItem.ChangedRevisionCount)
+			assert.False(t, baseItem.ModulesChanged)
+		},
+		"ModuleAppearOrDisappearSetsModulesChangedWithoutCountingRevision": func(t *testing.T) {
+			projectID := "proof-history-module-membership-project"
+			base := insertProofVersion(t, projectID, "proof-history-module-membership-base", "project-revision-1", 1)
+			moduleAdded := insertProofVersion(t, projectID, "proof-history-module-membership-added", "project-revision-1", 2)
+			moduleRemoved := insertProofVersion(t, projectID, "proof-history-module-membership-removed", "project-revision-1", 3)
+			moduleAddedWithProjectChange := insertProofVersion(t, projectID, "proof-history-module-membership-added-project", "project-revision-2", 4)
+
+			insertProofManifestWithModules(t, base, map[string]*manifest.Module{
+				"module1": {Branch: "main", Repo: "module-repo", Revision: "module-revision-1", Owner: "module-owner", URL: "module-url"},
+			})
+			insertProofManifestWithModules(t, moduleAdded, map[string]*manifest.Module{
+				"module1": {Branch: "main", Repo: "module-repo", Revision: "module-revision-1", Owner: "module-owner", URL: "module-url"},
+				"module2": {Branch: "main", Repo: "module-repo-2", Revision: "module-revision-2", Owner: "module-owner", URL: "module-url-2"},
+			})
+			insertProofManifestWithModules(t, moduleRemoved, map[string]*manifest.Module{
+				"module1": {Branch: "main", Repo: "module-repo", Revision: "module-revision-1", Owner: "module-owner", URL: "module-url"},
+			})
+			insertProofManifestWithModules(t, moduleAddedWithProjectChange, map[string]*manifest.Module{
+				"module1": {Branch: "main", Repo: "module-repo", Revision: "module-revision-1", Owner: "module-owner", URL: "module-url"},
+				"module2": {Branch: "main", Repo: "module-repo-2", Revision: "module-revision-2", Owner: "module-owner", URL: "module-url-2"},
+			})
+
+			handler := &versionManifestProofHistoryGetHandler{versionId: moduleAddedWithProjectChange.Id}
+			res := handler.Run(t.Context())
+			require.NotNil(t, res)
+			require.Equal(t, http.StatusOK, res.Status(), res.Data())
+
+			history, ok := res.Data().(*versionManifestProofHistoryResponse)
+			require.True(t, ok)
+			require.Len(t, history.Versions, 4)
+
+			addedWithProjectItem := proofHistoryItemByID(history.Versions, moduleAddedWithProjectChange.Id)
+			require.NotNil(t, addedWithProjectItem)
+			assert.True(t, addedWithProjectItem.OnlyOneRevisionChanged)
+			assert.Equal(t, 1, addedWithProjectItem.ChangedRevisionCount)
+			assert.True(t, addedWithProjectItem.ModulesChanged)
+
+			removedItem := proofHistoryItemByID(history.Versions, moduleRemoved.Id)
+			require.NotNil(t, removedItem)
+			assert.False(t, removedItem.OnlyOneRevisionChanged)
+			assert.Equal(t, 0, removedItem.ChangedRevisionCount)
+			assert.True(t, removedItem.ModulesChanged)
+
+			addedItem := proofHistoryItemByID(history.Versions, moduleAdded.Id)
+			require.NotNil(t, addedItem)
+			assert.False(t, addedItem.OnlyOneRevisionChanged)
+			assert.Equal(t, 0, addedItem.ChangedRevisionCount)
+			assert.True(t, addedItem.ModulesChanged)
 		},
 		"IgnoresNonSystemVersionsInHistory": func(t *testing.T) {
 			projectID := "proof-history-ignore-patch-project"
@@ -776,21 +830,26 @@ func insertProofVersionWithRequester(t *testing.T, projectID, versionID, request
 
 func insertProofManifest(t *testing.T, v serviceModel.Version, moduleRevision string) {
 	t.Helper()
+	insertProofManifestWithModules(t, v, map[string]*manifest.Module{
+		"module1": {
+			Branch:   "main",
+			Repo:     "module-repo",
+			Revision: moduleRevision,
+			Owner:    "module-owner",
+			URL:      "module-url",
+		},
+	})
+}
+
+func insertProofManifestWithModules(t *testing.T, v serviceModel.Version, modules map[string]*manifest.Module) {
+	t.Helper()
 	mfst := manifest.Manifest{
 		Id:          v.Id,
 		Revision:    v.Revision,
 		ProjectName: v.Identifier,
 		Branch:      "main",
 		IsBase:      true,
-		Modules: map[string]*manifest.Module{
-			"module1": {
-				Branch:   "main",
-				Repo:     "module-repo",
-				Revision: moduleRevision,
-				Owner:    "module-owner",
-				URL:      "module-url",
-			},
-		},
+		Modules:     modules,
 	}
 	exists, err := mfst.TryInsert(t.Context())
 	require.NoError(t, err)


### PR DESCRIPTION
DEVPROD-33463

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->
This adds a diagnostic manifest history proof route, that will be used for DEVPROD-33463 implementation.  The point of this route is provide users and myself with a quick way of checking many versions quickly. It doesn't give in-depth data about it, the route added in https://github.com/evergreen-ci/evergreen/pull/10349 does an in-depth breakdown.

### Testing

<!--add a description of how you tested it-->
Some unit tests that cover the common cases. I deployed to staging and got valid responses from the endpoint.

### Documentation

I added the openapi docs.

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
