### PR TITLE
DEVPROD-37019: apply timeout to total git fetch file operation

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1177,6 +1177,10 @@ func setupParallelGitIncludeDirs(ctx context.Context, modules ModuleList, includ
 // for the specific revision. Once the git clone is finished, it creates git
 // worktrees under the clone directory based on numWorktrees.
 func gitCloneAndCreateWorktrees(ctx context.Context, ownerRepo gitOwnerRepo, revision string, numWorktrees int) (cloneDir string, worktreeDirs []string, err error) {
+	const gitOperationTimeout = 15 * time.Second
+	ctx, cancel := context.WithTimeout(ctx, gitOperationTimeout)
+	defer cancel()
+
 	dir, err := thirdparty.GitCloneMinimal(ctx, ownerRepo.owner, ownerRepo.repo, revision)
 	if err != nil {
 		return "", []string{}, errors.Wrapf(err, "git cloning repo '%s/%s' at revision '%s'", ownerRepo.owner, ownerRepo.repo, revision)

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1177,8 +1177,7 @@ func setupParallelGitIncludeDirs(ctx context.Context, modules ModuleList, includ
 // for the specific revision. Once the git clone is finished, it creates git
 // worktrees under the clone directory based on numWorktrees.
 func gitCloneAndCreateWorktrees(ctx context.Context, ownerRepo gitOwnerRepo, revision string, numWorktrees int) (cloneDir string, worktreeDirs []string, err error) {
-	const gitOperationTimeout = 15 * time.Second
-	ctx, cancel := context.WithTimeout(ctx, gitOperationTimeout)
+	ctx, cancel := context.WithTimeout(ctx, thirdparty.GitOperationTimeout)
 	defer cancel()
 
 	dir, err := thirdparty.GitCloneMinimal(ctx, ownerRepo.owner, ownerRepo.repo, revision)

--- a/thirdparty/git.go
+++ b/thirdparty/git.go
@@ -280,6 +280,9 @@ func GitCloneMinimal(ctx context.Context, owner, repo, revision string) (string,
 	))
 	defer span.End()
 
+	ctx, cancel := context.WithTimeout(ctx, gitOperationTimeout)
+	defer cancel()
+
 	token, err := getInstallationToken(ctx, owner, repo, nil)
 	if err != nil {
 		return "", errors.Wrap(err, "creating GitHub app installation token")
@@ -388,6 +391,9 @@ func GitRestoreFile(ctx context.Context, owner, repo, revision, gitDir string, f
 		attribute.String(githubPathAttribute, fileName),
 	))
 	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, gitOperationTimeout)
+	defer cancel()
 
 	// Validate that the file is within the git directory to prevent attempts to
 	// access files outside the git repo. The requested file could be

--- a/thirdparty/git.go
+++ b/thirdparty/git.go
@@ -280,7 +280,7 @@ func GitCloneMinimal(ctx context.Context, owner, repo, revision string) (string,
 	))
 	defer span.End()
 
-	ctx, cancel := context.WithTimeout(ctx, gitOperationTimeout)
+	ctx, cancel := context.WithTimeout(ctx, GitOperationTimeout)
 	defer cancel()
 
 	token, err := getInstallationToken(ctx, owner, repo, nil)
@@ -336,7 +336,7 @@ func GitCloneMinimal(ctx context.Context, owner, repo, revision string) (string,
 	return tmpDir, nil
 }
 
-const gitOperationTimeout = 15 * time.Second
+const GitOperationTimeout = 15 * time.Second
 
 // GitCreateWorktree creates a new git worktree in worktreeDir based on gitDir.
 // It does not perform a checkout. Callers are assumed to have already cloned
@@ -346,7 +346,7 @@ func GitCreateWorktree(ctx context.Context, gitDir, worktreeDir string) error {
 	ctx, span := tracer.Start(ctx, "GitCreateWorktree")
 	defer span.End()
 
-	ctx, cancel := context.WithTimeout(ctx, gitOperationTimeout)
+	ctx, cancel := context.WithTimeout(ctx, GitOperationTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "git", "worktree", "add",
@@ -392,7 +392,7 @@ func GitRestoreFile(ctx context.Context, owner, repo, revision, gitDir string, f
 	))
 	defer span.End()
 
-	ctx, cancel := context.WithTimeout(ctx, gitOperationTimeout)
+	ctx, cancel := context.WithTimeout(ctx, GitOperationTimeout)
 	defer cancel()
 
 	// Validate that the file is within the git directory to prevent attempts to

--- a/thirdparty/git.go
+++ b/thirdparty/git.go
@@ -11,7 +11,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
@@ -268,8 +267,6 @@ func GetGitHubFileFromGit(ctx context.Context, owner, repo, ref, file, worktree 
 	return fileContent, errors.Wrap(err, "restoring git file")
 }
 
-const gitOperationTimeout = 15 * time.Second
-
 // GitCloneMinimal performs a minimal git clone of a repository using the GitHub
 // app. The minimal clone contains only git metadata for the one revision and
 // has no file content. Callers are expected to clean up the returned git
@@ -293,13 +290,6 @@ func GitCloneMinimal(ctx context.Context, owner, repo, revision string) (string,
 	}
 
 	repoURL := FormGitURLForApp(owner, repo, token)
-
-	// Limit how long this can clone to prevent this from running too long. This
-	// is an experimental feature and should not meaningfully impact performance
-	// while it's being tested out. Realistically, if it took more than this
-	// long to do a minimal clone, it would be too slow to be usable.
-	ctx, cancel := context.WithTimeout(ctx, gitOperationTimeout)
-	defer cancel()
 
 	// Clone the repository with the bare minimum metadata for just the one
 	// commit. Don't fetch any actual file blobs yet.
@@ -350,11 +340,8 @@ func GitCreateWorktree(ctx context.Context, gitDir, worktreeDir string) error {
 	ctx, span := tracer.Start(ctx, "GitCreateWorktree")
 	defer span.End()
 
-	// Limit how long this can spend creating the worktree to prevent this from
-	// running too long. This is an experimental feature and should not
-	// meaningfully impact performance while it's being tested out.
-	// Realistically, if it took more than this long to create a worktree,
-	// it would be too slow to be usable.
+	// This depends on fetching from GitHub, so limit how long this can spend
+	// creating the worktree to prevent this from running too long.
 	ctx, cancel := context.WithTimeout(ctx, gitOperationTimeout)
 	defer cancel()
 
@@ -407,14 +394,6 @@ func GitRestoreFile(ctx context.Context, owner, repo, revision, gitDir string, f
 	if err := validateFileIsWithinDirectory(gitDir, fileName); err != nil {
 		return nil, errors.Wrapf(err, "validating file path '%s' is within git repo directory", fileName)
 	}
-
-	// Limit how long this can spend restoring the file to prevent this from
-	// running too long. This is an experimental feature and should not
-	// meaningfully impact performance while it's being tested out.
-	// Realistically, if it took more than this long to restore a single file,
-	// it would be too slow to be usable.
-	ctx, cancel := context.WithTimeout(ctx, gitOperationTimeout)
-	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "git", "restore", "--source=HEAD", fileName)
 	cmd.Dir = gitDir

--- a/thirdparty/git.go
+++ b/thirdparty/git.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
@@ -332,6 +333,8 @@ func GitCloneMinimal(ctx context.Context, owner, repo, revision string) (string,
 	return tmpDir, nil
 }
 
+const gitOperationTimeout = 15 * time.Second
+
 // GitCreateWorktree creates a new git worktree in worktreeDir based on gitDir.
 // It does not perform a checkout. Callers are assumed to have already cloned
 // the repo into gitDir and HEAD is assumed to be already pointing to the
@@ -340,8 +343,6 @@ func GitCreateWorktree(ctx context.Context, gitDir, worktreeDir string) error {
 	ctx, span := tracer.Start(ctx, "GitCreateWorktree")
 	defer span.End()
 
-	// This depends on fetching from GitHub, so limit how long this can spend
-	// creating the worktree to prevent this from running too long.
 	ctx, cancel := context.WithTimeout(ctx, gitOperationTimeout)
 	defer cancel()
 

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -563,7 +563,12 @@ func parseGithubErrorResponse(resp *github.Response) error {
 // file can be retrieved with git, it reduces the amount of GitHub API calls.
 func GetGitHubFileContent(ctx context.Context, owner, repo, ref, path, worktree string, ghAppAuth *githubapp.GithubAppAuth, useGit bool) ([]byte, error) {
 	if useGit {
-		gitFile, err := GetGitHubFileFromGit(ctx, owner, repo, ref, path, worktree)
+		// Fetching files with git can be slow/network dependent. Bound how long
+		// it can run so it can fall back faster to the GitHub API when needed.
+		gitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		gitFile, err := GetGitHubFileFromGit(gitCtx, owner, repo, ref, path, worktree)
 		if err == nil {
 			return gitFile, nil
 		}

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -565,7 +565,7 @@ func GetGitHubFileContent(ctx context.Context, owner, repo, ref, path, worktree 
 	if useGit {
 		// Fetching files with git can be slow/network dependent. Bound how long
 		// it can run so it can fall back faster to the GitHub API when needed.
-		gitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		gitCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()
 
 		gitFile, err := GetGitHubFileFromGit(gitCtx, owner, repo, ref, path, worktree)

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -565,7 +565,7 @@ func GetGitHubFileContent(ctx context.Context, owner, repo, ref, path, worktree 
 	if useGit {
 		// Fetching files with git can be slow/network dependent. Bound how long
 		// it can run so it can fall back faster to the GitHub API when needed.
-		gitCtx, cancel := context.WithTimeout(ctx, gitOperationTimeout)
+		gitCtx, cancel := context.WithTimeout(ctx, GitOperationTimeout)
 		defer cancel()
 
 		gitFile, err := GetGitHubFileFromGit(gitCtx, owner, repo, ref, path, worktree)

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -565,7 +565,7 @@ func GetGitHubFileContent(ctx context.Context, owner, repo, ref, path, worktree 
 	if useGit {
 		// Fetching files with git can be slow/network dependent. Bound how long
 		// it can run so it can fall back faster to the GitHub API when needed.
-		gitCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		gitCtx, cancel := context.WithTimeout(ctx, gitOperationTimeout)
 		defer cancel()
 
 		gitFile, err := GetGitHubFileFromGit(gitCtx, owner, repo, ref, path, worktree)


### PR DESCRIPTION
DEVPROD-37019

### Description

The prior logic gave 15 seconds each to `git clone` and `git restore` files when fetching. Changed it so that the entire operation has 30 seconds to finish, so if it can't get the file from git in 15 seconds, it falls back to trying to get the file from the GitHub API. Slightly improves resilience by falling back to the GitHub API faster and applying the context timeout to fetching the installation token.

Slightly increases the chance that we'll use more GitHub API calls (which git is meant to fix), but maybe that's okay given that a file fetch shouldn't take more than ~10 seconds if the git provider is healthy.

### Testing
N/A