### PR TITLE
DEVPROD-36931 Add tasks created per day logs

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1592,6 +1592,13 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 	if err = allTasks.InsertUnordered(ctx); err != nil {
 		return nil, nil, errors.Wrap(err, "inserting tasks")
 	}
+	grip.Info(ctx, message.Fields{
+		"message":   "inserted tasks",
+		"num_tasks": len(allTasks),
+		"version":   creationInfo.Version.Id,
+		"project":   creationInfo.Version.Identifier,
+		"runner":    "addNewBuilds",
+	})
 	numTasksModified := numEstimatedActivatedGeneratedTasks + len(newActivatedTaskIds)
 	if err = task.UpdateSchedulingLimit(ctx, creationInfo.Version.AuthorID, creationInfo.Version.Requester, numTasksModified, true); err != nil {
 		return nil, nil, errors.Wrapf(err, "fetching user '%s' and updating their scheduling limit", creationInfo.Version.AuthorID)
@@ -1794,6 +1801,13 @@ func addNewTasksToExistingBuilds(ctx context.Context, creationInfo TaskCreationI
 	if err = allTasks.InsertUnordered(ctx); err != nil {
 		return nil, nil, errors.Wrap(err, "inserting tasks")
 	}
+	grip.Info(ctx, message.Fields{
+		"message":   "inserted tasks",
+		"num_tasks": len(allTasks),
+		"version":   creationInfo.Version.Id,
+		"project":   creationInfo.Version.Identifier,
+		"runner":    "addNewTasksToExistingBuilds",
+	})
 
 	if err = RefreshTasksCache(ctx, buildIdsToRefresh); err != nil {
 		return nil, nil, errors.Wrap(err, "refreshing task caches for updated builds")

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -853,6 +853,7 @@ func FinalizePatch(ctx context.Context, p *patch.Patch, requester string) (*Vers
 		"version":   patchVersion.Id,
 		"project":   patchVersion.Identifier,
 		"requester": requester,
+		"num_tasks": len(tasksToInsert),
 	})
 
 	// Update aggregate costs after transaction commits. We use a goroutine with

--- a/repotracker/repotracker.go
+++ b/repotracker/repotracker.go
@@ -1150,6 +1150,7 @@ func createVersionItems(ctx context.Context, v *model.Version, metadata model.Ve
 			"project":   v.Identifier,
 			"requester": v.Requester,
 			"runner":    RunnerName,
+			"num_tasks": len(tasksToCreate),
 		})
 		return nil
 	}


### PR DESCRIPTION
DEVPROD-36931

### Description

These additional logs will allow us to track how many tasks are created per day in Splunk. Added a line tracking how many tasks are created at version creation, and how many are added when generate.tasks / patch reconfiguration runs which should cover all cases when tasks are created.
### Testing

Existing tests.