### PR TITLE
DEVPROD-34609: Hide costs for admin-configured list of projects 

### DIFF
--- a/config_cost.go
+++ b/config_cost.go
@@ -24,6 +24,8 @@ type CostConfig struct {
 	S3Cost S3CostConfig `bson:"s3_cost" json:"s3_cost" yaml:"s3_cost"`
 	// EBSCost holds EBS-related cost discount configuration
 	EBSCost EBSCostConfig `bson:"ebs_cost" json:"ebs_cost" yaml:"ebs_cost"`
+	// HiddenCostProjects is the list of project IDs whose cost fields are hidden from the UI and API.
+	HiddenCostProjects []string `bson:"hidden_cost_projects,omitempty" json:"hidden_cost_projects,omitempty" yaml:"hidden_cost_projects,omitempty"`
 }
 
 // S3UploadCostConfig represents S3 upload cost discount configuration.
@@ -62,6 +64,7 @@ var (
 	financeConfigOnDemandDiscountKey    = bsonutil.MustHaveTag(CostConfig{}, "OnDemandDiscount")
 	financeConfigS3CostKey              = bsonutil.MustHaveTag(CostConfig{}, "S3Cost")
 	financeConfigEBSCostKey             = bsonutil.MustHaveTag(CostConfig{}, "EBSCost")
+	financeConfigHiddenCostProjectsKey  = bsonutil.MustHaveTag(CostConfig{}, "HiddenCostProjects")
 
 	s3CostConfigUploadKey  = bsonutil.MustHaveTag(S3CostConfig{}, "Upload")
 	s3CostConfigStorageKey = bsonutil.MustHaveTag(S3CostConfig{}, "Storage")
@@ -95,7 +98,8 @@ func (c *CostConfig) Set(ctx context.Context) error {
 			bsonutil.GetDottedKeyName(financeConfigS3CostKey, s3CostConfigStorageKey, s3StorageCostDefaultMaxArtifactExpirationDaysKey):         c.S3Cost.Storage.DefaultMaxArtifactExpirationDays,
 			bsonutil.GetDottedKeyName(financeConfigS3CostKey, s3CostConfigStorageKey, s3StorageCostDevprodOwnedAWSAccountIDsKey):                c.S3Cost.Storage.DevprodOwnedAWSAccountIDs,
 			bsonutil.GetDottedKeyName(financeConfigS3CostKey, s3CostConfigStorageKey, s3StorageCostArtifactAWSAccountsWithoutLifecycleRulesKey): c.S3Cost.Storage.ArtifactAWSAccountsWithoutLifecycleRules,
-			financeConfigEBSCostKey: c.EBSCost,
+			financeConfigEBSCostKey:            c.EBSCost,
+			financeConfigHiddenCostProjectsKey: c.HiddenCostProjects,
 		}}), "updating config section '%s'", c.SectionId(),
 	)
 }
@@ -185,6 +189,11 @@ func IsDevprodOwnedUpload(awsRoleARN, awsAccountID string, devprodOwnedAWSAccoun
 		return IsInDevProdOwnedAccountList(awsAccountID, devprodOwnedAWSAccountIDs)
 	}
 	return false
+}
+
+// ShouldHideCost reports whether the given project's cost fields should be hidden.
+func (c *CostConfig) ShouldHideCost(projectID string) bool {
+	return slices.Contains(c.HiddenCostProjects, projectID)
 }
 
 // IsConfigured returns true if any finance config field is set.

--- a/config_cost_test.go
+++ b/config_cost_test.go
@@ -8,6 +8,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestCostConfigShouldHideCost(t *testing.T) {
+	c := CostConfig{HiddenCostProjects: []string{"hidden-project-1", "hidden-project-2"}}
+	assert.True(t, c.ShouldHideCost("hidden-project-1"))
+	assert.True(t, c.ShouldHideCost("hidden-project-2"))
+	assert.False(t, c.ShouldHideCost("visible-project"))
+	assert.False(t, c.ShouldHideCost(""))
+
+	empty := CostConfig{}
+	assert.False(t, empty.ShouldHideCost("hidden-project-1"))
+}
+
 func TestCostConfigValidateAndDefault(t *testing.T) {
 	t.Run("ValidFinanceFields", func(t *testing.T) {
 		c := CostConfig{
@@ -260,6 +271,7 @@ func TestCostConfigSetAndGet(t *testing.T) {
 			FinanceFormula:      0.5,
 			SavingsPlanDiscount: 0.3,
 			OnDemandDiscount:    0.2,
+			HiddenCostProjects:  []string{"hidden-project-1", "hidden-project-2"},
 		}
 		require.NoError(t, original.Set(t.Context()))
 
@@ -269,6 +281,7 @@ func TestCostConfigSetAndGet(t *testing.T) {
 		assert.Equal(t, original.FinanceFormula, retrieved.FinanceFormula)
 		assert.Equal(t, original.SavingsPlanDiscount, retrieved.SavingsPlanDiscount)
 		assert.Equal(t, original.OnDemandDiscount, retrieved.OnDemandDiscount)
+		assert.Equal(t, original.HiddenCostProjects, retrieved.HiddenCostProjects)
 	})
 
 	t.Run("SetAndGetS3CostWithZeroValues", func(t *testing.T) {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -432,6 +432,7 @@ type ComplexityRoot struct {
 	CostConfig struct {
 		EBSCost             func(childComplexity int) int
 		FinanceFormula      func(childComplexity int) int
+		HiddenCostProjects  func(childComplexity int) int
 		OnDemandDiscount    func(childComplexity int) int
 		S3Cost              func(childComplexity int) int
 		SavingsPlanDiscount func(childComplexity int) int
@@ -4275,6 +4276,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.CostConfig.FinanceFormula(childComplexity), true
+	case "CostConfig.hiddenCostProjects":
+		if e.complexity.CostConfig.HiddenCostProjects == nil {
+			break
+		}
+
+		return e.complexity.CostConfig.HiddenCostProjects(childComplexity), true
 	case "CostConfig.onDemandDiscount":
 		if e.complexity.CostConfig.OnDemandDiscount == nil {
 			break
@@ -18999,6 +19006,8 @@ func (ec *executionContext) fieldContext_AdminSettings_cost(_ context.Context, f
 				return ec.fieldContext_CostConfig_s3Cost(ctx, field)
 			case "ebsCost":
 				return ec.fieldContext_CostConfig_ebsCost(ctx, field)
+			case "hiddenCostProjects":
+				return ec.fieldContext_CostConfig_hiddenCostProjects(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type CostConfig", field.Name)
 		},
@@ -25132,6 +25141,35 @@ func (ec *executionContext) fieldContext_CostConfig_ebsCost(_ context.Context, f
 				return ec.fieldContext_EBSCostConfig_ebsDiscount(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type EBSCostConfig", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _CostConfig_hiddenCostProjects(ctx context.Context, field graphql.CollectedField, obj *model.APICostConfig) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_CostConfig_hiddenCostProjects,
+		func(ctx context.Context) (any, error) {
+			return obj.HiddenCostProjects, nil
+		},
+		nil,
+		ec.marshalOString2ᚕstringᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_CostConfig_hiddenCostProjects(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "CostConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -82589,7 +82627,7 @@ func (ec *executionContext) unmarshalInputCostConfigInput(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"financeFormula", "savingsPlanDiscount", "onDemandDiscount", "s3Cost", "ebsCost"}
+	fieldsInOrder := [...]string{"financeFormula", "savingsPlanDiscount", "onDemandDiscount", "s3Cost", "ebsCost", "hiddenCostProjects"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -82631,6 +82669,13 @@ func (ec *executionContext) unmarshalInputCostConfigInput(ctx context.Context, o
 				return it, err
 			}
 			it.EBSCost = data
+		case "hiddenCostProjects":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("hiddenCostProjects"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.HiddenCostProjects = data
 		}
 	}
 
@@ -93970,6 +94015,8 @@ func (ec *executionContext) _CostConfig(ctx context.Context, sel ast.SelectionSe
 			out.Values[i] = ec._CostConfig_s3Cost(ctx, field, obj)
 		case "ebsCost":
 			out.Values[i] = ec._CostConfig_ebsCost(ctx, field, obj)
+		case "hiddenCostProjects":
+			out.Values[i] = ec._CostConfig_hiddenCostProjects(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/schema/types/adminSettings/other.graphql
+++ b/graphql/schema/types/adminSettings/other.graphql
@@ -217,6 +217,7 @@ input CostConfigInput {
   onDemandDiscount: Float
   s3Cost: S3CostConfigInput
   ebsCost: EBSCostConfigInput
+  hiddenCostProjects: [String!]
 }
 
 type CostConfig {
@@ -225,6 +226,7 @@ type CostConfig {
   onDemandDiscount: Float
   s3Cost: S3CostConfig
   ebsCost: EBSCostConfig
+  hiddenCostProjects: [String!]
 }
 
 input S3UploadCostConfigInput {

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -3167,6 +3167,7 @@ type APICostConfig struct {
 	OnDemandDiscount    *float64          `json:"on_demand_discount"`
 	S3Cost              *APIS3CostConfig  `json:"s3_cost"`
 	EBSCost             *APIEBSCostConfig `json:"ebs_cost"`
+	HiddenCostProjects  []string          `json:"hidden_cost_projects"`
 }
 
 type APIEBSCostConfig struct {
@@ -3205,6 +3206,7 @@ func (a *APICostConfig) BuildFromService(h any) error {
 		if err := a.EBSCost.BuildFromService(&v.EBSCost); err != nil {
 			return errors.Wrap(err, "building EBS cost config")
 		}
+		a.HiddenCostProjects = v.HiddenCostProjects
 	case evergreen.CostConfig:
 		a.FinanceFormula = &v.FinanceFormula
 		a.SavingsPlanDiscount = &v.SavingsPlanDiscount
@@ -3217,6 +3219,7 @@ func (a *APICostConfig) BuildFromService(h any) error {
 		if err := a.EBSCost.BuildFromService(&v.EBSCost); err != nil {
 			return errors.Wrap(err, "building EBS cost config")
 		}
+		a.HiddenCostProjects = v.HiddenCostProjects
 	default:
 		return errors.Errorf("incorrect type %T", v)
 	}
@@ -3246,6 +3249,7 @@ func (a *APICostConfig) ToService() (any, error) {
 		OnDemandDiscount:    utility.FromFloat64Ptr(a.OnDemandDiscount),
 		S3Cost:              s3Cost,
 		EBSCost:             ebsCost,
+		HiddenCostProjects:  a.HiddenCostProjects,
 	}, nil
 }
 

--- a/rest/model/cost.go
+++ b/rest/model/cost.go
@@ -1,0 +1,20 @@
+package model
+
+import "github.com/evergreen-ci/evergreen"
+
+// shouldHideCostForProject reports whether cost fields should be suppressed in API responses for the
+// given project ID.
+func shouldHideCostForProject(projectID string) bool {
+	if projectID == "" {
+		return false
+	}
+	env := evergreen.GetEnvironment()
+	if env == nil {
+		return false
+	}
+	settings := env.Settings()
+	if settings == nil {
+		return false
+	}
+	return settings.Cost.ShouldHideCost(projectID)
+}

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -341,15 +341,17 @@ func (apiPatch *APIPatch) populateCostFromVersion(ctx context.Context, versionID
 	if v == nil {
 		return
 	}
-	if !v.Cost.IsZero() {
-		versionCost := v.Cost
-		versionCost.Total = versionCost.AdjustedTotal()
-		apiPatch.Cost = &versionCost
-	}
-	if !v.PredictedCost.IsZero() {
-		predictedCost := v.PredictedCost
-		predictedCost.Total = predictedCost.AdjustedTotal()
-		apiPatch.PredictedCost = &predictedCost
+	if !shouldHideCostForProject(v.Identifier) {
+		if !v.Cost.IsZero() {
+			versionCost := v.Cost
+			versionCost.Total = versionCost.AdjustedTotal()
+			apiPatch.Cost = &versionCost
+		}
+		if !v.PredictedCost.IsZero() {
+			predictedCost := v.PredictedCost
+			predictedCost.Total = predictedCost.AdjustedTotal()
+			apiPatch.PredictedCost = &predictedCost
+		}
 	}
 	if !v.S3Usage.IsZero() {
 		apiPatch.S3Usage = &APIVersionS3Usage{
@@ -430,7 +432,9 @@ func (apiPatch *APIPatch) buildChildPatches(ctx context.Context, p patch.Patch) 
 	}
 	apiPatch.DownstreamTasks = downstreamTasks
 	apiPatch.ChildPatches = childPatches
-	addChildPatchesCostToParent(apiPatch, childPatches)
+	if !shouldHideCostForProject(p.Project) {
+		addChildPatchesCostToParent(apiPatch, childPatches)
+	}
 	if len(childPatches) == 0 {
 		return childPatchDocs, nil
 	}

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -408,17 +408,19 @@ func (at *APITask) buildTask(t *task.Task) error {
 		at.TimeTaken = NewAPIDuration(time.Since(t.StartTime))
 	}
 
-	if !t.TaskCost.IsZero() {
-		taskCost := t.TaskCost
-		taskCost.Total = taskCost.AdjustedTotal()
-		at.TaskCost = &taskCost
-	}
+	if !shouldHideCostForProject(t.Project) {
+		if !t.TaskCost.IsZero() {
+			taskCost := t.TaskCost
+			taskCost.Total = taskCost.AdjustedTotal()
+			at.TaskCost = &taskCost
+		}
 
-	// Populate expected cost fields if they exist (not zero)
-	if !t.PredictedTaskCost.IsZero() {
-		predictedCost := t.PredictedTaskCost
-		predictedCost.Total = predictedCost.AdjustedTotal()
-		at.PredictedTaskCost = &predictedCost
+		// Populate expected cost fields if they exist (not zero)
+		if !t.PredictedTaskCost.IsZero() {
+			predictedCost := t.PredictedTaskCost
+			predictedCost.Total = predictedCost.AdjustedTotal()
+			at.PredictedTaskCost = &predictedCost
+		}
 	}
 
 	if !t.S3Usage.IsZero() {

--- a/rest/model/task_test.go
+++ b/rest/model/task_test.go
@@ -9,8 +9,11 @@ import (
 	"github.com/evergreen-ci/evergreen/model/cost"
 	"github.com/evergreen-ci/evergreen/model/s3usage"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type taskCompare struct {
@@ -247,5 +250,39 @@ func TestTaskBuildFromService(t *testing.T) {
 				}
 			}
 		})
+	})
+}
+
+func TestAPITaskBuildFromServiceHiddenCost(t *testing.T) {
+	env := testutil.NewEnvironment(t.Context(), t)
+	originalEnv := evergreen.GetEnvironment()
+	evergreen.SetEnvironment(env)
+	t.Cleanup(func() { evergreen.SetEnvironment(originalEnv) })
+	env.Settings().Cost.HiddenCostProjects = []string{"hidden-project"}
+
+	t.Run("HiddenProjectSuppressesCost", func(t *testing.T) {
+		st := task.Task{
+			Id:                "t-hidden",
+			Project:           "hidden-project",
+			TaskCost:          cost.Cost{OnDemandEC2Cost: 15.0, AdjustedEC2Cost: 12.0},
+			PredictedTaskCost: cost.Cost{OnDemandEC2Cost: 5.0, AdjustedEC2Cost: 4.0},
+		}
+		at := APITask{}
+		require.NoError(t, at.BuildFromService(t.Context(), &st, nil))
+		assert.Nil(t, at.TaskCost)
+		assert.Nil(t, at.PredictedTaskCost)
+	})
+
+	t.Run("NonHiddenProjectKeepsCost", func(t *testing.T) {
+		st := task.Task{
+			Id:                "t-visible",
+			Project:           "visible-project",
+			TaskCost:          cost.Cost{OnDemandEC2Cost: 15.0, AdjustedEC2Cost: 12.0},
+			PredictedTaskCost: cost.Cost{OnDemandEC2Cost: 5.0, AdjustedEC2Cost: 4.0},
+		}
+		at := APITask{}
+		require.NoError(t, at.BuildFromService(t.Context(), &st, nil))
+		require.NotNil(t, at.TaskCost)
+		require.NotNil(t, at.PredictedTaskCost)
 	})
 }

--- a/rest/model/version.go
+++ b/rest/model/version.go
@@ -150,15 +150,17 @@ func (apiVersion *APIVersion) BuildFromService(ctx context.Context, v model.Vers
 		}
 	}
 
-	if !v.Cost.IsZero() {
-		versionCost := v.Cost
-		versionCost.Total = versionCost.AdjustedTotal()
-		apiVersion.Cost = &versionCost
-	}
-	if !v.PredictedCost.IsZero() {
-		predictedCost := v.PredictedCost
-		predictedCost.Total = predictedCost.AdjustedTotal()
-		apiVersion.PredictedCost = &predictedCost
+	if !shouldHideCostForProject(v.Identifier) {
+		if !v.Cost.IsZero() {
+			versionCost := v.Cost
+			versionCost.Total = versionCost.AdjustedTotal()
+			apiVersion.Cost = &versionCost
+		}
+		if !v.PredictedCost.IsZero() {
+			predictedCost := v.PredictedCost
+			predictedCost.Total = predictedCost.AdjustedTotal()
+			apiVersion.PredictedCost = &predictedCost
+		}
 	}
 	if !v.S3Usage.IsZero() {
 		apiVersion.S3Usage = &APIVersionS3Usage{

--- a/rest/model/version_test.go
+++ b/rest/model/version_test.go
@@ -4,10 +4,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/cost"
 	"github.com/evergreen-ci/evergreen/model/s3usage"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -143,6 +145,30 @@ func TestVersionBuildFromServiceCost(t *testing.T) {
 	t.Run("ZeroCostIsNil", func(t *testing.T) {
 		v := model.Version{
 			Id: "v-no-costs",
+		}
+
+		apiVersion := &APIVersion{}
+		apiVersion.BuildFromService(t.Context(), v)
+
+		assert.Nil(t, apiVersion.Cost)
+		assert.Nil(t, apiVersion.PredictedCost)
+	})
+
+	t.Run("HiddenCostProjectIsSuppressed", func(t *testing.T) {
+		env := testutil.NewEnvironment(t.Context(), t)
+		originalEnv := evergreen.GetEnvironment()
+		evergreen.SetEnvironment(env)
+		t.Cleanup(func() { evergreen.SetEnvironment(originalEnv) })
+		env.Settings().Cost.HiddenCostProjects = []string{"hidden-project"}
+
+		v := model.Version{
+			Id:         "v-hidden-cost",
+			Identifier: "hidden-project",
+			Cost:       cost.Cost{OnDemandEC2Cost: 15.0, AdjustedEC2Cost: 12.0},
+			PredictedCost: cost.Cost{
+				OnDemandEC2Cost: 5.0,
+				AdjustedEC2Cost: 4.0,
+			},
 		}
 
 		apiVersion := &APIVersion{}


### PR DESCRIPTION
DEVPROD-34609

### Description

Adds a `hiddenCostProjects` admin setting: a list of project IDs whose cost fields are hidden from users. This is for projects where a large share of the true cost comes from infrastructure provisioned outside the Evergreen fleet, so the Evergreen-only cost is misleadingly low.

### Testing

Added tests 

### Spruce PR
https://github.com/evergreen-ci/ui/pull/1776
