### PR TITLE
DEVPROD-36828: Support required_labels condition in github_pr_aliases

### DIFF
--- a/docs/Project-Configuration/Github-Integrations.md
+++ b/docs/Project-Configuration/Github-Integrations.md
@@ -20,6 +20,15 @@ If you'd like the option of creating patches but wouldn't like it to happen auto
 
 You can read more about these options [here](../Project-Configuration/Project-and-Distro-Settings#github-pull-request-testing).
 
+### Label-gated tasks
+
+You can gate GitHub patch definitions on PR labels using `required_labels` on
+`github_pr_aliases` entries (see [PR Aliases](../Project-Configuration/Project-and-Distro-Settings#pr-aliases)).
+Adding a label that matches an entry's `required_labels` runs that entry's tasks on
+the current PR version; removing the label does not cancel tasks that are already
+running. If the label is added before a PR version exists (for example on a
+manual-testing project), the tasks are selected the next time a version is created.
+
 ### Retry a patch
 
 ```bash

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -755,7 +755,18 @@ commit_queue_aliases:
 github_pr_aliases:
   - variant: "^lint$"
     task: "^generate-lint$"
+  # Runs only when the PR carries any one of required_labels (OR, exact match).
+  - variant_tags: ["pr-e2e"]
+    task_tags: ["e2e"]
+    required_labels: ["evergreen:e2e"]
 ```
+
+`required_labels` gates a PR alias entry on GitHub PR labels. An entry with no
+`required_labels` always runs. An entry with `required_labels` runs when the PR
+has any one of the listed labels (exact, case-sensitive match). Adding a matching
+label to an open PR injects the newly-implied tasks into the existing PR version;
+removing a label does not cancel already-running tasks. Label gating is currently
+configurable only in the YAML `github_pr_aliases` block.
 
 ### Git Tag Aliases
 

--- a/docs/decisions/2026-07-07_github_pr_required_labels.md
+++ b/docs/decisions/2026-07-07_github_pr_required_labels.md
@@ -1,0 +1,101 @@
+# 2026-07-07 GitHub PR Alias Selection via Required Labels
+
+- status: proposed
+- date: 2026-07-07
+- authors: Maciej Karaś
+
+## Context and Problem Statement
+
+`github_pr_aliases` select which variants/tasks run on a GitHub PR, but the set is
+static per project config: every alias entry runs on every PR. Teams want to scope
+expensive or situational checks (e.g. e2e, upgrade tests) to only the PRs that need
+them, without editing config or pushing new commits, to cut PR-check cost and keep
+default PR runs fast. How should Evergreen let a PR dynamically opt into additional
+alias-selected tasks, using a signal already native to GitHub PRs (DEVPROD-36828)?
+
+## Considered Options
+
+GitHub labels were chosen as the opt-in signal because they're a first-class GitHub PR
+concept: users can add/remove them without touching YAML or making commits, and GitHub
+already restricts who can mutate them on a PR.
+
+For materializing newly-implied tasks when a label is added after a version already
+exists, three options were considered:
+
+1. **In-place injection** into the existing PR version for the current head SHA,
+   reusing the `generate.tasks` add-tasks machinery.
+2. **A separate version per label group**, created alongside the original PR version.
+3. **Recreate a single version** from the union of default and label-implied tasks
+   (supersede the existing version).
+
+Option 2 was rejected because it produces multiple GitHub statuses per SHA, which is
+confusing UX and complicates status rollup. Option 3 was rejected because Evergreen has
+no general mechanism to safely replace a version's tasks after work may already be in
+progress on it, and doing so would risk losing state or duplicating effort for tasks
+that already ran.
+
+## Decision Outcome
+
+Add a `required_labels` field to `github_pr_aliases` entries. An entry contributes its
+variant/task selection to a PR when it has no `required_labels` (today's default), or
+the PR carries any one of the entry's `required_labels` (OR semantics, exact
+case-sensitive match). Multiple entries union as PR aliases do today.
+
+Labels are read at two points:
+
+- **Version creation** (`opened`/`reopened`/`synchronize`/
+  `automatic_base_change_succeeded`): the PR's current label set, taken from the
+  webhook payload, filters the resolved PR aliases before task/variant selection.
+- **`labeled` webhook events**: newly-implied tasks are injected in place into the
+  existing PR version for the current head SHA, chosen (Option 1 above) because it
+  reuses `generate.tasks`'s existing, proven mechanism for mutating a version's builds
+  and tasks in place, and it results in exactly one version and one GitHub status per
+  SHA — the best user experience. The injection computes an idempotent delta against
+  tasks already present in the version, so repeated or out-of-order `labeled`
+  deliveries are safe.
+
+Two related behaviors follow from reusing `generate.tasks`:
+
+- **`unlabeled` is a no-op.** `generate.tasks` only ever adds tasks to a version, never
+  removes them, so there is no existing reuse path for removal. Canceling
+  mid-flight tasks when a label is removed would also be surprising and unpredictable
+  for users, so it was explicitly rejected. Removing a label only affects which
+  entries are selected the next time a version is created.
+- **No auto-creation of a version from a label.** If a `labeled` event arrives and no
+  PR version exists yet for the current SHA (e.g. manual-testing projects, an
+  unauthorized PR, or a push still being processed), the event is a no-op. Evergreen
+  never creates a version purely from a label change; the labels are still honored the
+  next time a version is created normally. This preserves the existing contract for
+  projects that only patch on-demand.
+
+Authorization is unchanged: injected tasks inherit the version's existing
+activation/authorization state, so an outside-org PR's label-implied tasks remain
+unactivated until a maintainer authorizes, via the same gate applied to default PR
+tasks. Label additions cannot bypass this gate. Check-run limits and
+max-tasks-per-version are re-checked on injection, matching the constraints already
+enforced on the `generate.tasks` path.
+
+This is a v1, YAML-only change: there is no project/repo settings UI, GraphQL, or REST
+support for `required_labels` yet, only the underlying config and data model field.
+
+## More Information
+
+Positive consequences:
+
+- Reduces PR-check cost by letting teams scope expensive checks to the PRs that need
+  them, without config changes or new commits.
+- A single version and GitHub status per SHA regardless of how many labels are added,
+  preserving today's UX.
+- Injection reuses the `generate.tasks` machinery, which is already proven safe for
+  in-place version mutation, and the delta computation makes repeated label events
+  idempotent.
+
+Negative consequences / limitations:
+
+- Removing a label never cancels or unschedules tasks that were already added; users
+  must be aware that `unlabeled` only affects future version creation.
+- v1 is YAML-only, so there's no UI/GraphQL/REST visibility or editing of
+  `required_labels` until follow-up work adds it.
+- The injection job relies on idempotent delta computation and the version-scoped lock
+  shared with `generate.tasks`, rather than a fully independent concurrency
+  mechanism, so its safety is coupled to `generate.tasks`'s existing guarantees.

--- a/model/inject_tasks.go
+++ b/model/inject_tasks.go
@@ -81,6 +81,11 @@ func InjectTasksIntoVersion(ctx context.Context, settings *evergreen.Settings, v
 		Version:    v,
 		TaskIDs:    taskIDs,
 		Pairs:      pairsForExistingVariants,
+		// Injected tasks must follow the version's activation state so that an
+		// unactivated version (e.g. an outside-org PR pending authorization) is
+		// neither itself activated nor given an activated build/task from an
+		// injected new variant.
+		RespectVersionActivation: true,
 	}
 	// Only populated for patches, not mainline commits.
 	if evergreen.IsPatchRequester(v.Requester) {

--- a/model/inject_tasks.go
+++ b/model/inject_tasks.go
@@ -1,0 +1,199 @@
+package model
+
+import (
+	"context"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/pkg/errors"
+)
+
+// InjectTasksIntoVersion adds the given task/variant pairs to an already-created
+// version in place (reusing the generate.tasks machinery) and returns the IDs of
+// the tasks that were newly created. Pairs whose task already exists in the
+// version are skipped, so repeated calls with the same pairs are idempotent.
+// The tasks must already be defined in the project config; the parser project is
+// not modified. The patch's VariantsTasks is updated so the injected tasks
+// survive a later reconfigure or restart.
+func InjectTasksIntoVersion(ctx context.Context, settings *evergreen.Settings, v *Version, p *Project, pairs TaskVariantPairs) ([]string, error) {
+	existingBuilds, err := build.Find(ctx, build.ByVersion(v.Id))
+	if err != nil {
+		return nil, errors.Wrapf(err, "finding builds for version '%s'", v.Id)
+	}
+	buildSet := map[string]struct{}{}
+	for _, b := range existingBuilds {
+		buildSet[b.BuildVariant] = struct{}{}
+	}
+
+	// Compute the delta of pairs that don't yet exist in the version so that
+	// repeated calls with the same pairs are idempotent.
+	delta, err := deltaPairsNotInVersion(ctx, v, pairs)
+	if err != nil {
+		return nil, errors.Wrapf(err, "computing task/variant pairs to inject into version '%s'", v.Id)
+	}
+	if len(delta.ExecTasks) == 0 && len(delta.DisplayTasks) == 0 {
+		return nil, nil
+	}
+
+	projectRef, err := FindMergedProjectRef(ctx, p.Identifier, v.Id, true)
+	if err != nil {
+		return nil, errors.Wrapf(err, "finding merged project ref '%s' for version '%s'", p.Identifier, v.Id)
+	}
+	if projectRef == nil {
+		return nil, errors.Errorf("project '%s' not found", p.Identifier)
+	}
+
+	if v.Requester == evergreen.GithubPRRequester {
+		numCheckRuns := p.GetNumCheckRunsFromTaskVariantPairs(&delta)
+		if err := VerifyCheckRunLimit(numCheckRuns, settings.GitHubCheckRun.CheckRunLimit, projectRef.HasGitHubAppAuth(ctx)); err != nil {
+			return nil, err
+		}
+	}
+
+	pairsForExistingVariants, pairsForNewVariants := splitPairsByExistingVariants(delta, buildSet)
+
+	taskIDs, err := NewTaskIdConfig(p, v, delta, projectRef.Identifier)
+	if err != nil {
+		return nil, errors.Wrap(err, "creating task ID table for task/variant pairs to inject")
+	}
+	if err := validateGeneratedProjectMaxTasks(ctx, v, "", taskIDs.Length()); err != nil {
+		return nil, errors.Wrapf(err, "validating the number of tasks to inject into version '%s'", v.Id)
+	}
+
+	// The task ID config was built solely from the delta, so every entry it
+	// contains corresponds to a task that will be newly created. Capture these
+	// IDs now because the task-creation calls below mutate the config's maps to
+	// include IDs of pre-existing tasks.
+	createdTaskIDs := make([]string, 0, taskIDs.Length())
+	for _, id := range taskIDs.ExecutionTasks {
+		createdTaskIDs = append(createdTaskIDs, id)
+	}
+	for _, id := range taskIDs.DisplayTasks {
+		createdTaskIDs = append(createdTaskIDs, id)
+	}
+
+	creationInfo := TaskCreationInfo{
+		Project:    p,
+		ProjectRef: projectRef,
+		Version:    v,
+		TaskIDs:    taskIDs,
+		Pairs:      pairsForExistingVariants,
+	}
+	// Only populated for patches, not mainline commits.
+	if evergreen.IsPatchRequester(v.Requester) {
+		patchDoc, err := patch.FindOneId(ctx, v.Id)
+		if err != nil {
+			return nil, errors.Wrapf(err, "finding patch '%s'", v.Id)
+		}
+		if patchDoc != nil {
+			tsParams, err := newTestSelectionParams(patchDoc)
+			if err != nil {
+				return nil, errors.Wrap(err, "making test selection params for task creation")
+			}
+			creationInfo.TestSelectionParams = *tsParams
+		}
+	}
+
+	if _, _, err := addNewTasksToExistingBuilds(ctx, creationInfo, existingBuilds, evergreen.GenerateTasksActivator); err != nil {
+		return nil, errors.Wrap(err, "adding injected tasks to existing builds")
+	}
+
+	creationInfo.Pairs = pairsForNewVariants
+	if _, _, err := addNewBuilds(ctx, creationInfo, existingBuilds); err != nil {
+		return nil, errors.Wrap(err, "adding new builds for injected tasks")
+	}
+
+	if err := updateBuildStatusesForGeneratedTasks(ctx, v.Id, pairsForExistingVariants); err != nil {
+		return nil, errors.Wrap(err, "updating statuses for builds that have injected tasks")
+	}
+
+	if err := persistInjectedTasksToPatch(ctx, v.Id, delta); err != nil {
+		return nil, errors.Wrapf(err, "persisting injected tasks to patch '%s'", v.Id)
+	}
+
+	return createdTaskIDs, nil
+}
+
+// deltaPairsNotInVersion returns the subset of pairs whose task does not already
+// exist in the version.
+func deltaPairsNotInVersion(ctx context.Context, v *Version, pairs TaskVariantPairs) (TaskVariantPairs, error) {
+	existingTasks, err := task.FindAll(ctx, db.Query(task.ByVersion(v.Id)).WithFields(task.BuildVariantKey, task.DisplayNameKey))
+	if err != nil {
+		return TaskVariantPairs{}, errors.Wrapf(err, "finding tasks for version '%s'", v.Id)
+	}
+	existingPairs := map[TVPair]struct{}{}
+	for _, t := range existingTasks {
+		existingPairs[TVPair{Variant: t.BuildVariant, TaskName: t.DisplayName}] = struct{}{}
+	}
+
+	delta := TaskVariantPairs{}
+	for _, pair := range pairs.ExecTasks {
+		if _, ok := existingPairs[pair]; !ok {
+			delta.ExecTasks = append(delta.ExecTasks, pair)
+		}
+	}
+	for _, pair := range pairs.DisplayTasks {
+		if _, ok := existingPairs[pair]; !ok {
+			delta.DisplayTasks = append(delta.DisplayTasks, pair)
+		}
+	}
+	return delta, nil
+}
+
+// splitPairsByExistingVariants partitions pairs into those whose variant already
+// has a build in the version and those whose variant does not.
+func splitPairsByExistingVariants(pairs TaskVariantPairs, buildSet map[string]struct{}) (existing, new TaskVariantPairs) {
+	for _, execTask := range pairs.ExecTasks {
+		if _, ok := buildSet[execTask.Variant]; ok {
+			existing.ExecTasks = append(existing.ExecTasks, execTask)
+		} else {
+			new.ExecTasks = append(new.ExecTasks, execTask)
+		}
+	}
+	for _, dispTask := range pairs.DisplayTasks {
+		if _, ok := buildSet[dispTask.Variant]; ok {
+			existing.DisplayTasks = append(existing.DisplayTasks, dispTask)
+		} else {
+			new.DisplayTasks = append(new.DisplayTasks, dispTask)
+		}
+	}
+	return existing, new
+}
+
+// persistInjectedTasksToPatch unions the injected pairs into the patch's stored
+// VariantsTasks so the injected tasks survive a later reconfigure or restart. It
+// is a no-op if there is no patch for the version (e.g. mainline commits).
+func persistInjectedTasksToPatch(ctx context.Context, versionID string, delta TaskVariantPairs) error {
+	patchDoc, err := patch.FindOneId(ctx, versionID)
+	if err != nil {
+		return errors.Wrapf(err, "finding patch '%s'", versionID)
+	}
+	if patchDoc == nil {
+		return nil
+	}
+
+	merged := VariantTasksToTVPairs(patchDoc.VariantsTasks)
+	seenExec := map[TVPair]struct{}{}
+	for _, pair := range merged.ExecTasks {
+		seenExec[pair] = struct{}{}
+	}
+	seenDisplay := map[TVPair]struct{}{}
+	for _, pair := range merged.DisplayTasks {
+		seenDisplay[pair] = struct{}{}
+	}
+	for _, pair := range delta.ExecTasks {
+		if _, ok := seenExec[pair]; !ok {
+			merged.ExecTasks = append(merged.ExecTasks, pair)
+		}
+	}
+	for _, pair := range delta.DisplayTasks {
+		if _, ok := seenDisplay[pair]; !ok {
+			merged.DisplayTasks = append(merged.DisplayTasks, pair)
+		}
+	}
+
+	return errors.Wrap(patchDoc.SetVariantsTasks(ctx, merged.TVPairsToVariantTasks()), "setting patch variants and tasks")
+}

--- a/model/inject_tasks_test.go
+++ b/model/inject_tasks_test.go
@@ -167,6 +167,97 @@ func TestInjectTasksIntoVersionAddsDeltaAndUpdatesPatch(t *testing.T) {
 	assert.True(t, found, "injected task should be persisted in patch VariantsTasks")
 }
 
+func TestInjectTasksIntoVersionExistingBuildOnUnactivatedVersionStaysUnactivated(t *testing.T) {
+	ctx := testutil.TestSpan(t.Context(), t)
+	settings := testutil.TestConfig()
+
+	require.NoError(t, db.ClearCollections(ProjectRefCollection, VersionCollection, build.Collection, task.Collection, patch.Collection, ParserProjectCollection))
+
+	const (
+		projectID = "myproj"
+		variant   = "bv1"
+		existing  = "task_existing"
+		injected  = "task_new"
+	)
+
+	oid := mgobson.NewObjectId()
+	versionID := oid.Hex()
+
+	// An outside-org PR version is created unactivated pending maintainer authorization.
+	v := &Version{
+		Id:         versionID,
+		Identifier: projectID,
+		Requester:  evergreen.GithubPRRequester,
+		CreateTime: time.Now(),
+		Activated:  utility.FalsePtr(),
+		BuildIds:   []string{"b1"},
+		BuildVariants: []VersionBuildStatus{{
+			BuildVariant: variant,
+			BuildId:      "b1",
+		}},
+	}
+	require.NoError(t, v.Insert(t.Context()))
+
+	// The build for the injected task's variant already exists but is unactivated.
+	b := build.Build{
+		Id:           "b1",
+		BuildVariant: variant,
+		Version:      versionID,
+		Activated:    false,
+	}
+	require.NoError(t, b.Insert(t.Context()))
+
+	projectRef := ProjectRef{Id: projectID, Identifier: projectID}
+	require.NoError(t, projectRef.Insert(t.Context()))
+
+	pp := ParserProject{}
+	require.NoError(t, util.UnmarshalYAMLWithFallback([]byte(injectTasksConfig), &pp))
+	pp.Id = versionID
+	pp.Identifier = utility.ToStringPtr(projectID)
+	require.NoError(t, pp.Insert(t.Context()))
+
+	p, err := TranslateProject(ctx, &pp)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	p.Identifier = projectID
+
+	existingTask := task.Task{
+		Id:           "existing_task_id",
+		Version:      versionID,
+		BuildId:      "b1",
+		Project:      projectID,
+		DisplayName:  existing,
+		BuildVariant: variant,
+		Activated:    false,
+	}
+	require.NoError(t, existingTask.Insert(t.Context()))
+
+	patchDoc := patch.Patch{
+		Id:      oid,
+		Project: projectID,
+		Version: versionID,
+		VariantsTasks: []patch.VariantTasks{{
+			Variant: variant,
+			Tasks:   []string{existing},
+		}},
+	}
+	require.NoError(t, patchDoc.Insert(t.Context()))
+
+	// Inject a task onto bv1, whose build already exists, exercising the
+	// existing-build path.
+	pairs := TaskVariantPairs{ExecTasks: TVPairSet{{Variant: variant, TaskName: injected}}}
+
+	createdIDs, err := InjectTasksIntoVersion(ctx, settings, v, p, pairs)
+	require.NoError(t, err)
+	require.Len(t, createdIDs, 1)
+
+	injectedTask, err := task.FindOneId(ctx, createdIDs[0])
+	require.NoError(t, err)
+	require.NotNil(t, injectedTask)
+	assert.Equal(t, variant, injectedTask.BuildVariant)
+	assert.False(t, injectedTask.Activated, "injected task on an existing build of an unactivated version must not be activated")
+}
+
 func TestInjectTasksIntoVersionNewVariantOnUnactivatedVersionStaysUnactivated(t *testing.T) {
 	ctx := testutil.TestSpan(t.Context(), t)
 	settings := testutil.TestConfig()

--- a/model/inject_tasks_test.go
+++ b/model/inject_tasks_test.go
@@ -1,0 +1,155 @@
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
+	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const injectTasksConfig = `
+buildvariants:
+  - name: bv1
+    display_name: BV One
+    run_on:
+      - ubuntu1604-test
+    tasks:
+      - name: task_existing
+      - name: task_new
+
+tasks:
+  - name: task_existing
+    commands:
+      - command: shell.exec
+        params:
+          script: "echo hi"
+  - name: task_new
+    commands:
+      - command: shell.exec
+        params:
+          script: "echo hi"
+`
+
+func TestInjectTasksIntoVersionAddsDeltaAndUpdatesPatch(t *testing.T) {
+	ctx := testutil.TestSpan(t.Context(), t)
+	settings := testutil.TestConfig()
+
+	require.NoError(t, db.ClearCollections(ProjectRefCollection, VersionCollection, build.Collection, task.Collection, patch.Collection, ParserProjectCollection))
+
+	const (
+		projectID = "myproj"
+		variant   = "bv1"
+		existing  = "task_existing"
+		injected  = "task_new"
+	)
+
+	oid := mgobson.NewObjectId()
+	versionID := oid.Hex()
+
+	v := &Version{
+		Id:         versionID,
+		Identifier: projectID,
+		Requester:  evergreen.GithubPRRequester,
+		CreateTime: time.Now(),
+		BuildIds:   []string{"b1"},
+		BuildVariants: []VersionBuildStatus{{
+			BuildVariant: variant,
+			BuildId:      "b1",
+		}},
+	}
+	require.NoError(t, v.Insert(t.Context()))
+
+	b := build.Build{
+		Id:           "b1",
+		BuildVariant: variant,
+		Version:      versionID,
+		Activated:    true,
+	}
+	require.NoError(t, b.Insert(t.Context()))
+
+	projectRef := ProjectRef{Id: projectID, Identifier: projectID}
+	require.NoError(t, projectRef.Insert(t.Context()))
+
+	pp := ParserProject{}
+	require.NoError(t, util.UnmarshalYAMLWithFallback([]byte(injectTasksConfig), &pp))
+	pp.Id = versionID
+	pp.Identifier = utility.ToStringPtr(projectID)
+	require.NoError(t, pp.Insert(t.Context()))
+
+	p, err := TranslateProject(ctx, &pp)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	p.Identifier = projectID
+
+	existingTask := task.Task{
+		Id:           "existing_task_id",
+		Version:      versionID,
+		BuildId:      "b1",
+		Project:      projectID,
+		DisplayName:  existing,
+		BuildVariant: variant,
+		Activated:    true,
+	}
+	require.NoError(t, existingTask.Insert(t.Context()))
+
+	patchDoc := patch.Patch{
+		Id:      oid,
+		Project: projectID,
+		Version: versionID,
+		VariantsTasks: []patch.VariantTasks{{
+			Variant: variant,
+			Tasks:   []string{existing},
+		}},
+	}
+	require.NoError(t, patchDoc.Insert(t.Context()))
+
+	pairs := TaskVariantPairs{ExecTasks: TVPairSet{{Variant: variant, TaskName: injected}}}
+
+	createdIDs, err := InjectTasksIntoVersion(ctx, settings, v, p, pairs)
+	require.NoError(t, err)
+	require.Len(t, createdIDs, 1)
+
+	tasks, err := task.FindAll(ctx, db.Query(task.ByVersion(versionID)))
+	require.NoError(t, err)
+	names := map[string]bool{}
+	for _, tsk := range tasks {
+		names[tsk.DisplayName] = true
+	}
+	assert.True(t, names[existing])
+	assert.True(t, names[injected])
+	assert.Len(t, tasks, 2)
+
+	// A second call with the same pairs is idempotent: no new tasks, empty result.
+	createdIDsAgain, err := InjectTasksIntoVersion(ctx, settings, v, p, pairs)
+	require.NoError(t, err)
+	assert.Empty(t, createdIDsAgain)
+
+	tasks, err = task.FindAll(ctx, db.Query(task.ByVersion(versionID)))
+	require.NoError(t, err)
+	assert.Len(t, tasks, 2)
+
+	// The patch's VariantsTasks reflects the injected pair so it survives a restart.
+	reloaded, err := patch.FindOneId(ctx, versionID)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded)
+	found := false
+	for _, vt := range reloaded.VariantsTasks {
+		if vt.Variant == variant {
+			assert.Contains(t, vt.Tasks, existing)
+			if utility.StringSliceContains(vt.Tasks, injected) {
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "injected task should be persisted in patch VariantsTasks")
+}

--- a/model/inject_tasks_test.go
+++ b/model/inject_tasks_test.go
@@ -26,6 +26,12 @@ buildvariants:
     tasks:
       - name: task_existing
       - name: task_new
+  - name: bv2
+    display_name: BV Two
+    run_on:
+      - ubuntu1604-test
+    tasks:
+      - name: task_new
 
 tasks:
   - name: task_existing
@@ -61,6 +67,7 @@ func TestInjectTasksIntoVersionAddsDeltaAndUpdatesPatch(t *testing.T) {
 		Identifier: projectID,
 		Requester:  evergreen.GithubPRRequester,
 		CreateTime: time.Now(),
+		Activated:  utility.TruePtr(),
 		BuildIds:   []string{"b1"},
 		BuildVariants: []VersionBuildStatus{{
 			BuildVariant: variant,
@@ -129,6 +136,12 @@ func TestInjectTasksIntoVersionAddsDeltaAndUpdatesPatch(t *testing.T) {
 	assert.True(t, names[injected])
 	assert.Len(t, tasks, 2)
 
+	// The injected task lands on an already-activated build, so it is activated.
+	injectedTask, err := task.FindOneId(ctx, createdIDs[0])
+	require.NoError(t, err)
+	require.NotNil(t, injectedTask)
+	assert.True(t, injectedTask.Activated, "injected task on an activated build should be activated")
+
 	// A second call with the same pairs is idempotent: no new tasks, empty result.
 	createdIDsAgain, err := InjectTasksIntoVersion(ctx, settings, v, p, pairs)
 	require.NoError(t, err)
@@ -152,4 +165,100 @@ func TestInjectTasksIntoVersionAddsDeltaAndUpdatesPatch(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "injected task should be persisted in patch VariantsTasks")
+}
+
+func TestInjectTasksIntoVersionNewVariantOnUnactivatedVersionStaysUnactivated(t *testing.T) {
+	ctx := testutil.TestSpan(t.Context(), t)
+	settings := testutil.TestConfig()
+
+	require.NoError(t, db.ClearCollections(ProjectRefCollection, VersionCollection, build.Collection, task.Collection, patch.Collection, ParserProjectCollection))
+
+	const (
+		projectID  = "myproj"
+		existingBV = "bv1"
+		newBV      = "bv2"
+		existing   = "task_existing"
+		injected   = "task_new"
+	)
+
+	oid := mgobson.NewObjectId()
+	versionID := oid.Hex()
+
+	// An outside-org PR version is created unactivated pending maintainer authorization.
+	v := &Version{
+		Id:         versionID,
+		Identifier: projectID,
+		Requester:  evergreen.GithubPRRequester,
+		CreateTime: time.Now(),
+		Activated:  utility.FalsePtr(),
+		BuildIds:   []string{"b1"},
+		BuildVariants: []VersionBuildStatus{{
+			BuildVariant: existingBV,
+			BuildId:      "b1",
+		}},
+	}
+	require.NoError(t, v.Insert(t.Context()))
+
+	// The existing build (and only build) is for bv1 and is unactivated.
+	b := build.Build{
+		Id:           "b1",
+		BuildVariant: existingBV,
+		Version:      versionID,
+		Activated:    false,
+	}
+	require.NoError(t, b.Insert(t.Context()))
+
+	projectRef := ProjectRef{Id: projectID, Identifier: projectID}
+	require.NoError(t, projectRef.Insert(t.Context()))
+
+	pp := ParserProject{}
+	require.NoError(t, util.UnmarshalYAMLWithFallback([]byte(injectTasksConfig), &pp))
+	pp.Id = versionID
+	pp.Identifier = utility.ToStringPtr(projectID)
+	require.NoError(t, pp.Insert(t.Context()))
+
+	p, err := TranslateProject(ctx, &pp)
+	require.NoError(t, err)
+	require.NotNil(t, p)
+	p.Identifier = projectID
+
+	existingTask := task.Task{
+		Id:           "existing_task_id",
+		Version:      versionID,
+		BuildId:      "b1",
+		Project:      projectID,
+		DisplayName:  existing,
+		BuildVariant: existingBV,
+		Activated:    false,
+	}
+	require.NoError(t, existingTask.Insert(t.Context()))
+
+	patchDoc := patch.Patch{
+		Id:      oid,
+		Project: projectID,
+		Version: versionID,
+		VariantsTasks: []patch.VariantTasks{{
+			Variant: existingBV,
+			Tasks:   []string{existing},
+		}},
+	}
+	require.NoError(t, patchDoc.Insert(t.Context()))
+
+	// Inject a task onto bv2, which has no build yet, forcing the new-build path.
+	pairs := TaskVariantPairs{ExecTasks: TVPairSet{{Variant: newBV, TaskName: injected}}}
+
+	createdIDs, err := InjectTasksIntoVersion(ctx, settings, v, p, pairs)
+	require.NoError(t, err)
+	require.Len(t, createdIDs, 1)
+
+	injectedTask, err := task.FindOneId(ctx, createdIDs[0])
+	require.NoError(t, err)
+	require.NotNil(t, injectedTask)
+	assert.Equal(t, newBV, injectedTask.BuildVariant)
+	assert.False(t, injectedTask.Activated, "injected task on a new build of an unactivated version must not be activated")
+
+	newBuild, err := build.FindOneId(ctx, injectedTask.BuildId)
+	require.NoError(t, err)
+	require.NotNil(t, newBuild)
+	assert.False(t, newBuild.Activated, "new build for an unactivated version must not be activated")
 }

--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1507,6 +1507,9 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 		taskNames := creationInfo.Pairs.ExecTasks.TaskNames(pair.Variant)
 		displayNames := creationInfo.Pairs.DisplayTasks.TaskNames(pair.Variant)
 		activateVariant := !creationInfo.ActivationInfo.variantHasSpecificActivation(pair.Variant)
+		if creationInfo.RespectVersionActivation {
+			activateVariant = activateVariant && utility.FromBoolPtr(creationInfo.Version.Activated)
+		}
 		tsParams := creationInfo.TestSelectionParams
 		tsParams.CanBuildVariantEnableTestSelection = canBuildVariantEnableTestSelection(pair.Variant, creationInfo)
 		buildCreationArgs := TaskCreationInfo{
@@ -1767,13 +1770,18 @@ func addNewTasksToExistingBuilds(ctx context.Context, creationInfo TaskCreationI
 			return nil, nil, err
 		}
 	}
-	if creationInfo.ActivationInfo.hasActivationTasks() {
-		if err = creationInfo.Version.ActivateAndSetBuildVariants(ctx); err != nil {
-			return nil, nil, errors.Wrap(err, "activating version and adding batchtime tasks")
-		}
-	} else {
-		if err = creationInfo.Version.SetActivated(ctx, true); err != nil {
-			return nil, nil, errors.Wrap(err, "setting version activation to true")
+	// When respecting the version's activation state (e.g. injecting tasks into an
+	// unactivated PR version pending authorization), leave the version's activation
+	// untouched rather than forcing it active.
+	if !creationInfo.RespectVersionActivation {
+		if creationInfo.ActivationInfo.hasActivationTasks() {
+			if err = creationInfo.Version.ActivateAndSetBuildVariants(ctx); err != nil {
+				return nil, nil, errors.Wrap(err, "activating version and adding batchtime tasks")
+			}
+		} else {
+			if err = creationInfo.Version.SetActivated(ctx, true); err != nil {
+				return nil, nil, errors.Wrap(err, "setting version activation to true")
+			}
 		}
 	}
 

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -100,6 +100,9 @@ type githubIntent struct {
 
 	// Alias defines the variants and tasks to run this patch on. It will default to __github if not set.
 	Alias string `bson:"alias"`
+
+	// Labels is the set of GitHub PR label names present on the PR when the intent was created.
+	Labels []string `bson:"labels,omitempty"`
 }
 
 // BSON fields for the patches
@@ -190,7 +193,20 @@ func NewGithubIntent(ctx context.Context, msgDeliveryID, patchOwner, calledBy, a
 		CalledBy:      calledBy,
 		RepeatPatchId: repeat,
 		Alias:         alias,
+		Labels:        githubPRLabelNames(pr),
 	}, nil
+}
+
+// githubPRLabelNames returns the label names currently attached to the PR.
+func githubPRLabelNames(pr *github.PullRequest) []string {
+	if len(pr.Labels) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(pr.Labels))
+	for _, l := range pr.Labels {
+		names = append(names, l.GetName())
+	}
+	return names
 }
 
 // getRepeatPatchId returns the patch id to repeat the definitions from
@@ -312,6 +328,7 @@ func (g *githubIntent) NewPatch() *Patch {
 			MergeBase:  g.MergeBase,
 			Author:     g.User,
 			AuthorUID:  g.UID,
+			Labels:     g.Labels,
 		},
 	}
 	return patchDoc

--- a/model/patch/github_test.go
+++ b/model/patch/github_test.go
@@ -140,6 +140,23 @@ func (s *GithubSuite) TestNewGithubIntent() {
 	s.Equal(patchId, ghIntent.RepeatPatchId)
 }
 
+func (s *GithubSuite) TestNewGithubIntentPopulatesLabels() {
+	pr := testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, s.user, s.title)
+	pr.Labels = []*github.Label{
+		{Name: github.String("evergreen:e2e")},
+		{Name: github.String("evergreen:upgrade")},
+	}
+
+	intent, err := NewGithubIntent(s.T().Context(), "labels-1", "", "", "", "", pr)
+	s.Require().NoError(err)
+	s.Require().NotNil(intent)
+
+	ghIntent, ok := intent.(*githubIntent)
+	s.Require().True(ok)
+	s.Equal([]string{"evergreen:e2e", "evergreen:upgrade"}, ghIntent.Labels)
+	s.Equal([]string{"evergreen:e2e", "evergreen:upgrade"}, intent.NewPatch().GithubPatchData.Labels)
+}
+
 func (s *GithubSuite) TestNewGithubIntentSageBotUsesAssignee() {
 	assigneeLogin := "real-human"
 	var assigneeID int64 = 9999

--- a/model/project.go
+++ b/model/project.go
@@ -1846,6 +1846,12 @@ func (p *Project) ResolvePatchVTs(ctx context.Context, patchDoc *patch.Patch, re
 		aliases, err := findAliasesForPatch(ctx, p.Identifier, alias, patchDoc)
 		catcher.Wrapf(err, "retrieving alias '%s' for patched project config '%s'", alias, patchDoc.Id.Hex())
 
+		// GitHub PR alias entries may be gated on PR labels; only include the
+		// entries whose required labels are satisfied by the PR's current labels.
+		if alias == evergreen.GithubPRAlias {
+			aliases = ProjectAliases(aliases).FilterByLabels(patchDoc.GithubPatchData.Labels)
+		}
+
 		aliasPairs := TaskVariantPairs{}
 		if !catcher.HasErrors() {
 			aliasPairs, err = p.BuildProjectTVPairsWithAlias(aliases, requester)

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -67,17 +67,18 @@ const (
 // variants/tasks, assuming the tag matches the defined git_tag regex.
 // In this way, users can define different behavior for different kind of tags.
 type ProjectAlias struct {
-	ID          mgobson.ObjectId  `bson:"_id,omitempty" json:"_id" yaml:"id"`
-	ProjectID   string            `bson:"project_id" json:"project_id" yaml:"project_id"`
-	Alias       string            `bson:"alias" json:"alias" yaml:"alias"`
-	Variant     string            `bson:"variant,omitempty" json:"variant" yaml:"variant"`
-	Description string            `bson:"description" json:"description" yaml:"description"`
-	GitTag      string            `bson:"git_tag" json:"git_tag" yaml:"git_tag"`
-	RemotePath  string            `bson:"remote_path" json:"remote_path" yaml:"remote_path"`
-	VariantTags []string          `bson:"variant_tags,omitempty" json:"variant_tags" yaml:"variant_tags"`
-	Task        string            `bson:"task,omitempty" json:"task" yaml:"task"`
-	TaskTags    []string          `bson:"tags,omitempty" json:"tags" yaml:"task_tags"`
-	Parameters  []patch.Parameter `bson:"parameters,omitempty" json:"parameters" yaml:"parameters"`
+	ID             mgobson.ObjectId  `bson:"_id,omitempty" json:"_id" yaml:"id"`
+	ProjectID      string            `bson:"project_id" json:"project_id" yaml:"project_id"`
+	Alias          string            `bson:"alias" json:"alias" yaml:"alias"`
+	Variant        string            `bson:"variant,omitempty" json:"variant" yaml:"variant"`
+	Description    string            `bson:"description" json:"description" yaml:"description"`
+	GitTag         string            `bson:"git_tag" json:"git_tag" yaml:"git_tag"`
+	RemotePath     string            `bson:"remote_path" json:"remote_path" yaml:"remote_path"`
+	VariantTags    []string          `bson:"variant_tags,omitempty" json:"variant_tags" yaml:"variant_tags"`
+	Task           string            `bson:"task,omitempty" json:"task" yaml:"task"`
+	TaskTags       []string          `bson:"tags,omitempty" json:"tags" yaml:"task_tags"`
+	RequiredLabels []string          `bson:"required_labels,omitempty" json:"required_labels" yaml:"required_labels"`
+	Parameters     []patch.Parameter `bson:"parameters,omitempty" json:"parameters" yaml:"parameters"`
 
 	// Source is not stored; indicates where the alias is stored for the project.
 	Source string `bson:"-" json:"-" yaml:"-"`
@@ -503,6 +504,31 @@ func aliasesMatchingGitTag(a ProjectAliases, tag string) (ProjectAliases, error)
 		}
 	}
 	return res, nil
+}
+
+// FilterByLabels returns the aliases that are applicable given the provided set
+// of GitHub PR labels. An alias with no RequiredLabels is always included. An
+// alias with RequiredLabels is included when the PR carries any one of them
+// (OR semantics, exact case-sensitive match).
+func (a ProjectAliases) FilterByLabels(labels []string) ProjectAliases {
+	labelSet := make(map[string]struct{}, len(labels))
+	for _, l := range labels {
+		labelSet[l] = struct{}{}
+	}
+	filtered := ProjectAliases{}
+	for _, alias := range a {
+		if len(alias.RequiredLabels) == 0 {
+			filtered = append(filtered, alias)
+			continue
+		}
+		for _, required := range alias.RequiredLabels {
+			if _, ok := labelSet[required]; ok {
+				filtered = append(filtered, alias)
+				break
+			}
+		}
+	}
+	return filtered
 }
 
 // AliasesMatchingVariant returns the filtered set of project aliases for which

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -19,17 +19,18 @@ import (
 )
 
 var (
-	idKey          = bsonutil.MustHaveTag(ProjectAlias{}, "ID")
-	projectIDKey   = bsonutil.MustHaveTag(ProjectAlias{}, "ProjectID")
-	aliasKey       = bsonutil.MustHaveTag(ProjectAlias{}, "Alias")
-	gitTagKey      = bsonutil.MustHaveTag(ProjectAlias{}, "GitTag")
-	remotePathKey  = bsonutil.MustHaveTag(ProjectAlias{}, "RemotePath")
-	variantKey     = bsonutil.MustHaveTag(ProjectAlias{}, "Variant")
-	descriptionKey = bsonutil.MustHaveTag(ProjectAlias{}, "Description")
-	taskKey        = bsonutil.MustHaveTag(ProjectAlias{}, "Task")
-	parametersKey  = bsonutil.MustHaveTag(ProjectAlias{}, "Parameters")
-	variantTagsKey = bsonutil.MustHaveTag(ProjectAlias{}, "VariantTags")
-	taskTagsKey    = bsonutil.MustHaveTag(ProjectAlias{}, "TaskTags")
+	idKey             = bsonutil.MustHaveTag(ProjectAlias{}, "ID")
+	projectIDKey      = bsonutil.MustHaveTag(ProjectAlias{}, "ProjectID")
+	aliasKey          = bsonutil.MustHaveTag(ProjectAlias{}, "Alias")
+	gitTagKey         = bsonutil.MustHaveTag(ProjectAlias{}, "GitTag")
+	remotePathKey     = bsonutil.MustHaveTag(ProjectAlias{}, "RemotePath")
+	variantKey        = bsonutil.MustHaveTag(ProjectAlias{}, "Variant")
+	descriptionKey    = bsonutil.MustHaveTag(ProjectAlias{}, "Description")
+	taskKey           = bsonutil.MustHaveTag(ProjectAlias{}, "Task")
+	parametersKey     = bsonutil.MustHaveTag(ProjectAlias{}, "Parameters")
+	variantTagsKey    = bsonutil.MustHaveTag(ProjectAlias{}, "VariantTags")
+	taskTagsKey       = bsonutil.MustHaveTag(ProjectAlias{}, "TaskTags")
+	requiredLabelsKey = bsonutil.MustHaveTag(ProjectAlias{}, "RequiredLabels")
 )
 
 const (
@@ -428,16 +429,17 @@ func (p *ProjectAlias) Upsert(ctx context.Context) error {
 		p.ID = mgobson.NewObjectId()
 	}
 	update := bson.M{
-		aliasKey:       p.Alias,
-		gitTagKey:      p.GitTag,
-		remotePathKey:  p.RemotePath,
-		projectIDKey:   p.ProjectID,
-		variantKey:     p.Variant,
-		descriptionKey: p.Description,
-		variantTagsKey: p.VariantTags,
-		taskTagsKey:    p.TaskTags,
-		taskKey:        p.Task,
-		parametersKey:  p.Parameters,
+		aliasKey:          p.Alias,
+		gitTagKey:         p.GitTag,
+		remotePathKey:     p.RemotePath,
+		projectIDKey:      p.ProjectID,
+		variantKey:        p.Variant,
+		descriptionKey:    p.Description,
+		variantTagsKey:    p.VariantTags,
+		taskTagsKey:       p.TaskTags,
+		taskKey:           p.Task,
+		parametersKey:     p.Parameters,
+		requiredLabelsKey: p.RequiredLabels,
 	}
 
 	_, err := db.Upsert(ctx, ProjectAliasCollection, bson.M{

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -681,8 +681,19 @@ func ValidateProjectAliases(aliases []ProjectAlias, aliasType string) []string {
 			errs = append(errs, fmt.Sprintf("%s: cannot define git tag or remote path on line #%d", aliasType, i+1))
 		}
 		errs = append(errs, validateAliasPatchDefinition(pd, aliasType, i+1)...)
+		errs = append(errs, validateRequiredLabels(pd, aliasType, i+1)...)
 	}
 
+	return errs
+}
+
+func validateRequiredLabels(pd ProjectAlias, aliasType string, lineNum int) []string {
+	errs := []string{}
+	for i, label := range pd.RequiredLabels {
+		if strings.TrimSpace(label) == "" {
+			errs = append(errs, fmt.Sprintf("%s: required label #%d on line #%d can't be empty string", aliasType, i+1, lineNum))
+		}
+	}
 	return errs
 }
 

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -804,3 +804,45 @@ func TestFilterByLabels(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateProjectAliasesRequiredLabels(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		requiredLabels []string
+		expectedErrs   []string
+	}{
+		{
+			name:           "EmptyRequiredLabelErrors",
+			requiredLabels: []string{""},
+			expectedErrs:   []string{"aliasType: required label #1 on line #1 can't be empty string"},
+		},
+		{
+			name:           "WhitespaceOnlyRequiredLabelErrors",
+			requiredLabels: []string{"   "},
+			expectedErrs:   []string{"aliasType: required label #1 on line #1 can't be empty string"},
+		},
+		{
+			name:           "NonEmptyRequiredLabelsAreValid",
+			requiredLabels: []string{"evergreen:e2e", "evergreen:full"},
+			expectedErrs:   []string{},
+		},
+		{
+			name:           "NilRequiredLabelsAreValid",
+			requiredLabels: nil,
+			expectedErrs:   []string{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			aliases := []ProjectAlias{
+				{
+					Alias:          evergreen.GithubPRAlias,
+					Variant:        "^e2e$",
+					Task:           "^test$",
+					RequiredLabels: tc.requiredLabels,
+				},
+			}
+			errs := ValidateProjectAliases(aliases, "aliasType")
+			assert.Equal(t, tc.expectedErrs, errs)
+		})
+	}
+}

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -780,3 +780,27 @@ func TestValidateGitTagAlias(t *testing.T) {
 	errs = validateGitTagAlias(a, "gitTag", 1)
 	assert.Empty(t, errs)
 }
+
+func TestFilterByLabels(t *testing.T) {
+	noLabels := ProjectAlias{Alias: evergreen.GithubPRAlias, Variant: "^default$"}
+	e2e := ProjectAlias{Alias: evergreen.GithubPRAlias, Variant: "^e2e$", RequiredLabels: []string{"evergreen:e2e"}}
+	upgrade := ProjectAlias{Alias: evergreen.GithubPRAlias, Variant: "^upgrade$", RequiredLabels: []string{"evergreen:upgrade", "evergreen:full"}}
+	all := ProjectAliases{noLabels, e2e, upgrade}
+
+	for _, tc := range []struct {
+		name     string
+		labels   []string
+		expected ProjectAliases
+	}{
+		{name: "NoLabelsIncludesOnlyUngatedEntries", labels: nil, expected: ProjectAliases{noLabels}},
+		{name: "MatchingLabelIncludesGatedEntry", labels: []string{"evergreen:e2e"}, expected: ProjectAliases{noLabels, e2e}},
+		{name: "AnyOfRequiredLabelsMatches", labels: []string{"evergreen:full"}, expected: ProjectAliases{noLabels, upgrade}},
+		{name: "MultipleLabelsIncludeMultipleEntries", labels: []string{"evergreen:e2e", "evergreen:upgrade"}, expected: ProjectAliases{noLabels, e2e, upgrade}},
+		{name: "NonMatchingLabelIncludesOnlyUngated", labels: []string{"unrelated"}, expected: ProjectAliases{noLabels}},
+		{name: "MatchIsCaseSensitive", labels: []string{"Evergreen:E2E"}, expected: ProjectAliases{noLabels}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, all.FilterByLabels(tc.labels))
+		})
+	}
+}

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -2317,6 +2317,37 @@ func TestVariantTasksForSelectors(t *testing.T) {
 	}
 }
 
+func TestResolvePatchVTsFiltersGithubPRAliasesByLabels(t *testing.T) {
+	require.NoError(t, db.ClearCollections(ProjectAliasCollection))
+	defer func() {
+		assert.NoError(t, db.ClearCollections(ProjectAliasCollection))
+	}()
+	ctx := t.Context()
+
+	p := &Project{
+		Identifier: "proj",
+		BuildVariants: []BuildVariant{
+			{Name: "default", Tasks: []BuildVariantTaskUnit{{Name: "t", Variant: "default"}}},
+			{Name: "e2e", Tasks: []BuildVariantTaskUnit{{Name: "t", Variant: "e2e"}}},
+		},
+		Tasks: []ProjectTask{{Name: "t"}},
+	}
+	for _, a := range []ProjectAlias{
+		{ProjectID: "proj", Alias: evergreen.GithubPRAlias, Variant: "^default$", Task: "^t$"},
+		{ProjectID: "proj", Alias: evergreen.GithubPRAlias, Variant: "^e2e$", Task: "^t$", RequiredLabels: []string{"evergreen:e2e"}},
+	} {
+		require.NoError(t, a.Upsert(ctx))
+	}
+
+	withLabel := &patch.Patch{Alias: evergreen.GithubPRAlias, GithubPatchData: thirdparty.GithubPatch{Labels: []string{"evergreen:e2e"}}}
+	bvsWith, _, _ := p.ResolvePatchVTs(ctx, withLabel, evergreen.GithubPRRequester, evergreen.GithubPRAlias, false)
+	assert.ElementsMatch(t, []string{"default", "e2e"}, bvsWith)
+
+	withoutLabel := &patch.Patch{Alias: evergreen.GithubPRAlias, GithubPatchData: thirdparty.GithubPatch{}}
+	bvsWithout, _, _ := p.ResolvePatchVTs(ctx, withoutLabel, evergreen.GithubPRRequester, evergreen.GithubPRAlias, false)
+	assert.ElementsMatch(t, []string{"default"}, bvsWithout)
+}
+
 func TestSkipOnRequester(t *testing.T) {
 	t.Run("PatchRequester", func(t *testing.T) {
 		requester := evergreen.PatchVersionRequester

--- a/model/task_creation.go
+++ b/model/task_creation.go
@@ -43,6 +43,17 @@ type TaskCreationInfo struct {
 	// as dependencies.
 	ExplicitlyGeneratedTasks map[TVPair]bool
 	TestSelectionParams      TestSelectionParams // Task creation parameters for test selection
+	// RespectVersionActivation makes build and task creation follow the version's
+	// own activation state instead of unconditionally activating. When true, a
+	// newly-created build (and its tasks) is only activated if the version is
+	// activated (mirroring initial build creation in repotracker), and the
+	// version's activation state is left untouched rather than being forced to
+	// activated. This preserves the authorization gate when injecting tasks into
+	// an unactivated version (e.g. an outside-org PR pending authorization). When
+	// false (the default), builds activate unless they have specific activation
+	// conditions and the version is set activated, matching the generate.tasks
+	// and patch-reconfigure behavior.
+	RespectVersionActivation bool
 }
 
 // TestSelectionParams contains parameters for enabling test selection on tasks

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -39,6 +39,8 @@ const (
 	githubActionChecksRequested = "checks_requested"
 	githubActionRerequested     = "rerequested"
 	githubActionDestroyed       = "destroyed"
+	githubActionLabeled         = "labeled"
+	githubActionUnlabeled       = "unlabeled"
 
 	// pull request comments
 	retryComment            = "evergreen retry"
@@ -294,7 +296,43 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 			}
 
 			return gimlet.NewJSONResponse(struct{}{})
+		} else if action == githubActionLabeled {
+			labels := make([]string, 0, len(event.GetPullRequest().Labels))
+			for _, label := range event.GetPullRequest().Labels {
+				labels = append(labels, label.GetName())
+			}
+
+			grip.Info(ctx, message.Fields{
+				"source":    "GitHub hook",
+				"msg_id":    gh.msgID,
+				"event":     gh.eventType,
+				"action":    action,
+				"repo":      event.GetPullRequest().GetBase().GetRepo().GetFullName(),
+				"pr_number": event.GetPullRequest().GetNumber(),
+				"label":     event.GetLabel().GetName(),
+				"message":   "pull request labeled; injecting label-implied tasks",
+			})
+
+			j := units.NewGithubPRLabelInjectJob(evergreen.GetEnvironment(), event.Repo.Owner.GetLogin(), event.Repo.GetName(), event.PullRequest.GetNumber(), event.PullRequest.GetHead().GetSHA(), labels, gh.msgID)
+			if err := amboy.EnqueueUniqueJob(ctx, gh.queue, j); err != nil {
+				grip.Error(ctx, message.WrapError(err, message.Fields{
+					"source":    "GitHub hook",
+					"msg_id":    gh.msgID,
+					"event":     gh.eventType,
+					"action":    action,
+					"repo":      event.GetPullRequest().GetBase().GetRepo().GetFullName(),
+					"pr_number": event.GetPullRequest().GetNumber(),
+					"message":   "can't enqueue label inject job",
+				}))
+				return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "enqueueing label inject job"))
+			}
+
+			return gimlet.NewJSONResponse(struct{}{})
 		}
+		// The "unlabeled" action is intentionally not handled: removing a label
+		// never cancels tasks that are running or have already been added to a
+		// version. It only affects which tasks get added to the next version
+		// created for the PR.
 	case *github.PushEvent:
 		fromApp := event.GetInstallation() != nil
 		if gh.shouldSkipWebhook(ctx, event.Repo.Owner.GetLogin(), event.Repo.GetName(), fromApp) {

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -142,6 +142,55 @@ func (s *GithubWebhookRouteSuite) TestAddIntentAndFailsWithDuplicate() {
 	s.Equal(1, count)
 }
 
+func (s *GithubWebhookRouteSuite) TestLabeledEnqueuesInjectJobAndUnlabeledIsNoop() {
+	s.NoError(db.ClearCollections(model.ProjectRefCollection, patch.IntentCollection))
+
+	doc := &model.ProjectRef{
+		Owner:            "evergreen-ci",
+		Repo:             "evergreen",
+		Branch:           "main",
+		Enabled:          true,
+		BatchTime:        10,
+		Id:               "ident0",
+		PRTestingEnabled: utility.TruePtr(),
+	}
+	s.NoError(doc.Insert(s.T().Context()))
+
+	rawEvent, err := github.ParseWebHook("pull_request", s.prBody)
+	s.NoError(err)
+	event, ok := rawEvent.(*github.PullRequestEvent)
+	s.Require().True(ok)
+
+	labeledAction := githubActionLabeled
+	event.Action = &labeledAction
+	label := &github.Label{Name: utility.ToStringPtr("evg-added-label")}
+	event.Label = label
+	event.PullRequest.Labels = []*github.Label{label}
+
+	s.h.event = event
+	s.h.msgID = "labeled-1"
+
+	statsBefore, err := s.queue.Stats(s.T().Context()), error(nil)
+	s.NoError(err)
+
+	resp := s.h.Run(s.T().Context())
+	s.Equal(http.StatusOK, resp.Status())
+
+	statsAfterLabeled := s.queue.Stats(s.T().Context())
+	s.Equal(statsBefore.Total+1, statsAfterLabeled.Total)
+
+	unlabeledAction := githubActionUnlabeled
+	event.Action = &unlabeledAction
+	s.h.event = event
+	s.h.msgID = "unlabeled-1"
+
+	resp = s.h.Run(s.T().Context())
+	s.Equal(http.StatusOK, resp.Status())
+
+	statsAfterUnlabeled := s.queue.Stats(s.T().Context())
+	s.Equal(statsAfterLabeled.Total, statsAfterUnlabeled.Total)
+}
+
 func (s *GithubWebhookRouteSuite) TestParseAndValidateFailsWithoutSignature() {
 	ctx := context.Background()
 	secret := []byte(s.conf.GithubWebhookSecret)

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -175,6 +175,10 @@ type GithubPatch struct {
 	MergeBase     string `bson:"merge_base"`
 	// the patchId to copy the definitions for for the next patch the pr creates
 	RepeatPatchIdNextPatch string `bson:"repeat_patch_id_next_patch"`
+
+	// Labels is the set of GitHub PR label names present when the patch was
+	// created. Used to gate github_pr_aliases entries via required_labels.
+	Labels []string `bson:"labels,omitempty"`
 }
 
 // GithubMergeGroup stores patch data for patches created from GitHub merge groups

--- a/units/github_pr_label_inject.go
+++ b/units/github_pr_label_inject.go
@@ -106,7 +106,21 @@ func (j *githubPRLabelInjectJob) Run(ctx context.Context) {
 		return
 	}
 
-	aliases, err := model.FindAliasInProjectRepoOrProjectConfig(ctx, v.Identifier, evergreen.GithubPRAlias, nil)
+	// Label-gated PR aliases (github_pr_aliases with required_labels) are defined
+	// in the project's YAML, which the finalized patch stores as its patched
+	// project config rather than in the ProjectAliasCollection. Build a
+	// ProjectConfig from it so FindAliasInProjectRepoOrProjectConfig resolves the
+	// YAML-defined aliases, mirroring patch_intent's verifyValidAlias.
+	var projectConfig *model.ProjectConfig
+	if p.PatchedProjectConfig != "" {
+		projectConfig, err = model.CreateProjectConfig([]byte(p.PatchedProjectConfig), "")
+		if err != nil {
+			j.AddError(errors.Wrap(err, "creating project config"))
+			return
+		}
+	}
+
+	aliases, err := model.FindAliasInProjectRepoOrProjectConfig(ctx, v.Identifier, evergreen.GithubPRAlias, projectConfig)
 	if err != nil {
 		j.AddError(errors.Wrapf(err, "finding PR aliases for project '%s'", v.Identifier))
 		return

--- a/units/github_pr_label_inject.go
+++ b/units/github_pr_label_inject.go
@@ -1,0 +1,139 @@
+package units
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/mongodb/amboy"
+	"github.com/mongodb/amboy/job"
+	"github.com/mongodb/amboy/registry"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/pkg/errors"
+)
+
+const githubPRLabelInjectJobName = "github-pr-label-inject"
+
+func init() {
+	registry.AddJobType(githubPRLabelInjectJobName, func() amboy.Job { return makeGithubPRLabelInjectJob() })
+}
+
+type githubPRLabelInjectJob struct {
+	job.Base `bson:"job_base" json:"job_base" yaml:"job_base"`
+	Owner    string   `bson:"owner" json:"owner" yaml:"owner"`
+	Repo     string   `bson:"repo" json:"repo" yaml:"repo"`
+	PRNumber int      `bson:"pr_number" json:"pr_number" yaml:"pr_number"`
+	HeadSHA  string   `bson:"head_sha" json:"head_sha" yaml:"head_sha"`
+	Labels   []string `bson:"labels" json:"labels" yaml:"labels"`
+
+	env evergreen.Environment
+}
+
+func makeGithubPRLabelInjectJob() *githubPRLabelInjectJob {
+	j := &githubPRLabelInjectJob{
+		Base: job.Base{
+			JobType: amboy.JobType{
+				Name:    githubPRLabelInjectJobName,
+				Version: 0,
+			},
+		},
+	}
+	return j
+}
+
+// NewGithubPRLabelInjectJob returns a job that injects the tasks implied by a
+// GitHub PR's current label set into the existing PR version for the given head
+// SHA. If no such version exists (or the latest PR version is for a different
+// head SHA), the job is a no-op; it never creates a version.
+func NewGithubPRLabelInjectJob(env evergreen.Environment, owner, repo string, prNumber int, headSHA string, labels []string, ts string) amboy.Job {
+	j := makeGithubPRLabelInjectJob()
+	j.Owner = owner
+	j.Repo = repo
+	j.PRNumber = prNumber
+	j.HeadSHA = headSHA
+	j.Labels = labels
+	j.env = env
+
+	j.SetID(fmt.Sprintf("%s.%s.%s.%d.%s.%s", githubPRLabelInjectJobName, owner, repo, prNumber, headSHA, ts))
+	// The version's ID is not known at construction time, so we cannot acquire
+	// the generate.tasks version scope here to serialize against a concurrent
+	// generate.tasks job. Concurrency safety instead relies on the job-ID dedup
+	// above (identical deliveries collapse into one job) and on
+	// InjectTasksIntoVersion computing an idempotent delta of tasks not already
+	// in the version.
+	return j
+}
+
+func (j *githubPRLabelInjectJob) Run(ctx context.Context) {
+	defer j.MarkComplete()
+
+	if j.env == nil {
+		j.env = evergreen.GetEnvironment()
+	}
+
+	p, err := patch.FindLatestGithubPRPatch(ctx, j.Owner, j.Repo, j.PRNumber)
+	if err != nil {
+		j.AddError(errors.Wrapf(err, "finding latest PR patch for '%s/%s' PR #%d", j.Owner, j.Repo, j.PRNumber))
+		return
+	}
+	if p == nil || p.Version == "" || p.GithubPatchData.HeadHash != j.HeadSHA {
+		grip.Info(ctx, message.Fields{
+			"message":   "no finalized PR version for head SHA, skipping label task injection",
+			"job":       j.ID(),
+			"owner":     j.Owner,
+			"repo":      j.Repo,
+			"pr_number": j.PRNumber,
+			"head_sha":  j.HeadSHA,
+		})
+		return
+	}
+
+	v, err := model.VersionFindOneId(ctx, p.Version)
+	if err != nil {
+		j.AddError(errors.Wrapf(err, "finding version '%s'", p.Version))
+		return
+	}
+	if v == nil {
+		return
+	}
+
+	project, _, err := model.FindAndTranslateProjectForVersion(ctx, j.env.Settings(), v, false)
+	if err != nil {
+		j.AddError(errors.Wrapf(err, "loading project for version '%s'", v.Id))
+		return
+	}
+
+	aliases, err := model.FindAliasInProjectRepoOrProjectConfig(ctx, v.Identifier, evergreen.GithubPRAlias, nil)
+	if err != nil {
+		j.AddError(errors.Wrapf(err, "finding PR aliases for project '%s'", v.Identifier))
+		return
+	}
+
+	satisfied := model.ProjectAliases(aliases).FilterByLabels(j.Labels)
+	pairs, err := project.BuildProjectTVPairsWithAlias(satisfied, evergreen.GithubPRRequester)
+	if err != nil {
+		j.AddError(errors.Wrapf(err, "resolving label-gated aliases into task/variant pairs for version '%s'", v.Id))
+		return
+	}
+
+	added, err := model.InjectTasksIntoVersion(ctx, j.env.Settings(), v, project, pairs)
+	if err != nil {
+		j.AddError(errors.Wrapf(err, "injecting label-implied tasks into version '%s'", v.Id))
+		return
+	}
+
+	grip.Info(ctx, message.Fields{
+		"message":   "injected label-implied tasks into PR version",
+		"job":       j.ID(),
+		"version":   v.Id,
+		"num_added": len(added),
+		"labels":    j.Labels,
+		"owner":     j.Owner,
+		"repo":      j.Repo,
+		"pr_number": j.PRNumber,
+		"head_sha":  j.HeadSHA,
+	})
+}

--- a/units/github_pr_label_inject_test.go
+++ b/units/github_pr_label_inject_test.go
@@ -1,0 +1,186 @@
+package units
+
+import (
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
+	"github.com/evergreen-ci/evergreen/mock"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/testutil"
+	"github.com/evergreen-ci/evergreen/thirdparty"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+const githubPRLabelInjectConfig = `
+buildvariants:
+  - name: bv1
+    display_name: BV One
+    run_on:
+      - ubuntu1604-test
+    tasks:
+      - name: task_existing
+      - name: task_gated
+  - name: bv2
+    display_name: BV Two
+    run_on:
+      - ubuntu1604-test
+    tasks:
+      - name: task_gated
+
+tasks:
+  - name: task_existing
+    commands:
+      - command: shell.exec
+        params:
+          script: "echo hi"
+  - name: task_gated
+    commands:
+      - command: shell.exec
+        params:
+          script: "echo hi"
+`
+
+func TestGithubPRLabelInjectAddsGatedTasks(t *testing.T) {
+	ctx := testutil.TestSpan(t.Context(), t)
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
+	require.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.VersionCollection, build.Collection,
+		task.Collection, patch.Collection, model.ParserProjectCollection, model.ProjectAliasCollection))
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(model.ProjectRefCollection, model.VersionCollection, build.Collection,
+			task.Collection, patch.Collection, model.ParserProjectCollection, model.ProjectAliasCollection))
+	})
+
+	const (
+		projectID = "myproj"
+		owner     = "evergreen-ci"
+		repo      = "evergreen"
+		prNumber  = 42
+		headSHA   = "abc123"
+		variant   = "bv1"
+		existing  = "task_existing"
+		gated     = "task_gated"
+		label     = "run-gated"
+	)
+
+	oid := mgobson.NewObjectId()
+	versionID := oid.Hex()
+
+	v := &model.Version{
+		Id:         versionID,
+		Identifier: projectID,
+		Requester:  evergreen.GithubPRRequester,
+		CreateTime: time.Now(),
+		Activated:  utility.TruePtr(),
+		BuildIds:   []string{"b1"},
+		BuildVariants: []model.VersionBuildStatus{{
+			BuildVariant: variant,
+			BuildId:      "b1",
+		}},
+	}
+	require.NoError(t, v.Insert(t.Context()))
+
+	b := build.Build{
+		Id:           "b1",
+		BuildVariant: variant,
+		Version:      versionID,
+		Activated:    true,
+	}
+	require.NoError(t, b.Insert(t.Context()))
+
+	projectRef := model.ProjectRef{Id: projectID, Identifier: projectID}
+	require.NoError(t, projectRef.Insert(t.Context()))
+
+	pp := model.ParserProject{}
+	require.NoError(t, util.UnmarshalYAMLWithFallback([]byte(githubPRLabelInjectConfig), &pp))
+	pp.Id = versionID
+	pp.Identifier = utility.ToStringPtr(projectID)
+	require.NoError(t, pp.Insert(t.Context()))
+
+	existingTask := task.Task{
+		Id:           "existing_task_id",
+		Version:      versionID,
+		BuildId:      "b1",
+		Project:      projectID,
+		DisplayName:  existing,
+		BuildVariant: variant,
+		Activated:    true,
+	}
+	require.NoError(t, existingTask.Insert(t.Context()))
+
+	patchDoc := patch.Patch{
+		Id:      oid,
+		Project: projectID,
+		Version: versionID,
+		GithubPatchData: thirdparty.GithubPatch{
+			BaseOwner: owner,
+			BaseRepo:  repo,
+			PRNumber:  prNumber,
+			HeadHash:  headSHA,
+		},
+		VariantsTasks: []patch.VariantTasks{{
+			Variant: variant,
+			Tasks:   []string{existing},
+		}},
+	}
+	require.NoError(t, patchDoc.Insert(t.Context()))
+
+	// A label-gated PR alias that only applies when the PR carries the label.
+	alias := model.ProjectAlias{
+		ProjectID:      projectID,
+		Alias:          evergreen.GithubPRAlias,
+		Variant:        "^bv1$",
+		Task:           "^task_gated$",
+		RequiredLabels: []string{label},
+	}
+	require.NoError(t, alias.Upsert(t.Context()))
+
+	j := NewGithubPRLabelInjectJob(env, owner, repo, prNumber, headSHA, []string{label}, "ts")
+	j.Run(ctx)
+	require.NoError(t, j.Error())
+
+	tasks, err := task.FindAll(ctx, db.Query(task.ByVersion(versionID)))
+	require.NoError(t, err)
+	names := map[string]bool{}
+	for _, tsk := range tasks {
+		names[tsk.DisplayName] = true
+	}
+	assert.True(t, names[existing], "pre-existing task should remain")
+	assert.True(t, names[gated], "label-gated task should be injected")
+}
+
+func TestGithubPRLabelInjectNoVersionIsNoOp(t *testing.T) {
+	ctx := testutil.TestSpan(t.Context(), t)
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
+	require.NoError(t, db.ClearCollections(model.VersionCollection, task.Collection, patch.Collection))
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(model.VersionCollection, task.Collection, patch.Collection))
+	})
+
+	j := NewGithubPRLabelInjectJob(env, "evergreen-ci", "evergreen", 999, "deadbeef", []string{"run-gated"}, "ts")
+	j.Run(ctx)
+	require.NoError(t, j.Error())
+
+	versions, err := model.VersionFind(ctx, db.Query(bson.M{}))
+	assert.NoError(t, err)
+	assert.Empty(t, versions)
+
+	tasks, err := task.FindAll(ctx, db.Query(bson.M{}))
+	assert.NoError(t, err)
+	assert.Empty(t, tasks)
+}

--- a/units/github_pr_label_inject_test.go
+++ b/units/github_pr_label_inject_test.go
@@ -120,10 +120,22 @@ func TestGithubPRLabelInjectAddsGatedTasks(t *testing.T) {
 	}
 	require.NoError(t, existingTask.Insert(t.Context()))
 
+	// The label-gated github_pr_aliases entry lives in the project YAML, which a
+	// finalized PR patch stores as its patched project config. This is the only
+	// supported configuration for the feature, so the test must exercise the
+	// config path (not a DB alias).
+	patchedProjectConfig := `
+github_pr_aliases:
+  - variant: "^bv1$"
+    task: "^task_gated$"
+    required_labels: ["` + label + `"]
+`
+
 	patchDoc := patch.Patch{
-		Id:      oid,
-		Project: projectID,
-		Version: versionID,
+		Id:                   oid,
+		Project:              projectID,
+		Version:              versionID,
+		PatchedProjectConfig: patchedProjectConfig,
 		GithubPatchData: thirdparty.GithubPatch{
 			BaseOwner: owner,
 			BaseRepo:  repo,
@@ -136,16 +148,6 @@ func TestGithubPRLabelInjectAddsGatedTasks(t *testing.T) {
 		}},
 	}
 	require.NoError(t, patchDoc.Insert(t.Context()))
-
-	// A label-gated PR alias that only applies when the PR carries the label.
-	alias := model.ProjectAlias{
-		ProjectID:      projectID,
-		Alias:          evergreen.GithubPRAlias,
-		Variant:        "^bv1$",
-		Task:           "^task_gated$",
-		RequiredLabels: []string{label},
-	}
-	require.NoError(t, alias.Upsert(t.Context()))
 
 	j := NewGithubPRLabelInjectJob(env, owner, repo, prNumber, headSHA, []string{label}, "ts")
 	j.Run(ctx)


### PR DESCRIPTION
DEVPROD-36828

### Description

Adds a `required_labels` field to `github_pr_aliases` entries so a PR alias only contributes its variants/tasks when the PR carries a matching GitHub label. This lets teams dynamically scope which PR checks run — cutting PR-check cost and running only the tests relevant to a change — without editing project config or pushing new commits.

Behavior:
- An entry with no `required_labels` always runs (today's default). An entry with `required_labels` runs when the PR has **any one** of the listed labels (OR semantics, exact case-sensitive match). Empty/whitespace label strings are rejected by project validation.
- **Open/reopen/synchronize:** the PR version is built from default entries plus entries satisfied by the PR's current labels (filtered in `Project.ResolvePatchVTs`; labels captured on the intent → `GithubPatchData.Labels`).
- **`labeled` webhook:** enqueues a new `units/github_pr_label_inject` job that injects the newly-implied tasks **in place** into the existing PR version for the current head SHA (via the new `model.InjectTasksIntoVersion`, reusing the `generate.tasks` add-tasks machinery), so the single GitHub status reflects them.
- **`unlabeled`:** intentional no-op — removing a label never cancels running tasks; it only affects the next version creation.
- **No version yet** (e.g. manual-testing projects): the label event is a no-op; Evergreen never auto-creates a version from a label.
- **Authorization preserved:** injected tasks inherit the version's activation state via a new default-false `TaskCreationInfo.RespectVersionActivation` flag, so outside-org PRs' tasks stay unactivated until authorized. `generate.tasks`/`ConfigurePatch` behavior is unchanged. Check-run-limit and max-tasks-per-version are re-checked on the injection path.

v1 is YAML-only (no settings UI/GraphQL/REST field yet).

This is an external contribution; the design was written up as a Technical Design and the approach is pending Evergreen-team RLGTM (hence draft). An ADR is included under `docs/decisions/`.

### Testing

Unit/integration tests added and passing for each layer: `FilterByLabels` semantics, `required_labels` validation, label capture (intent → patch doc), `ResolvePatchVTs` label filtering, `InjectTasksIntoVersion` (idempotent delta, patch `VariantsTasks` update, activation inheritance on existing-build and new-variant paths incl. unactivated versions), webhook dispatch (`labeled` enqueues / `unlabeled` no-op), and the inject job (YAML-alias path + no-version no-op).

Verified locally: `test-model`, `test-model-patch`, `test-units`, `test-rest-route`, `test-thirdparty`, `test-validator`, and `lint-*` for touched packages — clean for this change (observed failures are pre-existing/unrelated, confirmed against the merge-base). Docs pass `markdownlint-cli` + `prettier`.

Staging validation of the live webhook path is planned before this is marked ready.

### Documentation

- Updated `docs/Project-Configuration/Project-and-Distro-Settings.md` (PR Aliases) and `docs/Project-Configuration/Github-Integrations.md`.
- Added an ADR: `docs/decisions/2026-07-07_github_pr_required_labels.md`.

<!-- Review considerations -->
**Data warehouse:** this adds a `Labels` field to the patch's `GithubPatchData` and changes PR-alias selection semantics. Happy to file a DPIPE ticket (watchers: @abby.vlosky, @amy.metlesitz, @kelly.mcmeekin) and post to #ask-data (cc @pta-devprod-analysts) — flagging for guidance on whether that's wanted.

**Backward compatibility:** opt-in by data shape; projects without `required_labels` are unaffected, and the newly-handled `labeled`/`unlabeled` actions were previously dropped.

**Open questions for reviewers:** (1) in-place injection vs. a separate version on `labeled`; (2) `unlabeled` as a no-op; (3) the inject job relies on job-ID dedup + delta idempotency rather than sharing the `generate.tasks` version scope — acceptable for v1?
