### PR TITLE
DEVPROD-36362: fix lint-markdown

### DIFF
--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1342,9 +1342,9 @@ by the Release Infrastructure team, and you may receive assistance with it in
     product: mongosh
     version: 1.0.0
     filenames:
-        - mongosh-linux-amd64.tar.gz
-        - mongosh-linux-arm64.tar.gz
-        - *.zip
+      - mongosh-linux-amd64.tar.gz
+      - mongosh-linux-arm64.tar.gz
+      - *.zip
 ```
 
 Parameters:


### PR DESCRIPTION
DEVPROD-36362

### Description

lint-markdown started failing randomly on a line that's been committed for years. Probably a prettier upgrade changed a linting expectation.

### Testing

lint-markdown passes.