### PR TITLE
DEVPROD-37076 Coalesce parser-project reads for concurrent same-version requests

### DIFF
--- a/model/project.go
+++ b/model/project.go
@@ -1353,7 +1353,9 @@ func FindLatestVersionWithValidProject(ctx context.Context, projectId string, pr
 		}
 
 		env := evergreen.GetEnvironment()
-		project, pp, err = FindAndTranslateProjectForVersion(ctx, env.Settings(), lastGoodVersion, preGeneration)
+		// The preGeneration path returns a pp that the caller (patch intent) mutates and re-upserts,
+		// so it must not share a coalesced read. Other callers discard pp and can coalesce.
+		project, pp, err = FindAndTranslateProjectForVersionWithOpts(ctx, env.Settings(), lastGoodVersion, preGeneration, !preGeneration)
 		if err != nil {
 			grip.Error(ctx, message.WrapError(err, message.Fields{
 				"message": "last known good version has malformed config",

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -672,9 +672,10 @@ func FindAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.
 	return findAndTranslateProjectForVersion(ctx, settings, v.Id, v.Identifier, v.ProjectStorageMethod, v.PreGenerationProjectStorageMethod, preGeneration, true)
 }
 
-// FindAndTranslateProjectForVersionWithOpts is like FindAndTranslateProjectForVersion but lets the
-// caller opt out of read coalescing. A caller that mutates the returned *ParserProject must pass
-// coalesceRead=false so it gets its own (unshared) parser project.
+// FindAndTranslateProjectForVersionWithOpts is like FindAndTranslateProjectForVersion but exposes two flags:
+//   - preGeneration: true for the parser project from before generate.tasks modified it; false (typical) for the current one.
+//   - coalesceRead: true (typical) to share one read across concurrent same-version callers, yielding a shared read-only
+//     *ParserProject. Pass false only if you must mutate the returned *ParserProject, which guarantees an unshared copy.
 func FindAndTranslateProjectForVersionWithOpts(ctx context.Context, settings *evergreen.Settings, v *Version, preGeneration, coalesceRead bool) (*Project, *ParserProject, error) {
 	return findAndTranslateProjectForVersion(ctx, settings, v.Id, v.Identifier, v.ProjectStorageMethod, v.PreGenerationProjectStorageMethod, preGeneration, coalesceRead)
 }

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -587,6 +587,11 @@ const (
 	// for the same version was already translating it, and shared that in-flight result instead
 	// of starting a redundant translation of its own.
 	ppTranslationDedupedOtelAttribute = "evergreen.parser_project.translation_deduped"
+	// ppReadDedupedOtelAttribute records whether this call was a follower that shared another
+	// in-flight request's parser-project read + translate for the same version instead of doing its
+	// own read. It counts followers only (reads saved), not the leader, so it reflects raw
+	// same-version request concurrency independent of the LRU state.
+	ppReadDedupedOtelAttribute = "evergreen.parser_project.read_deduped"
 	// ppTranslationCacheSizeOtelAttribute records how many translations the LRU is holding right now.
 	ppTranslationCacheSizeOtelAttribute = "evergreen.parser_project.translation_cache_size"
 	// ppTranslationCacheBytesOtelAttribute records the estimated byte total of the translations the
@@ -647,6 +652,10 @@ func FindAndTranslateProjectForVersionID(ctx context.Context, settings *evergree
 	return FindAndTranslateProjectForVersion(ctx, settings, v, preGeneration)
 }
 
+// parserProjectReadTimeout bounds a single coalesced read + translate, so a hung S3 read can't pin
+// the read singleflight slot indefinitely for the whole burst waiting behind it.
+const parserProjectReadTimeout = 90 * time.Second
+
 // FindAndTranslateProjectForVersion translates a parser project for a version into a Project.
 // Also sets the project ID. If the preGeneration flag is true, this function will attempt to
 // fetch and translate the parser project from before it was modified by generate.tasks.
@@ -654,34 +663,96 @@ func FindAndTranslateProjectForVersionID(ctx context.Context, settings *evergree
 // The returned *Project is the caller's own value: its top-level slices and maps (BuildVariants,
 // Tasks, Modules, etc.) are safe to reorder, append to, or replace. Structures nested below that
 // level are shared with the cache and must not be mutated.
+//
+// The returned *ParserProject is shared and read-only: concurrent same-version callers may receive
+// the same pointer via read coalescing, so it must not be mutated. Callers that transform the parser
+// project must clone it first or use FindAndTranslateProjectForVersionWithOpts to opt out of the
+// coalesced read.
 func FindAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.Settings, v *Version, preGeneration bool) (*Project, *ParserProject, error) {
-	return findAndTranslateProjectForVersion(ctx, settings, v.Id, v.Identifier, v.ProjectStorageMethod, v.PreGenerationProjectStorageMethod, preGeneration)
+	return findAndTranslateProjectForVersion(ctx, settings, v.Id, v.Identifier, v.ProjectStorageMethod, v.PreGenerationProjectStorageMethod, preGeneration, true)
 }
 
-func findAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.Settings, versionID, versionIdentifier string, projectStorageMethod, preGenerationProjectStorageMethod evergreen.ParserProjectStorageMethod, preGeneration bool) (*Project, *ParserProject, error) {
+// FindAndTranslateProjectForVersionWithOpts is like FindAndTranslateProjectForVersion but lets the
+// caller opt out of read coalescing. A caller that mutates the returned *ParserProject must pass
+// coalesceRead=false so it gets its own (unshared) parser project.
+func FindAndTranslateProjectForVersionWithOpts(ctx context.Context, settings *evergreen.Settings, v *Version, preGeneration, coalesceRead bool) (*Project, *ParserProject, error) {
+	return findAndTranslateProjectForVersion(ctx, settings, v.Id, v.Identifier, v.ProjectStorageMethod, v.PreGenerationProjectStorageMethod, preGeneration, coalesceRead)
+}
+
+// readTranslationResult packages the shared read + translate result so read-coalesced followers get
+// the same partial result (including any error) as the leader, mirroring the inner translationResult
+// pattern.
+type readTranslationResult struct {
+	project *Project
+	pp      *ParserProject
+	err     error
+}
+
+func findAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.Settings, versionID, versionIdentifier string, projectStorageMethod, preGenerationProjectStorageMethod evergreen.ParserProjectStorageMethod, preGeneration, coalesceRead bool) (*Project, *ParserProject, error) {
 	ctx, span := tracer.Start(ctx, "FindAndTranslateProjectForVersion", trace.WithAttributes(
 		attribute.String(evergreen.VersionIDOtelAttribute, versionID),
 		attribute.Bool(ppPreGenerationOtelAttribute, preGeneration),
 	))
 	defer span.End()
 
+	res, readDeduped := readAndTranslateProjectForVersionCoalesced(ctx, span, settings, versionID, versionIdentifier, projectStorageMethod, preGenerationProjectStorageMethod, preGeneration, coalesceRead)
+	span.SetAttributes(attribute.Bool(ppReadDedupedOtelAttribute, readDeduped))
+	return res.project, res.pp, res.err
+}
+
+// readAndTranslateProjectForVersionCoalesced runs the read + translate, optionally coalescing
+// concurrent same-version requests through the read singleflight. readDeduped reports whether this
+// call was a follower that shared another in-flight request's result (leaders and non-coalesced
+// calls report false), so it counts reads saved.
+func readAndTranslateProjectForVersionCoalesced(ctx context.Context, span trace.Span, settings *evergreen.Settings, versionID, versionIdentifier string, projectStorageMethod, preGenerationProjectStorageMethod evergreen.ParserProjectStorageMethod, preGeneration, coalesceRead bool) (readTranslationResult, bool) {
+	if !coalesceRead {
+		return readAndTranslateProjectForVersion(ctx, span, settings, versionID, versionIdentifier, projectStorageMethod, preGenerationProjectStorageMethod, preGeneration), false
+	}
+
+	storageMethod := projectStorageMethod
+	if preGeneration {
+		storageMethod = preGenerationProjectStorageMethod
+	}
+	key := versionReadKey(versionID, preGeneration, storageMethod)
+
+	// leader is set only inside the executed closure, so followers can be counted separately from the
+	// single leader for an accurate "reads saved" metric.
+	leader := false
+	v, sfErr, shared := getReadTranslationGroup().Do(key, func() (any, error) {
+		leader = true
+		// Detach from the leader's cancellation but keep an explicit deadline, so a follower with a
+		// live context isn't failed by the leader cancelling, while a hung read can't pin the slot
+		// forever. Failures are not cached: singleflight forgets the key when the closure returns.
+		readCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), parserProjectReadTimeout)
+		defer cancel()
+		return readAndTranslateProjectForVersion(readCtx, span, settings, versionID, versionIdentifier, projectStorageMethod, preGenerationProjectStorageMethod, preGeneration), nil
+	})
+	if sfErr != nil {
+		return readTranslationResult{err: sfErr}, false
+	}
+	return v.(readTranslationResult), shared && !leader
+}
+
+// readAndTranslateProjectForVersion performs the parser-project read (with a bounded retry) and
+// translate for a version. It is the shared body run under the read singleflight.
+func readAndTranslateProjectForVersion(ctx context.Context, span trace.Span, settings *evergreen.Settings, versionID, versionIdentifier string, projectStorageMethod, preGenerationProjectStorageMethod evergreen.ParserProjectStorageMethod, preGeneration bool) readTranslationResult {
 	var pp *ParserProject
 	var err error
 	if preGeneration {
 		preGeneratedId := preGeneratedParserProjectId(versionID)
-		pp, err = ParserProjectFindOneByID(ctx, settings, preGenerationProjectStorageMethod, preGeneratedId)
+		pp, err = findParserProjectWithRetry(ctx, settings, preGenerationProjectStorageMethod, preGeneratedId)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "finding parser project '%s'", preGeneratedId)
+			return readTranslationResult{err: errors.Wrapf(err, "finding parser project '%s'", preGeneratedId)}
 		}
 		// Fall back to the parser project post-generation if the pre-generation parser project was not found
 	}
 	if pp == nil {
-		pp, err = ParserProjectFindOneByID(ctx, settings, projectStorageMethod, versionID)
+		pp, err = findParserProjectWithRetry(ctx, settings, projectStorageMethod, versionID)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "finding parser project '%s'", versionID)
+			return readTranslationResult{err: errors.Wrapf(err, "finding parser project '%s'", versionID)}
 		}
 		if pp == nil {
-			return nil, nil, errors.Errorf("parser project not found for version '%s'", versionID)
+			return readTranslationResult{err: errors.Errorf("parser project not found for version '%s'", versionID)}
 		}
 	}
 	// Setting the translated project's ID is necessary here because some old
@@ -693,9 +764,26 @@ func findAndTranslateProjectForVersion(ctx context.Context, settings *evergreen.
 	cacheEnabled := projectTranslationCacheEnabled(settings)
 	p, err := translateAndCache(ctx, span, pp, versionIdentifier, versionTranslationKey(versionID, preGeneration), cacheEnabled)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "translating parser project '%s'", versionID)
+		return readTranslationResult{err: errors.Wrapf(err, "translating parser project '%s'", versionID)}
 	}
-	return p, pp, nil
+	return readTranslationResult{project: p, pp: pp}
+}
+
+// parserProjectFindOneByID is the parser-project read seam, overridable in tests to count reads and
+// inject failures.
+var parserProjectFindOneByID = ParserProjectFindOneByID
+
+// findParserProjectWithRetry reads a parser project with a bounded retry. Because read coalescing
+// correlates one transient failure across the whole burst and several callers don't retry, one
+// retry absorbs a transient blip for the entire burst without multiplying load.
+func findParserProjectWithRetry(ctx context.Context, settings *evergreen.Settings, method evergreen.ParserProjectStorageMethod, id string) (*ParserProject, error) {
+	var pp *ParserProject
+	err := utility.Retry(ctx, func() (bool, error) {
+		var err error
+		pp, err = parserProjectFindOneByID(ctx, settings, method, id)
+		return true, err
+	}, utility.RetryOptions{MaxAttempts: 2, MinDelay: 100 * time.Millisecond, MaxDelay: time.Second})
+	return pp, err
 }
 
 // LoadProjectInfoForVersion returns the project info for a version from its parser project.

--- a/model/project_read_coalesce_test.go
+++ b/model/project_read_coalesce_test.go
@@ -1,0 +1,259 @@
+package model
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/utility"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setParserProjectReadForTesting swaps the parser-project read seam and restores it on cleanup.
+func setParserProjectReadForTesting(t *testing.T, fn func(ctx context.Context, settings *evergreen.Settings, method evergreen.ParserProjectStorageMethod, id string) (*ParserProject, error)) {
+	orig := parserProjectFindOneByID
+	parserProjectFindOneByID = fn
+	t.Cleanup(func() { parserProjectFindOneByID = orig })
+}
+
+func TestReadCoalescing(t *testing.T) {
+	t.Run("ConcurrentSameVersionReadsPerformExactlyOneRead", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		resetTranslationCacheForTesting()
+
+		var reads atomic.Int64
+		release := make(chan struct{})
+		started := make(chan struct{}, 1)
+		setParserProjectReadForTesting(t, func(ctx context.Context, _ *evergreen.Settings, _ evergreen.ParserProjectStorageMethod, id string) (*ParserProject, error) {
+			reads.Add(1)
+			started <- struct{}{}
+			<-release
+			return &ParserProject{Id: id}, nil
+		})
+
+		const n = 5
+		var dedupedCount, leaderCount atomic.Int64
+		var wg sync.WaitGroup
+
+		// Launch the leader and wait until its read is in flight, so the followers coalesce.
+		_, leaderSpan := tracer.Start(t.Context(), "leader")
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			res, deduped := readAndTranslateProjectForVersionCoalesced(t.Context(), leaderSpan, &evergreen.Settings{}, "v1", "", evergreen.ProjectStorageMethodDB, "", false, true)
+			require.NoError(t, res.err)
+			if deduped {
+				dedupedCount.Add(1)
+			} else {
+				leaderCount.Add(1)
+			}
+		}()
+		<-started
+
+		for range n - 1 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, span := tracer.Start(t.Context(), "follower")
+				res, deduped := readAndTranslateProjectForVersionCoalesced(t.Context(), span, &evergreen.Settings{}, "v1", "", evergreen.ProjectStorageMethodDB, "", false, true)
+				require.NoError(t, res.err)
+				if deduped {
+					dedupedCount.Add(1)
+				} else {
+					leaderCount.Add(1)
+				}
+			}()
+		}
+
+		// Give followers time to join the in-flight singleflight before releasing the read.
+		time.Sleep(100 * time.Millisecond)
+		close(release)
+		wg.Wait()
+
+		assert.Equal(t, int64(1), reads.Load(), "a burst of same-version reads performs exactly one read")
+		assert.Equal(t, int64(1), leaderCount.Load(), "exactly one leader")
+		assert.Equal(t, int64(n-1), dedupedCount.Load(), "all followers report read_deduped")
+	})
+
+	t.Run("DifferentVersionsAreNotCoalesced", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		resetTranslationCacheForTesting()
+
+		var reads atomic.Int64
+		release := make(chan struct{})
+		var startedWG sync.WaitGroup
+		startedWG.Add(2)
+		setParserProjectReadForTesting(t, func(ctx context.Context, _ *evergreen.Settings, _ evergreen.ParserProjectStorageMethod, id string) (*ParserProject, error) {
+			reads.Add(1)
+			startedWG.Done()
+			<-release
+			return &ParserProject{Id: id}, nil
+		})
+
+		var wg sync.WaitGroup
+		for _, versionID := range []string{"v1", "v2"} {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, span := tracer.Start(t.Context(), "call")
+				res, deduped := readAndTranslateProjectForVersionCoalesced(t.Context(), span, &evergreen.Settings{}, versionID, "", evergreen.ProjectStorageMethodDB, "", false, true)
+				require.NoError(t, res.err)
+				assert.False(t, deduped, "different versions never coalesce")
+			}()
+		}
+		startedWG.Wait()
+		close(release)
+		wg.Wait()
+
+		assert.Equal(t, int64(2), reads.Load(), "different versions each read")
+	})
+
+	t.Run("OptedOutReadsAreNotShared", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		resetTranslationCacheForTesting()
+
+		release := make(chan struct{})
+		started := make(chan struct{}, 2)
+		setParserProjectReadForTesting(t, func(ctx context.Context, _ *evergreen.Settings, _ evergreen.ParserProjectStorageMethod, id string) (*ParserProject, error) {
+			started <- struct{}{}
+			<-release
+			return &ParserProject{Id: id, Tasks: []parserTask{{Name: "t"}}}, nil
+		})
+
+		var mu sync.Mutex
+		var pps []*ParserProject
+		var wg sync.WaitGroup
+		for range 2 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				// coalesceRead=false, as the generate path uses, so each caller gets its own pp.
+				_, pp, err := FindAndTranslateProjectForVersionWithOpts(t.Context(), &evergreen.Settings{}, &Version{Id: "v1", ProjectStorageMethod: evergreen.ProjectStorageMethodDB}, false, false)
+				require.NoError(t, err)
+				mu.Lock()
+				pps = append(pps, pp)
+				mu.Unlock()
+			}()
+		}
+		<-started
+		<-started
+		close(release)
+		wg.Wait()
+
+		require.Len(t, pps, 2)
+		assert.NotSame(t, pps[0], pps[1], "opted-out callers must not share a parser project pointer")
+		// Mutating one must not affect the other, as the generate path mutates pp in place.
+		pps[0].Tasks = append(pps[0].Tasks, parserTask{Name: "generated"})
+		assert.Len(t, pps[1].Tasks, 1, "a mutation of one caller's pp must not be visible to another")
+	})
+
+	t.Run("LeaderContextCancellationDoesNotFailFollower", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		resetTranslationCacheForTesting()
+
+		release := make(chan struct{})
+		started := make(chan struct{}, 1)
+		setParserProjectReadForTesting(t, func(ctx context.Context, _ *evergreen.Settings, _ evergreen.ParserProjectStorageMethod, id string) (*ParserProject, error) {
+			started <- struct{}{}
+			<-release
+			// The detached read context must stay live even after a caller cancels.
+			require.NoError(t, ctx.Err())
+			return &ParserProject{Id: id}, nil
+		})
+
+		leaderCtx, cancelLeader := context.WithCancel(t.Context())
+		var wg sync.WaitGroup
+		var leaderErr, followerErr error
+
+		_, leaderSpan := tracer.Start(leaderCtx, "leader")
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			res, _ := readAndTranslateProjectForVersionCoalesced(leaderCtx, leaderSpan, &evergreen.Settings{}, "v1", "", evergreen.ProjectStorageMethodDB, "", false, true)
+			leaderErr = res.err
+		}()
+		<-started
+
+		_, followerSpan := tracer.Start(t.Context(), "follower")
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			res, _ := readAndTranslateProjectForVersionCoalesced(t.Context(), followerSpan, &evergreen.Settings{}, "v1", "", evergreen.ProjectStorageMethodDB, "", false, true)
+			followerErr = res.err
+		}()
+
+		time.Sleep(100 * time.Millisecond)
+		cancelLeader()
+		close(release)
+		wg.Wait()
+
+		assert.NoError(t, leaderErr, "detached context lets the leader finish despite cancellation")
+		assert.NoError(t, followerErr, "a follower with a live context is not failed by the leader cancelling")
+	})
+
+	t.Run("ReadErrorIsSurfacedToAllCallersAndNotCached", func(t *testing.T) {
+		t.Cleanup(resetTranslationCacheForTesting)
+		resetTranslationCacheForTesting()
+
+		readErr := errors.New("transient read failure")
+		var reads atomic.Int64
+		release := make(chan struct{})
+		started := make(chan struct{}, 1)
+		setParserProjectReadForTesting(t, func(ctx context.Context, _ *evergreen.Settings, _ evergreen.ParserProjectStorageMethod, id string) (*ParserProject, error) {
+			if reads.Add(1) == 1 {
+				started <- struct{}{}
+				<-release
+			}
+			return nil, readErr
+		})
+
+		const n = 3
+		var wg sync.WaitGroup
+		var errCount atomic.Int64
+		_, leaderSpan := tracer.Start(t.Context(), "leader")
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			res, _ := readAndTranslateProjectForVersionCoalesced(t.Context(), leaderSpan, &evergreen.Settings{}, "v1", "", evergreen.ProjectStorageMethodDB, "", false, true)
+			if res.err != nil {
+				errCount.Add(1)
+			}
+		}()
+		<-started
+
+		for range n - 1 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_, span := tracer.Start(t.Context(), "follower")
+				res, _ := readAndTranslateProjectForVersionCoalesced(t.Context(), span, &evergreen.Settings{}, "v1", "", evergreen.ProjectStorageMethodDB, "", false, true)
+				if res.err != nil {
+					errCount.Add(1)
+				}
+			}()
+		}
+		time.Sleep(100 * time.Millisecond)
+		close(release)
+		wg.Wait()
+
+		assert.Equal(t, int64(n), errCount.Load(), "the read error is surfaced to every coalesced caller")
+		// The bounded retry fires within the coalesced closure (MaxAttempts=2), so the leader read twice.
+		assert.Equal(t, int64(2), reads.Load(), "the inline bounded retry fires for the leader")
+
+		// A failure is not cached: the next request reads fresh.
+		reads.Store(0)
+		setParserProjectReadForTesting(t, func(ctx context.Context, _ *evergreen.Settings, _ evergreen.ParserProjectStorageMethod, id string) (*ParserProject, error) {
+			reads.Add(1)
+			return &ParserProject{Id: id, Identifier: utility.ToStringPtr("proj")}, nil
+		})
+		_, retrySpan := tracer.Start(t.Context(), "retry")
+		res, _ := readAndTranslateProjectForVersionCoalesced(t.Context(), retrySpan, &evergreen.Settings{}, "v1", "", evergreen.ProjectStorageMethodDB, "", false, true)
+		require.NoError(t, res.err)
+		assert.Equal(t, int64(1), reads.Load(), "a failed read is not cached; the next request reads fresh")
+	})
+}

--- a/model/project_translate_cache.go
+++ b/model/project_translate_cache.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/trace"
@@ -39,6 +40,13 @@ var (
 	translationGroupPtr       atomic.Pointer[singleflight.Group]
 	translationCacheEvictions atomic.Int64
 
+	// readTranslationGroupPtr coalesces the parser-project read + translate for concurrent
+	// same-version requests within one process. It sits in front of the LRU (the read is required to
+	// compute the content-hash key), so it reflects raw same-version request concurrency independent
+	// of cache state. It is separate from translationGroupPtr, which coalesces only the inner
+	// content-hash translate.
+	readTranslationGroupPtr atomic.Pointer[singleflight.Group]
+
 	// translationCacheWriteMu serializes each insert together with the eviction that brings the cache
 	// back within budget, so the byte total stays consistent with the cache's contents across
 	// concurrent inserts of different keys.
@@ -56,6 +64,13 @@ var (
 
 func init() {
 	translationGroupPtr.Store(&singleflight.Group{})
+	readTranslationGroupPtr.Store(&singleflight.Group{})
+}
+
+// getReadTranslationGroup returns the process-wide singleflight group that coalesces the
+// parser-project read + translate on the version path.
+func getReadTranslationGroup() *singleflight.Group {
+	return readTranslationGroupPtr.Load()
 }
 
 // getTranslationCache returns the process-wide LRU cache for translated projects, initializing it on
@@ -216,6 +231,13 @@ func getOrComputeTranslation(key string, cacheEnabled bool, compute func() (*Pro
 // disabled. It must NOT be used as an LRU key; see getOrComputeTranslation.
 func versionTranslationKey(versionID string, preGeneration bool) string {
 	return fmt.Sprintf("v:%s:%v", versionID, preGeneration)
+}
+
+// versionReadKey keys the read singleflight for the version path. It extends versionTranslationKey
+// with the storage method so a version mid DB->S3 fallback can't cross-share a read with a
+// stale-method caller.
+func versionReadKey(versionID string, preGeneration bool, storageMethod evergreen.ParserProjectStorageMethod) string {
+	return fmt.Sprintf("%s:%s", versionTranslationKey(versionID, preGeneration), storageMethod)
 }
 
 // fileTranslationKey is the cheap singleflight-only key for the file path when the cache is

--- a/model/project_translate_cache_test.go
+++ b/model/project_translate_cache_test.go
@@ -23,6 +23,7 @@ func resetTranslationCacheForTesting() {
 	translationCache = nil
 	translationCacheMu.Unlock()
 	translationGroupPtr.Store(&singleflight.Group{})
+	readTranslationGroupPtr.Store(&singleflight.Group{})
 	translationCacheEvictions.Store(0)
 	translationCacheBytes.Store(0)
 	translationCacheBytesLimit.Store(0)

--- a/units/generate_tasks.go
+++ b/units/generate_tasks.go
@@ -103,7 +103,10 @@ func (j *generateTasksJob) generate(ctx context.Context, t *task.Task) error {
 	if v == nil {
 		return errors.Errorf("version '%s' not found", t.Version)
 	}
-	project, parserProject, err := model.FindAndTranslateProjectForVersion(ctx, j.env.Settings(), v, false)
+	// Opt out of read coalescing: this path mutates the parser project in place (via
+	// GeneratedProject.NewVersion -> addGeneratedProjectToConfig), so it must not share the pointer
+	// with concurrent readers. It's low-volume background work, so opting out is cheap.
+	project, parserProject, err := model.FindAndTranslateProjectForVersionWithOpts(ctx, j.env.Settings(), v, false, false)
 	if err != nil {
 		return errors.Wrapf(err, "loading project for version '%s'", t.Version)
 	}

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1359,7 +1359,9 @@ func fetchTriggerVersionInfo(ctx context.Context, patchDoc *patch.Patch) (*model
 		if v == nil {
 			return nil, nil, nil, errors.Errorf("version at revision '%s' not found", patchDoc.Triggers.DownstreamRevision)
 		}
-		project, pp, err := model.FindAndTranslateProjectForVersion(ctx, evergreen.GetEnvironment().Settings(), v, true)
+		// Opt out of read coalescing: this pp is later mutated via Init and re-upserted, so it must
+		// not share the pointer with concurrent readers.
+		project, pp, err := model.FindAndTranslateProjectForVersionWithOpts(ctx, evergreen.GetEnvironment().Settings(), v, true, false)
 		if err != nil {
 			return nil, nil, nil, errors.Wrapf(err, "getting downstream version at revision '%s' to use for patch '%s'", patchDoc.Triggers.DownstreamRevision, patchDoc.Id.Hex())
 		}


### PR DESCRIPTION
DEVPROD-37076

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

We already have a singleflight that coalesces the translate step, and sits behind the content-hash LRU. 

This adds an outer singleflight for the read layer, sitting in front of the LRU (you have to read the parser project to compute the content-hash key) that is keyed by version + preGeneration + storage method and wraps both the read and the existing translate/LRU path. That way a burst of same-version requests now performs one read and one translate, shared, instead of N reads. It has a bounded retry around the parser-project read inside the coalesced closure, so that a single transient failure does not immediately fail every request at once.

With this we'll have fewer redundant parser-project reads, which cuts DB load (and S3 load) and reduces connection-pool pressure during bursts 

It also adds a metric that actually reflects same-version request concurrency (`read_deduped`), so that we can measure the impact
 

### Testing

Added tests 

