### PR TITLE
DEVPROD-36667: Log unexpected CORS origins

### DIFF
--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -743,10 +743,35 @@ func AddCORSHeaders(allowedOrigins []string, next http.HandlerFunc) http.Handler
 				w.Header().Add("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PATCH, PUT")
 				w.Header().Add("Access-Control-Allow-Headers", fmt.Sprintf("%s, %s, %s", evergreen.APIKeyHeader, evergreen.APIUserHeader, gqlHeader))
 				w.Header().Add("Access-Control-Max-Age", "600")
+
+				// Only log the header if it doesn't match the expected URLs. This is to avoid over-logging.
+				if !isExpectedCORSOrigin(requester) {
+					grip.Info(r.Context(), message.Fields{
+						"message":    "CORS request from unexpected origin",
+						"origin":     requester,
+						"method":     r.Method,
+						"path":       r.URL.Path,
+						"user_agent": r.UserAgent(),
+					})
+				}
 			}
 		}
 		next(w, r)
 	}
+}
+
+func isExpectedCORSOrigin(origin string) bool {
+	expectedURLs := []string{
+		"https://spruce.corp.mongodb.com",
+		"https://spruce-staging.corp.mongodb.com",
+		"https://spruce-beta.corp.mongodb.com",
+		"https://spruce-local.corp.mongodb.com",
+		"https://parsley.corp.mongodb.com",
+		"https://parsley-staging.corp.mongodb.com",
+		"https://parsley-beta.corp.mongodb.com",
+		"https://parsley-local.corp.mongodb.com",
+	}
+	return slices.ContainsFunc(expectedURLs, func(u string) bool { return strings.HasPrefix(origin, u) })
 }
 
 func allowCORS(next http.HandlerFunc) http.HandlerFunc {

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -744,7 +744,8 @@ func AddCORSHeaders(allowedOrigins []string, next http.HandlerFunc) http.Handler
 				w.Header().Add("Access-Control-Allow-Headers", fmt.Sprintf("%s, %s, %s", evergreen.APIKeyHeader, evergreen.APIUserHeader, gqlHeader))
 				w.Header().Add("Access-Control-Max-Age", "600")
 
-				// Only log the header if it doesn't match the expected URLs. This is to avoid over-logging.
+				// TODO: Delete when resolving DEVPROD-36667.
+				// To avoid over-logging, only log the header if it doesn't match the expected URLs.
 				if !isExpectedCORSOrigin(requester) {
 					grip.Info(r.Context(), message.Fields{
 						"message":    "CORS request from unexpected origin",
@@ -760,6 +761,7 @@ func AddCORSHeaders(allowedOrigins []string, next http.HandlerFunc) http.Handler
 	}
 }
 
+// TODO: Delete when resolving DEVPROD-36667.
 func isExpectedCORSOrigin(origin string) bool {
 	expectedURLs := []string{
 		"https://spruce.corp.mongodb.com",


### PR DESCRIPTION
DEVPROD-36667

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Before turning on CORS restrictions, I want to log any requests coming from unexpected (i.e. not Spruce or Parsley) origins. This is to understand where requests are coming from and what origins we need to whitelist.

### Risks

If it logs a lot due to a lot of unexpected origins; I am hoping this is not the case.

### Testing
* Tested Splunk logging on staging (spruce-staging was commented out from the allowlist)
<img width="823" height="196" alt="Screenshot 2026-07-13 at 3 07 53 PM" src="https://github.com/user-attachments/assets/c6f2f1e9-d205-40c5-b358-a893d8a12dbe" />
