### PR TITLE
DEVPROD-31540 Change RunEveryMainlineCommit to bool pointer

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -50759,7 +50759,7 @@ func (ec *executionContext) _ProjectLite_runEveryMainlineCommit(ctx context.Cont
 			return obj.RunEveryMainlineCommit, nil
 		},
 		nil,
-		ec.marshalOBoolean2bool,
+		ec.marshalOBoolean2ᚖbool,
 		true,
 		false,
 	)

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -143,7 +143,7 @@ type ProjectRef struct {
 	// RunEveryMainlineCommit indicates that the project should activate the versions for all mainline commits.
 	// This goes against Evergreen's optimization of only activating the latest commit in a series of mainline commits.
 	// This is used for projects that use tasks on mainline commits to trigger downstream processes, like deployments.
-	RunEveryMainlineCommit bool `bson:"run_every_mainline_commit,omitempty" json:"run_every_mainline_commit,omitempty" yaml:"run_every_mainline_commit,omitempty"`
+	RunEveryMainlineCommit *bool `bson:"run_every_mainline_commit,omitempty" json:"run_every_mainline_commit,omitempty" yaml:"run_every_mainline_commit,omitempty"`
 }
 
 // GitHubDynamicTokenPermissionGroup is a permission group for GitHub dynamic access tokens.

--- a/model/version_activation.go
+++ b/model/version_activation.go
@@ -20,7 +20,7 @@ func DoProjectActivation(ctx context.Context, projectRef *ProjectRef, ts time.Ti
 	if !projectRef.IsWaterfallEnabled() {
 		return nil, nil
 	}
-	if projectRef.RunEveryMainlineCommit {
+	if projectRef.RunEveryMainlineCommit != nil && *projectRef.RunEveryMainlineCommit {
 		return activateEveryRecentMainlineCommitForProject(ctx, projectRef, ts)
 	}
 	return activateMostRecentNonIgnoredCommitForProject(ctx, projectRef, ts)

--- a/model/version_activation_test.go
+++ b/model/version_activation_test.go
@@ -215,7 +215,7 @@ func (s *VersionActivationSuite) TestDoProjectActivationMultipleUnactivatedCommi
 
 	projectRef := &ProjectRef{
 		Id:                     projectID,
-		RunEveryMainlineCommit: true,
+		RunEveryMainlineCommit: utility.TruePtr(),
 	}
 	require.NoError(projectRef.Insert(s.ctx))
 
@@ -348,7 +348,7 @@ func (s *VersionActivationSuite) TestDoProjectActivationNewProject() {
 
 	projectRef := &ProjectRef{
 		Id:                     projectID,
-		RunEveryMainlineCommit: true,
+		RunEveryMainlineCommit: utility.TruePtr(),
 	}
 	require.NoError(projectRef.Insert(s.ctx))
 
@@ -450,7 +450,7 @@ func (s *VersionActivationSuite) TestDoProjectActivationSingleCommitBehaviorPres
 
 	projectRef := &ProjectRef{
 		Id:                     projectID,
-		RunEveryMainlineCommit: true,
+		RunEveryMainlineCommit: utility.TruePtr(),
 	}
 	require.NoError(projectRef.Insert(s.ctx))
 
@@ -558,7 +558,7 @@ func (s *VersionActivationSuite) TestDoProjectActivationNoVersionsToActivate() {
 
 	projectRef := &ProjectRef{
 		Id:                     projectID,
-		RunEveryMainlineCommit: true,
+		RunEveryMainlineCommit: utility.TruePtr(),
 	}
 	require.NoError(projectRef.Insert(s.ctx))
 

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -654,7 +654,7 @@ func (p *APIProjectRef) ToService() (*model.ProjectRef, error) {
 		ProjectHealthView:                p.ProjectHealthView,
 		GitHubPermissionGroupByRequester: p.GitHubPermissionGroupByRequester,
 		TestSelection:                    p.TestSelection.ToService(),
-		RunEveryMainlineCommit:           utility.FromBoolPtr(p.RunEveryMainlineCommit),
+		RunEveryMainlineCommit:           p.RunEveryMainlineCommit,
 	}
 
 	if projectRef.ProjectHealthView == "" {
@@ -760,7 +760,7 @@ func (p *APIProjectRef) BuildPublicFields(ctx context.Context, projectRef model.
 	p.GithubMQTriggerAliases = utility.ToStringPtrSlice(projectRef.GithubMQTriggerAliases)
 	p.GitHubPermissionGroupByRequester = projectRef.GitHubPermissionGroupByRequester
 	p.TestSelection.BuildFromService(projectRef.TestSelection)
-	p.RunEveryMainlineCommit = utility.ToBoolPtr(projectRef.RunEveryMainlineCommit)
+	p.RunEveryMainlineCommit = projectRef.RunEveryMainlineCommit
 
 	if projectRef.ProjectHealthView == "" {
 		projectRef.ProjectHealthView = model.ProjectHealthViewFailed

--- a/rest/model/project_test.go
+++ b/rest/model/project_test.go
@@ -25,7 +25,7 @@ func TestRepoBuildFromService(t *testing.T) {
 			Allowed:        utility.FalsePtr(),
 			DefaultEnabled: utility.TruePtr(),
 		},
-		RunEveryMainlineCommit: true,
+		RunEveryMainlineCommit: utility.TruePtr(),
 	}}
 	apiRef := &APIProjectRef{}
 	assert.NoError(t, apiRef.BuildFromService(t.Context(), repoRef.ProjectRef))

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -473,7 +473,8 @@ func (s *ProjectPatchByIDSuite) TestRunEveryMainlineCommit() {
 
 	pRef, err := data.FindProjectById(s.T().Context(), "dimoxinil", false, false)
 	s.NoError(err)
-	s.True(pRef.RunEveryMainlineCommit)
+	s.NotNil(pRef.RunEveryMainlineCommit)
+	s.True(*pRef.RunEveryMainlineCommit)
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
DEVPROD-31540
<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

RunEveryMainlineCommit doesn't work with defaulting to repo settings (always gets set to false) and should be a bool pointer instead of a bool.

### Testing

Verified in staging that the value can correctly default to repo, rather than getting set to false.