### PR TITLE
DEVPROD-36649: Validate task identity on agent test results upload

### DIFF
--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1011,6 +1011,20 @@ func (h *attachTestResultsHandler) Parse(ctx context.Context, r *http.Request) e
 
 func (h *attachTestResultsHandler) Run(ctx context.Context) gimlet.Responder {
 	t := MustHaveTask(ctx)
+
+	if h.body.Info.TaskID != t.Id || h.body.Info.Execution != t.Execution {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusForbidden,
+			Message:    "test results task identity does not match the authenticated task",
+		})
+	}
+	if h.body.Stats.FailedCount < 0 || h.body.Stats.TotalCount < 0 {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusBadRequest,
+			Message:    "test results stats counts cannot be negative",
+		})
+	}
+
 	var err error
 	var record testresult.DbTaskTestResults
 	if !t.HasTestResults {

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/s3lifecycle"
 	"github.com/evergreen-ci/evergreen/model/s3usage"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
@@ -1645,5 +1646,49 @@ func TestLogLookupClosureUsesAdminBucketsConfig(t *testing.T) {
 	t.Run("UnknownBucketReturnsFalse", func(t *testing.T) {
 		_, ok := logLookup(t.Context(), "artifact-bucket", "")
 		assert.False(t, ok)
+	})
+}
+
+func TestAttachTestResultsHandlerRun(t *testing.T) {
+	const (
+		authedTaskID = "authed_task"
+		victimTaskID = "victim_task"
+	)
+	authedTask := &task.Task{Id: authedTaskID, Execution: 1}
+
+	makeHandler := func(body apimodels.AttachTestResultsRequest) *attachTestResultsHandler {
+		return &attachTestResultsHandler{taskID: authedTaskID, body: body}
+	}
+	matchingInfo := testresult.TestResultsInfo{TaskID: authedTaskID, Execution: 1}
+
+	t.Run("MismatchedTaskIDIsRejected", func(t *testing.T) {
+		h := makeHandler(apimodels.AttachTestResultsRequest{
+			Info: testresult.TestResultsInfo{TaskID: victimTaskID, Execution: 1},
+		})
+		ctx := context.WithValue(t.Context(), model.ApiTaskKey, authedTask)
+		assert.Equal(t, http.StatusForbidden, h.Run(ctx).Status())
+	})
+	t.Run("MismatchedExecutionIsRejected", func(t *testing.T) {
+		h := makeHandler(apimodels.AttachTestResultsRequest{
+			Info: testresult.TestResultsInfo{TaskID: authedTaskID, Execution: 2},
+		})
+		ctx := context.WithValue(t.Context(), model.ApiTaskKey, authedTask)
+		assert.Equal(t, http.StatusForbidden, h.Run(ctx).Status())
+	})
+	t.Run("NegativeFailedCountIsRejected", func(t *testing.T) {
+		h := makeHandler(apimodels.AttachTestResultsRequest{
+			Info:  matchingInfo,
+			Stats: testresult.TaskTestResultsStats{FailedCount: -1, TotalCount: 1},
+		})
+		ctx := context.WithValue(t.Context(), model.ApiTaskKey, authedTask)
+		assert.Equal(t, http.StatusBadRequest, h.Run(ctx).Status())
+	})
+	t.Run("NegativeTotalCountIsRejected", func(t *testing.T) {
+		h := makeHandler(apimodels.AttachTestResultsRequest{
+			Info:  matchingInfo,
+			Stats: testresult.TaskTestResultsStats{FailedCount: 0, TotalCount: -1},
+		})
+		ctx := context.WithValue(t.Context(), model.ApiTaskKey, authedTask)
+		assert.Equal(t, http.StatusBadRequest, h.Run(ctx).Status())
 	})
 }


### PR DESCRIPTION
DEVPROD-3664

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Harden the POST /task/{task_id}/test_results agent endpoint so that test-result stats and samples can only be written for the authenticated task. Also reject invalid stat counts.


### Testing

Added 



<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
