### PR TITLE
 DEVPROD-33407: Cache S3 assume-role credentials to reduce STS calls

### DIFF
--- a/agent/command/cache_util.go
+++ b/agent/command/cache_util.go
@@ -197,7 +197,7 @@ func (c *cacheCommon) createPailBucket(ctx context.Context, comm client.Communic
 		IfNotExists: ifNotExists,
 	}
 	if c.getRoleARN() != "" {
-		opts.Credentials = createEvergreenCredentials(comm, c.taskData, c.existingCredentials, c.getRoleARN(), nil)
+		opts.Credentials = newCachedEvergreenCredentials(comm, c.taskData, c.existingCredentials, c.getRoleARN(), nil)
 	} else if c.AwsKey != "" {
 		opts.Credentials = pail.CreateAWSStaticCredentials(c.AwsKey, c.AwsSecret, c.AwsSessionToken)
 	}

--- a/agent/command/s3_evergreen_credentials.go
+++ b/agent/command/s3_evergreen_credentials.go
@@ -53,6 +53,13 @@ func createEvergreenCredentials(comm client.Communicator, taskData client.TaskDa
 	}
 }
 
+// newCachedEvergreenCredentials wraps the Evergreen credential provider in an AWS
+// credentials cache so credentials are reused across request signings instead of
+// assuming a role on every S3 request.
+func newCachedEvergreenCredentials(comm client.Communicator, taskData client.TaskData, existingCredentials *aws.Credentials, roleARN string, updateExternalID func(string)) aws.CredentialsProvider {
+	return aws.NewCredentialsCache(createEvergreenCredentials(comm, taskData, existingCredentials, roleARN, updateExternalID))
+}
+
 func (p *evergreenCredentialProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
 	if p.existingCredentials != nil && p.existingCredentials.HasKeys() && !p.existingCredentials.Expired() {
 		return *p.existingCredentials, nil

--- a/agent/command/s3_evergreen_credentials_test.go
+++ b/agent/command/s3_evergreen_credentials_test.go
@@ -20,6 +20,23 @@ func TestEvergreenCredentials(t *testing.T) {
 		assert.Implements(t, (*aws.CredentialsProvider)(nil), provider)
 	})
 
+	t.Run("CachedProviderReusesCredentialsAcrossRetrieves", func(t *testing.T) {
+		comm.AssumeRoleCount = 0
+		comm.AssumeRoleResponse = &apimodels.AWSCredentials{
+			AccessKeyID:     "assume_access_key",
+			SecretAccessKey: "secret_access_key",
+			SessionToken:    "session_token",
+			Expiration:      time.Now().Add(time.Hour).Format(time.RFC3339),
+		}
+
+		provider := newCachedEvergreenCredentials(comm, taskData, nil, "role_arn", nil)
+		for range 5 {
+			_, err := provider.Retrieve(t.Context())
+			require.NoError(t, err)
+		}
+		assert.Equal(t, 1, comm.AssumeRoleCount)
+	})
+
 	t.Run("RoleARN", func(t *testing.T) {
 		t.Run("TimeFormat", func(t *testing.T) {
 			t.Run("Valid", func(t *testing.T) {

--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -388,7 +388,7 @@ func (c *s3get) createPailBucket(ctx context.Context, comm client.Communicator, 
 	}
 
 	if c.getRoleARN() != "" {
-		opts.Credentials = createEvergreenCredentials(comm, c.taskData, c.existingCredentials, c.getRoleARN(), nil)
+		opts.Credentials = newCachedEvergreenCredentials(comm, c.taskData, c.existingCredentials, c.getRoleARN(), nil)
 	} else if c.AwsKey != "" {
 		opts.Credentials = pail.CreateAWSStaticCredentials(c.AwsKey, c.AwsSecret, c.AwsSessionToken)
 	}

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -692,7 +692,7 @@ func (s3pc *s3put) createPailBucket(ctx context.Context, comm client.Communicato
 	opts := s3pc.s3PutOptions()
 
 	if s3pc.getRoleARN() != "" {
-		opts.Credentials = createEvergreenCredentials(comm, s3pc.taskData, s3pc.existingCredentials, s3pc.getRoleARN(), func(s string) {
+		opts.Credentials = newCachedEvergreenCredentials(comm, s3pc.taskData, s3pc.existingCredentials, s3pc.getRoleARN(), func(s string) {
 			s3pc.externalID = s
 		})
 	} else if s3pc.AwsKey != "" {

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -71,6 +71,7 @@ type Mock struct {
 	CreateGitHubDynamicAccessTokenFail   bool
 	RevokeGitHubDynamicAccessTokenFail   bool
 	AssumeRoleResponse                   *apimodels.AWSCredentials
+	AssumeRoleCount                      int
 	S3Response                           *apimodels.AWSCredentials
 	SendTaskDetailsShouldFail            bool
 
@@ -643,6 +644,7 @@ func (c *Mock) SelectTests(ctx context.Context, taskData TaskData, request restm
 }
 
 func (c *Mock) AssumeRole(ctx context.Context, td TaskData, request apimodels.AssumeRoleRequest) (*apimodels.AWSCredentials, error) {
+	c.AssumeRoleCount++
 	return c.AssumeRoleResponse, nil
 }
 

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-07-15a"
+	AgentVersion = "2026-07-21"
 )
 
 const (


### PR DESCRIPTION
 DEVPROD-33407

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

S3 commands using a role_arn passed the agent's credential provider to the AWS SDK without a cache, so the SDK re-etched credentials on every request signing, each one a round trip to STS AssumeRole. A single task could therefore generate thousands of STS calls, contributing to throttling and the sporadic  DB auth failures tracked here. This wraps the provider in aws.NewCredentialsCache via a new newCachedEvergreenCredentials helper at all S3 call sites, so credentials are reused until they expire instead of assumed per request.

### Testing

Added a test that makes sure  the cached provider only calls `AssumeRole` once across repeated `Retrieve()` calls.

