### PR TITLE
DEVPROD-36929: Remove testSelectionDisplayTaskStatusRequestParallel to let TSS run in parallel 

### DIFF
--- a/rest/data/select.go
+++ b/rest/data/select.go
@@ -32,10 +32,9 @@ const (
 )
 
 const (
-	testSelectionWriteTimeout                     = 10 * time.Second
-	testSelectionStatusTimeout                    = 4 * time.Second
-	testSelectionDecorationTimeout                = 5 * time.Second
-	testSelectionDisplayTaskStatusRequestParallel = 15
+	testSelectionWriteTimeout      = 10 * time.Second
+	testSelectionStatusTimeout     = 4 * time.Second
+	testSelectionDecorationTimeout = 5 * time.Second
 )
 
 // Using a shared HTTP client so we can reuse idle connections between TSS calls and reduce the number of reconnects.
@@ -409,7 +408,6 @@ func decorateDisplayTaskQuarantineStatus(ctx context.Context, displayTaskID stri
 		"missing_exec_task_ids": missingExecTaskIDs,
 	})
 	eg, ctx := errgroup.WithContext(ctx)
-	eg.SetLimit(testSelectionDisplayTaskStatusRequestParallel)
 	for _, execTask := range execTasks {
 		if !execTask.TestSelectionEnabled {
 			continue


### PR DESCRIPTION
DEVPROD-36929

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
We already have a timeout, which should prevent us from running into anything too damaging, limiting how many requests in parallel could cause too many timeouts. I think my addition of `testSelectionDisplayTaskStatusRequestParallel` was probably too much and we can add it later if need be.  

