### PR TITLE
DEVPROD-36091: Batch task and build queries in add-new-tasks

### DIFF
--- a/model/build/build.go
+++ b/model/build/build.go
@@ -187,16 +187,6 @@ func (b *Build) SetAllTasksBlocked(ctx context.Context, blocked bool) error {
 	)
 }
 
-// SetTasksCache updates one build with the given id
-// to contain the given task caches.
-func SetTasksCache(ctx context.Context, buildId string, tasks []TaskCache) error {
-	return UpdateOne(
-		ctx,
-		bson.M{IdKey: buildId},
-		bson.M{"$set": bson.M{TasksKey: tasks}},
-	)
-}
-
 func (b *Build) UpdateGithubCheckStatus(ctx context.Context, status string) error {
 	if b.GithubCheckStatus == status {
 		return nil

--- a/model/build/build_test.go
+++ b/model/build/build_test.go
@@ -268,6 +268,44 @@ func TestBuildSetHasUnfinishedEssentialTask(t *testing.T) {
 	}
 }
 
+func TestSetTasksCaches(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(Collection))
+	}()
+
+	t.Run("NoopsWithEmptyMap", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(Collection))
+		assert.NoError(t, SetTasksCaches(t.Context(), nil))
+	})
+
+	t.Run("SetsDistinctCachesPerBuild", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(Collection))
+		b0 := Build{Id: "b0"}
+		b1 := Build{Id: "b1"}
+		require.NoError(t, b0.Insert(t.Context()))
+		require.NoError(t, b1.Insert(t.Context()))
+
+		tasksByBuild := map[string][]TaskCache{
+			"b0": {{Id: "t0"}},
+			"b1": {{Id: "t1a"}, {Id: "t1b"}},
+		}
+		require.NoError(t, SetTasksCaches(t.Context(), tasksByBuild))
+
+		dbBuild0, err := FindOneId(t.Context(), "b0")
+		require.NoError(t, err)
+		require.NotNil(t, dbBuild0)
+		require.Len(t, dbBuild0.Tasks, 1)
+		assert.Equal(t, "t0", dbBuild0.Tasks[0].Id)
+
+		dbBuild1, err := FindOneId(t.Context(), "b1")
+		require.NoError(t, err)
+		require.NotNil(t, dbBuild1)
+		require.Len(t, dbBuild1.Tasks, 2)
+		assert.Equal(t, "t1a", dbBuild1.Tasks[0].Id)
+		assert.Equal(t, "t1b", dbBuild1.Tasks[1].Id)
+	})
+}
+
 func TestBulkInsert(t *testing.T) {
 	assert.NoError(t, db.ClearCollections(Collection))
 	builds := Builds{

--- a/model/build/db.go
+++ b/model/build/db.go
@@ -11,6 +11,8 @@ import (
 	adb "github.com/mongodb/anser/db"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // The MongoDB collection for build documents.
@@ -172,6 +174,23 @@ func UpdateAllBuilds(ctx context.Context, query any, update any) error {
 		update,
 	)
 	return err
+}
+
+// SetTasksCaches sets the task cache for multiple builds in a single bulk write,
+// where the keys of tasksByBuild are build IDs and the values are the task
+// caches to set for each build.
+func SetTasksCaches(ctx context.Context, tasksByBuild map[string][]TaskCache) error {
+	if len(tasksByBuild) == 0 {
+		return nil
+	}
+	writes := make([]mongo.WriteModel, 0, len(tasksByBuild))
+	for buildID, tasks := range tasksByBuild {
+		writes = append(writes, mongo.NewUpdateOneModel().
+			SetFilter(bson.M{IdKey: buildID}).
+			SetUpdate(bson.M{"$set": bson.M{TasksKey: tasks}}))
+	}
+	_, err := evergreen.GetEnvironment().DB().Collection(Collection).BulkWrite(ctx, writes, options.BulkWrite().SetOrdered(false))
+	return errors.Wrap(err, "bulk updating task caches")
 }
 
 func FindProjectForBuild(ctx context.Context, buildID string) (string, error) {

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -484,7 +484,7 @@ func RefreshTasksCache(ctx context.Context, buildIDs []string) error {
 		tasksByBuild[t.BuildId] = append(tasksByBuild[t.BuildId], t)
 	}
 
-	catcher := grip.NewBasicCatcher()
+	cachesByBuild := make(map[string][]build.TaskCache, len(buildIDs))
 	for _, buildID := range buildIDs {
 		buildTasks := tasksByBuild[buildID]
 		// trim out tasks that are part of a display task
@@ -502,10 +502,9 @@ func RefreshTasksCache(ctx context.Context, buildIDs []string) error {
 			}
 		}
 
-		cache := CreateTasksCache(buildTasks)
-		catcher.Wrapf(build.SetTasksCache(ctx, buildID, cache), "updating task cache for '%s'", buildID)
+		cachesByBuild[buildID] = CreateTasksCache(buildTasks)
 	}
-	return catcher.Resolve()
+	return errors.Wrap(build.SetTasksCaches(ctx, cachesByBuild), "updating task caches for builds")
 }
 
 // addTasksToBuild creates/activates the tasks for the given existing build.

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -509,11 +509,11 @@ func RefreshTasksCache(ctx context.Context, buildIDs []string) error {
 }
 
 // addTasksToBuild creates/activates the tasks for the given existing build.
-func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build.Build, task.Tasks, error) {
+func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build.Build, task.Tasks, bool, bool, error) {
 	// Find the build variant for this project/build
 	creationInfo.BuildVariant = creationInfo.Project.FindBuildVariant(creationInfo.Build.BuildVariant)
 	if creationInfo.BuildVariant == nil {
-		return nil, nil, errors.Errorf("could not find build '%s' in project file '%s'",
+		return nil, nil, false, false, errors.Errorf("could not find build '%s' in project file '%s'",
 			creationInfo.Build.BuildVariant, creationInfo.Project.Identifier)
 	}
 
@@ -532,7 +532,7 @@ func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build
 	// Create the new tasks for the build
 	tasks, err := createTasksForBuild(ctx, creationInfo)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "creating tasks for build '%s'", creationInfo.Build.Id)
+		return nil, nil, false, false, errors.Wrapf(err, "creating tasks for build '%s'", creationInfo.Build.Id)
 	}
 
 	var hasGitHubCheck bool
@@ -544,14 +544,6 @@ func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build
 		if t.IsEssentialToSucceed {
 			hasUnfinishedEssentialTask = true
 		}
-	}
-	if hasGitHubCheck {
-		if err := creationInfo.Build.SetIsGithubCheck(ctx); err != nil {
-			return nil, nil, errors.Wrapf(err, "setting build '%s' as a GitHub check", creationInfo.Build.Id)
-		}
-	}
-	if err := creationInfo.Build.SetHasUnfinishedEssentialTask(ctx, hasUnfinishedEssentialTask); err != nil {
-		return nil, nil, errors.Wrapf(err, "setting build '%s' as having an unfinished essential task", creationInfo.Build.Id)
 	}
 
 	batchTimeTaskStatuses := []BatchTimeTaskStatus{}
@@ -580,7 +572,7 @@ func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build
 	}
 
 	if _, err := creationInfo.Version.GetBuildVariants(ctx); err != nil {
-		return nil, nil, errors.Wrapf(err, "getting build variant info for version '%s'", creationInfo.Version.Id)
+		return nil, nil, false, false, errors.Wrapf(err, "getting build variant info for version '%s'", creationInfo.Version.Id)
 	}
 	// update the build in the variant
 	for i, status := range creationInfo.Version.BuildVariants {
@@ -596,7 +588,7 @@ func addTasksToBuild(ctx context.Context, creationInfo TaskCreationInfo) (*build
 		"version": creationInfo.Version.Id,
 	}))
 
-	return creationInfo.Build, tasks, nil
+	return creationInfo.Build, tasks, hasGitHubCheck, hasUnfinishedEssentialTask, nil
 }
 
 // CreateBuildFromVersionNoInsert creates a build given all of the necessary information
@@ -1670,18 +1662,31 @@ func addNewTasksToExistingBuilds(ctx context.Context, creationInfo TaskCreationI
 	}
 	creationInfo.TaskCreateTime = createTime
 
+	existingBuildIDs := make([]string, 0, len(existingBuilds))
+	for _, b := range existingBuilds {
+		existingBuildIDs = append(existingBuildIDs, b.Id)
+	}
+	allExistingTasks, err := task.FindAll(ctx, db.Query(task.ByBuildIds(existingBuildIDs)).WithFields(task.BuildIdKey, task.DisplayNameKey, task.ActivatedKey))
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "finding existing tasks for builds")
+	}
+	existingTasksByBuild := map[string][]task.Task{}
+	for _, t := range allExistingTasks {
+		existingTasksByBuild[t.BuildId] = append(existingTasksByBuild[t.BuildId], t)
+	}
+
 	activatedTaskIds := []string{}
 	activatedTasks := []task.Task{}
 	allTasks := task.Tasks{}
 	var buildIdsToActivate []string
 	var buildIdsToRefresh []string
+	var buildIdsToSetGithubCheck []string
+	var buildIdsToSetEssentialTask []string
+	var buildIdsToUnsetEssentialTask []string
 	for _, b := range existingBuilds {
 		wasActivated := b.Activated
 		// Find the set of task names that already exist for the given build, including display tasks.
-		tasksInBuild, err := task.FindAll(ctx, db.Query(task.ByBuildId(b.Id)).WithFields(task.DisplayNameKey, task.ActivatedKey))
-		if err != nil {
-			return nil, nil, err
-		}
+		tasksInBuild := existingTasksByBuild[b.Id]
 		existingTasksIndex := map[string]bool{}
 		hasActivatedTask := false
 		for _, t := range tasksInBuild {
@@ -1722,9 +1727,20 @@ func addNewTasksToExistingBuilds(ctx context.Context, creationInfo TaskCreationI
 		creationInfo.DisplayNames = displayTasksToAdd
 		creationInfo.DistroAliases = distroAliases
 		creationInfo.TestSelectionParams.CanBuildVariantEnableTestSelection = canBuildVariantEnableTestSelection(b.BuildVariant, creationInfo)
-		_, tasks, err := addTasksToBuild(ctx, creationInfo)
+		_, tasks, hasGitHubCheck, hasUnfinishedEssentialTask, err := addTasksToBuild(ctx, creationInfo)
 		if err != nil {
 			return nil, nil, err
+		}
+
+		if hasGitHubCheck && !b.IsGithubCheck {
+			buildIdsToSetGithubCheck = append(buildIdsToSetGithubCheck, b.Id)
+		}
+		if hasUnfinishedEssentialTask != b.HasUnfinishedEssentialTask {
+			if hasUnfinishedEssentialTask {
+				buildIdsToSetEssentialTask = append(buildIdsToSetEssentialTask, b.Id)
+			} else {
+				buildIdsToUnsetEssentialTask = append(buildIdsToUnsetEssentialTask, b.Id)
+			}
 		}
 
 		// This build received new tasks, so its tasks cache must be refreshed.
@@ -1751,6 +1767,30 @@ func addNewTasksToExistingBuilds(ctx context.Context, creationInfo TaskCreationI
 		attribute.Int(numTasksAddedAttribute, len(allTasks)),
 		attribute.Int(numActivatedTasksAttribute, len(activatedTaskIds)),
 	)
+
+	buildFlagCatcher := grip.NewBasicCatcher()
+	if len(buildIdsToSetGithubCheck) > 0 {
+		buildFlagCatcher.Wrap(build.UpdateAllBuilds(ctx,
+			bson.M{build.IdKey: bson.M{"$in": buildIdsToSetGithubCheck}},
+			bson.M{"$set": bson.M{build.IsGithubCheckKey: true}},
+		), "setting builds as GitHub checks")
+	}
+	if len(buildIdsToSetEssentialTask) > 0 {
+		buildFlagCatcher.Wrap(build.UpdateAllBuilds(ctx,
+			bson.M{build.IdKey: bson.M{"$in": buildIdsToSetEssentialTask}},
+			bson.M{"$set": bson.M{build.HasUnfinishedEssentialTaskKey: true}},
+		), "setting builds as having an unfinished essential task")
+	}
+	if len(buildIdsToUnsetEssentialTask) > 0 {
+		buildFlagCatcher.Wrap(build.UpdateAllBuilds(ctx,
+			bson.M{build.IdKey: bson.M{"$in": buildIdsToUnsetEssentialTask}},
+			bson.M{"$set": bson.M{build.HasUnfinishedEssentialTaskKey: false}},
+		), "setting builds as not having an unfinished essential task")
+	}
+	if buildFlagCatcher.HasErrors() {
+		return nil, nil, buildFlagCatcher.Resolve()
+	}
+
 	SetNumDependents(allTasks)
 	if err = allTasks.InsertUnordered(ctx); err != nil {
 		return nil, nil, errors.Wrap(err, "inserting tasks")

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -3103,6 +3103,62 @@ func TestAddNewTasks(t *testing.T) {
 	}
 }
 
+func TestAddNewTasksBatchesBuildFlagUpdates(t *testing.T) {
+	ctx := t.Context()
+	require.NoError(t, db.ClearCollections(VersionCollection, build.Collection, task.Collection))
+	defer func() {
+		assert.NoError(t, db.ClearCollections(VersionCollection, build.Collection, task.Collection))
+	}()
+
+	buildIDs := []string{"b0", "b1", "b2"}
+	builds := []build.Build{
+		{Id: "b0", BuildVariant: "bv0", Version: "v0", Activated: true},
+		{Id: "b1", BuildVariant: "bv1", Version: "v0", Activated: true},
+		{Id: "b2", BuildVariant: "bv2", Version: "v0", Activated: true},
+	}
+	for _, b := range builds {
+		require.NoError(t, b.Insert(ctx))
+	}
+
+	v := &Version{Id: "v0", BuildIds: buildIDs}
+	require.NoError(t, v.Insert(ctx))
+
+	project := Project{
+		BuildVariants: []BuildVariant{
+			{Name: "bv0", Tasks: []BuildVariantTaskUnit{{Name: "t1", Variant: "bv0", RunOn: []string{"d0"}}}},
+			{Name: "bv1", Tasks: []BuildVariantTaskUnit{{Name: "t1", Variant: "bv1", RunOn: []string{"d0"}}}},
+			{Name: "bv2", Tasks: []BuildVariantTaskUnit{{Name: "t1", Variant: "bv2", RunOn: []string{"d0"}}}},
+		},
+		Tasks: []ProjectTask{{Name: "t1"}},
+	}
+	pairs := TaskVariantPairs{ExecTasks: []TVPair{
+		{Variant: "bv0", TaskName: "t1"},
+		{Variant: "bv1", TaskName: "t1"},
+		{Variant: "bv2", TaskName: "t1"},
+	}}
+	creationInfo := TaskCreationInfo{
+		Project:                             &project,
+		ProjectRef:                          &ProjectRef{},
+		Version:                             v,
+		Pairs:                               pairs,
+		ActivatedTasksAreEssentialToSucceed: true,
+	}
+
+	_, _, err := addNewTasksToExistingBuilds(ctx, creationInfo, builds, "")
+	require.NoError(t, err)
+
+	for _, id := range buildIDs {
+		dbBuild, err := build.FindOneId(ctx, id)
+		require.NoError(t, err)
+		require.NotNil(t, dbBuild)
+		assert.True(t, dbBuild.HasUnfinishedEssentialTask, "build '%s' should be flagged as having an unfinished essential task", id)
+
+		tasksInBuild, err := task.FindAll(ctx, db.Query(bson.M{task.BuildIdKey: id}))
+		require.NoError(t, err)
+		assert.Len(t, tasksInBuild, 1, "build '%s' should have its new task created", id)
+	}
+}
+
 func TestCanBuildVariantEnableTestSelection(t *testing.T) {
 	t.Run("ReturnsTrueIfBVIncludedInTestSelection", func(t *testing.T) {
 		creationInfo := TaskCreationInfo{


### PR DESCRIPTION
DEVPROD-36091

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->
Follow-up to #10390 
- Look up the existing tasks for all builds in a single query instead of once per build
- Update the "is GitHub check" and "has unfinished required task" flags once instead of per build
- Use one write to refresh the task lists of all builds

### Testing

<!--add a description of how you tested it-->
- [Staging span](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/odRZdY5FvzC/trace/x5v1z36LE7o?fields[]=s_name&fields[]=s_serviceName&span=3335ea60851a6544) with 18 child spans; all O(n) DB operations have been removed

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
