### PR TITLE
 DEVPROD-36139 Extend the project translation cache to the file-based translate path

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -310,6 +310,7 @@ func GetPatchedProject(ctx context.Context, settings *evergreen.Settings, p *pat
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "fetching project options for patch")
 	}
+	opts.cacheEnabled = projectTranslationCacheEnabled(settings)
 
 	projectFileBytes, err := getPatchedProjectYAML(ctx, projectRef, opts, p)
 	if err != nil {

--- a/model/project.go
+++ b/model/project.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"maps"
 	"reflect"
 	"regexp"
 	"slices"
@@ -85,6 +86,25 @@ func (p *Project) buildTaskCache() {
 	for i := range p.Tasks {
 		p.tasksByName[p.Tasks[i].Name] = &p.Tasks[i]
 	}
+}
+
+// cloneForCacheReturn shallow-clones p's top-level slices and maps, and rebuilds the task cache
+// to point into the clone's Tasks. Nested structures below the top level remain shared and must
+// stay read-only. We do this instead of a deeper clone because that costs orders of magnitude more,
+// up to more than a full TranslateProject, which would defeat the point of caching.
+func (p *Project) cloneForCacheReturn() *Project {
+	cp := *p
+	cp.Ignore = slices.Clone(p.Ignore)
+	cp.Parameters = slices.Clone(p.Parameters)
+	cp.Modules = slices.Clone(p.Modules)
+	cp.BuildVariants = slices.Clone(p.BuildVariants)
+	cp.TaskGroups = slices.Clone(p.TaskGroups)
+	cp.Tasks = slices.Clone(p.Tasks)
+	if p.Functions != nil {
+		cp.Functions = maps.Clone(p.Functions)
+	}
+	cp.buildTaskCache()
+	return &cp
 }
 
 type ProjectInfo struct {

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -647,7 +647,9 @@ func FindAndTranslateProjectForVersionID(ctx context.Context, settings *evergree
 // Also sets the project ID. If the preGeneration flag is true, this function will attempt to
 // fetch and translate the parser project from before it was modified by generate.tasks.
 //
-// The returned *Project is always the caller's own copy, safe to read or mutate.
+// The returned *Project is the caller's own value: its top-level slices and maps (BuildVariants,
+// Tasks, Modules, etc.) are safe to reorder, append to, or replace. Structures nested below that
+// level are shared with the cache and must not be mutated.
 func FindAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.Settings, v *Version, preGeneration bool) (*Project, *ParserProject, error) {
 	return findAndTranslateProjectForVersion(ctx, settings, v.Id, v.Identifier, v.ProjectStorageMethod, v.PreGenerationProjectStorageMethod, preGeneration)
 }

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -592,7 +592,38 @@ const (
 	// ppTranslationCacheEvictionsOtelAttribute records the cumulative count of translations the LRU
 	// has dropped to make room for new ones (or because their TTL expired), before anything reused them.
 	ppTranslationCacheEvictionsOtelAttribute = "evergreen.parser_project.translation_cache_evictions"
+	// ppTranslationCacheHottestKeyOtelAttribute records the cache key with the most hits right now, so
+	// the hottest cached configs are identifiable in Honeycomb for tuning.
+	ppTranslationCacheHottestKeyOtelAttribute = "evergreen.parser_project.translation_cache_hottest_key"
+	// ppTranslationCacheHottestKeyHitsOtelAttribute records how many hits the hottest key has served.
+	ppTranslationCacheHottestKeyHitsOtelAttribute = "evergreen.parser_project.translation_cache_hottest_key_hits"
 )
+
+// projectTranslationCacheEnabled reports whether the project translation cache ServiceFlag is on.
+// Callers thread settings from the entry point rather than reading the global environment.
+func projectTranslationCacheEnabled(settings *evergreen.Settings) bool {
+	return settings != nil && settings.ServiceFlags.ProjectTranslationCacheEnabled
+}
+
+// setTranslationCacheSpanAttributes records the cache hit/dedup outcome on span, plus the LRU's
+// size, evictions, and hottest key when the cache is enabled.
+func setTranslationCacheSpanAttributes(span trace.Span, cacheHit, deduped, cacheEnabled bool) {
+	span.SetAttributes(
+		attribute.Bool(ppTranslationCacheHitOtelAttribute, cacheHit),
+		attribute.Bool(ppTranslationDedupedOtelAttribute, deduped),
+	)
+	if !cacheEnabled {
+		return
+	}
+	size, evictions := translationCacheStats()
+	hottestKey, hottestHits := hottestTranslationKey()
+	span.SetAttributes(
+		attribute.Int(ppTranslationCacheSizeOtelAttribute, size),
+		attribute.Int64(ppTranslationCacheEvictionsOtelAttribute, evictions),
+		attribute.String(ppTranslationCacheHottestKeyOtelAttribute, hottestKey),
+		attribute.Int64(ppTranslationCacheHottestKeyHitsOtelAttribute, hottestHits),
+	)
+}
 
 // FindAndTranslateProjectForVersionID translates a parser project for a version into a Project.
 func FindAndTranslateProjectForVersionID(ctx context.Context, settings *evergreen.Settings, versionID string, preGeneration bool) (*Project, *ParserProject, error) {
@@ -616,8 +647,7 @@ func FindAndTranslateProjectForVersionID(ctx context.Context, settings *evergree
 // Also sets the project ID. If the preGeneration flag is true, this function will attempt to
 // fetch and translate the parser project from before it was modified by generate.tasks.
 //
-// When the translation cache is enabled the returned *Project is a shared pointer. Callers
-// must not mutate it; make a local copy of any fields that need modification before use.
+// The returned *Project is always the caller's own copy, safe to read or mutate.
 func FindAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.Settings, v *Version, preGeneration bool) (*Project, *ParserProject, error) {
 	return findAndTranslateProjectForVersion(ctx, settings, v.Id, v.Identifier, v.ProjectStorageMethod, v.PreGenerationProjectStorageMethod, preGeneration)
 }
@@ -654,36 +684,8 @@ func findAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.
 		pp.Identifier = utility.ToStringPtr(versionIdentifier)
 	}
 
-	cacheEnabled := settings.ServiceFlags.ProjectTranslationCacheEnabled
-	var key string
-	if cacheEnabled {
-		var sha string
-		sha, err = parserProjectContentSHA(pp)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "computing parser project content hash")
-		}
-		key = contentTranslationKey(sha, versionIdentifier)
-	} else {
-		// When the cache is off, we don't need a key that changes whenever the parser project changes
-		// (which the LRU requires so it never serves a stale config after generate.tasks). We can instead
-		// use the version ID. It's cheaper and enough for singleflight, which only coalesces concurrent
-		// in-flight calls and retains nothing that could go stale.
-		key = versionTranslationKey(versionID, preGeneration)
-	}
-	p, cacheHit, deduped, err := getOrComputeTranslation(key, cacheEnabled, func() (*Project, error) {
-		return TranslateProject(ctx, pp)
-	})
-	span.SetAttributes(
-		attribute.Bool(ppTranslationCacheHitOtelAttribute, cacheHit),
-		attribute.Bool(ppTranslationDedupedOtelAttribute, deduped),
-	)
-	if cacheEnabled {
-		size, evictions := translationCacheStats()
-		span.SetAttributes(
-			attribute.Int(ppTranslationCacheSizeOtelAttribute, size),
-			attribute.Int64(ppTranslationCacheEvictionsOtelAttribute, evictions),
-		)
-	}
+	cacheEnabled := projectTranslationCacheEnabled(settings)
+	p, err := translateAndCache(ctx, span, pp, versionIdentifier, versionTranslationKey(versionID, preGeneration), cacheEnabled)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "translating parser project '%s'", versionID)
 	}
@@ -824,7 +826,12 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, pro
 	}
 
 	// Return project even with errors.
-	p, err := TranslateProject(ctx, intermediateProject)
+	cacheEnabled := opts != nil && opts.cacheEnabled
+	var revision string
+	if opts != nil {
+		revision = opts.Revision
+	}
+	p, err := loadTranslateProject(ctx, span, intermediateProject, projectID, revision, cacheEnabled)
 	if p != nil {
 		*project = *p
 	}
@@ -836,6 +843,12 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, pro
 	intermediateProject.Include = nil
 
 	return intermediateProject, errors.Wrapf(err, LoadProjectError)
+}
+
+// loadTranslateProject translates the post-merge intermediate project, optionally serving the
+// result from the content-hash translation cache keyed on its content and projectID.
+func loadTranslateProject(ctx context.Context, span trace.Span, intermediateProject *ParserProject, projectID, revision string, cacheEnabled bool) (*Project, error) {
+	return translateAndCache(ctx, span, intermediateProject, projectID, fileTranslationKey(projectID, revision), cacheEnabled)
 }
 
 // mergeIncludes merges all included files into intermediateProject.
@@ -1213,6 +1226,9 @@ type GetProjectOpts struct {
 	LocalIncludeDir string
 	// EnableYAMLAnchors opts into cross-file YAML anchor and alias support.
 	EnableYAMLAnchors bool
+	// cacheEnabled routes the translate step through the content-hash translation cache. It is only
+	// set internally by GetProjectFromFile from the ServiceFlag, so external callers stay uncached.
+	cacheEnabled bool
 }
 
 type PatchOpts struct {
@@ -1420,9 +1436,11 @@ const fetchProjectFilesTimeout = time.Minute
 
 // GetProjectFromFile fetches project configuration files from its source (e.g.
 // from a patch diff, GitHub, etc).
-func GetProjectFromFile(ctx context.Context, opts GetProjectOpts) (ProjectInfo, error) {
+func GetProjectFromFile(ctx context.Context, opts GetProjectOpts, settings *evergreen.Settings) (ProjectInfo, error) {
 	ctx, cancel := context.WithTimeout(ctx, fetchProjectFilesTimeout)
 	defer cancel()
+
+	opts.cacheEnabled = projectTranslationCacheEnabled(settings)
 
 	fileContents, err := retrieveFile(ctx, opts)
 	if err != nil {

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -8,8 +8,10 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
@@ -3911,4 +3913,209 @@ tasks:
 	assert.Equal(t, "shell.exec", cmd.Command)
 	assert.Equal(t, "./run.sh", cmd.Params["script"])
 	assert.Equal(t, "src", cmd.Params["working_dir"])
+}
+
+const cacheTestYML = `
+buildvariants:
+- name: bv1
+  run_on: d
+  tasks:
+  - name: t1
+tasks:
+- name: t1
+`
+
+const cacheTestYMLChanged = `
+buildvariants:
+- name: bv1
+  run_on: d
+  tasks:
+  - name: t1
+  - name: t2
+tasks:
+- name: t1
+- name: t2
+`
+
+// cacheTestMutationYML has two build variants whose display names sort in reverse of file order and
+// a module, so a test can reproduce the two real file-path mutations of a cached project:
+// NewTaskIdConfigForRepotrackerVersion's sort.Stable(BuildVariants) and the push-trigger Modules[i].Ref write.
+const cacheTestMutationYML = `
+modules:
+- name: m1
+  repo: git@github.com:foo/bar.git
+  branch: main
+buildvariants:
+- name: bvz
+  display_name: z
+  run_on: d
+  tasks:
+  - name: t1
+- name: bva
+  display_name: a
+  run_on: d
+  tasks:
+  - name: t1
+tasks:
+- name: t1
+`
+
+// loadProjectIntoCached mirrors what GetProjectFromFile does: it flips the internal cacheEnabled
+// flag so LoadProjectInto routes the translate step through the content-hash cache.
+func loadProjectIntoCached(ctx context.Context, t *testing.T, yml, projectID string) *Project {
+	proj := &Project{}
+	_, err := LoadProjectInto(ctx, []byte(yml), &GetProjectOpts{cacheEnabled: true}, projectID, proj)
+	require.NoError(t, err)
+	return proj
+}
+
+func TestLoadProjectIntoTranslationCache(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("FlagOffTranslatesEveryCallAndCachesNothing", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		proj := &Project{}
+		_, err := LoadProjectInto(ctx, []byte(cacheTestYML), nil, "id", proj)
+		require.NoError(t, err)
+		_, err = LoadProjectInto(ctx, []byte(cacheTestYML), nil, "id", proj)
+		require.NoError(t, err)
+		assert.Equal(t, 0, getTranslationCache().Len(), "cache stays empty when the flag is off")
+	})
+
+	t.Run("FlagOnSecondCallWithUnchangedContentIsCacheHit", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		first := loadProjectIntoCached(ctx, t, cacheTestYML, "id")
+		require.Len(t, first.Tasks, 1)
+		assert.Equal(t, 1, getTranslationCache().Len())
+
+		second := loadProjectIntoCached(ctx, t, cacheTestYML, "id")
+		assert.Equal(t, 1, getTranslationCache().Len(), "identical content reuses the single entry")
+		assert.Equal(t, first.Tasks, second.Tasks)
+	})
+
+	t.Run("DifferentProjectIDDoesNotCollideOnIdenticalContent", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		loadProjectIntoCached(ctx, t, cacheTestYML, "project_a")
+		loadProjectIntoCached(ctx, t, cacheTestYML, "project_b")
+		assert.Equal(t, 2, getTranslationCache().Len(), "same content under different projects gets distinct keys")
+	})
+
+	t.Run("ChangedContentIsAMissWithNoInvalidation", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		before := loadProjectIntoCached(ctx, t, cacheTestYML, "id")
+		require.Len(t, before.Tasks, 1)
+
+		after := loadProjectIntoCached(ctx, t, cacheTestYMLChanged, "id")
+		require.Len(t, after.Tasks, 2, "changed content is recomputed and reflects the new config")
+		assert.Equal(t, 2, getTranslationCache().Len(), "the changed content added a new entry; the old one was never invalidated")
+	})
+
+	t.Run("ConcurrentIdenticalLoadsCoalesce", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		const goroutines = 20
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for i := 0; i < goroutines; i++ {
+			go func() {
+				defer wg.Done()
+				proj := &Project{}
+				_, err := LoadProjectInto(ctx, []byte(cacheTestYML), &GetProjectOpts{cacheEnabled: true}, "id", proj)
+				assert.NoError(t, err)
+			}()
+		}
+		wg.Wait()
+		assert.Equal(t, 1, getTranslationCache().Len(), "concurrent identical loads produce a single cached entry")
+	})
+
+	t.Run("MutatingReturnedProjectDoesNotCorruptCachedEntry", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		const multiVariantYML = `
+buildvariants:
+- name: a
+  run_on: d
+  tasks:
+  - name: t1
+- name: b
+  run_on: d
+  tasks:
+  - name: t1
+tasks:
+- name: t1
+`
+		first := loadProjectIntoCached(ctx, t, multiVariantYML, "id")
+		require.Len(t, first.BuildVariants, 2)
+
+		// Mimic NewTaskIdConfigForRepotrackerVersion, which reorders BuildVariants in place.
+		first.BuildVariants[0], first.BuildVariants[1] = first.BuildVariants[1], first.BuildVariants[0]
+		first.BuildVariants = first.BuildVariants[:1]
+
+		second := loadProjectIntoCached(ctx, t, multiVariantYML, "id")
+		require.Len(t, second.BuildVariants, 2, "cache hit still returns all variants; the earlier truncation did not reach the cached entry")
+		assert.Equal(t, "a", second.BuildVariants[0].Name, "cache hit preserves original order despite the earlier in-place swap")
+	})
+
+	t.Run("HottestKeyTracksTheMostReusedConfig", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		// "hot" is loaded three times (two hits); "cold" is loaded twice (one hit).
+		loadProjectIntoCached(ctx, t, cacheTestYML, "hot")
+		loadProjectIntoCached(ctx, t, cacheTestYML, "hot")
+		loadProjectIntoCached(ctx, t, cacheTestYML, "hot")
+		loadProjectIntoCached(ctx, t, cacheTestYML, "cold")
+		loadProjectIntoCached(ctx, t, cacheTestYML, "cold")
+
+		key, hits := hottestTranslationKey()
+		sha, err := parserProjectContentSHA(mustLoadIntermediate(ctx, t, cacheTestYML))
+		require.NoError(t, err)
+		assert.Equal(t, contentTranslationKey(sha, "hot"), key)
+		assert.Equal(t, int64(2), hits)
+	})
+
+	t.Run("ReturnedCopyIsolatesCallerMutationsFromCache", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		first := loadProjectIntoCached(ctx, t, cacheTestMutationYML, "id")
+		require.Len(t, first.BuildVariants, 2)
+		require.Len(t, first.Modules, 1)
+		originalOrder := []string{first.BuildVariants[0].Name, first.BuildVariants[1].Name}
+		originalRef := first.Modules[0].Ref
+
+		// Reproduce the two real file-path mutations on the returned project: the repotracker path
+		// reorders BuildVariants via sort.Stable, and the push-trigger path overwrites Modules[i].Ref.
+		sort.Stable(first.BuildVariants)
+		require.NotEqual(t, originalOrder, []string{first.BuildVariants[0].Name, first.BuildVariants[1].Name}, "sort must actually reorder for this test to be meaningful")
+		first.Modules[0].Ref = "mutated-ref"
+
+		second := loadProjectIntoCached(ctx, t, cacheTestMutationYML, "id")
+		assert.Equal(t, originalOrder, []string{second.BuildVariants[0].Name, second.BuildVariants[1].Name}, "cached entry keeps original variant order despite the first caller's sort")
+		assert.Equal(t, originalRef, second.Modules[0].Ref, "cached entry's module ref is not corrupted by the first caller's write")
+	})
+
+	t.Run("ConcurrentCallersMutateReturnedCopiesRaceFree", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		// Warm the cache so every goroutine takes a hit and each gets its own copy.
+		loadProjectIntoCached(ctx, t, cacheTestMutationYML, "id")
+
+		const goroutines = 20
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for i := 0; i < goroutines; i++ {
+			go func() {
+				defer wg.Done()
+				proj := &Project{}
+				_, err := LoadProjectInto(ctx, []byte(cacheTestMutationYML), &GetProjectOpts{cacheEnabled: true}, "id", proj)
+				assert.NoError(t, err)
+				// If the copies shared backing arrays, concurrent sorts would trip the race detector.
+				sort.Stable(proj.BuildVariants)
+			}()
+		}
+		wg.Wait()
+	})
+}
+
+// mustLoadIntermediate returns the merged intermediate project for yml, matching what LoadProjectInto
+// hashes for the cache key.
+func mustLoadIntermediate(ctx context.Context, t *testing.T, yml string) *ParserProject {
+	proj := &Project{}
+	pp, err := LoadProjectInto(ctx, []byte(yml), nil, "id", proj)
+	require.NoError(t, err)
+	return pp
 }

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -3962,50 +3962,48 @@ tasks:
 
 // loadProjectIntoCached mirrors what GetProjectFromFile does: it flips the internal cacheEnabled
 // flag so LoadProjectInto routes the translate step through the content-hash cache.
-func loadProjectIntoCached(ctx context.Context, t *testing.T, yml, projectID string) *Project {
+func loadProjectIntoCached(t *testing.T, yml, projectID string) *Project {
 	proj := &Project{}
-	_, err := LoadProjectInto(ctx, []byte(yml), &GetProjectOpts{cacheEnabled: true}, projectID, proj)
+	_, err := LoadProjectInto(t.Context(), []byte(yml), &GetProjectOpts{cacheEnabled: true}, projectID, proj)
 	require.NoError(t, err)
 	return proj
 }
 
 func TestLoadProjectIntoTranslationCache(t *testing.T) {
-	ctx := context.Background()
-
 	t.Run("FlagOffTranslatesEveryCallAndCachesNothing", func(t *testing.T) {
 		t.Cleanup(resetTranslationCacheForTesting)
 		proj := &Project{}
-		_, err := LoadProjectInto(ctx, []byte(cacheTestYML), nil, "id", proj)
+		_, err := LoadProjectInto(t.Context(), []byte(cacheTestYML), nil, "id", proj)
 		require.NoError(t, err)
-		_, err = LoadProjectInto(ctx, []byte(cacheTestYML), nil, "id", proj)
+		_, err = LoadProjectInto(t.Context(), []byte(cacheTestYML), nil, "id", proj)
 		require.NoError(t, err)
 		assert.Equal(t, 0, getTranslationCache().Len(), "cache stays empty when the flag is off")
 	})
 
 	t.Run("FlagOnSecondCallWithUnchangedContentIsCacheHit", func(t *testing.T) {
 		t.Cleanup(resetTranslationCacheForTesting)
-		first := loadProjectIntoCached(ctx, t, cacheTestYML, "id")
+		first := loadProjectIntoCached(t, cacheTestYML, "id")
 		require.Len(t, first.Tasks, 1)
 		assert.Equal(t, 1, getTranslationCache().Len())
 
-		second := loadProjectIntoCached(ctx, t, cacheTestYML, "id")
+		second := loadProjectIntoCached(t, cacheTestYML, "id")
 		assert.Equal(t, 1, getTranslationCache().Len(), "identical content reuses the single entry")
 		assert.Equal(t, first.Tasks, second.Tasks)
 	})
 
 	t.Run("DifferentProjectIDDoesNotCollideOnIdenticalContent", func(t *testing.T) {
 		t.Cleanup(resetTranslationCacheForTesting)
-		loadProjectIntoCached(ctx, t, cacheTestYML, "project_a")
-		loadProjectIntoCached(ctx, t, cacheTestYML, "project_b")
+		loadProjectIntoCached(t, cacheTestYML, "project_a")
+		loadProjectIntoCached(t, cacheTestYML, "project_b")
 		assert.Equal(t, 2, getTranslationCache().Len(), "same content under different projects gets distinct keys")
 	})
 
 	t.Run("ChangedContentIsAMissWithNoInvalidation", func(t *testing.T) {
 		t.Cleanup(resetTranslationCacheForTesting)
-		before := loadProjectIntoCached(ctx, t, cacheTestYML, "id")
+		before := loadProjectIntoCached(t, cacheTestYML, "id")
 		require.Len(t, before.Tasks, 1)
 
-		after := loadProjectIntoCached(ctx, t, cacheTestYMLChanged, "id")
+		after := loadProjectIntoCached(t, cacheTestYMLChanged, "id")
 		require.Len(t, after.Tasks, 2, "changed content is recomputed and reflects the new config")
 		assert.Equal(t, 2, getTranslationCache().Len(), "the changed content added a new entry; the old one was never invalidated")
 	})
@@ -4019,7 +4017,7 @@ func TestLoadProjectIntoTranslationCache(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				proj := &Project{}
-				_, err := LoadProjectInto(ctx, []byte(cacheTestYML), &GetProjectOpts{cacheEnabled: true}, "id", proj)
+				_, err := LoadProjectInto(t.Context(), []byte(cacheTestYML), &GetProjectOpts{cacheEnabled: true}, "id", proj)
 				assert.NoError(t, err)
 			}()
 		}
@@ -4042,14 +4040,14 @@ buildvariants:
 tasks:
 - name: t1
 `
-		first := loadProjectIntoCached(ctx, t, multiVariantYML, "id")
+		first := loadProjectIntoCached(t, multiVariantYML, "id")
 		require.Len(t, first.BuildVariants, 2)
 
 		// Mimic NewTaskIdConfigForRepotrackerVersion, which reorders BuildVariants in place.
 		first.BuildVariants[0], first.BuildVariants[1] = first.BuildVariants[1], first.BuildVariants[0]
 		first.BuildVariants = first.BuildVariants[:1]
 
-		second := loadProjectIntoCached(ctx, t, multiVariantYML, "id")
+		second := loadProjectIntoCached(t, multiVariantYML, "id")
 		require.Len(t, second.BuildVariants, 2, "cache hit still returns all variants; the earlier truncation did not reach the cached entry")
 		assert.Equal(t, "a", second.BuildVariants[0].Name, "cache hit preserves original order despite the earlier in-place swap")
 	})
@@ -4057,14 +4055,14 @@ tasks:
 	t.Run("HottestKeyTracksTheMostReusedConfig", func(t *testing.T) {
 		t.Cleanup(resetTranslationCacheForTesting)
 		// "hot" is loaded three times (two hits); "cold" is loaded twice (one hit).
-		loadProjectIntoCached(ctx, t, cacheTestYML, "hot")
-		loadProjectIntoCached(ctx, t, cacheTestYML, "hot")
-		loadProjectIntoCached(ctx, t, cacheTestYML, "hot")
-		loadProjectIntoCached(ctx, t, cacheTestYML, "cold")
-		loadProjectIntoCached(ctx, t, cacheTestYML, "cold")
+		loadProjectIntoCached(t, cacheTestYML, "hot")
+		loadProjectIntoCached(t, cacheTestYML, "hot")
+		loadProjectIntoCached(t, cacheTestYML, "hot")
+		loadProjectIntoCached(t, cacheTestYML, "cold")
+		loadProjectIntoCached(t, cacheTestYML, "cold")
 
 		key, hits := hottestTranslationKey()
-		sha, err := parserProjectContentSHA(mustLoadIntermediate(ctx, t, cacheTestYML))
+		sha, err := parserProjectContentSHA(mustLoadIntermediate(t, cacheTestYML))
 		require.NoError(t, err)
 		assert.Equal(t, contentTranslationKey(sha, "hot"), key)
 		assert.Equal(t, int64(2), hits)
@@ -4072,7 +4070,7 @@ tasks:
 
 	t.Run("ReturnedCopyIsolatesCallerMutationsFromCache", func(t *testing.T) {
 		t.Cleanup(resetTranslationCacheForTesting)
-		first := loadProjectIntoCached(ctx, t, cacheTestMutationYML, "id")
+		first := loadProjectIntoCached(t, cacheTestMutationYML, "id")
 		require.Len(t, first.BuildVariants, 2)
 		require.Len(t, first.Modules, 1)
 		originalOrder := []string{first.BuildVariants[0].Name, first.BuildVariants[1].Name}
@@ -4084,7 +4082,7 @@ tasks:
 		require.NotEqual(t, originalOrder, []string{first.BuildVariants[0].Name, first.BuildVariants[1].Name}, "sort must actually reorder for this test to be meaningful")
 		first.Modules[0].Ref = "mutated-ref"
 
-		second := loadProjectIntoCached(ctx, t, cacheTestMutationYML, "id")
+		second := loadProjectIntoCached(t, cacheTestMutationYML, "id")
 		assert.Equal(t, originalOrder, []string{second.BuildVariants[0].Name, second.BuildVariants[1].Name}, "cached entry keeps original variant order despite the first caller's sort")
 		assert.Equal(t, originalRef, second.Modules[0].Ref, "cached entry's module ref is not corrupted by the first caller's write")
 	})
@@ -4092,7 +4090,7 @@ tasks:
 	t.Run("ConcurrentCallersMutateReturnedCopiesRaceFree", func(t *testing.T) {
 		t.Cleanup(resetTranslationCacheForTesting)
 		// Warm the cache so every goroutine takes a hit and each gets its own copy.
-		loadProjectIntoCached(ctx, t, cacheTestMutationYML, "id")
+		loadProjectIntoCached(t, cacheTestMutationYML, "id")
 
 		const goroutines = 20
 		var wg sync.WaitGroup
@@ -4101,7 +4099,7 @@ tasks:
 			go func() {
 				defer wg.Done()
 				proj := &Project{}
-				_, err := LoadProjectInto(ctx, []byte(cacheTestMutationYML), &GetProjectOpts{cacheEnabled: true}, "id", proj)
+				_, err := LoadProjectInto(t.Context(), []byte(cacheTestMutationYML), &GetProjectOpts{cacheEnabled: true}, "id", proj)
 				assert.NoError(t, err)
 				// If the copies shared backing arrays, concurrent sorts would trip the race detector.
 				sort.Stable(proj.BuildVariants)
@@ -4113,9 +4111,9 @@ tasks:
 
 // mustLoadIntermediate returns the merged intermediate project for yml, matching what LoadProjectInto
 // hashes for the cache key.
-func mustLoadIntermediate(ctx context.Context, t *testing.T, yml string) *ParserProject {
+func mustLoadIntermediate(t *testing.T, yml string) *ParserProject {
 	proj := &Project{}
-	pp, err := LoadProjectInto(ctx, []byte(yml), nil, "id", proj)
+	pp, err := LoadProjectInto(t.Context(), []byte(yml), nil, "id", proj)
 	require.NoError(t, err)
 	return pp
 }

--- a/model/project_translate_cache.go
+++ b/model/project_translate_cache.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -24,6 +26,11 @@ var (
 	translationCache          *expirable.LRU[string, *Project]
 	translationGroupPtr       atomic.Pointer[singleflight.Group]
 	translationCacheEvictions atomic.Int64
+
+	// translationKeyHits counts cache hits per key so the hottest cached configs are identifiable for
+	// tuning. Entries are removed when their key is evicted from the LRU, so it stays bounded by cache size.
+	translationKeyHitsMu sync.Mutex
+	translationKeyHits   = map[string]int64{}
 )
 
 func init() {
@@ -35,11 +42,34 @@ func getTranslationCache() *expirable.LRU[string, *Project] {
 	translationCacheMu.Lock()
 	defer translationCacheMu.Unlock()
 	if translationCache == nil {
-		translationCache = expirable.NewLRU[string, *Project](projectTranslationCacheSize, func(_ string, _ *Project) {
+		translationCache = expirable.NewLRU[string, *Project](projectTranslationCacheSize, func(key string, _ *Project) {
 			translationCacheEvictions.Add(1)
+			translationKeyHitsMu.Lock()
+			delete(translationKeyHits, key)
+			translationKeyHitsMu.Unlock()
 		}, projectTranslationCacheTTL)
 	}
 	return translationCache
+}
+
+// recordTranslationKeyHit increments the per-key hit counter for an LRU cache hit.
+func recordTranslationKeyHit(key string) {
+	translationKeyHitsMu.Lock()
+	translationKeyHits[key]++
+	translationKeyHitsMu.Unlock()
+}
+
+// hottestTranslationKey returns the cache key with the most hits and its hit count, or the zero
+// values if nothing has been hit yet.
+func hottestTranslationKey() (key string, hits int64) {
+	translationKeyHitsMu.Lock()
+	defer translationKeyHitsMu.Unlock()
+	for k, v := range translationKeyHits {
+		if v > hits {
+			key, hits = k, v
+		}
+	}
+	return key, hits
 }
 
 // translationCacheStats returns the LRU's current entry count and its cumulative eviction count
@@ -49,47 +79,60 @@ func translationCacheStats() (size int, evictions int64) {
 }
 
 // getOrComputeTranslation coalesces concurrent calls via singleflight and, when cacheEnabled, also
-// serves and stores results in a per-process LRU. When cacheEnabled, key must capture every input
-// that determines the translation. The cached *Project is shared and must not be mutated.
+// serves and stores results in a per-process LRU keyed by key, which must capture every input that
+// determines the translation. The returned *Project is shared and must not be mutated.
 //
-// deduped reports whether this call's singleflight request was coalesced into another in-flight
-// call for the same key; it is meaningful whether or not the cache is enabled. cacheHit reports
-// whether the result was served from the LRU without calling compute at all, which is only
-// possible when the cache is enabled. The two are orthogonal.
+// deduped reports whether this call was coalesced into another in-flight call for the same key.
+// cacheHit reports an LRU hit that skipped compute entirely. The two are orthogonal.
 func getOrComputeTranslation(key string, cacheEnabled bool, compute func() (*Project, error)) (project *Project, cacheHit bool, deduped bool, err error) {
 	if cacheEnabled {
 		if v, ok := getTranslationCache().Get(key); ok {
+			recordTranslationKeyHit(key)
 			return v, true, false, nil
 		}
 	}
 
-	v, err, shared := translationGroupPtr.Load().Do(key, func() (any, error) {
+	// compute can return a partial *Project alongside an error; package both into the value so
+	// singleflight.Do doesn't drop the partial result via its own error return.
+	type translationResult struct {
+		project *Project
+		err     error
+	}
+	v, sfErr, shared := translationGroupPtr.Load().Do(key, func() (any, error) {
 		// Re-check after winning the singleflight slot: another goroutine may
 		// have populated the cache while we were waiting.
 		if cacheEnabled {
 			if v, ok := getTranslationCache().Get(key); ok {
-				return v, nil
+				recordTranslationKeyHit(key)
+				return translationResult{project: v}, nil
 			}
 		}
 		result, err := compute()
 		if err != nil {
-			return nil, err
+			return translationResult{project: result, err: err}, nil
 		}
 		if cacheEnabled {
 			getTranslationCache().Add(key, result)
 		}
-		return result, nil
+		return translationResult{project: result}, nil
 	})
-	if err != nil {
-		return nil, false, shared, err
+	if sfErr != nil {
+		return nil, false, shared, sfErr
 	}
-	return v.(*Project), false, shared, nil
+	tr := v.(translationResult)
+	return tr.project, false, shared, tr.err
 }
 
-// versionTranslationKey is the cheap singleflight key for the cache-disabled path. It must NOT be
-// used as an LRU key; see getOrComputeTranslation.
+// versionTranslationKey is the cheap singleflight-only key for the version path when the cache is
+// disabled. It must NOT be used as an LRU key; see getOrComputeTranslation.
 func versionTranslationKey(versionID string, preGeneration bool) string {
 	return fmt.Sprintf("v:%s:%v", versionID, preGeneration)
+}
+
+// fileTranslationKey is the cheap singleflight-only key for the file path when the cache is
+// disabled. It must NOT be used as an LRU key; see getOrComputeTranslation.
+func fileTranslationKey(projectID, revision string) string {
+	return fmt.Sprintf("f:%s:%s", projectID, revision)
 }
 
 // contentTranslationKey keys a translation by a hash of the parser-project bytes plus identifier, so
@@ -98,9 +141,29 @@ func contentTranslationKey(contentsSHA, identifier string) string {
 	return fmt.Sprintf("c:%s:%s", contentsSHA, identifier)
 }
 
-// fileTranslationKey is the self-invalidating LRU key for the LoadProjectInto / GetProjectFromFile path.
-func fileTranslationKey(projectID, revision, contentsSHA string) string {
-	return fmt.Sprintf("f:%s:%s:%s", projectID, revision, contentsSHA)
+// translateAndCache translates pp with singleflight coalescing and, when cacheEnabled, the
+// content-hash LRU; disabledKey is the singleflight-only key used when cacheEnabled is false. It
+// returns an isolated clone because the underlying pointer is shared and callers mutate a project's
+// top-level containers in place (see cloneForCacheReturn).
+func translateAndCache(ctx context.Context, span trace.Span, pp *ParserProject, identifier, disabledKey string, cacheEnabled bool) (*Project, error) {
+	key := disabledKey
+	if cacheEnabled {
+		sha, err := parserProjectContentSHA(pp)
+		if err != nil {
+			return nil, errors.Wrap(err, "computing parser project content hash")
+		}
+		key = contentTranslationKey(sha, identifier)
+	}
+
+	p, cacheHit, deduped, err := getOrComputeTranslation(key, cacheEnabled, func() (*Project, error) {
+		return TranslateProject(ctx, pp)
+	})
+	setTranslationCacheSpanAttributes(span, cacheHit, deduped, cacheEnabled)
+	// A partial *Project can come back alongside an error; still clone and return it.
+	if p == nil {
+		return nil, err
+	}
+	return p.cloneForCacheReturn(), err
 }
 
 // parserProjectContentSHA returns the hex-encoded SHA-256 of pp marshaled as JSON.

--- a/model/project_translate_cache_test.go
+++ b/model/project_translate_cache_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -23,6 +24,9 @@ func resetTranslationCacheForTesting() {
 	translationCacheMu.Unlock()
 	translationGroupPtr.Store(&singleflight.Group{})
 	translationCacheEvictions.Store(0)
+	translationKeyHitsMu.Lock()
+	translationKeyHits = map[string]int64{}
+	translationKeyHitsMu.Unlock()
 }
 
 func TestGetOrComputeTranslation(t *testing.T) {
@@ -344,11 +348,12 @@ func TestContentTranslationKeySelfInvalidates(t *testing.T) {
 }
 
 func TestTranslationKeysAreDistinctAndStable(t *testing.T) {
-	// Distinct prefixes: an identical SHA never collides across the two key namespaces.
-	assert.NotEqual(t, contentTranslationKey("sha", "id"), fileTranslationKey("id", "rev", "sha"))
+	// Distinct prefixes: content and version keys never collide across namespaces.
+	assert.NotEqual(t, contentTranslationKey("sha", "id"), versionTranslationKey("id", false))
 	// Keys are deterministic for identical inputs.
 	assert.Equal(t, contentTranslationKey("s", "i"), contentTranslationKey("s", "i"))
-	assert.Equal(t, fileTranslationKey("p", "r", "s"), fileTranslationKey("p", "r", "s"))
+	// Different identifiers with identical content yield distinct keys.
+	assert.NotEqual(t, contentTranslationKey("s", "a"), contentTranslationKey("s", "b"))
 }
 
 func TestFindAndTranslateProjectForVersion(t *testing.T) {
@@ -377,6 +382,57 @@ func TestFindAndTranslateProjectForVersion(t *testing.T) {
 	require.NotNil(t, project)
 
 	assert.Equal(t, projectID, project.Identifier)
+}
+
+// TestFindAndTranslateProjectForVersionReturnedCopyIsolatesCallerMutations reproduces the manifest
+// path's real in-place mutation of a returned project (rest/route/agent.go's CreateManifest expands
+// Module fields via util.ExpandValues, which writes into the Module struct in place) and confirms it
+// cannot corrupt what a later call for the same version sees, with the cache both off and on.
+func TestFindAndTranslateProjectForVersionReturnedCopyIsolatesCallerMutations(t *testing.T) {
+	ctx := t.Context()
+	t.Cleanup(resetTranslationCacheForTesting)
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(ParserProjectCollection, VersionCollection))
+	})
+
+	for _, cacheEnabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("CacheEnabled=%v", cacheEnabled), func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(ParserProjectCollection, VersionCollection))
+			t.Cleanup(resetTranslationCacheForTesting)
+
+			versionID := "version_id"
+			projectID := "project_id"
+			pp := ParserProject{
+				Id:         versionID,
+				Identifier: utility.ToStringPtr(projectID),
+				Modules: []Module{
+					{Name: "m1", Owner: "orig-owner", Repo: "orig-repo", Ref: "orig-ref"},
+				},
+			}
+			require.NoError(t, pp.Insert(ctx))
+
+			settings := &evergreen.Settings{}
+			settings.ServiceFlags.ProjectTranslationCacheEnabled = cacheEnabled
+			v := &Version{Id: versionID, ProjectStorageMethod: evergreen.ProjectStorageMethodDB}
+
+			first, _, err := FindAndTranslateProjectForVersion(ctx, settings, v, false)
+			require.NoError(t, err)
+			require.Len(t, first.Modules, 1)
+
+			// Reproduce util.ExpandValues writing into the Module struct in place, as the manifest
+			// path does.
+			first.Modules[0].Owner = "expanded-owner"
+			first.Modules[0].Repo = "expanded-repo"
+			first.Modules[0].Ref = "expanded-ref"
+
+			second, _, err := FindAndTranslateProjectForVersion(ctx, settings, v, false)
+			require.NoError(t, err)
+			require.Len(t, second.Modules, 1)
+			assert.Equal(t, "orig-owner", second.Modules[0].Owner, "a later call must not see the first caller's in-place expansion")
+			assert.Equal(t, "orig-repo", second.Modules[0].Repo)
+			assert.Equal(t, "orig-ref", second.Modules[0].Ref)
+		})
+	}
 }
 
 func TestFindProjectFromVersionID(t *testing.T) {

--- a/repotracker/github_poller.go
+++ b/repotracker/github_poller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/google/go-github/v70/github"
@@ -16,13 +17,16 @@ import (
 // required of a RepoPoller
 type GithubRepositoryPoller struct {
 	ProjectRef *model.ProjectRef
+	// Settings gates the project translation cache when loading remote configs; may be nil.
+	Settings *evergreen.Settings
 }
 
 // NewGithubRepositoryPoller constructs and returns a pointer to a
 // GithubRepositoryPoller struct
-func NewGithubRepositoryPoller(projectRef *model.ProjectRef) *GithubRepositoryPoller {
+func NewGithubRepositoryPoller(projectRef *model.ProjectRef, settings *evergreen.Settings) *GithubRepositoryPoller {
 	return &GithubRepositoryPoller{
 		ProjectRef: projectRef,
+		Settings:   settings,
 	}
 }
 
@@ -64,7 +68,7 @@ func (gRepoPoller *GithubRepositoryPoller) GetRemoteConfig(ctx context.Context, 
 		Revision:     projectFileRevision,
 		ReadFileFrom: model.ReadFromGithub,
 	}
-	return model.GetProjectFromFile(ctx, opts)
+	return model.GetProjectFromFile(ctx, opts, gRepoPoller.Settings)
 }
 
 // GetRemoteConfig fetches the contents of a remote github repository's

--- a/repotracker/repotracker_test.go
+++ b/repotracker/repotracker_test.go
@@ -45,7 +45,7 @@ func TestFetchRevisions(t *testing.T) {
 		repoTracker := RepoTracker{
 			testConfig,
 			evgProjectRef,
-			NewGithubRepositoryPoller(evgProjectRef),
+			NewGithubRepositoryPoller(evgProjectRef, testConfig),
 		}
 
 		Convey("Fetching commits from the repository should not return any errors", func() {
@@ -86,7 +86,7 @@ func TestStoreRepositoryRevisions(t *testing.T) {
 	Convey("When storing revisions gotten from a repository...", t, func() {
 		err := modelutil.CreateTestLocalConfig(t.Context(), testConfig, "mci-test", "")
 		So(err, ShouldBeNil)
-		repoTracker := RepoTracker{testConfig, evgProjectRef, NewGithubRepositoryPoller(evgProjectRef)}
+		repoTracker := RepoTracker{testConfig, evgProjectRef, NewGithubRepositoryPoller(evgProjectRef, testConfig)}
 
 		d := distro.Distro{Id: "test-distro-one"}
 		So(d.Insert(ctx), ShouldBeNil)

--- a/repotracker/wrappers.go
+++ b/repotracker/wrappers.go
@@ -25,7 +25,7 @@ func getTracker(conf *evergreen.Settings, project model.ProjectRef) (*RepoTracke
 	tracker := &RepoTracker{
 		Settings:   conf,
 		ProjectRef: &project,
-		RepoPoller: NewGithubRepositoryPoller(&project),
+		RepoPoller: NewGithubRepositoryPoller(&project, conf),
 	}
 
 	return tracker, nil

--- a/rest/data/interface.go
+++ b/rest/data/interface.go
@@ -3,6 +3,7 @@ package data
 import (
 	"context"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/google/go-github/v70/github"
 )
@@ -15,7 +16,7 @@ type Connector interface {
 	// Get and Set URL provide access to the main url string of the API.
 	GetURL() string
 	SetURL(string)
-	GetProjectFromFile(context.Context, model.ProjectRef, string) (model.ProjectInfo, error)
+	GetProjectFromFile(context.Context, model.ProjectRef, string, *evergreen.Settings) (model.ProjectInfo, error)
 	CreateVersionFromConfig(context.Context, *model.ProjectInfo, model.VersionMetadata) (*model.Version, error)
 	GetGitHubPR(context.Context, string, string, int) (*github.PullRequest, error)
 	AddCommentToPR(context.Context, string, string, int, string) error

--- a/rest/data/mock_impl.go
+++ b/rest/data/mock_impl.go
@@ -34,7 +34,7 @@ func (pc *MockGitHubConnectorImpl) AddCommentToPR(ctx context.Context, owner, re
 	return nil
 }
 
-func (pc *MockGitHubConnectorImpl) GetProjectFromFile(ctx context.Context, pRef model.ProjectRef, file string) (model.ProjectInfo, error) {
+func (pc *MockGitHubConnectorImpl) GetProjectFromFile(ctx context.Context, pRef model.ProjectRef, file string, _ *evergreen.Settings) (model.ProjectInfo, error) {
 	config := `
 buildvariants:
 - name: v1

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -307,14 +307,14 @@ func getRequesterFromAlias(alias string) string {
 	return evergreen.PatchVersionRequester
 }
 
-func (pc *DBProjectConnector) GetProjectFromFile(ctx context.Context, pRef model.ProjectRef, file string) (model.ProjectInfo, error) {
+func (pc *DBProjectConnector) GetProjectFromFile(ctx context.Context, pRef model.ProjectRef, file string, settings *evergreen.Settings) (model.ProjectInfo, error) {
 	opts := model.GetProjectOpts{
 		Ref:          &pRef,
 		Revision:     pRef.Branch,
 		RemotePath:   file,
 		ReadFileFrom: model.ReadFromGithub,
 	}
-	return model.GetProjectFromFile(ctx, opts)
+	return model.GetProjectFromFile(ctx, opts, settings)
 }
 
 // HideBranch is used to "delete" a project via the rest route or the UI. It overwrites the project with a skeleton project.

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -1514,7 +1514,7 @@ func (gh *githubHookApi) createVersionForTag(ctx context.Context, pRef model.Pro
 				return nil, errors.Wrap(err, "getting admin settings")
 			}
 		}
-		projectInfo, err = gh.sc.GetProjectFromFile(ctx, pRef, remotePath)
+		projectInfo, err = gh.sc.GetProjectFromFile(ctx, pRef, remotePath, gh.settings)
 		if err != nil {
 			return nil, errors.Wrap(err, "loading project info from file")
 		}

--- a/trigger/project_triggers.go
+++ b/trigger/project_triggers.go
@@ -154,5 +154,5 @@ func makeDownstreamProjectFromFile(ctx context.Context, ref model.ProjectRef, fi
 		Revision:     ref.Branch,
 		ReadFileFrom: model.ReadFromGithub,
 	}
-	return model.GetProjectFromFile(ctx, opts)
+	return model.GetProjectFromFile(ctx, opts, nil)
 }


### PR DESCRIPTION
DEVPROD-36139

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Extends the existing content-hash translation cache from the version path to the file-based translate path (`GetProjectFromFile`/`GetPatchedProject` → `LoadProjectInto`), so PR-creation, merge-queue, and repotracker traffic get the same caching. Both paths now share one translate/cache helper.

I also added some more metrics as well. 

### Testing
Added 


<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
