### PR TITLE
 DEVPROD-36687: Scope project alias updates to the editing project

### DIFF
--- a/graphql/tests/mutation/saveProjectSettingsForSection/data.json
+++ b/graphql/tests/mutation/saveProjectSettingsForSection/data.json
@@ -44,6 +44,26 @@
       "repo_name": "commit-queue-sandbox"
     }
   ],
+  "project_aliases": [
+    {
+      "_id": { "$oid": "64c80057d1d6f12b0d4c69d0" },
+      "alias": "test",
+      "description": "alias",
+      "project_id": "sandbox_project_id",
+      "variant_tags": [".*"],
+      "tags": [".*"],
+      "parameters": [{ "key": "test", "value": "thing" }]
+    },
+    {
+      "_id": { "$oid": "65c80057d1d6f12b0d4c69d0" },
+      "alias": "test2",
+      "description": "second alias",
+      "project_id": "sandbox_project_id",
+      "variant_tags": [".*"],
+      "tags": [".*"],
+      "parameters": [{ "key": "test", "value": "thing" }]
+    }
+  ],
   "project_vars": [
     {
       "_id": "sandbox_project_id",

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -12,6 +12,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/anser/bsonutil"
+	adb "github.com/mongodb/anser/db"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
@@ -451,10 +452,19 @@ func (p *ProjectAlias) Upsert(ctx context.Context) error {
 func UpsertAliasesForProject(ctx context.Context, aliases []ProjectAlias, projectId string) error {
 	catcher := grip.NewBasicCatcher()
 	for i := range aliases {
-		if aliases[i].ProjectID != projectId { // new project, so we need a new document (new ID)
-			aliases[i].ProjectID = projectId
-			aliases[i].ID = ""
+		// If the caller supplied an existing alias ID, verify it belongs to this
+		// project before upserting it.
+		if aliases[i].ID.Valid() {
+			ownerProjectId, err := findAliasOwnerProject(ctx, aliases[i].ID.Hex())
+			if err != nil {
+				catcher.Wrapf(err, "verifying ownership of project alias '%s'", aliases[i].ID.Hex())
+				continue
+			}
+			if ownerProjectId != projectId {
+				aliases[i].ID = ""
+			}
 		}
+		aliases[i].ProjectID = projectId
 		catcher.Add(aliases[i].Upsert(ctx))
 	}
 	grip.Debug(ctx, message.WrapError(catcher.Resolve(), message.Fields{
@@ -464,13 +474,37 @@ func UpsertAliasesForProject(ctx context.Context, aliases []ProjectAlias, projec
 	return catcher.Resolve()
 }
 
+// findAliasOwnerProject returns the project ID that owns the alias with the
+// given document ID. It returns an empty string if no such alias exists.
+func findAliasOwnerProject(ctx context.Context, id string) (string, error) {
+	if !IsValidId(id) {
+		return "", nil
+	}
+	var alias ProjectAlias
+	q := db.Query(bson.M{idKey: mgobson.ObjectIdHex(id)})
+	err := db.FindOneQ(ctx, ProjectAliasCollection, q, &alias)
+	if adb.ResultsNotFound(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", errors.Wrapf(err, "finding project alias '%s'", id)
+	}
+	return alias.ProjectID, nil
+}
+
 // RemoveProjectAlias removes a project alias with the given document ID from the
 // database.
-func RemoveProjectAlias(ctx context.Context, id string) error {
+func RemoveProjectAlias(ctx context.Context, projectId, id string) error {
 	if id == "" {
 		return errors.New("can't remove project alias with empty id")
 	}
-	err := db.Remove(ctx, ProjectAliasCollection, bson.M{idKey: mgobson.ObjectIdHex(id)})
+	if projectId == "" {
+		return errors.New("can't remove project alias with empty project ID")
+	}
+	err := db.Remove(ctx, ProjectAliasCollection, bson.M{
+		idKey:        mgobson.ObjectIdHex(id),
+		projectIDKey: projectId,
+	})
 	if err != nil {
 		return errors.Wrapf(err, "removing project alias '%s'", id)
 	}

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -158,7 +158,7 @@ func (s *ProjectAliasSuite) TestRemove() {
 	s.Len(out, 10)
 
 	for i, a := range s.aliases {
-		s.NoError(RemoveProjectAlias(s.T().Context(), a.ID.Hex()))
+		s.NoError(RemoveProjectAlias(s.T().Context(), a.ProjectID, a.ID.Hex()))
 		s.NoError(db.FindAllQ(s.T().Context(), ProjectAliasCollection, q, &out))
 		s.Len(out, 10-i-1)
 	}
@@ -547,10 +547,9 @@ func (s *ProjectAliasSuite) TestFindAliasInProjectRepoOrConfig() {
 }
 
 func (s *ProjectAliasSuite) TestUpsertAliasesForProject() {
-	for _, a := range s.aliases {
-		a.ProjectID = "old-project"
-
-		s.NoError(a.Upsert(s.T().Context()))
+	for i := range s.aliases {
+		s.aliases[i].ProjectID = "old-project"
+		s.NoError(s.aliases[i].Upsert(s.T().Context()))
 	}
 	s.NoError(UpsertAliasesForProject(s.T().Context(), s.aliases, "new-project"))
 
@@ -558,10 +557,67 @@ func (s *ProjectAliasSuite) TestUpsertAliasesForProject() {
 	s.NoError(err)
 	s.Len(found, 10)
 
-	// verify old aliases not overwritten
 	found, err = FindAliasesForProjectFromDb(s.T().Context(), "old-project")
 	s.NoError(err)
 	s.Len(found, 10)
+}
+
+func (s *ProjectAliasSuite) TestUpsertAliasesForProjectWithMismatchedIDCreatesNewDocument() {
+	existing := ProjectAlias{
+		ProjectID: "project-a",
+		Alias:     "alias-a",
+		Variant:   "v1",
+		Task:      "t1",
+	}
+	s.NoError(existing.Upsert(s.T().Context()))
+	s.True(existing.ID.Valid())
+
+	// Upserting into a different project while reusing an existing alias's ID
+	// must create a fresh document rather than write to the other project's.
+	incoming := ProjectAlias{
+		ID:        existing.ID,
+		ProjectID: "project-b",
+		Alias:     "alias-b",
+		Variant:   "v2",
+		Task:      "t2",
+	}
+	s.NoError(UpsertAliasesForProject(s.T().Context(), []ProjectAlias{incoming}, "project-b"))
+
+	owner, err := findAliasOwnerProject(s.T().Context(), existing.ID.Hex())
+	s.NoError(err)
+	s.Equal("project-a", owner)
+
+	aliasesA, err := FindAliasesForProjectFromDb(s.T().Context(), "project-a")
+	s.NoError(err)
+	s.Require().Len(aliasesA, 1)
+	s.Equal("alias-a", aliasesA[0].Alias)
+
+	aliasesB, err := FindAliasesForProjectFromDb(s.T().Context(), "project-b")
+	s.NoError(err)
+	s.Require().Len(aliasesB, 1)
+	s.NotEqual(existing.ID.Hex(), aliasesB[0].ID.Hex())
+}
+
+func (s *ProjectAliasSuite) TestRemoveProjectAliasScopedToProject() {
+	alias := ProjectAlias{
+		ProjectID: "project-a",
+		Alias:     "alias-a",
+		Variant:   "v1",
+		Task:      "t1",
+	}
+	s.NoError(alias.Upsert(s.T().Context()))
+
+	// A mismatched project ID must not remove the alias.
+	s.NoError(RemoveProjectAlias(s.T().Context(), "project-b", alias.ID.Hex()))
+	owner, err := findAliasOwnerProject(s.T().Context(), alias.ID.Hex())
+	s.NoError(err)
+	s.Equal("project-a", owner)
+
+	// The owning project ID removes it.
+	s.NoError(RemoveProjectAlias(s.T().Context(), "project-a", alias.ID.Hex()))
+	owner, err = findAliasOwnerProject(s.T().Context(), alias.ID.Hex())
+	s.NoError(err)
+	s.Empty(owner)
 }
 
 func TestProjectAliasGitTagMatching(t *testing.T) {

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -2553,7 +2553,7 @@ func DefaultSectionToRepo(ctx context.Context, projectId string, section Project
 		for _, a := range before.Aliases {
 			// remove only internal aliases; any alias without these labels is a patch alias
 			if utility.StringSliceContains(evergreen.InternalAliases, a.Alias) {
-				err = RemoveProjectAlias(ctx, a.ID.Hex())
+				err = RemoveProjectAlias(ctx, projectId, a.ID.Hex())
 				if err == nil {
 					modified = true // track if any aliases here were correctly modified so we can log the changes
 				}
@@ -2574,7 +2574,7 @@ func DefaultSectionToRepo(ctx context.Context, projectId string, section Project
 		// remove only patch aliases, i.e. aliases without an Evergreen-internal label
 		for _, a := range before.Aliases {
 			if !utility.StringSliceContains(evergreen.InternalAliases, a.Alias) {
-				err = RemoveProjectAlias(ctx, a.ID.Hex())
+				err = RemoveProjectAlias(ctx, projectId, a.ID.Hex())
 				if err == nil {
 					modified = true // track if any aliases were correctly modified so we can log the changes
 				}

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -1340,7 +1340,7 @@ func TestDetachFromRepo(t *testing.T) {
 			assert.NoError(t, pRef.AttachToRepo(ctx, dbUser))
 			assert.NotEmpty(t, pRef.RepoRefId)
 			assert.True(t, pRef.UseRepoSettings())
-			assert.NoError(t, RemoveProjectAlias(ctx, projectAlias.ID.Hex()))
+			assert.NoError(t, RemoveProjectAlias(ctx, projectAlias.ProjectID, projectAlias.ID.Hex()))
 
 			assert.NoError(t, pRef.DetachFromRepo(t.Context(), dbUser))
 			aliases, err = FindAliasesForProjectFromDb(t.Context(), pRef.Id)

--- a/rest/data/aliases.go
+++ b/rest/data/aliases.go
@@ -79,7 +79,7 @@ func UpdateProjectAliases(ctx context.Context, projectId string, aliases []restM
 		return errors.Wrap(err, "upserting project aliases")
 	}
 	for _, aliasId := range aliasesToDelete {
-		catcher.Wrapf(model.RemoveProjectAlias(ctx, aliasId), "deleting project alias '%s'", aliasId)
+		catcher.Wrapf(model.RemoveProjectAlias(ctx, projectId, aliasId), "deleting project alias '%s'", aliasId)
 	}
 	return catcher.Resolve()
 }
@@ -112,7 +112,7 @@ func updateAliasesForSection(ctx context.Context, projectId string, updatedAlias
 		}
 		id := originalAlias.ID.Hex()
 		if _, ok := aliasesIdMap[id]; !ok {
-			catcher.Add(model.RemoveProjectAlias(ctx, id))
+			catcher.Add(model.RemoveProjectAlias(ctx, projectId, id))
 			modified = true
 		}
 	}

--- a/rest/data/project.go
+++ b/rest/data/project.go
@@ -362,7 +362,7 @@ func HideBranch(ctx context.Context, projectID string) error {
 		return errors.Wrapf(err, "finding aliases for project '%s'", pRef.Id)
 	}
 	for _, alias := range projectAliases {
-		if err := model.RemoveProjectAlias(ctx, alias.ID.Hex()); err != nil {
+		if err := model.RemoveProjectAlias(ctx, pRef.Id, alias.ID.Hex()); err != nil {
 			return errors.Wrapf(err, "removing project alias '%s' for project '%s'", alias.ID.Hex(), pRef.Id)
 		}
 	}

--- a/rest/route/alias_test.go
+++ b/rest/route/alias_test.go
@@ -32,7 +32,7 @@ func TestGetAliasesHandler(t *testing.T) {
 			projectAliases, err := dbModel.FindAliasesForProjectFromDb(ctx, "project_ref")
 			require.NoError(t, err)
 			require.Len(t, projectAliases, 1)
-			require.NoError(t, dbModel.RemoveProjectAlias(ctx, projectAliases[0].ID.Hex()))
+			require.NoError(t, dbModel.RemoveProjectAlias(ctx, projectAliases[0].ProjectID, projectAliases[0].ID.Hex()))
 
 			r, err := http.NewRequest(http.MethodGet, "/alias/project_ref", nil)
 			assert.NoError(t, err)


### PR DESCRIPTION
DEVPROD-36687

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Project alias upsert and delete operations were keyed only on the alias document ID, without verifying that the alias belonged to the project being edited. This change scopes both paths to the editing project:

### Testing
Added unit tests 


<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
