### PR TITLE
DEVPROD-36848: Limit inactive task history

### DIFF
--- a/model/task_history.go
+++ b/model/task_history.go
@@ -16,6 +16,8 @@ import (
 
 const (
 	maxTaskHistoryLimit = 50
+	maxInactiveTaskHistoryLimit = 300
+	taskHistoryQueryMaxTime = 30 * time.Second
 )
 
 // FindTaskHistoryOptions defines options that can be passed to queries for task history.
@@ -67,7 +69,7 @@ func findActiveTasksForHistory(ctx context.Context, opts FindTaskHistoryOptions)
 		queryLimit = utility.FromIntPtr(opts.Limit)
 	}
 
-	q := db.Query(filter).Sort(querySort).Limit(queryLimit)
+	q := db.Query(filter).Sort(querySort).Limit(queryLimit).Hint(TaskHistoryIndex).MaxTime(taskHistoryQueryMaxTime)
 	tasks, err := task.FindAll(ctx, q)
 
 	// We want the result to be sorted in descending order numbers. If it's currently sorted in ascending order,
@@ -94,7 +96,7 @@ func findInactiveTasksForHistory(ctx context.Context, opts FindTaskHistoryOption
 	}
 	filter[task.RevisionOrderNumberKey] = revisionFilter
 
-	q := db.Query(filter).Sort([]string{"-" + task.RevisionOrderNumberKey})
+	q := db.Query(filter).Sort([]string{"-" + task.RevisionOrderNumberKey}).Limit(maxInactiveTaskHistoryLimit).Hint(TaskHistoryIndex).MaxTime(taskHistoryQueryMaxTime)
 	tasks, err := task.FindAll(ctx, q)
 	return tasks, err
 }
@@ -304,7 +306,7 @@ func findActiveTasksForHistoryByCreateTime(ctx context.Context, opts FindTaskHis
 		queryLimit = utility.FromIntPtr(opts.Limit)
 	}
 
-	q := db.Query(filter).Sort(querySort).Limit(queryLimit)
+	q := db.Query(filter).Sort(querySort).Limit(queryLimit).MaxTime(taskHistoryQueryMaxTime)
 	tasks, err := task.FindAll(ctx, q)
 
 	// We want the result sorted in descending create_time. If it's currently sorted ascending, reverse it.
@@ -342,7 +344,7 @@ func findInactiveTasksForHistoryByCreateTime(ctx context.Context, opts FindTaskH
 	}
 	filter[task.CreateTimeKey] = createTimeFilter
 
-	q := db.Query(filter).Sort([]string{"-" + task.CreateTimeKey})
+	q := db.Query(filter).Sort([]string{"-" + task.CreateTimeKey}).Limit(maxInactiveTaskHistoryLimit).MaxTime(taskHistoryQueryMaxTime)
 	tasks, err := task.FindAll(ctx, q)
 	return tasks, err
 }

--- a/model/task_history_test.go
+++ b/model/task_history_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -87,6 +88,7 @@ func TestFindActiveTasksForHistory(t *testing.T) {
 	} {
 		t.Run(tName, func(t *testing.T) {
 			assert.NoError(t, db.ClearCollections(task.Collection))
+			assert.NoError(t, db.EnsureIndex(task.Collection, mongo.IndexModel{Keys: TaskHistoryIndex}))
 
 			t1 := task.Task{
 				Id:                  "t_1",
@@ -191,6 +193,7 @@ func TestFindInactiveTasksForHistory(t *testing.T) {
 	} {
 		t.Run(tName, func(t *testing.T) {
 			assert.NoError(t, db.ClearCollections(task.Collection))
+			assert.NoError(t, db.EnsureIndex(task.Collection, mongo.IndexModel{Keys: TaskHistoryIndex}))
 			t1 := task.Task{
 				Id:                  "t_1",
 				Requester:           evergreen.GithubPRRequester,
@@ -249,6 +252,47 @@ func TestFindInactiveTasksForHistory(t *testing.T) {
 			tCase(t, t.Context())
 		})
 	}
+}
+
+func TestFindInactiveTasksForHistoryCapsResults(t *testing.T) {
+	defer func() {
+		assert.NoError(t, db.ClearCollections(task.Collection))
+	}()
+	assert.NoError(t, db.ClearCollections(task.Collection))
+	assert.NoError(t, db.EnsureIndex(task.Collection, mongo.IndexModel{Keys: TaskHistoryIndex}))
+
+	projectId := "evergreen"
+	taskName := "test-graphql"
+	buildVariant := "ubuntu2204"
+
+	// Insert more inactive tasks than the cap so we can assert the query bounds the result set instead
+	// of streaming every inactive doc in the range (the cause of the History-tab timeouts).
+	total := maxInactiveTaskHistoryLimit + 5
+	for i := 0; i < total; i++ {
+		tsk := task.Task{
+			Id:                  fmt.Sprintf("t_%d", i),
+			Requester:           evergreen.RepotrackerVersionRequester,
+			RevisionOrderNumber: i + 1,
+			Activated:           false,
+			Project:             projectId,
+			DisplayName:         taskName,
+			BuildVariant:        buildVariant,
+		}
+		require.NoError(t, tsk.Insert(t.Context()))
+	}
+
+	tasks, err := findInactiveTasksForHistory(t.Context(), FindTaskHistoryOptions{
+		TaskName:     taskName,
+		BuildVariant: buildVariant,
+		ProjectId:    projectId,
+		LowerBound:   utility.ToIntPtr(1),
+		UpperBound:   utility.ToIntPtr(total),
+	})
+	require.NoError(t, err)
+	// The result is capped and returns the most recent (highest order) inactive tasks, sorted descending.
+	require.Len(t, tasks, maxInactiveTaskHistoryLimit)
+	assert.Equal(t, total, tasks[0].RevisionOrderNumber)
+	assert.Equal(t, total-maxInactiveTaskHistoryLimit+1, tasks[len(tasks)-1].RevisionOrderNumber)
 }
 
 func TestFindTasksForHistory(t *testing.T) {
@@ -324,6 +368,7 @@ func TestFindTasksForHistory(t *testing.T) {
 	} {
 		t.Run(tName, func(t *testing.T) {
 			assert.NoError(t, db.ClearCollections(task.Collection))
+			assert.NoError(t, db.EnsureIndex(task.Collection, mongo.IndexModel{Keys: TaskHistoryIndex}))
 			t1 := task.Task{
 				Id:                  "t_1",
 				Requester:           evergreen.GithubPRRequester,


### PR DESCRIPTION
DEVPROD-XXXX

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->

### Testing

<!--add a description of how you tested it-->

### Documentation

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
