### PR TITLE
 DEVPROD-36686: Scope host-is-up endpoint to the authenticated host

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -263,7 +263,6 @@ func (opts *DockerOptions) Validate() error {
 // HostMetadataOptions are options related to the ec2 instance's metadata.
 type HostMetadataOptions struct {
 	CloudProviderData
-	HostID        string `json:"host_id"`
 	EC2InstanceID string `json:"ec2_instance_id"`
 }
 

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -1608,7 +1608,6 @@ func (c *communicatorImpl) PostHostIsUp(ctx context.Context, opts host.HostMetad
 		method: http.MethodPost,
 		path:   fmt.Sprintf("/hosts/%s/is_up", c.hostID),
 	}
-	opts.HostID = c.hostID
 	r, err := c.createRequest(info, opts)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating request")

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -333,18 +333,18 @@ func makeSpawnOptions(options *restmodel.HostRequestOptions, user *user.DBUser) 
 }
 
 // PostHostIsUp indicates to the app server that a host is up.
-func PostHostIsUp(ctx context.Context, env evergreen.Environment, params host.HostMetadataOptions) (*restmodel.APIHost, error) {
-	h, err := host.FindOneByIdOrTag(ctx, params.HostID)
+func PostHostIsUp(ctx context.Context, env evergreen.Environment, hostID string, params host.HostMetadataOptions) (*restmodel.APIHost, error) {
+	h, err := host.FindOneByIdOrTag(ctx, hostID)
 	if err != nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
-			Message:    errors.Wrapf(err, "finding host '%s'", params.HostID).Error(),
+			Message:    errors.Wrapf(err, "finding host '%s'", hostID).Error(),
 		}
 	}
 	if h == nil {
 		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
-			Message:    fmt.Sprintf("host '%s' not found", params.HostID),
+			Message:    fmt.Sprintf("host '%s' not found", hostID),
 		}
 	}
 

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -446,6 +446,7 @@ func (rh *hostProvisioningOptionsGetHandler) Run(ctx context.Context) gimlet.Res
 // POST /hosts/{host_id}/is_up
 
 type hostIsUpPostHandler struct {
+	hostID string
 	params host.HostMetadataOptions
 	env    evergreen.Environment
 }
@@ -462,11 +463,14 @@ func (rh *hostIsUpPostHandler) Parse(ctx context.Context, r *http.Request) error
 	if err := utility.ReadJSON(r.Body, &rh.params); err != nil {
 		return errors.Wrap(err, "reading host is up parameters from JSON request body")
 	}
+
+	rh.hostID = MustHaveHost(r.Context()).Id
+
 	return nil
 }
 
 func (rh *hostIsUpPostHandler) Run(ctx context.Context) gimlet.Responder {
-	apiHost, err := data.PostHostIsUp(ctx, rh.env, rh.params)
+	apiHost, err := data.PostHostIsUp(ctx, rh.env, rh.hostID, rh.params)
 	if err != nil {
 		return gimlet.MakeJSONErrorResponder(err)
 	}

--- a/rest/route/host_test.go
+++ b/rest/route/host_test.go
@@ -1146,9 +1146,9 @@ func TestHostIsUpPostHandler(t *testing.T) {
 						VolumeID: "vol1",
 					}},
 				},
-				HostID:        h.Id,
 				EC2InstanceID: instanceID,
 			}
+			rh.hostID = h.Id
 			resp := rh.Run(ctx)
 
 			require.NotZero(t, resp)
@@ -1187,9 +1187,10 @@ func TestHostIsUpPostHandler(t *testing.T) {
 					Volumes: []host.VolumeAttachment{{
 						VolumeID: "vol1",
 					}},
-				}, HostID: h.Id,
+				},
 				EC2InstanceID: instanceID,
 			}
+			rh.hostID = h.Id
 
 			resp := rh.Run(ctx)
 
@@ -1229,9 +1230,10 @@ func TestHostIsUpPostHandler(t *testing.T) {
 					Volumes: []host.VolumeAttachment{{
 						VolumeID: "vol1",
 					}},
-				}, HostID: instanceID,
+				},
 				EC2InstanceID: instanceID,
 			}
+			rh.hostID = instanceID
 
 			resp := rh.Run(ctx)
 
@@ -1258,9 +1260,9 @@ func TestHostIsUpPostHandler(t *testing.T) {
 			require.NoError(t, h.Insert(ctx))
 
 			rh.params = host.HostMetadataOptions{
-				HostID:        instanceID,
 				EC2InstanceID: instanceID,
 			}
+			rh.hostID = instanceID
 
 			resp := rh.Run(ctx)
 
@@ -1287,9 +1289,8 @@ func TestHostIsUpPostHandler(t *testing.T) {
 			h.NeedsNewAgentMonitor = false
 			require.NoError(t, h.Insert(ctx))
 
-			rh.params = host.HostMetadataOptions{
-				HostID: instanceID,
-			}
+			rh.params = host.HostMetadataOptions{}
+			rh.hostID = instanceID
 
 			resp := rh.Run(ctx)
 
@@ -1317,9 +1318,8 @@ func TestHostIsUpPostHandler(t *testing.T) {
 			h.NeedsNewAgentMonitor = false
 			require.NoError(t, h.Insert(ctx))
 
-			rh.params = host.HostMetadataOptions{
-				HostID: instanceID,
-			}
+			rh.params = host.HostMetadataOptions{}
+			rh.hostID = instanceID
 
 			resp := rh.Run(ctx)
 


### PR DESCRIPTION
 DEVPROD-36686

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
The `POST /hosts/{host_id}/is_up` endpoint now uses the host identity from the authenticated request context rather than a value from the request body, so a request can only update its own host record.

### Testing

Updated existing tests 
### Documentation

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
