### PR TITLE
DEVPROD-36871 Bound the project translation cache by a configurable byte budget

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-07-06"
+	ClientVersion = "2026-07-07"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/config_scheduler.go
+++ b/config_scheduler.go
@@ -29,6 +29,7 @@ type SchedulerConfig struct {
 	NumDependentsFactor              float64 `bson:"num_dependents_factor" json:"num_dependents_factor" mapstructure:"num_dependents_factor"`
 	StepbackTaskFactor               int64   `bson:"stepback_task_factor" json:"stepback_task_factor" mapstructure:"stepback_task_factor"`
 	TranslateProjectConcurrencyLimit int     `bson:"translate_project_concurrency_limit" json:"translate_project_concurrency_limit" mapstructure:"translate_project_concurrency_limit"`
+	TranslateProjectCacheBytesLimit  int64   `bson:"translate_project_cache_bytes_limit" json:"translate_project_cache_bytes_limit" mapstructure:"translate_project_cache_bytes_limit"`
 }
 
 func (c *SchedulerConfig) SectionId() string { return "scheduler" }
@@ -59,6 +60,7 @@ func (c *SchedulerConfig) Set(ctx context.Context) error {
 			"num_dependents_factor":               c.NumDependentsFactor,
 			"stepback_task_factor":                c.StepbackTaskFactor,
 			"translate_project_concurrency_limit": c.TranslateProjectConcurrencyLimit,
+			"translate_project_cache_bytes_limit": c.TranslateProjectCacheBytesLimit,
 		}}), "updating config section '%s'", c.SectionId(),
 	)
 }
@@ -161,6 +163,9 @@ func (c *SchedulerConfig) ValidateAndDefault() error {
 	}
 	if c.TranslateProjectConcurrencyLimit < 0 {
 		return errors.New("translate project concurrency limit cannot be negative")
+	}
+	if c.TranslateProjectCacheBytesLimit < 0 {
+		return errors.New("translate project cache bytes limit cannot be negative")
 	}
 
 	return nil

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1726,6 +1726,7 @@ type ComplexityRoot struct {
 		StepbackTaskFactor               func(childComplexity int) int
 		TargetTimeSeconds                func(childComplexity int) int
 		TaskFinder                       func(childComplexity int) int
+		TranslateProjectCacheBytesLimit  func(childComplexity int) int
 		TranslateProjectConcurrencyLimit func(childComplexity int) int
 	}
 
@@ -10094,6 +10095,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.SchedulerConfig.TaskFinder(childComplexity), true
+	case "SchedulerConfig.translateProjectCacheBytesLimit":
+		if e.complexity.SchedulerConfig.TranslateProjectCacheBytesLimit == nil {
+			break
+		}
+
+		return e.complexity.SchedulerConfig.TranslateProjectCacheBytesLimit(childComplexity), true
 	case "SchedulerConfig.translateProjectConcurrencyLimit":
 		if e.complexity.SchedulerConfig.TranslateProjectConcurrencyLimit == nil {
 			break
@@ -20055,6 +20062,8 @@ func (ec *executionContext) fieldContext_AdminSettings_scheduler(_ context.Conte
 				return ec.fieldContext_SchedulerConfig_stepbackTaskFactor(ctx, field)
 			case "translateProjectConcurrencyLimit":
 				return ec.fieldContext_SchedulerConfig_translateProjectConcurrencyLimit(ctx, field)
+			case "translateProjectCacheBytesLimit":
+				return ec.fieldContext_SchedulerConfig_translateProjectCacheBytesLimit(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type SchedulerConfig", field.Name)
 		},
@@ -59211,6 +59220,35 @@ func (ec *executionContext) fieldContext_SchedulerConfig_translateProjectConcurr
 	return fc, nil
 }
 
+func (ec *executionContext) _SchedulerConfig_translateProjectCacheBytesLimit(ctx context.Context, field graphql.CollectedField, obj *model.APISchedulerConfig) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_SchedulerConfig_translateProjectCacheBytesLimit,
+		func(ctx context.Context) (any, error) {
+			return obj.TranslateProjectCacheBytesLimit, nil
+		},
+		nil,
+		ec.marshalOInt2int64,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_SchedulerConfig_translateProjectCacheBytesLimit(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SchedulerConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _SearchReturnInfo_featuresURL(ctx context.Context, field graphql.CollectedField, obj *thirdparty.SearchReturnInfo) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -88830,7 +88868,7 @@ func (ec *executionContext) unmarshalInputSchedulerConfigInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"taskFinder", "hostAllocator", "hostAllocatorRoundingRule", "hostAllocatorFeedbackRule", "hostsOverallocatedRule", "futureHostFraction", "cacheDurationSeconds", "targetTimeSeconds", "acceptableHostIdleTimeSeconds", "groupVersions", "patchFactor", "patchTimeInQueueFactor", "commitQueueFactor", "mainlineTimeInQueueFactor", "expectedRuntimeFactor", "generateTaskFactor", "numDependentsFactor", "stepbackTaskFactor", "translateProjectConcurrencyLimit"}
+	fieldsInOrder := [...]string{"taskFinder", "hostAllocator", "hostAllocatorRoundingRule", "hostAllocatorFeedbackRule", "hostsOverallocatedRule", "futureHostFraction", "cacheDurationSeconds", "targetTimeSeconds", "acceptableHostIdleTimeSeconds", "groupVersions", "patchFactor", "patchTimeInQueueFactor", "commitQueueFactor", "mainlineTimeInQueueFactor", "expectedRuntimeFactor", "generateTaskFactor", "numDependentsFactor", "stepbackTaskFactor", "translateProjectConcurrencyLimit", "translateProjectCacheBytesLimit"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -88970,6 +89008,13 @@ func (ec *executionContext) unmarshalInputSchedulerConfigInput(ctx context.Conte
 				return it, err
 			}
 			it.TranslateProjectConcurrencyLimit = data
+		case "translateProjectCacheBytesLimit":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("translateProjectCacheBytesLimit"))
+			data, err := ec.unmarshalOInt2int64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TranslateProjectCacheBytesLimit = data
 		}
 	}
 
@@ -105118,6 +105163,8 @@ func (ec *executionContext) _SchedulerConfig(ctx context.Context, sel ast.Select
 			out.Values[i] = ec._SchedulerConfig_stepbackTaskFactor(ctx, field, obj)
 		case "translateProjectConcurrencyLimit":
 			out.Values[i] = ec._SchedulerConfig_translateProjectConcurrencyLimit(ctx, field, obj)
+		case "translateProjectCacheBytesLimit":
+			out.Values[i] = ec._SchedulerConfig_translateProjectCacheBytesLimit(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/schema/types/adminSettings/runners.graphql
+++ b/graphql/schema/types/adminSettings/runners.graphql
@@ -84,6 +84,7 @@ input SchedulerConfigInput {
   numDependentsFactor: Float!
   stepbackTaskFactor: Int!
   translateProjectConcurrencyLimit: Int
+  translateProjectCacheBytesLimit: Int
 }
 
 type SchedulerConfig {
@@ -106,6 +107,7 @@ type SchedulerConfig {
   numDependentsFactor: Float
   stepbackTaskFactor: Int
   translateProjectConcurrencyLimit: Int
+  translateProjectCacheBytesLimit: Int
 }
 
 input RepotrackerConfigInput {

--- a/graphql/tests/mutation/saveAdminSettings/queries/runners.graphql
+++ b/graphql/tests/mutation/saveAdminSettings/queries/runners.graphql
@@ -48,6 +48,7 @@ mutation Runners {
         targetTimeSeconds: 1
         taskFinder: PARALLEL
         translateProjectConcurrencyLimit: 1
+        translateProjectCacheBytesLimit: 1
       }
     }
   ) {
@@ -102,6 +103,7 @@ mutation Runners {
       targetTimeSeconds
       taskFinder
       translateProjectConcurrencyLimit
+      translateProjectCacheBytesLimit
     }
   }
 }

--- a/graphql/tests/mutation/saveAdminSettings/results.json
+++ b/graphql/tests/mutation/saveAdminSettings/results.json
@@ -82,7 +82,8 @@
               "stepbackTaskFactor": 1,
               "targetTimeSeconds": 1,
               "taskFinder": "PARALLEL",
-              "translateProjectConcurrencyLimit": 1
+              "translateProjectConcurrencyLimit": 1,
+              "translateProjectCacheBytesLimit": 1
             }
           }
         }

--- a/graphql/tests/query/adminEvents/results.json
+++ b/graphql/tests/query/adminEvents/results.json
@@ -62,6 +62,7 @@
                   "stepback_task_factor": 10,
                   "target_time_seconds": 60,
                   "task_finder": "legacy",
+                  "translate_project_cache_bytes_limit": 0,
                   "translate_project_concurrency_limit": 0
                 },
                 "before": {
@@ -83,6 +84,7 @@
                   "stepback_task_factor": 10,
                   "target_time_seconds": 60,
                   "task_finder": "legacy",
+                  "translate_project_cache_bytes_limit": 0,
                   "translate_project_concurrency_limit": 0
                 },
                 "section": "scheduler",

--- a/graphql/tests/query/adminSettings/data.json
+++ b/graphql/tests/query/adminSettings/data.json
@@ -124,7 +124,8 @@
       "hosts_overallocated_rule": "no-terminations-when-overallocated",
       "stepback_task_factor": 10,
       "num_dependents_factor": 5,
-      "translate_project_concurrency_limit": 15
+      "translate_project_concurrency_limit": 15,
+      "translate_project_cache_bytes_limit": 1048576
     },
     {
       "_id": "task_limits",

--- a/graphql/tests/query/adminSettings/queries/runners.graphql
+++ b/graphql/tests/query/adminSettings/queries/runners.graphql
@@ -36,6 +36,7 @@ query Runners {
       numDependentsFactor
       stepbackTaskFactor
       translateProjectConcurrencyLimit
+      translateProjectCacheBytesLimit
       hostAllocator
       hostAllocatorRoundingRule
       hostAllocatorFeedbackRule

--- a/graphql/tests/query/adminSettings/results.json
+++ b/graphql/tests/query/adminSettings/results.json
@@ -205,6 +205,7 @@
               "numDependentsFactor": 5,
               "stepbackTaskFactor": 10,
               "translateProjectConcurrencyLimit": 15,
+              "translateProjectCacheBytesLimit": 1048576,
               "hostAllocator": "UTILIZATION",
               "hostAllocatorRoundingRule": "DOWN",
               "hostAllocatorFeedbackRule": "NO_FEEDBACK",

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -589,6 +589,9 @@ const (
 	ppTranslationDedupedOtelAttribute = "evergreen.parser_project.translation_deduped"
 	// ppTranslationCacheSizeOtelAttribute records how many translations the LRU is holding right now.
 	ppTranslationCacheSizeOtelAttribute = "evergreen.parser_project.translation_cache_size"
+	// ppTranslationCacheBytesOtelAttribute records the estimated byte total of the translations the
+	// LRU is holding right now, which the byte budget bounds.
+	ppTranslationCacheBytesOtelAttribute = "evergreen.parser_project.translation_cache_bytes"
 	// ppTranslationCacheEvictionsOtelAttribute records the cumulative count of translations the LRU
 	// has dropped to make room for new ones (or because their TTL expired), before anything reused them.
 	ppTranslationCacheEvictionsOtelAttribute = "evergreen.parser_project.translation_cache_evictions"
@@ -615,10 +618,11 @@ func setTranslationCacheSpanAttributes(span trace.Span, cacheHit, deduped, cache
 	if !cacheEnabled {
 		return
 	}
-	size, evictions := translationCacheStats()
+	size, evictions, bytes := translationCacheStats()
 	hottestKey, hottestHits := hottestTranslationKey()
 	span.SetAttributes(
 		attribute.Int(ppTranslationCacheSizeOtelAttribute, size),
+		attribute.Int64(ppTranslationCacheBytesOtelAttribute, bytes),
 		attribute.Int64(ppTranslationCacheEvictionsOtelAttribute, evictions),
 		attribute.String(ppTranslationCacheHottestKeyOtelAttribute, hottestKey),
 		attribute.Int64(ppTranslationCacheHottestKeyHitsOtelAttribute, hottestHits),

--- a/model/project_translate_cache.go
+++ b/model/project_translate_cache.go
@@ -17,15 +17,36 @@ import (
 )
 
 const (
-	projectTranslationCacheSize = 512
-	projectTranslationCacheTTL  = 30 * time.Minute
+	projectTranslationCacheTTL = 30 * time.Minute
+
+	// defaultTranslationCacheBytesLimit bounds the cache when the admin setting is unset or
+	// non-positive, so a missing config never leaves the cache unbounded. The budget is measured
+	// against each entry's JSON-serialized size (see estimateProjectSize), which underestimates live
+	// heap footprint, so the admin override should be set with headroom.
+	defaultTranslationCacheBytesLimit = 256 * 1024 * 1024
 )
+
+// cachedTranslation is the cache value: the shared translated project plus the estimated byte cost
+// recorded at insertion, so evictions can decrement the running byte total.
+type cachedTranslation struct {
+	project *Project
+	size    int64
+}
 
 var (
 	translationCacheMu        sync.Mutex
-	translationCache          *expirable.LRU[string, *Project]
+	translationCache          *expirable.LRU[string, cachedTranslation]
 	translationGroupPtr       atomic.Pointer[singleflight.Group]
 	translationCacheEvictions atomic.Int64
+
+	// translationCacheWriteMu serializes each insert together with the eviction that brings the cache
+	// back within budget, so the byte total stays consistent with the cache's contents across
+	// concurrent inserts of different keys.
+	translationCacheWriteMu sync.Mutex
+	// translationCacheBytes is the running sum of the sizes of all live entries.
+	translationCacheBytes atomic.Int64
+	// translationCacheBytesLimit is the configured byte budget; a value <= 0 falls back to the default.
+	translationCacheBytesLimit atomic.Int64
 
 	// translationKeyHits counts cache hits per key so the hottest cached configs are identifiable for
 	// tuning. Entries are removed when their key is evicted from the LRU, so it stays bounded by cache size.
@@ -37,12 +58,15 @@ func init() {
 	translationGroupPtr.Store(&singleflight.Group{})
 }
 
-// getTranslationCache returns the process-wide LRU cache for translated projects, initializing it on first call.
-func getTranslationCache() *expirable.LRU[string, *Project] {
+// getTranslationCache returns the process-wide LRU cache for translated projects, initializing it on
+// first call. The LRU is created with no entry-count limit; the cache is bounded by the byte budget
+// (see addToTranslationCache) and the TTL instead.
+func getTranslationCache() *expirable.LRU[string, cachedTranslation] {
 	translationCacheMu.Lock()
 	defer translationCacheMu.Unlock()
 	if translationCache == nil {
-		translationCache = expirable.NewLRU[string, *Project](projectTranslationCacheSize, func(key string, _ *Project) {
+		translationCache = expirable.NewLRU[string, cachedTranslation](0, func(key string, v cachedTranslation) {
+			translationCacheBytes.Add(-v.size)
 			translationCacheEvictions.Add(1)
 			translationKeyHitsMu.Lock()
 			delete(translationKeyHits, key)
@@ -50,6 +74,55 @@ func getTranslationCache() *expirable.LRU[string, *Project] {
 		}, projectTranslationCacheTTL)
 	}
 	return translationCache
+}
+
+// SetTranslationCacheBytesLimit sets the byte budget for the process-wide translation cache. A value
+// <= 0 restores the built-in default, which also applies until this is first called.
+func SetTranslationCacheBytesLimit(n int64) {
+	translationCacheBytesLimit.Store(n)
+}
+
+func currentTranslationCacheBytesLimit() int64 {
+	if n := translationCacheBytesLimit.Load(); n > 0 {
+		return n
+	}
+	return defaultTranslationCacheBytesLimit
+}
+
+// estimateProjectSize approximates p's memory cost as the length of its JSON encoding. This
+// underestimates live heap size but is proportional to it and, unlike the parser project, reflects
+// matrix and variant expansion. It returns 0 if p can't be marshaled, so an unsizable entry doesn't
+// block the cache.
+func estimateProjectSize(p *Project) int64 {
+	data, err := json.Marshal(p)
+	if err != nil {
+		return 0
+	}
+	return int64(len(data))
+}
+
+// addToTranslationCache inserts p under key and evicts least-recently-used entries until the running
+// byte total is within the configured budget. Eviction is by recency only, with no size bias and no
+// size-gated admission, so a large but actively used config stays resident while the coldest entries
+// are dropped first. A single entry larger than the whole budget is kept rather than immediately
+// evicted, so the budget can be exceeded transiently in that degenerate case.
+func addToTranslationCache(key string, p *Project) {
+	size := estimateProjectSize(p)
+	c := getTranslationCache()
+
+	translationCacheWriteMu.Lock()
+	defer translationCacheWriteMu.Unlock()
+
+	// Drop any prior (possibly TTL-expired but not-yet-swept) entry for this key so its bytes are
+	// subtracted before accounting for the replacement.
+	c.Remove(key)
+	translationCacheBytes.Add(size)
+	c.Add(key, cachedTranslation{project: p, size: size})
+
+	limit := currentTranslationCacheBytesLimit()
+	for translationCacheBytes.Load() > limit && c.Len() > 1 {
+		c.RemoveOldest()
+	}
 }
 
 // recordTranslationKeyHit increments the per-key hit counter for an LRU cache hit.
@@ -72,10 +145,11 @@ func hottestTranslationKey() (key string, hits int64) {
 	return key, hits
 }
 
-// translationCacheStats returns the LRU's current entry count and its cumulative eviction count
-// (including TTL expirations, which expirable.LRU reports through the same callback).
-func translationCacheStats() (size int, evictions int64) {
-	return getTranslationCache().Len(), translationCacheEvictions.Load()
+// translationCacheStats returns the LRU's current entry count, its cumulative eviction count
+// (including TTL expirations, which expirable.LRU reports through the same callback), and the running
+// byte total of the entries it's holding.
+func translationCacheStats() (size int, evictions, bytes int64) {
+	return getTranslationCache().Len(), translationCacheEvictions.Load(), translationCacheBytes.Load()
 }
 
 // getOrComputeTranslation coalesces concurrent calls via singleflight and, when cacheEnabled, also
@@ -88,7 +162,7 @@ func getOrComputeTranslation(key string, cacheEnabled bool, compute func() (*Pro
 	if cacheEnabled {
 		if v, ok := getTranslationCache().Get(key); ok {
 			recordTranslationKeyHit(key)
-			return v, true, false, nil
+			return v.project, true, false, nil
 		}
 	}
 
@@ -104,7 +178,7 @@ func getOrComputeTranslation(key string, cacheEnabled bool, compute func() (*Pro
 		if cacheEnabled {
 			if v, ok := getTranslationCache().Get(key); ok {
 				recordTranslationKeyHit(key)
-				return translationResult{project: v}, nil
+				return translationResult{project: v.project}, nil
 			}
 		}
 		result, err := compute()
@@ -112,7 +186,7 @@ func getOrComputeTranslation(key string, cacheEnabled bool, compute func() (*Pro
 			return translationResult{project: result, err: err}, nil
 		}
 		if cacheEnabled {
-			getTranslationCache().Add(key, result)
+			addToTranslationCache(key, result)
 		}
 		return translationResult{project: result}, nil
 	})

--- a/model/project_translate_cache.go
+++ b/model/project_translate_cache.go
@@ -91,14 +91,14 @@ func currentTranslationCacheBytesLimit() int64 {
 
 // estimateProjectSize approximates p's memory cost as the length of its JSON encoding. This
 // underestimates live heap size but is proportional to it and, unlike the parser project, reflects
-// matrix and variant expansion. It returns 0 if p can't be marshaled, so an unsizable entry doesn't
-// block the cache.
-func estimateProjectSize(p *Project) int64 {
+// matrix and variant expansion. The bool is false if p can't be marshaled, in which case the caller
+// must not cache it: an unsizable entry would escape the byte budget entirely.
+func estimateProjectSize(p *Project) (int64, bool) {
 	data, err := json.Marshal(p)
 	if err != nil {
-		return 0
+		return 0, false
 	}
-	return int64(len(data))
+	return int64(len(data)), true
 }
 
 // addToTranslationCache inserts p under key and evicts least-recently-used entries until the running
@@ -107,7 +107,10 @@ func estimateProjectSize(p *Project) int64 {
 // are dropped first. A single entry larger than the whole budget is kept rather than immediately
 // evicted, so the budget can be exceeded transiently in that degenerate case.
 func addToTranslationCache(key string, p *Project) {
-	size := estimateProjectSize(p)
+	size, ok := estimateProjectSize(p)
+	if !ok {
+		return
+	}
 	c := getTranslationCache()
 
 	translationCacheWriteMu.Lock()

--- a/model/project_translate_cache_test.go
+++ b/model/project_translate_cache_test.go
@@ -347,7 +347,8 @@ func TestByteBoundedCacheEvictsLRUToBudget(t *testing.T) {
 		}
 		return p
 	}
-	entrySize := estimateProjectSize(makeProject("sample"))
+	entrySize, ok := estimateProjectSize(makeProject("sample"))
+	require.True(t, ok)
 	require.Positive(t, entrySize)
 
 	// Budget holds ~3 entries at a time.

--- a/model/project_translate_cache_test.go
+++ b/model/project_translate_cache_test.go
@@ -24,6 +24,8 @@ func resetTranslationCacheForTesting() {
 	translationCacheMu.Unlock()
 	translationGroupPtr.Store(&singleflight.Group{})
 	translationCacheEvictions.Store(0)
+	translationCacheBytes.Store(0)
+	translationCacheBytesLimit.Store(0)
 	translationKeyHitsMu.Lock()
 	translationKeyHits = map[string]int64{}
 	translationKeyHitsMu.Unlock()
@@ -307,16 +309,77 @@ func TestTranslationCacheStats(t *testing.T) {
 
 	_, _, _, err := getOrComputeTranslation("k1", true, compute)
 	require.NoError(t, err)
-	size, evictions := translationCacheStats()
+	size, evictions, _ := translationCacheStats()
 	assert.Equal(t, 1, size)
 	assert.Equal(t, int64(0), evictions, "no eviction yet, the single entry still fits")
 
 	// Adding a second entry evicts the first because the LRU was resized down to 1.
 	_, _, _, err = getOrComputeTranslation("k2", true, compute)
 	require.NoError(t, err)
-	size, evictions = translationCacheStats()
+	size, evictions, _ = translationCacheStats()
 	assert.Equal(t, 1, size, "capacity is still 1")
 	assert.Equal(t, int64(1), evictions, "adding past capacity evicted the older entry")
+}
+
+func TestTranslationCacheBytesLimitFallsBackToDefault(t *testing.T) {
+	t.Cleanup(resetTranslationCacheForTesting)
+
+	SetTranslationCacheBytesLimit(0)
+	assert.Equal(t, int64(defaultTranslationCacheBytesLimit), currentTranslationCacheBytesLimit(), "non-positive limit falls back to the default")
+
+	SetTranslationCacheBytesLimit(-5)
+	assert.Equal(t, int64(defaultTranslationCacheBytesLimit), currentTranslationCacheBytesLimit(), "negative limit falls back to the default")
+
+	SetTranslationCacheBytesLimit(4096)
+	assert.Equal(t, int64(4096), currentTranslationCacheBytesLimit(), "positive limit is used as-is")
+}
+
+// TestByteBoundedCacheEvictsLRUToBudget shows the cache stays within the configured byte budget by
+// evicting the least-recently-used entries, keeping the most recent ones regardless of size.
+func TestByteBoundedCacheEvictsLRUToBudget(t *testing.T) {
+	t.Cleanup(resetTranslationCacheForTesting)
+	resetTranslationCacheForTesting()
+
+	makeProject := func(id string) *Project {
+		p := &Project{Identifier: id}
+		for i := 0; i < 50; i++ {
+			p.Tasks = append(p.Tasks, ProjectTask{Name: fmt.Sprintf("%s-task-%d", id, i)})
+		}
+		return p
+	}
+	entrySize := estimateProjectSize(makeProject("sample"))
+	require.Positive(t, entrySize)
+
+	// Budget holds ~3 entries at a time.
+	budget := entrySize*3 + entrySize/2
+	SetTranslationCacheBytesLimit(budget)
+
+	for _, k := range []string{"k1", "k2", "k3", "k4", "k5"} {
+		_, _, _, err := getOrComputeTranslation(k, true, func() (*Project, error) {
+			return makeProject(k), nil
+		})
+		require.NoError(t, err)
+	}
+
+	_, _, bytes := translationCacheStats()
+	assert.LessOrEqual(t, bytes, budget, "running byte total stays within budget")
+	assert.False(t, getTranslationCache().Contains("k1"), "oldest entry evicted to stay within budget")
+	assert.False(t, getTranslationCache().Contains("k2"), "second-oldest entry evicted to stay within budget")
+	assert.True(t, getTranslationCache().Contains("k5"), "most-recently-used entry retained")
+}
+
+// TestByteBoundedCacheKeepsSingleOversizedEntry shows an entry larger than the whole budget is kept
+// rather than evicted immediately, so the budget can be exceeded transiently in that degenerate case.
+func TestByteBoundedCacheKeepsSingleOversizedEntry(t *testing.T) {
+	t.Cleanup(resetTranslationCacheForTesting)
+	resetTranslationCacheForTesting()
+
+	SetTranslationCacheBytesLimit(1)
+	_, _, _, err := getOrComputeTranslation("big", true, func() (*Project, error) {
+		return &Project{Identifier: "big", Tasks: []ProjectTask{{Name: "t"}}}, nil
+	})
+	require.NoError(t, err)
+	assert.True(t, getTranslationCache().Contains("big"), "a single entry larger than the budget is kept")
 }
 
 // TestContentTranslationKeySelfInvalidates shows that changed content yields a new key, so a stale

--- a/operations/service_web.go
+++ b/operations/service_web.go
@@ -108,6 +108,7 @@ func startWebService() cli.Command {
 
 			settings := env.Settings()
 			evgmodel.SetTranslateConcurrencyLimit(settings.Scheduler.TranslateProjectConcurrencyLimit)
+			evgmodel.SetTranslationCacheBytesLimit(settings.Scheduler.TranslateProjectCacheBytesLimit)
 			// Remove the span from the senderCtx since the sender caches the ctx.
 			senderCtx := trace.ContextWithSpan(ctx, nil)
 			sender, err := settings.GetSender(senderCtx, env)

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2067,6 +2067,7 @@ type APISchedulerConfig struct {
 	NumDependentsFactor              float64 `json:"num_dependents_factor"`
 	StepbackTaskFactor               int64   `json:"stepback_task_factor"`
 	TranslateProjectConcurrencyLimit int     `json:"translate_project_concurrency_limit"`
+	TranslateProjectCacheBytesLimit  int64   `json:"translate_project_cache_bytes_limit"`
 }
 
 func (a *APISchedulerConfig) BuildFromService(h any) error {
@@ -2091,6 +2092,7 @@ func (a *APISchedulerConfig) BuildFromService(h any) error {
 		a.NumDependentsFactor = v.NumDependentsFactor
 		a.StepbackTaskFactor = v.StepbackTaskFactor
 		a.TranslateProjectConcurrencyLimit = v.TranslateProjectConcurrencyLimit
+		a.TranslateProjectCacheBytesLimit = v.TranslateProjectCacheBytesLimit
 	default:
 		return errors.Errorf("programmatic error: expected host scheduler config but got type %T", h)
 	}
@@ -2118,6 +2120,7 @@ func (a *APISchedulerConfig) ToService() (any, error) {
 		NumDependentsFactor:              a.NumDependentsFactor,
 		StepbackTaskFactor:               a.StepbackTaskFactor,
 		TranslateProjectConcurrencyLimit: a.TranslateProjectConcurrencyLimit,
+		TranslateProjectCacheBytesLimit:  a.TranslateProjectCacheBytesLimit,
 	}, nil
 }
 

--- a/scripts/check-go-vulnerabilities.sh
+++ b/scripts/check-go-vulnerabilities.sh
@@ -26,6 +26,7 @@ IGNORED_PACKAGES=(
     "golang.org/x/crypto"               # DEVPROD-33754 Go crypto package vulnerability tracking
     "golang.org/x/sys"                  # DEVPROD-33756 Go sys package vulnerability tracking
     "github.com/go-jose/go-jose/v4"     # DEVPROD-33891 go-jose vulnerability tracking
+    "github.com/slack-go/slack"         # DEVPROD-25290 slack-go vulnerability tracking (fix requires Go 1.25)
 )
 
 # Validate that each ignored package has a tracking ticket


### PR DESCRIPTION
DEVPROD-36871

### Description

After turning on caching we ran into issues where memory was spiking on kanopy because the cache was too large. The cache was bounded by entry count (512), this switches it to be bound by bytes that we can configure via admin settings. 

On insert, the cache evicts least-recently-used entries until the running byte total is within budget. Eviction is recency-only so there is no size bias and no size-gated admission — so a large but actively used config stays resident while the coldest entries (large or small) are dropped first.

There will be a corresponding Spruce PR to add the admin-settings UI field.

### Testing

<!--add a description of how you tested it-->
Added 
