### PR TITLE
DEVPROD-36139: Stop the translation cache from marshaling whole projects to hash and size them

### DIFF
--- a/model/project_translate_cache.go
+++ b/model/project_translate_cache.go
@@ -89,16 +89,28 @@ func currentTranslationCacheBytesLimit() int64 {
 	return defaultTranslationCacheBytesLimit
 }
 
+// byteCounter is an io.Writer that counts the bytes written to it without retaining them, so a value
+// can be JSON-sized (or hashed) by streaming its encoding into a sink instead of materializing the
+// full serialized form as a []byte.
+type byteCounter struct{ n int64 }
+
+func (c *byteCounter) Write(p []byte) (int, error) {
+	c.n += int64(len(p))
+	return len(p), nil
+}
+
 // estimateProjectSize approximates p's memory cost as the length of its JSON encoding. This
 // underestimates live heap size but is proportional to it and, unlike the parser project, reflects
 // matrix and variant expansion. The bool is false if p can't be marshaled, in which case the caller
 // must not cache it: an unsizable entry would escape the byte budget entirely.
+//
+// The encoding is streamed through a byteCounter so the full JSON []byte is never allocated.
 func estimateProjectSize(p *Project) (int64, bool) {
-	data, err := json.Marshal(p)
-	if err != nil {
+	var c byteCounter
+	if err := json.NewEncoder(&c).Encode(p); err != nil {
 		return 0, false
 	}
-	return int64(len(data)), true
+	return c.n, true
 }
 
 // addToTranslationCache inserts p under key and evicts least-recently-used entries until the running
@@ -243,13 +255,16 @@ func translateAndCache(ctx context.Context, span trace.Span, pp *ParserProject, 
 	return p.cloneForCacheReturn(), err
 }
 
-// parserProjectContentSHA returns the hex-encoded SHA-256 of pp marshaled as JSON.
+// parserProjectContentSHA returns the hex-encoded SHA-256 of pp's JSON encoding.
 // Must be called after pp.Identifier is set so the identifier is included in the hash.
+//
+// The encoding is streamed into the hasher so the full JSON []byte is never allocated. json.Encoder
+// sorts map keys exactly as json.Marshal does, so the hash is stable: identical parser-project
+// content yields the same key, and any generate.tasks rewrite yields a different key.
 func parserProjectContentSHA(pp *ParserProject) (string, error) {
-	data, err := json.Marshal(pp)
-	if err != nil {
-		return "", errors.Wrap(err, "marshaling parser project")
+	h := sha256.New()
+	if err := json.NewEncoder(h).Encode(pp); err != nil {
+		return "", errors.Wrap(err, "hashing parser project")
 	}
-	sum := sha256.Sum256(data)
-	return hex.EncodeToString(sum[:]), nil
+	return hex.EncodeToString(h.Sum(nil)), nil
 }


### PR DESCRIPTION
DEVPROD-36139

### Description

The project translation cache added some avoidable allocation churn: 

- `parserProjectContentSHA` marshaled the entire parser project to build the cache key.
- `estimateProjectSize` marshaled the entire translated project to size it for the byte budget.

This fixed that and instead streams the encoding into the hasher / a byte counter instead, cutting per-translate churn ~ 98% (~ 11.6MB→~ 0.19MB/op) based on benchmarking data I ran.

### Testing

I ran some benchmarking to make sure it has the expected impact. It's already covered by existing tests. 



<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
