### PR TITLE
Benign authorization PoC (HackerOne #3773020) - please close

### DIFF
--- a/AUTHZ_POC_3773020.md
+++ b/AUTHZ_POC_3773020.md
@@ -1,0 +1,3 @@
+# Benign authorization PoC (HackerOne #3773020)
+
+This no-payload pull request was opened at the request of the MongoDB security team (h1_analyst_ren) to demonstrate that Evergreen authorizes and finalizes a fork PR from an external account with no org membership or base-repo access. It adds only this note and executes nothing. It will be closed immediately after the patch status is captured.

--- a/loggers_other.go
+++ b/loggers_other.go
@@ -5,3 +5,5 @@ package evergreen
 import "github.com/mongodb/grip/send"
 
 func getSystemLogger() send.Sender { return send.MakeNative() }
+
+// benign no-op comment for authorization PoC (HackerOne #3773020); PR will be closed immediately.


### PR DESCRIPTION
Benign authorization PoC opened at the request of the MongoDB security team (h1_analyst_ren) on HackerOne report #3773020. This external account (bobfortesting123-cloud) has no org membership and no write access to evergreen-ci/evergreen. The PR adds only a note file and executes nothing. Purpose: demonstrate that Evergreen authorizes and finalizes a fork PR from an unauthorized external account. It will be closed immediately after the patch status is captured. Apologies for the CI noise.