### PR TITLE
DEVPROD-33393 cleanup sage bot attribution work

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -20,9 +20,6 @@ const (
 	GithubMergeUser   = "github_merge_queue"
 	PeriodicBuildUser = "periodic_build_user"
 	ParentPatchUser   = "parent_patch"
-	// GitHubSageBotLogin is the GitHub login for mongodb-sage-bot, which sets
-	// the PR assignee as the intended human author of the PR.
-	GitHubSageBotLogin = "mongodb-sage-bot[bot]"
 
 	HostRunning       = "running"
 	HostTerminated    = "terminated"

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -153,15 +153,6 @@ func NewGithubIntent(ctx context.Context, msgDeliveryID, patchOwner, calledBy, a
 	if patchOwner == "" {
 		patchOwner = pr.User.GetLogin()
 	}
-	// mongodb-sage-bot sets the PR assignee as the intended human author, so
-	// use the assignee's identity for attribution instead.
-	ownerUID := int(pr.User.GetID())
-	assigneeLogin := pr.GetAssignee().GetLogin()
-	assigneeUID := int(pr.GetAssignee().GetID())
-	if patchOwner == evergreen.GitHubSageBotLogin && assigneeLogin != "" && assigneeUID != 0 {
-		patchOwner = assigneeLogin
-		ownerUID = assigneeUID
-	}
 	if alias == "" {
 		alias = evergreen.GithubPRAlias
 	}
@@ -181,7 +172,7 @@ func NewGithubIntent(ctx context.Context, msgDeliveryID, patchOwner, calledBy, a
 		HeadBranch:    pr.Head.GetRef(),
 		PRNumber:      pr.GetNumber(),
 		User:          patchOwner,
-		UID:           ownerUID,
+		UID:           int(pr.User.GetID()),
 		HeadHash:      pr.Head.GetSHA(),
 		BaseHash:      pr.Base.GetSHA(),
 		MergeBase:     mergeBase,

--- a/model/patch/github_test.go
+++ b/model/patch/github_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/evergreen/thirdparty"
 	"github.com/evergreen-ci/utility"
-	"github.com/google/go-github/v70/github"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -138,38 +137,6 @@ func (s *GithubSuite) TestNewGithubIntent() {
 	ghIntent, ok = intent.(*githubIntent)
 	s.True(ok)
 	s.Equal(patchId, ghIntent.RepeatPatchId)
-}
-
-func (s *GithubSuite) TestNewGithubIntentSageBotUsesAssignee() {
-	assigneeLogin := "real-human"
-	var assigneeID int64 = 9999
-	pr := testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, evergreen.GitHubSageBotLogin, s.title)
-	pr.Assignee = &github.User{
-		Login: github.String(assigneeLogin),
-		ID:    github.Int64(assigneeID),
-	}
-
-	intent, err := NewGithubIntent(s.T().Context(), "sagebot-1", "", "", "", "", pr)
-	s.Require().NoError(err)
-	s.Require().NotNil(intent)
-
-	ghIntent, ok := intent.(*githubIntent)
-	s.Require().True(ok)
-	s.Equal(assigneeLogin, ghIntent.User)
-	s.Equal(int(assigneeID), ghIntent.UID)
-}
-
-func (s *GithubSuite) TestNewGithubIntentSageBotNoAssigneeUsesBot() {
-	pr := testutil.NewGithubPR(s.pr, s.baseRepo, s.baseHash, s.headRepo, s.hash, evergreen.GitHubSageBotLogin, s.title)
-
-	intent, err := NewGithubIntent(s.T().Context(), "sagebot-2", "", "", "", "", pr)
-	s.Require().NoError(err)
-	s.Require().NotNil(intent)
-
-	ghIntent, ok := intent.(*githubIntent)
-	s.Require().True(ok)
-	s.Equal(evergreen.GitHubSageBotLogin, ghIntent.User)
-	s.Equal(1234, ghIntent.UID)
 }
 
 func (s *GithubSuite) TestInsert() {

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -216,7 +216,6 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 				"pr_number": event.GetPullRequest().GetNumber(),
 				"hash":      event.GetPullRequest().GetHead().GetSHA(),
 				"user":      event.GetSender().GetLogin(),
-				"assignee":  event.GetPullRequest().GetAssignee().GetLogin(),
 				"message":   "PR accepted, attempting to queue",
 			})
 


### PR DESCRIPTION
DEVPROD-33393

Ultimately, Trevor is going to do this more properly by actually having users auth (DEVPROD-36135) so cleaning up our attempts here. 