### PR TITLE
DEVPROD-36959: Bound project versions endpoint limit to prevent OOM

### DIFF
--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -746,6 +746,11 @@ func (h *projectIDGetHandler) Run(ctx context.Context) gimlet.Responder {
 
 const defaultVersionLimit = 20
 
+// maxVersionLimit bounds how many versions a single request may fetch. Each returned version carries
+// its embedded build-variant status (and, with include_builds, looked-up build documents), so an
+// unbounded limit lets one request materialize gigabytes server-side and can OOM the process.
+const maxVersionLimit = 100
+
 type getProjectVersionsHandler struct {
 	projectName string
 	opts        dbModel.GetVersionsOptions
@@ -821,6 +826,9 @@ func (h *getProjectVersionsHandler) Parse(ctx context.Context, r *http.Request) 
 	}
 	if h.opts.Limit < 1 {
 		return errors.New("limit must be a positive integer")
+	}
+	if h.opts.Limit > maxVersionLimit {
+		return errors.Errorf("limit cannot exceed %d", maxVersionLimit)
 	}
 
 	startStr := params.Get("start")

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -770,7 +770,7 @@ func makeGetProjectVersionsHandler() gimlet.RouteHandler {
 //	@Security		Api-User || Api-Key
 //	@Param			project_id			path	string		true	"the project ID"
 //	@Param			skip				query	int			false	"Number of versions to skip."
-//	@Param			limit				query	int			false	"The number of versions to be returned per page of pagination. Defaults to 20."
+//	@Param			limit				query	int			false	"The number of versions to be returned per page of pagination. Defaults to 5, and cannot exceed 100."
 //	@Param			start				query	int			false	"The version order number to start at, for pagination. Will return the versions that are less than (and therefore older) the revision number specified."
 //	@Param			revision_end		query	int			false	"Will return the versions that are greater than (and therefore more recent) or equal to revision number specified."
 //	@Param			requester			query	string		false	"Returns versions for this requester only. Defaults to gitter_request (caused by git commit, aka the repotracker requester). Can also be set to patch_request, github_pull_request, trigger_request (Project Trigger versions) , github_merge_request (GitHub merge queue), and ad_hoc (periodic builds). Can be specified multiple times to include multiple requesters."

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -744,7 +744,7 @@ func (h *projectIDGetHandler) Run(ctx context.Context) gimlet.Responder {
 //
 // GET /rest/v2/projects/{project_id}/versions
 
-const defaultVersionLimit = 20
+const defaultVersionLimit = 5
 
 // maxVersionLimit bounds how many versions a single request may fetch. Each returned version carries
 // its embedded build-variant status (and, with include_builds, looked-up build documents), so an

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -1033,6 +1033,55 @@ func TestGetProjectVersionsParseRequesters(t *testing.T) {
 	}
 }
 
+func TestGetProjectVersionsParseLimit(t *testing.T) {
+	ctx := t.Context()
+
+	for tName, tCase := range map[string]func(t *testing.T){
+		"DefaultsWhenUnset": func(t *testing.T) {
+			h := &getProjectVersionsHandler{}
+			req, err := http.NewRequest(http.MethodGet, "https://example.com/rest/v2/projects/proj/versions", http.NoBody)
+			require.NoError(t, err)
+			req = gimlet.SetURLVars(req, map[string]string{"project_id": "proj"})
+			require.NoError(t, h.Parse(ctx, req))
+			assert.Equal(t, defaultVersionLimit, h.opts.Limit)
+		},
+		"AcceptsLimitAtMax": func(t *testing.T) {
+			h := &getProjectVersionsHandler{}
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://example.com/rest/v2/projects/proj/versions?limit=%d", maxVersionLimit), http.NoBody)
+			require.NoError(t, err)
+			req = gimlet.SetURLVars(req, map[string]string{"project_id": "proj"})
+			require.NoError(t, h.Parse(ctx, req))
+			assert.Equal(t, maxVersionLimit, h.opts.Limit)
+		},
+		"RejectsLimitAboveMax": func(t *testing.T) {
+			h := &getProjectVersionsHandler{}
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://example.com/rest/v2/projects/proj/versions?limit=%d", maxVersionLimit+1), http.NoBody)
+			require.NoError(t, err)
+			req = gimlet.SetURLVars(req, map[string]string{"project_id": "proj"})
+			assert.Error(t, h.Parse(ctx, req))
+		},
+		"ZeroLimitDefaults": func(t *testing.T) {
+			h := &getProjectVersionsHandler{}
+			req, err := http.NewRequest(http.MethodGet, "https://example.com/rest/v2/projects/proj/versions?limit=0", http.NoBody)
+			require.NoError(t, err)
+			req = gimlet.SetURLVars(req, map[string]string{"project_id": "proj"})
+			require.NoError(t, h.Parse(ctx, req))
+			assert.Equal(t, defaultVersionLimit, h.opts.Limit)
+		},
+		"RejectsNegativeLimit": func(t *testing.T) {
+			h := &getProjectVersionsHandler{}
+			req, err := http.NewRequest(http.MethodGet, "https://example.com/rest/v2/projects/proj/versions?limit=-1", http.NoBody)
+			require.NoError(t, err)
+			req = gimlet.SetURLVars(req, map[string]string{"project_id": "proj"})
+			assert.Error(t, h.Parse(ctx, req))
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			tCase(t)
+		})
+	}
+}
+
 func TestDeleteProject(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
DEVPROD-36959

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
The `GET /rest/v2/projects/{project_id}/versions` endpoint previously accepted an unbounded `limit`. Each returned version carries its embedded build-variant status, and with `include_builds` it also looks up build documents, so a single large request can materialize gigabytes of data server-side and OOM the process.

To fix this this PR: 
  - Caps the endpoint's `limit` at `maxVersionLimit` (100), returning a clear error when the request exceeds it.
  - Lowers the default page size (`defaultVersionLimit`) from 20 to 5 to reduce memory pressure for callers that don't specify a limit.

### Testing

Added 

### Documentation
Updated

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
