### PR TITLE
DEVPROD-37218: Add timeout for select tests from TSS

### DIFF
--- a/agent/internal/client/client_test.go
+++ b/agent/internal/client/client_test.go
@@ -49,7 +49,7 @@ func TestSelectTestsFailedDependencyShouldNotRetry(t *testing.T) {
 		Secret: "task_secret",
 	}, restmodel.SelectTestsRequest{})
 	require.Error(t, err)
-	assert.Equal(t, int32(1), calls.Load())
+	assert.EqualValues(t, 1, calls.Load())
 }
 
 func TestSelectTestsInternalServerErrorShouldRetry(t *testing.T) {
@@ -72,7 +72,7 @@ func TestSelectTestsInternalServerErrorShouldRetry(t *testing.T) {
 		Secret: "task_secret",
 	}, restmodel.SelectTestsRequest{})
 	require.NoError(t, err)
-	assert.Equal(t, int32(2), calls.Load())
+	assert.EqualValues(t, 2, calls.Load())
 }
 
 func TestLoggerProducerRedactorOptions(t *testing.T) {

--- a/agent/internal/client/client_test.go
+++ b/agent/internal/client/client_test.go
@@ -3,14 +3,18 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal/redactor"
 	agentutil "github.com/evergreen-ci/evergreen/agent/util"
 	"github.com/evergreen-ci/evergreen/model/task"
+	restmodel "github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,6 +31,48 @@ func TestEvergreenCommunicatorConstructor(t *testing.T) {
 	assert.Equal(t, defaultMaxAttempts, c.retry.MaxAttempts)
 	assert.Equal(t, defaultTimeoutStart, c.retry.MinDelay)
 	assert.Equal(t, defaultTimeoutMax, c.retry.MaxDelay)
+}
+
+func TestSelectTestsFailedDependencyShouldNotRetry(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "test selection timed out", http.StatusFailedDependency)
+	}))
+	t.Cleanup(server.Close)
+
+	communicator := NewHostCommunicator(server.URL, "host", "host_secret")
+	t.Cleanup(communicator.Close)
+
+	_, err := communicator.SelectTests(t.Context(), TaskData{
+		ID:     "task",
+		Secret: "task_secret",
+	}, restmodel.SelectTestsRequest{})
+	require.Error(t, err)
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+func TestSelectTestsInternalServerErrorShouldRetry(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if calls.Add(1) == 1 {
+			http.Error(w, "test selection failed", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", evergreen.ContentTypeValue)
+		_, _ = w.Write([]byte(`{"tests":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	communicator := NewHostCommunicator(server.URL, "host", "host_secret")
+	t.Cleanup(communicator.Close)
+
+	_, err := communicator.SelectTests(t.Context(), TaskData{
+		ID:     "task",
+		Secret: "task_secret",
+	}, restmodel.SelectTestsRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), calls.Load())
 }
 
 func TestLoggerProducerRedactorOptions(t *testing.T) {

--- a/rest/data/select.go
+++ b/rest/data/select.go
@@ -24,6 +24,7 @@ import (
 // Test selection service endpoint identifiers.
 const (
 	SelectTestsEndpoint       = "select_tests"
+	SelectKnownTestsEndpoint  = "select_known_tests"
 	TransitionTestsEndpoint   = "transition_tests"
 	TransitionTaskEndpoint    = "transition_task"
 	TransitionVariantEndpoint = "transition_variant"
@@ -33,6 +34,7 @@ const (
 
 const (
 	testSelectionWriteTimeout      = 10 * time.Second
+	testSelectionSelectTimeout     = 10 * time.Second
 	testSelectionStatusTimeout     = 4 * time.Second
 	testSelectionDecorationTimeout = 5 * time.Second
 )
@@ -115,6 +117,8 @@ func newTestSelectionClient(c *http.Client) *testselection.APIClient {
 // to run based on the provided SelectTestsRequest. It returns the list of
 // selected tests.
 func SelectTests(ctx context.Context, req model.SelectTestsRequest) ([]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, testSelectionSelectTimeout)
+	defer cancel()
 	c := newTestSelectionClient(testSelectionHTTPClient)
 	var strategies []testselection.StrategyEnum
 	for _, s := range req.Strategies {
@@ -127,7 +131,9 @@ func SelectTests(ctx context.Context, req model.SelectTestsRequest) ([]string, e
 		err              error
 	)
 	startAt := time.Now()
+	endpoint := SelectTestsEndpoint
 	if len(req.Tests) == 0 {
+		endpoint = SelectKnownTestsEndpoint
 		selectedTestPtrs, resp, err = c.TestSelectionAPI.SelectAllKnownTestsOfATaskApiTestSelectionSelectKnownTestsProjectIdRequesterBuildVariantNameTaskIdTaskNamePost(ctx, req.Project, req.Requester, req.BuildVariant, req.TaskID, req.TaskName).StrategyEnum(strategies).Execute()
 	} else {
 		reqBody := testselection.BodySelectTestsApiTestSelectionSelectTestsProjectIdRequesterBuildVariantNameTaskIdTaskNamePost{
@@ -145,7 +151,7 @@ func SelectTests(ctx context.Context, req model.SelectTestsRequest) ([]string, e
 	if err != nil {
 		logTSSError(ctx, err, resp, time.Since(startAt), message.Fields{
 			"message":       "error selecting tests",
-			"endpoint":      SelectTestsEndpoint,
+			"endpoint":      endpoint,
 			"project_id":    req.Project,
 			"requester":     req.Requester,
 			"build_variant": req.BuildVariant,

--- a/rest/data/select_test.go
+++ b/rest/data/select_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/testresult"
+	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/level"
 	"github.com/mongodb/grip/message"
@@ -21,6 +22,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func captureGripMessages(t *testing.T) *send.InternalSender {
 	originalSender := grip.GetSender()
@@ -66,6 +73,59 @@ func TestLogTSSError(t *testing.T) {
 		require.Equal(t, 1, sender.Len())
 		assert.Equal(t, level.Error, sender.GetMessage().Priority)
 	})
+}
+
+func TestSelectTestsSetsTimeout(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		tests            []string
+		expectedEndpoint string
+	}{
+		{
+			name:             "ExplicitTestsShouldSetTimeout",
+			tests:            []string{"test"},
+			expectedEndpoint: SelectTestsEndpoint,
+		},
+		{
+			name:             "AllKnownTestsShouldSetTimeout",
+			expectedEndpoint: SelectKnownTestsEndpoint,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			sender := captureGripMessages(t)
+			setTSSURLForTest(t, "http://tss.example.com")
+			startAt := time.Now()
+			originalClient := testSelectionHTTPClient
+			testSelectionHTTPClient = &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					deadline, ok := req.Context().Deadline()
+					require.True(t, ok)
+					assert.WithinDuration(t, startAt.Add(testSelectionSelectTimeout), deadline, time.Second)
+					return nil, context.DeadlineExceeded
+				}),
+			}
+			t.Cleanup(func() {
+				testSelectionHTTPClient = originalClient
+			})
+
+			selectedTests, err := SelectTests(t.Context(), model.SelectTestsRequest{
+				Project:      "project",
+				Requester:    evergreen.PatchVersionRequester,
+				BuildVariant: "build_variant",
+				TaskID:       "task_id",
+				TaskName:     "task_name",
+				Tests:        test.tests,
+			})
+			require.Error(t, err)
+			assert.Empty(t, selectedTests)
+			require.Equal(t, 1, sender.Len())
+			fields, ok := sender.GetMessage().Message.Raw().(message.Fields)
+			require.True(t, ok)
+			assert.Equal(t, test.expectedEndpoint, fields["endpoint"])
+			assert.Equal(t, true, fields["timeout"])
+			assert.Contains(t, fields, "duration_ms")
+		})
+	}
 }
 
 func TestGetTestsQuarantineStatus(t *testing.T) {

--- a/rest/data/select_test.go
+++ b/rest/data/select_test.go
@@ -117,6 +117,7 @@ func TestSelectTestsSetsTimeout(t *testing.T) {
 				Tests:        test.tests,
 			})
 			require.Error(t, err)
+			assert.ErrorIs(t, err, context.DeadlineExceeded)
 			assert.Empty(t, selectedTests)
 			require.Equal(t, 1, sender.Len())
 			fields, ok := sender.GetMessage().Message.Raw().(message.Fields)

--- a/rest/route/select.go
+++ b/rest/route/select.go
@@ -59,10 +59,22 @@ func (t *selectTestsHandler) Parse(ctx context.Context, r *http.Request) error {
 func (t *selectTestsHandler) Run(ctx context.Context) gimlet.Responder {
 	selectedTests, err := data.SelectTests(ctx, t.selectTests)
 	if err != nil {
-		return gimlet.NewJSONInternalErrorResponse(err)
+		return makeSelectTestsErrorResponse(err)
 	}
 
 	rhResp := t.selectTests
 	rhResp.Tests = selectedTests
 	return gimlet.NewJSONResponse(rhResp)
+}
+
+func makeSelectTestsErrorResponse(err error) gimlet.Responder {
+	if errors.Is(err, context.DeadlineExceeded) {
+		// The agent retries other server and timeout statuses, which would
+		// reissue the TSS request and amplify an outage.
+		return gimlet.NewJSONErrorResponse(gimlet.ErrorResponse{
+			StatusCode: http.StatusFailedDependency,
+			Message:    err.Error(),
+		})
+	}
+	return gimlet.NewJSONInternalErrorResponse(err)
 }

--- a/rest/route/select_test.go
+++ b/rest/route/select_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -102,6 +103,18 @@ func TestSelectTestsHandler(t *testing.T) {
 	req, _ = http.NewRequest(http.MethodPost, "/select/tests", bytes.NewBuffer(j))
 	sth = makeSelectTestsHandler(env)
 	require.Error(t, sth.Parse(ctx, req), "request should fail to parse when task name is missing")
+}
+
+func TestMakeSelectTestsErrorResponse(t *testing.T) {
+	t.Run("DeadlineExceededShouldReturnFailedDependency", func(t *testing.T) {
+		resp := makeSelectTestsErrorResponse(errors.Wrap(context.DeadlineExceeded, "selecting tests"))
+		assert.Equal(t, http.StatusFailedDependency, resp.Status())
+	})
+
+	t.Run("OtherErrorsShouldReturnInternalServerError", func(t *testing.T) {
+		resp := makeSelectTestsErrorResponse(errors.New("selecting tests"))
+		assert.Equal(t, http.StatusInternalServerError, resp.Status())
+	})
 }
 
 // Regression guard: user-authenticated requests must reach the handler.


### PR DESCRIPTION
DEVPROD-37218

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Before we were just timing out things that would impact loading evergreen UI such as the task page/tab. 

- This PR adds timeout for select_tests, which is what we use to decide what tests to run from TSS. We're adding this to make sure evergreen doesn't throttle from long TSS request from this endpoint.
- We're also making sure the evergreen agent doesn't retry when we time out the request

### Testing
* Unit tests

