### PR TITLE
DEVPROD-36929: Removing TSS as a hard dep on loading Spruce and using connection pooling

### DIFF
--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -22,6 +22,9 @@ import (
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
 
 // Total is the field resolver for Cost.total.
@@ -808,18 +811,46 @@ func (r *taskResolver) Tests(ctx context.Context, obj *restModel.APITask, opts *
 		return nil, err
 	}
 
-	taskResults, err := dbTask.GetTestResults(ctx, evergreen.GetEnvironment(), filterOpts)
+	tracer := otel.Tracer("github.com/evergreen-ci/evergreen/graphql")
+	getTestResultsCtx, getTestResultsSpan := tracer.Start(ctx, "task_tests.get_test_results")
+	getTestResultsSpan.SetAttributes(
+		attribute.String("task_id", dbTask.Id),
+		attribute.Int("execution", dbTask.Execution),
+		attribute.Bool("display_only", dbTask.DisplayOnly),
+		attribute.Bool("test_selection_enabled", dbTask.TestSelectionEnabled),
+	)
+	taskResults, err := dbTask.GetTestResults(getTestResultsCtx, evergreen.GetEnvironment(), filterOpts)
 	if err != nil {
+		getTestResultsSpan.RecordError(err)
+		getTestResultsSpan.SetStatus(codes.Error, err.Error())
+		getTestResultsSpan.End()
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting test results for APITask '%s': %s", dbTask.Id, err.Error()))
 	}
+	getTestResultsSpan.SetAttributes(
+		attribute.Int("test_results.count", len(taskResults.Results)),
+		attribute.Int("test_results.total_count", taskResults.Stats.TotalCount),
+		attribute.Int("test_results.filtered_count", utility.FromIntPtr(taskResults.Stats.FilteredCount)),
+	)
+	getTestResultsSpan.End()
 
 	if shouldDecorateTestQuarantineStatus(ctx) {
-		if err := data.DecorateQuarantineStatus(ctx, dbTask, taskResults.Results); err != nil {
+		decorateCtx, decorateSpan := tracer.Start(ctx, "task_tests.decorate_quarantine_status")
+		decorateSpan.SetAttributes(
+			attribute.String("task_id", dbTask.Id),
+			attribute.Int("execution", dbTask.Execution),
+			attribute.Bool("display_only", dbTask.DisplayOnly),
+			attribute.Bool("test_selection_enabled", dbTask.TestSelectionEnabled),
+			attribute.Int("test_results.count", len(taskResults.Results)),
+		)
+		if err := data.DecorateQuarantineStatus(decorateCtx, dbTask, taskResults.Results); err != nil {
+			decorateSpan.RecordError(err)
+			decorateSpan.SetStatus(codes.Error, err.Error())
 			grip.Error(ctx, message.WrapError(err, message.Fields{
 				"message": "decorating test quarantine statuses",
 				"task_id": dbTask.Id,
 			}))
 		}
+		decorateSpan.End()
 	}
 
 	apiResults := make([]*restModel.APITest, len(taskResults.Results))

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -878,7 +878,7 @@ func (r *taskResolver) Tests(ctx context.Context, obj *restModel.APITask, opts *
 	}, nil
 }
 
-// Filter out the quarantine status for test results that are not manually quarantined.
+// Filter out the quarantine status for test results that are not selecting for manually quarantined tests for TSS optimization.
 func shouldDecorateTestQuarantineStatus(ctx context.Context) bool {
 	if !gqlgen.HasOperationContext(ctx) {
 		return true

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	gqlgen "github.com/99designs/gqlgen/graphql"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/graphql/loaders"
@@ -876,31 +875,6 @@ func (r *taskResolver) Tests(ctx context.Context, obj *restModel.APITask, opts *
 		TotalTestCount:    taskResults.Stats.TotalCount,
 		FilteredTestCount: utility.FromIntPtr(taskResults.Stats.FilteredCount),
 	}, nil
-}
-
-func shouldDecorateTestQuarantineStatus(ctx context.Context) bool {
-	if !gqlgen.HasOperationContext(ctx) {
-		return true
-	}
-	return collectedFieldPathContains(gqlgen.GetOperationContext(ctx), gqlgen.CollectFieldsCtx(ctx, nil), []string{"testResults", "isManuallyQuarantined"})
-}
-
-func collectedFieldPathContains(opCtx *gqlgen.OperationContext, fields []gqlgen.CollectedField, path []string) bool {
-	if len(path) == 0 {
-		return true
-	}
-	for _, field := range fields {
-		if field.Name != path[0] {
-			continue
-		}
-		if len(path) == 1 {
-			return true
-		}
-		if collectedFieldPathContains(opCtx, gqlgen.CollectFields(opCtx, field.Selections, nil), path[1:]) {
-			return true
-		}
-	}
-	return false
 }
 
 // TotalTestCount is the resolver for the totalTestCount field.

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -847,11 +847,26 @@ func (r *taskResolver) Tests(ctx context.Context, obj *restModel.APITask, opts *
 	}, nil
 }
 
+// Filter out the quarantine status for test results that are not manually quarantined.
 func shouldDecorateTestQuarantineStatus(ctx context.Context) bool {
 	if !gqlgen.HasOperationContext(ctx) {
 		return true
 	}
-	return utility.StringSliceContains(gqlgen.CollectAllFields(ctx), "isManuallyQuarantined")
+	return collectedFieldsContain(gqlgen.GetOperationContext(ctx), gqlgen.CollectFieldsCtx(ctx, nil), "isManuallyQuarantined")
+}
+
+// collectedFieldsContain reports whether target is selected anywhere within the given fields or
+// their descendants.
+func collectedFieldsContain(opCtx *gqlgen.OperationContext, fields []gqlgen.CollectedField, target string) bool {
+	for _, field := range fields {
+		if field.Name == target {
+			return true
+		}
+		if collectedFieldsContain(opCtx, gqlgen.CollectFields(opCtx, field.Selections, nil), target) {
+			return true
+		}
+	}
+	return false
 }
 
 // TotalTestCount is the resolver for the totalTestCount field.

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -833,7 +833,7 @@ func (r *taskResolver) Tests(ctx context.Context, obj *restModel.APITask, opts *
 	)
 	getTestResultsSpan.End()
 
-	if !gqlgen.HasOperationContext(ctx) || gqlgen.FieldRequested(ctx, "testResults.isManuallyQuarantined") {
+	if shouldDecorateTestQuarantineStatus(ctx) {
 		decorateCtx, decorateSpan := tracer.Start(ctx, "task_tests.decorate_quarantine_status")
 		decorateSpan.SetAttributes(
 			attribute.String("task_id", dbTask.Id),
@@ -876,6 +876,31 @@ func (r *taskResolver) Tests(ctx context.Context, obj *restModel.APITask, opts *
 		TotalTestCount:    taskResults.Stats.TotalCount,
 		FilteredTestCount: utility.FromIntPtr(taskResults.Stats.FilteredCount),
 	}, nil
+}
+
+func shouldDecorateTestQuarantineStatus(ctx context.Context) bool {
+	if !gqlgen.HasOperationContext(ctx) {
+		return true
+	}
+	return collectedFieldPathContains(gqlgen.GetOperationContext(ctx), gqlgen.CollectFieldsCtx(ctx, nil), []string{"testResults", "isManuallyQuarantined"})
+}
+
+func collectedFieldPathContains(opCtx *gqlgen.OperationContext, fields []gqlgen.CollectedField, path []string) bool {
+	if len(path) == 0 {
+		return true
+	}
+	for _, field := range fields {
+		if field.Name != path[0] {
+			continue
+		}
+		if len(path) == 1 {
+			return true
+		}
+		if collectedFieldPathContains(opCtx, gqlgen.CollectFields(opCtx, field.Selections, nil), path[1:]) {
+			return true
+		}
+	}
+	return false
 }
 
 // TotalTestCount is the resolver for the totalTestCount field.

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	gqlgen "github.com/99designs/gqlgen/graphql"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/graphql/loaders"
@@ -812,11 +813,13 @@ func (r *taskResolver) Tests(ctx context.Context, obj *restModel.APITask, opts *
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting test results for APITask '%s': %s", dbTask.Id, err.Error()))
 	}
 
-	if err := data.DecorateQuarantineStatus(ctx, dbTask, taskResults.Results); err != nil {
-		grip.Error(ctx, message.WrapError(err, message.Fields{
-			"message": "decorating test quarantine statuses",
-			"task_id": dbTask.Id,
-		}))
+	if shouldDecorateTestQuarantineStatus(ctx) {
+		if err := data.DecorateQuarantineStatus(ctx, dbTask, taskResults.Results); err != nil {
+			grip.Error(ctx, message.WrapError(err, message.Fields{
+				"message": "decorating test quarantine statuses",
+				"task_id": dbTask.Id,
+			}))
+		}
 	}
 
 	apiResults := make([]*restModel.APITest, len(taskResults.Results))
@@ -842,6 +845,13 @@ func (r *taskResolver) Tests(ctx context.Context, obj *restModel.APITask, opts *
 		TotalTestCount:    taskResults.Stats.TotalCount,
 		FilteredTestCount: utility.FromIntPtr(taskResults.Stats.FilteredCount),
 	}, nil
+}
+
+func shouldDecorateTestQuarantineStatus(ctx context.Context) bool {
+	if !gqlgen.HasOperationContext(ctx) {
+		return true
+	}
+	return utility.StringSliceContains(gqlgen.CollectAllFields(ctx), "isManuallyQuarantined")
 }
 
 // TotalTestCount is the resolver for the totalTestCount field.

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -833,7 +833,7 @@ func (r *taskResolver) Tests(ctx context.Context, obj *restModel.APITask, opts *
 	)
 	getTestResultsSpan.End()
 
-	if shouldDecorateTestQuarantineStatus(ctx) {
+	if !gqlgen.HasOperationContext(ctx) || gqlgen.FieldRequested(ctx, "testResults.isManuallyQuarantined") {
 		decorateCtx, decorateSpan := tracer.Start(ctx, "task_tests.decorate_quarantine_status")
 		decorateSpan.SetAttributes(
 			attribute.String("task_id", dbTask.Id),
@@ -876,28 +876,6 @@ func (r *taskResolver) Tests(ctx context.Context, obj *restModel.APITask, opts *
 		TotalTestCount:    taskResults.Stats.TotalCount,
 		FilteredTestCount: utility.FromIntPtr(taskResults.Stats.FilteredCount),
 	}, nil
-}
-
-// Filter out the quarantine status for test results that are not selecting for manually quarantined tests for TSS optimization.
-func shouldDecorateTestQuarantineStatus(ctx context.Context) bool {
-	if !gqlgen.HasOperationContext(ctx) {
-		return true
-	}
-	return collectedFieldsContain(gqlgen.GetOperationContext(ctx), gqlgen.CollectFieldsCtx(ctx, nil), "isManuallyQuarantined")
-}
-
-// collectedFieldsContain reports whether target is selected anywhere within the given fields or
-// their descendants.
-func collectedFieldsContain(opCtx *gqlgen.OperationContext, fields []gqlgen.CollectedField, target string) bool {
-	for _, field := range fields {
-		if field.Name == target {
-			return true
-		}
-		if collectedFieldsContain(opCtx, gqlgen.CollectFields(opCtx, field.Selections, nil), target) {
-			return true
-		}
-	}
-	return false
 }
 
 // TotalTestCount is the resolver for the totalTestCount field.

--- a/graphql/task_resolver_helpers.go
+++ b/graphql/task_resolver_helpers.go
@@ -1,0 +1,32 @@
+package graphql
+
+import (
+	"context"
+
+	gqlgen "github.com/99designs/gqlgen/graphql"
+)
+
+func shouldDecorateTestQuarantineStatus(ctx context.Context) bool {
+	if !gqlgen.HasOperationContext(ctx) {
+		return true
+	}
+	return collectedFieldPathContains(gqlgen.GetOperationContext(ctx), gqlgen.CollectFieldsCtx(ctx, nil), []string{"testResults", "isManuallyQuarantined"})
+}
+
+func collectedFieldPathContains(opCtx *gqlgen.OperationContext, fields []gqlgen.CollectedField, path []string) bool {
+	if len(path) == 0 {
+		return true
+	}
+	for _, field := range fields {
+		if field.Name != path[0] {
+			continue
+		}
+		if len(path) == 1 {
+			return true
+		}
+		if collectedFieldPathContains(opCtx, gqlgen.CollectFields(opCtx, field.Selections, nil), path[1:]) {
+			return true
+		}
+	}
+	return false
+}

--- a/graphql/task_resolver_test.go
+++ b/graphql/task_resolver_test.go
@@ -1,0 +1,47 @@
+package graphql
+
+import (
+	"context"
+	"testing"
+
+	gqlgen "github.com/99designs/gqlgen/graphql"
+	"github.com/stretchr/testify/assert"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+func TestShouldDecorateTestQuarantineStatus(t *testing.T) {
+	// The tests field resolves to a TaskTestResult whose immediate children are testResults,
+	// totalTestCount, and filteredTestCount. isManuallyQuarantined is only reachable one level
+	// deeper, nested under testResults.
+	ctxWithTestResultsSelection := func(testResultsSelection ast.SelectionSet) context.Context {
+		ctx := gqlgen.WithOperationContext(context.Background(), &gqlgen.OperationContext{})
+		return gqlgen.WithFieldContext(ctx, &gqlgen.FieldContext{
+			Field: gqlgen.CollectedField{
+				Field: &ast.Field{Name: "tests", Alias: "tests"},
+				Selections: ast.SelectionSet{
+					&ast.Field{Name: "testResults", Alias: "testResults", SelectionSet: testResultsSelection},
+					&ast.Field{Name: "totalTestCount", Alias: "totalTestCount"},
+				},
+			},
+		})
+	}
+
+	t.Run("TrueWhenIsManuallyQuarantinedNestedUnderTestResults", func(t *testing.T) {
+		ctx := ctxWithTestResultsSelection(ast.SelectionSet{
+			&ast.Field{Name: "testFile", Alias: "testFile"},
+			&ast.Field{Name: "isManuallyQuarantined", Alias: "isManuallyQuarantined"},
+		})
+		assert.True(t, shouldDecorateTestQuarantineStatus(ctx))
+	})
+
+	t.Run("FalseWhenIsManuallyQuarantinedNotSelected", func(t *testing.T) {
+		ctx := ctxWithTestResultsSelection(ast.SelectionSet{
+			&ast.Field{Name: "testFile", Alias: "testFile"},
+		})
+		assert.False(t, shouldDecorateTestQuarantineStatus(ctx))
+	})
+
+	t.Run("TrueWithoutOperationContext", func(t *testing.T) {
+		assert.True(t, shouldDecorateTestQuarantineStatus(context.Background()))
+	})
+}

--- a/rest/data/select.go
+++ b/rest/data/select.go
@@ -18,6 +18,9 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -110,6 +113,18 @@ func newTestSelectionClient(c *http.Client) *testselection.APIClient {
 // to run based on the provided SelectTestsRequest. It returns the list of
 // selected tests.
 func SelectTests(ctx context.Context, req model.SelectTestsRequest) ([]string, error) {
+	ctx, span := otel.Tracer("github.com/evergreen-ci/evergreen/rest/data").Start(ctx, "test_selection.select_tests")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("project_id", req.Project),
+		attribute.String("requester", req.Requester),
+		attribute.String("build_variant", req.BuildVariant),
+		attribute.String("task_id", req.TaskID),
+		attribute.String("task_name", req.TaskName),
+		attribute.Int("input_test_count", len(req.Tests)),
+		attribute.Int("strategy_count", len(req.Strategies)),
+	)
+
 	c := newTestSelectionClient(testSelectionHTTPClient)
 	var strategies []testselection.StrategyEnum
 	for _, s := range req.Strategies {
@@ -148,6 +163,8 @@ func SelectTests(ctx context.Context, req model.SelectTestsRequest) ([]string, e
 			"task_name":     req.TaskName,
 			"test_count":    len(req.Tests),
 		})
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return nil, wrapTSSError(err)
 	}
 	selectedTests := make([]string, 0, len(selectedTestPtrs))
@@ -156,6 +173,7 @@ func SelectTests(ctx context.Context, req model.SelectTestsRequest) ([]string, e
 			selectedTests = append(selectedTests, *t)
 		}
 	}
+	span.SetAttributes(attribute.Int("selected_test_count", len(selectedTests)))
 	return selectedTests, nil
 }
 

--- a/rest/data/select.go
+++ b/rest/data/select.go
@@ -38,6 +38,7 @@ const (
 	testSelectionDisplayTaskStatusRequestParallel = 8
 )
 
+// Using a shared HTTP client so we can reuse idle connections between TSS calls and reduce the number of reconnects.
 var testSelectionHTTPClient = newTestSelectionHTTPClient()
 
 func newTestSelectionHTTPClient() *http.Client {
@@ -109,8 +110,6 @@ func newTestSelectionClient(c *http.Client) *testselection.APIClient {
 // to run based on the provided SelectTestsRequest. It returns the list of
 // selected tests.
 func SelectTests(ctx context.Context, req model.SelectTestsRequest) ([]string, error) {
-	ctx, cancel := context.WithTimeout(ctx, testSelectionWriteTimeout)
-	defer cancel()
 	c := newTestSelectionClient(testSelectionHTTPClient)
 	var strategies []testselection.StrategyEnum
 	for _, s := range req.Strategies {
@@ -415,7 +414,6 @@ func decorateDisplayTaskQuarantineStatus(ctx context.Context, displayTaskID stri
 		if !execTask.TestSelectionEnabled {
 			continue
 		}
-		execTask := execTask
 		indices := slices.Clone(resultIndicesByExecTaskID[execTask.Id])
 		eg.Go(func() error {
 			testNames := make([]string, 0, len(indices))

--- a/rest/data/select.go
+++ b/rest/data/select.go
@@ -35,7 +35,7 @@ const (
 	testSelectionWriteTimeout                     = 10 * time.Second
 	testSelectionStatusTimeout                    = 4 * time.Second
 	testSelectionDecorationTimeout                = 5 * time.Second
-	testSelectionDisplayTaskStatusRequestParallel = 8
+	testSelectionDisplayTaskStatusRequestParallel = 15
 )
 
 // Using a shared HTTP client so we can reuse idle connections between TSS calls and reduce the number of reconnects.

--- a/rest/data/select.go
+++ b/rest/data/select.go
@@ -18,9 +18,6 @@ import (
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -113,18 +110,6 @@ func newTestSelectionClient(c *http.Client) *testselection.APIClient {
 // to run based on the provided SelectTestsRequest. It returns the list of
 // selected tests.
 func SelectTests(ctx context.Context, req model.SelectTestsRequest) ([]string, error) {
-	ctx, span := otel.Tracer("github.com/evergreen-ci/evergreen/rest/data").Start(ctx, "test_selection.select_tests")
-	defer span.End()
-	span.SetAttributes(
-		attribute.String("project_id", req.Project),
-		attribute.String("requester", req.Requester),
-		attribute.String("build_variant", req.BuildVariant),
-		attribute.String("task_id", req.TaskID),
-		attribute.String("task_name", req.TaskName),
-		attribute.Int("input_test_count", len(req.Tests)),
-		attribute.Int("strategy_count", len(req.Strategies)),
-	)
-
 	c := newTestSelectionClient(testSelectionHTTPClient)
 	var strategies []testselection.StrategyEnum
 	for _, s := range req.Strategies {
@@ -163,8 +148,6 @@ func SelectTests(ctx context.Context, req model.SelectTestsRequest) ([]string, e
 			"task_name":     req.TaskName,
 			"test_count":    len(req.Tests),
 		})
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
 		return nil, wrapTSSError(err)
 	}
 	selectedTests := make([]string, 0, len(selectedTestPtrs))
@@ -173,7 +156,6 @@ func SelectTests(ctx context.Context, req model.SelectTestsRequest) ([]string, e
 			selectedTests = append(selectedTests, *t)
 		}
 	}
-	span.SetAttributes(attribute.Int("selected_test_count", len(selectedTests)))
 	return selectedTests, nil
 }
 

--- a/rest/data/select.go
+++ b/rest/data/select.go
@@ -2,7 +2,6 @@ package data
 
 import (
 	"context"
-	"net"
 	"net/http"
 	"time"
 
@@ -30,24 +29,17 @@ const (
 
 const (
 	testSelectionWriteTimeout                     = 10 * time.Second
-	testSelectionStatusTimeout                    = 2 * time.Second
+	testSelectionStatusTimeout                    = 4 * time.Second
+	testSelectionDecorationTimeout                = 5 * time.Second
 	testSelectionDisplayTaskStatusRequestParallel = 8
 )
 
 var testSelectionHTTPClient = newTestSelectionHTTPClient()
 
 func newTestSelectionHTTPClient() *http.Client {
-	transport := &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		DialContext: (&net.Dialer{
-			Timeout:   5 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).DialContext,
-		MaxIdleConnsPerHost:   100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   5 * time.Second,
-		ExpectContinueTimeout: time.Second,
-	}
+	// Each request's overall duration is bounded by the caller's context deadline but increase the idle connection pool to reduce the number of reconnects.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConnsPerHost = 100
 
 	return &http.Client{
 		Timeout:   testSelectionWriteTimeout,
@@ -334,11 +326,13 @@ func DecorateQuarantineStatus(ctx context.Context, t *task.Task, results []testr
 	if len(results) == 0 {
 		return nil
 	}
+	if !t.DisplayOnly && !t.TestSelectionEnabled {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, testSelectionDecorationTimeout)
+	defer cancel()
 	if t.DisplayOnly {
 		return decorateDisplayTaskQuarantineStatus(ctx, t.Id, results)
-	}
-	if !t.TestSelectionEnabled {
-		return nil
 	}
 	testNames := make([]string, 0, len(results))
 	for _, r := range results {

--- a/rest/data/select.go
+++ b/rest/data/select.go
@@ -2,7 +2,9 @@ package data
 
 import (
 	"context"
+	"net"
 	"net/http"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -10,10 +12,10 @@ import (
 	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	testselection "github.com/evergreen-ci/test-selection-client"
-	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
 )
 
 // Test selection service endpoint identifiers.
@@ -25,6 +27,33 @@ const (
 	GetTestsStateEndpoint     = "get_tests_state"
 	GetVariantStateEndpoint   = "get_variant_state"
 )
+
+const (
+	testSelectionWriteTimeout                     = 10 * time.Second
+	testSelectionStatusTimeout                    = 2 * time.Second
+	testSelectionDisplayTaskStatusRequestParallel = 8
+)
+
+var testSelectionHTTPClient = newTestSelectionHTTPClient()
+
+func newTestSelectionHTTPClient() *http.Client {
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConnsPerHost:   100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   5 * time.Second,
+		ExpectContinueTimeout: time.Second,
+	}
+
+	return &http.Client{
+		Timeout:   testSelectionWriteTimeout,
+		Transport: transport,
+	}
+}
 
 func logTSSError(ctx context.Context, err error, resp *http.Response, info message.Fields) {
 	// A 404 means the requested resource isn't tracked in the test selection
@@ -75,10 +104,9 @@ func newTestSelectionClient(c *http.Client) *testselection.APIClient {
 // to run based on the provided SelectTestsRequest. It returns the list of
 // selected tests.
 func SelectTests(ctx context.Context, req model.SelectTestsRequest) ([]string, error) {
-	httpClient := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(httpClient)
-
-	c := newTestSelectionClient(httpClient)
+	ctx, cancel := context.WithTimeout(ctx, testSelectionWriteTimeout)
+	defer cancel()
+	c := newTestSelectionClient(testSelectionHTTPClient)
 	var strategies []testselection.StrategyEnum
 	for _, s := range req.Strategies {
 		strategies = append(strategies, testselection.StrategyEnum(s))
@@ -128,9 +156,9 @@ func SelectTests(ctx context.Context, req model.SelectTestsRequest) ([]string, e
 // SetTestQuarantined marks the test as quarantined or unquarantined in the test
 // selection service.
 func SetTestQuarantined(ctx context.Context, projectID, bvName, taskName, testName string, isManuallyQuarantined bool) error {
-	httpClient := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(httpClient)
-	c := newTestSelectionClient(httpClient)
+	ctx, cancel := context.WithTimeout(ctx, testSelectionWriteTimeout)
+	defer cancel()
+	c := newTestSelectionClient(testSelectionHTTPClient)
 
 	_, resp, err := c.StateTransitionAPI.MarkTestsAsManuallyQuarantinedApiTestSelectionTransitionTestsProjectIdBuildVariantNameTaskNamePost(ctx, projectID, bvName, taskName).
 		IsManuallyQuarantined(isManuallyQuarantined).
@@ -163,9 +191,9 @@ func GetTestsQuarantineStatus(ctx context.Context, projectID, bvName, taskName s
 	if len(testNames) == 0 {
 		return testToQuarantineStatus, nil
 	}
-	httpClient := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(httpClient)
-	c := newTestSelectionClient(httpClient)
+	ctx, cancel := context.WithTimeout(ctx, testSelectionStatusTimeout)
+	defer cancel()
+	c := newTestSelectionClient(testSelectionHTTPClient)
 
 	result, resp, err := c.StateTransitionAPI.GetTestsStateApiTestSelectionGetTestsStateProjectIdBuildVariantNameTaskNamePost(ctx, projectID, bvName, taskName).
 		RequestBody(testNames).
@@ -178,16 +206,23 @@ func GetTestsQuarantineStatus(ctx context.Context, projectID, bvName, taskName s
 			return testToQuarantineStatus, nil
 		}
 		logTSSError(ctx, err, resp, message.Fields{
-			"message":       "error getting tests quarantine status",
+			"message":       "error getting tests quarantine status; continuing with default statuses",
 			"endpoint":      GetTestsStateEndpoint,
 			"project_id":    projectID,
 			"build_variant": bvName,
 			"task_name":     taskName,
 		})
-		return nil, wrapTSSError(err)
+		return testToQuarantineStatus, nil
 	}
 	if result == nil {
-		return nil, errors.New("nil response from test selection service")
+		grip.Error(ctx, message.Fields{
+			"message":       "nil response from test selection service; continuing with default statuses",
+			"endpoint":      GetTestsStateEndpoint,
+			"project_id":    projectID,
+			"build_variant": bvName,
+			"task_name":     taskName,
+		})
+		return testToQuarantineStatus, nil
 	}
 
 	for testName, stateInfo := range *result {
@@ -203,9 +238,9 @@ func GetTestsQuarantineStatus(ctx context.Context, projectID, bvName, taskName s
 // SetTaskQuarantined marks all known tests of a task as manually quarantined
 // (or unquarantines them) in the test selection service.
 func SetTaskQuarantined(ctx context.Context, projectID, bvName, taskName string, isManuallyQuarantined bool) error {
-	httpClient := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(httpClient)
-	c := newTestSelectionClient(httpClient)
+	ctx, cancel := context.WithTimeout(ctx, testSelectionWriteTimeout)
+	defer cancel()
+	c := newTestSelectionClient(testSelectionHTTPClient)
 
 	_, resp, err := c.StateTransitionAPI.MarkTaskAsManuallyQuarantinedApiTestSelectionTransitionTaskProjectIdBuildVariantNameTaskNamePost(ctx, projectID, bvName, taskName).
 		IsManuallyQuarantined(isManuallyQuarantined).
@@ -228,9 +263,9 @@ func SetTaskQuarantined(ctx context.Context, projectID, bvName, taskName string,
 // SetVariantQuarantined marks all known tests of a build variant as manually
 // quarantined (or unquarantines them) in the test selection service.
 func SetVariantQuarantined(ctx context.Context, projectID, bvName string, isManuallyQuarantined bool) error {
-	httpClient := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(httpClient)
-	c := newTestSelectionClient(httpClient)
+	ctx, cancel := context.WithTimeout(ctx, testSelectionWriteTimeout)
+	defer cancel()
+	c := newTestSelectionClient(testSelectionHTTPClient)
 
 	_, resp, err := c.StateTransitionAPI.MarkVariantAsManuallyQuarantinedApiTestSelectionTransitionVariantProjectIdBuildVariantNamePost(ctx, projectID, bvName).
 		IsManuallyQuarantined(isManuallyQuarantined).
@@ -254,9 +289,9 @@ func SetVariantQuarantined(ctx context.Context, projectID, bvName string, isManu
 // precedence rule: if override_state is present and non-null, it determines
 // the result; otherwise state is used.
 func GetVariantQuarantineStatus(ctx context.Context, projectID, bvName string) (map[string]map[string]bool, error) {
-	httpClient := utility.GetHTTPClient()
-	defer utility.PutHTTPClient(httpClient)
-	c := newTestSelectionClient(httpClient)
+	ctx, cancel := context.WithTimeout(ctx, testSelectionStatusTimeout)
+	defer cancel()
+	c := newTestSelectionClient(testSelectionHTTPClient)
 
 	result, resp, err := c.StateTransitionAPI.GetVariantStateApiTestSelectionGetVariantStateProjectIdBuildVariantNamePost(ctx, projectID, bvName).Execute()
 	if resp != nil {
@@ -357,25 +392,28 @@ func decorateDisplayTaskQuarantineStatus(ctx context.Context, displayTaskID stri
 		"display_task_id":       displayTaskID,
 		"missing_exec_task_ids": missingExecTaskIDs,
 	})
-	// TODO: issue these GetTestsQuarantineStatus calls concurrently with a
-	// bounded semaphore to reduce latency on display tasks with many execution
-	// tasks.
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.SetLimit(testSelectionDisplayTaskStatusRequestParallel)
 	for _, execTask := range execTasks {
 		if !execTask.TestSelectionEnabled {
 			continue
 		}
-		indices := resultIndicesByExecTaskID[execTask.Id]
-		testNames := make([]string, 0, len(indices))
-		for _, i := range indices {
-			testNames = append(testNames, results[i].GetDisplayTestName())
-		}
-		statuses, err := GetTestsQuarantineStatus(ctx, execTask.Project, execTask.BuildVariant, execTask.DisplayName, testNames)
-		if err != nil {
-			return errors.Wrapf(err, "fetching test quarantine statuses for execution task '%s'", execTask.Id)
-		}
-		for _, i := range indices {
-			results[i].IsManuallyQuarantined = statuses[results[i].GetDisplayTestName()]
-		}
+		execTask := execTask
+		indices := append([]int(nil), resultIndicesByExecTaskID[execTask.Id]...)
+		eg.Go(func() error {
+			testNames := make([]string, 0, len(indices))
+			for _, i := range indices {
+				testNames = append(testNames, results[i].GetDisplayTestName())
+			}
+			statuses, err := GetTestsQuarantineStatus(ctx, execTask.Project, execTask.BuildVariant, execTask.DisplayName, testNames)
+			if err != nil {
+				return errors.Wrapf(err, "fetching test quarantine statuses for execution task '%s'", execTask.Id)
+			}
+			for _, i := range indices {
+				results[i].IsManuallyQuarantined = statuses[results[i].GetDisplayTestName()]
+			}
+			return nil
+		})
 	}
-	return nil
+	return eg.Wait()
 }

--- a/rest/data/select.go
+++ b/rest/data/select.go
@@ -5,6 +5,7 @@ import (
 	stderrors "errors"
 	"net"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -45,7 +46,6 @@ func newTestSelectionHTTPClient() *http.Client {
 	transport.MaxIdleConnsPerHost = 100
 
 	return &http.Client{
-		Timeout:   testSelectionWriteTimeout,
 		Transport: otelhttp.NewTransport(transport),
 	}
 }
@@ -416,7 +416,7 @@ func decorateDisplayTaskQuarantineStatus(ctx context.Context, displayTaskID stri
 			continue
 		}
 		execTask := execTask
-		indices := append([]int(nil), resultIndicesByExecTaskID[execTask.Id]...)
+		indices := slices.Clone(resultIndicesByExecTaskID[execTask.Id])
 		eg.Go(func() error {
 			testNames := make([]string, 0, len(indices))
 			for _, i := range indices {

--- a/rest/data/select.go
+++ b/rest/data/select.go
@@ -2,6 +2,8 @@ package data
 
 import (
 	"context"
+	stderrors "errors"
+	"net"
 	"net/http"
 	"time"
 
@@ -14,6 +16,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -43,11 +46,11 @@ func newTestSelectionHTTPClient() *http.Client {
 
 	return &http.Client{
 		Timeout:   testSelectionWriteTimeout,
-		Transport: transport,
+		Transport: otelhttp.NewTransport(transport),
 	}
 }
 
-func logTSSError(ctx context.Context, err error, resp *http.Response, info message.Fields) {
+func logTSSError(ctx context.Context, err error, resp *http.Response, duration time.Duration, info message.Fields) {
 	// A 404 means the requested resource isn't tracked in the test selection
 	// service yet, which is expected and too noisy for Splunk. The error is
 	// still returned to the caller.
@@ -57,12 +60,22 @@ func logTSSError(ctx context.Context, err error, resp *http.Response, info messa
 	if resp != nil {
 		info["status"] = resp.StatusCode
 	}
+	info["duration_ms"] = duration.Milliseconds()
+	info["timeout"] = isTimeoutError(ctx, err)
 	info["error"] = err.Error()
 	var openAPIErr *testselection.GenericOpenAPIError
 	if errors.As(err, &openAPIErr) {
 		info["response_body"] = string(openAPIErr.Body())
 	}
 	grip.Error(ctx, info)
+}
+
+func isTimeoutError(ctx context.Context, err error) bool {
+	if ctx.Err() == context.DeadlineExceeded || stderrors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 // wrapTSSError wraps test selection service errors with the response body in the message. Callers handle logging and adding context.
@@ -109,6 +122,7 @@ func SelectTests(ctx context.Context, req model.SelectTestsRequest) ([]string, e
 		resp             *http.Response
 		err              error
 	)
+	startAt := time.Now()
 	if len(req.Tests) == 0 {
 		selectedTestPtrs, resp, err = c.TestSelectionAPI.SelectAllKnownTestsOfATaskApiTestSelectionSelectKnownTestsProjectIdRequesterBuildVariantNameTaskIdTaskNamePost(ctx, req.Project, req.Requester, req.BuildVariant, req.TaskID, req.TaskName).StrategyEnum(strategies).Execute()
 	} else {
@@ -125,7 +139,7 @@ func SelectTests(ctx context.Context, req model.SelectTestsRequest) ([]string, e
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		logTSSError(ctx, err, resp, message.Fields{
+		logTSSError(ctx, err, resp, time.Since(startAt), message.Fields{
 			"message":       "error selecting tests",
 			"endpoint":      SelectTestsEndpoint,
 			"project_id":    req.Project,
@@ -133,6 +147,7 @@ func SelectTests(ctx context.Context, req model.SelectTestsRequest) ([]string, e
 			"build_variant": req.BuildVariant,
 			"task_id":       req.TaskID,
 			"task_name":     req.TaskName,
+			"test_count":    len(req.Tests),
 		})
 		return nil, wrapTSSError(err)
 	}
@@ -152,6 +167,7 @@ func SetTestQuarantined(ctx context.Context, projectID, bvName, taskName, testNa
 	defer cancel()
 	c := newTestSelectionClient(testSelectionHTTPClient)
 
+	startAt := time.Now()
 	_, resp, err := c.StateTransitionAPI.MarkTestsAsManuallyQuarantinedApiTestSelectionTransitionTestsProjectIdBuildVariantNameTaskNamePost(ctx, projectID, bvName, taskName).
 		IsManuallyQuarantined(isManuallyQuarantined).
 		RequestBody([]*string{&testName}).
@@ -160,7 +176,7 @@ func SetTestQuarantined(ctx context.Context, projectID, bvName, taskName, testNa
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		logTSSError(ctx, err, resp, message.Fields{
+		logTSSError(ctx, err, resp, time.Since(startAt), message.Fields{
 			"message":       "error setting test quarantine status",
 			"endpoint":      TransitionTestsEndpoint,
 			"project_id":    projectID,
@@ -187,6 +203,7 @@ func GetTestsQuarantineStatus(ctx context.Context, projectID, bvName, taskName s
 	defer cancel()
 	c := newTestSelectionClient(testSelectionHTTPClient)
 
+	startAt := time.Now()
 	result, resp, err := c.StateTransitionAPI.GetTestsStateApiTestSelectionGetTestsStateProjectIdBuildVariantNameTaskNamePost(ctx, projectID, bvName, taskName).
 		RequestBody(testNames).
 		Execute()
@@ -197,12 +214,13 @@ func GetTestsQuarantineStatus(ctx context.Context, projectID, bvName, taskName s
 		if resp != nil && resp.StatusCode == http.StatusNotFound {
 			return testToQuarantineStatus, nil
 		}
-		logTSSError(ctx, err, resp, message.Fields{
+		logTSSError(ctx, err, resp, time.Since(startAt), message.Fields{
 			"message":       "error getting tests quarantine status; continuing with default statuses",
 			"endpoint":      GetTestsStateEndpoint,
 			"project_id":    projectID,
 			"build_variant": bvName,
 			"task_name":     taskName,
+			"test_count":    len(testNames),
 		})
 		return testToQuarantineStatus, nil
 	}
@@ -213,6 +231,8 @@ func GetTestsQuarantineStatus(ctx context.Context, projectID, bvName, taskName s
 			"project_id":    projectID,
 			"build_variant": bvName,
 			"task_name":     taskName,
+			"duration_ms":   time.Since(startAt).Milliseconds(),
+			"test_count":    len(testNames),
 		})
 		return testToQuarantineStatus, nil
 	}
@@ -234,6 +254,7 @@ func SetTaskQuarantined(ctx context.Context, projectID, bvName, taskName string,
 	defer cancel()
 	c := newTestSelectionClient(testSelectionHTTPClient)
 
+	startAt := time.Now()
 	_, resp, err := c.StateTransitionAPI.MarkTaskAsManuallyQuarantinedApiTestSelectionTransitionTaskProjectIdBuildVariantNameTaskNamePost(ctx, projectID, bvName, taskName).
 		IsManuallyQuarantined(isManuallyQuarantined).
 		Execute()
@@ -241,7 +262,7 @@ func SetTaskQuarantined(ctx context.Context, projectID, bvName, taskName string,
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		logTSSError(ctx, err, resp, message.Fields{
+		logTSSError(ctx, err, resp, time.Since(startAt), message.Fields{
 			"message":       "error setting task quarantine status",
 			"endpoint":      TransitionTaskEndpoint,
 			"project_id":    projectID,
@@ -259,6 +280,7 @@ func SetVariantQuarantined(ctx context.Context, projectID, bvName string, isManu
 	defer cancel()
 	c := newTestSelectionClient(testSelectionHTTPClient)
 
+	startAt := time.Now()
 	_, resp, err := c.StateTransitionAPI.MarkVariantAsManuallyQuarantinedApiTestSelectionTransitionVariantProjectIdBuildVariantNamePost(ctx, projectID, bvName).
 		IsManuallyQuarantined(isManuallyQuarantined).
 		Execute()
@@ -266,7 +288,7 @@ func SetVariantQuarantined(ctx context.Context, projectID, bvName string, isManu
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		logTSSError(ctx, err, resp, message.Fields{
+		logTSSError(ctx, err, resp, time.Since(startAt), message.Fields{
 			"message":       "error setting variant quarantine status",
 			"endpoint":      TransitionVariantEndpoint,
 			"project_id":    projectID,
@@ -285,12 +307,13 @@ func GetVariantQuarantineStatus(ctx context.Context, projectID, bvName string) (
 	defer cancel()
 	c := newTestSelectionClient(testSelectionHTTPClient)
 
+	startAt := time.Now()
 	result, resp, err := c.StateTransitionAPI.GetVariantStateApiTestSelectionGetVariantStateProjectIdBuildVariantNamePost(ctx, projectID, bvName).Execute()
 	if resp != nil {
 		defer resp.Body.Close()
 	}
 	if err != nil {
-		logTSSError(ctx, err, resp, message.Fields{
+		logTSSError(ctx, err, resp, time.Since(startAt), message.Fields{
 			"message":       "error getting variant quarantine status",
 			"endpoint":      GetVariantStateEndpoint,
 			"project_id":    projectID,

--- a/rest/data/select_test.go
+++ b/rest/data/select_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -139,17 +138,16 @@ func TestGetTestsQuarantineStatus(t *testing.T) {
 		assert.Equal(t, map[string]bool{"test_a": false}, statuses)
 	})
 
-	t.Run("ContextDeadlineReturnsDefaultStatuses", func(t *testing.T) {
+	t.Run("CanceledContextReturnsDefaultStatuses", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			time.Sleep(200 * time.Millisecond)
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"test_a":{"state":"manually_quarantined"}}`))
 		}))
 		t.Cleanup(srv.Close)
 		setTSSURL(t, srv.URL)
 
-		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
-		defer cancel()
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
 		statuses, err := GetTestsQuarantineStatus(ctx, projectID, bvName, taskName, []string{"test_a"})
 		require.NoError(t, err)
 		assert.Equal(t, map[string]bool{"test_a": false}, statuses)

--- a/rest/data/select_test.go
+++ b/rest/data/select_test.go
@@ -1,12 +1,14 @@
 package data
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
@@ -125,17 +127,32 @@ func TestGetTestsQuarantineStatus(t *testing.T) {
 		assert.Equal(t, map[string]bool{"test_a": true, "test_missing": false}, statuses)
 	})
 
-	t.Run("ServiceErrorReturnsWrappedError", func(t *testing.T) {
+	t.Run("ServiceErrorReturnsDefaultStatuses", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "boom", http.StatusInternalServerError)
 		}))
 		t.Cleanup(srv.Close)
 		setTSSURL(t, srv.URL)
 
-		_, err := GetTestsQuarantineStatus(t.Context(), projectID, bvName, taskName, []string{"test_a"})
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "forwarding request to test selection service")
-		assert.Contains(t, err.Error(), "boom")
+		statuses, err := GetTestsQuarantineStatus(t.Context(), projectID, bvName, taskName, []string{"test_a"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]bool{"test_a": false}, statuses)
+	})
+
+	t.Run("ContextDeadlineReturnsDefaultStatuses", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(200 * time.Millisecond)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"test_a":{"state":"manually_quarantined"}}`))
+		}))
+		t.Cleanup(srv.Close)
+		setTSSURL(t, srv.URL)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Millisecond)
+		defer cancel()
+		statuses, err := GetTestsQuarantineStatus(ctx, projectID, bvName, taskName, []string{"test_a"})
+		require.NoError(t, err)
+		assert.Equal(t, map[string]bool{"test_a": false}, statuses)
 	})
 
 	t.Run("NotFoundReturnsDefaultStatuses", func(t *testing.T) {
@@ -344,6 +361,25 @@ func TestDecorateQuarantineStatus(t *testing.T) {
 		require.NoError(t, DecorateQuarantineStatus(t.Context(), parent, results))
 		assert.True(t, results[0].IsManuallyQuarantined)
 		assert.False(t, results[1].IsManuallyQuarantined)
+	})
+
+	t.Run("ExecutionTaskTSSFailureDoesNotError", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "boom", http.StatusInternalServerError)
+		}))
+		t.Cleanup(srv.Close)
+		setTSSURL(t, srv.URL)
+
+		parent := &task.Task{
+			Id:                   "exec_task",
+			Project:              "p",
+			BuildVariant:         "bv",
+			DisplayName:          "exec_task",
+			TestSelectionEnabled: true,
+		}
+		results := []testresult.TestResult{{TaskID: "exec_task", TestName: "TestFoo"}}
+		require.NoError(t, DecorateQuarantineStatus(t.Context(), parent, results))
+		assert.False(t, results[0].IsManuallyQuarantined)
 	})
 
 	t.Run("DisplayTaskFansOutAcrossExecutionTasks", func(t *testing.T) {


### PR DESCRIPTION
DEVPROD-36929

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Goal is to let TSS hard fail or degrade and not impact evergreen or loading of spruce (anything on the hot path such as page loads) and also optimize our queries we're making to TSS where possible.

- Reuse HTTP client to keep connections warm
- Add TSS timeouts per operation
- Make GetTestsQuarantineStatus fail open (but we still log on failures) and return false as a default
- Limit how many display task fan out calls occur so we don't send an unbounded n requests in in parallel 
- Only call TSS from GraphQL when actually requested. 
- Send trace headers to TSS so they can accept them so we can have better cross service traces

Added extra spans, going to remove them after we turn back on TSS with no incidents.
 
### Testing
* Unit tests
* Smoke tested locally
