### PR TITLE
DEVPROD-33516 Fix cross-file YAML anchor backwards incompatibility

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -906,14 +906,14 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, pro
 	defer span.End()
 
 	unmarshalStrict := false
-	var anchorRegistry *anchorEntries
+	var registry *anchorRegistry
 	if opts != nil {
 		unmarshalStrict = opts.UnmarshalStrict
 		if opts.EnableYAMLAnchors {
-			anchorRegistry = &anchorEntries{}
+			registry = &anchorRegistry{}
 		}
 	}
-	intermediateProject, err := createIntermediateProject(data, unmarshalStrict, anchorRegistry)
+	intermediateProject, err := createIntermediateProject(data, unmarshalStrict, registry)
 	if err != nil {
 		return nil, errors.Wrapf(err, LoadProjectError)
 	}
@@ -923,7 +923,7 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, pro
 	}
 
 	if len(intermediateProject.Include) > 0 {
-		if err := mergeIncludes(ctx, projectID, intermediateProject, anchorRegistry, opts); err != nil {
+		if err := mergeIncludes(ctx, projectID, intermediateProject, registry, opts); err != nil {
 			return nil, errors.Wrap(err, "merging included files")
 		}
 	}
@@ -955,7 +955,7 @@ func loadTranslateProject(ctx context.Context, span trace.Span, intermediateProj
 }
 
 // mergeIncludes merges all included files into intermediateProject.
-func mergeIncludes(ctx context.Context, projectID string, intermediateProject *ParserProject, anchorRegistry *anchorEntries, opts *GetProjectOpts) error {
+func mergeIncludes(ctx context.Context, projectID string, intermediateProject *ParserProject, anchorRegistry *anchorRegistry, opts *GetProjectOpts) error {
 	ctx, span := tracer.Start(ctx, "mergeIncludes")
 	defer span.End()
 
@@ -1577,7 +1577,7 @@ func GetProjectFromFile(ctx context.Context, opts GetProjectOpts, settings *ever
 // If unmarshalStrict is true, use the strict version of unmarshalling.
 // When anchorRegistry is non-nil, cross-file anchor support is enabled: existing anchors are prepended so the
 // parser can resolve cross-file aliases, and any new anchor definitions are appended to the registry for future files.
-func createIntermediateProject(parseBytes []byte, unmarshalStrict bool, anchorRegistry *anchorEntries) (*ParserProject, error) {
+func createIntermediateProject(parseBytes []byte, unmarshalStrict bool, anchorRegistry *anchorRegistry) (*ParserProject, error) {
 	p := ParserProject{}
 
 	if anchorRegistry == nil {
@@ -1605,7 +1605,7 @@ func createIntermediateProject(parseBytes []byte, unmarshalStrict bool, anchorRe
 	}
 
 	// Prepend accumulated anchors as a preamble so the parser can resolve cross-file aliases.
-	if len(*anchorRegistry) > 0 {
+	if anchorRegistry.Length() > 0 {
 		preamble, err := buildAnchorPreamble(anchorRegistry)
 		if err != nil {
 			return nil, errors.Wrap(err, "building anchor preamble")
@@ -1626,7 +1626,7 @@ func createIntermediateProject(parseBytes []byte, unmarshalStrict bool, anchorRe
 // decodeWithAnchors decodes parseBytes into a ParserProject using a yaml.Node as an intermediate
 // representation, and merges any new anchor definitions found into anchorRegistry. Returns an
 // empty ParserProject for empty input.
-func decodeWithAnchors(parseBytes []byte, unmarshalStrict bool, anchorRegistry *anchorEntries) (*ParserProject, error) {
+func decodeWithAnchors(parseBytes []byte, unmarshalStrict bool, anchorRegistry *anchorRegistry) (*ParserProject, error) {
 	var node yaml.Node
 	if err := yaml.NewDecoder(bytes.NewReader(parseBytes)).Decode(&node); err != nil && !errors.Is(err, io.EOF) {
 		yamlErr := thirdparty.YAMLFormatError{Message: err.Error()}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1667,19 +1667,7 @@ func decodeWithAnchors(parseBytes []byte, unmarshalStrict bool, anchorRegistry *
 		}
 	}
 
-	for _, anchor := range collectAnchors(&node) {
-		replaced := false
-		for i, existing := range *anchorRegistry {
-			if existing.name == anchor.name {
-				(*anchorRegistry)[i] = anchor
-				replaced = true
-				break
-			}
-		}
-		if !replaced {
-			*anchorRegistry = append(*anchorRegistry, anchor)
-		}
-	}
+	anchorRegistry.mergeAnchorsFrom(&node)
 
 	return &p, nil
 }

--- a/model/project_parser_anchors.go
+++ b/model/project_parser_anchors.go
@@ -19,6 +19,30 @@ type anchorEntry struct {
 // anchorEntries accumulates YAML anchor definitions across include files for cross-file alias resolution.
 type anchorEntries []anchorEntry
 
+// mergeAnchorsFrom collects all anchor definitions from node and merges them into
+// the registry by name, so that later include files can resolve aliases defined in
+// earlier files. No-op if the receiver is nil.
+//
+// When an anchor name already exists, the old entry is removed and the new one is
+// appended at the end. This ensures that if a redefinition introduces alias
+// dependencies on anchors added by the same file, those dependencies always appear
+// earlier in the slice, and therefore earlier in the marshaled preamble, satisfying
+// YAML's anchor-before-alias rule.
+func (a *anchorEntries) mergeAnchorsFrom(node *yaml.Node) {
+	if a == nil {
+		return
+	}
+	for _, anchor := range collectAnchors(node) {
+		for i, existing := range *a {
+			if existing.name == anchor.name {
+				*a = append((*a)[:i], (*a)[i+1:]...)
+				break
+			}
+		}
+		*a = append(*a, anchor)
+	}
+}
+
 // collectAnchors walks node in pre-order and returns all anchored nodes in
 // encounter order. AliasNodes are not followed, so only anchor definitions
 // (&name) are collected, never alias uses (*name).

--- a/model/project_parser_anchors.go
+++ b/model/project_parser_anchors.go
@@ -16,41 +16,45 @@ type anchorEntry struct {
 	node *yaml.Node
 }
 
-// anchorEntries accumulates YAML anchor definitions across include files for cross-file alias resolution.
-type anchorEntries []anchorEntry
+// anchorRegistry accumulates YAML anchor definitions across include files for cross-file alias resolution.
+type anchorRegistry struct {
+	entries []anchorEntry
+}
 
-// mergeAnchorsFrom collects all anchor definitions from node and merges them into
-// the registry by name, so that later include files can resolve aliases defined in
-// earlier files. No-op if the receiver is nil.
-//
-// When an anchor name already exists, the old entry is removed and the new one is
-// appended at the end. This ensures that if a redefinition introduces alias
-// dependencies on anchors added by the same file, those dependencies always appear
-// earlier in the slice, and therefore earlier in the marshaled preamble, satisfying
-// YAML's anchor-before-alias rule.
-func (a *anchorEntries) mergeAnchorsFrom(node *yaml.Node) {
+// Length returns the number of accumulated anchors, treating a nil registry as empty.
+func (a *anchorRegistry) Length() int {
+	if a == nil {
+		return 0
+	}
+	return len(a.entries)
+}
+
+// mergeAnchorsFrom adds node's anchor definitions to the registry, keyed by name.
+// A redefined anchor is removed and re-appended so that any sibling anchors its
+// definition aliases stay ahead of it, keeping the marshaled preamble in
+// anchor-before-alias order. No-op if the receiver is nil.
+func (a *anchorRegistry) mergeAnchorsFrom(node *yaml.Node) {
 	if a == nil {
 		return
 	}
 	for _, anchor := range collectAnchors(node) {
-		for i, existing := range *a {
+		for i, existing := range a.entries {
 			if existing.name == anchor.name {
-				*a = append((*a)[:i], (*a)[i+1:]...)
+				a.entries = append(a.entries[:i], a.entries[i+1:]...)
 				break
 			}
 		}
-		*a = append(*a, anchor)
+		a.entries = append(a.entries, anchor)
 	}
 }
 
-// collectAnchors walks node in pre-order and returns all anchored nodes in
-// encounter order. AliasNodes are not followed, so only anchor definitions
-// (&name) are collected, never alias uses (*name).
-func collectAnchors(node *yaml.Node) anchorEntries {
+// collectAnchors walks node in pre-order and returns its anchor definitions
+// (&name) in encounter order. Alias uses (*name) are skipped.
+func collectAnchors(node *yaml.Node) []anchorEntry {
 	if node == nil {
 		return nil
 	}
-	var entries anchorEntries
+	var entries []anchorEntry
 	var walk func(*yaml.Node)
 	walk = func(n *yaml.Node) {
 		if n == nil || n.Kind == yaml.AliasNode {
@@ -67,20 +71,15 @@ func collectAnchors(node *yaml.Node) anchorEntries {
 	return entries
 }
 
-// buildAnchorPreamble marshals all registry entries into a YAML document under
-// the _evg_anchors key. Prepending the returned bytes to an include file's raw
-// bytes before parsing makes all accumulated anchor definitions visible to the
-// YAML parser, enabling cross-file alias resolution.
-//
-// Entries must be in encounter order so that any alias references within anchor
-// values (e.g. an anchor whose value itself uses an alias to an earlier anchor)
-// are valid when the preamble is parsed.
-func buildAnchorPreamble(entries *anchorEntries) ([]byte, error) {
-	if entries == nil || len(*entries) == 0 {
+// buildAnchorPreamble marshals the registry's anchors into a YAML document under
+// the _evg_anchors key. Prepending it to an include file makes all accumulated
+// anchors visible to the parser, enabling cross-file alias resolution.
+func buildAnchorPreamble(registry *anchorRegistry) ([]byte, error) {
+	if registry.Length() == 0 {
 		return nil, nil
 	}
-	seqContent := make([]*yaml.Node, 0, len(*entries))
-	for _, e := range *entries {
+	seqContent := make([]*yaml.Node, 0, len(registry.entries))
+	for _, e := range registry.entries {
 		seqContent = append(seqContent, e.node)
 	}
 	preambleDoc := &yaml.Node{
@@ -98,9 +97,8 @@ func buildAnchorPreamble(entries *anchorEntries) ([]byte, error) {
 	return yaml.Marshal(preambleDoc)
 }
 
-// stripEvgAnchorsKey removes the _evg_anchors key and its value from the
-// top-level mapping in node. Returns true if the key was found and removed.
-// No-op (returns false) when the key is absent.
+// stripEvgAnchorsKey removes the _evg_anchors key and its value from node's
+// top-level mapping, returning whether it was present.
 func stripEvgAnchorsKey(node *yaml.Node) bool {
 	mapping := node
 	if node.Kind == yaml.DocumentNode && len(node.Content) == 1 {

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -3509,7 +3509,7 @@ steps:
 	anchors := collectAnchors(&node)
 	require.Len(t, anchors, 2)
 
-	preamble, err := buildAnchorPreamble(&anchors)
+	preamble, err := buildAnchorPreamble(&anchorRegistry{entries: anchors})
 	require.NoError(t, err)
 	require.NotEmpty(t, preamble)
 
@@ -3717,21 +3717,21 @@ shared: &shared
   <<: *base
   a: 3
 `
-	registry := &anchorEntries{}
+	registry := &anchorRegistry{}
 
 	var firstNode yaml.Node
 	require.NoError(t, yaml.Unmarshal([]byte(first), &firstNode))
 	registry.mergeAnchorsFrom(&firstNode)
-	require.Len(t, *registry, 1)
-	assert.Equal(t, "shared", (*registry)[0].name)
+	require.Equal(t, 1, registry.Length())
+	assert.Equal(t, "shared", registry.entries[0].name)
 
 	var secondNode yaml.Node
 	require.NoError(t, yaml.Unmarshal([]byte(second), &secondNode))
 	registry.mergeAnchorsFrom(&secondNode)
 
-	require.Len(t, *registry, 2)
-	assert.Equal(t, "base", (*registry)[0].name, "sibling dependency must precede the redefined anchor")
-	assert.Equal(t, "shared", (*registry)[1].name, "redefined anchor must move to the end")
+	require.Equal(t, 2, registry.Length())
+	assert.Equal(t, "base", registry.entries[0].name, "sibling dependency must precede the redefined anchor")
+	assert.Equal(t, "shared", registry.entries[1].name, "redefined anchor must move to the end")
 
 	// The resulting preamble must resolve cleanly (no alias-before-definition).
 	preamble, err := buildAnchorPreamble(registry)

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -3698,6 +3698,111 @@ tasks:
 	assert.Equal(t, "git.get_project", tasksByName["third-task"].Commands[0].Command)
 }
 
+// TestMergeAnchorsFromReordersRedefinedAnchor verifies that redefining an anchor
+// moves it to the end of the registry rather than replacing it in place. In-place
+// replacement would leave a redefined anchor ahead of sibling anchors added by the
+// same file, so a redefinition that aliases such a sibling would emit an alias
+// before its definition in the marshaled preamble.
+func TestMergeAnchorsFromReordersRedefinedAnchor(t *testing.T) {
+	first := `
+shared: &shared
+  a: 1
+`
+	// The redefinition of &shared aliases &base, a sibling defined in the same
+	// document. &base is encountered first, so it must precede &shared afterward.
+	second := `
+base: &base
+  b: 2
+shared: &shared
+  <<: *base
+  a: 3
+`
+	registry := &anchorEntries{}
+
+	var firstNode yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(first), &firstNode))
+	registry.mergeAnchorsFrom(&firstNode)
+	require.Len(t, *registry, 1)
+	assert.Equal(t, "shared", (*registry)[0].name)
+
+	var secondNode yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(second), &secondNode))
+	registry.mergeAnchorsFrom(&secondNode)
+
+	require.Len(t, *registry, 2)
+	assert.Equal(t, "base", (*registry)[0].name, "sibling dependency must precede the redefined anchor")
+	assert.Equal(t, "shared", (*registry)[1].name, "redefined anchor must move to the end")
+
+	// The resulting preamble must resolve cleanly (no alias-before-definition).
+	preamble, err := buildAnchorPreamble(registry)
+	require.NoError(t, err)
+	var preambleNode yaml.Node
+	require.NoError(t, yaml.Unmarshal(preamble, &preambleNode), "reordered preamble should resolve all aliases")
+}
+
+// TestRedefinedAnchorAliasingSiblingResolvesAcrossFiles reproduces the reported
+// failure where an anchor redefined in a later include file merges in sibling
+// anchors via individual merge keys. In-place registry replacement placed the
+// redefined anchor ahead of those siblings in the preamble, producing an
+// "unknown anchor" error when a subsequent file used the anchor.
+func TestRedefinedAnchorAliasingSiblingResolvesAcrossFiles(t *testing.T) {
+	mainYAML := mainYAMLWithModuleIncludes("", "first.yml", "second.yml", "third.yml")
+
+	// first.yml: defines &shared-step, seeding the registry.
+	firstYAML := `
+tasks:
+- name: first-task
+  commands:
+  - &shared-step
+    command: shell.exec
+`
+	// second.yml: redefines &shared-step so its params come from two sibling
+	// anchors merged in via individual merge keys.
+	secondYAML := `
+tasks:
+- name: second-task
+  commands:
+  - &base-params
+    params:
+      script: ./base.sh
+  - &extra-params
+    params:
+      working_dir: /tmp
+  - &shared-step
+    command: git.get_project
+    <<: *base-params
+    <<: *extra-params
+`
+	// third.yml: no definition of its own, just uses *shared-step. This is the
+	// file whose preamble would break without the ordering fix.
+	thirdYAML := `
+tasks:
+- name: third-task
+  commands:
+  - *shared-step
+`
+	proj := &Project{}
+	_, err := LoadProjectInto(t.Context(), []byte(mainYAML),
+		anchorModuleIncludeOpts(
+			moduleInclude("first.yml", firstYAML),
+			moduleInclude("second.yml", secondYAML),
+			moduleInclude("third.yml", thirdYAML),
+		), "proj", proj)
+	require.NoError(t, err)
+
+	tasksByName := map[string]ProjectTask{}
+	for _, task := range proj.Tasks {
+		tasksByName[task.Name] = task
+	}
+
+	require.Contains(t, tasksByName, "third-task")
+	require.Len(t, tasksByName["third-task"].Commands, 1)
+	cmd := tasksByName["third-task"].Commands[0]
+	assert.Equal(t, "git.get_project", cmd.Command)
+	assert.Equal(t, "./base.sh", cmd.Params["script"])
+	assert.Equal(t, "/tmp", cmd.Params["working_dir"])
+}
+
 // TestAnchorWithNestedAlias verifies that a file can use an alias from an
 // earlier file within an anchor it defines, and a subsequent file can use that
 // anchor as an alias. This exercises the preamble-within-preamble ordering.


### PR DESCRIPTION
DEVPROD-33516

Anchor preamble processing is causing a bug with yamls that don't properly use the list format, even though the productionizing commit was reverted. 

Originally fixed this bug as part of productionizing, but that PR was pretty big, and this makes sense to break out since its an active bug in the codebase rn. Included a bit of clean-up (switching to using a struct for the anchor registry for example) to keep this clean. 