### PR TITLE
DEVPROD-36218 Add OAuth token expiration buffer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -175,7 +175,7 @@ require (
 	github.com/google/go-github/v70 v70.0.0
 	github.com/gorilla/csrf v1.7.3
 	github.com/gorilla/handlers v1.5.2
-	github.com/kanopy-platform/kanopy-oidc-lib v0.1.3
+	github.com/kanopy-platform/kanopy-oidc-lib v0.1.4
 	github.com/mongodb/jasper v0.0.0-20260330133616-5411573646d1
 	github.com/parquet-go/parquet-go v0.29.0
 	github.com/redis/go-redis/v9 v9.20.1

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/jpillora/longestcommon v0.0.0-20161227235612-adb9d91ee629 h1:1dSBUfGl
 github.com/jpillora/longestcommon v0.0.0-20161227235612-adb9d91ee629/go.mod h1:mb5nS4uRANwOJSZj8rlCWAfAcGi72GGMIXx+xGOjA7M=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/kanopy-platform/kanopy-oidc-lib v0.1.3 h1:IZOXREL5IIBnMgA3tbBR5H70J4+WfTmDkCv9bdYkJw0=
-github.com/kanopy-platform/kanopy-oidc-lib v0.1.3/go.mod h1:2MslZKpACq93y7SHOqa3e5A+G3yUMnEuyOI3/1G7w2A=
+github.com/kanopy-platform/kanopy-oidc-lib v0.1.4 h1:+22jXQJYRsrb+A/TjpnDBS5u8ltXhBqsSQKA1IecwAA=
+github.com/kanopy-platform/kanopy-oidc-lib v0.1.4/go.mod h1:2MslZKpACq93y7SHOqa3e5A+G3yUMnEuyOI3/1G7w2A=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
 github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -1968,6 +1968,7 @@ func GetOAuthToken(ctx context.Context, doNotUseBrowser bool, opts ...dex.Client
 		dex.WithContext(ctx),
 		dex.WithRefresh(),
 		dex.WithFallbackToStdOut(true),
+		dex.WithTokenExpiryBuffer(time.Minute),
 	)
 
 	flow := oauthFlowAuthCode


### PR DESCRIPTION
DEVPROD-36218

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->

Adds a 1 minute expiration buffer to our oauth tokens.

### Testing

<!--add a description of how you tested it-->

Ran the CLI locally, changed expiration to 2m, it didn't use the refresh token, changed expiration to 1m, and it refreshed my access token

### Kanopy-oidc-lib PR

https://github.com/kanopy-platform/kanopy-oidc-lib/pull/9