### PR TITLE
DEVPROD-36424: Restore persistent DNS cleanup on EC2 fleet host termination

### DIFF
--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -317,6 +317,28 @@ func (m *ec2FleetManager) TerminateInstance(ctx context.Context, h *host.Host, u
 		instanceID = aws.ToString(instance.InstanceId)
 	}
 
+	// Any host that has been unexpirable will have been given a DNS name, which we need to clean up.
+	if h.PersistentDNSName != "" {
+		dnsName := h.PersistentDNSName
+		err := deleteHostPersistentDNSName(ctx, m.env, h, m.client)
+		grip.Error(ctx, message.WrapError(err, message.Fields{
+			"message":    "could not delete host's persistent DNS name",
+			"op":         "delete",
+			"dashboard":  "evergreen sleep schedule health",
+			"host_id":    h.Id,
+			"started_by": h.StartedBy,
+			"dns_name":   dnsName,
+		}))
+		grip.InfoWhen(ctx, err == nil, message.Fields{
+			"message":    "deleted host's persistent DNS name",
+			"op":         "delete",
+			"dashboard":  "evergreen sleep schedule health",
+			"host_id":    h.Id,
+			"started_by": h.StartedBy,
+			"dns_name":   dnsName,
+		})
+	}
+
 	resp, err := m.client.TerminateInstances(ctx, &ec2.TerminateInstancesInput{
 		InstanceIds: []string{instanceID},
 	})

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -335,6 +335,7 @@ func TestFleet(t *testing.T) {
 			hDb, err := host.FindOneId(ctx, "i-12345")
 			require.NoError(t, err)
 			assert.Empty(t, hDb.PersistentDNSName, "should unset the host's persistent DNS name in the DB")
+		},
 		"TerminateInstanceUnsetsVolumeHost": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
 			h.Id = "i-12345"
 			require.NoError(t, db.ClearCollections(host.Collection, host.VolumesCollection))

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -312,6 +312,30 @@ func TestFleet(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, evergreen.HostTerminated, hDb.Status)
 		},
+		"TerminateInstanceDeletesPersistentDNSName": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
+			h.Id = "i-12345"
+			h.PersistentDNSName = "my-host.example.com"
+			h.PublicIPv4 = "127.0.0.1"
+			require.NoError(t, db.Clear(host.Collection))
+			require.NoError(t, h.Insert(ctx))
+
+			mockEnv, ok := m.env.(*mock.Environment)
+			require.True(t, ok)
+			mockEnv.EvergreenSettings.Providers.AWS.PersistentDNS.Domain = "example.com"
+			mockEnv.EvergreenSettings.Providers.AWS.PersistentDNS.HostedZoneID = "Z12345"
+
+			assert.NoError(t, m.TerminateInstance(ctx, h, "evergreen", ""))
+
+			require.NotNil(t, client.ChangeResourceRecordSetsInput)
+			assert.Equal(t, "Z12345", aws.ToString(client.ChangeResourceRecordSetsInput.HostedZoneId))
+			require.Len(t, client.ChangeResourceRecordSetsInput.ChangeBatch.Changes, 1)
+			assert.Equal(t, "my-host.example.com", aws.ToString(client.ChangeResourceRecordSetsInput.ChangeBatch.Changes[0].ResourceRecordSet.Name))
+			assert.Empty(t, h.PersistentDNSName, "should unset the host's persistent DNS name in memory")
+
+			hDb, err := host.FindOneId(ctx, "i-12345")
+			require.NoError(t, err)
+			assert.Empty(t, hDb.PersistentDNSName, "should unset the host's persistent DNS name in the DB")
+		},
 		"GetDNSName": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
 			dnsName, err := m.GetDNSName(ctx, h)
 			assert.NoError(t, err)


### PR DESCRIPTION
DEVPROD-36424

DEVPROD-25338 deleted the EC2 on-demand manager and migrated spawn hosts to the EC2 fleet manager, but the fleet manager's `TerminateInstance` never picked up the on-demand manager's persistent DNS name cleanup for unexpirable hosts. As a result, persistent DNS records are leaked when unexpirable hosts are terminated.

This restores the `deleteHostPersistentDNSName` call into `ec2FleetManager.TerminateInstance`, matching what `ec2Manager.TerminateInstance` still does.


Also adds new unit tests so we can't delete this anymore 