### PR TITLE
DEVPROD-36506 Output patch created time in CLI as local time

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-07-13"
+	ClientVersion = "2026-07-21"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -34,7 +34,7 @@ const largeNumFinalizedTasksThreshold = 1000
 var patchDisplayTemplate = template.Must(template.New("patch").Parse(`
          ID : {{.Patch.Id.Hex}}
     Project : {{.ProjectIdentifier}}
-    Created : {{.Patch.CreateTime}}
+    Created : {{.Patch.CreateTime.Local.String}}
 Description : {{if .Patch.Description}}{{.Patch.Description}}{{else}}<none>{{end}}
       Build : {{.Link}}
      Status : {{.Patch.Status}}


### PR DESCRIPTION
DEVPROD-36506

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->
Changes it to local time

### Testing

<!--add a description of how you tested it-->

Ran locally and it said:
```
         ID : 6a5fa807bd731d0007510e0f
    Project : evergreen
    Created : 2026-07-21 13:10:33.031 -0400 EDT
Description : DEVPROD-36506: DEVPROD-37210 Add wide-event attributes to generate.tasks and create-host job root spans (#10496)
      Build : https://spruce.corp.mongodb.com/patch/6a5fa807bd731d0007510e0f
     Status : created
```