### PR TITLE
DEVPROD-36670: always check permissions against path object in REST API

### DIFF
--- a/rest/data/middleware.go
+++ b/rest/data/middleware.go
@@ -181,17 +181,29 @@ func BuildProjectParameterMapForLegacy(query url.Values, vars map[string]string)
 		vars["version_id"], vars[versionIdKey],
 		vars["patch_id"], vars[patchIdKey],
 		vars["log_id"],
+		vars["project_id"], vars[projectIdKey],
 	) != ""
 
-	var projectIDValue string
 	if hasObjectIDInPath {
-		projectIDValue = util.CoalesceString(vars["project_id"], vars[projectIdKey])
-	} else {
-		projectIDValue = util.CoalesceStrings(append(query["project_id"], query[projectIdKey]...), vars["project_id"], vars[projectIdKey])
+		// When an ID is present in the path, derive every ID being accessed
+		// from the path vars only, ignoring IDs from the query string (e.g.
+		// check user permissions against project_id instead of something_else
+		// in /tasks/{project_id}?project_id=something_else). The route handlers
+		// act on the path-bound object, therefore permissions must be checked
+		// against that path object specifically.
+		return map[string]string{
+			projectIdKey: util.CoalesceString(vars["project_id"], vars[projectIdKey]),
+			repoIdKey:    util.CoalesceString(vars["repo_id"], vars[repoIdKey]),
+			versionIdKey: util.CoalesceString(vars["version_id"], vars[versionIdKey]),
+			patchIdKey:   util.CoalesceString(vars["patch_id"], vars[patchIdKey]),
+			buildIdKey:   util.CoalesceString(vars["build_id"], vars[buildIdKey]),
+			logIdKey:     vars["log_id"],
+			taskIdKey:    util.CoalesceString(vars["task_id"], vars[taskIdKey]),
+		}
 	}
 
-	paramsMap := map[string]string{
-		projectIdKey: projectIDValue,
+	return map[string]string{
+		projectIdKey: util.CoalesceStrings(append(query["project_id"], query[projectIdKey]...), vars["project_id"], vars[projectIdKey]),
 		repoIdKey:    util.CoalesceStrings(append(query["repo_id"], query[repoIdKey]...), vars["repo_id"], vars[repoIdKey]),
 		versionIdKey: util.CoalesceStrings(append(query["version_id"], query[versionIdKey]...), vars["version_id"], vars[versionIdKey]),
 		patchIdKey:   util.CoalesceStrings(append(query["patch_id"], query[patchIdKey]...), vars["patch_id"], vars[patchIdKey]),
@@ -199,5 +211,4 @@ func BuildProjectParameterMapForLegacy(query url.Values, vars map[string]string)
 		logIdKey:     util.CoalesceStrings(query["log_id"], vars["log_id"]),
 		taskIdKey:    util.CoalesceStrings(append(query["task_id"], query[taskIdKey]...), vars["task_id"], vars[taskIdKey]),
 	}
-	return paramsMap
 }

--- a/rest/data/middleware.go
+++ b/rest/data/middleware.go
@@ -187,10 +187,11 @@ func BuildProjectParameterMapForLegacy(query url.Values, vars map[string]string)
 	if hasObjectIDInPath {
 		// When an ID is present in the path, derive every ID being accessed
 		// from the path vars only, ignoring IDs from the query string (e.g.
-		// check user permissions against project_id instead of something_else
-		// in /tasks/{project_id}?project_id=something_else). The route handlers
-		// act on the path-bound object, therefore permissions must be checked
-		// against that path object specifically.
+		// check project permissions against task_id's project instead of
+		// unrelated_version's project when a request is made to
+		// /tasks/{task_id}?version_id=unrelated_version).
+		// The route handlers act on the path-bound object, therefore
+		// permissions must be checked against that path object specifically.
 		return map[string]string{
 			projectIdKey: util.CoalesceString(vars["project_id"], vars[projectIdKey]),
 			repoIdKey:    util.CoalesceString(vars["repo_id"], vars[repoIdKey]),

--- a/rest/data/middleware_test.go
+++ b/rest/data/middleware_test.go
@@ -1,7 +1,6 @@
 package data
 
 import (
-	"context"
 	"net/http"
 	"net/url"
 	"testing"
@@ -15,13 +14,13 @@ import (
 	"github.com/evergreen-ci/evergreen/model/testlog"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 func TestGetProjectIdFromParams(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	require.NoError(t, db.ClearCollections(task.Collection, model.VersionCollection, model.ProjectRefCollection,
 		model.RepoRefCollection, patch.Collection, build.Collection, testlog.TestLogCollection))
@@ -155,43 +154,76 @@ func TestGetProjectIdFromParams(t *testing.T) {
 }
 
 func TestBuildProjectParameterMapForLegacy(t *testing.T) {
-	t.Run("QueryProjectIDIgnoredWhenBuildIDInPath", func(t *testing.T) {
-		query := url.Values{"project_id": []string{"attacker_project"}}
-		vars := map[string]string{"build_id": "victim_build_id"}
-
-		paramsMap := BuildProjectParameterMapForLegacy(query, vars)
-
-		require.Empty(t, paramsMap[projectIdKey])
-		require.Equal(t, "victim_build_id", paramsMap[buildIdKey])
-	})
-
-	t.Run("QueryProjectIDIgnoredWhenTaskIDInPath", func(t *testing.T) {
-		query := url.Values{"project_id": []string{"attacker_project"}}
-		vars := map[string]string{"task_id": "victim_task_id"}
-
-		paramsMap := BuildProjectParameterMapForLegacy(query, vars)
-
-		require.Empty(t, paramsMap[projectIdKey])
-		require.Equal(t, "victim_task_id", paramsMap[taskIdKey])
-	})
-
-	t.Run("QueryProjectIDIgnoredWhenVersionIDInPath", func(t *testing.T) {
-		query := url.Values{"project_id": []string{"attacker_project"}}
-		vars := map[string]string{"version_id": "victim_version_id"}
-
-		paramsMap := BuildProjectParameterMapForLegacy(query, vars)
-
-		require.Empty(t, paramsMap[projectIdKey])
-		require.Equal(t, "victim_version_id", paramsMap[versionIdKey])
-	})
-
-	t.Run("QueryProjectIDIgnoredWhenPatchIDInPath", func(t *testing.T) {
-		query := url.Values{"project_id": []string{"attacker_project"}}
-		vars := map[string]string{"patch_id": "victim_patch_id"}
-
-		paramsMap := BuildProjectParameterMapForLegacy(query, vars)
-
-		require.Empty(t, paramsMap[projectIdKey])
-		require.Equal(t, "victim_patch_id", paramsMap[patchIdKey])
-	})
+	// When an object ID is in the path, the query string must not be able to
+	// override any of the resolved IDs, since the route handler acts on the
+	// path-bound object. When no object ID is in the path, query-string IDs are
+	// honored. Each expected entry asserts a single resolved param.
+	for name, tc := range map[string]struct {
+		query    url.Values
+		vars     map[string]string
+		expected map[string]string
+	}{
+		"QueryProjectIDIgnoredWhenBuildIDInPath": {
+			query:    url.Values{"project_id": []string{"unrelated_project"}},
+			vars:     map[string]string{"build_id": "target_build_id"},
+			expected: map[string]string{projectIdKey: "", buildIdKey: "target_build_id"},
+		},
+		"QueryProjectIDIgnoredWhenTaskIDInPath": {
+			query:    url.Values{"project_id": []string{"unrelated_project"}},
+			vars:     map[string]string{"task_id": "target_task_id"},
+			expected: map[string]string{projectIdKey: "", taskIdKey: "target_task_id"},
+		},
+		"QueryProjectIDIgnoredWhenVersionIDInPath": {
+			query:    url.Values{"project_id": []string{"unrelated_project"}},
+			vars:     map[string]string{"version_id": "target_version_id"},
+			expected: map[string]string{projectIdKey: "", versionIdKey: "target_version_id"},
+		},
+		"QueryProjectIDIgnoredWhenPatchIDInPath": {
+			query:    url.Values{"project_id": []string{"unrelated_project"}},
+			vars:     map[string]string{"patch_id": "target_patch_id"},
+			expected: map[string]string{projectIdKey: "", patchIdKey: "target_patch_id"},
+		},
+		"QueryVersionIDIgnoredWhenTaskIDInPath": {
+			query:    url.Values{"version_id": []string{"unrelated_version_id"}},
+			vars:     map[string]string{"task_id": "target_task_id"},
+			expected: map[string]string{versionIdKey: "", taskIdKey: "target_task_id"},
+		},
+		"QueryPatchIDIgnoredWhenTaskIDInPath": {
+			query:    url.Values{"patch_id": []string{"unrelated_patch_id"}},
+			vars:     map[string]string{"task_id": "target_task_id"},
+			expected: map[string]string{patchIdKey: "", taskIdKey: "target_task_id"},
+		},
+		"QueryBuildIDIgnoredWhenTaskIDInPath": {
+			query:    url.Values{"build_id": []string{"unrelated_build_id"}},
+			vars:     map[string]string{"task_id": "target_task_id"},
+			expected: map[string]string{buildIdKey: "", taskIdKey: "target_task_id"},
+		},
+		"QueryTaskIDIgnoredWhenPatchIDInPath": {
+			query:    url.Values{"task_id": []string{"unrelated_task_id"}},
+			vars:     map[string]string{"patch_id": "target_patch_id"},
+			expected: map[string]string{taskIdKey: "", patchIdKey: "target_patch_id"},
+		},
+		"QueryLogIDIgnoredWhenTaskIDInPath": {
+			query:    url.Values{"log_id": []string{"unrelated_log_id"}},
+			vars:     map[string]string{"task_id": "target_task_id"},
+			expected: map[string]string{logIdKey: "", taskIdKey: "target_task_id"},
+		},
+		"QueryProjectIDIgnoredWhenProjectIDInPath": {
+			query:    url.Values{"project_id": []string{"unrelated_project"}},
+			vars:     map[string]string{"project_id": "target_project"},
+			expected: map[string]string{projectIdKey: "target_project"},
+		},
+		"QueryObjectIDsUsedWhenNoObjectIDInPath": {
+			query:    url.Values{"version_id": []string{"query_version_id"}},
+			vars:     map[string]string{},
+			expected: map[string]string{versionIdKey: "query_version_id"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			paramsMap := BuildProjectParameterMapForLegacy(tc.query, tc.vars)
+			for key, expectedValue := range tc.expected {
+				assert.Equal(t, expectedValue, paramsMap[key])
+			}
+		})
+	}
 }


### PR DESCRIPTION
DEVPROD-36670

### Description

Before this change, a user could gain unauthorized project access to a resource by passing an unrelated resource in the query params (e.g. in `GET /tasks/{task_id}?version_id=unrelated_version`, it would check the user's project permissions against `unrelated_version`'s project rather than `task_id`'s project). The REST API always specifies the resource being accessed through the path params, not the query params, so I narrowed the permissions check to always use path params if they're available to resolve which project is actually being accessed.

### Testing

* Added unit tests.
* Tested in personal staging to confirm that pre-change, the above request checks project permissions against an unrelated project. Post-change, it always checks against the project for the path object being accessed.