### PR TITLE
DEVPROD-36684 Verify valid patchfile ID in /patchfile route

### DIFF
--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -1325,14 +1326,9 @@ func (h *gitServePatchFileHandler) Run(ctx context.Context) gimlet.Responder {
 		})
 	}
 
-	patchFileOwned := false
-	for _, mp := range p.Patches {
-		if mp.PatchSet.PatchFileId == h.patchID {
-			patchFileOwned = true
-			break
-		}
-	}
-	if !patchFileOwned {
+	if !slices.ContainsFunc(p.Patches, func(mp patch.ModulePatch) bool {
+		return mp.PatchSet.PatchFileId == h.patchID
+	}) {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
 			Message:    fmt.Sprintf("patch file '%s' not found", h.patchID),

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1299,6 +1299,46 @@ func (h *gitServePatchFileHandler) Parse(ctx context.Context, r *http.Request) e
 }
 
 func (h *gitServePatchFileHandler) Run(ctx context.Context) gimlet.Responder {
+	t := GetTask(ctx)
+	if t == nil {
+		var err error
+		t, err = task.FindOneId(ctx, h.taskID)
+		if err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding task '%s'", h.taskID))
+		}
+		if t == nil {
+			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+				StatusCode: http.StatusNotFound,
+				Message:    fmt.Sprintf("task '%s' not found", h.taskID),
+			})
+		}
+	}
+
+	p, err := patch.FindOne(ctx, patch.ByVersion(t.Version))
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding patch for version '%s'", t.Version))
+	}
+	if p == nil {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("patch for version '%s' not found", t.Version),
+		})
+	}
+
+	patchFileOwned := false
+	for _, mp := range p.Patches {
+		if mp.PatchSet.PatchFileId == h.patchID {
+			patchFileOwned = true
+			break
+		}
+	}
+	if !patchFileOwned {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    fmt.Sprintf("patch file '%s' not found", h.patchID),
+		})
+	}
+
 	patchContents, err := patch.FetchPatchContents(ctx, h.patchID)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "reading patch file from db"))

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -1645,5 +1646,57 @@ func TestLogLookupClosureUsesAdminBucketsConfig(t *testing.T) {
 	t.Run("UnknownBucketReturnsFalse", func(t *testing.T) {
 		_, ok := logLookup(t.Context(), "artifact-bucket", "")
 		assert.False(t, ok)
+	})
+}
+
+func TestGitServePatchFile(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+	testutil.ConfigureIntegrationTest(t, env.Settings())
+
+	require.NoError(t, db.ClearCollections(task.Collection, patch.Collection))
+
+	const patchFileID = "patchfile123"
+	const otherPatchFileID = "patchfile456"
+	const taskID = "task1"
+	const versionID = "aaaaaaaaaaff001122334455"
+
+	tsk := task.Task{
+		Id:      taskID,
+		Version: versionID,
+	}
+	require.NoError(t, tsk.Insert(ctx))
+
+	p := patch.Patch{
+		Id:      mgobson.NewObjectId(),
+		Version: versionID,
+		Patches: []patch.ModulePatch{
+			{
+				ModuleName: "",
+				PatchSet: patch.PatchSet{
+					PatchFileId: patchFileID,
+				},
+			},
+		},
+	}
+	require.NoError(t, p.Insert(ctx))
+
+	require.NoError(t, db.WriteGridFile(ctx, patch.GridFSPrefix, patchFileID, strings.NewReader("diff --git a/file")))
+
+	t.Run("ValidPatchFileIDReturnsContents", func(t *testing.T) {
+		h := &gitServePatchFileHandler{taskID: taskID, patchID: patchFileID}
+		resp := h.Run(ctx)
+		require.NotNil(t, resp)
+		assert.Equal(t, http.StatusOK, resp.Status())
+	})
+
+	t.Run("PatchFileIDBelongingToOtherPatchReturnsNotFound", func(t *testing.T) {
+		h := &gitServePatchFileHandler{taskID: taskID, patchID: otherPatchFileID}
+		resp := h.Run(ctx)
+		require.NotNil(t, resp)
+		assert.Equal(t, http.StatusNotFound, resp.Status())
 	})
 }


### PR DESCRIPTION
DEVPROD-36684

### Description

The patchfile endpoint was serving any GridFS file by ID without checking that the file actually belongs to the task in the URL, so a caller could read another project's patch diffs by swapping in a different patchfile ID. 

### Fix
Load the task's patch and confirm the requested patchfile ID is one of its own before serving it.

### Testing

<!--add a description of how you tested it-->