### PR TITLE
DEVPROD-36660 Add authorization to alias route

### DIFF
--- a/rest/route/alias.go
+++ b/rest/route/alias.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/pkg/errors"
 )
 
 type aliasGetHandler struct {
-	projectID            string
 	includeProjectConfig bool
 }
 
@@ -34,22 +32,21 @@ func (a *aliasGetHandler) Factory() gimlet.RouteHandler {
 }
 
 func (a *aliasGetHandler) Parse(ctx context.Context, r *http.Request) error {
-	a.projectID = gimlet.GetVars(r)["project_id"]
 	a.includeProjectConfig = r.URL.Query().Get("includeProjectConfig") == "true"
 	return nil
 }
 
 func (a *aliasGetHandler) Run(ctx context.Context) gimlet.Responder {
-	pRef, err := model.FindBranchProjectRefSecondary(ctx, a.projectID)
-	if err != nil {
-		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "finding project '%s'", a.projectID))
+	projCtx := MustHaveProjectContext(ctx)
+	if projCtx.ProjectRef == nil {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusNotFound,
+			Message:    "project not found",
+		})
 	}
-	if pRef == nil {
-		return gimlet.MakeJSONErrorResponder(errors.Errorf("project '%s' not found", a.projectID))
-	}
-	aliasModels, err := data.FindMergedProjectAliases(ctx, pRef.Id, pRef.RepoRefId, nil, a.includeProjectConfig)
+	aliasModels, err := data.FindMergedProjectAliases(ctx, projCtx.ProjectRef.Id, projCtx.ProjectRef.RepoRefId, nil, a.includeProjectConfig)
 	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding project aliases for project '%s'", pRef.Id))
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding project aliases for project '%s'", projCtx.ProjectRef.Id))
 	}
 
 	resp := gimlet.NewResponseBuilder()

--- a/rest/route/alias_test.go
+++ b/rest/route/alias_test.go
@@ -128,6 +128,8 @@ func TestGetAliasesHandler(t *testing.T) {
 				}}
 			require.NoError(t, projectConfig.Insert(t.Context()))
 
+			ctx = context.WithValue(ctx, RequestContext, &dbModel.Context{ProjectRef: projectRef})
+
 			rh, ok := makeFetchAliases().(*aliasGetHandler)
 			require.True(t, ok)
 

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -130,7 +130,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/admin/service_users").Version(2).Get().Wrap(requireUser, adminSettings).RouteHandler(makeGetServiceUsers())
 	app.AddRoute("/admin/service_users").Version(2).Post().Wrap(requireUser, adminSettings).RouteHandler(makeUpdateServiceUser())
 	app.AddRoute("/admin/service_users").Version(2).Delete().Wrap(requireUser, adminSettings).RouteHandler(makeDeleteServiceUser())
-	app.AddRoute("/alias/{project_id}").Version(2).Get().Wrap(requireUser, rateLimit).RouteHandler(makeFetchAliases())
+	app.AddRoute("/alias/{project_id}").Version(2).Get().Wrap(requireUser, addProject, viewProjectSettings, rateLimit).RouteHandler(makeFetchAliases())
 	app.AddRoute("/auth").Version(2).Get().Wrap(requireUser, rateLimit).RouteHandler(&authPermissionGetHandler{})
 	app.AddRoute("/auth/token_exchange/authorize").Version(2).Get().Wrap(requireUser, rateLimit).Handler(tokenExchangeAuthorizeHandler(env))
 	app.AddRoute("/auth/token_exchange/callback").Version(2).Get().Wrap(requireUser, rateLimit).RouteHandler(makeTokenExchangeCallback(env))

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -130,7 +130,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/admin/service_users").Version(2).Get().Wrap(requireUser, adminSettings).RouteHandler(makeGetServiceUsers())
 	app.AddRoute("/admin/service_users").Version(2).Post().Wrap(requireUser, adminSettings).RouteHandler(makeUpdateServiceUser())
 	app.AddRoute("/admin/service_users").Version(2).Delete().Wrap(requireUser, adminSettings).RouteHandler(makeDeleteServiceUser())
-	app.AddRoute("/alias/{project_id}").Version(2).Get().Wrap(requireUser, addProject, viewProjectSettings, rateLimit).RouteHandler(makeFetchAliases())
+	app.AddRoute("/alias/{project_id}").Version(2).Get().Wrap(requireUser, addProject, viewTasks, rateLimit).RouteHandler(makeFetchAliases())
 	app.AddRoute("/auth").Version(2).Get().Wrap(requireUser, rateLimit).RouteHandler(&authPermissionGetHandler{})
 	app.AddRoute("/auth/token_exchange/authorize").Version(2).Get().Wrap(requireUser, rateLimit).Handler(tokenExchangeAuthorizeHandler(env))
 	app.AddRoute("/auth/token_exchange/callback").Version(2).Get().Wrap(requireUser, rateLimit).RouteHandler(makeTokenExchangeCallback(env))


### PR DESCRIPTION
DEVPROD-36660

### Description

The `alias/{project_id}` endpoint only checked that the caller was a logged in user, meaning any user could read alias configurations for any project, including restricted ones. 

### Fix
Add viewTasks middleware to the route.
