### PR TITLE
DEVPROD-36690: check for repo ID in query params more safely

### DIFF
--- a/rest/data/middleware.go
+++ b/rest/data/middleware.go
@@ -88,7 +88,7 @@ func GetProjectIdFromParams(ctx context.Context, paramsMap map[string]string) (s
 		}
 	}
 
-	if repoID != "" {
+	if projectID == "" && repoID != "" {
 		var repoRef *model.RepoRef
 		repoRef, err = model.FindOneRepoRef(ctx, repoID)
 		if err != nil {
@@ -182,6 +182,7 @@ func BuildProjectParameterMapForLegacy(query url.Values, vars map[string]string)
 		vars["patch_id"], vars[patchIdKey],
 		vars["log_id"],
 		vars["project_id"], vars[projectIdKey],
+		vars["repo_id"], vars[repoIdKey],
 	) != ""
 
 	if hasObjectIDInPath {

--- a/rest/data/middleware.go
+++ b/rest/data/middleware.go
@@ -88,7 +88,7 @@ func GetProjectIdFromParams(ctx context.Context, paramsMap map[string]string) (s
 		}
 	}
 
-	if projectID == "" && repoID != "" {
+	if repoID != "" {
 		var repoRef *model.RepoRef
 		repoRef, err = model.FindOneRepoRef(ctx, repoID)
 		if err != nil {

--- a/rest/data/middleware_test.go
+++ b/rest/data/middleware_test.go
@@ -146,6 +146,11 @@ func TestGetProjectIdFromParams(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, statusCode)
 	require.Equal(t, "", projectId)
 
+	projectId, statusCode, err = GetProjectIdFromParams(ctx, map[string]string{"projectId": project.Id, "repoId": repo.ProjectRef.Id})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, statusCode)
+	require.Equal(t, project.Id, projectId, "project ID should take precedence over repo ID")
+
 	// Parameters are empty.
 	projectId, statusCode, err = GetProjectIdFromParams(ctx, map[string]string{})
 	require.Error(t, err)
@@ -212,6 +217,16 @@ func TestBuildProjectParameterMapForLegacy(t *testing.T) {
 			query:    url.Values{"project_id": []string{"unrelated_project"}},
 			vars:     map[string]string{"project_id": "target_project"},
 			expected: map[string]string{projectIdKey: "target_project"},
+		},
+		"QueryRepoIDIgnoredWhenTaskIDInPath": {
+			query:    url.Values{"repo_id": []string{"unrelated_repo_id"}},
+			vars:     map[string]string{"task_id": "target_task_id"},
+			expected: map[string]string{repoIdKey: "", taskIdKey: "target_task_id"},
+		},
+		"QueryRepoIDIgnoredWhenRepoIDInPath": {
+			query:    url.Values{"repo_id": []string{"unrelated_repo_id"}},
+			vars:     map[string]string{"repo_id": "target_repo_id"},
+			expected: map[string]string{repoIdKey: "target_repo_id"},
 		},
 		"QueryObjectIDsUsedWhenNoObjectIDInPath": {
 			query:    url.Values{"version_id": []string{"query_version_id"}},

--- a/rest/data/middleware_test.go
+++ b/rest/data/middleware_test.go
@@ -146,11 +146,6 @@ func TestGetProjectIdFromParams(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, statusCode)
 	require.Equal(t, "", projectId)
 
-	projectId, statusCode, err = GetProjectIdFromParams(ctx, map[string]string{"projectId": project.Id, "repoId": repo.ProjectRef.Id})
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, statusCode)
-	require.Equal(t, project.Id, projectId, "project ID should take precedence over repo ID")
-
 	// Parameters are empty.
 	projectId, statusCode, err = GetProjectIdFromParams(ctx, map[string]string{})
 	require.Error(t, err)


### PR DESCRIPTION
DEVPROD-36690

### Description

The concern in the ticket is around allowing permissions checks on query parameters. For example, you can pass a repo ID like `GET /projects/{project_id}?repo_id=something_else` in the query params and get access to the project as long as you're a repo admin for `something_else`. That was already addressed in DEVPROD-36670 (#10512), but I added some additional safety checks to future-proof in case we ever add routes with repo ID in the path parameters (there's no such route currently).

* Prefer repo ID if it's in path parameters.

### Testing
* Added unit tests.