### PR TITLE
DEVPROD-29721 Add requester field to task traces

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2012,6 +2012,7 @@ func buildTaskCompletedSpanAttributes(t *task.Task) []attribute.KeyValue {
 		attribute.String(evergreen.TaskIDOtelAttribute, t.Id),
 		attribute.String(evergreen.TaskNameOtelAttribute, t.DisplayName),
 		attribute.String(evergreen.TaskVariantOtelAttribute, t.BuildVariant),
+		attribute.String(evergreen.VersionRequesterOtelAttribute, t.Requester),
 	}
 	if !utility.IsZeroTime(t.ActivatedTime) && !utility.IsZeroTime(t.ScheduledTime) {
 		attrs = append(attrs, attribute.Int64(evergreen.TaskTimeWaitingForSchedulingMsOtelAttribute,


### PR DESCRIPTION
[DEVPROD-29721](https://jira.mongodb.org/browse/DEVPROD-29721)

add requester field so we can alert on merge queue tasks that take too long to get off the queue

tested that the field populates correctly in staging
https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/2xkS2rC4hsy

