### PR TITLE
DEVPROD-36848: Filter before svc.Get 

### DIFF
--- a/model/task/local_test_result_service.go
+++ b/model/task/local_test_result_service.go
@@ -97,9 +97,13 @@ func (s *localTestResultsService) Get(ctx context.Context, taskOpts []Task, getO
 	}
 
 	allTaskResults := make([]testresult.TaskTestResults, len(allDBTaskResults))
+	bounds := newTestResultBounds(getOpts)
 	for i, dbTaskResults := range allDBTaskResults {
+		skip, limit, include := bounds.forTask(dbTaskResults.Stats.TotalCount)
 		allTaskResults[i].Stats = dbTaskResults.Stats
-		allTaskResults[i].Results = dbTaskResults.Results
+		if include {
+			allTaskResults[i].Results = sliceTestResults(dbTaskResults.Results, skip, limit)
+		}
 		allTaskResults[i].QuarantinedTestsCount = dbTaskResults.QuarantinedTestsCount
 		allTaskResults[i].QuarantinedTests = dbTaskResults.QuarantinedTests
 	}

--- a/model/task/local_test_result_service_test.go
+++ b/model/task/local_test_result_service_test.go
@@ -118,6 +118,29 @@ func TestLocalService(t *testing.T) {
 				require.Equal(t, savedResults0[2*i], result)
 			}
 		})
+		t.Run("WithPaginationOpts", func(t *testing.T) {
+			taskOpts := []Task{task0}
+			filterOpts := &FilterOptions{Limit: 3, Page: 1}
+			taskResults, err := getMergedTaskTestResults(ctx, env, taskOpts, filterOpts)
+			require.NoError(t, err)
+
+			assert.Equal(t, len(savedResults0), taskResults.Stats.TotalCount)
+			assert.Equal(t, len(savedResults0), utility.FromIntPtr(taskResults.Stats.FilteredCount))
+			assert.Equal(t, savedResults0[3:6], taskResults.Results)
+		})
+	})
+	t.Run("GetAppliesResultBoundsAcrossTasks", func(t *testing.T) {
+		taskResults, err := svc.Get(ctx, []Task{task0, task1}, GetTaskTestResultsOptions{
+			Skip:  len(savedResults0) - 2,
+			Limit: 5,
+		})
+		require.NoError(t, err)
+		require.Len(t, taskResults, 2)
+
+		assert.Equal(t, len(savedResults0), taskResults[0].Stats.TotalCount)
+		assert.Equal(t, savedResults0[len(savedResults0)-2:], taskResults[0].Results)
+		assert.Equal(t, len(savedResults1), taskResults[1].Stats.TotalCount)
+		assert.Equal(t, savedResults1[:3], taskResults[1].Results)
 	})
 	t.Run("GetTaskTestResultsStats", func(t *testing.T) {
 		taskOpts := []Task{task1, task2, task0, emptyTask}

--- a/model/task/service_interface.go
+++ b/model/task/service_interface.go
@@ -18,6 +18,11 @@ type TestResultsService interface {
 type GetTaskTestResultsOptions struct {
 	// Fields limits the returned test result metadata to the specified fields.
 	Fields []string
+	// Limit limits the number of test result rows returned after Skip. A
+	// non-positive value returns all remaining rows.
+	Limit int
+	// Skip omits this many test result rows before returning results.
+	Skip int
 	// IncludeQuarantinedTests includes quarantined test snapshots. The snapshots
 	// are omitted by default because they can be large.
 	IncludeQuarantinedTests bool
@@ -35,4 +40,54 @@ type FilterOptions struct {
 	BaseTasks           []Task
 
 	IncludeQuarantinedTests bool
+}
+
+type testResultBounds struct {
+	skip      int
+	limit     int
+	hasLimit  bool
+	hasBounds bool
+}
+
+func newTestResultBounds(opts GetTaskTestResultsOptions) testResultBounds {
+	return testResultBounds{
+		skip:      opts.Skip,
+		limit:     opts.Limit,
+		hasLimit:  opts.Limit > 0,
+		hasBounds: opts.Skip > 0 || opts.Limit > 0,
+	}
+}
+
+func (b *testResultBounds) forTask(totalCount int) (int, int, bool) {
+	if !b.hasBounds {
+		return 0, 0, true
+	}
+	if b.skip >= totalCount {
+		b.skip -= totalCount
+		return 0, 0, false
+	}
+
+	skip := b.skip
+	b.skip = 0
+	if !b.hasLimit {
+		return skip, 0, true
+	}
+	if b.limit <= 0 {
+		return 0, 0, false
+	}
+
+	limit := min(b.limit, totalCount-skip)
+	b.limit -= limit
+	return skip, limit, true
+}
+
+func sliceTestResults(results []testresult.TestResult, skip, limit int) []testresult.TestResult {
+	if skip >= len(results) {
+		return nil
+	}
+	results = results[skip:]
+	if limit > 0 && limit < len(results) {
+		results = results[:limit]
+	}
+	return results
 }

--- a/model/task/test_result.go
+++ b/model/task/test_result.go
@@ -64,9 +64,9 @@ func getMergedTaskTestResults(ctx context.Context, env evergreen.Environment, ta
 		return testresult.TaskTestResults{}, errors.Wrap(err, "getting test results service")
 	}
 
-	svcOpts := GetTaskTestResultsOptions{}
-	if getOpts != nil {
-		svcOpts.IncludeQuarantinedTests = getOpts.IncludeQuarantinedTests
+	svcOpts, isServicePaginated, err := getTaskTestResultsServiceOptions(getOpts)
+	if err != nil {
+		return testresult.TaskTestResults{}, err
 	}
 	allTestResults, err := svc.Get(ctx, tasks, svcOpts)
 	if err != nil {
@@ -82,6 +82,11 @@ func getMergedTaskTestResults(ctx context.Context, env evergreen.Environment, ta
 		mergedTaskResults.QuarantinedTests = append(mergedTaskResults.QuarantinedTests, taskResults.QuarantinedTests...)
 	}
 
+	if isServicePaginated {
+		mergedTaskResults.Stats.FilteredCount = utility.ToIntPtr(mergedTaskResults.Stats.TotalCount)
+		return mergedTaskResults, nil
+	}
+
 	filteredResults, filteredCount, err := filterAndSortTestResults(ctx, env, mergedTaskResults.Results, getOpts)
 	if err != nil {
 		return testresult.TaskTestResults{}, err
@@ -90,6 +95,33 @@ func getMergedTaskTestResults(ctx context.Context, env evergreen.Environment, ta
 	mergedTaskResults.Stats.FilteredCount = &filteredCount
 
 	return mergedTaskResults, nil
+}
+
+func getTaskTestResultsServiceOptions(getOpts *FilterOptions) (GetTaskTestResultsOptions, bool, error) {
+	svcOpts := GetTaskTestResultsOptions{}
+	if getOpts == nil {
+		return svcOpts, false, nil
+	}
+	if err := validateFilterOptions(getOpts); err != nil {
+		return svcOpts, false, errors.Wrap(err, "invalid filter options")
+	}
+
+	svcOpts.IncludeQuarantinedTests = getOpts.IncludeQuarantinedTests
+	if canPaginateTestResultsInService(getOpts) {
+		svcOpts.Limit = getOpts.Limit
+		svcOpts.Skip = getOpts.Limit * getOpts.Page
+		return svcOpts, true, nil
+	}
+	return svcOpts, false, nil
+}
+
+func canPaginateTestResultsInService(getOpts *FilterOptions) bool {
+	return getOpts.Limit > 0 &&
+		getOpts.TestName == "" &&
+		len(getOpts.Statuses) == 0 &&
+		getOpts.GroupID == "" &&
+		len(getOpts.Sort) == 0 &&
+		len(getOpts.BaseTasks) == 0
 }
 
 // getTaskTestResultsStats returns test results belonging to the specified task run.

--- a/model/task/test_result_service.go
+++ b/model/task/test_result_service.go
@@ -96,9 +96,17 @@ func (s *testResultService) Get(ctx context.Context, taskOpts []Task, getOpts Ge
 	// in which case we only need to retrieve stats metadata from the cedar DB and do not need
 	// to download anything from s3.
 	if len(getOpts.Fields) == 0 {
-		toDownload := make(chan *testresult.DbTaskTestResults, len(allDBTaskResults))
+		bounds := newTestResultBounds(getOpts)
+		toDownload := make(chan testResultsDownload, len(allDBTaskResults))
 		for i := range allDBTaskResults {
-			toDownload <- &allDBTaskResults[i]
+			skip, limit, include := bounds.forTask(allDBTaskResults[i].Stats.TotalCount)
+			if include {
+				toDownload <- testResultsDownload{
+					dbTaskResults: &allDBTaskResults[i],
+					skip:          skip,
+					limit:         limit,
+				}
+			}
 		}
 		close(toDownload)
 
@@ -128,19 +136,25 @@ func (s *testResultService) Get(ctx context.Context, taskOpts []Task, getOpts Ge
 	return allTaskResults, nil
 }
 
-func workerDownload(ctx context.Context, toDownload <-chan *testresult.DbTaskTestResults, config *evergreen.Settings, catcher grip.Catcher, wg *sync.WaitGroup) {
+type testResultsDownload struct {
+	dbTaskResults *testresult.DbTaskTestResults
+	skip          int
+	limit         int
+}
+
+func workerDownload(ctx context.Context, toDownload <-chan testResultsDownload, config *evergreen.Settings, catcher grip.Catcher, wg *sync.WaitGroup) {
 	defer func() {
 		catcher.Add(recovery.HandlePanicWithError(recover(), nil, "test results download producer"))
 		wg.Done()
 	}()
 
 	for trs := range toDownload {
-		results, err := download(ctx, config, trs)
+		results, err := download(ctx, config, trs.dbTaskResults)
 		if err != nil {
 			catcher.Add(err)
 			return
 		}
-		trs.Results = results
+		trs.dbTaskResults.Results = sliceTestResults(results, trs.skip, trs.limit)
 
 		if err = ctx.Err(); err != nil {
 			catcher.Add(err)

--- a/model/task/test_result_service_test.go
+++ b/model/task/test_result_service_test.go
@@ -89,6 +89,29 @@ func TestEvergreenService(t *testing.T) {
 				require.Equal(t, savedResults0[2*i], result)
 			}
 		})
+		t.Run("WithPaginationOpts", func(t *testing.T) {
+			taskOpts := []Task{task0}
+			filterOpts := &FilterOptions{Limit: 3, Page: 1}
+			taskResults, err := getMergedTaskTestResults(ctx, env, taskOpts, filterOpts)
+			require.NoError(t, err)
+
+			assert.Equal(t, len(savedResults0), taskResults.Stats.TotalCount)
+			assert.Equal(t, len(savedResults0), utility.FromIntPtr(taskResults.Stats.FilteredCount))
+			assert.Equal(t, savedResults0[3:6], taskResults.Results)
+		})
+	})
+	t.Run("GetAppliesResultBoundsAcrossTasks", func(t *testing.T) {
+		taskResults, err := svc.Get(ctx, []Task{task0, task1}, GetTaskTestResultsOptions{
+			Skip:  len(savedResults0) - 2,
+			Limit: 5,
+		})
+		require.NoError(t, err)
+		require.Len(t, taskResults, 2)
+
+		assert.Equal(t, len(savedResults0), taskResults[0].Stats.TotalCount)
+		assert.Equal(t, savedResults0[len(savedResults0)-2:], taskResults[0].Results)
+		assert.Equal(t, len(savedResults1), taskResults[1].Stats.TotalCount)
+		assert.Equal(t, savedResults1[:3], taskResults[1].Results)
 	})
 	t.Run("GetTaskTestResultsStats", func(t *testing.T) {
 		taskOpts := []Task{task1, task2, task0, emptyTask}


### PR DESCRIPTION
DEVPROD-36848

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Compute pagination options up front in getMergedTaskTestResults. So when it's paginated we skip filterAndSortTestResults.

<!--add description, context, thought process, etc-->

### Testing

<!--add a description of how you tested it-->

### Documentation

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
