### PR TITLE
DEVPROD-24984 Use new agent monitor binary path

### DIFF
--- a/docs/Hosts/Agent-Monitor-Binaries.md
+++ b/docs/Hosts/Agent-Monitor-Binaries.md
@@ -12,4 +12,4 @@ These paths are internal to Evergreen.
 
 Some existing tasks invoke `~/evergreen` directly. The agent monitor refreshes this compatibility path best-effort whenever it downloads a new agent, but new callers should not rely on it being available or current.
 
-**Do not build new features or task commands against `~/evergreen_agent_monitor`.** Migrate callers to supported interfaces, like downloading the Evergreen binary inside your task's directory and using that download.
+**Do not build new features or task commands against `~/evergreen_agent_monitor`.** Migrate callers to supported interfaces: use the [static client download manifest](../CLI.md#static-client-download-manifest) to discover the latest platform-specific S3 URL, then download the Evergreen binary inside your task's directory and use that download.

--- a/docs/Hosts/Agent-Monitor-Binaries.md
+++ b/docs/Hosts/Agent-Monitor-Binaries.md
@@ -10,6 +10,6 @@ These paths are internal to Evergreen.
 | `<client_dir>/evergreen`    | Rolling agent binary downloaded by the monitor on each version change        | No — internal Evergreen use only    |
 | `~/evergreen`               | Compatibility copy of the current agent for workflows that still invoke it   | **No** — refreshed best-effort only |
 
-Some existing tasks invoke `~/evergreen` directly. The agent monitor refreshes this compatibility path best-effort whenever it downloads a new agent, but callers should not rely on it being available or current.
+Some existing tasks invoke `~/evergreen` directly. The agent monitor refreshes this compatibility path best-effort whenever it downloads a new agent, but new callers should not rely on it being available or current.
 
-**Do not build new features or task commands against `~/evergreen` or `~/evergreen_agent_monitor`.** Migrate callers to supported interfaces (spawn-host CLI layout, task-local tooling, etc.) instead.
+**Do not build new features or task commands against `~/evergreen_agent_monitor`.** Migrate callers to supported interfaces, like downloading the Evergreen binary inside your task's directory and using that download.

--- a/docs/Hosts/Agent-Monitor-Binaries.md
+++ b/docs/Hosts/Agent-Monitor-Binaries.md
@@ -1,0 +1,15 @@
+# Evergreen Binaries on Tasks
+
+Evergreen tasks may encounter multiple Evergreen binaries on their host. The agent monitor is a long-lived process that downloads and supervises the rolling agent binary used to execute tasks.
+
+These paths are internal to Evergreen.
+
+| Path                        | Role                                                                         | Supported for callers?              |
+| --------------------------- | ---------------------------------------------------------------------------- | ----------------------------------- |
+| `~/evergreen_agent_monitor` | Long-lived agent monitor binary (provision, host setup, Jasper monitor loop) | No — internal Evergreen use only    |
+| `<client_dir>/evergreen`    | Rolling agent binary downloaded by the monitor on each version change        | No — internal Evergreen use only    |
+| `~/evergreen`               | Compatibility copy of the current agent for workflows that still invoke it   | **No** — refreshed best-effort only |
+
+Some existing tasks invoke `~/evergreen` directly. The agent monitor refreshes this compatibility path best-effort whenever it downloads a new agent, but callers should not rely on it being available or current.
+
+**Do not build new features or task commands against `~/evergreen` or `~/evergreen_agent_monitor`.** Migrate callers to supported interfaces (spawn-host CLI layout, task-local tooling, etc.) instead.

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -483,6 +483,17 @@ func (d *Distro) BinaryName() string {
 	return name
 }
 
+// AgentMonitorBinaryName returns the filename of the agent monitor binary.
+// This is intentionally distinct from BinaryName so the long-lived monitor is
+// not the same file as the unsupported legacy ~/evergreen path.
+func (d *Distro) AgentMonitorBinaryName() string {
+	name := "evergreen_agent_monitor"
+	if d.IsWindows() {
+		return name + ".exe"
+	}
+	return name
+}
+
 // ExecutableSubPath returns the directory containing the compiled agents.
 func (d *Distro) ExecutableSubPath() string {
 	return filepath.Join(d.Arch, d.BinaryName())

--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -38,7 +38,7 @@ const OutputBufferSize = 1000
 
 // SetupCommand returns the command to run the host setup script.
 func (h *Host) SetupCommand() string {
-	cmd := fmt.Sprintf("cd %s && ./%s host setup", h.Distro.HomeDir(), h.Distro.BinaryName())
+	cmd := fmt.Sprintf("cd %s && ./%s host setup", h.Distro.HomeDir(), h.Distro.AgentMonitorBinaryName())
 
 	if h.Distro.SetupAsSudo {
 		cmd += " --setup_as_sudo"
@@ -98,25 +98,34 @@ func (h *Host) curlCommands(env evergreen.Environment, curlArgs string) ([]strin
 		return nil, errors.Errorf("S3 downloads are not configured")
 	}
 
+	monitorBinary := h.Distro.AgentMonitorBinaryName()
+	compatBinary := h.Distro.BinaryName()
+
 	cmds := []string{
 		fmt.Sprintf("cd %s", h.Distro.HomeDir()),
 	}
 	if h.Distro.IsMacOS() {
-		// Ensure the Evergreen client file is deleted on MacOS hosts before
-		// downloading it again. This is necessary to fix a MacOS-specific issue
+		// Ensure the Evergreen client files are deleted on MacOS hosts before
+		// downloading again. This is necessary to fix a MacOS-specific issue
 		// where if the host has System Integrity Protection (SIP) enabled and
 		// it runs an Evergreen client that has a problem (e.g. the binary was
 		// not signed by Apple), running that client results in SIGKILL. The
 		// SIGKILL issue will persist even if a valid agent is downloaded to
 		// replace it. Removing the binary before downloading it is the only
 		// known workaround to ensure that MacOS can run the client.
-		cmds = append(cmds, fmt.Sprintf("rm -f %s", h.Distro.BinaryName()))
+		cmds = append(cmds, fmt.Sprintf("rm -f %s %s", monitorBinary, compatBinary))
 	}
 	cmds = append(cmds,
-		// Download the agent from S3. Include -f to return an error code from curl if the HTTP request
-		// fails (e.g. it receives 403 Forbidden or 404 Not Found).
-		fmt.Sprintf("curl -fLO %s%s", h.Distro.S3ClientURL(env), curlArgs),
-		fmt.Sprintf("chmod +x %s", h.Distro.BinaryName()),
+		// Download the agent monitor from S3. Include -f to return an error
+		// code from curl if the HTTP request fails (e.g. it receives 403
+		// Forbidden or 404 Not Found). Use -o so the file is stored under the
+		// agent monitor name rather than the S3 object name (evergreen).
+		fmt.Sprintf("curl -fL -o %s %s%s", monitorBinary, h.Distro.S3ClientURL(env), curlArgs),
+		fmt.Sprintf("chmod +x %s", monitorBinary),
+		// Keep the legacy ~/evergreen path updated because existing workflows
+		// still call it and cannot be migrated yet. This path is unsupported.
+		// Best-effort so a failure to copy does not block provisioning.
+		fmt.Sprintf("(cp %s %s || true)", monitorBinary, compatBinary),
 	)
 
 	return cmds, nil
@@ -998,10 +1007,11 @@ func (h *Host) StopAgentMonitor(ctx context.Context, env evergreen.Environment) 
 }
 
 // AgentCommand returns the arguments to start the agent. If executablePath is not specified, it
-// will be assumed to be in the regular place (only pass this for container distros)
+// will be assumed to be the agent monitor binary in the home directory (only pass this for
+// container distros).
 func (h *Host) AgentCommand(settings *evergreen.Settings, executablePath string) []string {
 	if executablePath == "" {
-		executablePath = h.Distro.AbsPathCygwinCompatible(h.Distro.HomeDir(), h.Distro.BinaryName())
+		executablePath = h.Distro.AbsPathCygwinCompatible(h.Distro.HomeDir(), h.Distro.AgentMonitorBinaryName())
 	}
 	args := []string{
 		executablePath,
@@ -1044,12 +1054,14 @@ func (h *Host) AgentEnvSlice() []string {
 // agent monitor.
 func (h *Host) AgentMonitorOptions(settings *evergreen.Settings) *options.Create {
 	clientPath := h.Distro.AbsPathNotCygwinCompatible(h.Distro.BootstrapSettings.ClientDir, h.Distro.BinaryName())
+	compatClientPath := h.Distro.AbsPathNotCygwinCompatible(h.Distro.HomeDir(), h.Distro.BinaryName())
 	credsPath := h.Distro.AbsPathNotCygwinCompatible(h.Distro.BootstrapSettings.JasperCredentialsPath)
 	shellPath := h.Distro.AbsPathNotCygwinCompatible(h.Distro.BootstrapSettings.ShellPath)
 
 	args := append(h.AgentCommand(settings, ""), "monitor")
 	args = append(args,
 		fmt.Sprintf("--client_path=%s", clientPath),
+		fmt.Sprintf("--compat_client_path=%s", compatClientPath),
 		fmt.Sprintf("--distro=%s", h.Distro.Id),
 		fmt.Sprintf("--shell_path=%s", shellPath),
 		fmt.Sprintf("--jasper_port=%d", settings.HostJasper.Port),
@@ -1110,16 +1122,24 @@ func (h *Host) spawnHostSetupConfigDirCommands(conf []byte) string {
 		// Note: this will likely fail if the configuration file content
 		// contains quotes.
 		fmt.Sprintf("echo \"%s\" > %s", conf, h.spawnHostConfigFile()),
-		fmt.Sprintf("chmod +x %s", filepath.Join(h.AgentBinary())),
-		fmt.Sprintf("cp %s %s", h.AgentBinary(), h.spawnHostConfigDir()),
+		fmt.Sprintf("chmod +x %s", h.AgentMonitorBinary()),
+		fmt.Sprintf("cp %s %s", h.AgentMonitorBinary(), h.spawnHostConfigDir()),
 		fmt.Sprintf("(echo '\nexport PATH=\"${PATH}:%s\"\n' >> %s/.profile || true; echo '\nexport PATH=\"${PATH}:%s\"\n' >> %s/.bash_profile || true)", h.spawnHostConfigDir(), h.Distro.HomeDir(), h.spawnHostConfigDir(), h.Distro.HomeDir()),
 		fmt.Sprintf("(%s || true)", h.changeOwnerCommand(filepath.Join(h.Distro.HomeDir(), ".profile"), filepath.Join(h.Distro.HomeDir(), ".bash_profile"))),
 	}, " && ")
 }
 
-// AgentBinary returns the path to the evergreen agent binary.
+// AgentBinary returns the path to the legacy evergreen binary in the home
+// directory (typically ~/evergreen). That location is unsupported; Evergreen
+// only keeps refreshing it because existing workflows still call it and cannot
+// be migrated yet. The agent monitor runs from AgentMonitorBinary.
 func (h *Host) AgentBinary() string {
 	return filepath.Join(h.Distro.HomeDir(), h.Distro.BinaryName())
+}
+
+// AgentMonitorBinary returns the path to the agent monitor binary.
+func (h *Host) AgentMonitorBinary() string {
+	return filepath.Join(h.Distro.HomeDir(), h.Distro.AgentMonitorBinaryName())
 }
 
 // spawnHostConfigDir returns the directory containing the CLI and evergreen
@@ -1205,8 +1225,10 @@ func (h *Host) spawnHostConfig(ctx context.Context, settings *evergreen.Settings
 func (h *Host) SpawnHostGetTaskDataCommand(ctx context.Context, githubAppToken string, moduleTokens []string) []string {
 	s := []string{
 		// We can't use the absolute path for the binary because we always run
-		// it in a Cygwin context on Windows.
-		h.AgentBinary(),
+		// it in a Cygwin context on Windows. Use the agent monitor binary
+		// because provisioning downloads it first; ~/evergreen is only an
+		// unsupported legacy copy that we refresh best-effort.
+		h.AgentMonitorBinary(),
 		"-c", h.Distro.AbsPathNotCygwinCompatible(h.spawnHostConfigFile()),
 		"fetch",
 		"-t", h.ProvisionOptions.TaskId,
@@ -1299,11 +1321,11 @@ func (h *Host) GenerateFetchProvisioningScriptUserData(ctx context.Context, env 
 	if err != nil {
 		return nil, errors.Wrap(err, "creating curl command for evergreen client")
 	}
-	// User data runs as the privileged user, so ensure that the binary has
-	// permissions that allow it to be modified after user data is finished.
-	fixClientOwner := h.changeOwnerCommand(filepath.Join(h.Distro.HomeDir(), h.Distro.BinaryName()))
+	// User data runs as the privileged user, so ensure that the binaries have
+	// permissions that allow them to be modified after user data is finished.
+	fixClientOwner := h.changeOwnerCommand(h.AgentMonitorBinary(), h.AgentBinary())
 	fetchScriptCmd := strings.Join([]string{
-		filepath.Join(h.Distro.HomeDir(), h.Distro.BinaryName()),
+		h.AgentMonitorBinary(),
 		"host",
 		"provision",
 		fmt.Sprintf("--api_server=%s", env.Settings().Api.URL),

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -47,7 +47,7 @@ func TestCurlCommand(t *testing.T) {
 			},
 			User: "user",
 		}
-		expected := "cd /home/user && curl -fLO https://foo.com/linux_amd64/evergreen && chmod +x evergreen"
+		expected := "cd /home/user && curl -fL -o evergreen_agent_monitor https://foo.com/linux_amd64/evergreen && chmod +x evergreen_agent_monitor && (cp evergreen_agent_monitor evergreen || true)"
 		cmd, err := h.CurlCommand(env)
 		require.NoError(t, err)
 		assert.Equal(t, expected, cmd)
@@ -60,7 +60,7 @@ func TestCurlCommand(t *testing.T) {
 			},
 			User: "user",
 		}
-		expected := "cd /Users/user && rm -f evergreen && curl -fLO https://foo.com/darwin_arm64/evergreen && chmod +x evergreen"
+		expected := "cd /Users/user && rm -f evergreen_agent_monitor evergreen && curl -fL -o evergreen_agent_monitor https://foo.com/darwin_arm64/evergreen && chmod +x evergreen_agent_monitor && (cp evergreen_agent_monitor evergreen || true)"
 		cmd, err := h.CurlCommand(env)
 		require.NoError(t, err)
 		assert.Equal(t, expected, cmd)
@@ -78,7 +78,7 @@ func TestSpawnHostGetTaskDataCommand(t *testing.T) {
 			WorkDir: "/some/directory",
 		},
 	}
-	expected := []string{"/home/evergreen", "-c", "/home/.evergreen.yml", "fetch", "-t", "task_id", "--source", "--artifacts", "--dir", "/some/directory", "--use-app-token", "--revoke-tokens", "--token", "gh_something_token", "-m", "module:gh_module_token", "-m", "module2:gh_module2_token"}
+	expected := []string{"/home/evergreen_agent_monitor", "-c", "/home/.evergreen.yml", "fetch", "-t", "task_id", "--source", "--artifacts", "--dir", "/some/directory", "--use-app-token", "--revoke-tokens", "--token", "gh_something_token", "-m", "module:gh_module_token", "-m", "module2:gh_module2_token"}
 	cmd := h.SpawnHostGetTaskDataCommand(ctx, "gh_something_token", []string{"module:gh_module_token", "module2:gh_module2_token"})
 	assert.Equal(t, expected, cmd)
 }
@@ -97,7 +97,7 @@ func TestCurlCommandWithRetry(t *testing.T) {
 		},
 		User: "user",
 	}
-	expected := "cd /home/user && curl -fLO https://foo.com/linux_amd64/evergreen --retry 5 --retry-max-time 10 && chmod +x evergreen"
+	expected := "cd /home/user && curl -fL -o evergreen_agent_monitor https://foo.com/linux_amd64/evergreen --retry 5 --retry-max-time 10 && chmod +x evergreen_agent_monitor && (cp evergreen_agent_monitor evergreen || true)"
 	cmd, err := h.CurlCommandWithRetry(env, 5, 10)
 	require.NoError(t, err)
 	assert.Equal(t, expected, cmd)
@@ -1301,14 +1301,14 @@ func TestGenerateFetchProvisioningScriptUserData(t *testing.T) {
 
 			makeJasperDirs := h.MakeJasperDirsCommand()
 			fetchClient, err := h.CurlCommandWithDefaultRetry(env)
-			fixClientOwner := h.changeOwnerCommand(filepath.Join(h.Distro.HomeDir(), h.Distro.BinaryName()))
+			fixClientOwner := h.changeOwnerCommand(h.AgentMonitorBinary(), h.AgentBinary())
 			require.NoError(t, err)
 
 			expectedParts := []string{
 				makeJasperDirs,
 				fetchClient,
 				fixClientOwner,
-				"/home/user/evergreen host provision",
+				"/home/user/evergreen_agent_monitor host provision",
 				"--api_server=https://example.com",
 				"--host_id=host_id",
 				"--host_secret=host_secret",
@@ -1328,13 +1328,13 @@ func TestGenerateFetchProvisioningScriptUserData(t *testing.T) {
 			makeJasperDirs := h.MakeJasperDirsCommand()
 			fetchClient, err := h.CurlCommandWithDefaultRetry(env)
 			require.NoError(t, err)
-			fixClientOwner := h.changeOwnerCommand(filepath.Join(h.Distro.HomeDir(), h.Distro.BinaryName()))
+			fixClientOwner := h.changeOwnerCommand(h.AgentMonitorBinary(), h.AgentBinary())
 
 			expectedParts := []string{
 				makeJasperDirs,
 				fetchClient,
 				fixClientOwner,
-				"/home/user/evergreen.exe host provision",
+				"/home/user/evergreen_agent_monitor.exe host provision",
 				"--api_server=https://example.com",
 				"--host_id=host_id",
 				"--host_secret=host_secret",

--- a/operations/agent_monitor.go
+++ b/operations/agent_monitor.go
@@ -92,7 +92,7 @@ func agentMonitor() cli.Command {
 	const (
 		credentialsPathFlagName = "credentials"
 		clientPathFlagName      = "client_path"
-		// compactClientPathFlagName is the compatabile client path for
+		// compactClientPathFlagName is the compatible client path for
 		// legacy tasks that still rely on it.
 		compatClientPathFlagName = "compat_client_path"
 		distroIDFlagName         = "distro"

--- a/operations/agent_monitor.go
+++ b/operations/agent_monitor.go
@@ -3,6 +3,7 @@ package operations
 import (
 	"context"
 	"fmt"
+	"io"
 	"math"
 	"net"
 	"os"
@@ -52,16 +53,17 @@ func getLogID() int {
 // operate.
 type monitor struct {
 	// Monitor args
-	credentialsPath string
-	clientPath      string
-	hostID          string
-	cloudProvider   string
-	distroID        string
-	shellPath       string
-	logOutput       globals.LogOutputType
-	logPrefix       string
-	jasperPort      int
-	port            int
+	credentialsPath  string
+	clientPath       string
+	compatClientPath string
+	hostID           string
+	cloudProvider    string
+	distroID         string
+	shellPath        string
+	logOutput        globals.LogOutputType
+	logPrefix        string
+	jasperPort       int
+	port             int
 
 	// Args to be forwarded to the agent
 	agentArgs []string
@@ -90,12 +92,15 @@ func agentMonitor() cli.Command {
 	const (
 		credentialsPathFlagName = "credentials"
 		clientPathFlagName      = "client_path"
-		distroIDFlagName        = "distro"
-		shellPathFlagName       = "shell_path"
-		logOutputFlagName       = "log_output"
-		logPrefixFlagName       = "log_prefix"
-		jasperPortFlagName      = "jasper_port"
-		portFlagName            = "port"
+		// compactClientPathFlagName is the compatabile client path for
+		// legacy tasks that still rely on it.
+		compatClientPathFlagName = "compat_client_path"
+		distroIDFlagName         = "distro"
+		shellPathFlagName        = "shell_path"
+		logOutputFlagName        = "log_output"
+		logPrefixFlagName        = "log_prefix"
+		jasperPortFlagName       = "jasper_port"
+		portFlagName             = "port"
 	)
 
 	const (
@@ -114,6 +119,10 @@ func agentMonitor() cli.Command {
 			cli.StringFlag{
 				Name:  clientPathFlagName,
 				Usage: "the name of the agent's evergreen binary",
+			},
+			cli.StringFlag{
+				Name:  compatClientPathFlagName,
+				Usage: "internal only: legacy ~/evergreen path to refresh after each client download; unsupported and not for callers to rely on",
 			},
 			cli.StringFlag{
 				Name:  distroIDFlagName,
@@ -171,17 +180,18 @@ func agentMonitor() cli.Command {
 			comm.SetHostSecret(hostSecret)
 
 			m := &monitor{
-				comm:            comm,
-				credentialsPath: c.String(credentialsPathFlagName),
-				clientPath:      c.String(clientPathFlagName),
-				hostID:          hostID,
-				distroID:        c.String(distroIDFlagName),
-				cloudProvider:   c.Parent().String(agentCloudProviderFlagName),
-				shellPath:       c.String(shellPathFlagName),
-				jasperPort:      c.Int(jasperPortFlagName),
-				port:            c.Int(portFlagName),
-				logOutput:       globals.LogOutputType(c.String(logOutputFlagName)),
-				logPrefix:       c.String(logPrefixFlagName),
+				comm:             comm,
+				credentialsPath:  c.String(credentialsPathFlagName),
+				clientPath:       c.String(clientPathFlagName),
+				compatClientPath: c.String(compatClientPathFlagName),
+				hostID:           hostID,
+				distroID:         c.String(distroIDFlagName),
+				cloudProvider:    c.Parent().String(agentCloudProviderFlagName),
+				shellPath:        c.String(shellPathFlagName),
+				jasperPort:       c.Int(jasperPortFlagName),
+				port:             c.Int(portFlagName),
+				logOutput:        globals.LogOutputType(c.String(logOutputFlagName)),
+				logPrefix:        c.String(logPrefixFlagName),
 			}
 
 			m.agentArgs, err = getAgentArgs(c, os.Args)
@@ -305,6 +315,17 @@ func (m *monitor) removeMacOSClient() error {
 	return nil
 }
 
+// removeMacOSCompatClient deletes the legacy home evergreen binary on MacOS
+// hosts for the same SIP workaround as removeMacOSClient. Failures are ignored
+// by callers because refreshing that path is best-effort only.
+func (m *monitor) removeMacOSCompatClient() error {
+	if runtime.GOOS != "darwin" || m.compatClientPath == "" {
+		return nil
+	}
+
+	return errors.Wrapf(os.RemoveAll(m.compatClientPath), "removing legacy home client '%s'", m.compatClientPath)
+}
+
 // fetchClient downloads the evergreen client.
 func (m *monitor) fetchClient(ctx context.Context, urls []string, retry utility.RetryOptions) error {
 	var downloaded bool
@@ -336,6 +357,38 @@ func (m *monitor) fetchClient(ctx context.Context, urls []string, retry utility.
 	}
 
 	return errors.Wrap(os.Chmod(m.clientPath, 0755), "changing permissions of downloaded client")
+}
+
+// updateCompatClient copies the freshly downloaded agent client to the legacy
+// home path (typically ~/evergreen). That location is unsupported; we only
+// refresh it because existing tasks still call it and have not be migrated
+// yet. Failures are best-effort and must not fail the monitor loop.
+func (m *monitor) updateCompatClient() error {
+	if m.compatClientPath == "" {
+		return nil
+	}
+
+	src, err := os.Open(m.clientPath)
+	if err != nil {
+		return errors.Wrapf(err, "opening client '%s'", m.clientPath)
+	}
+	defer src.Close()
+
+	if err = os.MkdirAll(filepath.Dir(m.compatClientPath), 0755); err != nil {
+		return errors.Wrapf(err, "creating directory for legacy home client '%s'", m.compatClientPath)
+	}
+
+	dst, err := os.OpenFile(m.compatClientPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0755)
+	if err != nil {
+		return errors.Wrapf(err, "creating legacy home client '%s'", m.compatClientPath)
+	}
+	defer dst.Close()
+
+	if _, err = io.Copy(dst, src); err != nil {
+		return errors.Wrapf(err, "copying client to legacy home path '%s'", m.compatClientPath)
+	}
+
+	return errors.Wrapf(os.Chmod(m.compatClientPath, 0755), "changing permissions of legacy home client '%s'", m.compatClientPath)
 }
 
 // setupJasperConnection attempts to connect to the Jasper RPC service running
@@ -499,6 +552,14 @@ func (m *monitor) run(ctx context.Context) {
 				return true, err
 			}
 
+			if err := m.removeMacOSCompatClient(); err != nil {
+				grip.Warning(ctx, message.WrapError(err, message.Fields{
+					"message":            "could not remove MacOS legacy home client",
+					"distro":             m.distroID,
+					"compat_client_path": m.compatClientPath,
+				}))
+			}
+
 			clientURLs, err := m.comm.GetClientURLs(ctx, m.distroID)
 			if err != nil {
 				return true, errors.Wrap(err, "retrieving client URLs")
@@ -518,6 +579,18 @@ func (m *monitor) run(ctx context.Context) {
 			if _, err := os.Stat(m.clientPath); os.IsNotExist(err) {
 				grip.Error(ctx, errors.Wrapf(err, "getting file stat for client '%s'", m.clientPath))
 				return true, err
+			}
+
+			// Best-effort refresh of the unsupported legacy ~/evergreen path so
+			// existing callers that we cannot migrate yet are less likely to
+			// run a stale binary.
+			if err := m.updateCompatClient(); err != nil {
+				grip.Warning(ctx, message.WrapError(err, message.Fields{
+					"message":            "could not update legacy home evergreen binary",
+					"distro":             m.distroID,
+					"client_path":        m.clientPath,
+					"compat_client_path": m.compatClientPath,
+				}))
 			}
 
 			// This is only a warning because it's a best-effort attempt to give

--- a/operations/agent_monitor_test.go
+++ b/operations/agent_monitor_test.go
@@ -45,6 +45,21 @@ func TestAgentMonitorWithJasper(t *testing.T) {
 			require.NoError(t, err)
 			assert.NotZero(t, fileInfo.Size())
 		},
+		"UpdateCompatClientCopiesDownloadedClient": func(ctx context.Context, t *testing.T, m *monitor) {
+			require.NoError(t, m.fetchClient(ctx, []string{"https://example.com"}, agentMonitorDefaultRetryOptions()))
+			require.NoError(t, m.updateCompatClient())
+
+			clientInfo, err := os.Stat(m.clientPath)
+			require.NoError(t, err)
+			compatInfo, err := os.Stat(m.compatClientPath)
+			require.NoError(t, err)
+			assert.Equal(t, clientInfo.Size(), compatInfo.Size())
+		},
+		"UpdateCompatClientNoopsWhenCompatPathUnset": func(ctx context.Context, t *testing.T, m *monitor) {
+			m.compatClientPath = ""
+			require.NoError(t, m.fetchClient(ctx, []string{"https://example.com"}, agentMonitorDefaultRetryOptions()))
+			require.NoError(t, m.updateCompatClient())
+		},
 		"WaitUntilCompleteWaitsForProcessTermination": func(ctx context.Context, t *testing.T, m *monitor) {
 			opts := &options.Create{Args: []string{"sleep", "1"}}
 			proc, err := m.jasperClient.CreateProcess(ctx, opts)
@@ -107,12 +122,13 @@ func TestAgentMonitorWithJasper(t *testing.T) {
 			tmpDir := t.TempDir()
 
 			m := &monitor{
-				clientPath: filepath.Join(tmpDir, "evergreen"),
-				distroID:   "distro",
-				logOutput:  globals.LogOutputFile,
-				logPrefix:  filepath.Join(tmpDir, "agent-monitor"),
-				jasperPort: jasperPort,
-				port:       port,
+				clientPath:       filepath.Join(tmpDir, "evergreen"),
+				compatClientPath: filepath.Join(tmpDir, "compat", "evergreen"),
+				distroID:         "distro",
+				logOutput:        globals.LogOutputFile,
+				logPrefix:        filepath.Join(tmpDir, "agent-monitor"),
+				jasperPort:       jasperPort,
+				port:             port,
 			}
 
 			// Monitor should be able to connect without needing credentials when


### PR DESCRIPTION
DEVPROD-24984

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->

A lot of workflows use ~/evergreen, which is our agent monitor binary path. This binary doesn't get updated, so long standing hosts typically run an old binary. This has downstream effects, specifically when we revert, the agent binary is updated but we will see random tasks fail because they use the agent monitor binary which didn't pick up the revert.

### Testing

<!--add a description of how you tested it-->
Deployed to staging. I tested it on the hosts there and it worked with no bad behavior. After this is merged, I'll do some testing on static hosts on prod (I talked with Kim over the testing strategy here, feel free to DM me if you want more info/want to talk about it too!)

### Documentation

I documented the ~/evergreen and ~/evergreen_agent_monitor paths for future reference. These are not for official supported use cases.

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->