### PR TITLE
DEVPROD-36140: Add LRU translation cache infrastructure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -113,7 +113,7 @@ require (
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/klauspost/compress v1.18.3 // indirect
 	github.com/klauspost/pgzip v1.2.6

--- a/model/generate.go
+++ b/model/generate.go
@@ -260,12 +260,19 @@ func (g *GeneratedProject) saveNewBuildsAndTasks(ctx context.Context, settings *
 	defer span.End()
 
 	span.SetAttributes(attribute.Int(numGenerateTaskBVAttribute, len(g.BuildVariants)))
-	// Inherit priority from the parent generator task.
-	for i, projBv := range p.BuildVariants {
-		for j := range projBv.Tasks {
-			p.BuildVariants[i].Tasks[j].Priority = g.Task.Priority
+	// Copy the project so we don't mutate a pointer that may be shared with
+	// the translation cache, then inherit priority from the parent generator task.
+	pLocal := *p
+	pLocal.BuildVariants = make([]BuildVariant, len(p.BuildVariants))
+	for i, bv := range p.BuildVariants {
+		pLocal.BuildVariants[i] = bv
+		pLocal.BuildVariants[i].Tasks = make([]BuildVariantTaskUnit, len(bv.Tasks))
+		copy(pLocal.BuildVariants[i].Tasks, bv.Tasks)
+		for j := range pLocal.BuildVariants[i].Tasks {
+			pLocal.BuildVariants[i].Tasks[j].Priority = g.Task.Priority
 		}
 	}
+	p = &pLocal
 
 	existingBuilds, err := build.Find(ctx, build.ByVersion(v.Id))
 	if err != nil {

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -576,9 +576,12 @@ func FindAndTranslateProjectForPatch(ctx context.Context, settings *evergreen.Se
 	return project, pp, nil
 }
 
-// parserProjectPreGenerationOtelAttribute records whether a translation used the
-// pre-generation parser project copy.
-const parserProjectPreGenerationOtelAttribute = "evergreen.parser_project.pre_generation"
+const (
+	// parserProjectPreGenerationOtelAttribute records whether a translation used the
+	// pre-generation parser project copy.
+	parserProjectPreGenerationOtelAttribute = "evergreen.parser_project.pre_generation"
+	translationCacheHitOtelAttribute        = "evergreen.parser_project.translation_cache_hit"
+)
 
 // FindAndTranslateProjectForVersionID translates a parser project for a version into a Project.
 func FindAndTranslateProjectForVersionID(ctx context.Context, settings *evergreen.Settings, versionID string, preGeneration bool) (*Project, *ParserProject, error) {
@@ -638,11 +641,14 @@ func findAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.
 		pp.Identifier = utility.ToStringPtr(versionIdentifier)
 	}
 
-	// Coalesce concurrent translations for the same version into one compute.
+	// The cache is disabled, so this key is only used to coalesce concurrent translations of the same
+	// version. Before enabling the cache, switch to a content-derived key (contentTranslationKey),
+	// because a version ID would keep serving a stale config after generate.tasks rewrites the project.
 	key := versionTranslationKey(versionID, preGeneration)
-	p, err := getOrComputeTranslation(key, func() (*Project, error) {
+	p, cacheHit, err := getOrComputeTranslation(key, translationCacheEnabled, func() (*Project, error) {
 		return TranslateProject(pp)
 	})
+	span.SetAttributes(attribute.Bool(translationCacheHitOtelAttribute, cacheHit))
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "translating parser project '%s'", versionID)
 	}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -577,10 +577,10 @@ func FindAndTranslateProjectForPatch(ctx context.Context, settings *evergreen.Se
 }
 
 const (
-	// parserProjectPreGenerationOtelAttribute records whether a translation used the
+	// ppPreGenerationOtelAttribute records whether a translation used the
 	// pre-generation parser project copy.
-	parserProjectPreGenerationOtelAttribute = "evergreen.parser_project.pre_generation"
-	translationCacheHitOtelAttribute        = "evergreen.parser_project.translation_cache_hit"
+	ppPreGenerationOtelAttribute       = "evergreen.parser_project.pre_generation"
+	ppTranslationCacheHitOtelAttribute = "evergreen.parser_project.translation_cache_hit"
 )
 
 // FindAndTranslateProjectForVersionID translates a parser project for a version into a Project.
@@ -603,8 +603,10 @@ func FindAndTranslateProjectForVersionID(ctx context.Context, settings *evergree
 
 // FindAndTranslateProjectForVersion translates a parser project for a version into a Project.
 // Also sets the project ID. If the preGeneration flag is true, this function will attempt to
-// fetch and translate the parser project from before it was modified by generate.tasks
-// versionID, versionIdentifier, projectStorageMethod, preGenerationProjectStorageMethod are the fields from the version that are needed to translate the project.
+// fetch and translate the parser project from before it was modified by generate.tasks.
+//
+// When the translation cache is enabled the returned *Project is a shared pointer. Callers
+// must not mutate it; make a local copy of any fields that need modification before use.
 func FindAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.Settings, v *Version, preGeneration bool) (*Project, *ParserProject, error) {
 	return findAndTranslateProjectForVersion(ctx, settings, v.Id, v.Identifier, v.ProjectStorageMethod, v.PreGenerationProjectStorageMethod, preGeneration)
 }
@@ -612,7 +614,7 @@ func FindAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.
 func findAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.Settings, versionID, versionIdentifier string, projectStorageMethod, preGenerationProjectStorageMethod evergreen.ParserProjectStorageMethod, preGeneration bool) (*Project, *ParserProject, error) {
 	ctx, span := tracer.Start(ctx, "FindAndTranslateProjectForVersion", trace.WithAttributes(
 		attribute.String(evergreen.VersionIDOtelAttribute, versionID),
-		attribute.Bool(parserProjectPreGenerationOtelAttribute, preGeneration),
+		attribute.Bool(ppPreGenerationOtelAttribute, preGeneration),
 	))
 	defer span.End()
 
@@ -648,7 +650,7 @@ func findAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.
 	p, cacheHit, err := getOrComputeTranslation(key, translationCacheEnabled, func() (*Project, error) {
 		return TranslateProject(pp)
 	})
-	span.SetAttributes(attribute.Bool(translationCacheHitOtelAttribute, cacheHit))
+	span.SetAttributes(attribute.Bool(ppTranslationCacheHitOtelAttribute, cacheHit))
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "translating parser project '%s'", versionID)
 	}

--- a/model/project_translate_cache.go
+++ b/model/project_translate_cache.go
@@ -2,31 +2,85 @@ package model
 
 import (
 	"fmt"
+	"sync"
 	"sync/atomic"
+	"time"
 
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"golang.org/x/sync/singleflight"
 )
 
-var translationGroupPtr atomic.Pointer[singleflight.Group]
+const (
+	projectTranslationCacheSize = 512
+	projectTranslationCacheTTL  = 30 * time.Minute
+	translationCacheEnabled     = false
+)
+
+var (
+	translationCacheMu  sync.Mutex
+	translationCache    *expirable.LRU[string, *Project]
+	translationGroupPtr atomic.Pointer[singleflight.Group]
+)
 
 func init() {
 	translationGroupPtr.Store(&singleflight.Group{})
 }
 
-// getOrComputeTranslation coalesces concurrent calls for the same key into a
-// single compute via singleflight. Errors are not retained after the call
-// completes; the next caller will retry compute.
-func getOrComputeTranslation(key string, compute func() (*Project, error)) (*Project, error) {
-	v, err, _ := translationGroupPtr.Load().Do(key, func() (any, error) {
-		return compute()
-	})
-	if err != nil {
-		return nil, err
+func getTranslationCache() *expirable.LRU[string, *Project] {
+	translationCacheMu.Lock()
+	defer translationCacheMu.Unlock()
+	if translationCache == nil {
+		translationCache = expirable.NewLRU[string, *Project](projectTranslationCacheSize, nil, projectTranslationCacheTTL)
 	}
-	return v.(*Project), nil
+	return translationCache
 }
 
-// versionTranslationKey returns the singleflight/cache key for a version-based translation.
+// getOrComputeTranslation coalesces concurrent calls via singleflight and, when cacheEnabled, also
+// serves and stores results in a per-process LRU. When cacheEnabled, key must capture every input
+// that determines the translation. The cached *Project is shared and must not be mutated.
+func getOrComputeTranslation(key string, cacheEnabled bool, compute func() (*Project, error)) (*Project, bool, error) {
+	if cacheEnabled {
+		if v, ok := getTranslationCache().Get(key); ok {
+			return v, true, nil
+		}
+	}
+
+	v, err, _ := translationGroupPtr.Load().Do(key, func() (any, error) {
+		// Re-check after winning the singleflight slot: another goroutine may
+		// have populated the cache while we were waiting.
+		if cacheEnabled {
+			if v, ok := getTranslationCache().Get(key); ok {
+				return v, nil
+			}
+		}
+		result, err := compute()
+		if err != nil {
+			return nil, err
+		}
+		if cacheEnabled {
+			getTranslationCache().Add(key, result)
+		}
+		return result, nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	return v.(*Project), false, nil
+}
+
+// versionTranslationKey is the cheap singleflight key for the cache-disabled path. It must NOT be
+// used as an LRU key; see getOrComputeTranslation.
 func versionTranslationKey(versionID string, preGeneration bool) string {
 	return fmt.Sprintf("v:%s:%v", versionID, preGeneration)
+}
+
+// contentTranslationKey keys a translation by a hash of the parser-project bytes plus identifier, so
+// a changed parser project yields a new key and the LRU needs no invalidation.
+func contentTranslationKey(contentsSHA, identifier string) string {
+	return fmt.Sprintf("c:%s:%s", contentsSHA, identifier)
+}
+
+// fileTranslationKey is the self-invalidating LRU key for the LoadProjectInto / GetProjectFromFile path.
+func fileTranslationKey(projectID, revision, contentsSHA string) string {
+	return fmt.Sprintf("f:%s:%s:%s", projectID, revision, contentsSHA)
 }

--- a/model/project_translate_cache.go
+++ b/model/project_translate_cache.go
@@ -26,6 +26,7 @@ func init() {
 	translationGroupPtr.Store(&singleflight.Group{})
 }
 
+// getTranslationCache returns the process-wide LRU cache for translated projects, initializing it on first call.
 func getTranslationCache() *expirable.LRU[string, *Project] {
 	translationCacheMu.Lock()
 	defer translationCacheMu.Unlock()

--- a/model/project_translate_cache_test.go
+++ b/model/project_translate_cache_test.go
@@ -17,30 +17,79 @@ import (
 )
 
 func resetTranslationCacheForTesting() {
+	translationCacheMu.Lock()
+	translationCache = nil
+	translationCacheMu.Unlock()
 	translationGroupPtr.Store(&singleflight.Group{})
 }
 
 func TestGetOrComputeTranslation(t *testing.T) {
-	t.Run("SequentialCallsEachInvokeCompute", func(t *testing.T) {
+	t.Run("LRUDisabledSequentialCallsInvokeCompute", func(t *testing.T) {
 		t.Cleanup(resetTranslationCacheForTesting)
-		// Singleflight coalesces concurrent calls, not sequential ones.
+		// Without LRU, sequential calls each invoke compute (singleflight only
+		// coalesces concurrent calls, not sequential ones).
 		var callCount int
 		compute := func() (*Project, error) {
 			callCount++
 			return &Project{Identifier: "test"}, nil
 		}
 
-		p1, err := getOrComputeTranslation("k", compute)
+		p1, hit1, err := getOrComputeTranslation("k", false, compute)
 		require.NoError(t, err)
-		p2, err := getOrComputeTranslation("k", compute)
+		p2, hit2, err := getOrComputeTranslation("k", false, compute)
 		require.NoError(t, err)
 
 		assert.Equal(t, 2, callCount)
+		assert.False(t, hit1, "cache disabled, never a hit")
+		assert.False(t, hit2, "cache disabled, never a hit")
 		assert.Equal(t, "test", p1.Identifier)
 		assert.Equal(t, "test", p2.Identifier)
 	})
 
-	t.Run("CoalescesConcurrentCalls", func(t *testing.T) {
+	t.Run("CachesResult", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+
+		var callCount int
+		compute := func() (*Project, error) {
+			callCount++
+			return &Project{Identifier: "cached"}, nil
+		}
+
+		p1, hit1, err := getOrComputeTranslation("k", true, compute)
+		require.NoError(t, err)
+		p2, hit2, err := getOrComputeTranslation("k", true, compute)
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, callCount, "second call should be served from cache")
+		assert.False(t, hit1, "first call computes")
+		assert.True(t, hit2, "second call is an LRU hit")
+		assert.Equal(t, "cached", p1.Identifier)
+		assert.Equal(t, "cached", p2.Identifier)
+	})
+
+	t.Run("ErrorNotCached", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+
+		var callCount int
+		compute := func() (*Project, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, errors.New("compute failed")
+			}
+			return &Project{Identifier: "retry"}, nil
+		}
+
+		_, _, err := getOrComputeTranslation("k", true, compute)
+		require.Error(t, err)
+
+		p, _, err := getOrComputeTranslation("k", true, compute)
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, callCount, "error result must not be cached")
+		assert.Equal(t, "retry", p.Identifier)
+	})
+
+	t.Run("CoalescesConcurrentCallsLRUEnabled", func(t *testing.T) {
 		t.Cleanup(resetTranslationCacheForTesting)
 
 		entered := make(chan struct{})
@@ -64,7 +113,7 @@ func TestGetOrComputeTranslation(t *testing.T) {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
-				projs[i], errs[i] = getOrComputeTranslation("k", compute)
+				projs[i], _, errs[i] = getOrComputeTranslation("k", true, compute)
 			}(i)
 		}
 
@@ -80,7 +129,47 @@ func TestGetOrComputeTranslation(t *testing.T) {
 		}
 	})
 
-	t.Run("ErrorPropagatedToAllConcurrentWaiters", func(t *testing.T) {
+	t.Run("CoalescesConcurrentCallsLRUDisabled", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		// Singleflight coalesces concurrent calls even without the LRU cache.
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		var computeCount atomic.Int64
+		compute := func() (*Project, error) {
+			select {
+			case entered <- struct{}{}: // signal first entry
+			default:
+			}
+			<-release
+			computeCount.Add(1)
+			return &Project{Identifier: "coalesced-no-lru"}, nil
+		}
+
+		const n = 5
+		projs := make([]*Project, n)
+		errs := make([]error, n)
+		var wg sync.WaitGroup
+		for i := range n {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				projs[i], _, errs[i] = getOrComputeTranslation("k", false, compute)
+			}(i)
+		}
+
+		<-entered
+		time.Sleep(5 * time.Millisecond)
+		close(release)
+		wg.Wait()
+
+		assert.Equal(t, int64(1), computeCount.Load(), "singleflight coalesces even without LRU")
+		for i := range n {
+			require.NoError(t, errs[i])
+			assert.Equal(t, "coalesced-no-lru", projs[i].Identifier)
+		}
+	})
+
+	t.Run("LRUDisabledErrorPropagatedToAllWaiters", func(t *testing.T) {
 		t.Cleanup(resetTranslationCacheForTesting)
 		// All concurrent singleflight waiters receive the error when compute fails.
 		// The next sequential call must retry (singleflight does not cache errors).
@@ -104,7 +193,7 @@ func TestGetOrComputeTranslation(t *testing.T) {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
-				_, errs[i] = getOrComputeTranslation("k", compute)
+				_, _, errs[i] = getOrComputeTranslation("k", false, compute)
 			}(i)
 		}
 
@@ -119,12 +208,73 @@ func TestGetOrComputeTranslation(t *testing.T) {
 		}
 
 		// Error must not be cached — the next sequential call should retry.
-		p, err := getOrComputeTranslation("k", func() (*Project, error) {
+		p, _, err := getOrComputeTranslation("k", false, func() (*Project, error) {
 			return &Project{Identifier: "retry"}, nil
 		})
 		require.NoError(t, err)
 		assert.Equal(t, "retry", p.Identifier)
 	})
+
+	t.Run("ConcurrentReadersOfSharedPointerNoDataRace", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		// The LRU cache returns the same *Project pointer to concurrent callers.
+		compute := func() (*Project, error) {
+			return &Project{Identifier: "shared", Tasks: []ProjectTask{{Name: "t1"}}}, nil
+		}
+
+		// Warm the cache so all subsequent callers receive the cached pointer.
+		_, _, err := getOrComputeTranslation("k", true, compute)
+		require.NoError(t, err)
+
+		var wg sync.WaitGroup
+		for range 20 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				p, _, err := getOrComputeTranslation("k", true, compute)
+				require.NoError(t, err)
+				_ = p.Identifier
+				_ = len(p.Tasks)
+			}()
+		}
+		wg.Wait()
+	})
+}
+
+// TestContentTranslationKeySelfInvalidates shows that changed content yields a new key, so a stale
+// entry is never served and no invalidation is needed.
+func TestContentTranslationKeySelfInvalidates(t *testing.T) {
+	t.Cleanup(resetTranslationCacheForTesting)
+
+	identifier := "myproject"
+	keyBefore := contentTranslationKey("sha-before-generate", identifier)
+	keyAfter := contentTranslationKey("sha-after-generate", identifier)
+	require.NotEqual(t, keyBefore, keyAfter, "changed content must produce a different key")
+
+	pBefore, _, err := getOrComputeTranslation(keyBefore, true, func() (*Project, error) {
+		return &Project{Identifier: identifier, Tasks: []ProjectTask{{Name: "original"}}}, nil
+	})
+	require.NoError(t, err)
+	require.Len(t, pBefore.Tasks, 1)
+
+	// generate.tasks rewrites the parser project: new content, new key, served fresh.
+	pAfter, hit, err := getOrComputeTranslation(keyAfter, true, func() (*Project, error) {
+		return &Project{Identifier: identifier, Tasks: []ProjectTask{{Name: "original"}, {Name: "generated"}}}, nil
+	})
+	require.NoError(t, err)
+	assert.False(t, hit, "the new content key is a miss, so the new config is computed")
+	assert.Len(t, pAfter.Tasks, 2, "post-generation translation reflects the generated task")
+
+	// The stale pre-generation entry remains under its old key but is never looked up again.
+	assert.True(t, getTranslationCache().Contains(keyBefore))
+}
+
+func TestTranslationKeysAreDistinctAndStable(t *testing.T) {
+	// Distinct prefixes: an identical SHA never collides across the two key namespaces.
+	assert.NotEqual(t, contentTranslationKey("sha", "id"), fileTranslationKey("id", "rev", "sha"))
+	// Keys are deterministic for identical inputs.
+	assert.Equal(t, contentTranslationKey("s", "i"), contentTranslationKey("s", "i"))
+	assert.Equal(t, fileTranslationKey("p", "r", "s"), fileTranslationKey("p", "r", "s"))
 }
 
 func TestFindAndTranslateProjectForVersion(t *testing.T) {

--- a/model/project_translate_cache_test.go
+++ b/model/project_translate_cache_test.go
@@ -215,6 +215,25 @@ func TestGetOrComputeTranslation(t *testing.T) {
 		assert.Equal(t, "retry", p.Identifier)
 	})
 
+	t.Run("CachedPointerIsShared", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		// The LRU returns the same *Project pointer to all callers. Mutating the
+		// result of one call poisons the value seen by future callers. Callers must
+		// not mutate the returned project.
+		compute := func() (*Project, error) {
+			return &Project{Tasks: []ProjectTask{{Name: "t1", DependsOn: []TaskUnitDependency{{Name: "dep"}}}}}, nil
+		}
+
+		p1, _, err := getOrComputeTranslation("k", true, compute)
+		require.NoError(t, err)
+		p2, _, err := getOrComputeTranslation("k", true, compute)
+		require.NoError(t, err)
+
+		p1.Tasks[0].DependsOn = nil
+
+		assert.Nil(t, p2.Tasks[0].DependsOn, "mutating one caller's result affects all other callers that hold the same pointer")
+	})
+
 	t.Run("ConcurrentReadersOfSharedPointerNoDataRace", func(t *testing.T) {
 		t.Cleanup(resetTranslationCacheForTesting)
 		// The LRU cache returns the same *Project pointer to concurrent callers.

--- a/service/api.go
+++ b/service/api.go
@@ -171,14 +171,15 @@ func (as *APIServer) listProjects(w http.ResponseWriter, r *http.Request) {
 func (as *APIServer) listTasks(w http.ResponseWriter, r *http.Request) {
 	project := MustHaveProject(r)
 
-	// zero out the depends on and commands fields because they are
-	// unnecessary and may not get marshaled properly
-	for i := range project.Tasks {
-		project.Tasks[i].DependsOn = []model.TaskUnitDependency{}
-		project.Tasks[i].Commands = []model.PluginCommandConf{}
-
+	// Copy the slice before zeroing fields — the project pointer may be shared
+	// with the translation cache and must not be mutated.
+	tasks := make([]model.ProjectTask, len(project.Tasks))
+	copy(tasks, project.Tasks)
+	for i := range tasks {
+		tasks[i].DependsOn = []model.TaskUnitDependency{}
+		tasks[i].Commands = []model.PluginCommandConf{}
 	}
-	gimlet.WriteJSON(r.Context(), w, project.Tasks)
+	gimlet.WriteJSON(r.Context(), w, tasks)
 }
 func (as *APIServer) listVariants(w http.ResponseWriter, r *http.Request) {
 	project := MustHaveProject(r)


### PR DESCRIPTION
DEVPROD-36140

### Description

This PR lays the groundwork for caching project translations in memory. This will have no behavior changes in production, the cache is currently disabled and not yet wired to anything. I am doing it this way to avoid a huge PR. 

### Testing
Added tests 

