### PR TITLE
DEVPROD-33607: fix compile for modified IncludeDependencies

### DIFF
--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1721,7 +1721,7 @@ func partitionVariantsByPathFilter(patchDoc *patch.Patch, patchedProject *model.
 // 2. variants and tasks that are required dependencies of tasks in vts.
 func (j *patchIntentProcessor) getTasksAndDependencies(ctx context.Context, patchDoc *patch.Patch, patchedProject *model.Project, vts []patch.VariantTasks) map[string]map[string]bool {
 	tvPairs := model.VariantTasksToTVPairs(vts)
-	requiredTasksAndDependencies, err := model.IncludeDependencies(patchedProject, tvPairs.ExecTasks, patchDoc.GetRequester(), nil)
+	requiredTasksAndDependencies, err := model.IncludeDependencies(patchedProject, tvPairs.ExecTasks, patchDoc.GetRequester(), "", nil)
 	grip.Warning(ctx, message.WrapError(err, message.Fields{
 		"message":  "error resolving cross-variant dependencies on path-filtered variants",
 		"job":      j.ID(),


### PR DESCRIPTION
DEVPROD-33607

### Description

Compile is failing because #10435 modified the method signature of `IncludeDependencies`, which was incompatible with #10466 because that also called `IncludeDependencies` (with the old signature).

### Testing

Compile passes.