### PR TITLE
DEVPROD-36682: Cross-project admin bypass via spoofed GraphQL operation

### DIFF
--- a/graphql/directive_test.go
+++ b/graphql/directive_test.go
@@ -497,7 +497,7 @@ func TestRequireDistroAccess(t *testing.T) {
 	assert.EqualError(t, err, "input: user 'test_user' does not have permission to access settings for the distro 'distro-id'")
 }
 
-func TestRequireProjectAdmin(t *testing.T) {
+func TestRequireProjectCreate(t *testing.T) {
 	setupPermissions(t)
 	require.NoError(t, db.Clear(user.Collection),
 		"unable to clear user collection")
@@ -516,7 +516,6 @@ func TestRequireProjectAdmin(t *testing.T) {
 	config := New("/graphql")
 	require.NotNil(t, config)
 	ctx := context.Background()
-	obj := any(nil)
 
 	// callCount keeps track of how many times the function is called
 	callCount := 0
@@ -533,18 +532,11 @@ func TestRequireProjectAdmin(t *testing.T) {
 	ctx = gimlet.AttachUser(ctx, usr)
 	require.NotNil(t, ctx)
 
-	projectRef := model.ProjectRef{
-		Id:         "project_id",
-		Identifier: "project_identifier",
-	}
-	err = projectRef.Insert(t.Context())
-	require.NoError(t, err)
-
 	// superuser should always be successful, no matter the resolver
 	err = usr.AddRole(t.Context(), "superuser")
 	require.NoError(t, err)
 
-	res, err := config.Directives.RequireProjectAdmin(ctx, obj, next)
+	res, err := config.Directives.RequireProjectCreate(ctx, nil, next)
 	assert.NoError(t, err)
 	assert.Nil(t, res)
 	assert.Equal(t, 1, callCount)
@@ -552,119 +544,17 @@ func TestRequireProjectAdmin(t *testing.T) {
 	err = usr.RemoveRole(t.Context(), "superuser")
 	require.NoError(t, err)
 
-	// CreateProject - permission denied
-	operationContext := &graphql.OperationContext{
-		OperationName: CreateProjectMutation,
-	}
-	ctx = graphql.WithOperationContext(ctx, operationContext)
-	obj = map[string]any{
-		"project": map[string]any{
-			"identifier": "anything",
-		},
-	}
-	res, err = config.Directives.RequireProjectAdmin(ctx, obj, next)
-	assert.EqualError(t, err, "input: user test_user does not have permission to access the CreateProject resolver")
+	res, err = config.Directives.RequireProjectCreate(ctx, nil, next)
+	assert.EqualError(t, err, "input: user 'test_user' does not have permission to create projects")
 	assert.Nil(t, res)
 	assert.Equal(t, 1, callCount)
 
-	// CreateProject - successful
 	err = usr.AddRole(t.Context(), "admin_project")
 	require.NoError(t, err)
-	res, err = config.Directives.RequireProjectAdmin(ctx, obj, next)
+	res, err = config.Directives.RequireProjectCreate(ctx, nil, next)
 	assert.NoError(t, err)
 	assert.Nil(t, res)
 	assert.Equal(t, 2, callCount)
-
-	// CopyProject - permission denied
-	operationContext = &graphql.OperationContext{
-		OperationName: CopyProjectMutation,
-	}
-	ctx = graphql.WithOperationContext(ctx, operationContext)
-	obj = map[string]any{
-		"project": map[string]any{
-			"projectIdToCopy": "anything",
-		},
-	}
-	res, err = config.Directives.RequireProjectAdmin(ctx, obj, next)
-	assert.EqualError(t, err, "input: user test_user does not have permission to access the CopyProject resolver")
-	assert.Nil(t, res)
-	assert.Equal(t, 2, callCount)
-
-	// CopyProject - successful
-	obj = map[string]any{
-		"project": map[string]any{
-			"projectIdToCopy": "project_id",
-		},
-	}
-	res, err = config.Directives.RequireProjectAdmin(ctx, obj, next)
-	assert.NoError(t, err)
-	assert.Nil(t, res)
-	assert.Equal(t, 3, callCount)
-
-	// DeleteProject - permission denied
-	operationContext = &graphql.OperationContext{
-		OperationName: DeleteProjectMutation,
-	}
-	ctx = graphql.WithOperationContext(ctx, operationContext)
-	obj = map[string]any{"projectId": "anything"}
-	res, err = config.Directives.RequireProjectAdmin(ctx, obj, next)
-	assert.EqualError(t, err, "input: user test_user does not have permission to access the DeleteProject resolver")
-	assert.Nil(t, res)
-	assert.Equal(t, 3, callCount)
-
-	// DeleteProject - successful
-	obj = map[string]any{"projectId": "project_id"}
-	res, err = config.Directives.RequireProjectAdmin(ctx, obj, next)
-	assert.NoError(t, err)
-	assert.Nil(t, res)
-	assert.Equal(t, 4, callCount)
-
-	// SetLastRevision - successful
-	operationContext = &graphql.OperationContext{
-		OperationName: SetLastRevisionMutation,
-	}
-	ctx = graphql.WithOperationContext(ctx, operationContext)
-	obj = map[string]any{
-		"opts": map[string]any{
-			"projectIdentifier": "project_identifier",
-		},
-	}
-	res, err = config.Directives.RequireProjectAdmin(ctx, obj, next)
-	assert.NoError(t, err)
-	assert.Nil(t, res)
-	assert.Equal(t, 5, callCount)
-
-	// SetLastRevision - project not found
-	operationContext = &graphql.OperationContext{
-		OperationName: SetLastRevisionMutation,
-	}
-	ctx = graphql.WithOperationContext(ctx, operationContext)
-	obj = map[string]any{
-		"opts": map[string]any{
-			"projectIdentifier": "project_whatever",
-		},
-	}
-	res, err = config.Directives.RequireProjectAdmin(ctx, obj, next)
-	assert.EqualError(t, err, "input: project 'project_whatever' not found")
-	assert.Nil(t, res)
-	assert.Equal(t, 5, callCount)
-
-	// SetLastRevision - permission denied
-	operationContext = &graphql.OperationContext{
-		OperationName: SetLastRevisionMutation,
-	}
-	ctx = graphql.WithOperationContext(ctx, operationContext)
-	obj = map[string]any{
-		"opts": map[string]any{
-			"projectIdentifier": "project_identifier",
-		},
-	}
-	require.NoError(t, usr.RemoveRole(t.Context(), "admin_project"))
-	res, err = config.Directives.RequireProjectAdmin(ctx, obj, next)
-	assert.EqualError(t, err, "input: user test_user does not have permission to access the SetLastRevision resolver")
-	assert.Nil(t, res)
-	assert.Equal(t, 5, callCount)
-
 }
 
 func setupUser(t *testing.T) (*user.DBUser, error) {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -103,7 +103,7 @@ type DirectiveRoot struct {
 	RequireHostAccess            func(ctx context.Context, obj any, next graphql.Resolver, access HostAccessLevel) (res any, err error)
 	RequirePatchOwner            func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
 	RequireProjectAccess         func(ctx context.Context, obj any, next graphql.Resolver, permission ProjectPermission, access AccessLevel) (res any, err error)
-	RequireProjectAdmin          func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
+	RequireProjectCreate         func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
 	RequireProjectSettingsAccess func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
 	RequireRepoAccess            func(ctx context.Context, obj any, next graphql.Resolver, access AccessLevel) (res any, err error)
 	RequireVolumeAccess          func(ctx context.Context, obj any, next graphql.Resolver) (res any, err error)
@@ -13916,53 +13916,12 @@ func (ec *executionContext) field_Mutation_copyDistro_argsOpts(
 func (ec *executionContext) field_Mutation_copyProject_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
-
-	arg0, err := ec.field_Mutation_copyProject_argsProject(ctx, rawArgs)
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "project", ec.unmarshalNCopyProjectInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐCopyProjectOpts)
 	if err != nil {
 		return nil, err
 	}
 	args["project"] = arg0
 	return args, nil
-}
-
-func (ec *executionContext) field_Mutation_copyProject_argsProject(
-	ctx context.Context,
-	rawArgs map[string]any,
-) (model.CopyProjectOpts, error) {
-	if _, ok := rawArgs["project"]; !ok {
-		var zeroVal model.CopyProjectOpts
-		return zeroVal, nil
-	}
-
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("project"))
-	directive0 := func(ctx context.Context) (any, error) {
-		tmp, ok := rawArgs["project"]
-		if !ok {
-			var zeroVal model.CopyProjectOpts
-			return zeroVal, nil
-		}
-		return ec.unmarshalNCopyProjectInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐCopyProjectOpts(ctx, tmp)
-	}
-
-	directive1 := func(ctx context.Context) (any, error) {
-		if ec.directives.RequireProjectAdmin == nil {
-			var zeroVal model.CopyProjectOpts
-			return zeroVal, errors.New("directive requireProjectAdmin is not implemented")
-		}
-		return ec.directives.RequireProjectAdmin(ctx, rawArgs, directive0)
-	}
-
-	tmp, err := directive1(ctx)
-	if err != nil {
-		var zeroVal model.CopyProjectOpts
-		return zeroVal, graphql.ErrorOnPath(ctx, err)
-	}
-	if data, ok := tmp.(model.CopyProjectOpts); ok {
-		return data, nil
-	} else {
-		var zeroVal model.CopyProjectOpts
-		return zeroVal, graphql.ErrorOnPath(ctx, fmt.Errorf(`unexpected type %T from directive, should be github.com/evergreen-ci/evergreen/rest/model.CopyProjectOpts`, tmp))
-	}
 }
 
 func (ec *executionContext) field_Mutation_createDistro_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
@@ -14054,11 +14013,11 @@ func (ec *executionContext) field_Mutation_createProject_argsProject(
 	}
 
 	directive1 := func(ctx context.Context) (any, error) {
-		if ec.directives.RequireProjectAdmin == nil {
+		if ec.directives.RequireProjectCreate == nil {
 			var zeroVal model.APIProjectRef
-			return zeroVal, errors.New("directive requireProjectAdmin is not implemented")
+			return zeroVal, errors.New("directive requireProjectCreate is not implemented")
 		}
-		return ec.directives.RequireProjectAdmin(ctx, rawArgs, directive0)
+		return ec.directives.RequireProjectCreate(ctx, rawArgs, directive0)
 	}
 
 	tmp, err := directive1(ctx)
@@ -14161,11 +14120,21 @@ func (ec *executionContext) field_Mutation_deleteProject_argsProjectID(
 	}
 
 	directive1 := func(ctx context.Context) (any, error) {
-		if ec.directives.RequireProjectAdmin == nil {
+		permission, err := ec.unmarshalNProjectPermission2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐProjectPermission(ctx, "SETTINGS")
+		if err != nil {
 			var zeroVal string
-			return zeroVal, errors.New("directive requireProjectAdmin is not implemented")
+			return zeroVal, err
 		}
-		return ec.directives.RequireProjectAdmin(ctx, rawArgs, directive0)
+		access, err := ec.unmarshalNAccessLevel2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐAccessLevel(ctx, "EDIT")
+		if err != nil {
+			var zeroVal string
+			return zeroVal, err
+		}
+		if ec.directives.RequireProjectAccess == nil {
+			var zeroVal string
+			return zeroVal, errors.New("directive requireProjectAccess is not implemented")
+		}
+		return ec.directives.RequireProjectAccess(ctx, rawArgs, directive0, permission, access)
 	}
 
 	tmp, err := directive1(ctx)
@@ -15260,53 +15229,12 @@ func (ec *executionContext) field_Mutation_setAnnotationMetadataLinks_args(ctx c
 func (ec *executionContext) field_Mutation_setLastRevision_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
-
-	arg0, err := ec.field_Mutation_setLastRevision_argsOpts(ctx, rawArgs)
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "opts", ec.unmarshalNSetLastRevisionInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSetLastRevisionInput)
 	if err != nil {
 		return nil, err
 	}
 	args["opts"] = arg0
 	return args, nil
-}
-
-func (ec *executionContext) field_Mutation_setLastRevision_argsOpts(
-	ctx context.Context,
-	rawArgs map[string]any,
-) (SetLastRevisionInput, error) {
-	if _, ok := rawArgs["opts"]; !ok {
-		var zeroVal SetLastRevisionInput
-		return zeroVal, nil
-	}
-
-	ctx = graphql.WithPathContext(ctx, graphql.NewPathWithField("opts"))
-	directive0 := func(ctx context.Context) (any, error) {
-		tmp, ok := rawArgs["opts"]
-		if !ok {
-			var zeroVal SetLastRevisionInput
-			return zeroVal, nil
-		}
-		return ec.unmarshalNSetLastRevisionInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐSetLastRevisionInput(ctx, tmp)
-	}
-
-	directive1 := func(ctx context.Context) (any, error) {
-		if ec.directives.RequireProjectAdmin == nil {
-			var zeroVal SetLastRevisionInput
-			return zeroVal, errors.New("directive requireProjectAdmin is not implemented")
-		}
-		return ec.directives.RequireProjectAdmin(ctx, rawArgs, directive0)
-	}
-
-	tmp, err := directive1(ctx)
-	if err != nil {
-		var zeroVal SetLastRevisionInput
-		return zeroVal, graphql.ErrorOnPath(ctx, err)
-	}
-	if data, ok := tmp.(SetLastRevisionInput); ok {
-		return data, nil
-	} else {
-		var zeroVal SetLastRevisionInput
-		return zeroVal, graphql.ErrorOnPath(ctx, fmt.Errorf(`unexpected type %T from directive, should be github.com/evergreen-ci/evergreen/graphql.SetLastRevisionInput`, tmp))
-	}
 }
 
 func (ec *executionContext) field_Mutation_setPatchVisibility_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
@@ -82114,11 +82042,36 @@ func (ec *executionContext) unmarshalInputCopyProjectInput(ctx context.Context, 
 			it.NewProjectIdentifier = data
 		case "projectIdToCopy":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("projectIdToCopy"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalNString2string(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				permission, err := ec.unmarshalNProjectPermission2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐProjectPermission(ctx, "SETTINGS")
+				if err != nil {
+					var zeroVal string
+					return zeroVal, err
+				}
+				access, err := ec.unmarshalNAccessLevel2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐAccessLevel(ctx, "EDIT")
+				if err != nil {
+					var zeroVal string
+					return zeroVal, err
+				}
+				if ec.directives.RequireProjectAccess == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive requireProjectAccess is not implemented")
+				}
+				return ec.directives.RequireProjectAccess(ctx, obj, directive0, permission, access)
 			}
-			it.ProjectIdToCopy = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(string); ok {
+				it.ProjectIdToCopy = data
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		}
 	}
 
@@ -88638,11 +88591,36 @@ func (ec *executionContext) unmarshalInputSetLastRevisionInput(ctx context.Conte
 		switch k {
 		case "projectIdentifier":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("projectIdentifier"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
+			directive0 := func(ctx context.Context) (any, error) { return ec.unmarshalNString2string(ctx, v) }
+
+			directive1 := func(ctx context.Context) (any, error) {
+				permission, err := ec.unmarshalNProjectPermission2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐProjectPermission(ctx, "SETTINGS")
+				if err != nil {
+					var zeroVal string
+					return zeroVal, err
+				}
+				access, err := ec.unmarshalNAccessLevel2githubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐAccessLevel(ctx, "EDIT")
+				if err != nil {
+					var zeroVal string
+					return zeroVal, err
+				}
+				if ec.directives.RequireProjectAccess == nil {
+					var zeroVal string
+					return zeroVal, errors.New("directive requireProjectAccess is not implemented")
+				}
+				return ec.directives.RequireProjectAccess(ctx, obj, directive0, permission, access)
 			}
-			it.ProjectIdentifier = data
+
+			tmp, err := directive1(ctx)
+			if err != nil {
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
+			if data, ok := tmp.(string); ok {
+				it.ProjectIdentifier = data
+			} else {
+				err := fmt.Errorf(`unexpected type %T from directive, should be string`, tmp)
+				return it, graphql.ErrorOnPath(ctx, err)
+			}
 		case "revision":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("revision"))
 			data, err := ec.unmarshalNString2string(ctx, v)

--- a/graphql/project_admin_authorization_test.go
+++ b/graphql/project_admin_authorization_test.go
@@ -1,0 +1,157 @@
+package graphql
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/user"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProjectAdminOperationNameDoesNotBypassTargetAuthorization(t *testing.T) {
+	setupPermissions(t)
+
+	usr := &user.DBUser{
+		Id:          testUser,
+		SystemRoles: []string{"admin_project"},
+	}
+	require.NoError(t, usr.Insert(t.Context()))
+
+	authorizedProject := model.ProjectRef{
+		Id:         "project_id",
+		Identifier: "authorized_project",
+		Owner:      "authorized_owner",
+		Repo:       "authorized_repo",
+		Branch:     "main",
+	}
+	require.NoError(t, authorizedProject.Insert(t.Context()))
+
+	unauthorizedProject := model.ProjectRef{
+		Id:         "unauthorized_project_id",
+		Identifier: "unauthorized_project",
+		Owner:      "unauthorized_owner",
+		Repo:       "unauthorized_repo",
+		Branch:     "main",
+	}
+	require.NoError(t, unauthorizedProject.Insert(t.Context()))
+
+	const originalRevision = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	_, err := model.GetNewRevisionOrderNumber(t.Context(), unauthorizedProject.Id)
+	require.NoError(t, err)
+	require.NoError(t, model.UpdateLastRevision(t.Context(), unauthorizedProject.Id, originalRevision))
+
+	srv := handler.NewDefaultServer(NewExecutableSchema(New("/graphql")))
+	runMutationAndAssertUnauthorized := func(t *testing.T, query string, variables map[string]any) {
+		payload, err := json.Marshal(map[string]any{
+			"operationName": "CreateProject",
+			"query":         query,
+			"variables":     variables,
+		})
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodPost, "/graphql/query", bytes.NewReader(payload))
+		req.Header.Set("Content-Type", "application/json")
+		req = req.WithContext(gimlet.AttachUser(req.Context(), usr))
+		recorder := httptest.NewRecorder()
+		srv.ServeHTTP(recorder, req)
+
+		require.Equal(t, http.StatusOK, recorder.Code)
+		var response struct {
+			Errors []struct {
+				Message string `json:"message"`
+			} `json:"errors"`
+		}
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+		require.Len(t, response.Errors, 1)
+		assert.Contains(t, response.Errors[0].Message, "does not have permission")
+	}
+
+	t.Run("DeleteProject", func(t *testing.T) {
+		runMutationAndAssertUnauthorized(t, `mutation CreateProject($projectId: String!) {
+			spoofed: deleteProject(projectId: $projectId)
+		}`, map[string]any{"projectId": unauthorizedProject.Identifier})
+
+		project, err := model.FindBranchProjectRef(t.Context(), unauthorizedProject.Id)
+		require.NoError(t, err)
+		require.NotNil(t, project)
+		assert.False(t, project.IsHidden())
+		assert.Equal(t, unauthorizedProject.Owner, project.Owner)
+	})
+
+	t.Run("CopyProject", func(t *testing.T) {
+		const copiedProjectIdentifier = "copied_unauthorized_project"
+		runMutationAndAssertUnauthorized(t, `mutation CreateProject($project: CopyProjectInput!) {
+			spoofed: copyProject(project: $project) {
+				id
+			}
+		}`, map[string]any{
+			"project": map[string]any{
+				"newProjectIdentifier": copiedProjectIdentifier,
+				"projectIdToCopy":      unauthorizedProject.Identifier,
+			},
+		})
+
+		project, err := model.FindBranchProjectRef(t.Context(), copiedProjectIdentifier)
+		require.NoError(t, err)
+		assert.Nil(t, project)
+	})
+
+	t.Run("SetLastRevision", func(t *testing.T) {
+		runMutationAndAssertUnauthorized(t, `mutation CreateProject($projectIdentifier: String!, $revision: String!) {
+			spoofed: setLastRevision(opts: {
+				projectIdentifier: $projectIdentifier,
+				revision: $revision
+			}) {
+				mergeBaseRevision
+			}
+		}`, map[string]any{
+			"projectIdentifier": unauthorizedProject.Identifier,
+			"revision":          "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		})
+
+		repository, err := model.FindRepository(t.Context(), unauthorizedProject.Id)
+		require.NoError(t, err)
+		require.NotNil(t, repository)
+		assert.Equal(t, originalRevision, repository.LastRevision)
+	})
+
+	t.Run("TargetAdminCanUseArbitraryOperationName", func(t *testing.T) {
+		payload, err := json.Marshal(map[string]any{
+			"operationName": "ArbitraryOperation",
+			"query": `mutation ArbitraryOperation($projectId: String!) {
+				aliasedDelete: deleteProject(projectId: $projectId)
+			}`,
+			"variables": map[string]any{"projectId": authorizedProject.Identifier},
+		})
+		require.NoError(t, err)
+
+		req := httptest.NewRequest(http.MethodPost, "/graphql/query", bytes.NewReader(payload))
+		req.Header.Set("Content-Type", "application/json")
+		req = req.WithContext(gimlet.AttachUser(req.Context(), usr))
+		recorder := httptest.NewRecorder()
+		srv.ServeHTTP(recorder, req)
+
+		require.Equal(t, http.StatusOK, recorder.Code)
+		var response struct {
+			Data struct {
+				AliasedDelete bool `json:"aliasedDelete"`
+			} `json:"data"`
+			Errors []any `json:"errors"`
+		}
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+		assert.Empty(t, response.Errors)
+		assert.True(t, response.Data.AliasedDelete)
+
+		project, err := model.FindBranchProjectRef(t.Context(), authorizedProject.Id)
+		require.NoError(t, err)
+		require.NotNil(t, project)
+		assert.True(t, project.IsHidden())
+	})
+}

--- a/graphql/resolver.go
+++ b/graphql/resolver.go
@@ -19,13 +19,6 @@ import (
 	"github.com/evergreen-ci/utility"
 )
 
-const (
-	CreateProjectMutation   = "CreateProject"
-	CopyProjectMutation     = "CopyProject"
-	DeleteProjectMutation   = "DeleteProject"
-	SetLastRevisionMutation = "SetLastRevision"
-)
-
 type Resolver struct {
 	sc data.Connector
 }
@@ -164,86 +157,22 @@ func New(apiURL string) Config {
 		}
 		return nil, Forbidden.Send(ctx, fmt.Sprintf("user '%s' does not have permission to access settings for the distro '%s'", user.Username(), distroId))
 	}
-	c.Directives.RequireProjectAdmin = func(ctx context.Context, obj any, next graphql.Resolver) (any, error) {
+	c.Directives.RequireProjectCreate = func(ctx context.Context, _ any, next graphql.Resolver) (any, error) {
 		// Allow if user is superuser.
 		user := mustHaveUser(ctx)
-		opts := gimlet.PermissionOpts{
-			Resource:      evergreen.SuperUserPermissionsID,
-			ResourceType:  evergreen.SuperUserResourceType,
-			Permission:    evergreen.PermissionProjectCreate,
-			RequiredLevel: evergreen.ProjectCreate.Value,
-		}
-		if user.HasPermission(ctx, opts) {
+		if userHasSuperuserProjectPermission(ctx, user) {
 			return next(ctx)
 		}
 
-		operationContext := graphql.GetOperationContext(ctx).OperationName
-
-		if operationContext == CreateProjectMutation {
-			canCreate, err := user.HasProjectCreatePermission(ctx)
-			if err != nil {
-				return nil, InternalServerError.Send(ctx, fmt.Sprintf("checking user permissions: %s", err.Error()))
-			}
-			if canCreate {
-				return next(ctx)
-			}
+		canCreate, err := user.HasProjectCreatePermission(ctx)
+		if err != nil {
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("checking user permissions: %s", err.Error()))
+		}
+		if canCreate {
+			return next(ctx)
 		}
 
-		getPermissionOpts := func(projectId string) gimlet.PermissionOpts {
-			return gimlet.PermissionOpts{
-				Resource:      projectId,
-				ResourceType:  evergreen.ProjectResourceType,
-				Permission:    evergreen.PermissionProjectSettings,
-				RequiredLevel: evergreen.ProjectSettingsEdit.Value,
-			}
-		}
-
-		args, isStringMap := obj.(map[string]any)
-		if !isStringMap {
-			return nil, ResourceNotFound.Send(ctx, "Project not specified")
-		}
-
-		if operationContext == CopyProjectMutation {
-			projectIdToCopy, ok := args["project"].(map[string]any)["projectIdToCopy"].(string)
-			if !ok {
-				return nil, InternalServerError.Send(ctx, "finding projectIdToCopy for copy project operation")
-			}
-			opts := getPermissionOpts(projectIdToCopy)
-			if user.HasPermission(ctx, opts) {
-				return next(ctx)
-			}
-		}
-
-		if operationContext == DeleteProjectMutation {
-			projectId, ok := args["projectId"].(string)
-			if !ok {
-				return nil, InternalServerError.Send(ctx, "finding projectId for delete project operation")
-			}
-			opts := getPermissionOpts(projectId)
-			if user.HasPermission(ctx, opts) {
-				return next(ctx)
-			}
-		}
-
-		if operationContext == SetLastRevisionMutation {
-			projectIdentifier, ok := args["opts"].(map[string]any)["projectIdentifier"].(string)
-			if !ok {
-				return nil, InternalServerError.Send(ctx, "finding projectIdentifier for set last revision operation")
-			}
-			project, err := model.FindBranchProjectRef(ctx, projectIdentifier)
-			if err != nil {
-				return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding project '%s': %s", projectIdentifier, err.Error()))
-			}
-			if project == nil {
-				return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("project '%s' not found", projectIdentifier))
-			}
-			opts := getPermissionOpts(project.Id)
-			if user.HasPermission(ctx, opts) {
-				return next(ctx)
-			}
-		}
-
-		return nil, Forbidden.Send(ctx, fmt.Sprintf("user %s does not have permission to access the %s resolver", user.Username(), operationContext))
+		return nil, Forbidden.Send(ctx, fmt.Sprintf("user '%s' does not have permission to create projects", user.Username()))
 	}
 	c.Directives.RequireRepoAccess = func(ctx context.Context, obj any, next graphql.Resolver, access AccessLevel) (any, error) {
 		usr := mustHaveUser(ctx)

--- a/graphql/schema/directives.graphql
+++ b/graphql/schema/directives.graphql
@@ -1,7 +1,7 @@
 """
-requireProjectAdmin is used to restrict certain actions to admins.
+requireProjectCreate is used to restrict project creation to users who administer a project.
 """
-directive @requireProjectAdmin on ARGUMENT_DEFINITION
+directive @requireProjectCreate on ARGUMENT_DEFINITION
 
 """
 requireProjectAccess is used to restrict admin, view, and edit access for repos.

--- a/graphql/schema/mutation.graphql
+++ b/graphql/schema/mutation.graphql
@@ -64,18 +64,18 @@ type Mutation {
   # project
   attachProjectToNewRepo(project: MoveProjectInput!): Project! # Has directive on MoveProjectInput.
   attachProjectToRepo(projectId: String! @requireRepoAccess(access: ADMIN) @requireProjectAccess(permission: SETTINGS, access: EDIT)): Project!
-  createProject(project: CreateProjectInput! @requireProjectAdmin): Project!
-  copyProject(project: CopyProjectInput! @requireProjectAdmin): Project! 
+  createProject(project: CreateProjectInput! @requireProjectCreate): Project!
+  copyProject(project: CopyProjectInput!): Project! # Has directive on CopyProjectInput.
   deactivateStepbackTask(opts: DeactivateStepbackTaskInput!): Boolean!
   defaultSectionToRepo(opts: DefaultSectionToRepoInput!): String
   deleteGithubAppCredentials(opts: DeleteGithubAppCredentialsInput!): DeleteGithubAppCredentialsPayload
-  deleteProject(projectId: String! @requireProjectAdmin): Boolean!
+  deleteProject(projectId: String! @requireProjectAccess(permission: SETTINGS, access: EDIT)): Boolean! # Authorization is based on the target project rather than the GraphQL operation name.
   detachProjectFromRepo(projectId: String! @requireProjectAccess(permission: SETTINGS, access: EDIT)): Project!
   forceRepotrackerRun(projectId: String! @requireProjectAccess(permission: SETTINGS, access: EDIT)): Boolean!
   promoteVarsToRepo(opts: PromoteVarsToRepoInput!): Boolean!
   saveProjectSettingsForSection(projectSettings: ProjectSettingsInput, section: ProjectSettingsSection!): ProjectSettings! # Has directive on ProjectSettingsInput.
   saveRepoSettingsForSection(repoSettings: RepoSettingsInput, section: ProjectSettingsSection!): RepoSettings! # Has directive on RepoSettingsInput.
-  setLastRevision(opts: SetLastRevisionInput! @requireProjectAdmin): SetLastRevisionPayload!
+  setLastRevision(opts: SetLastRevisionInput!): SetLastRevisionPayload! # Has directive on SetLastRevisionInput.
 
   # spawn
   attachVolumeToHost(volumeAndHost: VolumeHost!): Boolean! # Has directive on VolumeHost.

--- a/graphql/schema/types/project.graphql
+++ b/graphql/schema/types/project.graphql
@@ -18,7 +18,7 @@ It contains information about a project to be duplicated.
 input CopyProjectInput {
   newProjectId: String
   newProjectIdentifier: String!
-  projectIdToCopy: String!
+  projectIdToCopy: String! @requireProjectAccess(permission: SETTINGS, access: EDIT)
 }
 
 """
@@ -36,7 +36,7 @@ SetLastRevisionInput is the input to the setLastRevision mutation.
 It contains information used to fix the repotracker error of a project.
 """
 input SetLastRevisionInput {
-  projectIdentifier: String!
+  projectIdentifier: String! @requireProjectAccess(permission: SETTINGS, access: EDIT)
   revision: String!
 }
 

--- a/graphql/tests/mutation/deleteProject/data.json
+++ b/graphql/tests/mutation/deleteProject/data.json
@@ -9,13 +9,13 @@
   ],
   "project_ref": [
     {
-      "_id" : "already_hidden",
+      "_id" : "spruce",
       "enabled" : false,
       "parameter_store_enabled": true,
       "hidden": true
     },
     {
-      "_id" : "evergreen_id",
+      "_id" : "evergreen",
       "identifier" : "evergreen",
       "display_name" : "evergreem",
       "enabled" : true,

--- a/graphql/tests/mutation/deleteProject/queries/already_hidden.graphql
+++ b/graphql/tests/mutation/deleteProject/queries/already_hidden.graphql
@@ -1,5 +1,5 @@
 mutation {
   deleteProject(
-    projectId: "already_hidden"
+    projectId: "spruce"
   )
 }

--- a/graphql/tests/mutation/deleteProject/queries/not_attached_to_repo.graphql
+++ b/graphql/tests/mutation/deleteProject/queries/not_attached_to_repo.graphql
@@ -1,5 +1,5 @@
 mutation {
   deleteProject(
-    projectId: "evergreen_id"
+    projectId: "evergreen"
   )
 }

--- a/graphql/tests/mutation/deleteProject/results.json
+++ b/graphql/tests/mutation/deleteProject/results.json
@@ -6,7 +6,7 @@
         "data": null,
         "errors": [
           {
-            "message": "400 (Bad Request): project 'already_hidden' is already hidden",
+            "message": "400 (Bad Request): project 'spruce' is already hidden",
             "path": [
               "deleteProject"
             ],
@@ -23,6 +23,7 @@
     },
     {
       "query_file": "success.graphql",
+      "test_user_id": "privileged_user",
       "result": { "data": { "deleteProject": true } }
     }
   ]

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1128,6 +1128,15 @@ func userHasVolumePermission(ctx context.Context, u *user.DBUser, volumeId strin
 	return u.Username() == createdBy || u.HasPermission(ctx, opts)
 }
 
+func userHasSuperuserProjectPermission(ctx context.Context, u *user.DBUser) bool {
+	return u.HasPermission(ctx, gimlet.PermissionOpts{
+		Resource:      evergreen.SuperUserPermissionsID,
+		ResourceType:  evergreen.SuperUserResourceType,
+		Permission:    evergreen.PermissionProjectCreate,
+		RequiredLevel: evergreen.ProjectCreate.Value,
+	})
+}
+
 // canViewUserSubscriptions returns whether the requesting user is allowed to
 // view the personal subscriptions belonging to ownerUserID. A user may view
 // their own subscriptions, and superusers may view anyone's.

--- a/rest/data/middleware.go
+++ b/rest/data/middleware.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	projectIdKey  = "projectId"
-	identifierKey = "identifier"
+	projectIdKey       = "projectId"
+	projectIdToCopyKey = "projectIdToCopy"
+	identifierKey      = "identifier"
 
 	// Keys that are used in the paramsMap.
 	projectIdentifierKey = "projectIdentifier"
@@ -105,7 +106,7 @@ func GetProjectIdFromParams(ctx context.Context, paramsMap map[string]string) (s
 		return "", http.StatusNotFound, errors.New("no project found")
 	}
 
-	projectRef, err := model.FindMergedProjectRefSecondary(ctx, projectID, versionID, true)
+	projectRef, err := model.FindBranchProjectRefSecondary(ctx, projectID)
 	if err != nil {
 		return "", http.StatusInternalServerError, errors.Wrap(err, "finding project")
 	}
@@ -150,6 +151,9 @@ func BuildProjectParameterMapForGraphQL(args map[string]any) (map[string]string,
 	}
 	if projectId, hasProjectId := args[projectIdKey].(string); hasProjectId {
 		paramsMap[projectIdentifierKey] = projectId
+	}
+	if projectIdToCopy, hasProjectIdToCopy := args[projectIdToCopyKey].(string); hasProjectIdToCopy {
+		paramsMap[projectIdentifierKey] = projectIdToCopy
 	}
 	if repoId, hasRepoId := args[repoIdKey].(string); hasRepoId {
 		paramsMap[repoIdKey] = repoId

--- a/rest/data/middleware_test.go
+++ b/rest/data/middleware_test.go
@@ -42,6 +42,17 @@ func TestGetProjectIdFromParams(t *testing.T) {
 	require.Equal(t, http.StatusOK, statusCode)
 	require.Equal(t, projectId, project.Id)
 
+	projectWithMissingRepo := &model.ProjectRef{
+		Id:         "project_with_missing_repo_id",
+		Identifier: "project_with_missing_repo_identifier",
+		RepoRefId:  "missing_repo_id",
+	}
+	require.NoError(t, projectWithMissingRepo.Insert(t.Context()))
+	projectId, statusCode, err = GetProjectIdFromParams(ctx, map[string]string{"projectIdentifier": projectWithMissingRepo.Identifier})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, statusCode)
+	require.Equal(t, projectId, projectWithMissingRepo.Id)
+
 	// Parameters include taskId.
 	task := &task.Task{
 		Id:      "task_id",
@@ -151,6 +162,16 @@ func TestGetProjectIdFromParams(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, http.StatusNotFound, statusCode)
 	require.Equal(t, "", projectId)
+}
+
+func TestBuildProjectParameterMapForGraphQL(t *testing.T) {
+	t.Run("ProjectIDToCopyMapsToProjectIdentifier", func(t *testing.T) {
+		paramsMap, err := BuildProjectParameterMapForGraphQL(map[string]any{
+			projectIdToCopyKey: "source_project",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "source_project", paramsMap[projectIdentifierKey])
+	})
 }
 
 func TestBuildProjectParameterMapForLegacy(t *testing.T) {


### PR DESCRIPTION
[DEVPROD-36682](https://jira.mongodb.org/browse/DEVPROD-36682)

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Glass wing ticket

Problem: the `@requireProjectAdmin` directive protect the GraphQL mutations deleteProject, copyProject, and setLastRevision. `@requireProjectAdmin` decides what auth branch to run by reading what the caller supplied/the mutation actually being executed.

For example: `{{ mutation CreateProject { deleteProject(projectId: "victim-id") } }}; `. After called the directive takes the CreateProject branch and looks to see if the user can create projects and then if so, deletes the project. So a user who is admin on any project can use this bypass to delete, copy, or modify the last revision of another project.



<!--add description, context, thought process, etc-->

### Testing
* Added an integration test to test the new flow

<!--add a description of how you tested it-->

