### PR TITLE
DEVPROD-37067: Reduce TSS logging

### DIFF
--- a/rest/data/select.go
+++ b/rest/data/select.go
@@ -58,6 +58,12 @@ func logTSSError(ctx context.Context, err error, resp *http.Response, duration t
 	if resp != nil && resp.StatusCode == http.StatusNotFound {
 		return
 	}
+	if ctx.Err() == context.Canceled || stderrors.Is(err, context.Canceled) {
+		return
+	}
+	if endpoint, ok := info["endpoint"].(string); ok && endpoint == GetTestsStateEndpoint && isTimeoutError(ctx, err) {
+		return
+	}
 	if resp != nil {
 		info["status"] = resp.StatusCode
 	}

--- a/rest/data/select_test.go
+++ b/rest/data/select_test.go
@@ -8,14 +8,65 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/testresult"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/level"
+	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/send"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func captureGripMessages(t *testing.T) *send.InternalSender {
+	originalSender := grip.GetSender()
+	sender := send.MakeInternalLogger()
+	require.NoError(t, grip.SetSender(sender))
+	t.Cleanup(func() {
+		require.NoError(t, grip.SetSender(originalSender))
+	})
+	return sender
+}
+
+func TestLogTSSError(t *testing.T) {
+	t.Run("CanceledRequestIsNotLogged", func(t *testing.T) {
+		sender := captureGripMessages(t)
+
+		logTSSError(t.Context(), context.Canceled, nil, time.Second, message.Fields{
+			"message":  "test selection request canceled",
+			"endpoint": GetTestsStateEndpoint,
+		})
+
+		assert.Zero(t, sender.Len())
+	})
+
+	t.Run("GetTestsStateTimeoutIsNotLogged", func(t *testing.T) {
+		sender := captureGripMessages(t)
+
+		logTSSError(t.Context(), context.DeadlineExceeded, nil, time.Second, message.Fields{
+			"message":  "test selection request timed out",
+			"endpoint": GetTestsStateEndpoint,
+		})
+
+		assert.Zero(t, sender.Len())
+	})
+
+	t.Run("MutationTimeoutIsError", func(t *testing.T) {
+		sender := captureGripMessages(t)
+
+		logTSSError(t.Context(), context.DeadlineExceeded, nil, time.Second, message.Fields{
+			"message":  "test selection request timed out",
+			"endpoint": TransitionTestsEndpoint,
+		})
+
+		require.Equal(t, 1, sender.Len())
+		assert.Equal(t, level.Error, sender.GetMessage().Priority)
+	})
+}
 
 func TestGetTestsQuarantineStatus(t *testing.T) {
 	const (


### PR DESCRIPTION
DEVPROD-37067

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Reduce TSS logging, specifically context cancelled/timeouts for the get endpoint and a duplicate log. [Splunk logs,](https://mongodb.splunkcloud.com/en-US/app/search/search?q=search%20index%3Devergreen%20metadata.level%20%3E%3D%2070%20%20message%3D%22decorating%20test%20quarantine%20statuses%22&earliest=1783436400&latest=1783524943&sid=1783701142.158923&display.page.search.mode=verbose&dispatch.sample_ratio=1&workload_pool=&display.events.timelineEarliestTime=1783450800&display.events.timelineLatestTime=1783465200) currently around 2000 per day, these are going to be monitored in honeycomb instead. Removing to keep costs/logs down.


### Testing
- Unit tests
