### PR TITLE
DEVPROD-36207: stop writing webhook secrets to the DB

### DIFF
--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -595,19 +595,22 @@ func RemoveSubscription(ctx context.Context, id string) error {
 		}
 	}
 
-	if err := db.Remove(ctx, SubscriptionsCollection, bson.M{
-		subscriptionIDKey: id,
-	}); err != nil {
-		return err
-	}
-
 	catcher := grip.NewBasicCatcher()
+	// Continue on error while deleting the secrets from Parameter Store because
+	// the secrets could have been deleted already (e.g. if this is a
+	// retry attempt to delete the subscription). Secret cleanup is best-effort
+	// and leaving behind a lingering secret is preferable over blocking
+	// the deletion of the subscription entirely.
 	if webhookSecretParamToDelete != "" {
 		catcher.Wrap(deleteWebhookSecretFromParameterStore(ctx, webhookSecretParamToDelete), "cleaning up webhook secret parameter")
 	}
 	if authHeaderParamToDelete != "" {
 		catcher.Wrap(deleteWebhookSecretFromParameterStore(ctx, authHeaderParamToDelete), "cleaning up webhook Authorization header parameter")
 	}
+
+	catcher.Wrap(db.Remove(ctx, SubscriptionsCollection, bson.M{
+		subscriptionIDKey: id,
+	}), "removing DB subscription")
 
 	return catcher.Resolve()
 }

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -1,7 +1,6 @@
 package event
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"regexp"
@@ -503,10 +502,12 @@ func (s *Subscription) Upsert(ctx context.Context) error {
 		subscriptionSelectorsKey:      s.Selectors,
 		subscriptionRegexSelectorsKey: s.RegexSelectors,
 		subscriptionFilterKey:         s.Filter,
-		subscriptionSubscriberKey:     s.Subscriber,
-		subscriptionOwnerKey:          s.Owner,
-		subscriptionOwnerTypeKey:      s.OwnerType,
-		subscriptionTriggerDataKey:    s.TriggerData,
+		// Redact webhook subscriber secrets before writing the subscriber to
+		// the DB so they're not persisted in plaintext.
+		subscriptionSubscriberKey:  s.redactedSubscriberForDB(),
+		subscriptionOwnerKey:       s.Owner,
+		subscriptionOwnerTypeKey:   s.OwnerType,
+		subscriptionTriggerDataKey: s.TriggerData,
 	}
 	if !utility.IsZeroTime(s.LastUpdated) {
 		update[subscriptionLastUpdatedKey] = s.LastUpdated
@@ -593,20 +594,17 @@ func RemoveSubscription(ctx context.Context, id string) error {
 				}
 			}
 			if ws.AuthorizationHeaderParameter != "" {
+				// kim: TODO: consider doing this after db.Remove so it still
+				// does the removal. Similar to project vars, it makes this more
+				// resilient to interrupts between deleting here and removing
+				// the doc entirely.
 				if delErr := deleteWebhookSecretFromParameterStore(ctx, ws.AuthorizationHeaderParameter); delErr != nil {
 					grip.Warning(ctx, message.WrapError(delErr, message.Fields{
-						"message":         "deleting webhook Authorization header from Parameter Store on subscription removal",
+						"message":         "could not delete webhook Authorization header from Parameter Store on subscription removal",
 						"subscription_id": id,
 						"parameter_name":  ws.AuthorizationHeaderParameter,
 						"ticket":          "DEVPROD-15500",
 					}))
-				} else {
-					grip.Debug(ctx, message.Fields{
-						"message":         "deleted webhook Authorization header from Parameter Store on subscription removal",
-						"subscription_id": id,
-						"parameter_name":  ws.AuthorizationHeaderParameter,
-						"ticket":          "DEVPROD-15500",
-					})
 				}
 			}
 		}
@@ -1038,7 +1036,34 @@ func NewSpawnHostOutcomeByOwner(owner string, sub Subscriber) Subscription {
 	}
 }
 
-// saveWebhookSecretIfNeeded saves the webhook secret to Parameter Store on every upsert.
+// redactedSubscriberForDB returns a copy of s.Subscriber with secrets removed.
+// For webhook subscriptions, the plaintext secret and Authorization header are
+// stripped since those live in Parameter Store.
+func (s *Subscription) redactedSubscriberForDB() Subscriber {
+	if s.Subscriber.Type != EvergreenWebhookSubscriberType {
+		return s.Subscriber
+	}
+	webhookSub, ok := s.Subscriber.Target.(*WebhookSubscriber)
+	if !ok {
+		return s.Subscriber
+	}
+
+	stripped := *webhookSub
+	stripped.Secret = nil
+	var headers []WebhookHeader
+	for _, h := range webhookSub.Headers {
+		if h.Key != WebhookAuthorizationHeader {
+			headers = append(headers, h)
+		}
+	}
+	stripped.Headers = headers
+	return Subscriber{
+		Type:   s.Subscriber.Type,
+		Target: &stripped,
+	}
+}
+
+// saveWebhookSecretIfNeeded saves the webhook secret to Parameter Store.
 func (s *Subscription) saveWebhookSecretIfNeeded(ctx context.Context) error {
 	if s.Subscriber.Type != EvergreenWebhookSubscriberType {
 		return nil
@@ -1050,14 +1075,19 @@ func (s *Subscription) saveWebhookSecretIfNeeded(ctx context.Context) error {
 	}
 
 	if len(webhookSub.Secret) > 0 {
-		webhookSub.SecretParameter = saveWebhookParameter(ctx, s.ID, GetWebhookSecretParameterPath(s.ID), webhookSub.Secret)
-		// Keep Secret in MongoDB as a fallback until the Phase 2 cleanup job removes it.
+		paramName, err := saveSubscriptionParameter(ctx, GetWebhookSecretParameterPath(s.ID), webhookSub.Secret)
+		if err != nil {
+			return errors.Wrap(err, "saving webhook secret to Parameter Store")
+		}
+		webhookSub.SecretParameter = paramName
 	}
 
 	return nil
 }
 
 // saveWebhookAuthHeaderIfNeeded saves the webhook Authorization header to Parameter Store on every upsert.
+// kim: TODO: can likely consolidate with saveWebhookSecretIfNeeded since
+// they're both saving webhook-specific secrets.
 func (s *Subscription) saveWebhookAuthHeaderIfNeeded(ctx context.Context) error {
 	if s.Subscriber.Type != EvergreenWebhookSubscriberType {
 		return nil
@@ -1069,7 +1099,11 @@ func (s *Subscription) saveWebhookAuthHeaderIfNeeded(ctx context.Context) error 
 	}
 
 	if authValue := webhookSub.GetHeader(WebhookAuthorizationHeader); authValue != "" {
-		webhookSub.AuthorizationHeaderParameter = saveWebhookParameter(ctx, s.ID, getWebhookAuthParameterPath(s.ID), []byte(authValue))
+		paramName, err := saveSubscriptionParameter(ctx, getWebhookAuthParameterPath(s.ID), []byte(authValue))
+		if err != nil {
+			return errors.Wrap(err, "saving webhook Authorization header to Parameter Store")
+		}
+		webhookSub.AuthorizationHeaderParameter = paramName
 	} else if s.ID != "" {
 		// Authorization header was removed on update. Clean up the old PS entry if
 		// one exists, so we don't leave orphaned parameters in Parameter Store.
@@ -1107,41 +1141,19 @@ func (s *Subscription) saveWebhookAuthHeaderIfNeeded(ctx context.Context) error 
 	return nil
 }
 
-// saveWebhookParameter saves value to Parameter Store and returns the parameter name on success, or empty string on failure.
-func saveWebhookParameter(ctx context.Context, subID, paramPath string, value []byte) string {
+// saveSubscriptionParameter saves value to Parameter Store and returns the parameter's name.
+func saveSubscriptionParameter(ctx context.Context, paramPath string, value []byte) (string, error) {
 	paramMgr := evergreen.GetEnvironment().ParameterManager()
 	param, err := paramMgr.Put(ctx, paramPath, string(value))
 	if err != nil {
-		grip.Warning(ctx, message.Fields{
-			"message":         "putting webhook parameter to Parameter Store, falling back to MongoDB",
-			"subscription_id": subID,
-			"parameter_path":  paramPath,
-			"error":           err.Error(),
-			"ticket":          "DEVPROD-15500",
-		})
-		return ""
+		return "", errors.Wrap(err, "putting webhook secret in Parameter Store")
 	}
-	if err := verifyWebhookSecretInParameterStore(ctx, param.Name, value); err != nil {
-		grip.Warning(ctx, message.Fields{
-			"message":         "verifying webhook parameter in Parameter Store, falling back to MongoDB",
-			"subscription_id": subID,
-			"parameter_name":  param.Name,
-			"error":           err.Error(),
-			"ticket":          "DEVPROD-15500",
-		})
-		_ = deleteWebhookSecretFromParameterStore(ctx, param.Name)
-		return ""
-	}
-	grip.Debug(ctx, message.Fields{
-		"message":         "saved webhook parameter to Parameter Store",
-		"subscription_id": subID,
-		"parameter_name":  param.Name,
-		"ticket":          "DEVPROD-15500",
-	})
-	return param.Name
+	return param.Name, nil
 }
 
-// populateWebhookSecrets loads webhook secrets from Parameter Store, falling back to MongoDB for unmigrated subscriptions.
+// populateWebhookSecrets loads webhook secrets from Parameter Store for subscriptions that have a
+// parameter path set. Subscriptions without a parameter path retain whatever value was read from
+// MongoDB (legacy support for unmigrated subscriptions).
 func populateWebhookSecrets(ctx context.Context, subscriptions []Subscription) error {
 	for i := range subscriptions {
 		if subscriptions[i].Subscriber.Type != EvergreenWebhookSubscriberType {
@@ -1156,31 +1168,17 @@ func populateWebhookSecrets(ctx context.Context, subscriptions []Subscription) e
 		if webhookSub.SecretParameter != "" {
 			secret, err := getWebhookSecretFromParameterStore(ctx, webhookSub.SecretParameter)
 			if err != nil {
-				grip.Debug(ctx, message.Fields{
-					"message":         "failed to read webhook secret from Parameter Store, falling back to MongoDB",
-					"subscription_id": subscriptions[i].ID,
-					"error":           err.Error(),
-					"ticket":          "DEVPROD-15500",
-				})
-				// Secret is already populated from the DB read — leave it as-is.
-			} else {
-				webhookSub.Secret = secret
+				return errors.Wrap(err, "reading webhook secret from Parameter Store")
 			}
+			webhookSub.Secret = secret
 		}
 
 		if webhookSub.AuthorizationHeaderParameter != "" {
-			authValue, err := getWebhookSecretFromParameterStore(ctx, webhookSub.AuthorizationHeaderParameter)
+			authHeaderValue, err := getWebhookSecretFromParameterStore(ctx, webhookSub.AuthorizationHeaderParameter)
 			if err != nil {
-				grip.Debug(ctx, message.Fields{
-					"message":         "failed to read webhook Authorization header from Parameter Store, falling back to MongoDB",
-					"subscription_id": subscriptions[i].ID,
-					"error":           err.Error(),
-					"ticket":          "DEVPROD-15500",
-				})
-				// Authorization header is already populated from the DB read — leave it as-is.
-			} else {
-				webhookSub.setHeader(WebhookAuthorizationHeader, string(authValue))
+				return errors.Wrap(err, "reading webhook Authorization header from Parameter Store")
 			}
+			webhookSub.setHeader(WebhookAuthorizationHeader, string(authHeaderValue))
 		}
 
 	}
@@ -1201,18 +1199,6 @@ func getWebhookAuthParameterPath(subscriptionID string) string {
 // This exported form is used by the migration job in units/.
 func GetWebhookAuthParameterPath(subscriptionID string) string {
 	return getWebhookAuthParameterPath(subscriptionID)
-}
-
-// verifyWebhookSecretInParameterStore confirms the stored secret matches the expected value.
-func verifyWebhookSecretInParameterStore(ctx context.Context, paramName string, expected []byte) error {
-	storedSecret, err := getWebhookSecretFromParameterStore(ctx, paramName)
-	if err != nil {
-		return errors.Wrap(err, "reading back webhook secret from Parameter Store")
-	}
-	if !bytes.Equal(storedSecret, expected) {
-		return errors.New("Parameter Store value does not match intended secret")
-	}
-	return nil
 }
 
 // deleteWebhookSecretFromParameterStore removes a webhook secret from Parameter Store. Empty input is a no-op.

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -533,6 +533,24 @@ func (s *Subscription) Upsert(ctx context.Context) error {
 }
 
 func FindSubscriptionByID(ctx context.Context, id string) (*Subscription, error) {
+	sub, err := dbFindSubscriptionByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if sub == nil {
+		return nil, nil
+	}
+
+	if err := populateWebhookSecrets(ctx, []Subscription{*sub}); err != nil {
+		return nil, errors.Wrap(err, "populating webhook secret")
+	}
+
+	return sub, nil
+}
+
+// dbFindSubscriptionByID finds a subscription by ID from the DB. It does not
+// load secret values from Parameter Store.
+func dbFindSubscriptionByID(ctx context.Context, id string) (*Subscription, error) {
 	out := Subscription{}
 	query := bson.M{
 		subscriptionIDKey: id,
@@ -555,10 +573,6 @@ func FindSubscriptionByID(ctx context.Context, id string) (*Subscription, error)
 		return nil, errors.Wrap(err, "fetching subcription by ID")
 	}
 
-	if err := populateWebhookSecrets(ctx, []Subscription{out}); err != nil {
-		return nil, errors.Wrap(err, "populating webhook secret")
-	}
-
 	return &out, nil
 }
 
@@ -567,52 +581,39 @@ func RemoveSubscription(ctx context.Context, id string) error {
 		return errors.New("id is not valid, cannot remove")
 	}
 
-	// Look up the subscription directly (bypassing populateWebhookSecrets) to clean up its
-	// Parameter Store entry. PS failures are logged but do not block the removal.
-	var sub Subscription
-	err := db.FindOneQ(ctx, SubscriptionsCollection, db.Query(bson.M{subscriptionIDKey: id}), &sub)
-	if err != nil && !adb.ResultsNotFound(err) {
+	// Look up the subscription to figure out what secrets need to be cleaned up
+	// in Parameter Store.
+	var webhookSecretParamToDelete, authHeaderParamToDelete string
+	sub, err := dbFindSubscriptionByID(ctx, id)
+	if err != nil {
 		return errors.Wrapf(err, "looking up subscription '%s' before removal", id)
 	}
-	if err == nil {
+	if sub != nil {
 		if ws, ok := sub.Subscriber.Target.(*WebhookSubscriber); ok && ws != nil {
 			if ws.SecretParameter != "" {
-				if delErr := deleteWebhookSecretFromParameterStore(ctx, ws.SecretParameter); delErr != nil {
-					grip.Warning(ctx, message.WrapError(delErr, message.Fields{
-						"message":         "deleting webhook secret from Parameter Store on subscription removal",
-						"subscription_id": id,
-						"parameter_name":  ws.SecretParameter,
-						"ticket":          "DEVPROD-15500",
-					}))
-				} else {
-					grip.Debug(ctx, message.Fields{
-						"message":         "webhook secret removed from Parameter Store",
-						"subscription_id": id,
-						"parameter_name":  ws.SecretParameter,
-						"ticket":          "DEVPROD-15500",
-					})
-				}
+				webhookSecretParamToDelete = ws.SecretParameter
 			}
 			if ws.AuthorizationHeaderParameter != "" {
-				// kim: TODO: consider doing this after db.Remove so it still
-				// does the removal. Similar to project vars, it makes this more
-				// resilient to interrupts between deleting here and removing
-				// the doc entirely.
-				if delErr := deleteWebhookSecretFromParameterStore(ctx, ws.AuthorizationHeaderParameter); delErr != nil {
-					grip.Warning(ctx, message.WrapError(delErr, message.Fields{
-						"message":         "could not delete webhook Authorization header from Parameter Store on subscription removal",
-						"subscription_id": id,
-						"parameter_name":  ws.AuthorizationHeaderParameter,
-						"ticket":          "DEVPROD-15500",
-					}))
-				}
+				authHeaderParamToDelete = ws.AuthorizationHeaderParameter
 			}
 		}
 	}
 
-	return db.Remove(ctx, SubscriptionsCollection, bson.M{
+	if err := db.Remove(ctx, SubscriptionsCollection, bson.M{
 		subscriptionIDKey: id,
-	})
+	}); err != nil {
+		return err
+	}
+
+	catcher := grip.NewBasicCatcher()
+	if webhookSecretParamToDelete != "" {
+		catcher.Wrap(deleteWebhookSecretFromParameterStore(ctx, webhookSecretParamToDelete), "cleaning up webhook secret parameter")
+	}
+	if authHeaderParamToDelete != "" {
+		catcher.Wrap(deleteWebhookSecretFromParameterStore(ctx, authHeaderParamToDelete), "cleaning up webhook Authorization header parameter")
+	}
+
+	return catcher.Resolve()
 }
 
 func (s *Subscription) ValidateSelectors() error {
@@ -1050,11 +1051,13 @@ func (s *Subscription) redactedSubscriberForDB() Subscriber {
 
 	stripped := *webhookSub
 	stripped.Secret = nil
+
 	var headers []WebhookHeader
 	for _, h := range webhookSub.Headers {
-		if h.Key != WebhookAuthorizationHeader {
-			headers = append(headers, h)
+		if h.Key == WebhookAuthorizationHeader {
+			continue
 		}
+		headers = append(headers, h)
 	}
 	stripped.Headers = headers
 	return Subscriber{
@@ -1075,7 +1078,7 @@ func (s *Subscription) saveWebhookSecretIfNeeded(ctx context.Context) error {
 	}
 
 	if len(webhookSub.Secret) > 0 {
-		paramName, err := saveSubscriptionParameter(ctx, GetWebhookSecretParameterPath(s.ID), webhookSub.Secret)
+		paramName, err := saveWebhookParameter(ctx, GetWebhookSecretParameterPath(s.ID), webhookSub.Secret)
 		if err != nil {
 			return errors.Wrap(err, "saving webhook secret to Parameter Store")
 		}
@@ -1086,8 +1089,6 @@ func (s *Subscription) saveWebhookSecretIfNeeded(ctx context.Context) error {
 }
 
 // saveWebhookAuthHeaderIfNeeded saves the webhook Authorization header to Parameter Store on every upsert.
-// kim: TODO: can likely consolidate with saveWebhookSecretIfNeeded since
-// they're both saving webhook-specific secrets.
 func (s *Subscription) saveWebhookAuthHeaderIfNeeded(ctx context.Context) error {
 	if s.Subscriber.Type != EvergreenWebhookSubscriberType {
 		return nil
@@ -1099,7 +1100,7 @@ func (s *Subscription) saveWebhookAuthHeaderIfNeeded(ctx context.Context) error 
 	}
 
 	if authValue := webhookSub.GetHeader(WebhookAuthorizationHeader); authValue != "" {
-		paramName, err := saveSubscriptionParameter(ctx, getWebhookAuthParameterPath(s.ID), []byte(authValue))
+		paramName, err := saveWebhookParameter(ctx, getWebhookAuthParameterPath(s.ID), []byte(authValue))
 		if err != nil {
 			return errors.Wrap(err, "saving webhook Authorization header to Parameter Store")
 		}
@@ -1141,8 +1142,8 @@ func (s *Subscription) saveWebhookAuthHeaderIfNeeded(ctx context.Context) error 
 	return nil
 }
 
-// saveSubscriptionParameter saves value to Parameter Store and returns the parameter's name.
-func saveSubscriptionParameter(ctx context.Context, paramPath string, value []byte) (string, error) {
+// saveWebhookParameter saves value to Parameter Store and returns the parameter's name.
+func saveWebhookParameter(ctx context.Context, paramPath string, value []byte) (string, error) {
 	paramMgr := evergreen.GetEnvironment().ParameterManager()
 	param, err := paramMgr.Put(ctx, paramPath, string(value))
 	if err != nil {
@@ -1151,9 +1152,8 @@ func saveSubscriptionParameter(ctx context.Context, paramPath string, value []by
 	return param.Name, nil
 }
 
-// populateWebhookSecrets loads webhook secrets from Parameter Store for subscriptions that have a
-// parameter path set. Subscriptions without a parameter path retain whatever value was read from
-// MongoDB (legacy support for unmigrated subscriptions).
+// populateWebhookSecrets loads webhook secrets from Parameter Store for
+// subscriptions that have a parameter path set.
 func populateWebhookSecrets(ctx context.Context, subscriptions []Subscription) error {
 	for i := range subscriptions {
 		if subscriptions[i].Subscriber.Type != EvergreenWebhookSubscriberType {

--- a/model/event/subscriptions.go
+++ b/model/event/subscriptions.go
@@ -590,12 +590,8 @@ func RemoveSubscription(ctx context.Context, id string) error {
 	}
 	if sub != nil {
 		if ws, ok := sub.Subscriber.Target.(*WebhookSubscriber); ok && ws != nil {
-			if ws.SecretParameter != "" {
-				webhookSecretParamToDelete = ws.SecretParameter
-			}
-			if ws.AuthorizationHeaderParameter != "" {
-				authHeaderParamToDelete = ws.AuthorizationHeaderParameter
-			}
+			webhookSecretParamToDelete = ws.SecretParameter
+			authHeaderParamToDelete = ws.AuthorizationHeaderParameter
 		}
 	}
 

--- a/model/event/subscriptions_test.go
+++ b/model/event/subscriptions_test.go
@@ -566,7 +566,7 @@ func (s *subscriptionsSuite) TestUpsertWebhookSavesSecretToParameterStore() {
 		URL:    "https://example.com/webhook",
 		Secret: []byte("my-secret"),
 	}
-	sub := Subscription{
+	sub := &Subscription{
 		ID:           "webhook-sub",
 		ResourceType: ResourceTypePatch,
 		Trigger:      TriggerOutcome,
@@ -581,54 +581,28 @@ func (s *subscriptionsSuite) TestUpsertWebhookSavesSecretToParameterStore() {
 	}
 	s.Require().NoError(sub.Upsert(s.T().Context()))
 
-	// Secret should have been saved to Parameter Store.
-	s.Require().NotEmpty(webhookSub.SecretParameter)
-	fakeParams, err := fakeparameter.FindByIDs(s.T().Context(), webhookSub.SecretParameter)
-	s.Require().NoError(err)
-	s.Require().Len(fakeParams, 1)
-	s.Equal("my-secret", fakeParams[0].Value)
+	s.Equal([]byte("my-secret"), webhookSub.Secret, "secret should still be present after upsert")
+	s.Require().NotEmpty(webhookSub.SecretParameter, "secret parameter should be set after upsert")
 
-	// The plaintext secret must not be written to the DB document.
-	sub = Subscription{}
-	// Intentionally use db.FindOneQ instead of FindSubscriptionByID because
-	// that helper populates secrets from Parameter Store. We want to confirm
-	// what's stored in the DB.
-	s.Require().NoError(db.FindOneQ(s.T().Context(), SubscriptionsCollection, db.Query(bson.M{subscriptionIDKey: "webhook-sub"}), &sub))
+	// Secret should be available when reading it back out from Parameter Store.
+	sub, err := FindSubscriptionByID(s.T().Context(), sub.ID)
+	s.Require().NoError(err)
+	s.Require().NotZero(sub)
 	webhookSub, ok := sub.Subscriber.Target.(*WebhookSubscriber)
 	s.Require().True(ok)
 	s.Require().NotNil(webhookSub)
-	s.Zero(webhookSub.Secret)
-	s.NotEmpty(webhookSub.SecretParameter)
-}
+	s.Equal([]byte("my-secret"), webhookSub.Secret)
 
-func (s *subscriptionsSuite) TestFindSubscriptionByIDPopulatesSecretFromParameterStore() {
-	webhookSub := &WebhookSubscriber{
-		URL:    "https://example.com/webhook",
-		Secret: []byte("ps-secret"),
-	}
-	sub := Subscription{
-		ID:           "webhook-find",
-		ResourceType: ResourceTypePatch,
-		Trigger:      TriggerOutcome,
-		Selectors:    []Selector{{Type: SelectorID, Data: "test"}},
-		Filter:       Filter{ID: "test"},
-		Subscriber: Subscriber{
-			Type:   EvergreenWebhookSubscriberType,
-			Target: webhookSub,
-		},
-		Owner:     "me",
-		OwnerType: OwnerTypePerson,
-	}
-	s.Require().NoError(sub.Upsert(s.T().Context()))
-
-	found, err := FindSubscriptionByID(s.T().Context(), "webhook-find")
+	// The plaintext secret must not be written to the DB document.
+	sub, err = dbFindSubscriptionByID(s.T().Context(), sub.ID)
 	s.Require().NoError(err)
-	s.Require().NotNil(found)
-	foundWebhook, ok := found.Subscriber.Target.(*WebhookSubscriber)
+	s.Require().NotZero(sub)
+	webhookSub, ok = sub.Subscriber.Target.(*WebhookSubscriber)
 	s.Require().True(ok)
-	s.Require().NotNil(foundWebhook)
-	s.Equal([]byte("ps-secret"), foundWebhook.Secret)
-	s.NotEmpty(foundWebhook.SecretParameter)
+	s.Require().NotNil(webhookSub)
+	s.Zero(webhookSub.Secret, "webhook secret should not be set in the DB")
+	s.NotEmpty(webhookSub.SecretParameter, "webhook secret parameter should be set")
+	s.Empty(webhookSub.AuthorizationHeaderParameter, "should not create Authorization header parameter if there's no Authorization header")
 }
 
 func (s *subscriptionsSuite) TestFindSubscriptionsByOwnerPopulatesSecrets() {
@@ -699,14 +673,13 @@ func (s *subscriptionsSuite) TestRemoveSubscriptionDeletesWebhookSecretFromParam
 
 func (s *subscriptionsSuite) TestUpsertWebhookSavesAuthHeaderToParameterStore() {
 	webhookSub := &WebhookSubscriber{
-		URL:    "https://example.com/webhook",
-		Secret: []byte("my-secret"),
+		URL: "https://example.com/webhook",
 		Headers: []WebhookHeader{
 			{Key: WebhookAuthorizationHeader, Value: "Bearer my-token"},
 			{Key: "X-Custom", Value: "custom-value"},
 		},
 	}
-	sub := Subscription{
+	sub := &Subscription{
 		ID:           "webhook-auth-sub",
 		ResourceType: ResourceTypePatch,
 		Trigger:      TriggerOutcome,
@@ -721,95 +694,31 @@ func (s *subscriptionsSuite) TestUpsertWebhookSavesAuthHeaderToParameterStore() 
 	}
 	s.Require().NoError(sub.Upsert(s.T().Context()))
 
-	s.Require().NotEmpty(webhookSub.AuthorizationHeaderParameter)
-	authParams, err := fakeparameter.FindByIDs(s.T().Context(), webhookSub.AuthorizationHeaderParameter)
-	s.Require().NoError(err)
-	s.Require().Len(authParams, 1)
-	s.Equal("Bearer my-token", authParams[0].Value)
-
 	// The in-memory struct must still have the Authorization header after the upsert.
-	s.Equal("Bearer my-token", webhookSub.GetHeader(WebhookAuthorizationHeader), "Upsert must not clear the in-memory Authorization header")
+	s.Equal("Bearer my-token", webhookSub.GetHeader(WebhookAuthorizationHeader), "Authorization header should still be present after upsert")
+	s.Require().NotEmpty(webhookSub.AuthorizationHeaderParameter, "Authorization header parameter should be set after upsert")
+
+	// Authorization header should be available when reading it back out from
+	// Parameter Store.
+	sub, err := FindSubscriptionByID(s.T().Context(), sub.ID)
+	s.Require().NoError(err)
+	s.Require().NotZero(sub)
+	webhookSub, ok := sub.Subscriber.Target.(*WebhookSubscriber)
+	s.Require().True(ok)
+	s.Require().NotNil(webhookSub)
+	s.Equal("Bearer my-token", webhookSub.GetHeader(WebhookAuthorizationHeader))
+	s.Equal("custom-value", webhookSub.GetHeader("X-Custom"), "non-sensitive header should be preserved")
 
 	// The Authorization header must not be written to the DB document.
-	sub = Subscription{}
-	// Intentionally use db.FindOneQ instead of FindSubscriptionByID because
-	// that helper populates secrets from Parameter Store. We want to confirm
-	// what's stored in the DB.
-	s.Require().NoError(db.FindOneQ(s.T().Context(), SubscriptionsCollection, db.Query(bson.M{subscriptionIDKey: "webhook-auth-sub"}), &sub))
-	webhookSub, ok := sub.Subscriber.Target.(*WebhookSubscriber)
+	sub, err = dbFindSubscriptionByID(s.T().Context(), sub.ID)
+	s.Require().NoError(err)
+	s.Require().NotZero(sub)
+	webhookSub, ok = sub.Subscriber.Target.(*WebhookSubscriber)
 	s.Require().True(ok)
 	s.Require().NotNil(webhookSub)
 	s.Empty(webhookSub.GetHeader(WebhookAuthorizationHeader))
 	s.NotEmpty(webhookSub.AuthorizationHeaderParameter)
-
-	found, err := FindSubscriptionByID(s.T().Context(), "webhook-auth-sub")
-	s.Require().NoError(err)
-	s.Require().NotNil(found)
-	foundWebhook, ok := found.Subscriber.Target.(*WebhookSubscriber)
-	s.Require().True(ok)
-	s.Require().NotNil(foundWebhook)
-	s.NotEmpty(foundWebhook.AuthorizationHeaderParameter, "authorization_header_parameter path should be stored in MongoDB")
-	s.Equal("Bearer my-token", foundWebhook.GetHeader(WebhookAuthorizationHeader), "Authorization header should be populated from Parameter Store on read")
-	s.Equal("custom-value", foundWebhook.GetHeader("X-Custom"), "non-sensitive header should be preserved")
-}
-
-func (s *subscriptionsSuite) TestUpsertWebhookWithoutAuthHeaderDoesNotCreateAuthParameter() {
-	webhookSub := &WebhookSubscriber{
-		URL:    "https://example.com/webhook",
-		Secret: []byte("my-secret"),
-	}
-	sub := Subscription{
-		ID:           "webhook-no-auth",
-		ResourceType: ResourceTypePatch,
-		Trigger:      TriggerOutcome,
-		Selectors:    []Selector{{Type: SelectorID, Data: "test"}},
-		Filter:       Filter{ID: "test"},
-		Subscriber: Subscriber{
-			Type:   EvergreenWebhookSubscriberType,
-			Target: webhookSub,
-		},
-		Owner:     "me",
-		OwnerType: OwnerTypePerson,
-	}
-	s.Require().NoError(sub.Upsert(s.T().Context()))
-
-	s.Empty(webhookSub.AuthorizationHeaderParameter, "no auth header means no authorization_header_parameter")
-	secretParams, err := fakeparameter.FindByIDs(s.T().Context(), webhookSub.SecretParameter)
-	s.Require().NoError(err)
-	s.Require().Len(secretParams, 1, "only the secret parameter should exist")
-}
-
-func (s *subscriptionsSuite) TestFindSubscriptionByIDPopulatesAuthHeaderFromParameterStore() {
-	webhookSub := &WebhookSubscriber{
-		URL:    "https://example.com/webhook",
-		Secret: []byte("my-secret"),
-		Headers: []WebhookHeader{
-			{Key: WebhookAuthorizationHeader, Value: "Bearer ps-token"},
-		},
-	}
-	sub := Subscription{
-		ID:           "webhook-auth-find",
-		ResourceType: ResourceTypePatch,
-		Trigger:      TriggerOutcome,
-		Selectors:    []Selector{{Type: SelectorID, Data: "test"}},
-		Filter:       Filter{ID: "test"},
-		Subscriber: Subscriber{
-			Type:   EvergreenWebhookSubscriberType,
-			Target: webhookSub,
-		},
-		Owner:     "me",
-		OwnerType: OwnerTypePerson,
-	}
-	s.Require().NoError(sub.Upsert(s.T().Context()))
-
-	found, err := FindSubscriptionByID(s.T().Context(), "webhook-auth-find")
-	s.Require().NoError(err)
-	s.Require().NotNil(found)
-	foundWebhook, ok := found.Subscriber.Target.(*WebhookSubscriber)
-	s.Require().True(ok)
-	s.Require().NotNil(foundWebhook)
-	s.Equal("Bearer ps-token", foundWebhook.GetHeader(WebhookAuthorizationHeader))
-	s.NotEmpty(foundWebhook.AuthorizationHeaderParameter)
+	s.Equal("custom-value", webhookSub.GetHeader("X-Custom"), "non-sensitive header should be preserved")
 }
 
 // TODO(DEVPROD-15500): remove this test once the migration job has backfilled all legacy subscriptions.

--- a/model/event/subscriptions_test.go
+++ b/model/event/subscriptions_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func TestSubscriptions(t *testing.T) {
@@ -589,19 +588,17 @@ func (s *subscriptionsSuite) TestUpsertWebhookSavesSecretToParameterStore() {
 	s.Require().Len(fakeParams, 1)
 	s.Equal("my-secret", fakeParams[0].Value)
 
-	// Both the secret bytes and the Parameter Store path are persisted to MongoDB during
-	// Phase 1. The secret stays in MongoDB as a fallback until the Phase 2 cleanup job removes it.
-	// TODO(DEVPROD-15500): remove this assertion once Phase 2 cleanup job removes secrets from MongoDB.
-	raw := bson.M{}
-	s.Require().NoError(db.FindOneQ(s.T().Context(), SubscriptionsCollection, db.Query(bson.M{"_id": "webhook-sub"}), &raw))
-	subscriberRaw, ok := raw["subscriber"].(bson.M)
+	// The plaintext secret must not be written to the DB document.
+	sub = Subscription{}
+	// Intentionally use db.FindOneQ instead of FindSubscriptionByID because
+	// that helper populates secrets from Parameter Store. We want to confirm
+	// what's stored in the DB.
+	s.Require().NoError(db.FindOneQ(s.T().Context(), SubscriptionsCollection, db.Query(bson.M{subscriptionIDKey: "webhook-sub"}), &sub))
+	webhookSub, ok := sub.Subscriber.Target.(*WebhookSubscriber)
 	s.Require().True(ok)
-	targetRaw, ok := subscriberRaw["target"].(bson.M)
-	s.Require().True(ok)
-	storedSecret, ok := targetRaw["secret"].(primitive.Binary)
-	s.Require().True(ok, "secret should be persisted to MongoDB as a fallback during Phase 1")
-	s.Equal([]byte("my-secret"), storedSecret.Data)
-	s.NotEmpty(targetRaw["secret_parameter"], "secret_parameter path should be stored in MongoDB")
+	s.Require().NotNil(webhookSub)
+	s.Zero(webhookSub.Secret)
+	s.NotEmpty(webhookSub.SecretParameter)
 }
 
 func (s *subscriptionsSuite) TestFindSubscriptionByIDPopulatesSecretFromParameterStore() {
@@ -632,37 +629,6 @@ func (s *subscriptionsSuite) TestFindSubscriptionByIDPopulatesSecretFromParamete
 	s.Require().NotNil(foundWebhook)
 	s.Equal([]byte("ps-secret"), foundWebhook.Secret)
 	s.NotEmpty(foundWebhook.SecretParameter)
-}
-
-func (s *subscriptionsSuite) TestFindSubscriptionByIDFallsBackToMongoDBSecret() {
-	// Simulate a legacy subscription with secret in MongoDB but no SecretParameter.
-	// Insert directly to bypass the Upsert write path which saves to PS.
-	sub := Subscription{
-		ID:           "legacy-webhook",
-		ResourceType: ResourceTypePatch,
-		Trigger:      TriggerOutcome,
-		Filter:       Filter{ID: "test"},
-		Subscriber: Subscriber{
-			Type: EvergreenWebhookSubscriberType,
-			Target: &WebhookSubscriber{
-				URL:    "https://legacy.example.com",
-				Secret: []byte("legacy-secret"),
-			},
-		},
-		Owner:     "me",
-		OwnerType: OwnerTypePerson,
-	}
-	_, err := evergreen.GetEnvironment().DB().Collection(SubscriptionsCollection).InsertOne(s.T().Context(), sub)
-	s.Require().NoError(err)
-
-	found, err := FindSubscriptionByID(s.T().Context(), "legacy-webhook")
-	s.Require().NoError(err)
-	s.Require().NotNil(found)
-	foundWebhook, ok := found.Subscriber.Target.(*WebhookSubscriber)
-	s.Require().True(ok)
-	s.Require().NotNil(foundWebhook)
-	s.Equal([]byte("legacy-secret"), foundWebhook.Secret, "should fall back to MongoDB secret")
-	s.Empty(foundWebhook.SecretParameter, "legacy subscription should not have a parameter path")
 }
 
 func (s *subscriptionsSuite) TestFindSubscriptionsByOwnerPopulatesSecrets() {
@@ -731,43 +697,6 @@ func (s *subscriptionsSuite) TestRemoveSubscriptionDeletesWebhookSecretFromParam
 	s.Empty(fakeParams, "webhook secret should be removed from Parameter Store when its subscription is deleted")
 }
 
-// TODO(DEVPROD-15500): remove this test once the migration job has backfilled all legacy subscriptions.
-func (s *subscriptionsSuite) TestRemoveSubscriptionDoesNotTouchParameterStoreForLegacyWebhook() {
-	// Simulate a legacy webhook subscription with the secret in MongoDB but no SecretParameter set.
-	// Insert directly to bypass the Upsert write path, which would otherwise save to Parameter Store.
-	sub := Subscription{
-		ID:           "legacy-webhook-delete",
-		ResourceType: ResourceTypePatch,
-		Trigger:      TriggerOutcome,
-		Filter:       Filter{ID: "test"},
-		Subscriber: Subscriber{
-			Type: EvergreenWebhookSubscriberType,
-			Target: &WebhookSubscriber{
-				URL:    "https://legacy.example.com",
-				Secret: []byte("legacy-secret"),
-			},
-		},
-		Owner:     "me",
-		OwnerType: OwnerTypePerson,
-	}
-	_, err := evergreen.GetEnvironment().DB().Collection(SubscriptionsCollection).InsertOne(s.T().Context(), sub)
-	s.Require().NoError(err)
-
-	allParams, err := fakeparameter.FindByIDs(s.T().Context())
-	s.Require().NoError(err)
-	s.Require().Empty(allParams)
-
-	s.Require().NoError(RemoveSubscription(s.T().Context(), "legacy-webhook-delete"))
-
-	found, err := FindSubscriptionByID(s.T().Context(), "legacy-webhook-delete")
-	s.Require().NoError(err)
-	s.Nil(found)
-
-	allParams, err = fakeparameter.FindByIDs(s.T().Context())
-	s.Require().NoError(err)
-	s.Empty(allParams, "legacy webhook removal should not touch Parameter Store since no SecretParameter is set")
-}
-
 func (s *subscriptionsSuite) TestUpsertWebhookSavesAuthHeaderToParameterStore() {
 	webhookSub := &WebhookSubscriber{
 		URL:    "https://example.com/webhook",
@@ -798,6 +727,21 @@ func (s *subscriptionsSuite) TestUpsertWebhookSavesAuthHeaderToParameterStore() 
 	s.Require().Len(authParams, 1)
 	s.Equal("Bearer my-token", authParams[0].Value)
 
+	// The in-memory struct must still have the Authorization header after the upsert.
+	s.Equal("Bearer my-token", webhookSub.GetHeader(WebhookAuthorizationHeader), "Upsert must not clear the in-memory Authorization header")
+
+	// The Authorization header must not be written to the DB document.
+	sub = Subscription{}
+	// Intentionally use db.FindOneQ instead of FindSubscriptionByID because
+	// that helper populates secrets from Parameter Store. We want to confirm
+	// what's stored in the DB.
+	s.Require().NoError(db.FindOneQ(s.T().Context(), SubscriptionsCollection, db.Query(bson.M{subscriptionIDKey: "webhook-auth-sub"}), &sub))
+	webhookSub, ok := sub.Subscriber.Target.(*WebhookSubscriber)
+	s.Require().True(ok)
+	s.Require().NotNil(webhookSub)
+	s.Empty(webhookSub.GetHeader(WebhookAuthorizationHeader))
+	s.NotEmpty(webhookSub.AuthorizationHeaderParameter)
+
 	found, err := FindSubscriptionByID(s.T().Context(), "webhook-auth-sub")
 	s.Require().NoError(err)
 	s.Require().NotNil(found)
@@ -806,6 +750,7 @@ func (s *subscriptionsSuite) TestUpsertWebhookSavesAuthHeaderToParameterStore() 
 	s.Require().NotNil(foundWebhook)
 	s.NotEmpty(foundWebhook.AuthorizationHeaderParameter, "authorization_header_parameter path should be stored in MongoDB")
 	s.Equal("Bearer my-token", foundWebhook.GetHeader(WebhookAuthorizationHeader), "Authorization header should be populated from Parameter Store on read")
+	s.Equal("custom-value", foundWebhook.GetHeader("X-Custom"), "non-sensitive header should be preserved")
 }
 
 func (s *subscriptionsSuite) TestUpsertWebhookWithoutAuthHeaderDoesNotCreateAuthParameter() {

--- a/units/webhook_secret_migration_test.go
+++ b/units/webhook_secret_migration_test.go
@@ -69,7 +69,7 @@ func insertWebhookSubscriptionWithAuthHeader(t *testing.T, id, authValue string)
 				URL:    "https://example.com/webhook",
 				Secret: []byte("the-secret"),
 				Headers: []event.WebhookHeader{
-					{Key: "Authorization", Value: authValue},
+					{Key: event.WebhookAuthorizationHeader, Value: authValue},
 				},
 			},
 		},
@@ -94,7 +94,7 @@ func insertWebhookSubscriptionWithBothUnmigrated(t *testing.T, id, secret, authV
 				URL:    "https://example.com/webhook",
 				Secret: []byte(secret),
 				Headers: []event.WebhookHeader{
-					{Key: "Authorization", Value: authValue},
+					{Key: event.WebhookAuthorizationHeader, Value: authValue},
 				},
 			},
 		},
@@ -310,7 +310,7 @@ func TestWebhookSecretMigrationJobRun(t *testing.T) {
 					"url":                            "https://example.com/webhook",
 					"secret":                         []byte("already-in-ps"),
 					"secret_parameter":               "/some/secret/param",
-					"headers":                        bson.A{bson.M{"key": "Authorization", "value": "Bearer token"}},
+					"headers":                        bson.A{bson.M{"key": event.WebhookAuthorizationHeader, "value": "Bearer token"}},
 					"authorization_header_parameter": "/some/auth/param",
 				},
 			},
@@ -489,7 +489,7 @@ func TestWebhookSecretCleanupJobRun(t *testing.T) {
 					"url":                            "https://example.com/webhook",
 					"secret":                         []byte("old-secret"),
 					"secret_parameter":               "/some/secret/param",
-					"headers":                        bson.A{bson.M{"key": "Authorization", "value": "Bearer old-token"}},
+					"headers":                        bson.A{bson.M{"key": event.WebhookAuthorizationHeader, "value": "Bearer old-token"}},
 					"authorization_header_parameter": "/some/auth/param",
 				},
 			},
@@ -523,7 +523,7 @@ func TestWebhookSecretCleanupJobRun(t *testing.T) {
 		for _, h := range headers {
 			headerMap, ok := h.(bson.M)
 			require.True(t, ok)
-			assert.NotEqual(t, "Authorization", headerMap["key"], "Authorization header should be removed")
+			assert.NotEqual(t, event.WebhookAuthorizationHeader, headerMap["key"], "Authorization header should be removed")
 		}
 	})
 
@@ -570,7 +570,7 @@ func TestFindMigratedWebhookSubscriptionIDs(t *testing.T) {
 			"type": event.EvergreenWebhookSubscriberType,
 			"target": bson.M{
 				"url":                            "https://example.com/webhook",
-				"headers":                        bson.A{bson.M{"key": "Authorization", "value": "Bearer old"}},
+				"headers":                        bson.A{bson.M{"key": event.WebhookAuthorizationHeader, "value": "Bearer old"}},
 				"authorization_header_parameter": "/auth/param",
 			},
 		},


### PR DESCRIPTION
DEVPROD-36207

### Description

Currently, webhook secrets are written to both the DB and Parameter Store. In order to complete the migration and delete all the remaining webhook secrets from the DB, I changed it to stop writing webhook secrets to the DB.

* Stop writing webhook secrets to the DB and remove fallbacks to using the DB.
* When deleting subscriptions, clean up the webhook secrets in Parameter Store after deleting the DB document (to avoid issues where the webhook secret could be deleted but not the subscription).
* Refactor some common helper logic for tidiness.
* Clean up unit tests, which had some duplicate coverage.

### Testing

* Unit tests pass.
* Tested in personal staging to verify that I could still save/delete a webhook subscription and the DB/PS data looked reasonable.
