### PR TITLE
DEVPROD-33607: preserve cross-variant dependencies with path filtering

### DIFF
--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1650,9 +1650,12 @@ func (j *patchIntentProcessor) getEvergreenRulesForStatuses(ctx context.Context,
 	return utility.UniqueStrings(allRules)
 }
 
-// filterOutIgnoredVariants checks which variants should be ignored based on their path patterns
-// and the changed files in the patch. It removes ignored variants from all relevant patch fields
-// and returns the list of ignored variant names.
+// filterOutIgnoredVariants checks which variants should be ignored based on
+// their path patterns and the changed files in the patch.If a variant is
+// ignored by path filtering but has tasks that are required for cross-variant
+// dependencies, those dependencies will not be ignored (in other words,
+// dependencies can override path filtering). It removes ignored variants from
+// all relevant patch fields and returns the list of ignored variant names.
 func (j *patchIntentProcessor) filterOutIgnoredVariants(ctx context.Context, patchDoc *patch.Patch, patchedProject *model.Project) []string {
 	ignoredVariants := []string{}
 	if j.skipFilteringIgnoredVariants(ctx, patchDoc, patchedProject) {
@@ -1663,10 +1666,11 @@ func (j *patchIntentProcessor) filterOutIgnoredVariants(ctx context.Context, pat
 
 	filteredVTs := vtsNotIgnored
 	if len(candidateVTsToIgnore) > 0 {
-		// A task that's not ignored may depend on a task in a variant that path
-		// filtering would otherwise ignore. Cross-variant dependencies must be
-		// preserved regardless of path filtering. Determine which tasks in the
-		// ignored variants need to be kept due to cross-variant dependencies.
+		// A task that's not ignored may have a cross-variant dependency on a
+		// task in a variant that path filtering would otherwise ignore.
+		// Cross-variant dependencies must be preserved regardless of path
+		// filtering, so determine which tasks in the ignored variants need to
+		// be kept for cross-variant dependencies.
 		variantsToNeededTasks := j.getTasksAndDependencies(ctx, patchDoc, patchedProject, vtsNotIgnored)
 		for _, vt := range candidateVTsToIgnore {
 			neededTasks := variantsToNeededTasks[vt.Variant]
@@ -1692,10 +1696,10 @@ func (j *patchIntentProcessor) filterOutIgnoredVariants(ctx context.Context, pat
 	return ignoredVariants
 }
 
-// partitionVariantsByPathFilter splits the patch's variant tasks into those that
-// are kept and those that can potentially be ignored A variant is a candidate
-// to be ignored when it has path filters and none of the patch's changed
-// files match them.
+// partitionVariantsByPathFilter splits the patch's variant tasks into those
+// that are kept and those that can potentially be ignored. A variant is a
+// candidate to be ignored when it has path filters and none of the patch's
+// changed files match them.
 func partitionVariantsByPathFilter(patchDoc *patch.Patch, patchedProject *model.Project) (vtsNotIgnored, candidateVTsToIgnore []patch.VariantTasks) {
 	changedFiles := patchDoc.FilesChanged()
 	for _, vt := range patchDoc.VariantsTasks {

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1667,7 +1667,7 @@ func (j *patchIntentProcessor) filterOutIgnoredVariants(ctx context.Context, pat
 		// filtering would otherwise ignore. Cross-variant dependencies must be
 		// preserved regardless of path filtering. Determine which tasks in the
 		// ignored variants need to be kept due to cross-variant dependencies.
-		variantsToNeededTasks := j.getTasksNeededByDependencies(ctx, patchDoc, patchedProject, vtsNotIgnored)
+		variantsToNeededTasks := j.getTasksAndDependencies(ctx, patchDoc, patchedProject, vtsNotIgnored)
 		for _, vt := range candidateVTsToIgnore {
 			neededTasks := variantsToNeededTasks[vt.Variant]
 			if len(neededTasks) == 0 {
@@ -1678,10 +1678,10 @@ func (j *patchIntentProcessor) filterOutIgnoredVariants(ctx context.Context, pat
 				continue
 			}
 
-			// The variant is path-filtered but holds tasks that a kept task
-			// depends on, so reinstate specifically those tasks (not the entire
-			// variant).
-			depVT := reinstateNeededTasksForVariant(patchedProject, vt, neededTasks)
+			// The variant is path-filtered but holds tasks that a non-ignored
+			// task in another variant depends on, so reinstate specifically
+			// those tasks (not the entire variant).
+			depVT := reinstateDependenciesForVariant(patchedProject, vt, neededTasks)
 
 			filteredVTs = append(filteredVTs, depVT)
 		}
@@ -1709,13 +1709,15 @@ func partitionVariantsByPathFilter(patchDoc *patch.Patch, patchedProject *model.
 	return vtsNotIgnored, candidateVTsToIgnore
 }
 
-// getTasksNeededByDependencies returns, for each variant, the set of that
-// variant's task names that the tasks depend on.
-func (j *patchIntentProcessor) getTasksNeededByDependencies(ctx context.Context, patchDoc *patch.Patch, patchedProject *model.Project, vts []patch.VariantTasks) map[string]map[string]bool {
-	keptPairs := model.VariantTasksToTVPairs(vts)
-	requiredTasksAndDependencies, err := model.IncludeDependencies(patchedProject, keptPairs.ExecTasks, patchDoc.GetRequester(), nil)
+// getTasksAndDependencies returns a map of variants to the tasks that should
+// run in those variants. This includes:
+// 1. the initial set of tasks in vts and
+// 2. tasks that are required as dependencies of tasks in vts.
+func (j *patchIntentProcessor) getTasksAndDependencies(ctx context.Context, patchDoc *patch.Patch, patchedProject *model.Project, vts []patch.VariantTasks) map[string]map[string]bool {
+	tvPairs := model.VariantTasksToTVPairs(vts)
+	requiredTasksAndDependencies, err := model.IncludeDependencies(patchedProject, tvPairs.ExecTasks, patchDoc.GetRequester(), nil)
 	grip.Warning(ctx, message.WrapError(err, message.Fields{
-		"message":  "hit warnings trying to resolve cross-variant dependencies on ignored variants",
+		"message":  "error resolving cross-variant dependencies on path-filtered variants",
 		"job":      j.ID(),
 		"patch_id": patchDoc.Id.Hex(),
 	}))
@@ -1730,11 +1732,14 @@ func (j *patchIntentProcessor) getTasksNeededByDependencies(ctx context.Context,
 	return variantsToNeededTasks
 }
 
-// reinstateNeededTasksForVariant builds the subset of neededTasksInVariant (and
-// their parent display tasks) that are needed as a dependency for a task in vt.
-// A reinstated display task may not include all of the execution tasks it would
-// normally have.
-func reinstateNeededTasksForVariant(patchedProject *model.Project, vt patch.VariantTasks, neededTasksInVariant map[string]bool) patch.VariantTasks {
+// reinstateDependenciesForVariant builds the subset of neededTasksInVariant
+// (and their parent display tasks) that are needed as a dependency for a task
+// in vt. This includes all regular tasks, execution tasks, and parent display
+// tasks needed for dependencies.
+// A reinstated display task includes only the minimal set of tasks that are
+// needed as dependencies, so not all of display task's execution tasks are
+// guaranteed to be included.
+func reinstateDependenciesForVariant(patchedProject *model.Project, vt patch.VariantTasks, neededTasksInVariant map[string]bool) patch.VariantTasks {
 	depVT := patch.VariantTasks{Variant: vt.Variant}
 	for _, t := range vt.Tasks {
 		if neededTasksInVariant[t] {

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1713,8 +1713,8 @@ func partitionVariantsByPathFilter(patchDoc *patch.Patch, patchedProject *model.
 	return vtsNotIgnored, candidateVTsToIgnore
 }
 
-// getTasksAndDependencies returns a map of variants to the tasks that should
-// run in those variants. This includes:
+// getTasksAndDependencies returns a map of variants to the set of tasks that
+// should run in those variants. This includes:
 // 1. the initial set of variants and tasks in vts and
 // 2. variants and tasks that are required dependencies of tasks in vts.
 func (j *patchIntentProcessor) getTasksAndDependencies(ctx context.Context, patchDoc *patch.Patch, patchedProject *model.Project, vts []patch.VariantTasks) map[string]map[string]bool {

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1659,37 +1659,116 @@ func (j *patchIntentProcessor) filterOutIgnoredVariants(ctx context.Context, pat
 		return ignoredVariants
 	}
 
-	filteredVariantsTasks := []patch.VariantTasks{}
-	filteredBuildVariants := []string{}
-
 	changedFiles := patchDoc.FilesChanged()
-	// Check each variant in VariantsTasks to see if it should be ignored
+
+	// keptVTs tracks those tasks are not impacted by path filtering (i.e. they
+	// either don't use path filtering or the changed files match the path
+	// filter).
+	keptVTs := []patch.VariantTasks{}
+	// candidateVTsToIgnore tracks those tasks that have path filtering and
+	// their changed files don't match the path filter (i.e. the path filter
+	// says to ignore them).
+	candidateVTsToIgnore := []patch.VariantTasks{}
 	for _, vt := range patchDoc.VariantsTasks {
 		bv := patchedProject.FindBuildVariant(vt.Variant)
-		if bv == nil {
-			// If we can't find the build variant, keep it (don't ignore)
-			filteredVariantsTasks = append(filteredVariantsTasks, vt)
-			filteredBuildVariants = append(filteredBuildVariants, vt.Variant)
+		if bv != nil && len(bv.Paths) > 0 && !bv.ChangedFilesMatchPaths(changedFiles) {
+			candidateVTsToIgnore = append(candidateVTsToIgnore, vt)
 			continue
 		}
+		keptVTs = append(keptVTs, vt)
+	}
 
-		// If the variant has path patterns and none of the changed files match, ignore it
-		if len(bv.Paths) > 0 && !bv.ChangedFilesMatchPaths(changedFiles) {
-			ignoredVariants = append(ignoredVariants, vt.Variant)
-		} else {
-			// Keep this variant
-			filteredVariantsTasks = append(filteredVariantsTasks, vt)
-			filteredBuildVariants = append(filteredBuildVariants, vt.Variant)
+	filteredVTs := keptVTs
+	if len(candidateVTsToIgnore) > 0 {
+		// A kept task may depend on a task that's going to be ignored due to
+		// path filtering. However, that task should not be path filtered out
+		// because it's a cross-variant dependency and Evergreen should preserve
+		// dependencies regardless of path filtering.
+		// Recompute dependencies for the kept tasks to determine which tasks in
+		// the ignored variants are depended on by the kept tasks.
+		keptPairs := model.VariantTasksToTVPairs(keptVTs)
+		requiredTasksAndDependencies, err := model.IncludeDependencies(patchedProject, keptPairs.ExecTasks, patchDoc.GetRequester(), nil)
+		grip.Warning(ctx, message.WrapError(err, message.Fields{
+			"message":  "resolving dependencies while filtering ignored variants",
+			"job":      j.ID(),
+			"patch_id": patchDoc.Id.Hex(),
+		}))
+
+		variantsToNeededTasks := map[string]map[string]bool{}
+		for _, pair := range requiredTasksAndDependencies {
+			if variantsToNeededTasks[pair.Variant] == nil {
+				variantsToNeededTasks[pair.Variant] = map[string]bool{}
+			}
+			variantsToNeededTasks[pair.Variant][pair.TaskName] = true
+		}
+
+		for _, vt := range candidateVTsToIgnore {
+			variant := vt.Variant
+			neededTasks := variantsToNeededTasks[variant]
+			if len(neededTasks) == 0 {
+				// The variant is path-filtered out and none of the tasks are
+				// depended on by a kept task. Therefore, it's safe to ignore
+				// the entire variant.
+				ignoredVariants = append(ignoredVariants, variant)
+				continue
+			}
+
+			// The variant is path-filtered but holds tasks that a kept task
+			// depends on. Reinstate only those dependency tasks (and their
+			// parent display tasks) rather than the whole variant.
+			// Note that because tasks can depend on a subset of execution
+			// tasks within a display task, it's possible for the display task
+			// to not contain all the execution tasks it would typically have
+			// because only the necessary execution tasks are kept for
+			// dependencies.
+			depVT := patch.VariantTasks{Variant: variant}
+			for _, t := range vt.Tasks {
+				if neededTasks[t] {
+					depVT.Tasks = append(depVT.Tasks, t)
+				}
+			}
+			if bv := patchedProject.FindBuildVariant(variant); bv != nil {
+				for _, dt := range vt.DisplayTasks {
+					projectDT := bv.GetDisplayTask(dt.Name)
+					if projectDT == nil {
+						continue
+					}
+					for _, et := range projectDT.ExecTasks {
+						if neededTasks[et] {
+							depVT.DisplayTasks = append(depVT.DisplayTasks, patch.DisplayTask{Name: dt.Name})
+							break
+						}
+					}
+				}
+			}
+
+			// kim: TODO: remove this temporary debug log once the interaction
+			// between path filtering and cross-variant dependencies is confirmed.
+			grip.Info(ctx, message.Fields{
+				"message":                  "kim: reinstating path-filtered variant because a non-filtered task depends on its tasks",
+				"job":                      j.ID(),
+				"patch_id":                 patchDoc.Id.Hex(),
+				"variant":                  variant,
+				"reinstated_tasks":         depVT.Tasks,
+				"reinstated_display_tasks": depVT.DisplayTasks,
+			})
+
+			filteredVTs = append(filteredVTs, depVT)
 		}
 	}
 
+	filteredBuildVariants := make([]string, 0, len(filteredVTs))
+	for _, vt := range filteredVTs {
+		filteredBuildVariants = append(filteredBuildVariants, vt.Variant)
+	}
+
 	// Update the patch document with the filtered variants
-	patchDoc.VariantsTasks = filteredVariantsTasks
+	patchDoc.VariantsTasks = filteredVTs
 	patchDoc.BuildVariants = filteredBuildVariants
 
 	// Update Tasks to only include tasks that are still used by remaining variants
 	usedTasks := make(map[string]bool)
-	for _, vt := range filteredVariantsTasks {
+	for _, vt := range filteredVTs {
 		for _, task := range vt.Tasks {
 			usedTasks[task] = true
 		}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1683,17 +1683,6 @@ func (j *patchIntentProcessor) filterOutIgnoredVariants(ctx context.Context, pat
 			// variant).
 			depVT := reinstateNeededTasksForVariant(patchedProject, vt, neededTasks)
 
-			// kim: TODO: remove this temporary debug log once the interaction
-			// between path filtering and cross-variant dependencies is confirmed.
-			grip.Info(ctx, message.Fields{
-				"message":                  "kim: reinstating path-filtered variant because a non-filtered task depends on its tasks",
-				"job":                      j.ID(),
-				"patch_id":                 patchDoc.Id.Hex(),
-				"variant":                  vt.Variant,
-				"reinstated_tasks":         depVT.Tasks,
-				"reinstated_display_tasks": depVT.DisplayTasks,
-			})
-
 			filteredVTs = append(filteredVTs, depVT)
 		}
 	}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1659,88 +1659,29 @@ func (j *patchIntentProcessor) filterOutIgnoredVariants(ctx context.Context, pat
 		return ignoredVariants
 	}
 
-	changedFiles := patchDoc.FilesChanged()
+	vtsNotIgnored, candidateVTsToIgnore := partitionVariantsByPathFilter(patchDoc, patchedProject)
 
-	// keptVTs tracks those tasks are not impacted by path filtering (i.e. they
-	// either don't use path filtering or the changed files match the path
-	// filter).
-	keptVTs := []patch.VariantTasks{}
-	// candidateVTsToIgnore tracks those tasks that have path filtering and
-	// their changed files don't match the path filter (i.e. the path filter
-	// says to ignore them).
-	candidateVTsToIgnore := []patch.VariantTasks{}
-	for _, vt := range patchDoc.VariantsTasks {
-		bv := patchedProject.FindBuildVariant(vt.Variant)
-		if bv != nil && len(bv.Paths) > 0 && !bv.ChangedFilesMatchPaths(changedFiles) {
-			candidateVTsToIgnore = append(candidateVTsToIgnore, vt)
-			continue
-		}
-		keptVTs = append(keptVTs, vt)
-	}
-
-	filteredVTs := keptVTs
+	filteredVTs := vtsNotIgnored
 	if len(candidateVTsToIgnore) > 0 {
-		// A kept task may depend on a task that's going to be ignored due to
-		// path filtering. However, that task should not be path filtered out
-		// because it's a cross-variant dependency and Evergreen should preserve
-		// dependencies regardless of path filtering.
-		// Recompute dependencies for the kept tasks to determine which tasks in
-		// the ignored variants are depended on by the kept tasks.
-		keptPairs := model.VariantTasksToTVPairs(keptVTs)
-		requiredTasksAndDependencies, err := model.IncludeDependencies(patchedProject, keptPairs.ExecTasks, patchDoc.GetRequester(), nil)
-		grip.Warning(ctx, message.WrapError(err, message.Fields{
-			"message":  "resolving dependencies while filtering ignored variants",
-			"job":      j.ID(),
-			"patch_id": patchDoc.Id.Hex(),
-		}))
-
-		variantsToNeededTasks := map[string]map[string]bool{}
-		for _, pair := range requiredTasksAndDependencies {
-			if variantsToNeededTasks[pair.Variant] == nil {
-				variantsToNeededTasks[pair.Variant] = map[string]bool{}
-			}
-			variantsToNeededTasks[pair.Variant][pair.TaskName] = true
-		}
-
+		// A task that's not ignored may depend on a task in a variant that path
+		// filtering would otherwise ignore. Cross-variant dependencies must be
+		// preserved regardless of path filtering. Determine which tasks in the
+		// ignored variants need to be kept due to cross-variant dependencies.
+		variantsToNeededTasks := j.getTasksNeededByDependencies(ctx, patchDoc, patchedProject, vtsNotIgnored)
 		for _, vt := range candidateVTsToIgnore {
-			variant := vt.Variant
-			neededTasks := variantsToNeededTasks[variant]
+			neededTasks := variantsToNeededTasks[vt.Variant]
 			if len(neededTasks) == 0 {
-				// The variant is path-filtered out and none of the tasks are
-				// depended on by a kept task. Therefore, it's safe to ignore
-				// the entire variant.
-				ignoredVariants = append(ignoredVariants, variant)
+				// The variant is path-filtered out and none of its tasks are
+				// depended on by a non-ignored task, so it's safe to ignore the
+				// entire variant.
+				ignoredVariants = append(ignoredVariants, vt.Variant)
 				continue
 			}
 
 			// The variant is path-filtered but holds tasks that a kept task
-			// depends on. Reinstate only those dependency tasks (and their
-			// parent display tasks) rather than the whole variant.
-			// Note that because tasks can depend on a subset of execution
-			// tasks within a display task, it's possible for the display task
-			// to not contain all the execution tasks it would typically have
-			// because only the necessary execution tasks are kept for
-			// dependencies.
-			depVT := patch.VariantTasks{Variant: variant}
-			for _, t := range vt.Tasks {
-				if neededTasks[t] {
-					depVT.Tasks = append(depVT.Tasks, t)
-				}
-			}
-			if bv := patchedProject.FindBuildVariant(variant); bv != nil {
-				for _, dt := range vt.DisplayTasks {
-					projectDT := bv.GetDisplayTask(dt.Name)
-					if projectDT == nil {
-						continue
-					}
-					for _, et := range projectDT.ExecTasks {
-						if neededTasks[et] {
-							depVT.DisplayTasks = append(depVT.DisplayTasks, patch.DisplayTask{Name: dt.Name})
-							break
-						}
-					}
-				}
-			}
+			// depends on, so reinstate specifically those tasks (not the entire
+			// variant).
+			depVT := reinstateNeededTasksForVariant(patchedProject, vt, neededTasks)
 
 			// kim: TODO: remove this temporary debug log once the interaction
 			// between path filtering and cross-variant dependencies is confirmed.
@@ -1748,7 +1689,7 @@ func (j *patchIntentProcessor) filterOutIgnoredVariants(ctx context.Context, pat
 				"message":                  "kim: reinstating path-filtered variant because a non-filtered task depends on its tasks",
 				"job":                      j.ID(),
 				"patch_id":                 patchDoc.Id.Hex(),
-				"variant":                  variant,
+				"variant":                  vt.Variant,
 				"reinstated_tasks":         depVT.Tasks,
 				"reinstated_display_tasks": depVT.DisplayTasks,
 			})
@@ -1757,20 +1698,89 @@ func (j *patchIntentProcessor) filterOutIgnoredVariants(ctx context.Context, pat
 		}
 	}
 
-	filteredBuildVariants := make([]string, 0, len(filteredVTs))
-	for _, vt := range filteredVTs {
-		filteredBuildVariants = append(filteredBuildVariants, vt.Variant)
+	setFilteredVariantsTasks(patchDoc, filteredVTs)
+
+	return ignoredVariants
+}
+
+// partitionVariantsByPathFilter splits the patch's variant tasks into those that
+// are kept and those that can potentially be ignored A variant is a candidate
+// to be ignored when it has path filters and none of the patch's changed
+// files match them.
+func partitionVariantsByPathFilter(patchDoc *patch.Patch, patchedProject *model.Project) (vtsNotIgnored, candidateVTsToIgnore []patch.VariantTasks) {
+	changedFiles := patchDoc.FilesChanged()
+	for _, vt := range patchDoc.VariantsTasks {
+		bv := patchedProject.FindBuildVariant(vt.Variant)
+		if bv != nil && len(bv.Paths) > 0 && !bv.ChangedFilesMatchPaths(changedFiles) {
+			candidateVTsToIgnore = append(candidateVTsToIgnore, vt)
+			continue
+		}
+		vtsNotIgnored = append(vtsNotIgnored, vt)
+	}
+	return vtsNotIgnored, candidateVTsToIgnore
+}
+
+// getTasksNeededByDependencies returns, for each variant, the set of that
+// variant's task names that the tasks depend on.
+func (j *patchIntentProcessor) getTasksNeededByDependencies(ctx context.Context, patchDoc *patch.Patch, patchedProject *model.Project, vts []patch.VariantTasks) map[string]map[string]bool {
+	keptPairs := model.VariantTasksToTVPairs(vts)
+	requiredTasksAndDependencies, err := model.IncludeDependencies(patchedProject, keptPairs.ExecTasks, patchDoc.GetRequester(), nil)
+	grip.Warning(ctx, message.WrapError(err, message.Fields{
+		"message":  "hit warnings trying to resolve cross-variant dependencies on ignored variants",
+		"job":      j.ID(),
+		"patch_id": patchDoc.Id.Hex(),
+	}))
+
+	variantsToNeededTasks := map[string]map[string]bool{}
+	for _, pair := range requiredTasksAndDependencies {
+		if variantsToNeededTasks[pair.Variant] == nil {
+			variantsToNeededTasks[pair.Variant] = map[string]bool{}
+		}
+		variantsToNeededTasks[pair.Variant][pair.TaskName] = true
+	}
+	return variantsToNeededTasks
+}
+
+// reinstateNeededTasksForVariant builds the subset of neededTasksInVariant (and
+// their parent display tasks) that are needed as a dependency for a task in vt.
+// A reinstated display task may not include all of the execution tasks it would
+// normally have.
+func reinstateNeededTasksForVariant(patchedProject *model.Project, vt patch.VariantTasks, neededTasksInVariant map[string]bool) patch.VariantTasks {
+	depVT := patch.VariantTasks{Variant: vt.Variant}
+	for _, t := range vt.Tasks {
+		if neededTasksInVariant[t] {
+			depVT.Tasks = append(depVT.Tasks, t)
+		}
 	}
 
-	// Update the patch document with the filtered variants
-	patchDoc.VariantsTasks = filteredVTs
-	patchDoc.BuildVariants = filteredBuildVariants
+	bv := patchedProject.FindBuildVariant(vt.Variant)
+	if bv == nil {
+		return depVT
+	}
+	for _, dt := range vt.DisplayTasks {
+		projectDT := bv.GetDisplayTask(dt.Name)
+		if projectDT == nil {
+			continue
+		}
+		for _, et := range projectDT.ExecTasks {
+			if neededTasksInVariant[et] {
+				depVT.DisplayTasks = append(depVT.DisplayTasks, patch.DisplayTask{Name: dt.Name})
+				break
+			}
+		}
+	}
+	return depVT
+}
 
-	// Update Tasks to only include tasks that are still used by remaining variants
-	usedTasks := make(map[string]bool)
+// setFilteredVariantsTasks updates the patch document to only include the given
+// variant tasks, pruning the build variants and tasks that are no longer used.
+func setFilteredVariantsTasks(patchDoc *patch.Patch, filteredVTs []patch.VariantTasks) {
+	filteredBuildVariants := make([]string, 0, len(filteredVTs))
+	usedTasks := map[string]bool{}
 	for _, vt := range filteredVTs {
-		for _, task := range vt.Tasks {
-			usedTasks[task] = true
+		filteredBuildVariants = append(filteredBuildVariants, vt.Variant)
+		for _, t := range vt.Tasks {
+			usedTasks[t] = true
 		}
 		for _, dt := range vt.DisplayTasks {
 			usedTasks[dt.Name] = true
@@ -1778,14 +1788,15 @@ func (j *patchIntentProcessor) filterOutIgnoredVariants(ctx context.Context, pat
 	}
 
 	filteredTasks := []string{}
-	for _, task := range patchDoc.Tasks {
-		if usedTasks[task] {
-			filteredTasks = append(filteredTasks, task)
+	for _, t := range patchDoc.Tasks {
+		if usedTasks[t] {
+			filteredTasks = append(filteredTasks, t)
 		}
 	}
-	patchDoc.Tasks = filteredTasks
 
-	return ignoredVariants
+	patchDoc.VariantsTasks = filteredVTs
+	patchDoc.BuildVariants = filteredBuildVariants
+	patchDoc.Tasks = filteredTasks
 }
 
 // skipFilteringIgnoredVariants verifies that the patch should apply filtering, i.e. there are changed files,

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1651,7 +1651,7 @@ func (j *patchIntentProcessor) getEvergreenRulesForStatuses(ctx context.Context,
 }
 
 // filterOutIgnoredVariants checks which variants should be ignored based on
-// their path patterns and the changed files in the patch.If a variant is
+// their path patterns and the changed files in the patch. If a variant is
 // ignored by path filtering but has tasks that are required for cross-variant
 // dependencies, those dependencies will not be ignored (in other words,
 // dependencies can override path filtering). It removes ignored variants from
@@ -1715,8 +1715,8 @@ func partitionVariantsByPathFilter(patchDoc *patch.Patch, patchedProject *model.
 
 // getTasksAndDependencies returns a map of variants to the tasks that should
 // run in those variants. This includes:
-// 1. the initial set of tasks in vts and
-// 2. tasks that are required as dependencies of tasks in vts.
+// 1. the initial set of variants and tasks in vts and
+// 2. variants and tasks that are required dependencies of tasks in vts.
 func (j *patchIntentProcessor) getTasksAndDependencies(ctx context.Context, patchDoc *patch.Patch, patchedProject *model.Project, vts []patch.VariantTasks) map[string]map[string]bool {
 	tvPairs := model.VariantTasksToTVPairs(vts)
 	requiredTasksAndDependencies, err := model.IncludeDependencies(patchedProject, tvPairs.ExecTasks, patchDoc.GetRequester(), nil)

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -2083,20 +2083,6 @@ func TestMakeMergeQueueDescriptionOmitsMergeBaseWhenEmpty(t *testing.T) {
 	assert.Equal(t, "GitHub Merge Queue: I'm a commit! (0e312ff)", makeMergeQueueDescription(mergeGroup))
 }
 
-// kim: TODO: remove this temporary standalone test. It bypasses the suite's
-// integration-test gating (SetupTest -> ConfigureIntegrationTest) so the pure
-// in-memory filtering logic can be verified locally without integration
-// credentials. The real coverage lives in
-// PatchIntentUnitsSuite.TestFilterOutIgnoredVariants.
-func TestFilterOutIgnoredVariantsStandalone(t *testing.T) {
-	s := &PatchIntentUnitsSuite{}
-	s.project = "mci"
-	s.user = evergreen.GithubPatchUser
-	s.hash = "8b9b7ee42ef46d40e391910e3afd00e187a9dae8"
-	s.SetT(t)
-	s.TestFilterOutIgnoredVariants()
-}
-
 func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 	testCases := []struct {
 		name                    string

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -2483,71 +2483,6 @@ func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 					},
 				},
 				VariantsTasks: []patch.VariantTasks{
-					{Variant: "bvA", Tasks: []string{"taskA"}},
-					{Variant: "bvB", Tasks: []string{"taskB"}},
-				},
-				BuildVariants: []string{"bvA", "bvB"},
-				Tasks:         []string{"taskA", "taskB"},
-			},
-			project: &model.Project{
-				Identifier: s.project,
-				Tasks: []model.ProjectTask{
-					{Name: "taskA"},
-					{Name: "taskB"},
-				},
-				BuildVariants: model.BuildVariants{
-					{
-						Name:  "bvA",
-						Paths: []string{"src/**"},
-						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "taskA", Variant: "bvA"},
-						},
-					},
-					{
-						Name: "bvB",
-						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "taskB", Variant: "bvB", DependsOn: []model.TaskUnitDependency{
-								{Name: "taskA", Variant: "bvA"},
-							}},
-						},
-					},
-				},
-			},
-			// bvA is path-filtered but taskB (in the unfiltered bvB) depends on
-			// taskA, so bvA must be reinstated rather than ignored.
-			expectedIgnoredVariants: []string{},
-			expectedVariantsTasks:   2,
-			expectedBuildVariants:   2,
-			expectedTasks:           2,
-			expectedVariantTasks: map[string][]string{
-				"bvA": {"taskA"},
-				"bvB": {"taskB"},
-			},
-		},
-		{
-			name: "OnlyDependencyTaskReinstatedNotWholeVariant",
-			patchDoc: &patch.Patch{
-				Id:      mgobson.NewObjectId(),
-				Project: s.project,
-				Author:  s.user,
-				Githash: s.hash,
-				GithubPatchData: thirdparty.GithubPatch{
-					PRNumber:  123,
-					BaseOwner: "owner",
-					BaseRepo:  "repo",
-					HeadOwner: "contributor",
-					HeadRepo:  "repo",
-				},
-				Patches: []patch.ModulePatch{
-					{
-						PatchSet: patch.PatchSet{
-							Summary: []thirdparty.Summary{
-								{Name: "docs/README.md", Additions: 1, Deletions: 0},
-							},
-						},
-					},
-				},
-				VariantsTasks: []patch.VariantTasks{
 					{Variant: "bvA", Tasks: []string{"taskA", "taskX"}},
 					{Variant: "bvB", Tasks: []string{"taskB"}},
 				},
@@ -2592,7 +2527,7 @@ func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 			},
 		},
 		{
-			name: "TransitiveCrossVariantDependencyPreserved",
+			name: "TransitiveCrossVariantDependencyIntoIgnoredVariantPreserved",
 			patchDoc: &patch.Patch{
 				Id:      mgobson.NewObjectId(),
 				Project: s.project,
@@ -2631,32 +2566,32 @@ func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 				},
 				BuildVariants: model.BuildVariants{
 					{
-						Name:  "bvA",
-						Paths: []string{"src/**"},
+						Name: "bvA",
 						Tasks: []model.BuildVariantTaskUnit{
 							{Name: "taskA", Variant: "bvA", DependsOn: []model.TaskUnitDependency{
+								{Name: "taskB", Variant: "bvB"},
+							}},
+						},
+					},
+					{
+						Name:  "bvB",
+						Paths: []string{"lib/**"},
+						Tasks: []model.BuildVariantTaskUnit{
+							{Name: "taskB", Variant: "bvB", DependsOn: []model.TaskUnitDependency{
 								{Name: "taskC", Variant: "bvC"},
 							}},
 						},
 					},
 					{
-						Name: "bvB",
-						Tasks: []model.BuildVariantTaskUnit{
-							{Name: "taskB", Variant: "bvB", DependsOn: []model.TaskUnitDependency{
-								{Name: "taskA", Variant: "bvA"},
-							}},
-						},
-					},
-					{
 						Name:  "bvC",
-						Paths: []string{"lib/**"},
+						Paths: []string{"src/**"},
 						Tasks: []model.BuildVariantTaskUnit{
 							{Name: "taskC", Variant: "bvC"},
 						},
 					},
 				},
 			},
-			// taskB depends on taskA (bvA) which depends on taskC (bvC); both
+			// taskA depends on taskB (bvB) which depends on taskC (bvC); both
 			// path-filtered variants must be reinstated transitively.
 			expectedIgnoredVariants: []string{},
 			expectedVariantsTasks:   3,
@@ -2669,7 +2604,7 @@ func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 			},
 		},
 		{
-			name: "DisplayTaskWrapperPreservedForReinstatedDependency",
+			name: "DisplayTaskPreservedForCrossVariantDependencyIntoIgnoredVariant",
 			patchDoc: &patch.Patch{
 				Id:      mgobson.NewObjectId(),
 				Project: s.project,
@@ -2818,7 +2753,7 @@ func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 	for _, tc := range testCases {
 		s.T().Run(tc.name, func(t *testing.T) {
 			j := &patchIntentProcessor{}
-			ctx := context.Background()
+			ctx := t.Context()
 			ignoredVariants := j.filterOutIgnoredVariants(ctx, tc.patchDoc, tc.project)
 
 			assert.Equal(t, tc.expectedIgnoredVariants, ignoredVariants)

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -2083,6 +2083,20 @@ func TestMakeMergeQueueDescriptionOmitsMergeBaseWhenEmpty(t *testing.T) {
 	assert.Equal(t, "GitHub Merge Queue: I'm a commit! (0e312ff)", makeMergeQueueDescription(mergeGroup))
 }
 
+// kim: TODO: remove this temporary standalone test. It bypasses the suite's
+// integration-test gating (SetupTest -> ConfigureIntegrationTest) so the pure
+// in-memory filtering logic can be verified locally without integration
+// credentials. The real coverage lives in
+// PatchIntentUnitsSuite.TestFilterOutIgnoredVariants.
+func TestFilterOutIgnoredVariantsStandalone(t *testing.T) {
+	s := &PatchIntentUnitsSuite{}
+	s.project = "mci"
+	s.user = evergreen.GithubPatchUser
+	s.hash = "8b9b7ee42ef46d40e391910e3afd00e187a9dae8"
+	s.SetT(t)
+	s.TestFilterOutIgnoredVariants()
+}
+
 func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 	testCases := []struct {
 		name                    string
@@ -2094,6 +2108,12 @@ func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 		expectedTasks           int
 		expectedVariantNames    []string
 		expectedTaskNames       []string
+		// expectedVariantTasks, when set, asserts the exact tasks kept for each
+		// named variant regardless of variant ordering.
+		expectedVariantTasks map[string][]string
+		// expectedVariantDisplayTasks, when set, asserts the exact display tasks
+		// kept for each named variant regardless of variant ordering.
+		expectedVariantDisplayTasks map[string][]string
 	}{
 		{
 			name: "NonGitHubPRPatch",
@@ -2453,6 +2473,360 @@ func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 			expectedBuildVariants:   2,
 			expectedTasks:           2,
 		},
+		{
+			name: "CrossVariantDependencyIntoIgnoredVariantIsPreserved",
+			patchDoc: &patch.Patch{
+				Id:      mgobson.NewObjectId(),
+				Project: s.project,
+				Author:  s.user,
+				Githash: s.hash,
+				GithubPatchData: thirdparty.GithubPatch{
+					PRNumber:  123,
+					BaseOwner: "owner",
+					BaseRepo:  "repo",
+					HeadOwner: "contributor",
+					HeadRepo:  "repo",
+				},
+				Patches: []patch.ModulePatch{
+					{
+						PatchSet: patch.PatchSet{
+							Summary: []thirdparty.Summary{
+								{Name: "docs/README.md", Additions: 1, Deletions: 0},
+							},
+						},
+					},
+				},
+				VariantsTasks: []patch.VariantTasks{
+					{Variant: "bvA", Tasks: []string{"taskA"}},
+					{Variant: "bvB", Tasks: []string{"taskB"}},
+				},
+				BuildVariants: []string{"bvA", "bvB"},
+				Tasks:         []string{"taskA", "taskB"},
+			},
+			project: &model.Project{
+				Identifier: s.project,
+				Tasks: []model.ProjectTask{
+					{Name: "taskA"},
+					{Name: "taskB"},
+				},
+				BuildVariants: model.BuildVariants{
+					{
+						Name:  "bvA",
+						Paths: []string{"src/**"},
+						Tasks: []model.BuildVariantTaskUnit{
+							{Name: "taskA", Variant: "bvA"},
+						},
+					},
+					{
+						Name: "bvB",
+						Tasks: []model.BuildVariantTaskUnit{
+							{Name: "taskB", Variant: "bvB", DependsOn: []model.TaskUnitDependency{
+								{Name: "taskA", Variant: "bvA"},
+							}},
+						},
+					},
+				},
+			},
+			// bvA is path-filtered but taskB (in the unfiltered bvB) depends on
+			// taskA, so bvA must be reinstated rather than ignored.
+			expectedIgnoredVariants: []string{},
+			expectedVariantsTasks:   2,
+			expectedBuildVariants:   2,
+			expectedTasks:           2,
+			expectedVariantTasks: map[string][]string{
+				"bvA": {"taskA"},
+				"bvB": {"taskB"},
+			},
+		},
+		{
+			name: "OnlyDependencyTaskReinstatedNotWholeVariant",
+			patchDoc: &patch.Patch{
+				Id:      mgobson.NewObjectId(),
+				Project: s.project,
+				Author:  s.user,
+				Githash: s.hash,
+				GithubPatchData: thirdparty.GithubPatch{
+					PRNumber:  123,
+					BaseOwner: "owner",
+					BaseRepo:  "repo",
+					HeadOwner: "contributor",
+					HeadRepo:  "repo",
+				},
+				Patches: []patch.ModulePatch{
+					{
+						PatchSet: patch.PatchSet{
+							Summary: []thirdparty.Summary{
+								{Name: "docs/README.md", Additions: 1, Deletions: 0},
+							},
+						},
+					},
+				},
+				VariantsTasks: []patch.VariantTasks{
+					{Variant: "bvA", Tasks: []string{"taskA", "taskX"}},
+					{Variant: "bvB", Tasks: []string{"taskB"}},
+				},
+				BuildVariants: []string{"bvA", "bvB"},
+				Tasks:         []string{"taskA", "taskX", "taskB"},
+			},
+			project: &model.Project{
+				Identifier: s.project,
+				Tasks: []model.ProjectTask{
+					{Name: "taskA"},
+					{Name: "taskX"},
+					{Name: "taskB"},
+				},
+				BuildVariants: model.BuildVariants{
+					{
+						Name:  "bvA",
+						Paths: []string{"src/**"},
+						Tasks: []model.BuildVariantTaskUnit{
+							{Name: "taskA", Variant: "bvA"},
+							{Name: "taskX", Variant: "bvA"},
+						},
+					},
+					{
+						Name: "bvB",
+						Tasks: []model.BuildVariantTaskUnit{
+							{Name: "taskB", Variant: "bvB", DependsOn: []model.TaskUnitDependency{
+								{Name: "taskA", Variant: "bvA"},
+							}},
+						},
+					},
+				},
+			},
+			// Only taskA is depended on, so taskX in the path-filtered bvA is
+			// still dropped while taskA is reinstated.
+			expectedIgnoredVariants: []string{},
+			expectedVariantsTasks:   2,
+			expectedBuildVariants:   2,
+			expectedTasks:           2,
+			expectedVariantTasks: map[string][]string{
+				"bvA": {"taskA"},
+				"bvB": {"taskB"},
+			},
+		},
+		{
+			name: "TransitiveCrossVariantDependencyPreserved",
+			patchDoc: &patch.Patch{
+				Id:      mgobson.NewObjectId(),
+				Project: s.project,
+				Author:  s.user,
+				Githash: s.hash,
+				GithubPatchData: thirdparty.GithubPatch{
+					PRNumber:  123,
+					BaseOwner: "owner",
+					BaseRepo:  "repo",
+					HeadOwner: "contributor",
+					HeadRepo:  "repo",
+				},
+				Patches: []patch.ModulePatch{
+					{
+						PatchSet: patch.PatchSet{
+							Summary: []thirdparty.Summary{
+								{Name: "docs/README.md", Additions: 1, Deletions: 0},
+							},
+						},
+					},
+				},
+				VariantsTasks: []patch.VariantTasks{
+					{Variant: "bvA", Tasks: []string{"taskA"}},
+					{Variant: "bvB", Tasks: []string{"taskB"}},
+					{Variant: "bvC", Tasks: []string{"taskC"}},
+				},
+				BuildVariants: []string{"bvA", "bvB", "bvC"},
+				Tasks:         []string{"taskA", "taskB", "taskC"},
+			},
+			project: &model.Project{
+				Identifier: s.project,
+				Tasks: []model.ProjectTask{
+					{Name: "taskA"},
+					{Name: "taskB"},
+					{Name: "taskC"},
+				},
+				BuildVariants: model.BuildVariants{
+					{
+						Name:  "bvA",
+						Paths: []string{"src/**"},
+						Tasks: []model.BuildVariantTaskUnit{
+							{Name: "taskA", Variant: "bvA", DependsOn: []model.TaskUnitDependency{
+								{Name: "taskC", Variant: "bvC"},
+							}},
+						},
+					},
+					{
+						Name: "bvB",
+						Tasks: []model.BuildVariantTaskUnit{
+							{Name: "taskB", Variant: "bvB", DependsOn: []model.TaskUnitDependency{
+								{Name: "taskA", Variant: "bvA"},
+							}},
+						},
+					},
+					{
+						Name:  "bvC",
+						Paths: []string{"lib/**"},
+						Tasks: []model.BuildVariantTaskUnit{
+							{Name: "taskC", Variant: "bvC"},
+						},
+					},
+				},
+			},
+			// taskB depends on taskA (bvA) which depends on taskC (bvC); both
+			// path-filtered variants must be reinstated transitively.
+			expectedIgnoredVariants: []string{},
+			expectedVariantsTasks:   3,
+			expectedBuildVariants:   3,
+			expectedTasks:           3,
+			expectedVariantTasks: map[string][]string{
+				"bvA": {"taskA"},
+				"bvB": {"taskB"},
+				"bvC": {"taskC"},
+			},
+		},
+		{
+			name: "DisplayTaskWrapperPreservedForReinstatedDependency",
+			patchDoc: &patch.Patch{
+				Id:      mgobson.NewObjectId(),
+				Project: s.project,
+				Author:  s.user,
+				Githash: s.hash,
+				GithubPatchData: thirdparty.GithubPatch{
+					PRNumber:  123,
+					BaseOwner: "owner",
+					BaseRepo:  "repo",
+					HeadOwner: "contributor",
+					HeadRepo:  "repo",
+				},
+				Patches: []patch.ModulePatch{
+					{
+						PatchSet: patch.PatchSet{
+							Summary: []thirdparty.Summary{
+								{Name: "docs/README.md", Additions: 1, Deletions: 0},
+							},
+						},
+					},
+				},
+				VariantsTasks: []patch.VariantTasks{
+					{
+						Variant: "bvA",
+						Tasks:   []string{"unit-test", "integration-test"},
+						DisplayTasks: []patch.DisplayTask{
+							{Name: "suite", ExecTasks: []string{"unit-test", "integration-test"}},
+						},
+					},
+					{Variant: "bvB", Tasks: []string{"taskB"}},
+				},
+				BuildVariants: []string{"bvA", "bvB"},
+				Tasks:         []string{"unit-test", "integration-test", "taskB", "suite"},
+			},
+			project: &model.Project{
+				Identifier: s.project,
+				Tasks: []model.ProjectTask{
+					{Name: "unit-test"},
+					{Name: "integration-test"},
+					{Name: "taskB"},
+				},
+				BuildVariants: model.BuildVariants{
+					{
+						Name:  "bvA",
+						Paths: []string{"src/**"},
+						Tasks: []model.BuildVariantTaskUnit{
+							{Name: "unit-test", Variant: "bvA"},
+							{Name: "integration-test", Variant: "bvA"},
+						},
+						DisplayTasks: []patch.DisplayTask{
+							{Name: "suite", ExecTasks: []string{"unit-test", "integration-test"}},
+						},
+					},
+					{
+						Name: "bvB",
+						Tasks: []model.BuildVariantTaskUnit{
+							{Name: "taskB", Variant: "bvB", DependsOn: []model.TaskUnitDependency{
+								{Name: "unit-test", Variant: "bvA"},
+							}},
+						},
+					},
+				},
+			},
+			// taskB depends on unit-test, which is grouped under the "suite"
+			// display task, so the display task wrapper is preserved even though
+			// integration-test is dropped.
+			expectedIgnoredVariants: []string{},
+			expectedVariantsTasks:   2,
+			expectedBuildVariants:   2,
+			// patchDoc.Tasks keeps unit-test (reinstated), taskB, and the "suite"
+			// display task, dropping the unneeded integration-test.
+			expectedTasks: 3,
+			expectedVariantTasks: map[string][]string{
+				"bvA": {"unit-test"},
+				"bvB": {"taskB"},
+			},
+			expectedVariantDisplayTasks: map[string][]string{
+				"bvA": {"suite"},
+				"bvB": {},
+			},
+		},
+		{
+			name: "IgnoredVariantWithNoDependentsStillIgnored",
+			patchDoc: &patch.Patch{
+				Id:      mgobson.NewObjectId(),
+				Project: s.project,
+				Author:  s.user,
+				Githash: s.hash,
+				GithubPatchData: thirdparty.GithubPatch{
+					PRNumber:  123,
+					BaseOwner: "owner",
+					BaseRepo:  "repo",
+					HeadOwner: "contributor",
+					HeadRepo:  "repo",
+				},
+				Patches: []patch.ModulePatch{
+					{
+						PatchSet: patch.PatchSet{
+							Summary: []thirdparty.Summary{
+								{Name: "src/main.go", Additions: 1, Deletions: 0},
+							},
+						},
+					},
+				},
+				VariantsTasks: []patch.VariantTasks{
+					{Variant: "bvA", Tasks: []string{"taskA"}},
+					{Variant: "bvB", Tasks: []string{"taskB"}},
+				},
+				BuildVariants: []string{"bvA", "bvB"},
+				Tasks:         []string{"taskA", "taskB"},
+			},
+			project: &model.Project{
+				Identifier: s.project,
+				Tasks: []model.ProjectTask{
+					{Name: "taskA"},
+					{Name: "taskB"},
+				},
+				BuildVariants: model.BuildVariants{
+					{
+						Name:  "bvA",
+						Paths: []string{"src/**"},
+						Tasks: []model.BuildVariantTaskUnit{
+							{Name: "taskA", Variant: "bvA"},
+						},
+					},
+					{
+						Name:  "bvB",
+						Paths: []string{"docs/**"},
+						Tasks: []model.BuildVariantTaskUnit{
+							{Name: "taskB", Variant: "bvB"},
+						},
+					},
+				},
+			},
+			// bvB has no changed files matching its paths and nothing depends on
+			// taskB, so it is still ignored.
+			expectedIgnoredVariants: []string{"bvB"},
+			expectedVariantsTasks:   1,
+			expectedBuildVariants:   1,
+			expectedTasks:           1,
+			expectedVariantNames:    []string{"bvA"},
+			expectedTaskNames:       []string{"taskA"},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -2476,6 +2850,29 @@ func (s *PatchIntentUnitsSuite) TestFilterOutIgnoredVariants() {
 
 			if tc.expectedTaskNames != nil {
 				assert.Equal(t, tc.expectedTaskNames, tc.patchDoc.Tasks)
+			}
+
+			if tc.expectedVariantTasks != nil {
+				actualVariantTasks := map[string][]string{}
+				for _, vt := range tc.patchDoc.VariantsTasks {
+					actualVariantTasks[vt.Variant] = vt.Tasks
+				}
+				assert.Len(t, actualVariantTasks, len(tc.expectedVariantTasks))
+				for variant, expectedTasks := range tc.expectedVariantTasks {
+					assert.ElementsMatch(t, expectedTasks, actualVariantTasks[variant], "variant '%s'", variant)
+				}
+			}
+
+			if tc.expectedVariantDisplayTasks != nil {
+				actualDisplayTasks := map[string][]string{}
+				for _, vt := range tc.patchDoc.VariantsTasks {
+					for _, dt := range vt.DisplayTasks {
+						actualDisplayTasks[vt.Variant] = append(actualDisplayTasks[vt.Variant], dt.Name)
+					}
+				}
+				for variant, expectedDisplayTasks := range tc.expectedVariantDisplayTasks {
+					assert.ElementsMatch(t, expectedDisplayTasks, actualDisplayTasks[variant], "variant '%s'", variant)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
DEVPROD-33607

### Description

Fixes an issue where if path filter is enabled and none of the changed files apply to the paths, it'll also prevent creating dependencies in those filtered-out variants. For example:
```yaml
buildvariants:
- name: bvA
  paths:
    - "*.go"
  tasks:
    - name: taskA # Task can be filtered out by paths
- name: bvB
  tasks:
    - name: taskB
      depends_on:
        # Cross-variant dependency on a task that could be filtered out by paths
        - name: taskA
          variant: bvA
```

In PR/merge queue patches, taskB will always run, but taskA won't be created at all if a Go file isn't modified, so taskB will just run with no dependency. I changed it to create a task if it's required as a dependency, even if path filtering says the task is not needed.

* Keep cross-variant dependencies in build variants that may be ignored by path filtering.
* Refactor the path filtering logic into some helpers for readability.

### Testing

* Added unit tests.
* Tested in [personal staging PR patch](https://github.com/evergreen-ci/commit-queue-sandbox/pull/861) that pre-change, it wouldn't create a cross-variant dependency task if it's ignored by path filtering. Post-change, it does create the cross-variant dependency.

### Documentation
N/A - this seems more intuitive with how dependencies typically behave, so I don't think we need to document this specific interaction.