### PR TITLE
DEVPROD-36022 Make host allocator aware of max large PP tasks

### DIFF
--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -66,8 +66,8 @@ type DistroQueueInfo struct {
 	DurationOverThreshold time.Duration `bson:"duration_over_threshold" json:"duration_over_threshold"`
 	// CountWaitOverThreshold represents the number of tasks that have been waiting the MaxDurationThreshold since their dependencies were met
 	CountWaitOverThreshold int `bson:"count_wait_over_threshold" json:"count_wait_over_threshold"`
-	// CountLargeParserProjectTasks is the number of dependency-met tasks who use S3 for their parser project.
-	CountLargeParserProjectTasks int `bson:"count_large_parser_project_tasks" json:"count_large_parser_project_tasks"`
+	// NumQueuedLargeParserProjectTasks is the number of dependency-met tasks in this queue that use S3 for their parser project.
+	NumQueuedLargeParserProjectTasks int `bson:"num_queued_large_parser_project_tasks" json:"num_queued_large_parser_project_tasks"`
 	// TaskGroupInfos is a list of info that contains the same information as in this struct, but granularized to be only for tasks in
 	// a specific group (standalone tasks are included as well, denoted by an empty string for the group name)
 	TaskGroupInfos []TaskGroupInfo `bson:"task_group_infos" json:"task_group_infos"`

--- a/model/task_queue.go
+++ b/model/task_queue.go
@@ -66,6 +66,8 @@ type DistroQueueInfo struct {
 	DurationOverThreshold time.Duration `bson:"duration_over_threshold" json:"duration_over_threshold"`
 	// CountWaitOverThreshold represents the number of tasks that have been waiting the MaxDurationThreshold since their dependencies were met
 	CountWaitOverThreshold int `bson:"count_wait_over_threshold" json:"count_wait_over_threshold"`
+	// CountLargeParserProjectTasks is the number of dependency-met tasks who use S3 for their parser project.
+	CountLargeParserProjectTasks int `bson:"count_large_parser_project_tasks" json:"count_large_parser_project_tasks"`
 	// TaskGroupInfos is a list of info that contains the same information as in this struct, but granularized to be only for tasks in
 	// a specific group (standalone tasks are included as well, denoted by an empty string for the group name)
 	TaskGroupInfos []TaskGroupInfo `bson:"task_group_infos" json:"task_group_infos"`

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -147,17 +147,17 @@ func GetDistroQueueInfo(ctx context.Context, distroID string, tasks []task.Task,
 	}
 
 	distroQueueInfo := model.DistroQueueInfo{
-		Length:                        len(tasks),
-		LengthWithDependenciesMet:     numTasksDepsMet,
-		ExpectedDuration:              distroExpectedDuration,
-		MaxDurationThreshold:          maxDurationThreshold,
-		CountDepFilledMergeQueueTasks: numMergeQueueTasks,
-		CountDurationOverThreshold:    distroCountDurationOverThreshold,
-		DurationOverThreshold:         distroDurationOverThreshold,
-		CountWaitOverThreshold:        distroCountWaitOverThreshold,
-		CountLargeParserProjectTasks:  numLargeParserProjectTasks,
-		TaskGroupInfos:                taskGroupInfos,
-		SecondaryQueue:                isSecondaryQueue,
+		Length:                           len(tasks),
+		LengthWithDependenciesMet:        numTasksDepsMet,
+		ExpectedDuration:                 distroExpectedDuration,
+		MaxDurationThreshold:             maxDurationThreshold,
+		CountDepFilledMergeQueueTasks:    numMergeQueueTasks,
+		CountDurationOverThreshold:       distroCountDurationOverThreshold,
+		DurationOverThreshold:            distroDurationOverThreshold,
+		CountWaitOverThreshold:           distroCountWaitOverThreshold,
+		NumQueuedLargeParserProjectTasks: numLargeParserProjectTasks,
+		TaskGroupInfos:                   taskGroupInfos,
+		SecondaryQueue:                   isSecondaryQueue,
 	}
 
 	return distroQueueInfo

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -56,7 +56,7 @@ const RunnerName = "scheduler"
 // GetDistroQueueInfo returns the distroQueueInfo for the given set of tasks having set the task.ExpectedDuration for each task.
 func GetDistroQueueInfo(ctx context.Context, distroID string, tasks []task.Task, maxDurationThreshold time.Duration, opts TaskPlannerOptions) model.DistroQueueInfo {
 	var distroExpectedDuration, distroDurationOverThreshold time.Duration
-	var distroCountDurationOverThreshold, distroCountWaitOverThreshold, numTasksDepsMet, numMergeQueueTasks int
+	var distroCountDurationOverThreshold, distroCountWaitOverThreshold, numTasksDepsMet, numMergeQueueTasks, numLargeParserProjectTasks int
 	var isSecondaryQueue bool
 	taskGroupInfosMap := make(map[string]*model.TaskGroupInfo)
 	depCache := make(map[string]task.Task, len(tasks))
@@ -102,6 +102,9 @@ func GetDistroQueueInfo(ctx context.Context, distroID string, tasks []task.Task,
 			if evergreen.IsGithubMergeQueueRequester(task.Requester) {
 				numMergeQueueTasks++
 				info.CountDepFilledMergeQueueTasks++
+			}
+			if task.CachedProjectStorageMethod == evergreen.ProjectStorageMethodS3 {
+				numLargeParserProjectTasks++
 			}
 		}
 		if !opts.IncludesDependencies || dependenciesMet {
@@ -152,6 +155,7 @@ func GetDistroQueueInfo(ctx context.Context, distroID string, tasks []task.Task,
 		CountDurationOverThreshold:    distroCountDurationOverThreshold,
 		DurationOverThreshold:         distroDurationOverThreshold,
 		CountWaitOverThreshold:        distroCountWaitOverThreshold,
+		CountLargeParserProjectTasks:  numLargeParserProjectTasks,
 		TaskGroupInfos:                taskGroupInfos,
 		SecondaryQueue:                isSecondaryQueue,
 	}

--- a/units/host_allocator.go
+++ b/units/host_allocator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/hoststat"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/scheduler"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
@@ -145,6 +146,8 @@ func (j *hostAllocatorJob) Run(ctx context.Context) {
 		j.AddError(errors.Wrapf(err, "getting distro queue info for distro '%s'", j.DistroID))
 		return
 	}
+
+	distroQueueInfo = adjustForLargeParserProjectLimit(ctx, j.DistroID, distroQueueInfo, config)
 
 	existingHosts, err := host.AllActiveHosts(ctx, j.DistroID)
 	if err != nil {
@@ -467,4 +470,55 @@ func (j *hostAllocatorJob) saveHostStats(ctx context.Context, d *distro.Distro, 
 		}))
 	}
 
+}
+
+// adjustForLargeParserProjectLimit reduces the effective queue length when
+// the max concurrent large parser project task limit is hit.
+func adjustForLargeParserProjectLimit(ctx context.Context, distroID string, info model.DistroQueueInfo, config *evergreen.Settings) model.DistroQueueInfo {
+	if info.CountLargeParserProjectTasks == 0 {
+		return info
+	}
+
+	limit := model.GetMaxConcurrentLargeParserProjTasks(config)
+	if limit <= 0 {
+		return info
+	}
+
+	currentlyRunning, err := task.CountLargeParserProjectTasks(ctx)
+	if err != nil {
+		grip.Warning(ctx, message.WrapError(err, message.Fields{
+			"message": "could not count running large parser project tasks",
+			"runner":  hostAllocatorJobName,
+			"distro":  distroID,
+		}))
+		return info
+	}
+
+	remainingCapacity := limit - currentlyRunning
+	if remainingCapacity < 0 {
+		remainingCapacity = 0
+	}
+
+	blocked := info.CountLargeParserProjectTasks - remainingCapacity
+	if blocked <= 0 {
+		return info
+	}
+	if blocked > info.LengthWithDependenciesMet {
+		blocked = info.LengthWithDependenciesMet
+	}
+
+	info.LengthWithDependenciesMet -= blocked
+
+	grip.Info(ctx, message.Fields{
+		"message": "adjusted queue for large parser project task limit",
+		"runner":  hostAllocatorJobName,
+		"distro":  distroID,
+		"currently_running_large_parser_proj_tasks": currentlyRunning,
+		"max_large_parser_project_task_limit":       limit,
+		"remaining_capacity":                        remainingCapacity,
+		"distro_s3_tasks_in_queue":                  info.CountLargeParserProjectTasks,
+		"adjusted_length_deps_met":                  info.LengthWithDependenciesMet,
+	})
+
+	return info
 }

--- a/units/host_allocator.go
+++ b/units/host_allocator.go
@@ -475,7 +475,7 @@ func (j *hostAllocatorJob) saveHostStats(ctx context.Context, d *distro.Distro, 
 // adjustForLargeParserProjectLimit reduces the effective queue length when
 // the max concurrent large parser project task limit is hit.
 func adjustForLargeParserProjectLimit(ctx context.Context, distroID string, info model.DistroQueueInfo, config *evergreen.Settings) model.DistroQueueInfo {
-	if info.CountLargeParserProjectTasks == 0 {
+	if info.NumQueuedLargeParserProjectTasks == 0 {
 		return info
 	}
 
@@ -494,17 +494,11 @@ func adjustForLargeParserProjectLimit(ctx context.Context, distroID string, info
 		return info
 	}
 
-	remainingCapacity := limit - currentlyRunning
-	if remainingCapacity < 0 {
-		remainingCapacity = 0
-	}
+	remainingCapacity := max(0, limit-currentlyRunning)
 
-	blocked := info.CountLargeParserProjectTasks - remainingCapacity
+	blocked := info.NumQueuedLargeParserProjectTasks - remainingCapacity
 	if blocked <= 0 {
 		return info
-	}
-	if blocked > info.LengthWithDependenciesMet {
-		blocked = info.LengthWithDependenciesMet
 	}
 
 	info.LengthWithDependenciesMet -= blocked
@@ -516,7 +510,7 @@ func adjustForLargeParserProjectLimit(ctx context.Context, distroID string, info
 		"currently_running_large_parser_proj_tasks": currentlyRunning,
 		"max_large_parser_project_task_limit":       limit,
 		"remaining_capacity":                        remainingCapacity,
-		"distro_s3_tasks_in_queue":                  info.CountLargeParserProjectTasks,
+		"distro_s3_tasks_in_queue":                  info.NumQueuedLargeParserProjectTasks,
 		"adjusted_length_deps_met":                  info.LengthWithDependenciesMet,
 	})
 

--- a/units/host_allocator_test.go
+++ b/units/host_allocator_test.go
@@ -267,6 +267,9 @@ func TestAdjustForLargeParserProjectLimit(t *testing.T) {
 			TaskLimits: evergreen.TaskLimitsConfig{
 				MaxConcurrentLargeParserProjectTasks: 10,
 			},
+			ServiceFlags: evergreen.ServiceFlags{
+				CPUDegradedModeDisabled: true,
+			},
 		}
 		result := adjustForLargeParserProjectLimit(ctx, "distro-1", info, config)
 		assert.Equal(t, 10, result.LengthWithDependenciesMet)
@@ -288,6 +291,9 @@ func TestAdjustForLargeParserProjectLimit(t *testing.T) {
 		config := &evergreen.Settings{
 			TaskLimits: evergreen.TaskLimitsConfig{
 				MaxConcurrentLargeParserProjectTasks: 5,
+			},
+			ServiceFlags: evergreen.ServiceFlags{
+				CPUDegradedModeDisabled: true,
 			},
 		}
 		result := adjustForLargeParserProjectLimit(ctx, "distro-1", info, config)

--- a/units/host_allocator_test.go
+++ b/units/host_allocator_test.go
@@ -260,8 +260,8 @@ func TestAdjustForLargeParserProjectLimit(t *testing.T) {
 			}).Insert(ctx))
 		}
 		info := model.DistroQueueInfo{
-			LengthWithDependenciesMet:    10,
-			CountLargeParserProjectTasks: 5,
+			LengthWithDependenciesMet:        10,
+			NumQueuedLargeParserProjectTasks: 5,
 		}
 		config := &evergreen.Settings{
 			TaskLimits: evergreen.TaskLimitsConfig{
@@ -285,8 +285,8 @@ func TestAdjustForLargeParserProjectLimit(t *testing.T) {
 			}).Insert(ctx))
 		}
 		info := model.DistroQueueInfo{
-			LengthWithDependenciesMet:    10,
-			CountLargeParserProjectTasks: 5,
+			LengthWithDependenciesMet:        10,
+			NumQueuedLargeParserProjectTasks: 5,
 		}
 		config := &evergreen.Settings{
 			TaskLimits: evergreen.TaskLimitsConfig{

--- a/units/host_allocator_test.go
+++ b/units/host_allocator_test.go
@@ -1,6 +1,7 @@
 package units
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -238,6 +240,60 @@ func TestApplyTaskHostOverrides(t *testing.T) {
 		assert.Equal(t, nonZeroOverrides.ProviderAccount, d.ProviderAccount)
 		assert.Empty(t, d.ProviderSettingsList)
 	})
+}
+
+func TestAdjustForLargeParserProjectLimit(t *testing.T) {
+	ctx := testutil.TestSpan(t.Context(), t)
+
+	require.NoError(t, db.ClearCollections(task.Collection))
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(task.Collection))
+	})
+
+	t.Run("NoAdjustmentWhenLimitNotSaturated", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(task.Collection))
+		for i := 0; i < 2; i++ {
+			require.NoError(t, (&task.Task{
+				Id:                         fmt.Sprintf("running-%d", i),
+				Status:                     evergreen.TaskStarted,
+				CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3,
+			}).Insert(ctx))
+		}
+		info := model.DistroQueueInfo{
+			LengthWithDependenciesMet:    10,
+			CountLargeParserProjectTasks: 5,
+		}
+		config := &evergreen.Settings{
+			TaskLimits: evergreen.TaskLimitsConfig{
+				MaxConcurrentLargeParserProjectTasks: 10,
+			},
+		}
+		result := adjustForLargeParserProjectLimit(ctx, "distro-1", info, config)
+		assert.Equal(t, 10, result.LengthWithDependenciesMet)
+	})
+
+	t.Run("ReducesQueueLengthWhenLimitSaturated", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(task.Collection))
+		for i := 0; i < 3; i++ {
+			require.NoError(t, (&task.Task{
+				Id:                         fmt.Sprintf("running-%d", i),
+				Status:                     evergreen.TaskStarted,
+				CachedProjectStorageMethod: evergreen.ProjectStorageMethodS3,
+			}).Insert(ctx))
+		}
+		info := model.DistroQueueInfo{
+			LengthWithDependenciesMet:    10,
+			CountLargeParserProjectTasks: 5,
+		}
+		config := &evergreen.Settings{
+			TaskLimits: evergreen.TaskLimitsConfig{
+				MaxConcurrentLargeParserProjectTasks: 5,
+			},
+		}
+		result := adjustForLargeParserProjectLimit(ctx, "distro-1", info, config)
+		assert.Equal(t, 7, result.LengthWithDependenciesMet)
+	})
+
 }
 
 func TestHostAllocatorJobTaskHostOverrides(t *testing.T) {


### PR DESCRIPTION
DEVPROD-36022

### Description

When `MaxConcurrentLargeParserProjectTasks` limit is hit, the host allocator continues spinning up hosts for tasks that can't be dispatched. This leads to idle hosts accumulating with no work to do (DEVPROD-35404).

### Solution
Before running allocation, check how many large parser project tasks in the distro's queue are blocked by the global limit, and subtract that result from the effective queue length.

### Testing
Added unit tests for the adjustment logic.