### PR TITLE
DEVPROD-36308 Preserve version project identifiers during project translation

### DIFF
--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -377,15 +377,7 @@ func (r *taskResolver) ExecutionSteps(ctx context.Context, obj *restModel.APITas
 		return nil, nil
 	}
 
-	v, err := model.VersionFindOneId(ctx, versionID)
-	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding version: %s", err.Error()))
-	}
-	if v == nil {
-		return nil, nil
-	}
-
-	project, _, err := model.FindAndTranslateProjectForVersion(ctx, evergreen.GetEnvironment().Settings(), v, false)
+	project, _, err := model.FindAndTranslateProjectForVersionID(ctx, evergreen.GetEnvironment().Settings(), versionID, false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("loading project: %s", err.Error()))
 	}

--- a/model/project.go
+++ b/model/project.go
@@ -1270,17 +1270,9 @@ func (p *Project) FindTaskGroupForTask(bvName, taskName string) *TaskGroup {
 }
 
 func FindProjectFromVersionID(ctx context.Context, versionStr string) (*Project, error) {
-	ver, err := VersionFindOne(ctx, VersionById(versionStr).WithFields(VersionIdKey, VersionIdentifierKey, VersionProjectStorageMethodKey))
-	if err != nil {
-		return nil, err
-	}
-	if ver == nil {
-		return nil, errors.Errorf("version '%s' not found", versionStr)
-	}
-
 	env := evergreen.GetEnvironment()
 
-	project, _, err := FindAndTranslateProjectForVersion(ctx, env.Settings(), ver, false)
+	project, _, err := FindAndTranslateProjectForVersionID(ctx, env.Settings(), versionStr, false)
 	if err != nil {
 		return nil, errors.Wrapf(err, "loading project config for version '%s'", versionStr)
 	}

--- a/model/project.go
+++ b/model/project.go
@@ -1270,7 +1270,7 @@ func (p *Project) FindTaskGroupForTask(bvName, taskName string) *TaskGroup {
 }
 
 func FindProjectFromVersionID(ctx context.Context, versionStr string) (*Project, error) {
-	ver, err := VersionFindOne(ctx, VersionById(versionStr).WithFields(VersionIdKey))
+	ver, err := VersionFindOne(ctx, VersionById(versionStr).WithFields(VersionIdKey, VersionIdentifierKey, VersionProjectStorageMethodKey))
 	if err != nil {
 		return nil, err
 	}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -569,26 +569,46 @@ func FindAndTranslateProjectForPatch(ctx context.Context, settings *evergreen.Se
 	}
 
 	// This fallback handles the case where the patch is already finalized.
-	v, err := VersionFindOneId(ctx, p.Version)
+	project, pp, err := FindAndTranslateProjectForVersionID(ctx, settings, p.Version, false)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "finding version '%s' for patch '%s'", p.Version, p.Id.Hex())
+		return nil, nil, errors.Wrapf(err, "finding project for patch '%s'", p.Id.Hex())
 	}
-	if v == nil {
-		return nil, nil, errors.Errorf("version '%s' not found for patch '%s'", p.Version, p.Id.Hex())
-	}
-	return FindAndTranslateProjectForVersion(ctx, settings, v, false)
+	return project, pp, nil
 }
 
 // parserProjectPreGenerationOtelAttribute records whether a translation used the
 // pre-generation parser project copy.
 const parserProjectPreGenerationOtelAttribute = "evergreen.parser_project.pre_generation"
 
+// FindAndTranslateProjectForVersionID translates a parser project for a version into a Project.
+func FindAndTranslateProjectForVersionID(ctx context.Context, settings *evergreen.Settings, versionID string, preGeneration bool) (*Project, *ParserProject, error) {
+	v, err := VersionFindOne(ctx, VersionById(versionID).WithFields(
+		VersionIdKey,
+		VersionIdentifierKey,
+		VersionProjectStorageMethodKey,
+		VersionPreGenerationProjectStorageMethodKey,
+	))
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "finding version '%s'", versionID)
+	}
+	if v == nil {
+		return nil, nil, errors.Errorf("version '%s' not found", versionID)
+	}
+
+	return FindAndTranslateProjectForVersion(ctx, settings, v, preGeneration)
+}
+
 // FindAndTranslateProjectForVersion translates a parser project for a version into a Project.
 // Also sets the project ID. If the preGeneration flag is true, this function will attempt to
 // fetch and translate the parser project from before it was modified by generate.tasks
+// versionID, versionIdentifier, projectStorageMethod, preGenerationProjectStorageMethod are the fields from the version that are needed to translate the project.
 func FindAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.Settings, v *Version, preGeneration bool) (*Project, *ParserProject, error) {
+	return findAndTranslateProjectForVersion(ctx, settings, v.Id, v.Identifier, v.ProjectStorageMethod, v.PreGenerationProjectStorageMethod, preGeneration)
+}
+
+func findAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.Settings, versionID, versionIdentifier string, projectStorageMethod, preGenerationProjectStorageMethod evergreen.ParserProjectStorageMethod, preGeneration bool) (*Project, *ParserProject, error) {
 	ctx, span := tracer.Start(ctx, "FindAndTranslateProjectForVersion", trace.WithAttributes(
-		attribute.String(evergreen.VersionIDOtelAttribute, v.Id),
+		attribute.String(evergreen.VersionIDOtelAttribute, versionID),
 		attribute.Bool(parserProjectPreGenerationOtelAttribute, preGeneration),
 	))
 	defer span.End()
@@ -596,35 +616,35 @@ func FindAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.
 	var pp *ParserProject
 	var err error
 	if preGeneration {
-		preGeneratedId := preGeneratedParserProjectId(v.Id)
-		pp, err = ParserProjectFindOneByID(ctx, settings, v.PreGenerationProjectStorageMethod, preGeneratedId)
+		preGeneratedId := preGeneratedParserProjectId(versionID)
+		pp, err = ParserProjectFindOneByID(ctx, settings, preGenerationProjectStorageMethod, preGeneratedId)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "finding parser project '%s'", preGeneratedId)
 		}
 		// Fall back to the parser project post-generation if the pre-generation parser project was not found
 	}
 	if pp == nil {
-		pp, err = ParserProjectFindOneByID(ctx, settings, v.ProjectStorageMethod, v.Id)
+		pp, err = ParserProjectFindOneByID(ctx, settings, projectStorageMethod, versionID)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "finding parser project '%s'", v.Id)
+			return nil, nil, errors.Wrapf(err, "finding parser project '%s'", versionID)
 		}
 		if pp == nil {
-			return nil, nil, errors.Errorf("parser project not found for version '%s'", v.Id)
+			return nil, nil, errors.Errorf("parser project not found for version '%s'", versionID)
 		}
 	}
 	// Setting the translated project's ID is necessary here because some old
 	// parser projects used to not be stored with the ID.
-	if v.Identifier != "" {
-		pp.Identifier = utility.ToStringPtr(v.Identifier)
+	if versionIdentifier != "" {
+		pp.Identifier = utility.ToStringPtr(versionIdentifier)
 	}
 
 	// Coalesce concurrent translations for the same version into one compute.
-	key := versionTranslationKey(v.Id, preGeneration)
+	key := versionTranslationKey(versionID, preGeneration)
 	p, err := getOrComputeTranslation(key, func() (*Project, error) {
 		return TranslateProject(pp)
 	})
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "translating parser project '%s'", v.Id)
+		return nil, nil, errors.Wrapf(err, "translating parser project '%s'", versionID)
 	}
 	return p, pp, nil
 }

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -612,10 +612,11 @@ func FindAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.
 			return nil, nil, errors.Errorf("parser project not found for version '%s'", v.Id)
 		}
 	}
-	// Setting the translated project's ID is necessary here because the version
-	// always has an identifier, but some old parser projects used to not be
-	// stored with the ID.
-	pp.Identifier = utility.ToStringPtr(v.Identifier)
+	// Setting the translated project's ID is necessary here because some old
+	// parser projects used to not be stored with the ID.
+	if v.Identifier != "" {
+		pp.Identifier = utility.ToStringPtr(v.Identifier)
+	}
 
 	// Coalesce concurrent translations for the same version into one compute.
 	key := versionTranslationKey(v.Id, preGeneration)

--- a/model/project_translate_cache_test.go
+++ b/model/project_translate_cache_test.go
@@ -6,6 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/mock"
+	"github.com/evergreen-ci/utility"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -121,4 +125,60 @@ func TestGetOrComputeTranslation(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "retry", p.Identifier)
 	})
+}
+
+func TestFindAndTranslateProjectForVersion(t *testing.T) {
+	ctx := t.Context()
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+	t.Cleanup(resetTranslationCacheForTesting)
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(ParserProjectCollection, VersionCollection))
+	})
+	require.NoError(t, db.ClearCollections(ParserProjectCollection, VersionCollection))
+
+	versionID := "version_id"
+	projectID := "project_id"
+	pp := ParserProject{
+		Id:         versionID,
+		Identifier: utility.ToStringPtr(projectID),
+	}
+	require.NoError(t, pp.Insert(ctx))
+
+	project, _, err := FindAndTranslateProjectForVersion(ctx, env.Settings(), &Version{
+		Id:                   versionID,
+		ProjectStorageMethod: evergreen.ProjectStorageMethodDB,
+	}, false)
+	require.NoError(t, err)
+	require.NotNil(t, project)
+
+	assert.Equal(t, projectID, project.Identifier)
+}
+
+func TestFindProjectFromVersionID(t *testing.T) {
+	ctx := t.Context()
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+	t.Cleanup(resetTranslationCacheForTesting)
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(ParserProjectCollection, VersionCollection))
+	})
+	require.NoError(t, db.ClearCollections(ParserProjectCollection, VersionCollection))
+
+	versionID := "version_id"
+	projectID := "project_id"
+	require.NoError(t, (&Version{
+		Id:                   versionID,
+		Identifier:           projectID,
+		ProjectStorageMethod: evergreen.ProjectStorageMethodDB,
+	}).Insert(ctx))
+	require.NoError(t, (&ParserProject{
+		Id: versionID,
+	}).Insert(ctx))
+
+	project, err := FindProjectFromVersionID(ctx, versionID)
+	require.NoError(t, err)
+	require.NotNil(t, project)
+
+	assert.Equal(t, projectID, project.Identifier)
 }

--- a/rest/route/patch.go
+++ b/rest/route/patch.go
@@ -655,7 +655,7 @@ func (p *schedulePatchHandler) Run(ctx context.Context) gimlet.Responder {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding project for patch '%s'", p.patchId))
 		}
 	} else {
-		project, err = dbModel.FindProjectFromVersionID(ctx, dbVersion.Id)
+		project, _, err = dbModel.FindAndTranslateProjectForVersion(ctx, p.env.Settings(), dbVersion, false)
 		if err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding project for version '%s'", dbVersion.Id))
 		}


### PR DESCRIPTION
DEVPROD-36308

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Fixes a regression from #10386 (DEVPROD-36045) where some tasks created during patch configuration could end up with an empty project ID (`task.branch`). That made those tasks unschedulable and could break patch UI navigation and other Evergreen systems.

The root cause was `FindAndTranslateProjectForVersion` overwriting the parser project's identifier with `v.Identifier` even when the caller only had a partial `Version` (identifier unset). With singleflight coalescing concurrent translations for the same version, a caller like `FindProjectFromVersionID` could overwrite others and produce a translated project with `Identifier == ""`. New tasks then inherited that empty value. TLDR, a niche race condition because we batch some stuff now.

### Testing

Adds unit tests that simulate the bugged behavior. They fail on main and pass on this PR.