### PR TITLE
DEVPROD-32002 Reduce and consolidate logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,7 +96,7 @@ require (
 	github.com/evergreen-ci/baobab v1.0.1-0.20220107150152-03b522479f52 // indirect
 	github.com/evergreen-ci/bond v0.0.0-20260326192958-a16b1d604e29 // indirect
 	github.com/evergreen-ci/lru v0.0.0-20260326190734-0d627bf39810 // indirect
-	github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035 // indirect
+	github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -306,6 +306,9 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 			"event":  gh.eventType,
 			"ref":    event.GetRef(),
 			"is_tag": isTag(event.GetRef()),
+			"repo":   event.Repo.GetName(),
+			"owner":  event.Repo.Owner.GetLogin(),
+			"action": event.GetAction(),
 		})
 		// Regardless of whether a tag or commit is being pushed, we want to trigger the repotracker
 		// to ensure we're up-to-date on the commit the tag is being pushed to.

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -301,12 +301,11 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 			break
 		}
 		grip.Debug(ctx, message.Fields{
-			"source":     "GitHub hook",
-			"msg_id":     gh.msgID,
-			"event":      gh.eventType,
-			"event_data": event,
-			"ref":        event.GetRef(),
-			"is_tag":     isTag(event.GetRef()),
+			"source": "GitHub hook",
+			"msg_id": gh.msgID,
+			"event":  gh.eventType,
+			"ref":    event.GetRef(),
+			"is_tag": isTag(event.GetRef()),
 		})
 		// Regardless of whether a tag or commit is being pushed, we want to trigger the repotracker
 		// to ensure we're up-to-date on the commit the tag is being pushed to.

--- a/service/api_patch.go
+++ b/service/api_patch.go
@@ -432,14 +432,13 @@ func (as *APIServer) existingPatchRequest(w http.ResponseWriter, r *http.Request
 			return
 		}
 		grip.Info(ctx, message.Fields{
-			"operation":     "patch creation",
-			"message":       "finalized patch",
-			"from":          "CLI",
-			"patch_id":      p.Id,
-			"variants":      p.BuildVariants,
-			"tasks":         p.Tasks,
-			"variant_tasks": p.VariantsTasks,
-			"alias":         p.Alias,
+			"operation":    "patch creation",
+			"message":      "finalized patch",
+			"from":         "CLI",
+			"patch_id":     p.Id,
+			"num_variants": len(p.BuildVariants),
+			"num_tasks":    len(p.Tasks),
+			"alias":        p.Alias,
 		})
 
 		gimlet.WriteJSON(r.Context(), w, "patch finalized")

--- a/service/sampled_request_logger.go
+++ b/service/sampled_request_logger.go
@@ -1,0 +1,140 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+	"runtime/debug"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/negroni"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+)
+
+const (
+	heartbeatRouteSuffix = "/heartbeat"
+	nextTaskRouteSuffix  = "/agent/next_task"
+
+	sampledRouteWindow = time.Minute
+)
+
+var sampledRouteSuffixes = []string{
+	nextTaskRouteSuffix,
+	heartbeatRouteSuffix,
+}
+
+func sampledRouteKey(path string) (string, bool) {
+	for _, suffix := range sampledRouteSuffixes {
+		if strings.HasSuffix(path, suffix) {
+			return suffix, true
+		}
+	}
+	return "", false
+}
+
+type routeWindow struct {
+	start time.Time
+	count int
+	paths map[string]struct{}
+}
+
+// sampledRequestLogger wraps gimlet's recovery logger. Requests matching
+// sampledRouteSuffixes are counted and summarized once per sampledRouteWindow
+// instead of logged individually; every other request falls back to
+// gimlet's normal per-request logging and panic recovery, unchanged.
+type sampledRequestLogger struct {
+	fallback gimlet.Middleware
+
+	mu      sync.Mutex
+	windows map[string]*routeWindow
+}
+
+func newSampledRequestLogger() gimlet.Middleware {
+	return &sampledRequestLogger{
+		fallback: gimlet.MakeRecoveryLogger(),
+		windows:  map[string]*routeWindow{},
+	}
+}
+
+func (l *sampledRequestLogger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	key, ok := sampledRouteKey(r.URL.Path)
+	if !ok {
+		l.fallback.ServeHTTP(rw, r, next)
+		return
+	}
+
+	defer func() {
+		if p := recover(); p != nil {
+			grip.Error(r.Context(), message.Fields{
+				"action": "aborted",
+				"path":   r.URL.Path,
+				"remote": r.RemoteAddr,
+				"panic":  fmt.Sprintf("%v", p),
+				"stack":  string(debug.Stack()),
+			})
+			gimlet.WriteJSONInternalError(r.Context(), rw, gimlet.ErrorResponse{
+				StatusCode: http.StatusInternalServerError,
+				Message:    "request aborted",
+			})
+		}
+	}()
+
+	next(rw, r)
+
+	// Log as normal if route failed.
+	status := rw.(negroni.ResponseWriter).Status()
+	if status != http.StatusOK {
+		grip.Error(r.Context(), message.Fields{
+			"action": "completed",
+			"method": r.Method,
+			"path":   r.URL.Path,
+			"remote": r.RemoteAddr,
+			"status": status,
+		})
+		return
+	}
+
+	l.recordSuccess(r, key, status)
+}
+
+// recordSuccess counts a successful call to a sampled route and flushes a
+// summary log line within one sample window.
+func (l *sampledRequestLogger) recordSuccess(r *http.Request, key string, status int) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	w, ok := l.windows[key]
+	if !ok {
+		w = &routeWindow{start: time.Now(), paths: map[string]struct{}{}}
+		l.windows[key] = w
+	}
+	w.count++
+	w.paths[r.URL.Path] = struct{}{}
+
+	if time.Since(w.start) < sampledRouteWindow {
+		return
+	}
+
+	paths := make([]string, 0, len(w.paths))
+	for path := range w.paths {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	grip.Info(r.Context(), message.Fields{
+		"action":        "completed",
+		"route":         key,
+		"status":        status,
+		"count":         w.count,
+		"window_secs":   time.Since(w.start).Seconds(),
+		"sampled_paths": paths,
+	})
+
+	w.start = time.Now()
+	w.count = 0
+	w.paths = map[string]struct{}{}
+}

--- a/service/sampled_request_logger.go
+++ b/service/sampled_request_logger.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"runtime/debug"
@@ -18,8 +19,6 @@ import (
 const (
 	heartbeatRouteSuffix = "/heartbeat"
 	nextTaskRouteSuffix  = "/agent/next_task"
-
-	sampledRouteWindow = time.Minute
 )
 
 var sampledRouteSuffixes = []string{
@@ -37,13 +36,13 @@ func sampledRouteKey(path string) (string, bool) {
 }
 
 type routeWindow struct {
-	start time.Time
-	count int
-	paths map[string]struct{}
+	count  int
+	status int
+	paths  map[string]struct{}
 }
 
 // sampledRequestLogger wraps gimlet's recovery logger. Requests matching
-// sampledRouteSuffixes are counted and summarized once per sampledRouteWindow
+// sampledRouteSuffixes are counted and summarized once per minute
 // instead of logged individually; every other request falls back to
 // gimlet's normal per-request logging and panic recovery, unchanged.
 type sampledRequestLogger struct {
@@ -53,11 +52,22 @@ type sampledRequestLogger struct {
 	windows map[string]*routeWindow
 }
 
-func newSampledRequestLogger() gimlet.Middleware {
-	return &sampledRequestLogger{
+// newSampledRequestLogger starts a background goroutine that flushes each
+// sampled route's summary every minute.
+func newSampledRequestLogger(ctx context.Context) gimlet.Middleware {
+	l := &sampledRequestLogger{
 		fallback: gimlet.MakeRecoveryLogger(),
 		windows:  map[string]*routeWindow{},
 	}
+
+	ticker := time.NewTicker(time.Minute)
+	go func() {
+		for range ticker.C {
+			l.flush(ctx)
+		}
+	}()
+
+	return l
 }
 
 func (l *sampledRequestLogger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
@@ -98,43 +108,49 @@ func (l *sampledRequestLogger) ServeHTTP(rw http.ResponseWriter, r *http.Request
 		return
 	}
 
-	l.recordSuccess(r, key, status)
+	l.recordSuccess(key, r.URL.Path, status)
 }
 
-// recordSuccess counts a successful call to a sampled route and flushes a
-// summary log line within one sample window.
-func (l *sampledRequestLogger) recordSuccess(r *http.Request, key string, status int) {
+// recordSuccess counts a successful call to a sampled route.
+func (l *sampledRequestLogger) recordSuccess(key, path string, status int) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	w, ok := l.windows[key]
 	if !ok {
-		w = &routeWindow{start: time.Now(), paths: map[string]struct{}{}}
+		w = &routeWindow{paths: map[string]struct{}{}}
 		l.windows[key] = w
 	}
 	w.count++
-	w.paths[r.URL.Path] = struct{}{}
+	w.status = status
+	w.paths[path] = struct{}{}
+}
 
-	if time.Since(w.start) < sampledRouteWindow {
-		return
+// flush logs and resets every route's accumulated count and paths.
+func (l *sampledRequestLogger) flush(ctx context.Context) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for key, w := range l.windows {
+		if w.count == 0 {
+			continue
+		}
+
+		paths := make([]string, 0, len(w.paths))
+		for path := range w.paths {
+			paths = append(paths, path)
+		}
+		sort.Strings(paths)
+
+		grip.Info(ctx, message.Fields{
+			"action":        "completed",
+			"route":         key,
+			"status":        w.status,
+			"count":         w.count,
+			"sampled_paths": paths,
+		})
+
+		w.count = 0
+		w.paths = map[string]struct{}{}
 	}
-
-	paths := make([]string, 0, len(w.paths))
-	for path := range w.paths {
-		paths = append(paths, path)
-	}
-	sort.Strings(paths)
-
-	grip.Info(r.Context(), message.Fields{
-		"action":        "completed",
-		"route":         key,
-		"status":        status,
-		"count":         w.count,
-		"window_secs":   time.Since(w.start).Seconds(),
-		"sampled_paths": paths,
-	})
-
-	w.start = time.Now()
-	w.count = 0
-	w.paths = map[string]struct{}{}
 }

--- a/service/service.go
+++ b/service/service.go
@@ -36,7 +36,7 @@ func GetServer(ctx context.Context, addr string, n http.Handler) *http.Server {
 
 func GetRouter(ctx context.Context, as *APIServer, uis *UIServer) (http.Handler, error) {
 	app := gimlet.NewApp()
-	app.AddMiddleware(gimlet.MakeRecoveryLogger())
+	app.AddMiddleware(newSampledRequestLogger())
 	app.AddMiddleware(gimlet.UserMiddleware(ctx, uis.env.UserManager(), uis.umconf))
 	app.AddMiddleware(evergreen.NewHTTPRequestOtelMiddleware())
 	app.AddMiddleware(gimlet.NewAuthenticationHandler(gimlet.NewBasicAuthenticator(nil, nil), uis.env.UserManager()))

--- a/service/service.go
+++ b/service/service.go
@@ -36,7 +36,7 @@ func GetServer(ctx context.Context, addr string, n http.Handler) *http.Server {
 
 func GetRouter(ctx context.Context, as *APIServer, uis *UIServer) (http.Handler, error) {
 	app := gimlet.NewApp()
-	app.AddMiddleware(newSampledRequestLogger())
+	app.AddMiddleware(newSampledRequestLogger(ctx))
 	app.AddMiddleware(gimlet.UserMiddleware(ctx, uis.env.UserManager(), uis.umconf))
 	app.AddMiddleware(evergreen.NewHTTPRequestOtelMiddleware())
 	app.AddMiddleware(gimlet.NewAuthenticationHandler(gimlet.NewBasicAuthenticator(nil, nil), uis.env.UserManager()))

--- a/units/host_status.go
+++ b/units/host_status.go
@@ -115,6 +115,7 @@ clientsLoop:
 				continue clientsLoop
 			}
 
+			var numStatusErrors int
 			for i := range hosts {
 				hostID := hosts[i].Id
 				status, ok := statuses[hostID]
@@ -126,7 +127,17 @@ clientsLoop:
 					}))
 					statuses[hostID] = cloud.StatusNonExistent
 				}
-				j.AddError(errors.Wrapf(j.setCloudHostStatus(ctx, hosts[i], status), "setting status for host '%s' based on its cloud instance's status", hosts[i].Id))
+				if err := j.setCloudHostStatus(ctx, hosts[i], status); err != nil {
+					grip.Error(ctx, message.WrapError(err, message.Fields{
+						"message": "setting status for host based on its cloud instance's status",
+						"host_id": hostID,
+						"job":     j.ID(),
+					}))
+					numStatusErrors++
+				}
+			}
+			if numStatusErrors > 0 {
+				j.AddError(errors.Errorf("failed to set cloud host status for %d host(s)", numStatusErrors))
 			}
 
 			continue


### PR DESCRIPTION
DEVPROD-32002

### Description
reduces the size and number of logs
no longer prints the entire event from github 
consolidates successful heartbeat and next_task  completed routes

### Testing
tested on staging 

heartbeat logs now look like this 
<img width="936" height="431" alt="image" src="https://github.com/user-attachments/assets/69b8a9af-f97f-4e9c-8844-1b8665dda8f5" />

<img width="886" height="360" alt="image" src="https://github.com/user-attachments/assets/a6f44fa4-0171-4675-a0c2-f25021523c0d" />


confirmed that errors will still log normally 
