### PR TITLE
DEVPROD-27062 Prohibit project YAML from setting itself as a module

### DIFF
--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -183,6 +183,7 @@ var projectSettingsValidators = []projectSettingsValidator{
 	validateTimeoutLimits,
 	validateReferentialIntegrity,
 	validateGitHubAppCheckRuns,
+	validateModulesNotOwnRepo,
 }
 
 func (vr ValidationError) Error() string {
@@ -1068,6 +1069,28 @@ func validateReferentialIntegrity(ctx context.Context, settings *evergreen.Setti
 	}
 	validationErrs = append(validationErrs, ensureReferentialIntegrity(p, distroIDs, distroAliases, singleTaskDistroIDs, singleTaskDistroAllowlist, distroWarnings)...)
 	return validationErrs
+}
+
+// validateModulesNotOwnRepo returns an error if a module points at the same
+// repo as the project.
+func validateModulesNotOwnRepo(_ context.Context, _ *evergreen.Settings, p *model.Project, ref *model.ProjectRef, _ bool) ValidationErrors {
+	errs := ValidationErrors{}
+	if ref == nil || ref.Owner == "" || ref.Repo == "" {
+		return errs
+	}
+	for _, module := range p.Modules {
+		owner, repo, err := module.GetOwnerAndRepo()
+		if err != nil {
+			continue
+		}
+		if strings.EqualFold(owner, ref.Owner) && strings.EqualFold(repo, ref.Repo) {
+			errs = append(errs, ValidationError{
+				Level:   Error,
+				Message: fmt.Sprintf("module '%s' cannot use the same repo ('%s/%s') as the project it is defined for", module.Name, ref.Owner, ref.Repo),
+			})
+		}
+	}
+	return errs
 }
 
 // validateGitHubAppCheckRuns returns warnings if the project has more check runs configured than allowed (which varies depending on GitHub App setup).


### PR DESCRIPTION
DEVPROD-27062

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Adds a new validation function to the project validator to disallow setting the project repo as a module. 