### PR TITLE
DEVPROD-36391 Gate project translation cache behind a service flag 

### DIFF
--- a/config_db.go
+++ b/config_db.go
@@ -98,6 +98,7 @@ var (
 	webhookSecretMigrationEnabledKey      = bsonutil.MustHaveTag(ServiceFlags{}, "WebhookSecretMigrationEnabled")
 	webhookSecretCleanupEnabledKey        = bsonutil.MustHaveTag(ServiceFlags{}, "WebhookSecretCleanupEnabled")
 	retryFailedLogMoveEnabledKey          = bsonutil.MustHaveTag(ServiceFlags{}, "RetryFailedLogMoveEnabled")
+	projectTranslationCacheEnabledKey     = bsonutil.MustHaveTag(ServiceFlags{}, "ProjectTranslationCacheEnabled")
 	secondaryReadsDisabledKey             = bsonutil.MustHaveTag(ServiceFlags{}, "SecondaryReadsDisabled")
 	backgroundCommandFailureEnabledKey    = bsonutil.MustHaveTag(ServiceFlags{}, "BackgroundCommandFailureEnabled")
 	apiRateLimiterDisabledKey             = bsonutil.MustHaveTag(ServiceFlags{}, "APIRateLimiterDisabled")

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -46,6 +46,7 @@ type ServiceFlags struct {
 	WebhookSecretMigrationEnabled      bool `bson:"webhook_secret_migration_enabled" json:"webhook_secret_migration_enabled"`
 	WebhookSecretCleanupEnabled        bool `bson:"webhook_secret_cleanup_enabled" json:"webhook_secret_cleanup_enabled"`
 	RetryFailedLogMoveEnabled          bool `bson:"retry_failed_log_move_enabled" json:"retry_failed_log_move_enabled"`
+	ProjectTranslationCacheEnabled     bool `bson:"project_translation_cache_enabled" json:"project_translation_cache_enabled"`
 
 	// Notification Flags
 	EventProcessingDisabled      bool `bson:"event_processing_disabled" json:"event_processing_disabled"`
@@ -113,6 +114,7 @@ func (c *ServiceFlags) Set(ctx context.Context) error {
 			webhookSecretMigrationEnabledKey:      c.WebhookSecretMigrationEnabled,
 			webhookSecretCleanupEnabledKey:        c.WebhookSecretCleanupEnabled,
 			retryFailedLogMoveEnabledKey:          c.RetryFailedLogMoveEnabled,
+			projectTranslationCacheEnabledKey:     c.ProjectTranslationCacheEnabled,
 			secondaryReadsDisabledKey:             c.SecondaryReadsDisabled,
 			backgroundCommandFailureEnabledKey:    c.BackgroundCommandFailureEnabled,
 			apiRateLimiterDisabledKey:             c.APIRateLimiterDisabled,

--- a/graphql/tests/mutation/setServiceFlags/results.json
+++ b/graphql/tests/mutation/setServiceFlags/results.json
@@ -57,6 +57,7 @@
             { "name": "webhook_secret_migration_enabled", "enabled": false },
             { "name": "webhook_secret_cleanup_enabled", "enabled": false },
             { "name": "retry_failed_log_move_enabled", "enabled": false },
+            { "name": "project_translation_cache_enabled", "enabled": false },
             { "name": "event_processing_disabled", "enabled": false },
             { "name": "jira_notifications_disabled", "enabled": false },
             { "name": "slack_notifications_disabled", "enabled": false },

--- a/graphql/tests/query/adminSettings/results.json
+++ b/graphql/tests/query/adminSettings/results.json
@@ -622,6 +622,7 @@
               { "name": "webhook_secret_migration_enabled", "enabled": false },
               { "name": "webhook_secret_cleanup_enabled", "enabled": false },
               { "name": "retry_failed_log_move_enabled", "enabled": false },
+              { "name": "project_translation_cache_enabled", "enabled": false },
               { "name": "event_processing_disabled", "enabled": false },
               { "name": "jira_notifications_disabled", "enabled": false },
               { "name": "slack_notifications_disabled", "enabled": false },

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -643,8 +643,9 @@ func findAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.
 		pp.Identifier = utility.ToStringPtr(versionIdentifier)
 	}
 
+	cacheEnabled := settings.ServiceFlags.ProjectTranslationCacheEnabled
 	var key string
-	if translationCacheEnabled {
+	if cacheEnabled {
 		var sha string
 		sha, err = parserProjectContentSHA(pp)
 		if err != nil {
@@ -658,7 +659,7 @@ func findAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.
 		// in-flight calls and retains nothing that could go stale.
 		key = versionTranslationKey(versionID, preGeneration)
 	}
-	p, cacheHit, err := getOrComputeTranslation(key, translationCacheEnabled, func() (*Project, error) {
+	p, cacheHit, err := getOrComputeTranslation(key, cacheEnabled, func() (*Project, error) {
 		return TranslateProject(pp)
 	})
 	span.SetAttributes(attribute.Bool(ppTranslationCacheHitOtelAttribute, cacheHit))

--- a/model/project_translate_cache.go
+++ b/model/project_translate_cache.go
@@ -17,7 +17,6 @@ import (
 const (
 	projectTranslationCacheSize = 512
 	projectTranslationCacheTTL  = 30 * time.Minute
-	translationCacheEnabled     = false
 )
 
 var (

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2156,6 +2156,7 @@ type APIServiceFlags struct {
 	WebhookSecretMigrationEnabled      bool `json:"webhook_secret_migration_enabled"`
 	WebhookSecretCleanupEnabled        bool `json:"webhook_secret_cleanup_enabled"`
 	RetryFailedLogMoveEnabled          bool `json:"retry_failed_log_move_enabled"`
+	ProjectTranslationCacheEnabled     bool `json:"project_translation_cache_enabled"`
 
 	// Notifications Flags
 	EventProcessingDisabled      bool `json:"event_processing_disabled"`
@@ -2620,6 +2621,7 @@ func (as *APIServiceFlags) BuildFromService(h any) error {
 		as.WebhookSecretMigrationEnabled = v.WebhookSecretMigrationEnabled
 		as.WebhookSecretCleanupEnabled = v.WebhookSecretCleanupEnabled
 		as.RetryFailedLogMoveEnabled = v.RetryFailedLogMoveEnabled
+		as.ProjectTranslationCacheEnabled = v.ProjectTranslationCacheEnabled
 		as.BackgroundCommandFailureEnabled = v.BackgroundCommandFailureEnabled
 		as.APIRateLimiterDisabled = v.APIRateLimiterDisabled
 		as.GraphQLComplexityLimiterDisabled = v.GraphQLComplexityLimiterDisabled
@@ -2674,6 +2676,7 @@ func (as *APIServiceFlags) ToService() (any, error) {
 		WebhookSecretMigrationEnabled:      as.WebhookSecretMigrationEnabled,
 		WebhookSecretCleanupEnabled:        as.WebhookSecretCleanupEnabled,
 		RetryFailedLogMoveEnabled:          as.RetryFailedLogMoveEnabled,
+		ProjectTranslationCacheEnabled:     as.ProjectTranslationCacheEnabled,
 		BackgroundCommandFailureEnabled:    as.BackgroundCommandFailureEnabled,
 		APIRateLimiterDisabled:             as.APIRateLimiterDisabled,
 		GraphQLComplexityLimiterDisabled:   as.GraphQLComplexityLimiterDisabled,


### PR DESCRIPTION
DEVPROD-36391 

### Description
This swaps the hardcoded flag for a proper service flag so it can be productionized, and toggled off quickly if issues arise. This will still be off when deployed, conversations around turning it on will happen separately. 

### Testing

Added to existing tests 

