### PR TITLE
DEVPROD-36648 Only override safe settings for local client configuration files

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-07-10"
+	ClientVersion = "2026-07-13"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/model.go
+++ b/operations/model.go
@@ -164,6 +164,17 @@ type ClientSettings struct {
 	StagingEnvironment string `json:"staging_environment,omitempty" yaml:"staging_environment,omitempty"`
 }
 
+// localClientSettings contains the settings that may safely be overridden by
+// a configuration file in the current working directory.
+type localClientSettings struct {
+	UncommittedChanges         *bool                       `yaml:"patch_uncommitted_changes,omitempty"`
+	PreserveCommits            *bool                       `yaml:"preserve_commits,omitempty"`
+	Projects                   []ClientProjectConf         `yaml:"projects,omitempty"`
+	DisableAutoDefaulting      *bool                       `yaml:"disable_auto_defaulting"`
+	ProjectsForDirectory       map[string]string           `yaml:"projects_for_directory,omitempty"`
+	LastRevisionCriteriaGroups []lastRevisionCriteriaGroup `yaml:"last_revision_criteria_groups,omitempty"`
+}
+
 func NewClientSettings(fn string) (*ClientSettings, error) {
 	path, err := findConfigFilePath(context.Background(), fn)
 	if err != nil {
@@ -188,10 +199,30 @@ func NewClientSettings(fn string) (*ClientSettings, error) {
 		return nil, errors.Wrapf(err, "reading local configuration from file '%s'", localConfigPath)
 	}
 
-	// Unmarshalling into the same struct will only override fields which are set
-	// in the new YAML
-	if err = yaml.Unmarshal(localData, conf); err != nil {
+	// Only merge settings that describe the local project and working tree.
+	// Connection, authentication, and update settings must come from the
+	// explicitly selected configuration file rather than the current directory.
+	localConf := &localClientSettings{}
+	if err = yaml.Unmarshal(localData, localConf); err != nil {
 		return nil, errors.Wrapf(err, "unmarshalling YAML data from local configuration file '%s'", localConfigPath)
+	}
+	if localConf.UncommittedChanges != nil {
+		conf.UncommittedChanges = *localConf.UncommittedChanges
+	}
+	if localConf.PreserveCommits != nil {
+		conf.PreserveCommits = *localConf.PreserveCommits
+	}
+	if localConf.Projects != nil {
+		conf.Projects = localConf.Projects
+	}
+	if localConf.DisableAutoDefaulting != nil {
+		conf.DisableAutoDefaulting = *localConf.DisableAutoDefaulting
+	}
+	if localConf.ProjectsForDirectory != nil {
+		conf.ProjectsForDirectory = localConf.ProjectsForDirectory
+	}
+	if localConf.LastRevisionCriteriaGroups != nil {
+		conf.LastRevisionCriteriaGroups = localConf.LastRevisionCriteriaGroups
 	}
 
 	return conf, nil

--- a/operations/model_test.go
+++ b/operations/model_test.go
@@ -167,6 +167,10 @@ projects:
 
 	err = os.WriteFile(localConfigPath,
 		[]byte(`
+api_server_host: https://malicious.evergreen.api
+auto_upgrade_cli: true
+oauth:
+  issuer: https://malicious.evergreen.oauth
 user: some-other-username
 projects:
 - name: my-other-project
@@ -194,8 +198,8 @@ projects_for_directory:
 		UIServerHost: "https://some.evergreen.ui",
 		// from global config
 		APIKey: "not-a-valid-token",
-		// from local config
-		User: "some-other-username",
+		// The local config cannot override connection or authentication settings.
+		User: "myusername",
 		// from global config
 		LoadedFrom: globalTestConfigPath,
 		// from local config


### PR DESCRIPTION
DEVPROD-36648

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->
This changes our local client configuration to only override certain fields rather than all of them, to prevent malicious local evergreen files.

### Testing

<!--add a description of how you tested it-->
Unit tests and a local test with the built binary.