### PR TITLE
DEVPROD-36673: Add ownership check to REST attach-volume handler

### DIFF
--- a/rest/route/host_spawn.go
+++ b/rest/route/host_spawn.go
@@ -576,6 +576,14 @@ func (h *attachVolumeHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Errorf("attachment '%s' does not exist", h.attachment.VolumeID))
 	}
 
+	// Only allow users to attach their own volumes.
+	if user.Id != v.CreatedBy {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusUnauthorized,
+			Message:    fmt.Sprintf("not authorized to attach volume '%s'", v.ID),
+		})
+	}
+
 	if v.AvailabilityZone != targetHost.Zone {
 		return gimlet.MakeJSONErrorResponder(errors.New("host and volume must have same availability zone"))
 	}

--- a/rest/route/host_spawn_test.go
+++ b/rest/route/host_spawn_test.go
@@ -774,7 +774,8 @@ func TestAttachVolumeHandler(t *testing.T) {
 	// wrong availability zone
 	v.VolumeID = "my-volume"
 	volume := host.Volume{
-		ID: v.VolumeID,
+		ID:        v.VolumeID,
+		CreatedBy: "user",
 	}
 	assert.NoError(t, volume.Insert(t.Context()))
 
@@ -795,6 +796,28 @@ func TestAttachVolumeHandler(t *testing.T) {
 	resp := h.Run(ctx)
 	assert.NotNil(t, resp)
 	assert.Equal(t, http.StatusBadRequest, resp.Status())
+
+	// another user's volume
+	otherVolume := host.Volume{
+		ID:        "other-volume",
+		CreatedBy: "another-user",
+	}
+	assert.NoError(t, otherVolume.Insert(t.Context()))
+
+	v.VolumeID = otherVolume.ID
+	jsonBody, err = json.Marshal(v)
+	assert.NoError(t, err)
+	buffer = bytes.NewBuffer(jsonBody)
+
+	r, err = http.NewRequest(http.MethodGet, "/hosts/my-host/attach", buffer)
+	assert.NoError(t, err)
+	r = gimlet.SetURLVars(r, map[string]string{"host_id": "my-host"})
+
+	assert.NoError(t, h.Parse(ctx, r))
+
+	resp = h.Run(ctx)
+	assert.NotNil(t, resp)
+	assert.Equal(t, http.StatusUnauthorized, resp.Status())
 }
 
 func TestDetachVolumeHandler(t *testing.T) {


### PR DESCRIPTION
DEVPROD-36673

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

The REST attach-volume handler validated host ownership but did not verify that the caller owned the volume being attached. This adds an ownership check consistent with other volume handlers and the GraphQL  path.

### Testing

Added 

