### PR TITLE
DEVPROD-36685: Escape user-provided description in notification emails

### DIFF
--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -63,10 +63,6 @@ type commonTemplateData struct {
 	emailContent *template.Template
 }
 
-type emailTemplateData struct {
-	commonTemplateData
-}
-
 const emailSubjectTemplateString string = `Evergreen: {{ .Object }} {{.DisplayName}} in '{{ .Project }}' has {{ .PastTenseStatus }}!`
 
 var subjectTmpl = template.Must(template.New("subject").Parse(emailSubjectTemplateString))
@@ -251,30 +247,27 @@ func makeHeaders(headerMap map[string][]string) http.Header {
 }
 
 func emailPayload(t *commonTemplateData) (*message.Email, error) {
-	emailData := &emailTemplateData{
-		commonTemplateData: *t,
-	}
 	bodyTmpl, err := emailBodyTemplate.Clone()
 	if err != nil {
 		return nil, errors.Wrap(err, "cloning email body template")
 	}
-	if emailData.emailContent == nil {
+	if t.emailContent == nil {
 		_, err = bodyTmpl.AddParseTree("content", emailDefaultContentTemplate.Tree)
 	} else {
-		_, err = bodyTmpl.AddParseTree("content", emailData.emailContent.Tree)
+		_, err = bodyTmpl.AddParseTree("content", t.emailContent.Tree)
 	}
 	if err != nil {
 		return nil, errors.Wrap(err, "adding email content")
 	}
 	buf := &bytes.Buffer{}
-	err = bodyTmpl.ExecuteTemplate(buf, "emailbody", emailData)
+	err = bodyTmpl.ExecuteTemplate(buf, "emailbody", t)
 	if err != nil {
 		return nil, errors.Wrap(err, "executing email template")
 	}
 	body := buf.String()
 
 	buf = &bytes.Buffer{}
-	err = subjectTmpl.Execute(buf, emailData)
+	err = subjectTmpl.Execute(buf, t)
 	if err != nil {
 		return nil, errors.Wrap(err, "executing email subject template")
 	}
@@ -284,13 +277,13 @@ func emailPayload(t *commonTemplateData) (*message.Email, error) {
 		Subject:           subject,
 		Body:              body,
 		PlainTextContents: false,
-		Headers:           emailData.Headers,
+		Headers:           t.Headers,
 	}
 
 	// prevent Gmail from threading notifications with similar subjects
-	m.Headers["X-Entity-Ref-Id"] = []string{fmt.Sprintf("%s-%s-%s", emailData.Object, emailData.SubscriptionID, emailData.EventID)}
-	m.Headers["X-Evergreen-Event-Id"] = []string{emailData.EventID}
-	m.Headers["X-Evergreen-Subscription-Id"] = []string{emailData.SubscriptionID}
+	m.Headers["X-Entity-Ref-Id"] = []string{fmt.Sprintf("%s-%s-%s", t.Object, t.SubscriptionID, t.EventID)}
+	m.Headers["X-Evergreen-Event-Id"] = []string{t.EventID}
+	m.Headers["X-Evergreen-Subscription-Id"] = []string{t.SubscriptionID}
 
 	return &m, nil
 }

--- a/trigger/payloads.go
+++ b/trigger/payloads.go
@@ -65,7 +65,6 @@ type commonTemplateData struct {
 
 type emailTemplateData struct {
 	commonTemplateData
-	Description template.HTML
 }
 
 const emailSubjectTemplateString string = `Evergreen: {{ .Object }} {{.DisplayName}} in '{{ .Project }}' has {{ .PastTenseStatus }}!`
@@ -254,7 +253,6 @@ func makeHeaders(headerMap map[string][]string) http.Header {
 func emailPayload(t *commonTemplateData) (*message.Email, error) {
 	emailData := &emailTemplateData{
 		commonTemplateData: *t,
-		Description:        template.HTML(t.Description),
 	}
 	bodyTmpl, err := emailBodyTemplate.Clone()
 	if err != nil {

--- a/trigger/payloads_test.go
+++ b/trigger/payloads_test.go
@@ -76,6 +76,17 @@ func (s *payloadSuite) TestEmailWithNilContent() {
 	s.Contains(m.Body, "Event: eventid")
 }
 
+func (s *payloadSuite) TestEmailEscapesDescriptionMarkup() {
+	s.t.Description = "<tag>text</tag>"
+
+	m, err := emailPayload(&s.t)
+	s.NoError(err)
+	s.Require().NotNil(m)
+
+	s.NotContains(m.Body, "<tag>")
+	s.Contains(m.Body, "&lt;tag&gt;text&lt;/tag&gt;")
+}
+
 func (s *payloadSuite) TestEmailWithTaskContent() {
 	s.t.Object = "task"
 	s.t.Task = &task.Task{


### PR DESCRIPTION
DEVPROD-36685

### Description

Notification emails now render the description field through Go's html/template auto-escaping instead of treating it as trusted markup. This keeps user-provided content from being interpreted as raw HTML in the rendered email body. 

### Testing

Added a test covering the escaping behavior.


<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
