### PR TITLE
DEVPROD-36425 Fix TestGetOrComputeTranslation 

### DIFF
--- a/model/project_translate_cache_test.go
+++ b/model/project_translate_cache_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -92,20 +93,19 @@ func TestGetOrComputeTranslation(t *testing.T) {
 	t.Run("CoalescesConcurrentCallsLRUEnabled", func(t *testing.T) {
 		t.Cleanup(resetTranslationCacheForTesting)
 
-		entered := make(chan struct{})
-		release := make(chan struct{})
+		const n = 5
+		var calledCount atomic.Int64
 		var computeCount atomic.Int64
 		compute := func() (*Project, error) {
-			select {
-			case entered <- struct{}{}: // signal first entry
-			default:
+			// Yield until all goroutines have called getOrComputeTranslation so
+			// they are queued in singleflight before compute returns.
+			for calledCount.Load() < n {
+				runtime.Gosched()
 			}
-			<-release
 			computeCount.Add(1)
 			return &Project{Identifier: "coalesced"}, nil
 		}
 
-		const n = 5
 		projs := make([]*Project, n)
 		errs := make([]error, n)
 		var wg sync.WaitGroup
@@ -113,13 +113,11 @@ func TestGetOrComputeTranslation(t *testing.T) {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
+				calledCount.Add(1)
 				projs[i], _, errs[i] = getOrComputeTranslation("k", true, compute)
 			}(i)
 		}
 
-		<-entered                        // first goroutine is inside compute
-		time.Sleep(5 * time.Millisecond) // let remaining goroutines queue in singleflight
-		close(release)
 		wg.Wait()
 
 		assert.Equal(t, int64(1), computeCount.Load(), "concurrent calls should coalesce into one compute")
@@ -132,34 +130,48 @@ func TestGetOrComputeTranslation(t *testing.T) {
 	t.Run("CoalescesConcurrentCallsLRUDisabled", func(t *testing.T) {
 		t.Cleanup(resetTranslationCacheForTesting)
 		// Singleflight coalesces concurrent calls even without the LRU cache.
-		entered := make(chan struct{})
-		release := make(chan struct{})
+		// Unlike the LRU-enabled path, there is no re-check inside Do, so the
+		// test must ensure all followers have reached singleflight.Do before
+		// compute returns. We launch followers only after compute is running,
+		// then sleep briefly after all followers signal so they can enter Do.
+		const n = 5
 		var computeCount atomic.Int64
+
+		computeActive := make(chan struct{})
+		var followerCount atomic.Int64
+
 		compute := func() (*Project, error) {
-			select {
-			case entered <- struct{}{}: // signal first entry
-			default:
+			close(computeActive)
+			for followerCount.Load() < n-1 {
+				runtime.Gosched()
 			}
-			<-release
+			// Give followers time to reach singleflight.Do before returning.
+			time.Sleep(time.Millisecond)
 			computeCount.Add(1)
 			return &Project{Identifier: "coalesced-no-lru"}, nil
 		}
 
-		const n = 5
 		projs := make([]*Project, n)
 		errs := make([]error, n)
 		var wg sync.WaitGroup
-		for i := range n {
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			projs[0], _, errs[0] = getOrComputeTranslation("k", false, compute)
+		}()
+
+		<-computeActive
+
+		for i := 1; i < n; i++ {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
+				followerCount.Add(1)
 				projs[i], _, errs[i] = getOrComputeTranslation("k", false, compute)
 			}(i)
 		}
 
-		<-entered
-		time.Sleep(5 * time.Millisecond)
-		close(release)
 		wg.Wait()
 
 		assert.Equal(t, int64(1), computeCount.Load(), "singleflight coalesces even without LRU")
@@ -173,33 +185,42 @@ func TestGetOrComputeTranslation(t *testing.T) {
 		t.Cleanup(resetTranslationCacheForTesting)
 		// All concurrent singleflight waiters receive the error when compute fails.
 		// The next sequential call must retry (singleflight does not cache errors).
-		entered := make(chan struct{})
-		release := make(chan struct{})
+		const n = 5
 		var computeCount atomic.Int64
+
+		computeActive := make(chan struct{})
+		var followerCount atomic.Int64
+
 		compute := func() (*Project, error) {
-			select {
-			case entered <- struct{}{}:
-			default:
+			close(computeActive)
+			for followerCount.Load() < n-1 {
+				runtime.Gosched()
 			}
-			<-release
+			time.Sleep(time.Millisecond)
 			computeCount.Add(1)
 			return nil, errors.New("compute error")
 		}
 
-		const n = 5
 		errs := make([]error, n)
 		var wg sync.WaitGroup
-		for i := range n {
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, errs[0] = getOrComputeTranslation("k", false, compute)
+		}()
+
+		<-computeActive
+
+		for i := 1; i < n; i++ {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()
+				followerCount.Add(1)
 				_, _, errs[i] = getOrComputeTranslation("k", false, compute)
 			}(i)
 		}
 
-		<-entered
-		time.Sleep(5 * time.Millisecond)
-		close(release)
 		wg.Wait()
 
 		assert.Equal(t, int64(1), computeCount.Load(), "singleflight should coalesce concurrent failed computes")


### PR DESCRIPTION
DEVPROD-36425

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
The problem was that time.Sleep(5ms) was too short to guarantee singleflight coalescing. The fix replaces the sleep with a counter that compute waits on, yielding the CPU via runtime.Gosched() until all goroutines have queued up.

The problem was that goroutines incremented a shared counter before entering singleflight.Do, so compute could see all N counts and return before some goroutines had actually queued up, causing extra compute calls on the LRU-disabled path. The fix launchesthe remaining goroutines only after compute is confirmed running, then waits for all of them to signal and sleeps briefly so they reach singleflight.Do before compute returns.

### Testing
[They pass in CI now ](https://spruce.corp.mongodb.com/version/6a43efe692866e0007f2676c/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

### Documentation

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
