### PR TITLE
DEVPROD-36627 Only run Windows tests if agent files are changed

### DIFF
--- a/agent/command/archive_util.go
+++ b/agent/command/archive_util.go
@@ -447,7 +447,7 @@ func findArchiveContents(ctx context.Context, rootPath string, includes, exclude
 		dir, filematch := filepath.Split(includePattern)
 		dir = filepath.Join(rootPath, dir)
 
-		if !utility.FileExists(dir) {
+		if strings.ContainsAny(dir, "*?[]") || !utility.FileExists(dir) {
 			continue
 		}
 

--- a/agent/command/archive_util_test.go
+++ b/agent/command/archive_util_test.go
@@ -343,7 +343,12 @@ func TestValidateRelativePath(t *testing.T) {
 		{name: "TraversalRejected", filePath: filepath.Join("..", "escape"), valid: false},
 		{name: "ParentRejected", filePath: "..", valid: false},
 		{name: "NestedTraversalRejected", filePath: filepath.Join("a", "..", "..", "b"), valid: false},
-		{name: "AbsolutePathRejected", filePath: filepath.Join(root, "file"), valid: false},
+		{name: "AbsolutePathRejected", filePath: func() string {
+			if runtime.GOOS == "windows" {
+				return `C:\absolute\file`
+			}
+			return filepath.Join(root, "file")
+		}(), valid: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := validateRelativePath(tc.filePath, root)

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -971,6 +972,9 @@ func (s *GitGetProjectSuite) TestMultipleModules() {
 func (s *GitGetProjectSuite) TestCloningWikiModule() {
 	if testing.Short() {
 		s.T().Skip("skipping network integration test in short mode")
+	}
+	if runtime.GOOS == "windows" {
+		s.T().Skip("the evergreen wiki repo contains a file with a colon in its name, which is illegal on Windows")
 	}
 	const ignoredPatchHash = "7b817a1908f7505cb9c05ac5601d4692793e1c0a"
 	const ignoredYAMLRef = "0000000000000000000000000000000000000001"

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-07-21"
+	AgentVersion = "2026-07-22"
 )
 
 const (

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -972,6 +972,8 @@ buildvariants:
 
   - name: windows
     display_name: Windows
+    paths:
+      - "agent/**"
     run_on:
       - windows-vsCurrent-small
       - windows-vsCurrent-large


### PR DESCRIPTION
DEVPROD-36627

### Description

I [fixed](https://spruce.corp.mongodb.com/version/6a60d92ad1fca40007b8e738/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) our windows tests and added BV filtering to only run the tests if the agent dir is changed. After merging I will update our own PR aliases accordingly!