### PR TITLE
DEVPROD-36471 Add dedup-rate and cache size/eviction observability to the project translation cache

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -579,8 +579,19 @@ func FindAndTranslateProjectForPatch(ctx context.Context, settings *evergreen.Se
 const (
 	// ppPreGenerationOtelAttribute records whether a translation used the
 	// pre-generation parser project copy.
-	ppPreGenerationOtelAttribute       = "evergreen.parser_project.pre_generation"
+	ppPreGenerationOtelAttribute = "evergreen.parser_project.pre_generation"
+	// ppTranslationCacheHitOtelAttribute records whether this call reused a translation already
+	// stored in the LRU, so it never had to recompute one at all.
 	ppTranslationCacheHitOtelAttribute = "evergreen.parser_project.translation_cache_hit"
+	// ppTranslationDedupedOtelAttribute records whether this call arrived while another request
+	// for the same version was already translating it, and shared that in-flight result instead
+	// of starting a redundant translation of its own.
+	ppTranslationDedupedOtelAttribute = "evergreen.parser_project.translation_deduped"
+	// ppTranslationCacheSizeOtelAttribute records how many translations the LRU is holding right now.
+	ppTranslationCacheSizeOtelAttribute = "evergreen.parser_project.translation_cache_size"
+	// ppTranslationCacheEvictionsOtelAttribute records the cumulative count of translations the LRU
+	// has dropped to make room for new ones (or because their TTL expired), before anything reused them.
+	ppTranslationCacheEvictionsOtelAttribute = "evergreen.parser_project.translation_cache_evictions"
 )
 
 // FindAndTranslateProjectForVersionID translates a parser project for a version into a Project.
@@ -659,10 +670,20 @@ func findAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.
 		// in-flight calls and retains nothing that could go stale.
 		key = versionTranslationKey(versionID, preGeneration)
 	}
-	p, cacheHit, err := getOrComputeTranslation(key, cacheEnabled, func() (*Project, error) {
+	p, cacheHit, deduped, err := getOrComputeTranslation(key, cacheEnabled, func() (*Project, error) {
 		return TranslateProject(pp)
 	})
-	span.SetAttributes(attribute.Bool(ppTranslationCacheHitOtelAttribute, cacheHit))
+	span.SetAttributes(
+		attribute.Bool(ppTranslationCacheHitOtelAttribute, cacheHit),
+		attribute.Bool(ppTranslationDedupedOtelAttribute, deduped),
+	)
+	if cacheEnabled {
+		size, evictions := translationCacheStats()
+		span.SetAttributes(
+			attribute.Int(ppTranslationCacheSizeOtelAttribute, size),
+			attribute.Int64(ppTranslationCacheEvictionsOtelAttribute, evictions),
+		)
+	}
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "translating parser project '%s'", versionID)
 	}

--- a/model/project_translate_cache.go
+++ b/model/project_translate_cache.go
@@ -20,9 +20,10 @@ const (
 )
 
 var (
-	translationCacheMu  sync.Mutex
-	translationCache    *expirable.LRU[string, *Project]
-	translationGroupPtr atomic.Pointer[singleflight.Group]
+	translationCacheMu        sync.Mutex
+	translationCache          *expirable.LRU[string, *Project]
+	translationGroupPtr       atomic.Pointer[singleflight.Group]
+	translationCacheEvictions atomic.Int64
 )
 
 func init() {
@@ -34,22 +35,35 @@ func getTranslationCache() *expirable.LRU[string, *Project] {
 	translationCacheMu.Lock()
 	defer translationCacheMu.Unlock()
 	if translationCache == nil {
-		translationCache = expirable.NewLRU[string, *Project](projectTranslationCacheSize, nil, projectTranslationCacheTTL)
+		translationCache = expirable.NewLRU[string, *Project](projectTranslationCacheSize, func(_ string, _ *Project) {
+			translationCacheEvictions.Add(1)
+		}, projectTranslationCacheTTL)
 	}
 	return translationCache
+}
+
+// translationCacheStats returns the LRU's current entry count and its cumulative eviction count
+// (including TTL expirations, which expirable.LRU reports through the same callback).
+func translationCacheStats() (size int, evictions int64) {
+	return getTranslationCache().Len(), translationCacheEvictions.Load()
 }
 
 // getOrComputeTranslation coalesces concurrent calls via singleflight and, when cacheEnabled, also
 // serves and stores results in a per-process LRU. When cacheEnabled, key must capture every input
 // that determines the translation. The cached *Project is shared and must not be mutated.
-func getOrComputeTranslation(key string, cacheEnabled bool, compute func() (*Project, error)) (*Project, bool, error) {
+//
+// deduped reports whether this call's singleflight request was coalesced into another in-flight
+// call for the same key; it is meaningful whether or not the cache is enabled. cacheHit reports
+// whether the result was served from the LRU without calling compute at all, which is only
+// possible when the cache is enabled. The two are orthogonal.
+func getOrComputeTranslation(key string, cacheEnabled bool, compute func() (*Project, error)) (project *Project, cacheHit bool, deduped bool, err error) {
 	if cacheEnabled {
 		if v, ok := getTranslationCache().Get(key); ok {
-			return v, true, nil
+			return v, true, false, nil
 		}
 	}
 
-	v, err, _ := translationGroupPtr.Load().Do(key, func() (any, error) {
+	v, err, shared := translationGroupPtr.Load().Do(key, func() (any, error) {
 		// Re-check after winning the singleflight slot: another goroutine may
 		// have populated the cache while we were waiting.
 		if cacheEnabled {
@@ -67,9 +81,9 @@ func getOrComputeTranslation(key string, cacheEnabled bool, compute func() (*Pro
 		return result, nil
 	})
 	if err != nil {
-		return nil, false, err
+		return nil, false, shared, err
 	}
-	return v.(*Project), false, nil
+	return v.(*Project), false, shared, nil
 }
 
 // versionTranslationKey is the cheap singleflight key for the cache-disabled path. It must NOT be

--- a/model/project_translate_cache_test.go
+++ b/model/project_translate_cache_test.go
@@ -22,6 +22,7 @@ func resetTranslationCacheForTesting() {
 	translationCache = nil
 	translationCacheMu.Unlock()
 	translationGroupPtr.Store(&singleflight.Group{})
+	translationCacheEvictions.Store(0)
 }
 
 func TestGetOrComputeTranslation(t *testing.T) {
@@ -35,14 +36,16 @@ func TestGetOrComputeTranslation(t *testing.T) {
 			return &Project{Identifier: "test"}, nil
 		}
 
-		p1, hit1, err := getOrComputeTranslation("k", false, compute)
+		p1, hit1, deduped1, err := getOrComputeTranslation("k", false, compute)
 		require.NoError(t, err)
-		p2, hit2, err := getOrComputeTranslation("k", false, compute)
+		p2, hit2, deduped2, err := getOrComputeTranslation("k", false, compute)
 		require.NoError(t, err)
 
 		assert.Equal(t, 2, callCount)
 		assert.False(t, hit1, "cache disabled, never a hit")
 		assert.False(t, hit2, "cache disabled, never a hit")
+		assert.False(t, deduped1, "uncontended call is never deduped")
+		assert.False(t, deduped2, "uncontended call is never deduped")
 		assert.Equal(t, "test", p1.Identifier)
 		assert.Equal(t, "test", p2.Identifier)
 	})
@@ -56,14 +59,16 @@ func TestGetOrComputeTranslation(t *testing.T) {
 			return &Project{Identifier: "cached"}, nil
 		}
 
-		p1, hit1, err := getOrComputeTranslation("k", true, compute)
+		p1, hit1, deduped1, err := getOrComputeTranslation("k", true, compute)
 		require.NoError(t, err)
-		p2, hit2, err := getOrComputeTranslation("k", true, compute)
+		p2, hit2, deduped2, err := getOrComputeTranslation("k", true, compute)
 		require.NoError(t, err)
 
 		assert.Equal(t, 1, callCount, "second call should be served from cache")
 		assert.False(t, hit1, "first call computes")
 		assert.True(t, hit2, "second call is an LRU hit")
+		assert.False(t, deduped1, "uncontended call is never deduped")
+		assert.False(t, deduped2, "an LRU hit returns before singleflight is ever invoked")
 		assert.Equal(t, "cached", p1.Identifier)
 		assert.Equal(t, "cached", p2.Identifier)
 	})
@@ -80,10 +85,10 @@ func TestGetOrComputeTranslation(t *testing.T) {
 			return &Project{Identifier: "retry"}, nil
 		}
 
-		_, _, err := getOrComputeTranslation("k", true, compute)
+		_, _, _, err := getOrComputeTranslation("k", true, compute)
 		require.Error(t, err)
 
-		p, _, err := getOrComputeTranslation("k", true, compute)
+		p, _, _, err := getOrComputeTranslation("k", true, compute)
 		require.NoError(t, err)
 
 		assert.Equal(t, 2, callCount, "error result must not be cached")
@@ -114,7 +119,7 @@ func TestGetOrComputeTranslation(t *testing.T) {
 			go func(i int) {
 				defer wg.Done()
 				calledCount.Add(1)
-				projs[i], _, errs[i] = getOrComputeTranslation("k", true, compute)
+				projs[i], _, _, errs[i] = getOrComputeTranslation("k", true, compute)
 			}(i)
 		}
 
@@ -152,13 +157,14 @@ func TestGetOrComputeTranslation(t *testing.T) {
 		}
 
 		projs := make([]*Project, n)
+		dedupedFlags := make([]bool, n)
 		errs := make([]error, n)
 		var wg sync.WaitGroup
 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			projs[0], _, errs[0] = getOrComputeTranslation("k", false, compute)
+			projs[0], _, dedupedFlags[0], errs[0] = getOrComputeTranslation("k", false, compute)
 		}()
 
 		<-computeActive
@@ -168,7 +174,7 @@ func TestGetOrComputeTranslation(t *testing.T) {
 			go func(i int) {
 				defer wg.Done()
 				followerCount.Add(1)
-				projs[i], _, errs[i] = getOrComputeTranslation("k", false, compute)
+				projs[i], _, dedupedFlags[i], errs[i] = getOrComputeTranslation("k", false, compute)
 			}(i)
 		}
 
@@ -178,6 +184,9 @@ func TestGetOrComputeTranslation(t *testing.T) {
 		for i := range n {
 			require.NoError(t, errs[i])
 			assert.Equal(t, "coalesced-no-lru", projs[i].Identifier)
+			// singleflight.Do reports shared=true to the leader too once at least
+			// one follower has joined its in-flight call, not just to the followers.
+			assert.True(t, dedupedFlags[i], "every caller's request overlapped with another for the same key")
 		}
 	})
 
@@ -207,7 +216,7 @@ func TestGetOrComputeTranslation(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, _, errs[0] = getOrComputeTranslation("k", false, compute)
+			_, _, _, errs[0] = getOrComputeTranslation("k", false, compute)
 		}()
 
 		<-computeActive
@@ -217,7 +226,7 @@ func TestGetOrComputeTranslation(t *testing.T) {
 			go func(i int) {
 				defer wg.Done()
 				followerCount.Add(1)
-				_, _, errs[i] = getOrComputeTranslation("k", false, compute)
+				_, _, _, errs[i] = getOrComputeTranslation("k", false, compute)
 			}(i)
 		}
 
@@ -229,7 +238,7 @@ func TestGetOrComputeTranslation(t *testing.T) {
 		}
 
 		// Error must not be cached — the next sequential call should retry.
-		p, _, err := getOrComputeTranslation("k", false, func() (*Project, error) {
+		p, _, _, err := getOrComputeTranslation("k", false, func() (*Project, error) {
 			return &Project{Identifier: "retry"}, nil
 		})
 		require.NoError(t, err)
@@ -245,9 +254,9 @@ func TestGetOrComputeTranslation(t *testing.T) {
 			return &Project{Tasks: []ProjectTask{{Name: "t1", DependsOn: []TaskUnitDependency{{Name: "dep"}}}}}, nil
 		}
 
-		p1, _, err := getOrComputeTranslation("k", true, compute)
+		p1, _, _, err := getOrComputeTranslation("k", true, compute)
 		require.NoError(t, err)
-		p2, _, err := getOrComputeTranslation("k", true, compute)
+		p2, _, _, err := getOrComputeTranslation("k", true, compute)
 		require.NoError(t, err)
 
 		p1.Tasks[0].DependsOn = nil
@@ -263,7 +272,7 @@ func TestGetOrComputeTranslation(t *testing.T) {
 		}
 
 		// Warm the cache so all subsequent callers receive the cached pointer.
-		_, _, err := getOrComputeTranslation("k", true, compute)
+		_, _, _, err := getOrComputeTranslation("k", true, compute)
 		require.NoError(t, err)
 
 		var wg sync.WaitGroup
@@ -271,7 +280,7 @@ func TestGetOrComputeTranslation(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				p, _, err := getOrComputeTranslation("k", true, compute)
+				p, _, _, err := getOrComputeTranslation("k", true, compute)
 				require.NoError(t, err)
 				_ = p.Identifier
 				_ = len(p.Tasks)
@@ -279,6 +288,31 @@ func TestGetOrComputeTranslation(t *testing.T) {
 		}
 		wg.Wait()
 	})
+}
+
+func TestTranslationCacheStats(t *testing.T) {
+	t.Cleanup(resetTranslationCacheForTesting)
+
+	getTranslationCache().Resize(1)
+
+	var callCount int
+	compute := func() (*Project, error) {
+		callCount++
+		return &Project{Identifier: "stats"}, nil
+	}
+
+	_, _, _, err := getOrComputeTranslation("k1", true, compute)
+	require.NoError(t, err)
+	size, evictions := translationCacheStats()
+	assert.Equal(t, 1, size)
+	assert.Equal(t, int64(0), evictions, "no eviction yet, the single entry still fits")
+
+	// Adding a second entry evicts the first because the LRU was resized down to 1.
+	_, _, _, err = getOrComputeTranslation("k2", true, compute)
+	require.NoError(t, err)
+	size, evictions = translationCacheStats()
+	assert.Equal(t, 1, size, "capacity is still 1")
+	assert.Equal(t, int64(1), evictions, "adding past capacity evicted the older entry")
 }
 
 // TestContentTranslationKeySelfInvalidates shows that changed content yields a new key, so a stale
@@ -291,14 +325,14 @@ func TestContentTranslationKeySelfInvalidates(t *testing.T) {
 	keyAfter := contentTranslationKey("sha-after-generate", identifier)
 	require.NotEqual(t, keyBefore, keyAfter, "changed content must produce a different key")
 
-	pBefore, _, err := getOrComputeTranslation(keyBefore, true, func() (*Project, error) {
+	pBefore, _, _, err := getOrComputeTranslation(keyBefore, true, func() (*Project, error) {
 		return &Project{Identifier: identifier, Tasks: []ProjectTask{{Name: "original"}}}, nil
 	})
 	require.NoError(t, err)
 	require.Len(t, pBefore.Tasks, 1)
 
 	// generate.tasks rewrites the parser project: new content, new key, served fresh.
-	pAfter, hit, err := getOrComputeTranslation(keyAfter, true, func() (*Project, error) {
+	pAfter, hit, _, err := getOrComputeTranslation(keyAfter, true, func() (*Project, error) {
 		return &Project{Identifier: identifier, Tasks: []ProjectTask{{Name: "original"}, {Name: "generated"}}}, nil
 	})
 	require.NoError(t, err)
@@ -439,13 +473,13 @@ func TestParserProjectContentSHASelfInvalidation(t *testing.T) {
 	require.NoError(t, err)
 	key := contentTranslationKey(sha, identifier)
 
-	_, hit, err := getOrComputeTranslation(key, true, func() (*Project, error) {
+	_, hit, _, err := getOrComputeTranslation(key, true, func() (*Project, error) {
 		return &Project{Identifier: identifier, Tasks: []ProjectTask{{Name: "original-task"}}}, nil
 	})
 	require.NoError(t, err)
 	assert.False(t, hit, "first call is a cache miss")
 
-	_, hit, err = getOrComputeTranslation(key, true, func() (*Project, error) {
+	_, hit, _, err = getOrComputeTranslation(key, true, func() (*Project, error) {
 		t.Fatal("compute must not be called on a cache hit")
 		return nil, nil
 	})
@@ -462,7 +496,7 @@ func TestParserProjectContentSHASelfInvalidation(t *testing.T) {
 	require.NotEqual(t, sha, shaGenerated, "new content must produce a different hash")
 	keyGenerated := contentTranslationKey(shaGenerated, identifier)
 
-	pGenerated, hit, err := getOrComputeTranslation(keyGenerated, true, func() (*Project, error) {
+	pGenerated, hit, _, err := getOrComputeTranslation(keyGenerated, true, func() (*Project, error) {
 		return &Project{Identifier: identifier, Tasks: []ProjectTask{{Name: "original-task"}, {Name: "generated-task"}}}, nil
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
DEVPROD-36471 

### Description
This adds some metrics that will help us understand how well the cache is doing beyond what we can see from pprof data. 

It adds two telemetry signals to the project translation cache: an otel span attribute recording whether a request's translation was coalesced into another in-flight request for the same version (singleflight dedup), and attributes recording the LRU's current size and cumulative eviction count. It does this because neither signal exists today, and without them we can't tell whether singleflight is actually collapsing concurrent duplicate work in production, or, once the LRU is enabled, whether a low hit rate means expected invalidation churn versus the cache being undersized.

### Testing

Added tests 

### Documentation

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
