### PR TITLE
DEVPROD-36220: Don't allow mainline commtis to be influenced by TSS

### DIFF
--- a/agent/command/test_selection_get.go
+++ b/agent/command/test_selection_get.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/evergreen-ci/evergreen/rest/model"
@@ -193,9 +194,13 @@ func (c *testSelectionGet) Execute(ctx context.Context, comm client.Communicator
 	return c.writeTestList(selectedTests)
 }
 
-// isTestSelectionAllowed checks if test selection is allowed in the project and the running task.
+// isTestSelectionAllowed checks if test selection is allowed in the project and
+// the running task. Test selection is restricted to patches so that it cannot
+// change which tests run on mainline commits and other non-patch requesters.
 func (c *testSelectionGet) isTestSelectionAllowed(conf *internal.TaskConfig) bool {
-	return utility.FromBoolPtr(conf.ProjectRef.TestSelection.Allowed) && conf.Task.TestSelectionEnabled
+	return utility.FromBoolPtr(conf.ProjectRef.TestSelection.Allowed) &&
+		conf.Task.TestSelectionEnabled &&
+		evergreen.IsPatchRequester(conf.Task.Requester)
 }
 
 // writeTestList writes the list of tests to the output file as JSON in the required format.

--- a/agent/command/test_selection_get_test.go
+++ b/agent/command/test_selection_get_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/evergreen-ci/evergreen/model"
@@ -71,6 +72,20 @@ func TestTestSelectionGet(t *testing.T) {
 			require.NoError(t, cmd.Execute(t.Context(), comm, logger, conf))
 
 			output = testSelectionOutputFile{}
+			require.NoError(t, utility.ReadJSONFile(cmd.OutputFile, &output))
+			assert.Empty(t, output.Tests)
+		},
+		"SkipsForNonPatchRequester": func(t *testing.T, conf *internal.TaskConfig, comm *client.Mock, logger client.LoggerProducer) {
+			cmd := &testSelectionGet{OutputFile: "test.json", Tests: []string{"test1", "test3"}}
+
+			// Test selection must not run on mainline commits even when allowed
+			// and enabled, so that it never changes which tests they run.
+			conf.Task.Requester = evergreen.RepotrackerVersionRequester
+			require.NoError(t, cmd.Execute(t.Context(), comm, logger, conf))
+
+			assert.False(t, comm.SelectTestsCalled)
+
+			var output testSelectionOutputFile
 			require.NoError(t, utility.ReadJSONFile(cmd.OutputFile, &output))
 			assert.Empty(t, output.Tests)
 		},
@@ -182,6 +197,7 @@ func TestTestSelectionGet(t *testing.T) {
 			require.NoError(t, err)
 
 			conf.Task.TestSelectionEnabled = true
+			conf.Task.Requester = evergreen.PatchVersionRequester
 			conf.ProjectRef.TestSelection.Allowed = utility.TruePtr()
 
 			tCase(t, conf, comm, logger)

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-06-18"
+	AgentVersion = "2026-06-30"
 )
 
 const (

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1840,7 +1840,10 @@ This command allows a task to get a recommended list of tests from the [test sel
 service](https://wiki.corp.mongodb.com/spaces/DBDEVPROD/pages/385846915/Test+Selection+Services). The command will
 populate an output JSON file, which your task can use to decide which tests should run.
 
-This command can only be used if [the test selection feature is enabled by the project](Project-and-Distro-Settings#test-selection-settings).
+This command can only request selected tests if [the test selection feature is enabled by the
+project](Project-and-Distro-Settings#test-selection-settings) and the task is running in a patch. On mainline commits and
+other non-patch versions, the command writes an empty test list to the output file and does not select out any tests,
+even if the version page shows that test selection is enabled.
 
 ```yaml
 - command: test_selection.get

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1842,8 +1842,8 @@ populate an output JSON file, which your task can use to decide which tests shou
 
 This command can only request selected tests if [the test selection feature is enabled by the
 project](Project-and-Distro-Settings#test-selection-settings) and the task is running in a patch. On mainline commits and
-other non-patch versions, the command writes an empty test list to the output file and does not select out any tests,
-even if the version page shows that test selection is enabled.
+other non-patch versions, the command writes an empty test list to the output file, so no tests are excluded, even if the
+version page shows that test selection is enabled.
 
 ```yaml
 - command: test_selection.get

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -839,7 +839,7 @@ selection when submitting a manual patch from [the CLI](../CLI.md#test-selection
 
 Test selection can appear enabled on mainline commit versions when these project and task settings are enabled. However,
 the [test selection command](Project-Commands#test_selectionget) only requests selected tests for patch tasks. On
-mainline commits and other non-patch versions, the command writes an empty test list and does not select out any tests.
+mainline commits and other non-patch versions, the command writes an empty test list, so no tests are excluded.
 
 ## GitHub App Settings
 

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -823,21 +823,23 @@ task_annotation_settings:
 
 ## Test Selection Settings
 
-Test selection is an experimental feature to help projects reduce testing that provides low signal. For example, if you
-submit a patch for your change but one of the tests fails due to a known issue that's not related to your change, then
-the test did not need to run because it's giving a false negative signal about your patch's mergeability. This can
-improve the signal of a project's tests, reduce time for versions to finish, and save on the cost of running low-signal
-tasks.
+Test selection is a feature to help projects reduce testing that provides low signal. For example, if you submit a patch
+for your change but one of the tests fails due to a known issue that's not related to your change, then the test did not
+need to run because it's giving a false negative signal about your patch's mergeability. This can improve the signal of
+a project's tests, reduce time for versions to finish, and save on the cost of running low-signal tasks.
 
 To allow any test selection features to be used in your project, first go to "Test Selection" -> "Project-Level Test
-Selection" and enable it. Doing this will allow any test selection features to be used. Patches in the project may use
-the [test selection command](Project-Commands#test_selectionget) (note: only supported in patches currently, non-patch
-versions will not have test selection features enabled).
+Selection" and enable it. Doing this is necessary to allow any test selection features to be used. Patch tasks in the
+project may use the [test selection command](Project-Commands#test_selectionget).
 
 To enable test selection by default for all patch tasks, go to "Test Selection" -> "Task-Level Test Selection" and
 enable it. Doing this will enable the usage of the [test selection command](Project-Commands#test_selectionget) in all
 patch tasks by default. This default can still be overridden by choosing specific variants/tasks in which to enable test
-selection from [the CLI](../CLI.md#test-selection).
+selection when submitting a manual patch from [the CLI](../CLI.md#test-selection).
+
+Test selection can appear enabled on mainline commit versions when these project and task settings are enabled. However,
+the [test selection command](Project-Commands#test_selectionget) only requests selected tests for patch tasks. On
+mainline commits and other non-patch versions, the command writes an empty test list and does not select out any tests.
 
 ## GitHub App Settings
 

--- a/rest/data/select.go
+++ b/rest/data/select.go
@@ -174,6 +174,9 @@ func GetTestsQuarantineStatus(ctx context.Context, projectID, bvName, taskName s
 		defer resp.Body.Close()
 	}
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return testToQuarantineStatus, nil
+		}
 		logTSSError(ctx, err, resp, message.Fields{
 			"message":       "error getting tests quarantine status",
 			"endpoint":      GetTestsStateEndpoint,

--- a/rest/data/select_test.go
+++ b/rest/data/select_test.go
@@ -138,16 +138,16 @@ func TestGetTestsQuarantineStatus(t *testing.T) {
 		assert.Contains(t, err.Error(), "boom")
 	})
 
-	t.Run("NotFoundStillReturnsWrappedError", func(t *testing.T) {
+	t.Run("NotFoundReturnsDefaultStatuses", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "not found", http.StatusNotFound)
 		}))
 		t.Cleanup(srv.Close)
 		setTSSURL(t, srv.URL)
 
-		_, err := GetTestsQuarantineStatus(t.Context(), projectID, bvName, taskName, []string{"test_a"})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "forwarding request to test selection service")
+		statuses, err := GetTestsQuarantineStatus(t.Context(), projectID, bvName, taskName, []string{"test_a"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]bool{"test_a": false}, statuses)
 	})
 }
 


### PR DESCRIPTION
DEVPROD-36220

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Prevent TSS from impacting mainline builds, but still allow people to quarantine things, it just won't impact mainline builds. 

### Testing
* Added tests
* Tried testing in staging, but wasn't able to as it was really hard to replicate, however the unit tests pretty directly test this.

