### PR TITLE
DEVPROD-36658: Add owner check on home volume in REST spawn-host path

### DIFF
--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -113,6 +113,26 @@ func (hph *hostPostHandler) Run(ctx context.Context) gimlet.Responder {
 		}
 	}
 
+	if hph.options.HomeVolumeID != "" {
+		volume, err := host.FindVolumeByID(ctx, hph.options.HomeVolumeID)
+		if err != nil {
+			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding volume '%s'", hph.options.HomeVolumeID))
+		}
+		if volume == nil {
+			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+				StatusCode: http.StatusNotFound,
+				Message:    fmt.Sprintf("volume '%s' not found", hph.options.HomeVolumeID),
+			})
+		}
+		// Only allow users to attach their own volumes.
+		if user.Id != volume.CreatedBy {
+			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+				StatusCode: http.StatusUnauthorized,
+				Message:    fmt.Sprintf("not authorized to attach volume '%s'", volume.ID),
+			})
+		}
+	}
+
 	intentHost, err := data.NewIntentHost(ctx, hph.options, user, hph.env)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "creating intent host"))

--- a/rest/route/host_spawn_test.go
+++ b/rest/route/host_spawn_test.go
@@ -269,6 +269,39 @@ func TestHostPostHandler(t *testing.T) {
 			require.NotZero(t, resp)
 			assert.NotEqual(t, http.StatusOK, resp.Status(), resp.Data())
 		},
+		"AllowsSpawnWithOwnHomeVolume": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			v := host.Volume{
+				ID:        "my-volume",
+				CreatedBy: u.Id,
+			}
+			require.NoError(t, v.Insert(ctx))
+
+			rh.options.HomeVolumeID = v.ID
+
+			resp := rh.Run(ctx)
+			require.NotZero(t, resp)
+			assert.Equal(t, http.StatusOK, resp.Status(), resp.Data())
+		},
+		"RejectsSpawnWithAnotherUsersHomeVolume": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			v := host.Volume{
+				ID:        "victim-volume",
+				CreatedBy: "another-user",
+			}
+			require.NoError(t, v.Insert(ctx))
+
+			rh.options.HomeVolumeID = v.ID
+
+			resp := rh.Run(ctx)
+			require.NotZero(t, resp)
+			assert.Equal(t, http.StatusUnauthorized, resp.Status(), resp.Data())
+		},
+		"RejectsSpawnWithNonexistentHomeVolume": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			rh.options.HomeVolumeID = "nonexistent-volume"
+
+			resp := rh.Run(ctx)
+			require.NotZero(t, resp)
+			assert.Equal(t, http.StatusNotFound, resp.Status(), resp.Data())
+		},
 		"RejectsSpawnWithTaskFromUnauthorizedProject": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
 			tsk := &task.Task{
 				Id:      "secret-task",
@@ -315,7 +348,7 @@ func TestHostPostHandler(t *testing.T) {
 		t.Run(tName, func(t *testing.T) {
 			ctx := t.Context()
 
-			require.NoError(t, db.ClearCollections(distro.Collection, host.Collection, task.Collection, user.Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
+			require.NoError(t, db.ClearCollections(distro.Collection, host.Collection, host.VolumesCollection, task.Collection, user.Collection, evergreen.ScopeCollection, evergreen.RoleCollection))
 			env := &mock.Environment{}
 			assert.NoError(t, env.Configure(ctx))
 			env.EvergreenSettings.Spawnhost.SpawnHostsPerUser = 10

--- a/rest/route/host_spawn_test.go
+++ b/rest/route/host_spawn_test.go
@@ -270,13 +270,19 @@ func TestHostPostHandler(t *testing.T) {
 			assert.NotEqual(t, http.StatusOK, resp.Status(), resp.Data())
 		},
 		"AllowsSpawnWithOwnHomeVolume": func(ctx context.Context, t *testing.T, env *mock.Environment, rh *hostPostHandler, u *user.DBUser, d *distro.Distro) {
+			az := evergreen.DefaultEC2Region + "a"
+			env.EvergreenSettings.Providers.AWS.Subnets = []evergreen.Subnet{
+				{AZ: az, SubnetID: "subnet-123"},
+			}
 			v := host.Volume{
-				ID:        "my-volume",
-				CreatedBy: u.Id,
+				ID:               "my-volume",
+				CreatedBy:        u.Id,
+				AvailabilityZone: az,
 			}
 			require.NoError(t, v.Insert(ctx))
 
 			rh.options.HomeVolumeID = v.ID
+			rh.options.Region = evergreen.DefaultEC2Region
 
 			resp := rh.Run(ctx)
 			require.NotZero(t, resp)


### PR DESCRIPTION
DEVPROD-36658

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

The GraphQL spawn path and the REST modify/delete-volume paths already enforce an owner check. This adds it to the REST spawn path as well. 

### Testing
Added 



<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
