### PR TITLE
DEVPROD-36641 Reject path traversal in patch config rename/copy paths

### DIFF
--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -449,6 +449,9 @@ func MakePatchedConfig(ctx context.Context, opts GetProjectOpts, projectConfig s
 		// If this is a renamed include file, retrieve the bytes of the file before it
 		// was renamed and use it as our local config.
 		if renamedFilePath != "" {
+			if err = validatePatchRelativePath(renamedFilePath); err != nil {
+				return nil, errors.Wrapf(err, "invalid rename/copy source path '%s'", renamedFilePath)
+			}
 			opts.RemotePath = renamedFilePath
 			if projectConfig == "" {
 				renamedProjectConfig, err = getFileForPatchDiff(ctx, opts)
@@ -466,6 +469,9 @@ func MakePatchedConfig(ctx context.Context, opts GetProjectOpts, projectConfig s
 				workingDirectory,
 				remoteConfigPath,
 			)
+		}
+		if err = ensurePathWithinDir(workingDirectory, localConfigPath); err != nil {
+			return nil, err
 		}
 		// write project configuration
 		configFilePath, err := util.WriteToTempFile(projectConfig)
@@ -518,6 +524,9 @@ func MakePatchedConfig(ctx context.Context, opts GetProjectOpts, projectConfig s
 				workingDirectory,
 				remoteConfigPath,
 			)
+			if err = ensurePathWithinDir(workingDirectory, patchedConfigPath); err != nil {
+				return nil, err
+			}
 			defer os.Remove(patchedConfigPath)
 		}
 		data, err := os.ReadFile(patchedConfigPath)
@@ -567,6 +576,38 @@ func parseRenamedOrCopiedFile(patchContents, filename string) string {
 		return copyFrom
 	}
 	return ""
+}
+
+// validatePatchRelativePath rejects absolute paths and directory traversal so
+// values from patch diffs cannot escape the temporary working directory.
+func validatePatchRelativePath(path string) error {
+	if filepath.IsAbs(path) {
+		return errors.New("path must be relative")
+	}
+	if strings.Contains(path, "..") {
+		return errors.New("path must not contain directory traversal")
+	}
+	return nil
+}
+
+// ensurePathWithinDir verifies that target resolves within baseDir.
+func ensurePathWithinDir(baseDir, target string) error {
+	absBase, err := filepath.Abs(baseDir)
+	if err != nil {
+		return errors.Wrap(err, "resolving base directory")
+	}
+	absTarget, err := filepath.Abs(target)
+	if err != nil {
+		return errors.Wrap(err, "resolving target path")
+	}
+	rel, err := filepath.Rel(absBase, absTarget)
+	if err != nil {
+		return errors.Wrap(err, "computing path relative to working directory")
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return errors.Errorf("path '%s' escapes working directory '%s'", target, baseDir)
+	}
+	return nil
 }
 
 // FinalizePatch finalizes a patch:

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -761,6 +761,96 @@ func TestMakePatchedConfigShellMetacharactersInPath(t *testing.T) {
 	assert.NoFileExists(t, "/tmp/test")
 }
 
+func TestMakePatchedConfigRenameFromPathTraversal(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	env := evergreen.GetEnvironment()
+	cwd := testutil.GetDirectoryOfFile()
+	projectBytes, err := os.ReadFile(filepath.Join(cwd, "testdata", "include1.yml"))
+	require.NoError(t, err)
+
+	victimPath := filepath.Join(t.TempDir(), "victim.txt")
+	require.NoError(t, os.WriteFile(victimPath, []byte("do-not-overwrite"), 0600))
+
+	for testName, testCase := range map[string]struct {
+		fromPath string
+		prefix   string
+	}{
+		"RenameFromTraversalShouldError": {
+			fromPath: "../../../../etc/passwd",
+			prefix:   "rename",
+		},
+		"CopyFromTraversalShouldError": {
+			fromPath: "../../../../etc/passwd",
+			prefix:   "copy",
+		},
+		"RenameFromAbsolutePathShouldError": {
+			fromPath: victimPath,
+			prefix:   "rename",
+		},
+		"CopyFromAbsolutePathShouldError": {
+			fromPath: victimPath,
+			prefix:   "copy",
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			diff := fmt.Sprintf(`diff --git a/%[1]s b/renamed.yml
+similarity index 100%%
+%[2]s from %[1]s
+%[2]s to renamed.yml
+`, testCase.fromPath, testCase.prefix)
+			p := &patch.Patch{
+				Patches: []patch.ModulePatch{{
+					Githash: "revision",
+					PatchSet: patch.PatchSet{
+						Patch: diff,
+						Summary: []thirdparty.Summary{{
+							Name: "renamed.yml",
+						}},
+					},
+				}},
+			}
+			opts := GetProjectOpts{
+				Ref:        &ProjectRef{},
+				RemotePath: "renamed.yml",
+				PatchOpts: &PatchOpts{
+					env:   env,
+					patch: p,
+				},
+			}
+
+			_, err := MakePatchedConfig(ctx, opts, string(projectBytes))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid rename/copy source path")
+
+			contents, readErr := os.ReadFile(victimPath)
+			require.NoError(t, readErr)
+			assert.Equal(t, "do-not-overwrite", string(contents))
+			assert.FileExists(t, victimPath)
+		})
+	}
+}
+
+func TestValidatePatchRelativePath(t *testing.T) {
+	assert.NoError(t, validatePatchRelativePath("config/evergreen.yml"))
+	assert.NoError(t, validatePatchRelativePath("include1.yml"))
+
+	assert.Error(t, validatePatchRelativePath("/etc/passwd"))
+	assert.Error(t, validatePatchRelativePath("../etc/passwd"))
+	assert.Error(t, validatePatchRelativePath("foo/../../etc/passwd"))
+}
+
+func TestEnsurePathWithinDir(t *testing.T) {
+	baseDir := t.TempDir()
+
+	assert.NoError(t, ensurePathWithinDir(baseDir, filepath.Join(baseDir, "config.yml")))
+	assert.NoError(t, ensurePathWithinDir(baseDir, filepath.Join(baseDir, "subdir", "config.yml")))
+
+	assert.Error(t, ensurePathWithinDir(baseDir, filepath.Join(baseDir, "..", "outside.yml")))
+	assert.Error(t, ensurePathWithinDir(baseDir, filepath.Join(string(filepath.Separator), "etc", "passwd")))
+}
+
 func TestParseRenamedOrCopiedFile(t *testing.T) {
 	patchContents := `
 diff --git a/include2.yml b/copiedInclude.yml

--- a/thirdparty/git.go
+++ b/thirdparty/git.go
@@ -454,9 +454,13 @@ func validateFileIsWithinDirectory(dir, file string) error {
 		return errors.Errorf("file '%s' must be a relative path, not absolute", file)
 	}
 
-	// Reject paths containing ".." (prevent attempts to escape the directory).
-	if strings.Contains(cleanPath, "..") {
-		return errors.Errorf("file '%s' cannot traverse directories using '..'", file)
+	// Reject parent-directory components to prevent attempts to escape the directory.
+	for _, pathComponent := range strings.FieldsFunc(file, func(r rune) bool {
+		return r == '/' || r == '\\'
+	}) {
+		if pathComponent == ".." {
+			return errors.Errorf("file '%s' cannot traverse directories using '..'", file)
+		}
 	}
 
 	fullFilePath := filepath.Join(dir, cleanPath)
@@ -468,9 +472,9 @@ func validateFileIsWithinDirectory(dir, file string) error {
 		return errors.Wrap(err, "verifying that the file is relative to the directory")
 	}
 
-	// If the relative path still contains "..", it may try to escape the
+	// If the relative path points to a parent directory, it may escape the
 	// directory.
-	if strings.Contains(relPath, "..") {
+	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
 		return errors.Errorf("file '%s' escapes directory using '..'", file)
 	}
 

--- a/thirdparty/git_test.go
+++ b/thirdparty/git_test.go
@@ -205,6 +205,11 @@ func TestValidateFileIsWithinDirectory(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("RelativePathWithDoubleDotInFileNameAllowed", func(t *testing.T) {
+		err := validateFileIsWithinDirectory(parentDir, "src/config..backup.yml")
+		assert.NoError(t, err)
+	})
+
 	t.Run("FilePathWithTraversalDisallowed", func(t *testing.T) {
 		err := validateFileIsWithinDirectory(parentDir, "../etc/passwd")
 		assert.Error(t, err)


### PR DESCRIPTION
DEVPROD-36641

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->

Checks for paths like `../` since they can be client-controlled

### Testing

<!--add a description of how you tested it-->
Unit tests