### PR TITLE
DEVPROD-5442: Use match then project for better perf and hopefully index usage

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2347,9 +2347,12 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 	if !opts.IncludeNeverActivatedTasks {
 		match[ActivatedTimeKey] = bson.M{"$ne": utility.ZeroTime}
 	}
+	// The $match must precede the $project so the version index can drive the
+	// query. A leading exclusion $project can prevent the aggregation optimizer
+	// from using the index on version, forcing a collection scan of every task.
 	pipeline := []bson.M{
-		{"$project": projectOut},
 		{"$match": match},
+		{"$project": projectOut},
 	}
 
 	if !opts.IncludeExecutionTasks {

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -2347,9 +2347,8 @@ func getTasksByVersionPipeline(versionID string, opts GetTasksByVersionOptions) 
 	if !opts.IncludeNeverActivatedTasks {
 		match[ActivatedTimeKey] = bson.M{"$ne": utility.ZeroTime}
 	}
-	// The $match must precede the $project so the version index can drive the
-	// query. A leading exclusion $project can prevent the aggregation optimizer
-	// from using the index on version, forcing a collection scan of every task.
+	// $match must precede $project so the version index can drive the query;
+	// a leading $project can force a collection scan.
 	pipeline := []bson.M{
 		{"$match": match},
 		{"$project": projectOut},


### PR DESCRIPTION
DEVPROD-5442

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Basically filtering (match) then reshape (project) which should reduce things to filter but also because we match first, we should be able to use the index more effectively so hopefully two for one.

We're doing this to reduce latency on the mainlinecommits query which you can see can spike in [latency](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen/result/jbnK52BvLwy), especially for >P95s with over 40 seconds in some cases

<img width="1273" height="839" alt="Screenshot 2026-07-20 at 3 53 21 PM" src="https://github.com/user-attachments/assets/36f4e46a-2800-471b-abcc-f1d763d7d382" />



### Testing
* Smoke tested locally but should be pretty inert