### PR TITLE
DEVPROD-37078: Make project translation cache TTL an admin setting

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-07-07"
+	ClientVersion = "2026-07-10"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/config_scheduler.go
+++ b/config_scheduler.go
@@ -30,6 +30,7 @@ type SchedulerConfig struct {
 	StepbackTaskFactor               int64   `bson:"stepback_task_factor" json:"stepback_task_factor" mapstructure:"stepback_task_factor"`
 	TranslateProjectConcurrencyLimit int     `bson:"translate_project_concurrency_limit" json:"translate_project_concurrency_limit" mapstructure:"translate_project_concurrency_limit"`
 	TranslateProjectCacheBytesLimit  int64   `bson:"translate_project_cache_bytes_limit" json:"translate_project_cache_bytes_limit" mapstructure:"translate_project_cache_bytes_limit"`
+	TranslateProjectCacheTTLSeconds  int64   `bson:"translate_project_cache_ttl_seconds" json:"translate_project_cache_ttl_seconds" mapstructure:"translate_project_cache_ttl_seconds"`
 }
 
 func (c *SchedulerConfig) SectionId() string { return "scheduler" }
@@ -61,6 +62,7 @@ func (c *SchedulerConfig) Set(ctx context.Context) error {
 			"stepback_task_factor":                c.StepbackTaskFactor,
 			"translate_project_concurrency_limit": c.TranslateProjectConcurrencyLimit,
 			"translate_project_cache_bytes_limit": c.TranslateProjectCacheBytesLimit,
+			"translate_project_cache_ttl_seconds": c.TranslateProjectCacheTTLSeconds,
 		}}), "updating config section '%s'", c.SectionId(),
 	)
 }
@@ -166,6 +168,9 @@ func (c *SchedulerConfig) ValidateAndDefault() error {
 	}
 	if c.TranslateProjectCacheBytesLimit < 0 {
 		return errors.New("translate project cache bytes limit cannot be negative")
+	}
+	if c.TranslateProjectCacheTTLSeconds < 0 {
+		return errors.New("translate project cache TTL seconds cannot be negative")
 	}
 
 	return nil

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1722,6 +1722,7 @@ type ComplexityRoot struct {
 		TargetTimeSeconds                func(childComplexity int) int
 		TaskFinder                       func(childComplexity int) int
 		TranslateProjectCacheBytesLimit  func(childComplexity int) int
+		TranslateProjectCacheTTLSeconds  func(childComplexity int) int
 		TranslateProjectConcurrencyLimit func(childComplexity int) int
 	}
 
@@ -10065,6 +10066,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.SchedulerConfig.TranslateProjectCacheBytesLimit(childComplexity), true
+	case "SchedulerConfig.translateProjectCacheTTLSeconds":
+		if e.complexity.SchedulerConfig.TranslateProjectCacheTTLSeconds == nil {
+			break
+		}
+
+		return e.complexity.SchedulerConfig.TranslateProjectCacheTTLSeconds(childComplexity), true
 	case "SchedulerConfig.translateProjectConcurrencyLimit":
 		if e.complexity.SchedulerConfig.TranslateProjectConcurrencyLimit == nil {
 			break
@@ -20022,6 +20029,8 @@ func (ec *executionContext) fieldContext_AdminSettings_scheduler(_ context.Conte
 				return ec.fieldContext_SchedulerConfig_translateProjectConcurrencyLimit(ctx, field)
 			case "translateProjectCacheBytesLimit":
 				return ec.fieldContext_SchedulerConfig_translateProjectCacheBytesLimit(ctx, field)
+			case "translateProjectCacheTTLSeconds":
+				return ec.fieldContext_SchedulerConfig_translateProjectCacheTTLSeconds(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type SchedulerConfig", field.Name)
 		},
@@ -59040,6 +59049,35 @@ func (ec *executionContext) fieldContext_SchedulerConfig_translateProjectCacheBy
 	return fc, nil
 }
 
+func (ec *executionContext) _SchedulerConfig_translateProjectCacheTTLSeconds(ctx context.Context, field graphql.CollectedField, obj *model.APISchedulerConfig) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_SchedulerConfig_translateProjectCacheTTLSeconds,
+		func(ctx context.Context) (any, error) {
+			return obj.TranslateProjectCacheTTLSeconds, nil
+		},
+		nil,
+		ec.marshalOInt2int64,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_SchedulerConfig_translateProjectCacheTTLSeconds(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "SchedulerConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _SearchReturnInfo_issues(ctx context.Context, field graphql.CollectedField, obj *thirdparty.SearchReturnInfo) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -88595,7 +88633,7 @@ func (ec *executionContext) unmarshalInputSchedulerConfigInput(ctx context.Conte
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"taskFinder", "hostAllocator", "hostAllocatorRoundingRule", "hostAllocatorFeedbackRule", "hostsOverallocatedRule", "futureHostFraction", "cacheDurationSeconds", "targetTimeSeconds", "acceptableHostIdleTimeSeconds", "groupVersions", "patchFactor", "patchTimeInQueueFactor", "commitQueueFactor", "mainlineTimeInQueueFactor", "expectedRuntimeFactor", "generateTaskFactor", "numDependentsFactor", "stepbackTaskFactor", "translateProjectConcurrencyLimit", "translateProjectCacheBytesLimit"}
+	fieldsInOrder := [...]string{"taskFinder", "hostAllocator", "hostAllocatorRoundingRule", "hostAllocatorFeedbackRule", "hostsOverallocatedRule", "futureHostFraction", "cacheDurationSeconds", "targetTimeSeconds", "acceptableHostIdleTimeSeconds", "groupVersions", "patchFactor", "patchTimeInQueueFactor", "commitQueueFactor", "mainlineTimeInQueueFactor", "expectedRuntimeFactor", "generateTaskFactor", "numDependentsFactor", "stepbackTaskFactor", "translateProjectConcurrencyLimit", "translateProjectCacheBytesLimit", "translateProjectCacheTTLSeconds"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -88742,6 +88780,13 @@ func (ec *executionContext) unmarshalInputSchedulerConfigInput(ctx context.Conte
 				return it, err
 			}
 			it.TranslateProjectCacheBytesLimit = data
+		case "translateProjectCacheTTLSeconds":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("translateProjectCacheTTLSeconds"))
+			data, err := ec.unmarshalOInt2int64(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.TranslateProjectCacheTTLSeconds = data
 		}
 	}
 
@@ -104882,6 +104927,8 @@ func (ec *executionContext) _SchedulerConfig(ctx context.Context, sel ast.Select
 			out.Values[i] = ec._SchedulerConfig_translateProjectConcurrencyLimit(ctx, field, obj)
 		case "translateProjectCacheBytesLimit":
 			out.Values[i] = ec._SchedulerConfig_translateProjectCacheBytesLimit(ctx, field, obj)
+		case "translateProjectCacheTTLSeconds":
+			out.Values[i] = ec._SchedulerConfig_translateProjectCacheTTLSeconds(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/schema/types/adminSettings/runners.graphql
+++ b/graphql/schema/types/adminSettings/runners.graphql
@@ -85,6 +85,7 @@ input SchedulerConfigInput {
   stepbackTaskFactor: Int!
   translateProjectConcurrencyLimit: Int
   translateProjectCacheBytesLimit: Int
+  translateProjectCacheTTLSeconds: Int
 }
 
 type SchedulerConfig {
@@ -108,6 +109,7 @@ type SchedulerConfig {
   stepbackTaskFactor: Int
   translateProjectConcurrencyLimit: Int
   translateProjectCacheBytesLimit: Int
+  translateProjectCacheTTLSeconds: Int
 }
 
 input RepotrackerConfigInput {

--- a/graphql/tests/mutation/saveAdminSettings/queries/runners.graphql
+++ b/graphql/tests/mutation/saveAdminSettings/queries/runners.graphql
@@ -49,6 +49,7 @@ mutation Runners {
         taskFinder: PARALLEL
         translateProjectConcurrencyLimit: 1
         translateProjectCacheBytesLimit: 1
+        translateProjectCacheTTLSeconds: 1
       }
     }
   ) {
@@ -104,6 +105,7 @@ mutation Runners {
       taskFinder
       translateProjectConcurrencyLimit
       translateProjectCacheBytesLimit
+      translateProjectCacheTTLSeconds
     }
   }
 }

--- a/graphql/tests/mutation/saveAdminSettings/results.json
+++ b/graphql/tests/mutation/saveAdminSettings/results.json
@@ -83,7 +83,8 @@
               "targetTimeSeconds": 1,
               "taskFinder": "PARALLEL",
               "translateProjectConcurrencyLimit": 1,
-              "translateProjectCacheBytesLimit": 1
+              "translateProjectCacheBytesLimit": 1,
+              "translateProjectCacheTTLSeconds": 1
             }
           }
         }

--- a/graphql/tests/query/adminEvents/results.json
+++ b/graphql/tests/query/adminEvents/results.json
@@ -63,6 +63,7 @@
                   "target_time_seconds": 60,
                   "task_finder": "legacy",
                   "translate_project_cache_bytes_limit": 0,
+                  "translate_project_cache_ttl_seconds": 0,
                   "translate_project_concurrency_limit": 0
                 },
                 "before": {
@@ -85,6 +86,7 @@
                   "target_time_seconds": 60,
                   "task_finder": "legacy",
                   "translate_project_cache_bytes_limit": 0,
+                  "translate_project_cache_ttl_seconds": 0,
                   "translate_project_concurrency_limit": 0
                 },
                 "section": "scheduler",

--- a/graphql/tests/query/adminSettings/data.json
+++ b/graphql/tests/query/adminSettings/data.json
@@ -125,7 +125,8 @@
       "stepback_task_factor": 10,
       "num_dependents_factor": 5,
       "translate_project_concurrency_limit": 15,
-      "translate_project_cache_bytes_limit": 1048576
+      "translate_project_cache_bytes_limit": 1048576,
+      "translate_project_cache_ttl_seconds": 1800
     },
     {
       "_id": "task_limits",

--- a/graphql/tests/query/adminSettings/queries/runners.graphql
+++ b/graphql/tests/query/adminSettings/queries/runners.graphql
@@ -37,6 +37,7 @@ query Runners {
       stepbackTaskFactor
       translateProjectConcurrencyLimit
       translateProjectCacheBytesLimit
+      translateProjectCacheTTLSeconds
       hostAllocator
       hostAllocatorRoundingRule
       hostAllocatorFeedbackRule

--- a/graphql/tests/query/adminSettings/results.json
+++ b/graphql/tests/query/adminSettings/results.json
@@ -206,6 +206,7 @@
               "stepbackTaskFactor": 10,
               "translateProjectConcurrencyLimit": 15,
               "translateProjectCacheBytesLimit": 1048576,
+              "translateProjectCacheTTLSeconds": 1800,
               "hostAllocator": "UTILIZATION",
               "hostAllocatorRoundingRule": "DOWN",
               "hostAllocatorFeedbackRule": "NO_FEEDBACK",

--- a/model/project_translate_cache.go
+++ b/model/project_translate_cache.go
@@ -17,7 +17,9 @@ import (
 )
 
 const (
-	projectTranslationCacheTTL = 30 * time.Minute
+	// defaultTranslationCacheTTL is the entry lifetime used when the admin setting is unset or
+	// non-positive.
+	defaultTranslationCacheTTL = 30 * time.Minute
 
 	// defaultTranslationCacheBytesLimit bounds the cache when the admin setting is unset or
 	// non-positive, so a missing config never leaves the cache unbounded. The budget is measured
@@ -38,6 +40,9 @@ var (
 	translationCache          *expirable.LRU[string, cachedTranslation]
 	translationGroupPtr       atomic.Pointer[singleflight.Group]
 	translationCacheEvictions atomic.Int64
+	// translationCacheTTL is the entry lifetime the cache is (re)built with; it's guarded by
+	// translationCacheMu. A value <= 0 falls back to defaultTranslationCacheTTL.
+	translationCacheTTL time.Duration
 
 	// translationCacheWriteMu serializes each insert together with the eviction that brings the cache
 	// back within budget, so the byte total stays consistent with the cache's contents across
@@ -71,9 +76,42 @@ func getTranslationCache() *expirable.LRU[string, cachedTranslation] {
 			translationKeyHitsMu.Lock()
 			delete(translationKeyHits, key)
 			translationKeyHitsMu.Unlock()
-		}, projectTranslationCacheTTL)
+		}, currentTranslationCacheTTL())
 	}
 	return translationCache
+}
+
+// currentTranslationCacheTTL returns the configured entry lifetime, falling back to the default when
+// unset. Callers must hold translationCacheMu.
+func currentTranslationCacheTTL() time.Duration {
+	if translationCacheTTL > 0 {
+		return translationCacheTTL
+	}
+	return defaultTranslationCacheTTL
+}
+
+// SetTranslationCacheTTL sets the entry lifetime for the process-wide translation cache. A value <= 0
+// restores the built-in default. Changing the TTL rebuilds the cache, dropping any cached entries,
+// because the underlying LRU's TTL is fixed at construction.
+func SetTranslationCacheTTL(d time.Duration) {
+	if d <= 0 {
+		d = defaultTranslationCacheTTL
+	}
+
+	translationCacheMu.Lock()
+	defer translationCacheMu.Unlock()
+	if d == currentTranslationCacheTTL() {
+		return
+	}
+	translationCacheTTL = d
+
+	// Drop the existing cache so the next getTranslationCache rebuilds it with the new TTL, and
+	// reset byte accounting to match the now-empty cache since the eviction callback won't fire.
+	translationCache = nil
+	translationCacheBytes.Store(0)
+	translationKeyHitsMu.Lock()
+	translationKeyHits = map[string]int64{}
+	translationKeyHitsMu.Unlock()
 }
 
 // SetTranslationCacheBytesLimit sets the byte budget for the process-wide translation cache. A value

--- a/model/project_translate_cache_test.go
+++ b/model/project_translate_cache_test.go
@@ -21,6 +21,7 @@ import (
 func resetTranslationCacheForTesting() {
 	translationCacheMu.Lock()
 	translationCache = nil
+	translationCacheTTL = 0
 	translationCacheMu.Unlock()
 	translationGroupPtr.Store(&singleflight.Group{})
 	translationCacheEvictions.Store(0)
@@ -332,6 +333,38 @@ func TestTranslationCacheBytesLimitFallsBackToDefault(t *testing.T) {
 
 	SetTranslationCacheBytesLimit(4096)
 	assert.Equal(t, int64(4096), currentTranslationCacheBytesLimit(), "positive limit is used as-is")
+}
+
+func TestTranslationCacheTTLFallsBackToDefault(t *testing.T) {
+	t.Cleanup(resetTranslationCacheForTesting)
+
+	readTTL := func() time.Duration {
+		translationCacheMu.Lock()
+		defer translationCacheMu.Unlock()
+		return currentTranslationCacheTTL()
+	}
+
+	SetTranslationCacheTTL(0)
+	assert.Equal(t, defaultTranslationCacheTTL, readTTL(), "non-positive TTL falls back to the default")
+
+	SetTranslationCacheTTL(-5 * time.Minute)
+	assert.Equal(t, defaultTranslationCacheTTL, readTTL(), "negative TTL falls back to the default")
+
+	SetTranslationCacheTTL(time.Hour)
+	assert.Equal(t, time.Hour, readTTL(), "positive TTL is used as-is")
+}
+
+func TestSetTranslationCacheTTLRebuildsAndClearsEntries(t *testing.T) {
+	t.Cleanup(resetTranslationCacheForTesting)
+
+	addToTranslationCache("k", &Project{Identifier: "test"})
+	require.Equal(t, 1, getTranslationCache().Len(), "entry is cached before the TTL change")
+	require.Positive(t, translationCacheBytes.Load(), "byte total reflects the cached entry")
+
+	SetTranslationCacheTTL(time.Hour)
+
+	assert.Equal(t, 0, getTranslationCache().Len(), "changing the TTL rebuilds the cache and drops entries")
+	assert.Zero(t, translationCacheBytes.Load(), "byte accounting is reset to match the empty cache")
 }
 
 // TestByteBoundedCacheEvictsLRUToBudget shows the cache stays within the configured byte budget by

--- a/operations/service_web.go
+++ b/operations/service_web.go
@@ -109,6 +109,7 @@ func startWebService() cli.Command {
 			settings := env.Settings()
 			evgmodel.SetTranslateConcurrencyLimit(settings.Scheduler.TranslateProjectConcurrencyLimit)
 			evgmodel.SetTranslationCacheBytesLimit(settings.Scheduler.TranslateProjectCacheBytesLimit)
+			evgmodel.SetTranslationCacheTTL(time.Duration(settings.Scheduler.TranslateProjectCacheTTLSeconds) * time.Second)
 			// Remove the span from the senderCtx since the sender caches the ctx.
 			senderCtx := trace.ContextWithSpan(ctx, nil)
 			sender, err := settings.GetSender(senderCtx, env)

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2068,6 +2068,7 @@ type APISchedulerConfig struct {
 	StepbackTaskFactor               int64   `json:"stepback_task_factor"`
 	TranslateProjectConcurrencyLimit int     `json:"translate_project_concurrency_limit"`
 	TranslateProjectCacheBytesLimit  int64   `json:"translate_project_cache_bytes_limit"`
+	TranslateProjectCacheTTLSeconds  int64   `json:"translate_project_cache_ttl_seconds"`
 }
 
 func (a *APISchedulerConfig) BuildFromService(h any) error {
@@ -2093,6 +2094,7 @@ func (a *APISchedulerConfig) BuildFromService(h any) error {
 		a.StepbackTaskFactor = v.StepbackTaskFactor
 		a.TranslateProjectConcurrencyLimit = v.TranslateProjectConcurrencyLimit
 		a.TranslateProjectCacheBytesLimit = v.TranslateProjectCacheBytesLimit
+		a.TranslateProjectCacheTTLSeconds = v.TranslateProjectCacheTTLSeconds
 	default:
 		return errors.Errorf("programmatic error: expected host scheduler config but got type %T", h)
 	}
@@ -2121,6 +2123,7 @@ func (a *APISchedulerConfig) ToService() (any, error) {
 		StepbackTaskFactor:               a.StepbackTaskFactor,
 		TranslateProjectConcurrencyLimit: a.TranslateProjectConcurrencyLimit,
 		TranslateProjectCacheBytesLimit:  a.TranslateProjectCacheBytesLimit,
+		TranslateProjectCacheTTLSeconds:  a.TranslateProjectCacheTTLSeconds,
 	}, nil
 }
 


### PR DESCRIPTION
DEVPROD-37078

### Description

The project translation cache entry TTL was hardcoded to 30 minutes. This change moves it to an admin setting (`translateProjectCacheTTLSeconds` on the scheduler config) so it can be tuned without a code change or deploy. This will let us adjust it to find the right value that gets us the best cache hit rate

### Testing

Added

### Spruce PR
https://github.com/evergreen-ci/ui/pull/1783

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
