### PR TITLE
Revert "DEVPROD-27528: Support for multiple aliases in one patch (#10374)"

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-07-01"
+	ClientVersion = "2026-07-06"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/docs/Project-Configuration/Github-Integrations.md
+++ b/docs/Project-Configuration/Github-Integrations.md
@@ -61,10 +61,10 @@ evergreen patch
 If your project is configured for manual testing, then Evergreen will only add GitHub checks to the PR when prompted, as opposed to for every commit. Commenting `evergreen patch` will trigger this.
 
 ```bash
-evergreen patch --alias <alias> [--alias <alias>]...
+evergreen patch --alias <alias>
 ```
 
-Override the default GitHub PR patch definition with custom aliases.
+Override the default GitHub PR patch definition with a custom alias.
 
 ### Refresh GitHub checks
 

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -233,10 +233,6 @@ For example:
 
 Aliases can also be defined locally as shown [here](../CLI#local-aliases).
 
-#### Multiple Aliases
-
-A patch can be run with multiple aliases specified via the CLI. A deduplicated set of tasks from all specified patches will be scheduled, as long as parameters on all aliases match after user-supplied parameter overrides are applied.
-
 ### GitHub Pull Request Testing
 
 Definitions for this section exist under the GitHub "Pull Request Testing" tab.

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1208,7 +1208,6 @@ type ComplexityRoot struct {
 	Patch struct {
 		Activated             func(childComplexity int) int
 		Alias                 func(childComplexity int) int
-		Aliases               func(childComplexity int) int
 		Author                func(childComplexity int) int
 		AuthorDisplayName     func(childComplexity int) int
 		Builds                func(childComplexity int) int
@@ -7616,12 +7615,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Patch.Alias(childComplexity), true
-	case "Patch.aliases":
-		if e.complexity.Patch.Aliases == nil {
-			break
-		}
-
-		return e.complexity.Patch.Aliases(childComplexity), true
 	case "Patch.author":
 		if e.complexity.Patch.Author == nil {
 			break
@@ -38013,8 +38006,6 @@ func (ec *executionContext) fieldContext_Mutation_setPatchVisibility(ctx context
 				return ec.fieldContext_Patch_activated(ctx, field)
 			case "alias":
 				return ec.fieldContext_Patch_alias(ctx, field)
-			case "aliases":
-				return ec.fieldContext_Patch_aliases(ctx, field)
 			case "author":
 				return ec.fieldContext_Patch_author(ctx, field)
 			case "authorDisplayName":
@@ -38132,8 +38123,6 @@ func (ec *executionContext) fieldContext_Mutation_schedulePatch(ctx context.Cont
 				return ec.fieldContext_Patch_activated(ctx, field)
 			case "alias":
 				return ec.fieldContext_Patch_alias(ctx, field)
-			case "aliases":
-				return ec.fieldContext_Patch_aliases(ctx, field)
 			case "author":
 				return ec.fieldContext_Patch_author(ctx, field)
 			case "authorDisplayName":
@@ -44996,35 +44985,6 @@ func (ec *executionContext) fieldContext_Patch_alias(_ context.Context, field gr
 	return fc, nil
 }
 
-func (ec *executionContext) _Patch_aliases(ctx context.Context, field graphql.CollectedField, obj *model.APIPatch) (ret graphql.Marshaler) {
-	return graphql.ResolveField(
-		ctx,
-		ec.OperationContext,
-		field,
-		ec.fieldContext_Patch_aliases,
-		func(ctx context.Context) (any, error) {
-			return obj.Aliases, nil
-		},
-		nil,
-		ec.marshalOString2ᚕstringᚄ,
-		true,
-		false,
-	)
-}
-
-func (ec *executionContext) fieldContext_Patch_aliases(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Patch",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _Patch_author(ctx context.Context, field graphql.CollectedField, obj *model.APIPatch) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -45189,8 +45149,6 @@ func (ec *executionContext) fieldContext_Patch_childPatches(_ context.Context, f
 				return ec.fieldContext_Patch_activated(ctx, field)
 			case "alias":
 				return ec.fieldContext_Patch_alias(ctx, field)
-			case "aliases":
-				return ec.fieldContext_Patch_aliases(ctx, field)
 			case "author":
 				return ec.fieldContext_Patch_author(ctx, field)
 			case "authorDisplayName":
@@ -47055,8 +47013,6 @@ func (ec *executionContext) fieldContext_Patches_patches(_ context.Context, fiel
 				return ec.fieldContext_Patch_activated(ctx, field)
 			case "alias":
 				return ec.fieldContext_Patch_alias(ctx, field)
-			case "aliases":
-				return ec.fieldContext_Patch_aliases(ctx, field)
 			case "author":
 				return ec.fieldContext_Patch_author(ctx, field)
 			case "authorDisplayName":
@@ -53718,8 +53674,6 @@ func (ec *executionContext) fieldContext_Query_patch(ctx context.Context, field 
 				return ec.fieldContext_Patch_activated(ctx, field)
 			case "alias":
 				return ec.fieldContext_Patch_alias(ctx, field)
-			case "aliases":
-				return ec.fieldContext_Patch_aliases(ctx, field)
 			case "author":
 				return ec.fieldContext_Patch_author(ctx, field)
 			case "authorDisplayName":
@@ -65617,8 +65571,6 @@ func (ec *executionContext) fieldContext_Task_patch(_ context.Context, field gra
 				return ec.fieldContext_Patch_activated(ctx, field)
 			case "alias":
 				return ec.fieldContext_Patch_alias(ctx, field)
-			case "aliases":
-				return ec.fieldContext_Patch_aliases(ctx, field)
 			case "author":
 				return ec.fieldContext_Patch_author(ctx, field)
 			case "authorDisplayName":
@@ -76218,8 +76170,6 @@ func (ec *executionContext) fieldContext_Version_patch(_ context.Context, field 
 				return ec.fieldContext_Patch_activated(ctx, field)
 			case "alias":
 				return ec.fieldContext_Patch_alias(ctx, field)
-			case "aliases":
-				return ec.fieldContext_Patch_aliases(ctx, field)
 			case "author":
 				return ec.fieldContext_Patch_author(ctx, field)
 			case "authorDisplayName":
@@ -100874,8 +100824,6 @@ func (ec *executionContext) _Patch(ctx context.Context, sel ast.SelectionSet, ob
 			}
 		case "alias":
 			out.Values[i] = ec._Patch_alias(ctx, field, obj)
-		case "aliases":
-			out.Values[i] = ec._Patch_aliases(ctx, field, obj)
 		case "author":
 			out.Values[i] = ec._Patch_author(ctx, field, obj)
 			if out.Values[i] == graphql.Null {

--- a/graphql/schema/types/patch.graphql
+++ b/graphql/schema/types/patch.graphql
@@ -68,7 +68,6 @@ type Patch {
   id: ID!
   activated: Boolean!
   alias: String
-  aliases: [String!]
   author: String!
   authorDisplayName: String!
   builds: [Build!]!

--- a/model/patch/cli_intent.go
+++ b/model/patch/cli_intent.go
@@ -90,9 +90,6 @@ type cliIntent struct {
 	// alias defines the variants and tasks to run this patch on.
 	Alias string `bson:"alias"`
 
-	// aliases defines a list of aliases when one or more patch aliases are specified.
-	Aliases []string `bson:"aliases,omitempty"`
-
 	// path defines the path to an evergreen project configuration file.
 	Path string `bson:"path"`
 
@@ -203,7 +200,6 @@ func (c *cliIntent) NewPatch() *Patch {
 		RegexTestSelectionExcludedBuildVariants: c.RegexTestSelectionExcludedBuildVariants,
 		Parameters:                              c.Parameters,
 		Alias:                                   c.Alias,
-		Aliases:                                 c.Aliases,
 		Triggers:                                TriggerInfo{Aliases: c.TriggerAliases},
 		Tasks:                                   c.Tasks,
 		RegexTasks:                              c.RegexTasks,
@@ -246,7 +242,6 @@ type CLIIntentParams struct {
 	RegexTestSelectionTasks            []string
 	RegexTestSelectionExcludedTasks    []string
 	Alias                              string
-	Aliases                            []string
 	TriggerAliases                     []string
 	RepeatDefinition                   bool
 	RepeatFailed                       bool
@@ -264,7 +259,7 @@ func NewCliIntent(params CLIIntentParams) (Intent, error) {
 	if params.BaseGitHash == "" {
 		return nil, errors.New("no base hash provided")
 	}
-	if params.Finalize && params.Alias == "" && len(params.Aliases) == 0 && !params.RepeatFailed && !params.RepeatDefinition {
+	if params.Finalize && params.Alias == "" && !params.RepeatFailed && !params.RepeatDefinition {
 		if len(params.Variants)+len(params.RegexVariants)+len(params.Tasks)+len(params.RegexTasks) == 0 {
 			return nil, errors.New("no tasks or variants provided")
 		}
@@ -297,7 +292,6 @@ func NewCliIntent(params CLIIntentParams) (Intent, error) {
 		Finalize:                                params.Finalize,
 		Module:                                  params.Module,
 		Alias:                                   params.Alias,
-		Aliases:                                 params.Aliases,
 		TriggerAliases:                          params.TriggerAliases,
 		GitInfo:                                 params.GitInfo,
 		RepeatDefinition:                        params.RepeatDefinition,

--- a/model/patch/cli_intent_test.go
+++ b/model/patch/cli_intent_test.go
@@ -131,23 +131,6 @@ func (s *CliIntentSuite) TestNewCliIntent() {
 	s.NoError(err)
 }
 
-func (s *CliIntentSuite) TestNewCliIntentSetsAliases() {
-	intent, err := NewCliIntent(CLIIntentParams{
-		User:        s.user,
-		Project:     s.projectID,
-		BaseGitHash: s.hash,
-		Finalize:    true,
-		Aliases:     []string{"a", "b"},
-	})
-	s.Require().NoError(err)
-	s.Require().NotNil(intent)
-
-	cIntent, ok := intent.(*cliIntent)
-	s.Require().True(ok)
-	s.Equal([]string{"a", "b"}, cIntent.Aliases)
-	s.Equal([]string{"a", "b"}, intent.NewPatch().Aliases)
-}
-
 func (s *CliIntentSuite) TestNewCliIntentRejectsInvalidIntents() {
 	intent, err := NewCliIntent(CLIIntentParams{
 		Project:      s.projectID,

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -53,7 +53,6 @@ var (
 	ProjectStorageMethodKey        = bsonutil.MustHaveTag(Patch{}, "ProjectStorageMethod")
 	PatchedProjectConfigKey        = bsonutil.MustHaveTag(Patch{}, "PatchedProjectConfig")
 	AliasKey                       = bsonutil.MustHaveTag(Patch{}, "Alias")
-	AliasesKey                     = bsonutil.MustHaveTag(Patch{}, "Aliases")
 	GithubMergeDataKey             = bsonutil.MustHaveTag(Patch{}, "GithubMergeData")
 	githubPatchDataKey             = bsonutil.MustHaveTag(Patch{}, "GithubPatchData")
 	MergePatchKey                  = bsonutil.MustHaveTag(Patch{}, "MergePatch")

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -100,12 +100,9 @@ type Patch struct {
 	// unfinalized and is cleared once the patch has been finalized.
 	ProjectStorageMethod evergreen.ParserProjectStorageMethod `bson:"project_storage_method,omitempty"`
 	PatchedProjectConfig string                               `bson:"patched_project_config"`
-	// Alias is a single selection alias applied to the patch, for single-alias patches or internal
-	// aliases (e.g. __github), while Aliases holds multiple aliases for multi-alias patches.
-	Alias      string      `bson:"alias"`
-	Aliases    []string    `bson:"aliases,omitempty"`
-	Triggers   TriggerInfo `bson:"triggers"`
-	MergePatch string      `bson:"merge_patch"`
+	Alias                string                               `bson:"alias"`
+	Triggers             TriggerInfo                          `bson:"triggers"`
+	MergePatch           string                               `bson:"merge_patch"`
 	// GithubPatchData stores GitHub PR patch metadata.
 	GithubPatchData thirdparty.GithubPatch `bson:"github_patch_data,omitempty"`
 	// GithubMergeData stores GitHub merge queue metadata.
@@ -667,19 +664,6 @@ func (p *Patch) IsMergeQueuePatch() bool {
 
 func (p *Patch) IsChild() bool {
 	return p.Triggers.ParentPatch != ""
-}
-
-// AliasesToResolve returns the aliases used to resolve the patch's tasks and
-// parameters, using the multi-alias list when available and falling back to the single
-// Alias (which holds internal aliases and single-alias patches).
-func (p *Patch) AliasesToResolve() []string {
-	if len(p.Aliases) > 0 {
-		return p.Aliases
-	}
-	if p.Alias != "" {
-		return []string{p.Alias}
-	}
-	return nil
 }
 
 // CollectiveStatus returns the aggregate display status of all tasks and child patches.

--- a/model/patch/patch_test.go
+++ b/model/patch/patch_test.go
@@ -15,22 +15,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func TestAliasesToResolve(t *testing.T) {
-	for name, tc := range map[string]struct {
-		patch    Patch
-		expected []string
-	}{
-		"MultipleAliases":     {patch: Patch{Aliases: []string{"x", "y"}}, expected: []string{"x", "y"}},
-		"SingleAliasMirrored": {patch: Patch{Alias: "a", Aliases: []string{"a"}}, expected: []string{"a"}},
-		"OnlyAliasSet":        {patch: Patch{Alias: "a"}, expected: []string{"a"}},
-		"EmptyWhenNeitherSet": {patch: Patch{}, expected: nil},
-	} {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, tc.expected, tc.patch.AliasesToResolve())
-		})
-	}
-}
-
 func TestConfigChanged(t *testing.T) {
 	assert := assert.New(t)
 	remoteConfigPath := "config/evergreen.yml"

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"time"
 
@@ -913,47 +912,29 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 	return patchVersion, nil
 }
 
-// getFullPatchParams retrieves the parameters defined on the patch's alias(es)
-// merged with the user-specified parameters, with the latter taking precedence.
-// A version has a single global set of parameters, so when multiple aliases are
-// specified their fully-resolved parameter sets must be identical, otherwise the
-// patch cannot be finalized.
+// getFullPatchParams will retrieve a merged list of parameters defined on the patch alias (if any)
+// with the parameters that were explicitly user-specified, with the latter taking precedence.
 func getFullPatchParams(ctx context.Context, p *patch.Patch) ([]patch.Parameter, error) {
-	aliasNames := p.AliasesToResolve()
-	// Internal aliases (commit queue, GitHub, etc.) don't carry user parameters.
-	if len(aliasNames) == 0 || (len(aliasNames) == 1 && !IsPatchAlias(aliasNames[0])) {
+	paramsMap := map[string]string{}
+	if p.Alias == "" || !IsPatchAlias(p.Alias) {
 		return p.Parameters, nil
 	}
-
-	var commonParams map[string]string
-	for i, aliasName := range aliasNames {
-		aliases, err := findAliasesForPatch(ctx, p.Project, aliasName, p) // Get all records for the alias.
-		if err != nil {
-			return nil, errors.Wrapf(err, "retrieving alias '%s' for patch '%s'", aliasName, p.Id.Hex())
-		}
-
-		// Overwrite configured parameters with user-specified ones, which take precedence.
-		paramsMap := map[string]string{}
-		for _, alias := range aliases {
+	aliases, err := findAliasesForPatch(ctx, p.Project, p.Alias, p)
+	if err != nil {
+		return nil, errors.Wrapf(err, "retrieving alias '%s' for patch '%s'", p.Alias, p.Id.Hex())
+	}
+	for _, alias := range aliases {
+		if len(alias.Parameters) > 0 {
 			for _, aliasParam := range alias.Parameters {
 				paramsMap[aliasParam.Key] = aliasParam.Value
 			}
 		}
-		for _, param := range p.Parameters {
-			paramsMap[param.Key] = param.Value
-		}
-		// Set the parameters from the first alias as the common set to compare against.
-		if i == 0 {
-			commonParams = paramsMap
-			continue
-		}
-		if !reflect.DeepEqual(paramsMap, commonParams) {
-			return nil, errors.Errorf("aliases %v resolve to conflicting parameter sets; a patch version has a single set of parameters, so specify a single alias or aliases whose parameters match", aliasNames)
-		}
 	}
-
+	for _, param := range p.Parameters {
+		paramsMap[param.Key] = param.Value
+	}
 	var fullParams []patch.Parameter
-	for k, v := range commonParams {
+	for k, v := range paramsMap {
 		fullParams = append(fullParams, patch.Parameter{
 			Key:   k,
 			Value: v,

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -547,45 +547,6 @@ func TestGetFullPatchParams(t *testing.T) {
 	}
 }
 
-func TestGetFullPatchParamsMultiAlias(t *testing.T) {
-	require.NoError(t, db.ClearCollections(ProjectRefCollection, ProjectAliasCollection))
-	ctx := t.Context()
-	pRef := ProjectRef{Id: "proj"}
-	require.NoError(t, pRef.Insert(ctx))
-
-	noParamsA := ProjectAlias{ProjectID: "proj", Alias: "a", Variant: ".*", Task: ".*"}
-	noParamsB := ProjectAlias{ProjectID: "proj", Alias: "b", Variant: ".*", Task: ".*"}
-	withParam := ProjectAlias{ProjectID: "proj", Alias: "c", Variant: ".*", Task: ".*", Parameters: []patch.Parameter{{Key: "k", Value: "v"}}}
-	require.NoError(t, noParamsA.Upsert(ctx))
-	require.NoError(t, noParamsB.Upsert(ctx))
-	require.NoError(t, withParam.Upsert(ctx))
-
-	t.Run("MatchingParamSetsMerge", func(t *testing.T) {
-		p := patch.Patch{
-			Id:         patch.NewId("aaaaaaaaaaff001122334455"),
-			Project:    "proj",
-			Aliases:    []string{"a", "b"},
-			Parameters: []patch.Parameter{{Key: "user", Value: "1"}},
-		}
-		params, err := getFullPatchParams(ctx, &p)
-		require.NoError(t, err)
-		require.Len(t, params, 1)
-		assert.Equal(t, "user", params[0].Key)
-		assert.Equal(t, "1", params[0].Value)
-	})
-
-	t.Run("ConflictingParamSetsError", func(t *testing.T) {
-		p := patch.Patch{
-			Id:      patch.NewId("bbbbbbbbbbff001122334455"),
-			Project: "proj",
-			Aliases: []string{"a", "c"},
-		}
-		_, err := getFullPatchParams(ctx, &p)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "conflicting parameter")
-	})
-}
-
 func TestMakePatchedConfig(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/model/project.go
+++ b/model/project.go
@@ -1,12 +1,10 @@
 package model
 
 import (
-	"cmp"
 	"context"
 	"fmt"
 	"reflect"
 	"regexp"
-	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -785,14 +783,6 @@ type TVPair struct {
 }
 
 type TVPairSet []TVPair
-
-// dedupeTVPairs removes duplicate task/variant pairs
-func dedupeTVPairs(pairs TVPairSet) TVPairSet {
-	slices.SortFunc(pairs, func(a, b TVPair) int {
-		return cmp.Or(cmp.Compare(a.Variant, b.Variant), cmp.Compare(a.TaskName, b.TaskName))
-	})
-	return slices.Compact(pairs)
-}
 
 // ByVariant returns a list of TVPairs filtered to include only those
 // for the given variant
@@ -1740,8 +1730,8 @@ func (p *Project) IgnoresAllFiles(files []string) bool {
 // variants will run and which tasks will run on each build variant. This
 // filters out tasks that cannot run due to being disabled or having an
 // unmatched requester (e.g. a patch-only task for a mainline commit).
-func (p *Project) BuildProjectTVPairs(ctx context.Context, patchDoc *patch.Patch, aliases []string) {
-	patchDoc.BuildVariants, patchDoc.Tasks, patchDoc.VariantsTasks = p.ResolvePatchVTs(ctx, patchDoc, patchDoc.GetRequester(), aliases, true)
+func (p *Project) BuildProjectTVPairs(ctx context.Context, patchDoc *patch.Patch, alias string) {
+	patchDoc.BuildVariants, patchDoc.Tasks, patchDoc.VariantsTasks = p.ResolvePatchVTs(ctx, patchDoc, patchDoc.GetRequester(), alias, true)
 
 	// Connect the execution tasks to the display tasks.
 	displayTasksToExecTasks := map[string][]string{}
@@ -1772,7 +1762,7 @@ func (p *Project) BuildProjectTVPairs(ctx context.Context, patchDoc *patch.Patch
 // variant. If includeDeps is set, it will also resolve task dependencies. This
 // filters out tasks that cannot run due to being disabled or having an
 // unmatched requester (e.g. a patch-only task for a mainline commit).
-func (p *Project) ResolvePatchVTs(ctx context.Context, patchDoc *patch.Patch, requester string, aliases []string, includeDeps bool) (resolvedBVs []string, resolvedTasks []string, vts []patch.VariantTasks) {
+func (p *Project) ResolvePatchVTs(ctx context.Context, patchDoc *patch.Patch, requester, alias string, includeDeps bool) (resolvedBVs []string, resolvedTasks []string, vts []patch.VariantTasks) {
 	var bvs, bvTags, tasks, taskTags []string
 	for _, bv := range patchDoc.BuildVariants {
 		// Tags should start with "."
@@ -1851,17 +1841,14 @@ func (p *Project) ResolvePatchVTs(ctx context.Context, patchDoc *patch.Patch, re
 		}
 	}
 
-	for _, alias := range aliases {
-		if alias == "" {
-			continue
-		}
+	if alias != "" {
 		catcher := grip.NewBasicCatcher()
-		aliasDefs, err := findAliasesForPatch(ctx, p.Identifier, alias, patchDoc)
+		aliases, err := findAliasesForPatch(ctx, p.Identifier, alias, patchDoc)
 		catcher.Wrapf(err, "retrieving alias '%s' for patched project config '%s'", alias, patchDoc.Id.Hex())
 
 		aliasPairs := TaskVariantPairs{}
 		if !catcher.HasErrors() {
-			aliasPairs, err = p.BuildProjectTVPairsWithAlias(aliasDefs, requester)
+			aliasPairs, err = p.BuildProjectTVPairsWithAlias(aliases, requester)
 			catcher.Wrap(err, "getting task/variant pairs for alias")
 		}
 		grip.Error(ctx, message.WrapError(catcher.Resolve(), message.Fields{
@@ -1876,11 +1863,6 @@ func (p *Project) ResolvePatchVTs(ctx context.Context, patchDoc *patch.Patch, re
 		}
 	}
 
-	// Aliases can select overlapping task/variant pairs, so deduplicate them.
-	if len(aliases) > 1 {
-		pairs.ExecTasks = dedupeTVPairs(pairs.ExecTasks)
-		pairs.DisplayTasks = dedupeTVPairs(pairs.DisplayTasks)
-	}
 	pairs = p.extractDisplayTasks(pairs)
 	if includeDeps {
 		var err error
@@ -1956,7 +1938,6 @@ func (p *Project) IsGenerateTask(taskName string) bool {
 	return ok
 }
 
-// findAliasesForPatch finds all DB entries matching the given alias on the project.
 func findAliasesForPatch(ctx context.Context, projectId, alias string, patchDoc *patch.Patch) ([]ProjectAlias, error) {
 	aliases, err := findAliasInProjectOrRepoFromDb(ctx, projectId, alias)
 	if err != nil {

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1009,7 +1009,7 @@ func (s *projectSuite) TestBuildProjectTVPairs() {
 		Tasks:         []string{"all"},
 	}
 
-	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, []string{evergreen.PatchVersionRequester})
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, evergreen.PatchVersionRequester)
 
 	s.Len(patchDoc.BuildVariants, 2)
 	s.ElementsMatch([]string{"bv_1", "bv_2"}, patchDoc.BuildVariants)
@@ -1053,7 +1053,7 @@ func (s *projectSuite) TestBuildProjectTVPairs() {
 	patchDoc.Tasks = []string{"all"}
 	patchDoc.VariantsTasks = []patch.VariantTasks{}
 
-	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, []string{evergreen.PatchVersionRequester})
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, evergreen.PatchVersionRequester)
 
 	s.Len(patchDoc.BuildVariants, 2)
 	s.Len(patchDoc.Tasks, 6)
@@ -1062,40 +1062,10 @@ func (s *projectSuite) TestBuildProjectTVPairs() {
 	patchDoc.BuildVariants = []string{"all"}
 	patchDoc.VariantsTasks = []patch.VariantTasks{}
 
-	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, []string{evergreen.PatchVersionRequester})
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, evergreen.PatchVersionRequester)
 
 	s.Len(patchDoc.BuildVariants, 2)
 	s.Len(patchDoc.Tasks, 6)
-}
-
-func (s *projectSuite) TestResolvePatchVTsMultipleAliases() {
-	req := (&patch.Patch{}).GetRequester()
-	flatten := func(vts []patch.VariantTasks) []string {
-		var out []string
-		for _, vt := range vts {
-			for _, t := range vt.Tasks {
-				out = append(out, vt.Variant+"/"+t)
-			}
-		}
-		return out
-	}
-	resolve := func(aliases ...string) []string {
-		_, _, vts := s.project.ResolvePatchVTs(s.T().Context(), &patch.Patch{}, req, aliases, false)
-		return flatten(vts)
-	}
-
-	// A duplicated alias resolves to the same pairs, with no duplicates.
-	single := resolve("aTags")
-	dup := resolve("aTags", "aTags")
-	s.NotEmpty(single)
-	s.ElementsMatch(single, dup)
-	s.Len(dup, len(utility.UniqueStrings(dup)))
-
-	// Two different (overlapping) aliases union their pairs, deduped.
-	a := resolve("bv2")
-	b := resolve("2tasks")
-	union := resolve("bv2", "2tasks")
-	s.ElementsMatch(utility.UniqueStrings(append(append([]string{}, a...), b...)), union)
 }
 
 func (s *projectSuite) TestResolvePatchVTs() {
@@ -1105,7 +1075,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		Tasks:         []string{"all"},
 	}
 
-	bvs, tasks, variantTasks := s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), nil, true)
+	bvs, tasks, variantTasks := s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "", true)
 	s.Len(bvs, 2)
 	s.ElementsMatch([]string{"bv_1", "bv_2"}, bvs)
 	s.Len(tasks, 7)
@@ -1152,7 +1122,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		RegexTasks:         []string{"_1$"},
 	}
 
-	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), nil, true)
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "", true)
 	s.Len(bvs, 2)
 	s.Len(tasks, 7)
 	s.Len(variantTasks, 2)
@@ -1163,7 +1133,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		RegexTasks:         []string{"_1$"},
 	}
 
-	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), nil, true)
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "", true)
 	s.Len(bvs, 2)
 	s.Contains(bvs, "bv_1")
 	s.Contains(bvs, "bv_2")
@@ -1185,7 +1155,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		RegexTasks:    []string{"_1$"},
 	}
 
-	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), nil, true)
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "", true)
 	s.Len(bvs, 2)
 	s.Contains(bvs, "bv_1")
 	s.Contains(bvs, "bv_2")
@@ -1207,7 +1177,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		RegexTasks:    []string{"_1$"},
 	}
 
-	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), nil, true)
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "", true)
 	s.Len(bvs, 2)
 	s.Contains(bvs, "bv_1")
 	s.Contains(bvs, "bv_2")
@@ -1229,7 +1199,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		RegexTasks:         []string{"_1$"},
 	}
 
-	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), []string{"aTags"}, true)
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "aTags", true)
 	s.Len(bvs, 2)
 	s.Contains(bvs, "bv_1")
 	s.Contains(bvs, "bv_2")
@@ -1253,7 +1223,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		Tasks:         []string{".a", ".1"},
 	}
 
-	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), nil, true)
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "", true)
 	s.Len(bvs, 1)
 	s.Contains(bvs, "bv_2")
 	s.Len(tasks, 3)
@@ -1276,7 +1246,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		Tasks:         []string{".a", ".1", "b_task_2"},
 	}
 
-	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), nil, true)
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "", true)
 	s.Len(bvs, 2)
 	s.Contains(bvs, "bv_1")
 	s.Contains(bvs, "bv_2")
@@ -1303,7 +1273,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 		RegexTasks:    []string{"_1$"},
 	}
 
-	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), nil, true)
+	bvs, tasks, variantTasks = s.project.ResolvePatchVTs(s.T().Context(), &patchDoc, patchDoc.GetRequester(), "", true)
 	s.Len(bvs, 2)
 	s.Contains(bvs, "bv_1")
 	s.Contains(bvs, "bv_2")
@@ -1326,7 +1296,7 @@ func (s *projectSuite) TestResolvePatchVTs() {
 func (s *projectSuite) TestBuildProjectTVPairsWithAlias() {
 	patchDoc := patch.Patch{}
 
-	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, []string{"2tasks(obsolete)"})
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "2tasks(obsolete)")
 
 	s.Len(patchDoc.BuildVariants, 2)
 	s.Contains(patchDoc.BuildVariants, "bv_1")
@@ -1352,7 +1322,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithBadBuildVariant() {
 		Tasks:         []string{"a_task_1", "b_task_1"},
 	}
 
-	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, nil)
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "")
 
 	s.Require().Len(patchDoc.Tasks, 2)
 	s.Contains(patchDoc.Tasks, "a_task_1")
@@ -1375,7 +1345,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithBadBuildVariant() {
 func (s *projectSuite) TestBuildProjectTVPairsWithAliasWithTags() {
 	patchDoc := patch.Patch{}
 
-	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, []string{"aTags"})
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "aTags")
 
 	s.Len(patchDoc.BuildVariants, 2)
 	s.Contains(patchDoc.BuildVariants, "bv_1")
@@ -1398,7 +1368,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithAliasWithTags() {
 func (s *projectSuite) TestBuildProjectTVPairsWithAliasWithDisplayTask() {
 	patchDoc := patch.Patch{}
 
-	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, []string{"memes"})
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "memes")
 	s.Len(patchDoc.BuildVariants, 2)
 	s.Contains(patchDoc.BuildVariants, "bv_1")
 	s.Contains(patchDoc.BuildVariants, "bv_2")
@@ -1425,7 +1395,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithAliasWithDisplayTask() {
 func (s *projectSuite) TestBuildProjectTVPairsWithDisabledBuildVariant() {
 	patchDoc := patch.Patch{}
 
-	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, []string{"disabled_stuff"})
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "disabled_stuff")
 	s.Empty(patchDoc.BuildVariants)
 	s.Empty(patchDoc.Tasks)
 	s.Empty(patchDoc.VariantsTasks)
@@ -1435,7 +1405,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithDisabledBuildVariant() {
 		Tasks:         []string{"disabled_task"},
 	}
 
-	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, nil)
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "")
 	s.Empty(patchDoc.BuildVariants)
 	s.Empty(patchDoc.Tasks)
 	s.Empty(patchDoc.VariantsTasks)
@@ -1447,7 +1417,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithDisplayTaskWithDependencies() 
 		Tasks:         []string{"memes"},
 	}
 
-	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, nil)
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "")
 	s.Len(patchDoc.BuildVariants, 2)
 	s.Contains(patchDoc.BuildVariants, "bv_1")
 	s.Contains(patchDoc.BuildVariants, "bv_2")
@@ -1479,7 +1449,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithDisplayTaskWithDependencies() 
 
 func (s *projectSuite) TestBuildProjectTVPairsWithExecutionTaskFromTags() {
 	patchDoc := patch.Patch{}
-	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, []string{"part_of_memes"})
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "part_of_memes")
 	s.Len(patchDoc.BuildVariants, 2)
 	s.Contains(patchDoc.BuildVariants, "bv_1")
 	s.Len(patchDoc.Tasks, 3)
@@ -1506,7 +1476,7 @@ func (s *projectSuite) TestBuildProjectTVPairsWithExecutionTask() {
 		BuildVariants: []string{"bv_1"},
 		Tasks:         []string{"9001_task"},
 	}
-	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, nil)
+	s.project.BuildProjectTVPairs(s.T().Context(), &patchDoc, "")
 	s.Len(patchDoc.BuildVariants, 2)
 	s.Contains(patchDoc.BuildVariants, "bv_1")
 	s.Contains(patchDoc.BuildVariants, "bv_2")
@@ -3189,27 +3159,5 @@ func TestVerifyCheckRunLimit(t *testing.T) {
 	})
 	t.Run("WithAppAuthIgnoresThreshold", func(t *testing.T) {
 		assert.NoError(t, VerifyCheckRunLimit(CheckRunGitHubAppAuthThreshold+1, CheckRunGitHubAppAuthThreshold+2, true))
-	})
-}
-
-func TestDedupeTVPairs(t *testing.T) {
-	t.Run("PreservesTaskAcrossDifferentVariants", func(t *testing.T) {
-		pairs := TVPairSet{
-			{Variant: "ubuntu2004", TaskName: "taskA"},
-			{Variant: "ubuntu2204", TaskName: "taskA"},
-		}
-		result := dedupeTVPairs(pairs)
-		require.Len(t, result, 2)
-		assert.Contains(t, result, TVPair{Variant: "ubuntu2004", TaskName: "taskA"})
-		assert.Contains(t, result, TVPair{Variant: "ubuntu2204", TaskName: "taskA"})
-	})
-	t.Run("RemovesDuplicatePairOnSameVariant", func(t *testing.T) {
-		pairs := TVPairSet{
-			{Variant: "ubuntu2004", TaskName: "taskA"},
-			{Variant: "ubuntu2004", TaskName: "taskA"},
-		}
-		result := dedupeTVPairs(pairs)
-		require.Len(t, result, 1)
-		assert.Equal(t, TVPair{Variant: "ubuntu2004", TaskName: "taskA"}, result[0])
 	})
 }

--- a/operations/http.go
+++ b/operations/http.go
@@ -525,7 +525,6 @@ func (ac *legacyClient) PutPatch(ctx context.Context, incomingPatch patchSubmiss
 		PatchBytes                         []byte                     `json:"patch_bytes"`
 		Githash                            string                     `json:"githash"`
 		Alias                              string                     `json:"alias"`
-		Aliases                            []string                   `json:"aliases"`
 		Variants                           []string                   `json:"buildvariants_new"`
 		Tasks                              []string                   `json:"tasks"`
 		RegexVariants                      []string                   `json:"regex_buildvariants"`
@@ -551,7 +550,6 @@ func (ac *legacyClient) PutPatch(ctx context.Context, incomingPatch patchSubmiss
 		PatchBytes:                         []byte(incomingPatch.patchData),
 		Githash:                            incomingPatch.base,
 		Alias:                              incomingPatch.alias,
-		Aliases:                            incomingPatch.aliases,
 		Variants:                           incomingPatch.variants,
 		Tasks:                              incomingPatch.tasks,
 		RegexVariants:                      incomingPatch.regexVariants,

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -56,9 +56,9 @@ func getPatchFlags(flags ...cli.Flag) []cli.Flag {
 				Name:  joinFlagNames(tasksFlagName, "t"),
 				Usage: "task names (\"all\" for all tasks)",
 			},
-			cli.StringSliceFlag{
+			cli.StringFlag{
 				Name:  joinFlagNames(patchAliasFlagName, "a"),
-				Usage: "patch alias (set by project admin) or local alias (set individually in evergreen.yml); repeat the flag to apply multiple aliases",
+				Usage: "patch alias (set by project admin) or local alias (set individually in evergreen.yml)",
 			},
 			cli.StringFlag{
 				Name:  joinFlagNames(patchDescriptionFlagName, "d"),
@@ -163,7 +163,7 @@ func Patch() cli.Command {
 				Browse:                             c.Bool(patchBrowseFlagName),
 				ShowSummary:                        c.Bool(patchVerboseFlagName),
 				Large:                              c.Bool(largeFlagName),
-				Aliases:                            utility.SplitCommas(c.StringSlice(patchAliasFlagName)),
+				Alias:                              c.String(patchAliasFlagName),
 				Ref:                                c.String(refFlagName),
 				Uncommitted:                        c.Bool(uncommittedChangesFlag),
 				PreserveCommits:                    c.Bool(preserveCommitsFlag),
@@ -240,7 +240,7 @@ func Patch() cli.Command {
 			hasTasksOrVariants := len(params.Tasks) > 0 || len(params.Variants) > 0
 			hasRegexTasksOrVariants := len(params.RegexTasks) > 0 || len(params.RegexVariants) > 0
 
-			if isReusing && (hasTasksOrVariants || hasRegexTasksOrVariants || len(params.Aliases) > 0) {
+			if isReusing && (hasTasksOrVariants || hasRegexTasksOrVariants || len(params.Alias) > 0) {
 				return errors.Errorf("can't define tasks, variants, regex tasks, regex variants or aliases when reusing previous patch's tasks and variants")
 			}
 
@@ -481,7 +481,7 @@ func PatchFile() cli.Command {
 				Project:          c.String(projectFlagName),
 				Variants:         utility.SplitCommas(c.StringSlice(variantsFlagName)),
 				Tasks:            utility.SplitCommas(c.StringSlice(tasksFlagName)),
-				Aliases:          utility.SplitCommas(c.StringSlice(patchAliasFlagName)),
+				Alias:            c.String(patchAliasFlagName),
 				SkipConfirm:      c.Bool(skipConfirmFlagName) || outputJSON,
 				Description:      c.String(patchDescriptionFlagName),
 				AutoDescription:  c.Bool(autoDescriptionFlag),

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -62,12 +62,9 @@ type localDiff struct {
 type patchParams struct {
 	Project string
 	Path    string
-	// Alias holds the single alias for the patch if only one was applied.
-	Alias string
-	// The Aliases field holds the raw aliases passed from the command line.
-	Aliases []string
-	// isUsingLocalAlias indicates that at least one specified alias matches a
-	// local alias.
+	Alias   string
+	// isUsingLocalAlias indicates that the user-specified alias matches a local
+	// alias.
 	isUsingLocalAlias                  bool
 	Variants                           []string
 	Tasks                              []string
@@ -105,7 +102,6 @@ type patchSubmission struct {
 	description                        string
 	base                               string
 	alias                              string
-	aliases                            []string
 	path                               string
 	variants                           []string
 	tasks                              []string
@@ -142,7 +138,6 @@ func (p *patchParams) createPatch(ctx context.Context, ac *legacyClient, diffDat
 		regexTestSelectionTasks:            p.RegexTestSelectionTasks,
 		regexTestSelectionExcludedTasks:    p.RegexTestSelectionExcludedTasks,
 		alias:                              p.Alias,
-		aliases:                            p.submissionAliases(),
 		finalize:                           p.Finalize,
 		parameters:                         p.Parameters,
 		triggerAliases:                     p.TriggerAliases,
@@ -293,34 +288,16 @@ func (p *patchParams) validatePatchCommand(ctx context.Context, conf *ClientSett
 		}
 	}
 
-	if p.Finalize && p.Alias == "" && len(p.Aliases) == 0 && !p.RepeatFailed && !p.RepeatDefinition && !p.hasTasksAndVariants() {
+	if p.Finalize && p.Alias == "" && !p.RepeatFailed && !p.RepeatDefinition && !p.hasTasksAndVariants() {
 		return ref, errors.Errorf("Need to specify at least one task/variant or alias when finalizing")
 	}
 
 	return ref, nil
 }
 
-// submissionAliases returns the server-side aliases to submit, preferring the
-// multi-alias list and falling back to the single resolved Alias.
-func (p *patchParams) submissionAliases() []string {
-	if len(p.Aliases) > 0 {
-		return p.Aliases
-	}
-	if p.Alias != "" {
-		return []string{p.Alias}
-	}
-	return nil
-}
-
 func (p *patchParams) setNonRepeatedDefaults(ctx context.Context, conf *ClientSettings) {
 	if err := p.setLocalAliases(conf); err != nil {
 		grip.Warningf(ctx, "warning - setting local aliases: %s\n", err)
-	}
-
-	// When a single alias remains, mirror it into Alias for
-	// downstream resolution and backwards compatibility.
-	if len(p.Aliases) == 1 {
-		p.Alias = p.Aliases[0]
 	}
 
 	if err := p.loadAlias(ctx, conf); err != nil {
@@ -366,35 +343,20 @@ func (p *patchParams) loadProject(ctx context.Context, conf *ClientSettings) err
 }
 
 func (p *patchParams) setLocalAliases(conf *ClientSettings) error {
-	if len(p.Aliases) == 0 {
-		return nil
-	}
-
-	var localAliases []model.ProjectAlias
-	for i := range conf.Projects {
-		if conf.Projects[i].Name == p.Project {
-			if errStrs := model.ValidateProjectAliases(conf.Projects[i].LocalAliases, "Local Aliases"); len(errStrs) != 0 {
-				return errors.Errorf("validating local aliases: '%s'", errStrs)
-			}
-			localAliases = append(localAliases, conf.Projects[i].LocalAliases...)
-		}
-	}
-
-	var serverAliases []string
-	for _, specified := range p.Aliases {
-		isLocal := false
-		for _, localAlias := range localAliases {
-			if localAlias.Alias == specified {
-				p.addAliasToPatchParams(localAlias)
-				isLocal = true
+	if p.Alias != "" {
+		for i := range conf.Projects {
+			if conf.Projects[i].Name == p.Project {
+				if errStrs := model.ValidateProjectAliases(conf.Projects[i].LocalAliases, "Local Aliases"); len(errStrs) != 0 {
+					return errors.Errorf("validating local aliases: '%s'", errStrs)
+				}
+				for _, alias := range conf.Projects[i].LocalAliases {
+					if alias.Alias == p.Alias {
+						p.addAliasToPatchParams(alias)
+					}
+				}
 			}
 		}
-		if !isLocal {
-			serverAliases = append(serverAliases, specified)
-		}
 	}
-	p.Aliases = serverAliases
-
 	return nil
 }
 
@@ -420,6 +382,7 @@ func (p *patchParams) addAliasToPatchParams(alias model.ProjectAlias) {
 		}
 		p.Tasks = append(p.Tasks, formattedTags...)
 	}
+	p.Alias = ""
 	p.isUsingLocalAlias = true
 }
 
@@ -454,7 +417,7 @@ func (p *patchParams) loadAlias(ctx context.Context, conf *ClientSettings) error
 				return errors.Wrap(err, "setting default alias")
 			}
 		}
-	} else if len(p.Aliases) == 0 && !p.hasTasksAndVariants() {
+	} else if !p.hasTasksAndVariants() {
 		// No --alias or variant/task pair was passed, use the default
 		p.Alias = conf.FindDefaultAlias(p.Project)
 		grip.InfoWhen(ctx, p.Alias != "", "Using default alias set in local config")
@@ -474,7 +437,7 @@ func (p *patchParams) loadVariants(ctx context.Context, conf *ClientSettings) er
 				return errors.Wrap(err, "setting default variants")
 			}
 		}
-	} else if p.Alias == "" && len(p.Aliases) == 0 && len(p.RegexVariants) == 0 && !p.isUsingLocalAlias {
+	} else if p.Alias == "" && len(p.RegexVariants) == 0 && !p.isUsingLocalAlias {
 		p.Variants = conf.FindDefaultVariants(p.Project)
 		grip.InfoWhen(ctx, len(p.Variants) > 0, "Using default variants set in local config")
 	}
@@ -518,7 +481,7 @@ func (p *patchParams) loadTasks(ctx context.Context, conf *ClientSettings) error
 				return errors.Wrap(err, "setting default tasks")
 			}
 		}
-	} else if p.Alias == "" && len(p.Aliases) == 0 && len(p.RegexTasks) == 0 && !p.isUsingLocalAlias {
+	} else if p.Alias == "" && len(p.RegexTasks) == 0 && !p.isUsingLocalAlias {
 		// Only use default tasks if no alias or regex tasks were specified.
 		p.Tasks = conf.FindDefaultTasks(p.Project)
 		grip.InfoWhen(ctx, len(p.Tasks) > 0, "Using default tasks set in local config")

--- a/operations/patch_util_test.go
+++ b/operations/patch_util_test.go
@@ -164,7 +164,7 @@ func (s *PatchUtilTestSuite) TestVariantsTasksFromCLI() {
 func (s *PatchUtilTestSuite) TestNonRepeatedDefaultsLoadsExplicitAlias() {
 	pp := patchParams{
 		Project: "project",
-		Aliases: []string{"duck"},
+		Alias:   "duck",
 	}
 	conf := &ClientSettings{
 		Projects: []ClientProjectConf{
@@ -186,7 +186,7 @@ func (s *PatchUtilTestSuite) TestNonRepeatedDefaultsLoadsExplicitAlias() {
 func (s *PatchUtilTestSuite) TestNonRepeatedDefaultsWithLocalAliasOverridesOtherDefaults() {
 	pp := patchParams{
 		Project: "project",
-		Aliases: []string{"duck"},
+		Alias:   "duck",
 	}
 	conf := &ClientSettings{
 		Projects: []ClientProjectConf{
@@ -252,43 +252,6 @@ func (s *PatchUtilTestSuite) TestNonRepeatedDefaultsLoadsDefaultVariantsAndTasks
 	s.Empty(pp.Alias, "should not set an alias when there is no default")
 	s.ElementsMatch([]string{"default-bv0", "default-bv1"}, pp.Variants, "variants should be defaulted")
 	s.ElementsMatch([]string{"default-task0", "default-task1"}, pp.Tasks, "tasks should be defaulted")
-}
-
-func (s *PatchUtilTestSuite) TestMultipleLocalAliasesExpandIntoTasksAndVariants() {
-	pp := patchParams{
-		Project:     "project",
-		Aliases:     []string{"duck", "goose"},
-		SkipConfirm: true,
-	}
-	conf := &ClientSettings{
-		Projects: []ClientProjectConf{
-			{
-				Name: "project",
-				LocalAliases: []model.ProjectAlias{
-					{Alias: "duck", Variant: "bv0", Task: "task0"},
-					{Alias: "goose", Variant: "bv1", Task: "task1"},
-				},
-			},
-		},
-	}
-
-	pp.setNonRepeatedDefaults(s.T().Context(), conf)
-
-	s.Empty(pp.Aliases, "local aliases should be consumed during expansion")
-	s.Empty(pp.Alias, "no server-side alias should remain")
-	s.True(pp.isUsingLocalAlias)
-	s.ElementsMatch([]string{"bv0", "bv1"}, pp.RegexVariants)
-	s.ElementsMatch([]string{"task0", "task1"}, pp.RegexTasks)
-}
-
-func (s *PatchUtilTestSuite) TestMultipleServerAliasesSubmitted() {
-	// Multiple server-side aliases are submitted as-is (no longer rejected).
-	pp := patchParams{Aliases: []string{"server-alias-1", "server-alias-2"}}
-	s.Equal([]string{"server-alias-1", "server-alias-2"}, pp.submissionAliases())
-
-	// A single resolved alias still submits as a one-element list.
-	pp = patchParams{Alias: "solo"}
-	s.Equal([]string{"solo"}, pp.submissionAliases())
 }
 
 func (s *PatchUtilTestSuite) TestGetRemoteFromOutput() {

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -285,7 +285,7 @@ func GetProjectAliasResults(ctx context.Context, p *model.Project, alias string,
 	matches := []restModel.APIVariantTasks{}
 	for _, projectAlias := range projectAliases {
 		requester := getRequesterFromAlias(projectAlias.Alias)
-		_, _, variantTasks := p.ResolvePatchVTs(ctx, &patch.Patch{}, requester, []string{projectAlias.Alias}, includeDeps)
+		_, _, variantTasks := p.ResolvePatchVTs(ctx, &patch.Patch{}, requester, projectAlias.Alias, includeDeps)
 		for _, variantTask := range variantTasks {
 			matches = append(matches, restModel.APIVariantTasksBuildFromService(variantTask))
 		}

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -68,7 +68,6 @@ type APIPatch struct {
 	// Repeated from GithubMergeData to preserve backwards compatibility.
 	InvalidatedByUpstream bool                 `json:"invalidated_by_upstream"`
 	Alias                 *string              `json:"alias,omitempty"`
-	Aliases               []string             `json:"aliases,omitempty"`
 	GithubPatchData       APIGithubPatch       `json:"github_patch_data"`
 	GithubMergeData       APIGithubMergeGroup  `json:"github_merge_data"`
 	ModuleCodeChanges     []APIModulePatch     `json:"module_code_changes"`
@@ -305,7 +304,6 @@ func (apiPatch *APIPatch) buildBasePatch(p patch.Patch) {
 	apiPatch.VariantsTasks = variantTasks
 	apiPatch.Activated = p.Activated
 	apiPatch.Alias = utility.ToStringPtr(p.Alias)
-	apiPatch.Aliases = p.Aliases
 	apiPatch.Requester = utility.ToStringPtr(p.GetRequester())
 
 	if p.Parameters != nil {
@@ -514,7 +512,6 @@ func (apiPatch *APIPatch) ToService() (patch.Patch, error) {
 	res.Version = utility.FromStringPtr(apiPatch.Version)
 	res.Status = utility.FromStringPtr(apiPatch.Status)
 	res.Alias = utility.FromStringPtr(apiPatch.Alias)
-	res.Aliases = apiPatch.Aliases
 	res.Activated = apiPatch.Activated
 	res.CreateTime, err = FromTimePtr(apiPatch.CreateTime)
 	catcher.Add(err)

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -115,7 +115,6 @@ type patchData struct {
 	Finalize                           bool                       `json:"finalize"`
 	TriggerAliases                     []string                   `json:"trigger_aliases"`
 	Alias                              string                     `json:"alias"`
-	Aliases                            []string                   `json:"aliases"`
 	RepeatFailed                       bool                       `json:"repeat_failed"`
 	RepeatDefinition                   bool                       `json:"reuse_definition"`
 	RepeatPatchId                      string                     `json:"repeat_patch_id"`
@@ -203,7 +202,6 @@ func (as *APIServer) submitPatch(w http.ResponseWriter, r *http.Request) {
 		RegexTestSelectionTasks:            data.RegexTestSelectionTasks,
 		RegexTestSelectionExcludedTasks:    data.RegexTestSelectionExcludedTasks,
 		Alias:                              data.Alias,
-		Aliases:                            data.Aliases,
 		TriggerAliases:                     data.TriggerAliases,
 		GitInfo:                            data.GitMetadata,
 		RepeatDefinition:                   data.RepeatDefinition,

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -350,7 +350,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 			}
 		}
 	}
-	if err = j.verifyValidAliases(ctx, pref.Id, patchDoc.AliasesToResolve(), patchDoc.PatchedProjectConfig); err != nil {
+	if err = j.verifyValidAlias(ctx, pref.Id, patchDoc.PatchedProjectConfig); err != nil {
 		j.gitHubError = invalidAlias
 		return err
 	}
@@ -647,7 +647,7 @@ func (j *patchIntentProcessor) buildTasksAndVariants(ctx context.Context, patchD
 	}
 
 	if len(patchDoc.VariantsTasks) == 0 {
-		project.BuildProjectTVPairs(ctx, patchDoc, patchDoc.AliasesToResolve())
+		project.BuildProjectTVPairs(ctx, patchDoc, j.intent.GetAlias())
 	}
 	return nil
 }
@@ -1366,8 +1366,9 @@ func fetchTriggerVersionInfo(ctx context.Context, patchDoc *patch.Patch) (*model
 	return v, project, pp, nil
 }
 
-func (j *patchIntentProcessor) verifyValidAliases(ctx context.Context, projectId string, aliases []string, configStr string) error {
-	if len(aliases) == 0 {
+func (j *patchIntentProcessor) verifyValidAlias(ctx context.Context, projectId string, configStr string) error {
+	alias := j.intent.GetAlias()
+	if alias == "" {
 		return nil
 	}
 	var projectConfig *model.ProjectConfig
@@ -1378,16 +1379,14 @@ func (j *patchIntentProcessor) verifyValidAliases(ctx context.Context, projectId
 			return errors.Wrap(err, "creating project config")
 		}
 	}
-	for _, alias := range aliases {
-		found, err := model.FindAliasInProjectRepoOrProjectConfig(ctx, projectId, alias, projectConfig)
-		if err != nil {
-			return errors.Wrapf(err, "retrieving aliases for project '%s'", projectId)
-		}
-		if len(found) == 0 {
-			return errors.Errorf("alias '%s' could not be found on project '%s'", alias, projectId)
-		}
+	aliases, err := model.FindAliasInProjectRepoOrProjectConfig(ctx, projectId, alias, projectConfig)
+	if err != nil {
+		return errors.Wrapf(err, "retrieving aliases for project '%s'", projectId)
 	}
-	return nil
+	if len(aliases) > 0 {
+		return nil
+	}
+	return errors.Errorf("alias '%s' could not be found on project '%s'", alias, projectId)
 }
 
 func findEvergreenUserForPR(ctx context.Context, githubUID int) (*user.DBUser, error) {


### PR DESCRIPTION
### Description

This reverts commit f90da6a52f865d454f9d170c6d5a37df809c5f8b.