### PR TITLE
DEVPROD-30934 Add default AWS region for host creation in API

### DIFF
--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -130,6 +130,11 @@ func CreateSpawnHost(ctx context.Context, so SpawnOptions, settings *evergreen.S
 			return nil, errors.Errorf("getting DBUser from User")
 		}
 		so.Region = dbUser.GetRegion()
+		// If the region could not be resolved from the user, use system-wide default.
+		if so.Region == "" {
+			grip.Warningf(ctx, "unable to determine region for spawn host, using default region: '%s'", evergreen.DefaultEC2Region)
+			so.Region = evergreen.DefaultEC2Region
+		}
 	}
 	if so.Userdata != "" {
 		if !evergreen.IsEc2Provider(d.Provider) {


### PR DESCRIPTION
DEVPROD-30934

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

`evergreen host create` was timing out because it depended on getting the region from the user's profile. If the user doesn't specify a region for the host and there's no region set on their profile, use the Evergreen default region (the description for region flag already indicates this behavior).

### Testing

<!--add a description of how you tested it-->

Verified in staging that the CLI command successfully spawns a host in the default region when no region is specified or configured in the user settings.