### PR TITLE
DEVPROD-37368 Remove yaml.v2 fallback from YAML unmarshalling

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-07-13"
+	ClientVersion = "2026-07-21"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/model/generate.go
+++ b/model/generate.go
@@ -120,7 +120,7 @@ func MergeGeneratedProjects(ctx context.Context, projects []GeneratedProject) (*
 func ParseProjectFromJSONString(data string) (GeneratedProject, error) {
 	g := GeneratedProject{}
 	dataAsJSON := []byte(data)
-	if err := util.UnmarshalYAMLWithFallback(dataAsJSON, &g); err != nil {
+	if err := util.UnmarshalYAML(dataAsJSON, &g); err != nil {
 		return g, errors.Wrap(err, "unmarshalling generated project from YAML data")
 	}
 	return g, nil

--- a/model/generate_test.go
+++ b/model/generate_test.go
@@ -669,7 +669,7 @@ func (s *GenerateSuite) TestSaveWithMaxTasksPerVersion() {
 		BuildIds: []string{"sample_build"},
 	}
 	pp := &ParserProject{}
-	err := util.UnmarshalYAMLWithFallback([]byte(sampleProjYmlTaskGroups), &pp)
+	err := util.UnmarshalYAML([]byte(sampleProjYmlTaskGroups), &pp)
 	s.NoError(err)
 	pp.Id = "version_that_called_generate_task"
 	s.NoError(pp.Insert(s.ctx))
@@ -997,7 +997,7 @@ func (s *GenerateSuite) TestSaveNewBuildsAndTasksWithBatchtime() {
 	}
 	s.NoError(v.Insert(s.ctx))
 	pp := &ParserProject{}
-	err := util.UnmarshalYAMLWithFallback([]byte(sampleProjYml), &pp)
+	err := util.UnmarshalYAML([]byte(sampleProjYml), &pp)
 	s.NoError(err)
 	pp.Id = "version_that_called_generate_task"
 	s.NoError(pp.Insert(s.ctx))
@@ -1112,7 +1112,7 @@ func (s *GenerateSuite) TestSaveWithAlreadyGeneratedTasksAndVariants() {
 	}
 	s.NoError(v.Insert(s.ctx))
 	pp := &ParserProject{}
-	err := util.UnmarshalYAMLWithFallback([]byte(sampleProjYmlTaskGroups), &pp)
+	err := util.UnmarshalYAML([]byte(sampleProjYmlTaskGroups), &pp)
 	s.NoError(err)
 	pp.Id = "version_that_called_generate_task"
 	s.NoError(pp.Insert(s.ctx))
@@ -1202,7 +1202,7 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependencies() {
 		BuildIds: []string{"sample_build"},
 	}
 	pp := &ParserProject{}
-	err := util.UnmarshalYAMLWithFallback([]byte(sampleProjYmlTaskGroups), &pp)
+	err := util.UnmarshalYAML([]byte(sampleProjYmlTaskGroups), &pp)
 	s.NoError(err)
 	pp.Id = "version_that_called_generate_task"
 	s.NoError(pp.Insert(s.ctx))
@@ -1274,7 +1274,7 @@ func (s *GenerateSuite) TestSaveNewTasksWithDependenciesInNewBuilds() {
 		BuildVariants: []VersionBuildStatus{},
 	}
 	pp := &ParserProject{}
-	err := util.UnmarshalYAMLWithFallback([]byte(projYmlTwoBVs), &pp)
+	err := util.UnmarshalYAML([]byte(projYmlTwoBVs), &pp)
 	s.NoError(err)
 	pp.Id = "version_that_called_generate_task"
 	s.NoError(pp.Insert(s.ctx))
@@ -1357,7 +1357,7 @@ buildvariants:
   tasks:
   - name: finished_task
 `
-	s.NoError(util.UnmarshalYAMLWithFallback([]byte(initialConfig), &parserProj))
+	s.NoError(util.UnmarshalYAML([]byte(initialConfig), &parserProj))
 	parserProj.Id = "v1"
 	s.NoError(parserProj.Insert(s.ctx))
 
@@ -1441,7 +1441,7 @@ buildvariants:
   tasks:
   - name: generator
 `
-	s.NoError(util.UnmarshalYAMLWithFallback([]byte(initialConfig), &parserProj))
+	s.NoError(util.UnmarshalYAML([]byte(initialConfig), &parserProj))
 	parserProj.Id = "v1"
 	s.NoError(parserProj.Insert(s.ctx))
 
@@ -1523,7 +1523,7 @@ buildvariants:
   tasks:
   - name: generator
 `
-	s.NoError(util.UnmarshalYAMLWithFallback([]byte(initialConfig), &parserProj))
+	s.NoError(util.UnmarshalYAML([]byte(initialConfig), &parserProj))
 	parserProj.Id = "v1"
 	s.NoError(parserProj.Insert(s.ctx))
 
@@ -1632,7 +1632,7 @@ buildvariants:
   - name: existing_task
 
 `
-	s.NoError(util.UnmarshalYAMLWithFallback([]byte(initialConfig), &parserProj))
+	s.NoError(util.UnmarshalYAML([]byte(initialConfig), &parserProj))
 	parserProj.Id = "v1"
 	s.NoError(parserProj.Insert(s.ctx))
 
@@ -1739,7 +1739,7 @@ buildvariants:
   tasks:
   - name: existing_task
 `
-	s.NoError(util.UnmarshalYAMLWithFallback([]byte(initialConfig), &parserProj))
+	s.NoError(util.UnmarshalYAML([]byte(initialConfig), &parserProj))
 	parserProj.Id = "v1"
 	s.NoError(parserProj.Insert(s.ctx))
 
@@ -1814,7 +1814,7 @@ func (s *GenerateSuite) TestSaveNewTaskWithExistingExecutionTask() {
 		BuildIds: []string{"sample_build"},
 	}
 	pp := &ParserProject{}
-	err := util.UnmarshalYAMLWithFallback([]byte(smallYml), &pp)
+	err := util.UnmarshalYAML([]byte(smallYml), &pp)
 	s.NoError(err)
 	pp.Id = "version_that_called_generate_task"
 	s.NoError(pp.Insert(s.ctx))
@@ -2537,7 +2537,7 @@ buildvariants:
   - name: generator_task
   - name: prerequisite_task
 `
-	require.NoError(t, util.UnmarshalYAMLWithFallback([]byte(initialConfig), &parserProj))
+	require.NoError(t, util.UnmarshalYAML([]byte(initialConfig), &parserProj))
 	parserProj.Id = "v1"
 	require.NoError(t, parserProj.Insert(t.Context()))
 
@@ -2639,7 +2639,7 @@ buildvariants:
 }
 `
 	pp := &ParserProject{}
-	require.NoError(t, util.UnmarshalYAMLWithFallback([]byte(baseYAML), &pp))
+	require.NoError(t, util.UnmarshalYAML([]byte(baseYAML), &pp))
 	p0, err := TranslateProject(t.Context(), pp)
 	require.NoError(t, err)
 
@@ -2718,7 +2718,7 @@ buildvariants:
   - name: generator_task
   - name: prerequisite_task
 `
-	require.NoError(t, util.UnmarshalYAMLWithFallback([]byte(initialConfig), &parserProj))
+	require.NoError(t, util.UnmarshalYAML([]byte(initialConfig), &parserProj))
 	parserProj.Id = "v1"
 	require.NoError(t, parserProj.Insert(t.Context()))
 

--- a/model/project_config.go
+++ b/model/project_config.go
@@ -88,7 +88,7 @@ func (pc *ProjectConfig) AllAliases() ProjectAliases {
 // intermediate configs representation.
 func CreateProjectConfig(yml []byte, identifier string) (*ProjectConfig, error) {
 	p := &ProjectConfig{}
-	if err := util.UnmarshalYAMLWithFallback(yml, p); err != nil {
+	if err := util.UnmarshalYAML(yml, p); err != nil {
 		yamlErr := thirdparty.YAMLFormatError{Message: err.Error()}
 		return nil, errors.Wrap(yamlErr, TranslateProjectConfigError)
 	}

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1589,12 +1589,12 @@ func createIntermediateProject(parseBytes []byte, unmarshalStrict bool, anchorRe
 				// to a non-existent variables field.
 				Variables any `yaml:"variables,omitempty" bson:"-"`
 			}{}
-			if err := util.UnmarshalYAMLStrictWithFallback(parseBytes, &strictProjectWithVariables); err != nil {
+			if err := util.UnmarshalYAMLStrict(parseBytes, &strictProjectWithVariables); err != nil {
 				return nil, errors.Wrap(err, "unmarshalling parser project from YAML")
 			}
 			p = strictProjectWithVariables.ParserProject
 		} else {
-			if err := util.UnmarshalYAMLWithFallback(parseBytes, &p); err != nil {
+			if err := util.UnmarshalYAML(parseBytes, &p); err != nil {
 				return nil, errors.Wrap(err, "unmarshalling parser project from YAML")
 			}
 		}
@@ -1651,7 +1651,7 @@ func decodeWithAnchors(parseBytes []byte, unmarshalStrict bool, anchorRegistry *
 			// EvgAnchors silences the "unknown field" error in strict mode when the anchor preamble is prepended.
 			EvgAnchors any `yaml:"_evg_anchors,omitempty"`
 		}{}
-		if err := util.UnmarshalYAMLStrictWithFallback(parseBytes, &strictProjectWithVariables); err != nil {
+		if err := util.UnmarshalYAMLStrict(parseBytes, &strictProjectWithVariables); err != nil {
 			return nil, errors.Wrap(err, "unmarshalling parser project from YAML")
 		}
 		p = strictProjectWithVariables.ParserProject

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -1333,9 +1333,9 @@ buildvariants:
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already defined")
 
-	// unless not using strict
+	// yaml.v3 rejects duplicate keys even when not using strict mode.
 	_, err = LoadProjectInto(ctx, []byte(yamlWithDup), nil, "example_project", &proj)
-	assert.NoError(t, err)
+	assert.Error(t, err)
 }
 
 func TestTranslateProjectDoesNotModifyParserProject(t *testing.T) {
@@ -1421,7 +1421,6 @@ task_groups:
   setup_task_timeout_secs: 10
   teardown_task_can_fail_task: true
   teardown_task_timeout_secs: 10
-  teardown_task_can_fail_task: true
   teardown_group_timeout_secs: 10
   setup_group:
   - command: shell.exec

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -100,7 +100,7 @@ func TestFindProject(t *testing.T) {
 				RevisionOrderNumber: 8,
 			}
 			pp := &ParserProject{}
-			err := util.UnmarshalYAMLWithFallback([]byte("owner: fakeowner\nrepo: fakerepo\nbranch: fakebranch"), &pp)
+			err := util.UnmarshalYAML([]byte("owner: fakeowner\nrepo: fakerepo\nbranch: fakebranch"), &pp)
 			So(err, ShouldBeNil)
 			pp.Id = "good_version"
 			So(badVersion.Insert(t.Context()), ShouldBeNil)
@@ -125,7 +125,7 @@ func TestFindProject(t *testing.T) {
 				RevisionOrderNumber: 8,
 			}
 			pp := &ParserProject{}
-			err := util.UnmarshalYAMLWithFallback([]byte("owner: fakeowner\nrepo: fakerepo\nbranch: fakebranch"), &pp)
+			err := util.UnmarshalYAML([]byte("owner: fakeowner\nrepo: fakerepo\nbranch: fakebranch"), &pp)
 			So(err, ShouldBeNil)
 			pp.Id = "good_version"
 			So(goodVersion.Insert(t.Context()), ShouldBeNil)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2121,7 +2121,7 @@ func TestMarkEndWithTaskGroup(t *testing.T) {
 				Status: evergreen.VersionStarted,
 			}
 			pp := &ParserProject{}
-			err := util.UnmarshalYAMLWithFallback([]byte(sampleProjYmlTaskGroups), &pp)
+			err := util.UnmarshalYAML([]byte(sampleProjYmlTaskGroups), &pp)
 			assert.NoError(err)
 			pp.Id = b.Version
 			assert.NoError(pp.Insert(t.Context()))
@@ -2322,7 +2322,7 @@ func TestMarkEndIsAutomaticRestart(t *testing.T) {
 				Status: evergreen.VersionStarted,
 			}
 			pp := &ParserProject{}
-			err := util.UnmarshalYAMLWithFallback([]byte(sampleProjYmlTaskGroups), &pp)
+			err := util.UnmarshalYAML([]byte(sampleProjYmlTaskGroups), &pp)
 			assert.NoError(err)
 			pp.Id = b.Version
 			assert.NoError(pp.Insert(t.Context()))
@@ -3015,7 +3015,7 @@ buildvariants:
        stepback: true
 `
 		pp := &ParserProject{}
-		err := util.UnmarshalYAMLWithFallback([]byte(config), &pp)
+		err := util.UnmarshalYAML([]byte(config), &pp)
 		assert.NoError(t, err)
 		pp.Id = "version_id"
 		assert.NoError(t, pp.Insert(t.Context()))
@@ -5355,7 +5355,7 @@ buildvariants:
    deactivate_previous: false
 `
 	pp := &ParserProject{}
-	err := util.UnmarshalYAMLWithFallback([]byte(config), &pp)
+	err := util.UnmarshalYAML([]byte(config), &pp)
 	assert.NoError(t, err)
 
 	project, err := TranslateProject(t.Context(), pp)
@@ -5891,7 +5891,7 @@ tasks:
 	}
 	require.NoError(t, v.Insert(t.Context()))
 	pp := &ParserProject{}
-	err := util.UnmarshalYAMLWithFallback([]byte(yml), &pp)
+	err := util.UnmarshalYAML([]byte(yml), &pp)
 	assert.NoError(err)
 	//pp.Id = v.Id
 	//assert.NoError(pp.Insert(t.Context()))

--- a/model/testutil/api.go
+++ b/model/testutil/api.go
@@ -102,7 +102,7 @@ func SetupAPITestData(testConfig *evergreen.Settings, taskDisplayName string, va
 	}
 
 	versionParserProject := &model.ParserProject{}
-	if err = util.UnmarshalYAMLWithFallback(projectConfig, &versionParserProject); err != nil {
+	if err = util.UnmarshalYAML(projectConfig, &versionParserProject); err != nil {
 		return nil, errors.Wrap(err, "unmarshalling parser project from YAML")
 	}
 	versionParserProject.Id = "sample_version"

--- a/operations/cli_integration_test.go
+++ b/operations/cli_integration_test.go
@@ -106,7 +106,7 @@ func setupCLITestHarness(ctx context.Context) cliTestHarness {
 	So(version.Insert(ctx), ShouldBeNil)
 
 	pp := model.ParserProject{}
-	err = util.UnmarshalYAMLWithFallback(localConfBytes, &pp)
+	err = util.UnmarshalYAML(localConfBytes, &pp)
 	So(err, ShouldBeNil)
 	pp.Id = "sample_version"
 	So(pp.Insert(ctx), ShouldBeNil)

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -608,7 +608,7 @@ func getLocalModuleIncludes(ctx context.Context, params *patchParams, conf *Clie
 		return nil, errors.Wrapf(err, "reading local project config '%s'", remotePath)
 	}
 	p := model.ParserProject{}
-	if err := util.UnmarshalYAMLWithFallback(yml, &p); err != nil {
+	if err := util.UnmarshalYAML(yml, &p); err != nil {
 		yamlErr := thirdparty.YAMLFormatError{Message: err.Error()}
 		return nil, errors.Wrap(yamlErr, "unmarshalling parser project from local project config")
 	}

--- a/rest/data/host_create_test.go
+++ b/rest/data/host_create_test.go
@@ -182,7 +182,7 @@ buildvariants:
 		}
 		assert.NoError(t, h1.Insert(ctx))
 		pp := &model.ParserProject{}
-		err := util.UnmarshalYAMLWithFallback([]byte(versionYaml), &pp)
+		err := util.UnmarshalYAML([]byte(versionYaml), &pp)
 		assert.NoError(t, err)
 		pp.Id = "v1"
 		assert.NoError(t, pp.Insert(t.Context()))
@@ -250,7 +250,7 @@ buildvariants:
 		}
 		assert.NoError(t, h2.Insert(ctx))
 		pp := &model.ParserProject{}
-		err := util.UnmarshalYAMLWithFallback([]byte(versionYaml), &pp)
+		err := util.UnmarshalYAML([]byte(versionYaml), &pp)
 		assert.NoError(t, err)
 		pp.Id = "v2"
 		assert.NoError(t, pp.Insert(t.Context()))
@@ -319,7 +319,7 @@ buildvariants:
 		}
 		assert.NoError(t, h3.Insert(ctx))
 		pp := &model.ParserProject{}
-		err := util.UnmarshalYAMLWithFallback([]byte(versionYaml), &pp)
+		err := util.UnmarshalYAML([]byte(versionYaml), &pp)
 		assert.NoError(t, err)
 		pp.Id = "v3"
 		assert.NoError(t, pp.Insert(t.Context()))
@@ -385,7 +385,7 @@ buildvariants:
 		assert.NoError(t, h4.Insert(ctx))
 
 		pp := &model.ParserProject{}
-		err := util.UnmarshalYAMLWithFallback([]byte(versionYaml), &pp)
+		err := util.UnmarshalYAML([]byte(versionYaml), &pp)
 		assert.NoError(t, err)
 		pp.Id = "v4"
 		assert.NoError(t, pp.Insert(t.Context()))

--- a/rest/route/patch_test.go
+++ b/rest/route/patch_test.go
@@ -982,7 +982,7 @@ buildvariants:
 	require.NoError(t, unfinalized.Insert(t.Context()))
 
 	pp := &serviceModel.ParserProject{}
-	require.NoError(t, util.UnmarshalYAMLWithFallback([]byte(config), pp))
+	require.NoError(t, util.UnmarshalYAML([]byte(config), pp))
 	pp.Id = unfinalized.Id.Hex()
 	require.NoError(t, pp.Insert(t.Context()))
 
@@ -1085,7 +1085,7 @@ buildvariants:
 	}
 	assert.NoError(t, patch2.Insert(t.Context()))
 
-	err = util.UnmarshalYAMLWithFallback([]byte(config), &pp)
+	err = util.UnmarshalYAML([]byte(config), &pp)
 	require.NoError(t, err)
 	pp.Id = patch2.Id.Hex()
 	require.NoError(t, pp.Insert(t.Context()))
@@ -1119,7 +1119,7 @@ buildvariants:
 	}
 	assert.NoError(t, patch3.Insert(t.Context()))
 
-	err = util.UnmarshalYAMLWithFallback([]byte(config), &pp)
+	err = util.UnmarshalYAML([]byte(config), &pp)
 	require.NoError(t, err)
 	pp.Id = patch3.Id.Hex()
 	require.NoError(t, pp.Insert(t.Context()))
@@ -1400,7 +1400,7 @@ tasks:
 	require.NoError(t, unfinalized.Insert(t.Context()))
 
 	pp := &serviceModel.ParserProject{}
-	require.NoError(t, util.UnmarshalYAMLWithFallback([]byte(config), pp))
+	require.NoError(t, util.UnmarshalYAML([]byte(config), pp))
 	pp.Id = unfinalized.Id.Hex()
 	require.NoError(t, pp.Insert(t.Context()))
 

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -527,7 +527,7 @@ func TestGenerateTasksWithDifferentGeneratedJSONStorageMethods(t *testing.T) {
 			require.NoError(sampleBuild.Insert(t.Context()))
 
 			pp := model.ParserProject{}
-			err := util.UnmarshalYAMLWithFallback([]byte(sampleBaseProject), &pp)
+			err := util.UnmarshalYAML([]byte(sampleBaseProject), &pp)
 			require.NoError(err)
 			pp.Id = "sample_version"
 			require.NoError(pp.Insert(t.Context()))
@@ -665,7 +665,7 @@ func TestGeneratedTasksAreNotDependencies(t *testing.T) {
 	require.NoError(b3.Insert(t.Context()))
 
 	pp := model.ParserProject{}
-	err := util.UnmarshalYAMLWithFallback([]byte(omitGeneratedTasksConfig), &pp)
+	err := util.UnmarshalYAML([]byte(omitGeneratedTasksConfig), &pp)
 	require.NoError(err)
 	pp.Id = "sample_version"
 	require.NoError(pp.Insert(t.Context()))
@@ -709,7 +709,7 @@ func TestGeneratedTasksAreNotDependencies(t *testing.T) {
 
 	// check that the generated tasks are included as dependencies by default
 	pp = model.ParserProject{}
-	err = util.UnmarshalYAMLWithFallback([]byte(dependOnGeneratedTasksConfig), &pp)
+	err = util.UnmarshalYAML([]byte(dependOnGeneratedTasksConfig), &pp)
 	require.NoError(err)
 	pp.Id = "sample_version"
 	require.NoError(pp.Insert(t.Context()))
@@ -747,7 +747,7 @@ func TestGeneratedTasksAreNotDependencies(t *testing.T) {
 
 	// check that the generated tasks are included as dependencies by default
 	pp = model.ParserProject{}
-	err = util.UnmarshalYAMLWithFallback([]byte(shouldGenerateNewBVConfig), &pp)
+	err = util.UnmarshalYAML([]byte(shouldGenerateNewBVConfig), &pp)
 	require.NoError(err)
 	pp.Id = "sample_version"
 	require.NoError(pp.Insert(t.Context()))
@@ -892,7 +892,7 @@ buildvariants:
 		},
 	}
 	sampleParserProject := model.ParserProject{}
-	err := util.UnmarshalYAMLWithFallback([]byte(sampleBaseProject), &sampleParserProject)
+	err := util.UnmarshalYAML([]byte(sampleBaseProject), &sampleParserProject)
 	require.NoError(err)
 	sampleParserProject.Id = "sample_version"
 	require.NoError(sampleParserProject.Insert(t.Context()))

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -1628,7 +1628,7 @@ func (s *PatchIntentUnitsSuite) TestProcessTriggerAliases() {
 	s.Require().NoError(latestVersion.Insert(s.ctx))
 
 	latestVersionParserProject := &model.ParserProject{}
-	s.Require().NoError(util.UnmarshalYAMLWithFallback([]byte(`
+	s.Require().NoError(util.UnmarshalYAML([]byte(`
 buildvariants:
 - name: my-build-variant
   display_name: my-build-variant
@@ -1716,7 +1716,7 @@ func (s *PatchIntentUnitsSuite) TestTriggerAliasWithDownstreamRevision() {
 	s.Require().NoError(specificRevision.Insert(s.ctx))
 
 	specificVersionParserProject := &model.ParserProject{}
-	s.Require().NoError(util.UnmarshalYAMLWithFallback([]byte(`
+	s.Require().NoError(util.UnmarshalYAML([]byte(`
 buildvariants:
 - name: my-build-variant
   display_name: my-build-variant
@@ -1782,7 +1782,7 @@ func (s *PatchIntentUnitsSuite) TestBuildTriggerPatchDocGithubPRParentModule() {
 	s.Require().NoError(latestVersion.Insert(s.ctx))
 
 	latestVersionParserProject := &model.ParserProject{}
-	s.Require().NoError(util.UnmarshalYAMLWithFallback([]byte(`
+	s.Require().NoError(util.UnmarshalYAML([]byte(`
 buildvariants:
 - name: my-build-variant
   display_name: my-build-variant
@@ -1858,7 +1858,7 @@ func (s *PatchIntentUnitsSuite) TestBuildTriggerPatchDocGithubPRParentSameBranch
 	s.Require().NoError(latestVersion.Insert(s.ctx))
 
 	latestVersionParserProject := &model.ParserProject{}
-	s.Require().NoError(util.UnmarshalYAMLWithFallback([]byte(`
+	s.Require().NoError(util.UnmarshalYAML([]byte(`
 buildvariants:
 - name: my-build-variant
   display_name: my-build-variant
@@ -1964,7 +1964,7 @@ func (s *PatchIntentUnitsSuite) TestProcessTriggerAliasesWithAliasThatDoesNotMat
 	s.Require().NoError(latestVersion.Insert(s.ctx))
 
 	latestVersionParserProject := &model.ParserProject{}
-	s.Require().NoError(util.UnmarshalYAMLWithFallback([]byte(`
+	s.Require().NoError(util.UnmarshalYAML([]byte(`
 buildvariants:
 - name: my-build-variant
   display_name: my-build-variant
@@ -2037,7 +2037,7 @@ func (s *PatchIntentUnitsSuite) TestProcessTriggerAliasesWithInadequatePermissio
 	s.Require().NoError(latestVersion.Insert(s.ctx))
 
 	latestVersionParserProject := &model.ParserProject{}
-	s.Require().NoError(util.UnmarshalYAMLWithFallback([]byte(`
+	s.Require().NoError(util.UnmarshalYAML([]byte(`
 buildvariants:
 - name: my-build-variant
   display_name: my-build-variant

--- a/units/task_monitor_execution_timeout_test.go
+++ b/units/task_monitor_execution_timeout_test.go
@@ -113,7 +113,7 @@ func TestTaskExecutionTimeoutJob(t *testing.T) {
 			yml, err := yaml.Marshal(p)
 			require.NoError(t, err)
 			pp := &model.ParserProject{}
-			err = util.UnmarshalYAMLWithFallback(yml, &pp)
+			err = util.UnmarshalYAML(yml, &pp)
 			require.NoError(t, err)
 			pp.Id = v.Id
 			require.NoError(t, pp.Insert(t.Context()))

--- a/util/yaml.go
+++ b/util/yaml.go
@@ -4,36 +4,22 @@ import (
 	"bytes"
 
 	"github.com/pkg/errors"
-	yaml2 "gopkg.in/yaml.v2"
 	"gopkg.in/yaml.v3"
 )
 
 const UnmarshalStrictError = "error unmarshalling yaml strict"
 
-// UnmarshalYAMLWithFallback attempts to use yaml v3 to unmarshal, but on failure attempts yaml v2. If this
-// succeeds then we can assume in is outdated yaml and requires v2, otherwise we only return the error relevant to the
-// current yaml version. This should only be used for cases where we expect v3 to fail for legacy cases.
-func UnmarshalYAMLWithFallback(in []byte, out any) error {
-	err := yaml.Unmarshal(in, out)
-	if err != nil {
-		// try the older version of yaml before erroring, in case it's just an outdated yaml
-		if err2 := yaml2.Unmarshal(in, out); err2 != nil {
-			return err
-		}
-	}
-	return nil
+// UnmarshalYAML unmarshals the input YAML using yaml.v3.
+func UnmarshalYAML(in []byte, out any) error {
+	return yaml.Unmarshal(in, out)
 }
 
-// UnmarshalYAMLStrictWithFallback attempts to use yaml v3 to unmarshal strict, but on failure attempts yaml v2. If this
-// succeeds then we can assume in is outdated yaml and requires v2, otherwise we only return the error relevant to the
-// current yaml version. This should only be used for cases where we expect v3 to fail for legacy cases.
-func UnmarshalYAMLStrictWithFallback(in []byte, out any) error {
+// UnmarshalYAMLStrict unmarshals the input YAML using yaml.v3 in strict mode, erroring on unknown fields.
+func UnmarshalYAMLStrict(in []byte, out any) error {
 	d := yaml.NewDecoder(bytes.NewReader(in))
 	d.KnownFields(true)
 	if err := d.Decode(out); err != nil {
-		if err2 := yaml2.UnmarshalStrict(in, out); err2 != nil {
-			return errors.Wrap(err, UnmarshalStrictError)
-		}
+		return errors.Wrap(err, UnmarshalStrictError)
 	}
 	return nil
 }

--- a/util/yaml_test.go
+++ b/util/yaml_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnmarshalYAMLStrictWithFallback(t *testing.T) {
+func TestUnmarshalYAMLStrict(t *testing.T) {
 	smallYml := `
 top_level:
     field: first
@@ -24,7 +24,7 @@ top_level:
 	}
 	// duplicate map items should error
 	var myStruct SmallStruct
-	err := UnmarshalYAMLStrictWithFallback([]byte(smallYml), &myStruct)
+	err := UnmarshalYAMLStrict([]byte(smallYml), &myStruct)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already defined")
 
@@ -35,7 +35,7 @@ top_level:
 top_level:
     field: ohno
 `
-	err = UnmarshalYAMLStrictWithFallback([]byte(smallYml), &myStruct)
+	err = UnmarshalYAMLStrict([]byte(smallYml), &myStruct)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already defined")
 
@@ -46,7 +46,7 @@ some_list:
 some_list:
   - my other item
 `
-	err = UnmarshalYAMLStrictWithFallback([]byte(smallYml), &myStruct)
+	err = UnmarshalYAMLStrict([]byte(smallYml), &myStruct)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already defined")
 
@@ -62,7 +62,7 @@ pieces:
   tiny_pieces:
   - something: blue
 `
-	err = UnmarshalYAMLStrictWithFallback([]byte(smallYml), &largeStruct)
+	err = UnmarshalYAMLStrict([]byte(smallYml), &largeStruct)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "already defined")
 


### PR DESCRIPTION
DEVPROD-37368

### Description

This strips the yaml.v2 fallback from `util.UnmarshalYAMLWithFallback` and `util.UnmarshalYAMLStrictWithFallback` so YAML unmarshalling uses only yaml.v3. Since the functions no longer fall back, they're renamed to `util.UnmarshalYAML` and `util.UnmarshalYAMLStrict`, and all callers are updated.
