### PR TITLE
DEVPROD-31115 Require display task name in project validation

### DIFF
--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1416,6 +1416,13 @@ func validateDisplayTaskNames(project *model.Project) ValidationErrors {
 	// check display tasks
 	for _, bv := range project.BuildVariants {
 		for _, dp := range bv.DisplayTasks {
+			if dp.Name == "" {
+				errs = append(errs,
+					ValidationError{
+						Level:   Error,
+						Message: fmt.Sprintf("display task in buildvariant '%s' must have a name", bv.Name),
+					})
+			}
 			for _, etn := range dp.ExecTasks {
 				if strings.HasPrefix(etn, "display_") {
 					errs = append(errs,

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -4767,6 +4767,26 @@ buildvariants:
 	assert.Empty(warnings)
 }
 
+func TestDisplayTaskEmptyNameValidation(t *testing.T) {
+	project := &model.Project{
+		BuildVariants: []model.BuildVariant{
+			{
+				Name: "bv",
+				DisplayTasks: []patch.DisplayTask{
+					{
+						Name:      "",
+						ExecTasks: []string{"one"},
+					},
+				},
+			},
+		},
+	}
+	errs := validateDisplayTaskNames(project)
+	require.Len(t, errs, 1)
+	assert.Equal(t, Error, errs[0].Level)
+	assert.Equal(t, "display task in buildvariant 'bv' must have a name", errs[0].Message)
+}
+
 func TestValidateCreateHosts(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)


### PR DESCRIPTION
DEVPROD-31115

### Description

A display task could be defined in a project config without a name, which resulted in a strange and confusing UI. This adds a project validation error when a display task is missing a name, so such configs are rejected at validation time.

### Testing

Added `TestDisplayTaskEmptyNameValidation` covering the new error, and confirmed existing `TestDisplayTaskExecutionTasksNameValidation` still passes via `make test-validator RUN_TEST=TestDisplayTask`.

### Documentation

No doc changes needed.