### PR TITLE
DEVPROD-33891 Update Go-Jose Lib to address JWE vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -196,7 +196,7 @@ require (
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/coreos/go-oidc/v3 v3.16.0 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/google/go-github/v73 v73.0.0 // indirect
 	github.com/google/go-github/v75 v75.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -187,8 +187,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/fuyufjh/splunk-hec-go v0.4.0 h1:tU2RhiBEbKOqwl85JA4y77/orhpMOIVAI5YT4s/5Rr0=
 github.com/fuyufjh/splunk-hec-go v0.4.0/go.mod h1:r2fKHCRSkUIiz63Nh9FWGHrUr0N0WH2T4GO0JHuMCCU=
-github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
-github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/scripts/check-go-vulnerabilities.sh
+++ b/scripts/check-go-vulnerabilities.sh
@@ -25,7 +25,6 @@ IGNORED_PACKAGES=(
     "golang.org/x/net"                  # DEVPROD-33048 Go networking packages Lib
     "golang.org/x/crypto"               # DEVPROD-33754 Go crypto package vulnerability tracking
     "golang.org/x/sys"                  # DEVPROD-33756 Go sys package vulnerability tracking
-    "github.com/go-jose/go-jose/v4"     # DEVPROD-33891 go-jose vulnerability tracking
     "github.com/slack-go/slack"         # DEVPROD-25290 slack-go vulnerability tracking (fix requires Go 1.25)
 )
 


### PR DESCRIPTION
DEVPROD-33891

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Updated go-jose lib to v4.1.4 and removed from ignore list in vulnerabilities check script. 