### PR TITLE
DEVPROD-36342 Remove unused dependency.finished field

### DIFF
--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -2273,7 +2273,6 @@ func TestVersionRestart(t *testing.T) {
 		if t.Id == "task3" {
 			require.Len(t.DependsOn, 1)
 			assert.Equal("task1", t.DependsOn[0].TaskId)
-			assert.False(t.DependsOn[0].Finished, "restarting task1 should have marked dependency as unfinished")
 			assert.Equal(evergreen.TaskWillRun, t.DisplayStatusCache)
 		}
 	}
@@ -2285,7 +2284,6 @@ func TestVersionRestart(t *testing.T) {
 	require.NotZero(dbTask5)
 	require.Len(dbTask5.DependsOn, 1)
 	assert.Equal("task1", dbTask5.DependsOn[0].TaskId)
-	assert.False(dbTask5.DependsOn[0].Finished, "restarting task1 should have marked dependency in execution task as unfinished")
 
 	dbVersion, err := VersionFindOneId(t.Context(), "version")
 	assert.NoError(err)
@@ -2623,8 +2621,7 @@ func resetTaskData() error {
 		Activated:     true,
 		DependsOn: []task.Dependency{
 			{
-				TaskId:   task1.Id,
-				Finished: true,
+				TaskId: task1.Id,
 			},
 		},
 	}
@@ -2654,8 +2651,7 @@ func resetTaskData() error {
 		DispatchTime:  time.Now(),
 		DependsOn: []task.Dependency{
 			{
-				TaskId:   task1.Id,
-				Finished: true,
+				TaskId: task1.Id,
 			},
 		},
 	}

--- a/model/task/db.go
+++ b/model/task/db.go
@@ -166,7 +166,6 @@ var (
 	DependencyTaskIdKey             = bsonutil.MustHaveTag(Dependency{}, "TaskId")
 	DependencyStatusKey             = bsonutil.MustHaveTag(Dependency{}, "Status")
 	DependencyUnattainableKey       = bsonutil.MustHaveTag(Dependency{}, "Unattainable")
-	DependencyFinishedKey           = bsonutil.MustHaveTag(Dependency{}, "Finished")
 	DependencyFinishedAtKey         = bsonutil.MustHaveTag(Dependency{}, "FinishedAt")
 	DependencyOmitGeneratedTasksKey = bsonutil.MustHaveTag(Dependency{}, "OmitGeneratedTasks")
 )

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -846,7 +846,6 @@ func (t *Task) MarkDependenciesFinished(ctx context.Context, finished bool) erro
 		},
 		bson.M{
 			"$set": bson.M{
-				bsonutil.GetDottedKeyName(DependsOnKey, "$[elem]", DependencyFinishedKey):   finished,
 				bsonutil.GetDottedKeyName(DependsOnKey, "$[elem]", DependencyFinishedAtKey): finishedAt,
 			},
 		},

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -428,8 +428,6 @@ type Dependency struct {
 	TaskId       string `bson:"_id" json:"id"`
 	Status       string `bson:"status" json:"status"`
 	Unattainable bool   `bson:"unattainable" json:"unattainable"`
-	// Finished indicates if the task's dependency has finished running or not.
-	Finished bool `bson:"finished" json:"finished"`
 	// FinishedAt indicates the time the task's dependency was finished at.
 	FinishedAt time.Time `bson:"finished_at,omitempty" json:"finished_at,omitempty"`
 	// OmitGeneratedTasks causes tasks that depend on a generator task to not depend on

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -666,7 +666,6 @@ func TestMarkDependenciesFinished(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, dbTask2)
 			require.Len(t, dbTask2.DependsOn, 1)
-			assert.False(t, dbTask2.DependsOn[0].Finished, "unconnected dependency edge should not be marked finished")
 			assert.True(t, utility.IsZeroTime(dbTask2.DependsOn[0].FinishedAt), "unconnected dependency edge should not be marked finished")
 		},
 		"UpdatesDependencyWithMatchingStatus": func(t *testing.T) {
@@ -693,7 +692,6 @@ func TestMarkDependenciesFinished(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, dbTask1)
 			require.Len(t, dbTask1.DependsOn, 1)
-			assert.True(t, dbTask1.DependsOn[0].Finished)
 			assert.False(t, utility.IsZeroTime(dbTask1.DependsOn[0].FinishedAt))
 		},
 		"UpdatesDependencyWithUnmatchingStatus": func(t *testing.T) {
@@ -721,7 +719,6 @@ func TestMarkDependenciesFinished(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, dbTask1)
 			require.Len(t, dbTask1.DependsOn, 1)
-			assert.True(t, dbTask1.DependsOn[0].Finished)
 			assert.False(t, utility.IsZeroTime(dbTask1.DependsOn[0].FinishedAt))
 
 			met, err := dbTask1.DependenciesMet(ctx, map[string]Task{})
@@ -754,7 +751,6 @@ func TestMarkDependenciesFinished(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, dbTask1)
 			require.Len(t, dbTask1.DependsOn, 1)
-			assert.True(t, dbTask1.DependsOn[0].Finished)
 			assert.False(t, utility.IsZeroTime(dbTask1.DependsOn[0].FinishedAt))
 
 			met, err := dbTask1.DependenciesMet(ctx, map[string]Task{})
@@ -800,9 +796,7 @@ func TestMarkDependenciesFinished(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, dbTask2)
 			require.Len(t, dbTask2.DependsOn, 2)
-			assert.True(t, dbTask2.DependsOn[0].Finished)
 			assert.False(t, utility.IsZeroTime(dbTask2.DependsOn[0].FinishedAt))
-			assert.True(t, dbTask2.DependsOn[1].Finished)
 			assert.False(t, utility.IsZeroTime(dbTask2.DependsOn[1].FinishedAt))
 
 			met, err := dbTask2.DependenciesMet(ctx, map[string]Task{})
@@ -838,13 +832,9 @@ func TestMarkDependenciesFinished(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, dbTask1)
 			require.Len(t, dbTask1.DependsOn, 4)
-			assert.False(t, dbTask1.DependsOn[0].Finished)
 			assert.True(t, utility.IsZeroTime(dbTask1.DependsOn[0].FinishedAt))
-			assert.False(t, dbTask1.DependsOn[1].Finished)
 			assert.True(t, utility.IsZeroTime(dbTask1.DependsOn[1].FinishedAt))
-			assert.True(t, dbTask1.DependsOn[2].Finished)
 			assert.False(t, utility.IsZeroTime(dbTask1.DependsOn[2].FinishedAt))
-			assert.False(t, dbTask1.DependsOn[3].Finished)
 			assert.True(t, utility.IsZeroTime(dbTask1.DependsOn[3].FinishedAt))
 		},
 		"UpdatesDirectDependenciesOnly": func(t *testing.T) {
@@ -875,14 +865,12 @@ func TestMarkDependenciesFinished(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, dbTask1)
 			require.Len(t, dbTask1.DependsOn, 1)
-			assert.True(t, dbTask1.DependsOn[0].Finished, "direct dependency should be marked finished")
 			assert.False(t, utility.IsZeroTime(dbTask1.DependsOn[0].FinishedAt), "direct dependency should be marked finished")
 
 			dbTask2, err := FindOneId(ctx, t2.Id)
 			require.NoError(t, err)
 			require.NotZero(t, dbTask2)
 			require.Len(t, dbTask2.DependsOn, 1)
-			assert.False(t, dbTask2.DependsOn[0].Finished, "indirect dependency edge should not be marked finished")
 			assert.True(t, utility.IsZeroTime(dbTask2.DependsOn[0].FinishedAt), "indirect dependency edge should not be marked finished")
 		},
 		"UpdateDependencyToUnfinished": func(t *testing.T) {
@@ -894,8 +882,7 @@ func TestMarkDependenciesFinished(t *testing.T) {
 				Id: "task1",
 				DependsOn: []Dependency{
 					{
-						TaskId:   "task0",
-						Finished: true,
+						TaskId: "task0",
 					},
 				},
 			}
@@ -908,7 +895,6 @@ func TestMarkDependenciesFinished(t *testing.T) {
 			require.NoError(t, err)
 			require.NotZero(t, dbTask1)
 			require.Len(t, dbTask1.DependsOn, 1)
-			assert.False(t, dbTask1.DependsOn[0].Finished, "direct dependency should not be marked finished")
 			assert.True(t, utility.IsZeroTime(dbTask1.DependsOn[0].FinishedAt), "direct dependency should not be marked finished")
 		},
 	} {
@@ -4574,7 +4560,7 @@ func TestWillRun(t *testing.T) {
 		tsk := Task{
 			Status:    evergreen.TaskUndispatched,
 			Activated: true,
-			DependsOn: []Dependency{{Finished: false}},
+			DependsOn: []Dependency{{}},
 		}
 		assert.True(t, tsk.WillRun())
 	})
@@ -4583,7 +4569,7 @@ func TestWillRun(t *testing.T) {
 			Status:            evergreen.TaskUndispatched,
 			Activated:         true,
 			ExecutionPlatform: ExecutionPlatformContainer,
-			DependsOn:         []Dependency{{Finished: true, Unattainable: false}},
+			DependsOn:         []Dependency{{Unattainable: false}},
 		}
 		assert.True(t, tsk.WillRun())
 	})
@@ -4592,7 +4578,7 @@ func TestWillRun(t *testing.T) {
 			Status:            evergreen.TaskUndispatched,
 			Activated:         true,
 			ExecutionPlatform: ExecutionPlatformContainer,
-			DependsOn:         []Dependency{{Finished: true, Unattainable: true}},
+			DependsOn:         []Dependency{{Unattainable: true}},
 		}
 		assert.False(t, tsk.WillRun())
 	})

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -1957,7 +1957,6 @@ func TestMarkEnd(t *testing.T) {
 	require.NotZero(dbDependentTask)
 	require.Len(dbDependentTask.DependsOn, 1)
 	assert.Equal(testTask.Id, dbDependentTask.DependsOn[0].TaskId)
-	assert.True(dbDependentTask.DependsOn[0].Finished, "dependency should be marked finished")
 
 	Convey("with a task that is part of a display task", t, func() {
 		p := &Project{
@@ -2460,7 +2459,7 @@ func TestTryResetTask(t *testing.T) {
 				Project:   "sample",
 				Version:   b.Version,
 				DependsOn: []task.Dependency{
-					{TaskId: testTask.Id, Status: evergreen.TaskSucceeded, Finished: true},
+					{TaskId: testTask.Id, Status: evergreen.TaskSucceeded},
 				},
 			}
 			detail := &apimodels.TaskEndDetail{
@@ -2501,7 +2500,6 @@ func TestTryResetTask(t *testing.T) {
 				So(dbDependentTask, ShouldNotBeNil)
 				So(len(dbDependentTask.DependsOn), ShouldEqual, 1)
 				So(dbDependentTask.DependsOn[0].TaskId, ShouldEqual, testTask.Id)
-				So(dbDependentTask.DependsOn[0].Finished, ShouldBeFalse)
 			})
 		})
 		Convey("resetting a task with a max number of executions", func() {
@@ -4260,7 +4258,6 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 	require.NotNil(t, dependencyTask)
 	require.NoError(t, err)
 	assert.True(dependencyTask.DependsOn[0].Unattainable)
-	assert.True(dependencyTask.DependsOn[0].Finished)
 
 	dt, err := task.FindOne(ctx, db.Query(task.ById("displayTask")))
 	require.NoError(t, err)
@@ -4545,7 +4542,6 @@ func TestResetStaleTask(t *testing.T) {
 			require.NotNil(t, dependencyTask)
 			require.NoError(t, err)
 			assert.False(t, dependencyTask.DependsOn[0].Unattainable)
-			assert.False(t, dependencyTask.DependsOn[0].Finished)
 		},
 		"SuccessfullySystemFailsAbortedTask": func(t *testing.T, tsk task.Task) {
 			tsk.Aborted = true
@@ -4567,7 +4563,6 @@ func TestResetStaleTask(t *testing.T) {
 			require.NotNil(t, dependencyTask)
 			require.NoError(t, err)
 			assert.True(t, dependencyTask.DependsOn[0].Unattainable)
-			assert.True(t, dependencyTask.DependsOn[0].Finished)
 		},
 		"ResetsParentDisplayTaskForStaleExecutionTask": func(t *testing.T, tsk task.Task) {
 			otherExecTask := task.Task{


### PR DESCRIPTION
DEVPROD-36342

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Removes declarations and uses of the Finished field since it's no longer used.