### PR TITLE
DEVPROD-36666: check permissions for user/project subscriptions

### DIFF
--- a/graphql/user_resolver.go
+++ b/graphql/user_resolver.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -36,7 +37,11 @@ func (r *userResolver) Permissions(ctx context.Context, obj *restModel.APIDBUser
 
 // Subscriptions is the resolver for the subscriptions field.
 func (r *userResolver) Subscriptions(ctx context.Context, obj *restModel.APIDBUser) ([]*restModel.APISubscription, error) {
-	return getAPISubscriptionsForOwner(ctx, utility.FromStringPtr(obj.UserID), event.OwnerTypePerson)
+	ownerID := utility.FromStringPtr(obj.UserID)
+	if !canViewUserSubscriptions(ctx, ownerID) {
+		return nil, Forbidden.Send(ctx, fmt.Sprintf("not authorized to view subscriptions for user '%s'", ownerID))
+	}
+	return getAPISubscriptionsForOwner(ctx, ownerID, event.OwnerTypePerson)
 }
 
 // HasTokenExchangePending is the resolver for the hasTokenExchangePending field.
@@ -64,6 +69,9 @@ func (r *userLiteResolver) Settings(ctx context.Context, obj *user.DBUser) (*res
 
 // Subscriptions is the resolver for the subscriptions field.
 func (r *userLiteResolver) Subscriptions(ctx context.Context, obj *user.DBUser) ([]*restModel.APISubscription, error) {
+	if !canViewUserSubscriptions(ctx, obj.Id) {
+		return nil, Forbidden.Send(ctx, fmt.Sprintf("not authorized to view subscriptions for user '%s'", obj.Id))
+	}
 	return getAPISubscriptionsForOwner(ctx, obj.Id, event.OwnerTypePerson)
 }
 

--- a/graphql/user_resolver_test.go
+++ b/graphql/user_resolver_test.go
@@ -1,0 +1,81 @@
+package graphql
+
+import (
+	"testing"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/event"
+	"github.com/evergreen-ci/evergreen/model/user"
+	restModel "github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserSubscriptionsOwnership(t *testing.T) {
+	require.NoError(t, db.ClearCollections(event.SubscriptionsCollection, user.Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(event.SubscriptionsCollection, user.Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
+	})
+
+	const targetUser = "target-user"
+	sub := event.Subscription{
+		ID:           "sub-id",
+		ResourceType: event.ResourceTypeTask,
+		Trigger:      "outcome",
+		Owner:        targetUser,
+		OwnerType:    event.OwnerTypePerson,
+		Selectors:    []event.Selector{{Type: event.SelectorObject, Data: "task"}},
+		Subscriber:   event.Subscriber{Type: event.EmailSubscriberType, Target: "target@example.com"},
+	}
+	require.NoError(t, sub.Upsert(t.Context()))
+
+	roleManager := evergreen.GetEnvironment().RoleManager()
+	require.NoError(t, roleManager.AddScope(t.Context(), gimlet.Scope{
+		ID:        "superuser-scope",
+		Type:      evergreen.SuperUserResourceType,
+		Resources: []string{evergreen.SuperUserPermissionsID},
+	}))
+	require.NoError(t, roleManager.UpdateRole(t.Context(), gimlet.Role{
+		ID:          "superuser",
+		Scope:       "superuser-scope",
+		Permissions: gimlet.Permissions{evergreen.PermissionAdminSettings: evergreen.AdminSettingsEdit.Value},
+	}))
+
+	config := New("/graphql")
+	obj := &restModel.APIDBUser{UserID: utility.ToStringPtr(targetUser)}
+
+	for name, testCase := range map[string]struct {
+		requester     *user.DBUser
+		expectAllowed bool
+	}{
+		"OwnerCanViewOwnSubscriptions": {
+			requester:     &user.DBUser{Id: targetUser},
+			expectAllowed: true,
+		},
+		"OtherUserIsForbidden": {
+			requester:     &user.DBUser{Id: "other-user"},
+			expectAllowed: false,
+		},
+		"SuperuserCanView": {
+			requester:     &user.DBUser{Id: "admin-user", SystemRoles: []string{"superuser"}},
+			expectAllowed: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx := gimlet.AttachUser(t.Context(), testCase.requester)
+			subs, err := config.Resolvers.User().Subscriptions(ctx, obj)
+			if !testCase.expectAllowed {
+				require.Error(t, err)
+				assert.Nil(t, subs)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, subs, 1)
+			assert.Equal(t, sub.ID, utility.FromStringPtr(subs[0].ID))
+		})
+	}
+}

--- a/graphql/user_resolver_test.go
+++ b/graphql/user_resolver_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUserSubscriptionsOwnership(t *testing.T) {
+func TestUserSubscriptionsPermissions(t *testing.T) {
 	require.NoError(t, db.ClearCollections(event.SubscriptionsCollection, user.Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
 	t.Cleanup(func() {
 		assert.NoError(t, db.ClearCollections(event.SubscriptionsCollection, user.Collection, evergreen.ScopeCollection, evergreen.RoleCollection))

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1127,6 +1127,22 @@ func userHasVolumePermission(ctx context.Context, u *user.DBUser, volumeId strin
 	return u.Username() == createdBy || u.HasPermission(ctx, opts)
 }
 
+// canViewUserSubscriptions returns whether the requesting user is allowed to
+// view the personal subscriptions belonging to ownerUserID. A user may view
+// their own subscriptions, and superusers may view anyone's.
+func canViewUserSubscriptions(ctx context.Context, ownerUserID string) bool {
+	u := mustHaveUser(ctx)
+	if u.Username() == ownerUserID {
+		return true
+	}
+	return u.HasPermission(ctx, gimlet.PermissionOpts{
+		Resource:      evergreen.SuperUserPermissionsID,
+		ResourceType:  evergreen.SuperUserResourceType,
+		Permission:    evergreen.PermissionAdminSettings,
+		RequiredLevel: evergreen.AdminSettingsEdit.Value,
+	})
+}
+
 func userHasProjectSettingsPermission(ctx context.Context, u *user.DBUser, projectId string, requiredLevel int) bool {
 	opts := gimlet.PermissionOpts{
 		Resource:      projectId,

--- a/rest/route/subscription.go
+++ b/rest/route/subscription.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/evergreen-ci/evergreen"
 	dbModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/rest/data"
@@ -87,6 +88,17 @@ func (s *subscriptionGetHandler) Parse(ctx context.Context, r *http.Request) err
 			return errors.Wrapf(err, "getting ID for project '%s'", s.owner)
 		}
 		s.owner = id
+		if !u.HasPermission(ctx, gimlet.PermissionOpts{
+			Resource:      s.owner,
+			ResourceType:  evergreen.ProjectResourceType,
+			Permission:    evergreen.PermissionProjectSettings,
+			RequiredLevel: evergreen.ProjectSettingsView.Value,
+		}) {
+			return gimlet.ErrorResponse{
+				StatusCode: http.StatusUnauthorized,
+				Message:    "not authorized to view subscriptions for this project",
+			}
+		}
 	}
 
 	return nil

--- a/rest/route/subscription_test.go
+++ b/rest/route/subscription_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -36,7 +34,11 @@ func (s *SubscriptionRouteSuite) SetupSuite() {
 }
 
 func (s *SubscriptionRouteSuite) SetupTest() {
-	s.NoError(db.ClearCollections(event.SubscriptionsCollection))
+	s.NoError(db.ClearCollections(dbModel.ProjectRefCollection, user.Collection, evergreen.ScopeCollection, evergreen.RoleCollection, event.SubscriptionsCollection))
+}
+
+func (s *SubscriptionRouteSuite) TearDownTest() {
+	s.NoError(db.ClearCollections(dbModel.ProjectRefCollection, user.Collection, evergreen.ScopeCollection, evergreen.RoleCollection, event.SubscriptionsCollection))
 }
 
 func (s *SubscriptionRouteSuite) TestSubscriptionPost() {
@@ -274,70 +276,58 @@ func (s *SubscriptionRouteSuite) TestDeleteValidation() {
 	s.Equal(401, resp.Status())
 }
 
-func TestGetProjectSubscriptionRequiresPermission(t *testing.T) {
-	t.Cleanup(func() {
-		assert.NoError(t, db.ClearCollections(dbModel.ProjectRefCollection, user.Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
-	})
-
-	for tName, tCase := range map[string]func(t *testing.T, pRef *dbModel.ProjectRef, role string){
-		"AuthorizedUserResolvesProjectID": func(t *testing.T, pRef *dbModel.ProjectRef, role string) {
-			usr := &user.DBUser{Id: "authorized", SystemRoles: []string{role}}
-			ctx := gimlet.AttachUser(t.Context(), usr)
-			r, err := http.NewRequest(http.MethodGet, "/subscriptions?owner="+pRef.Identifier+"&type=project", nil)
-			require.NoError(t, err)
-
-			h := &subscriptionGetHandler{}
-			require.NoError(t, h.Parse(ctx, r))
-			require.NoError(t, err)
-			assert.Equal(t, pRef.Id, h.owner)
-		},
-		"UnauthorizedUserIsRejected": func(t *testing.T, pRef *dbModel.ProjectRef, role string) {
-			usr := &user.DBUser{Id: "unauthorized"}
-			ctx := gimlet.AttachUser(t.Context(), usr)
-			r, err := http.NewRequest(http.MethodGet, "/subscriptions?owner="+pRef.Identifier+"&type=project", nil)
-			require.NoError(t, err)
-
-			h := &subscriptionGetHandler{}
-			err = h.Parse(ctx, r)
-			assert.Error(t, err)
-			respErr, ok := err.(gimlet.ErrorResponse)
-			require.True(t, ok)
-			assert.Equal(t, http.StatusUnauthorized, respErr.StatusCode)
-		},
-	} {
-		t.Run(tName, func(t *testing.T) {
-			require.NoError(t, db.ClearCollections(dbModel.ProjectRefCollection, user.Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
-
-			pRef := &dbModel.ProjectRef{
-				Id:         "project-id",
-				Identifier: "my-project",
-			}
-			require.NoError(t, pRef.Insert(t.Context()))
-
-			roleManager := evergreen.GetEnvironment().RoleManager()
-			scope := gimlet.Scope{
-				ID:        "project-view-scope",
-				Type:      evergreen.ProjectResourceType,
-				Resources: []string{pRef.Id},
-			}
-			require.NoError(t, roleManager.AddScope(t.Context(), scope))
-			role := gimlet.Role{
-				ID:          "project-viewer",
-				Scope:       scope.ID,
-				Permissions: gimlet.Permissions{evergreen.PermissionProjectSettings: evergreen.ProjectSettingsView.Value},
-			}
-			require.NoError(t, roleManager.UpdateRole(t.Context(), role))
-
-			tCase(t, pRef, role.ID)
-		})
-	}
-}
-
 func (s *SubscriptionRouteSuite) TestGetWithoutUser() {
 	s.PanicsWithValue("no user attached to request", func() {
 		ctx := context.Background()
 		h := &subscriptionGetHandler{}
 		_ = h.Parse(ctx, nil)
+	})
+}
+
+func (s *SubscriptionRouteSuite) TestGetProjectSubscriptionPermissions() {
+	pRef := &dbModel.ProjectRef{
+		Id:         "project-id",
+		Identifier: "my-project",
+	}
+	s.Require().NoError(pRef.Insert(s.T().Context()))
+
+	roleManager := evergreen.GetEnvironment().RoleManager()
+	scope := gimlet.Scope{
+		ID:        "project-view-scope",
+		Type:      evergreen.ProjectResourceType,
+		Resources: []string{pRef.Id},
+	}
+	s.Require().NoError(roleManager.AddScope(s.T().Context(), scope))
+	role := gimlet.Role{
+		ID:          "project-viewer",
+		Scope:       scope.ID,
+		Permissions: gimlet.Permissions{evergreen.PermissionProjectSettings: evergreen.ProjectSettingsView.Value},
+	}
+	s.Require().NoError(roleManager.UpdateRole(s.T().Context(), role))
+
+	s.T().Run("AuthorizedUser", func(t *testing.T) {
+		usr := &user.DBUser{Id: "authorized", SystemRoles: []string{role.ID}}
+		ctx := gimlet.AttachUser(s.T().Context(), usr)
+		r, err := http.NewRequest(http.MethodGet, "/subscriptions?owner="+pRef.Identifier+"&type=project", nil)
+		s.Require().NoError(err)
+
+		h := &subscriptionGetHandler{}
+		s.Require().NoError(h.Parse(ctx, r))
+		s.Require().NoError(err)
+		s.Equal(pRef.Id, h.owner)
+	})
+	s.T().Run("UnauthorizedUser", func(t *testing.T) {
+		usr := &user.DBUser{Id: "unauthorized"}
+		ctx := gimlet.AttachUser(s.T().Context(), usr)
+		r, err := http.NewRequest(http.MethodGet, "/subscriptions?owner="+pRef.Identifier+"&type=project", nil)
+		s.Require().NoError(err)
+
+		h := &subscriptionGetHandler{}
+		err = h.Parse(ctx, r)
+		s.Error(err)
+		respErr, ok := err.(gimlet.ErrorResponse)
+		s.Require().True(ok)
+		s.Equal(http.StatusUnauthorized, respErr.StatusCode)
 	})
 }
 

--- a/rest/route/subscription_test.go
+++ b/rest/route/subscription_test.go
@@ -8,12 +8,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
+	dbModel "github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -268,6 +272,65 @@ func (s *SubscriptionRouteSuite) TestDeleteValidation() {
 	s.NoError(d.Parse(ctx, r))
 	resp = d.Run(ctx)
 	s.Equal(401, resp.Status())
+}
+
+func TestGetProjectSubscriptionRequiresPermission(t *testing.T) {
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(dbModel.ProjectRefCollection, user.Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
+	})
+
+	for tName, tCase := range map[string]func(t *testing.T, pRef *dbModel.ProjectRef, role string){
+		"AuthorizedUserResolvesProjectID": func(t *testing.T, pRef *dbModel.ProjectRef, role string) {
+			usr := &user.DBUser{Id: "authorized", SystemRoles: []string{role}}
+			ctx := gimlet.AttachUser(t.Context(), usr)
+			r, err := http.NewRequest(http.MethodGet, "/subscriptions?owner="+pRef.Identifier+"&type=project", nil)
+			require.NoError(t, err)
+
+			h := &subscriptionGetHandler{}
+			require.NoError(t, h.Parse(ctx, r))
+			require.NoError(t, err)
+			assert.Equal(t, pRef.Id, h.owner)
+		},
+		"UnauthorizedUserIsRejected": func(t *testing.T, pRef *dbModel.ProjectRef, role string) {
+			usr := &user.DBUser{Id: "unauthorized"}
+			ctx := gimlet.AttachUser(t.Context(), usr)
+			r, err := http.NewRequest(http.MethodGet, "/subscriptions?owner="+pRef.Identifier+"&type=project", nil)
+			require.NoError(t, err)
+
+			h := &subscriptionGetHandler{}
+			err = h.Parse(ctx, r)
+			assert.Error(t, err)
+			respErr, ok := err.(gimlet.ErrorResponse)
+			require.True(t, ok)
+			assert.Equal(t, http.StatusUnauthorized, respErr.StatusCode)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(dbModel.ProjectRefCollection, user.Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
+
+			pRef := &dbModel.ProjectRef{
+				Id:         "project-id",
+				Identifier: "my-project",
+			}
+			require.NoError(t, pRef.Insert(t.Context()))
+
+			roleManager := evergreen.GetEnvironment().RoleManager()
+			scope := gimlet.Scope{
+				ID:        "project-view-scope",
+				Type:      evergreen.ProjectResourceType,
+				Resources: []string{pRef.Id},
+			}
+			require.NoError(t, roleManager.AddScope(t.Context(), scope))
+			role := gimlet.Role{
+				ID:          "project-viewer",
+				Scope:       scope.ID,
+				Permissions: gimlet.Permissions{evergreen.PermissionProjectSettings: evergreen.ProjectSettingsView.Value},
+			}
+			require.NoError(t, roleManager.UpdateRole(t.Context(), role))
+
+			tCase(t, pRef, role.ID)
+		})
+	}
 }
 
 func (s *SubscriptionRouteSuite) TestGetWithoutUser() {

--- a/rest/route/subscription_test.go
+++ b/rest/route/subscription_test.go
@@ -305,7 +305,7 @@ func (s *SubscriptionRouteSuite) TestGetProjectSubscriptionPermissions() {
 	}
 	s.Require().NoError(roleManager.UpdateRole(s.T().Context(), role))
 
-	s.T().Run("AuthorizedUser", func(t *testing.T) {
+	s.T().Run("UserWithProjectViewRoleIsAuthorized", func(t *testing.T) {
 		usr := &user.DBUser{Id: "authorized", SystemRoles: []string{role.ID}}
 		ctx := gimlet.AttachUser(s.T().Context(), usr)
 		r, err := http.NewRequest(http.MethodGet, "/subscriptions?owner="+pRef.Identifier+"&type=project", nil)
@@ -316,7 +316,7 @@ func (s *SubscriptionRouteSuite) TestGetProjectSubscriptionPermissions() {
 		s.Require().NoError(err)
 		s.Equal(pRef.Id, h.owner)
 	})
-	s.T().Run("UnauthorizedUser", func(t *testing.T) {
+	s.T().Run("UserWithoutProjectViewRoleIsUnauthorized", func(t *testing.T) {
 		usr := &user.DBUser{Id: "unauthorized"}
 		ctx := gimlet.AttachUser(s.T().Context(), usr)
 		r, err := http.NewRequest(http.MethodGet, "/subscriptions?owner="+pRef.Identifier+"&type=project", nil)


### PR DESCRIPTION
DEVPROD-36666

### Description

* Only allow superusers or the user themselves to read a user's subscriptions from GraphQL.
* Only allow users with project view access to view subscriptions from the REST API.

### Testing

Added unit tests.