### PR TITLE
DEVPROD-33516 introduce yaml anchor support more safely

### DIFF
--- a/config_db.go
+++ b/config_db.go
@@ -60,6 +60,7 @@ var (
 	taskDispatchKey                       = bsonutil.MustHaveTag(ServiceFlags{}, "TaskDispatchDisabled")
 	hostInitKey                           = bsonutil.MustHaveTag(ServiceFlags{}, "HostInitDisabled")
 	largeParserProjectsDisabledKey        = bsonutil.MustHaveTag(ServiceFlags{}, "LargeParserProjectsDisabled")
+	crossFileYAMLAnchorsDisabledKey       = bsonutil.MustHaveTag(ServiceFlags{}, "CrossFileYAMLAnchorsDisabled")
 	monitorKey                            = bsonutil.MustHaveTag(ServiceFlags{}, "MonitorDisabled")
 	alertsKey                             = bsonutil.MustHaveTag(ServiceFlags{}, "AlertsDisabled")
 	agentStartKey                         = bsonutil.MustHaveTag(ServiceFlags{}, "AgentStartDisabled")

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -14,6 +14,7 @@ type ServiceFlags struct {
 	TaskDispatchDisabled               bool `bson:"task_dispatch_disabled" json:"task_dispatch_disabled"`
 	HostInitDisabled                   bool `bson:"host_init_disabled" json:"host_init_disabled"`
 	LargeParserProjectsDisabled        bool `bson:"large_parser_projects_disabled" json:"large_parser_projects_disabled"`
+	CrossFileYAMLAnchorsDisabled       bool `bson:"cross_file_yaml_anchors_disabled" json:"cross_file_yaml_anchors_disabled"`
 	MonitorDisabled                    bool `bson:"monitor_disabled" json:"monitor_disabled"`
 	AlertsDisabled                     bool `bson:"alerts_disabled" json:"alerts_disabled"`
 	AgentStartDisabled                 bool `bson:"agent_start_disabled" json:"agent_start_disabled"`
@@ -75,6 +76,7 @@ func (c *ServiceFlags) Set(ctx context.Context) error {
 			taskDispatchKey:                       c.TaskDispatchDisabled,
 			hostInitKey:                           c.HostInitDisabled,
 			largeParserProjectsDisabledKey:        c.LargeParserProjectsDisabled,
+			crossFileYAMLAnchorsDisabledKey:       c.CrossFileYAMLAnchorsDisabled,
 			monitorKey:                            c.MonitorDisabled,
 			alertsKey:                             c.AlertsDisabled,
 			agentStartKey:                         c.AgentStartDisabled,

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -737,11 +737,14 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, pro
 	defer span.End()
 
 	unmarshalStrict := false
-	anchorRegistry := &anchorRegistry{}
+	var registry *anchorRegistry
+	if opts == nil || !opts.DisableCrossFileAnchors {
+		registry = &anchorRegistry{}
+	}
 	if opts != nil {
 		unmarshalStrict = opts.UnmarshalStrict
 	}
-	intermediateProject, err := createIntermediateProject(data, unmarshalStrict, anchorRegistry)
+	intermediateProject, err := createIntermediateProject(data, unmarshalStrict, registry)
 	if err != nil {
 		return nil, errors.Wrapf(err, LoadProjectError)
 	}
@@ -751,7 +754,7 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, pro
 	}
 
 	if len(intermediateProject.Include) > 0 {
-		if err := mergeIncludes(ctx, projectID, intermediateProject, anchorRegistry, opts); err != nil {
+		if err := mergeIncludes(ctx, projectID, intermediateProject, registry, opts); err != nil {
 			return nil, errors.Wrap(err, "merging included files")
 		}
 	}
@@ -1144,6 +1147,11 @@ type GetProjectOpts struct {
 	// LocalIncludeDir is the base directory for resolving relative include
 	// file paths when ReadFileFrom is ReadFromLocal.
 	LocalIncludeDir string
+	// DisableCrossFileAnchors disables cross-file YAML anchor resolution.
+	// When set, include files are parsed in isolation without a preamble of
+	// anchors from prior files, matching pre-feature behavior.
+	// Callers should set this from ServiceFlags.CrossFileYAMLAnchorsDisabled.
+	DisableCrossFileAnchors bool
 }
 
 type PatchOpts struct {

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -3959,6 +3959,61 @@ tasks:
 	assert.Equal(t, "shell.exec", tasksByName["include-task"].Commands[0].Command)
 }
 
+// TestCrossFileAnchorsDisabledMatchesEnabled verifies that for a project whose
+// include files do not use cross-file aliases, disabling the feature produces
+// exactly the same parsed result as leaving it enabled. This is the primary
+// backwards-compatibility check for the preamble injection change.
+func TestCrossFileAnchorsDisabledMatchesEnabled(t *testing.T) {
+	mainYAML := mainYAMLWithModuleIncludes(`
+tasks:
+- name: main-task
+  commands:
+  - &shared-cmd
+    command: shell.exec
+    params:
+      script: ./run.sh
+`, "include.yml")
+
+	// include.yml defines its own anchor and does NOT reference any anchor from main.
+	includeYAML := `
+tasks:
+- name: include-task
+  commands:
+  - &local-cmd
+    command: shell.exec
+    params:
+      script: ./include.sh
+  - *local-cmd
+buildvariants:
+- name: linux
+  display_name: Linux
+  run_on:
+  - rhel80-small
+  tasks:
+  - name: include-task
+`
+	parseWith := func(t *testing.T, disable bool) *Project {
+		t.Helper()
+		proj := &Project{}
+		opts := moduleIncludeOpts(moduleInclude("include.yml", includeYAML))
+		opts.DisableCrossFileAnchors = disable
+		_, err := LoadProjectInto(t.Context(), []byte(mainYAML), opts, "proj", proj)
+		require.NoError(t, err)
+		return proj
+	}
+
+	enabled := parseWith(t, false)
+	disabled := parseWith(t, true)
+
+	// Both should produce the same tasks and build variants.
+	require.Equal(t, len(disabled.Tasks), len(enabled.Tasks), "task count should match")
+	require.Equal(t, len(disabled.BuildVariants), len(enabled.BuildVariants), "build variant count should match")
+	for i := range enabled.Tasks {
+		assert.Equal(t, disabled.Tasks[i].Name, enabled.Tasks[i].Name)
+		assert.Equal(t, len(disabled.Tasks[i].Commands), len(enabled.Tasks[i].Commands))
+	}
+}
+
 // TestNoAnchorsInIncludeFiles verifies that projects without anchors produce
 // identical output before and after the Stage 2 changes (no regression).
 func TestNoAnchorsInIncludeFiles(t *testing.T) {

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -3916,6 +3916,49 @@ tasks:
 	assert.Equal(t, "shell.exec", tasksByName["include-task"].Commands[0].Command)
 }
 
+// TestMergeKeyListSyntaxInIncludeFile verifies that the standard YAML list merge
+// key syntax (<<: [*a, *b]) works correctly when the referenced anchors are
+// defined in an earlier include file. Earlier entries in the list take priority
+// over later ones for conflicting keys.
+func TestMergeKeyListSyntaxInIncludeFile(t *testing.T) {
+	mainYAML := mainYAMLWithModuleIncludes(`
+tasks:
+- name: main-task
+  commands:
+  - &base-cmd
+    command: shell.exec
+    params:
+      script: ./base.sh
+      working_dir: src
+  - &override-cmd
+    command: shell.exec
+    params:
+      script: ./override.sh
+`, "include.yml")
+
+	// include.yml uses <<: [*base-cmd, *override-cmd]; earlier entry (*base-cmd) wins on conflicts.
+	includeYAML := `
+tasks:
+- name: include-task
+  commands:
+  - <<: [*base-cmd, *override-cmd]
+`
+	proj := &Project{}
+	_, err := LoadProjectInto(t.Context(), []byte(mainYAML),
+		moduleIncludeOpts(moduleInclude("include.yml", includeYAML)), "proj", proj)
+	require.NoError(t, err)
+
+	tasksByName := map[string]ProjectTask{}
+	for _, task := range proj.Tasks {
+		tasksByName[task.Name] = task
+	}
+	require.Contains(t, tasksByName, "include-task")
+	require.Len(t, tasksByName["include-task"].Commands, 1)
+	// *base-cmd is listed first in the merge list, so it wins on key conflicts.
+	// Both command: shell.exec entries agree, so the command field is shell.exec.
+	assert.Equal(t, "shell.exec", tasksByName["include-task"].Commands[0].Command)
+}
+
 // TestNoAnchorsInIncludeFiles verifies that projects without anchors produce
 // identical output before and after the Stage 2 changes (no regression).
 func TestNoAnchorsInIncludeFiles(t *testing.T) {


### PR DESCRIPTION
 DEVPROD-33516

This PR productionizes cross-file YAML anchor support that was previously behind a flag, and makes it safe for production based on lessons from the first deploy.

  1. Made cross-file anchors always-on; Updated docs to drop beta language (from the previous deploy)
  2. Fixed anchor preamble ordering bug (root cause of the production failure): when an anchor was redefined with new alias dependencies (e.g. *other-anchor), the in-place upsert left the redefined entry at its original index in the registry, before the entries it now depended on. Changed mergeAnchorsFrom to remove-then-append, ensuring redefined anchors always appear after their dependencies in the preamble. Added TestAnchorRedefinedWithAliasDependencyDoesNotError reproducing the exact three-file failure pattern from mongodb-mongo-master.
  4. Added fallback when preamble parse fails — if prepending the anchor preamble causes a parse error (should be rare post-fix, but belt-and-suspenders), we log a Splunk warning and retry parsing without the preamble. This is to avoid production meltdown.
  5. Added <<: [*a, *b] list merge key test — verified that the supported YAML list syntax for merge keys works correctly across include files. (Thought of this from a different yaml related thread)
  6. Added ServiceFlags.CrossFileYAMLAnchorsDisabled kill switch — allows turning off the feature from admin settings without a deploy, just another production precaution.