### PR TITLE
DEVPROD-36353: update test selection docs to remove patch-only description

### DIFF
--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -823,21 +823,19 @@ task_annotation_settings:
 
 ## Test Selection Settings
 
-Test selection is an experimental feature to help projects reduce testing that provides low signal. For example, if you
-submit a patch for your change but one of the tests fails due to a known issue that's not related to your change, then
-the test did not need to run because it's giving a false negative signal about your patch's mergeability. This can
-improve the signal of a project's tests, reduce time for versions to finish, and save on the cost of running low-signal
-tasks.
+Test selection is a feature to help projects reduce testing that provides low signal. For example, if you submit a patch
+for your change but one of the tests fails due to a known issue that's not related to your change, then the test did not
+need to run because it's giving a false negative signal about your patch's mergeability. This can improve the signal of
+a project's tests, reduce time for versions to finish, and save on the cost of running low-signal tasks.
 
 To allow any test selection features to be used in your project, first go to "Test Selection" -> "Project-Level Test
-Selection" and enable it. Doing this will allow any test selection features to be used. Patches in the project may use
-the [test selection command](Project-Commands#test_selectionget) (note: only supported in patches currently, non-patch
-versions will not have test selection features enabled).
+Selection" and enable it. Doing this is necessary to allow any test selection features to be used. Patches in the
+project may use the [test selection command](Project-Commands#test_selectionget).
 
 To enable test selection by default for all patch tasks, go to "Test Selection" -> "Task-Level Test Selection" and
 enable it. Doing this will enable the usage of the [test selection command](Project-Commands#test_selectionget) in all
-patch tasks by default. This default can still be overridden by choosing specific variants/tasks in which to enable test
-selection from [the CLI](../CLI.md#test-selection).
+tasks by default. This default can still be overridden by choosing specific variants/tasks in which to enable test
+selection when submitting a manual patch from [the CLI](../CLI.md#test-selection).
 
 ## GitHub App Settings
 


### PR DESCRIPTION
DEVPROD-36353

### Description

Update docs to reflect current behavior that test selection is not limited to patches only.

lint-markdown failure is pre-existing and not related.