### PR TITLE
DEVPROD-36421: Restore volume cleanup on EC2 fleet host termination

### DIFF
--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -350,6 +350,37 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 		"allocation_id":  h.IPAllocationID,
 	}))
 
+	for _, vol := range h.Volumes {
+		volDB, err := host.FindVolumeByID(ctx, vol.VolumeID)
+		if err != nil {
+			return errors.Wrap(err, "finding volumes for host")
+		}
+		if volDB == nil {
+			continue
+		}
+
+		if volDB.Expiration.Before(time.Now().Add(evergreen.UnattachedVolumeExpiration)) {
+			if err = m.ec2Mgr.modifyVolumeExpiration(ctx, volDB, time.Now().Add(evergreen.UnattachedVolumeExpiration)); err != nil {
+				grip.Error(ctx, message.WrapError(err, message.Fields{
+					"message": "error updating volume expiration",
+					"user":    user,
+					"host_id": h.Id,
+					"volume":  volDB.ID,
+				}))
+				return errors.Wrapf(err, "updating expiration for volume '%s'", volDB.ID)
+			}
+		}
+
+		if err = host.UnsetVolumeHost(ctx, volDB.ID); err != nil {
+			grip.Error(ctx, message.WrapError(err, message.Fields{
+				"host_id":   h.Id,
+				"volume_id": volDB.ID,
+				"op":        "terminating host",
+				"message":   "problem un-setting host info on volume records",
+			}))
+		}
+	}
+
 	return errors.Wrap(h.Terminate(ctx, user, reason), "terminating instance in DB")
 }
 

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -314,8 +314,7 @@ func TestFleet(t *testing.T) {
 		},
 		"TerminateInstanceUnsetsVolumeHost": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
 			h.Id = "i-12345"
-			require.NoError(t, db.Clear(host.Collection))
-			require.NoError(t, db.Clear(host.VolumesCollection))
+			require.NoError(t, db.ClearCollections(host.Collection, host.VolumesCollection))
 
 			vol := &host.Volume{
 				ID:         "volume1",

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -312,6 +312,28 @@ func TestFleet(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, evergreen.HostTerminated, hDb.Status)
 		},
+		"TerminateInstanceUnsetsVolumeHost": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
+			h.Id = "i-12345"
+			require.NoError(t, db.Clear(host.Collection))
+			require.NoError(t, db.Clear(host.VolumesCollection))
+
+			vol := &host.Volume{
+				ID:         "volume1",
+				Host:       h.Id,
+				Expiration: time.Now().Add(365 * 24 * time.Hour),
+			}
+			require.NoError(t, vol.Insert(ctx))
+
+			h.Volumes = []host.VolumeAttachment{{VolumeID: vol.ID}}
+			require.NoError(t, h.Insert(ctx))
+
+			assert.NoError(t, m.TerminateInstance(ctx, h, "evergreen", ""))
+
+			volDb, err := host.FindVolumeByID(ctx, vol.ID)
+			require.NoError(t, err)
+			require.NotNil(t, volDb)
+			assert.Empty(t, volDb.Host, "should unset the volume's host after terminating the instance")
+		},
 		"GetDNSName": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
 			dnsName, err := m.GetDNSName(ctx, h)
 			assert.NoError(t, err)


### PR DESCRIPTION
DEVPROD-36421

DEVPROD-25338 deleted the EC2 on-demand manager and migrated spawn hosts to the EC2 fleet manager, but the fleet manager's `TerminateInstance` never picked up the on-demand manager's spawn-host volume cleanup logic. As a result, volumes attached to spawn hosts are leaked on termination instead of being expiration-extended/unset.


###Testing
https://spruce-staging.corp.mongodb.com/host/i-0c4f30ed978bbac7c

created host and terminated it and the volume is set to expire now 

also added a unit test