### PR TITLE
DEVPROD-35243: Add skipOnParentCompleted option to prevTaskCompleted

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1919,7 +1919,7 @@ type ComplexityRoot struct {
 		PatchNumber             func(childComplexity int) int
 		PredictedTaskCost       func(childComplexity int) int
 		PrevTask                func(childComplexity int) int
-		PrevTaskCompleted       func(childComplexity int) int
+		PrevTaskCompleted       func(childComplexity int, prevTaskOptions *PrevTaskOptions) int
 		PrevTaskFailing         func(childComplexity int) int
 		PrevTaskPassing         func(childComplexity int) int
 		Priority                func(childComplexity int) int
@@ -2770,7 +2770,7 @@ type TaskResolver interface {
 	Patch(ctx context.Context, obj *model.APITask) (*model.APIPatch, error)
 	PatchNumber(ctx context.Context, obj *model.APITask) (*int, error)
 	PrevTask(ctx context.Context, obj *model.APITask) (*model.APITask, error)
-	PrevTaskCompleted(ctx context.Context, obj *model.APITask) (*model.APITask, error)
+	PrevTaskCompleted(ctx context.Context, obj *model.APITask, prevTaskOptions *PrevTaskOptions) (*model.APITask, error)
 	PrevTaskFailing(ctx context.Context, obj *model.APITask) (*model.APITask, error)
 	PrevTaskPassing(ctx context.Context, obj *model.APITask) (*model.APITask, error)
 
@@ -10914,7 +10914,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			break
 		}
 
-		return e.complexity.Task.PrevTaskCompleted(childComplexity), true
+		args, err := ec.field_Task_prevTaskCompleted_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Task.PrevTaskCompleted(childComplexity, args["prevTaskOptions"].(*PrevTaskOptions)), true
 	case "Task.prevTaskFailing":
 		if e.complexity.Task.PrevTaskFailing == nil {
 			break
@@ -13322,6 +13327,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputPersistentDNSConfigInput,
 		ec.unmarshalInputPlannerSettingsInput,
 		ec.unmarshalInputPreconditionScriptInput,
+		ec.unmarshalInputPrevTaskOptions,
 		ec.unmarshalInputProjectAliasInput,
 		ec.unmarshalInputProjectBannerInput,
 		ec.unmarshalInputProjectCreationConfigInput,
@@ -17300,6 +17306,17 @@ func (ec *executionContext) field_Query_waterfall_args(ctx context.Context, rawA
 		return nil, err
 	}
 	args["options"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Task_prevTaskCompleted_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "prevTaskOptions", ec.unmarshalOPrevTaskOptions2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPrevTaskOptions)
+	if err != nil {
+		return nil, err
+	}
+	args["prevTaskOptions"] = arg0
 	return args, nil
 }
 
@@ -64972,7 +64989,8 @@ func (ec *executionContext) _Task_prevTaskCompleted(ctx context.Context, field g
 		field,
 		ec.fieldContext_Task_prevTaskCompleted,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Task().PrevTaskCompleted(ctx, obj)
+			fc := graphql.GetFieldContext(ctx)
+			return ec.resolvers.Task().PrevTaskCompleted(ctx, obj, fc.Args["prevTaskOptions"].(*PrevTaskOptions))
 		},
 		nil,
 		ec.marshalOTask2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITask,
@@ -64981,7 +64999,7 @@ func (ec *executionContext) _Task_prevTaskCompleted(ctx context.Context, field g
 	)
 }
 
-func (ec *executionContext) fieldContext_Task_prevTaskCompleted(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_Task_prevTaskCompleted(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "Task",
 		Field:      field,
@@ -65170,6 +65188,17 @@ func (ec *executionContext) fieldContext_Task_prevTaskCompleted(_ context.Contex
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Task", field.Name)
 		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Task_prevTaskCompleted_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
 	}
 	return fc, nil
 }
@@ -86340,6 +86369,33 @@ func (ec *executionContext) unmarshalInputPreconditionScriptInput(ctx context.Co
 				return it, err
 			}
 			it.Script = data
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputPrevTaskOptions(ctx context.Context, obj any) (PrevTaskOptions, error) {
+	var it PrevTaskOptions
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"skipOnParentCompleted"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "skipOnParentCompleted":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("skipOnParentCompleted"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SkipOnParentCompleted = data
 		}
 	}
 
@@ -121732,6 +121788,14 @@ var (
 		model.KanopyPreferredType: "KANOPY",
 	}
 )
+
+func (ec *executionContext) unmarshalOPrevTaskOptions2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐPrevTaskOptions(ctx context.Context, v any) (*PrevTaskOptions, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputPrevTaskOptions(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
 
 func (ec *executionContext) unmarshalOPriorityLevel2ᚖstring(ctx context.Context, v any) (*string, error) {
 	if v == nil {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -381,6 +381,10 @@ type Permissions struct {
 	UserID               string              `json:"userId"`
 }
 
+type PrevTaskOptions struct {
+	SkipOnParentCompleted *bool `json:"skipOnParentCompleted,omitempty"`
+}
+
 type ProjectBuildVariant struct {
 	DisplayName string   `json:"displayName"`
 	Name        string   `json:"name"`

--- a/graphql/schema/types/task.graphql
+++ b/graphql/schema/types/task.graphql
@@ -44,6 +44,10 @@ input TaskPriority {
   priority: Int!
 }
 
+input PrevTaskOptions {
+  skipOnParentCompleted: Boolean
+}
+
 ###### TYPES ######
 """
 Task models a task, the simplest unit of execution for Evergreen.
@@ -124,7 +128,7 @@ type Task {
   prevTask may be in-progress
   """
   prevTask: Task
-  prevTaskCompleted: Task
+  prevTaskCompleted(prevTaskOptions: PrevTaskOptions): Task
   prevTaskFailing: Task
   prevTaskPassing: Task
   priority: Int

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -3,6 +3,7 @@ package graphql
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/apimodels"
@@ -658,7 +659,11 @@ func (r *taskResolver) PrevTask(ctx context.Context, obj *restModel.APITask) (*r
 }
 
 // PrevTaskCompleted is the resolver for the prevTaskCompleted field.
-func (r *taskResolver) PrevTaskCompleted(ctx context.Context, obj *restModel.APITask) (*restModel.APITask, error) {
+func (r *taskResolver) PrevTaskCompleted(ctx context.Context, obj *restModel.APITask, prevTaskOptions *PrevTaskOptions) (*restModel.APITask, error) {
+	if prevTaskOptions != nil && utility.FromBoolPtr(prevTaskOptions.SkipOnParentCompleted) && !slices.Contains(evergreen.TaskUncompletedStatuses, utility.FromStringPtr(obj.Status)) {
+		return nil, nil
+	}
+
 	tsk, err := getPrevTask(ctx, obj, evergreen.TaskCompletedStatuses)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding previous completed task for '%s': %s", utility.FromStringPtr(obj.Id), err.Error()))

--- a/graphql/tests/task/adjacentTasks/queries/prev_completed_no_skip_completed_task.graphql
+++ b/graphql/tests/task/adjacentTasks/queries/prev_completed_no_skip_completed_task.graphql
@@ -1,0 +1,10 @@
+{
+  task(taskId: "only_success_next") {
+    id
+    status
+    prevTaskCompleted(prevTaskOptions: { skipOnParentCompleted: false }) {
+      id
+      status
+    }
+  }
+}

--- a/graphql/tests/task/adjacentTasks/queries/prev_completed_skip_on_success_active_task.graphql
+++ b/graphql/tests/task/adjacentTasks/queries/prev_completed_skip_on_success_active_task.graphql
@@ -1,0 +1,10 @@
+{
+  task(taskId: "current_task") {
+    id
+    status
+    prevTaskCompleted(prevTaskOptions: { skipOnParentCompleted: true }) {
+      id
+      status
+    }
+  }
+}

--- a/graphql/tests/task/adjacentTasks/queries/prev_completed_skip_on_success_completed_task.graphql
+++ b/graphql/tests/task/adjacentTasks/queries/prev_completed_skip_on_success_completed_task.graphql
@@ -1,0 +1,10 @@
+{
+  task(taskId: "only_success_next") {
+    id
+    status
+    prevTaskCompleted(prevTaskOptions: { skipOnParentCompleted: true }) {
+      id
+      status
+    }
+  }
+}

--- a/graphql/tests/task/adjacentTasks/results.json
+++ b/graphql/tests/task/adjacentTasks/results.json
@@ -181,6 +181,48 @@
       }
     },
     {
+      "query_file": "prev_completed_skip_on_success_completed_task.graphql",
+      "result": {
+        "data": {
+          "task": {
+            "id": "only_success_next",
+            "status": "success",
+            "prevTaskCompleted": null
+          }
+        }
+      }
+    },
+    {
+      "query_file": "prev_completed_skip_on_success_active_task.graphql",
+      "result": {
+        "data": {
+          "task": {
+            "id": "current_task",
+            "status": "started",
+            "prevTaskCompleted": {
+              "id": "prev_success",
+              "status": "success"
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "prev_completed_no_skip_completed_task.graphql",
+      "result": {
+        "data": {
+          "task": {
+            "id": "only_success_next",
+            "status": "success",
+            "prevTaskCompleted": {
+              "id": "only_success_prev",
+              "status": "success"
+            }
+          }
+        }
+      }
+    },
+    {
       "query_file": "patch_task_error.graphql",
       "result": {
         "errors": [


### PR DESCRIPTION
DEVPROD-35243 - supports https://github.com/evergreen-ci/ui/pull/1800

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->
Add optional `skipOnParentCompleted` option to `prevTaskCompleted` resolver so it can return null if the parent task has finished running. This will help avoid extra lookups for all tasks in the version tasks table.

### Testing

<!--add a description of how you tested it-->
Add GraphQL tests

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
