### PR TITLE
DEVPROD-36666: make webhook subscription headers case-insensitive

### DIFF
--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -164,15 +164,20 @@ func (s *WebhookSubscriber) validate() error {
 	catcher.AddWhen(s.TimeoutMS < 0, errors.New("timeout cannot be negative"))
 	catcher.AddWhen(s.TimeoutMS > webhookTimeoutLimit, errors.Errorf("timeout cannot be greater than %d ms", webhookTimeoutLimit))
 
+	seenHeaders := map[string]struct{}{}
 	for _, header := range s.Headers {
 		catcher.AddWhen(header.Key == "", errors.New("header key cannot be empty"))
 		catcher.AddWhen(header.Value == "", errors.New("header value cannot be empty"))
+		for seenHeader := range seenHeaders {
+			catcher.ErrorfWhen(strings.EqualFold(header.Key, seenHeader), "duplicate header key '%s'", header.Key)
+		}
+		seenHeaders[header.Key] = struct{}{}
 	}
 
 	return catcher.Resolve()
 }
 
-// GetHeader gets the value for the given key (case-insensitive).
+// GetHeader gets the value for the given key.
 func (s *WebhookSubscriber) GetHeader(key string) string {
 	for _, h := range s.Headers {
 		if strings.EqualFold(h.Key, key) {

--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -172,8 +172,7 @@ func (s *WebhookSubscriber) validate() error {
 	return catcher.Resolve()
 }
 
-// GetHeader gets the value for the given key.
-// kim: TODO: test case-insensitivity.
+// GetHeader gets the value for the given key (case-insensitive).
 func (s *WebhookSubscriber) GetHeader(key string) string {
 	for _, h := range s.Headers {
 		if strings.EqualFold(h.Key, key) {

--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -2,6 +2,7 @@ package event
 
 import (
 	"fmt"
+	"strings"
 
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/utility"
@@ -172,9 +173,10 @@ func (s *WebhookSubscriber) validate() error {
 }
 
 // GetHeader gets the value for the given key.
+// kim: TODO: test case-insensitivity.
 func (s *WebhookSubscriber) GetHeader(key string) string {
 	for _, h := range s.Headers {
-		if h.Key == key {
+		if strings.EqualFold(h.Key, key) {
 			return h.Value
 		}
 	}
@@ -183,7 +185,7 @@ func (s *WebhookSubscriber) GetHeader(key string) string {
 
 func (s *WebhookSubscriber) setHeader(key, value string) {
 	for i := range s.Headers {
-		if s.Headers[i].Key == key {
+		if strings.EqualFold(s.Headers[i].Key, key) {
 			s.Headers[i].Value = value
 			return
 		}

--- a/model/event/subscribers_test.go
+++ b/model/event/subscribers_test.go
@@ -161,6 +161,28 @@ func TestValidate(t *testing.T) {
 			},
 			errorExpected: false,
 		},
+		"WebhookWithDuplicateHeadersIsInvalid": {
+			s: Subscriber{
+				Type: EvergreenWebhookSubscriberType,
+				Target: WebhookSubscriber{
+					URL:     "https://evergreen.mongodb.com",
+					Secret:  []byte("shh"),
+					Headers: []WebhookHeader{{Key: "X-Header", Value: "value1"}, {Key: "x-header", Value: "value2"}},
+				},
+			},
+			errorExpected: true,
+		},
+		"WebhookWithUniqueHeadersIsValid": {
+			s: Subscriber{
+				Type: EvergreenWebhookSubscriberType,
+				Target: WebhookSubscriber{
+					URL:     "https://evergreen.mongodb.com",
+					Secret:  []byte("shh"),
+					Headers: []WebhookHeader{{Key: "X-Header", Value: "value1"}, {Key: "X-Another-Header", Value: "value2"}},
+				},
+			},
+			errorExpected: false,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if testCase.errorExpected {

--- a/model/event/subscriptions_test.go
+++ b/model/event/subscriptions_test.go
@@ -985,6 +985,23 @@ func (s *subscriptionsSuite) TestUpsertWebhookDeletesAuthParameterWhenHeaderRemo
 	s.Equal("custom-value", updatedTarget.GetHeader("X-Custom-Header"), "non-sensitive header should remain")
 }
 
+func TestGetHeader(t *testing.T) {
+	ws := &WebhookSubscriber{
+		Headers: []WebhookHeader{
+			{Key: "authorization", Value: "Bearer my-token"},
+			{Key: "X-Custom", Value: "custom"},
+		},
+	}
+
+	// The Authorization header is matched case-insensitively regardless of how
+	// it was originally stored, consistent with how HTTP treats header names.
+	assert.Equal(t, "Bearer my-token", ws.GetHeader("authorization"))
+	assert.Equal(t, "Bearer my-token", ws.GetHeader("Authorization"))
+	assert.Equal(t, "Bearer my-token", ws.GetHeader("AUTHORIZATION"))
+	assert.Equal(t, "custom", ws.GetHeader("x-custom"))
+	assert.Empty(t, ws.GetHeader("X-Missing"))
+}
+
 func TestSetHeader(t *testing.T) {
 	t.Run("UpdatesExistingKey", func(t *testing.T) {
 		ws := &WebhookSubscriber{
@@ -997,6 +1014,20 @@ func TestSetHeader(t *testing.T) {
 		require.Len(t, ws.Headers, 2)
 		assert.Equal(t, "Bearer new-token", ws.GetHeader(WebhookAuthorizationHeader))
 		assert.Equal(t, "custom", ws.GetHeader("X-Custom"))
+	})
+
+	t.Run("UpdatesExistingKeyWithDifferentCasing", func(t *testing.T) {
+		ws := &WebhookSubscriber{
+			Headers: []WebhookHeader{
+				{Key: "authorization", Value: "Bearer old-token"},
+			},
+		}
+		ws.setHeader(WebhookAuthorizationHeader, "Bearer new-token")
+		// The existing header is updated in place rather than duplicated, and its
+		// original key casing is preserved.
+		require.Len(t, ws.Headers, 1)
+		assert.Equal(t, "authorization", ws.Headers[0].Key)
+		assert.Equal(t, "Bearer new-token", ws.Headers[0].Value)
 	})
 
 	t.Run("AddsNewKey", func(t *testing.T) {

--- a/model/project_event.go
+++ b/model/project_event.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -277,7 +278,7 @@ func getRedactedSubscriptionsCopy(subscriptions []event.Subscription, modifiedSe
 			redacted.Secret = nil
 		}
 		for j := range redacted.Headers {
-			if redacted.Headers[j].Key == event.WebhookAuthorizationHeader {
+			if strings.EqualFold(redacted.Headers[j].Key, event.WebhookAuthorizationHeader) {
 				if _, authHeaderModified := modifiedAuthHeaderIDs[result[i].ID]; authHeaderModified {
 					redacted.Headers[j].Value = placeholder
 				} else {

--- a/model/project_event_test.go
+++ b/model/project_event_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
@@ -285,7 +286,7 @@ func (s *ProjectEventSuite) TestRedactSubscriptionSecrets() {
 					require.NotNil(t, webhookSub)
 					assert.Equal(t, expectedSecret, string(webhookSub.Secret))
 					for _, header := range webhookSub.Headers {
-						if header.Key == event.WebhookAuthorizationHeader {
+						if strings.EqualFold(header.Key, event.WebhookAuthorizationHeader) {
 							assert.Equal(t, expectedAuth, header.Value)
 						}
 						if header.Key == "Content-Type" {

--- a/rest/data/project_settings.go
+++ b/rest/data/project_settings.go
@@ -623,7 +623,7 @@ func unredactWebhookSubscription(unredactedPreviousSubscriptions []event.Subscri
 	unredactedNewHeaders := []restModel.APIWebhookHeader{}
 	for _, redactedHeader := range redactedNewWebhookSubscription.Headers {
 		// If the header is the Authorization header and set to redacted, replace it with the unredacted value.
-		if utility.FromStringPtr(redactedHeader.Key) == event.WebhookAuthorizationHeader && utility.FromStringPtr(redactedHeader.Value) == evergreen.RedactedValue {
+		if strings.EqualFold(utility.FromStringPtr(redactedHeader.Key), event.WebhookAuthorizationHeader) && utility.FromStringPtr(redactedHeader.Value) == evergreen.RedactedValue {
 			redactedHeader.Value = utility.ToStringPtr(unredactedPreviousWebhookSubscription.GetHeader(event.WebhookAuthorizationHeader))
 		}
 		unredactedNewHeaders = append(unredactedNewHeaders, redactedHeader)

--- a/rest/model/subscriber.go
+++ b/rest/model/subscriber.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model/event"
@@ -304,7 +305,7 @@ func (s *APIWebhookSubscriber) ToService() event.WebhookSubscriber {
 
 func (s *APIWebhookHeader) BuildFromService(h event.WebhookHeader) {
 	s.Key = &h.Key
-	if h.Key == event.WebhookAuthorizationHeader {
+	if strings.EqualFold(h.Key, event.WebhookAuthorizationHeader) {
 		s.Value = utility.ToStringPtr(evergreen.RedactedValue)
 	} else {
 		s.Value = &h.Value


### PR DESCRIPTION
DEVPROD-36666

### Description

Treat headers as case-insensitive (e.g. `Authorization`, `authorization`, and `AUTHORIZATION` are all the same header key). This is to address an issue where a header with unusual casing (e.g. `AUTHORIZATION`) wouldn't get redacted.

* Treat header keys with different casing as the same header.
* Validate that header keys are case-insensitively unique.

### Testing

* Added unit tests.
* Verified that no existing webhook subscriptions have duplicate header keys with different casing.