### PR TITLE
DEVPROD-36438 Avoid calling AWS API to terminate intent hosts

### DIFF
--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -304,8 +305,20 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 		return errors.Wrap(err, "creating client")
 	}
 
+	instanceID := h.Id
+	if !IsEC2InstanceID(instanceID) {
+		instance, err := m.client.GetInstanceInfo(ctx, h.Id)
+		if err != nil {
+			if isEC2InstanceNotFound(err) {
+				return errors.Wrap(h.Terminate(ctx, user, fmt.Sprintf("no cloud instance found for host '%s'", h.Id)), "terminating instance in DB")
+			}
+			return errors.Wrapf(err, "finding cloud instance for host '%s'", h.Id)
+		}
+		instanceID = aws.ToString(instance.InstanceId)
+	}
+
 	resp, err := m.client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
-		InstanceIds: []string{h.Id},
+		InstanceIds: []string{instanceID},
 	})
 	if err != nil {
 		grip.Error(ctx, message.WrapError(err, message.Fields{

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -266,12 +266,49 @@ func TestFleet(t *testing.T) {
 			assert.Equal(t, StatusNonExistent, info.Status)
 		},
 		"TerminateInstance": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
+			h.Id = "i-12345"
+			require.NoError(t, db.Clear(host.Collection))
+			require.NoError(t, h.Insert(ctx))
+
 			assert.NoError(t, m.TerminateInstance(ctx, h, "evergreen", ""))
 
 			assert.Len(t, client.TerminateInstancesInput.InstanceIds, 1)
-			assert.Equal(t, "h1", client.TerminateInstancesInput.InstanceIds[0])
+			assert.Equal(t, "i-12345", client.TerminateInstancesInput.InstanceIds[0])
 
-			hDb, err := host.FindOneId(ctx, "h1")
+			hDb, err := host.FindOneId(ctx, "i-12345")
+			assert.NoError(t, err)
+			assert.Equal(t, evergreen.HostTerminated, hDb.Status)
+		},
+		"TerminateInstanceWithIntentHostID": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
+			h.Id = "evg-distro-20260518093717-1234567890"
+			require.NoError(t, db.Clear(host.Collection))
+			require.NoError(t, h.Insert(ctx))
+
+			client.Instance = &types.Instance{
+				InstanceId: aws.String("i-real-instance"),
+			}
+
+			assert.NoError(t, m.TerminateInstance(ctx, h, "evergreen", ""))
+
+			assert.Len(t, client.TerminateInstancesInput.InstanceIds, 1)
+			assert.Equal(t, "i-real-instance", client.TerminateInstancesInput.InstanceIds[0])
+
+			hDb, err := host.FindOneId(ctx, h.Id)
+			assert.NoError(t, err)
+			assert.Equal(t, evergreen.HostTerminated, hDb.Status)
+		},
+		"TerminateInstanceWithIntentHostIDNotFoundInCloud": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
+			h.Id = "evg-distro-20260518093717-1234567890"
+			require.NoError(t, db.Clear(host.Collection))
+			require.NoError(t, h.Insert(ctx))
+
+			client.RequestGetInstanceInfoError = noReservationError
+
+			assert.NoError(t, m.TerminateInstance(ctx, h, "evergreen", ""))
+
+			assert.Nil(t, client.TerminateInstancesInput, "should not call TerminateInstances when instance is not found")
+
+			hDb, err := host.FindOneId(ctx, h.Id)
 			assert.NoError(t, err)
 			assert.Equal(t, evergreen.HostTerminated, hDb.Status)
 		},


### PR DESCRIPTION
DEVPROD-36438

### Description

When we try to terminate an intent host, we're passing its generated name (e.g. `evg-distro-...`) directly to AWS as an instance ID, which fails. This burns rate limit and risks orphaning hosts. We already have logic to look up the real instance by tag (in the on-demand manager). This applies that same pattern to the fleet manager.

So if the instance really does exist in AWS, we will still resolve it via tag lookup and terminate normally. If it doesn't exist, we just mark the host terminated in the DB, and if lookup fails, we return an error so the termination job retries.
### Testing
Added some unit tests