### PR TITLE
DEVPROD-36693: Fix synchronization in GitHub sender cache

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -1377,8 +1377,11 @@ type CreateInstallationTokenFunc func(ctx context.Context, owner, repo string) (
 // In case of GitHub app errors, the function returns the legacy GitHub sender with a global token attached.
 // The senders are only unique to orgs, not repos, but the repo name is needed to generate a token if necessary.
 func (e *envState) GetGitHubSender(owner, repo string, createInstallationToken CreateInstallationTokenFunc) (send.Sender, error) {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
+	// Hold a write lock for the whole function because the cache-miss path
+	// mutates e.githubSenders. Minting a sender is rare, so the loss of read
+	// concurrency is negligible and it avoids a concurrent map write.
+	e.mu.Lock()
+	defer e.mu.Unlock()
 
 	githubSender, ok := e.githubSenders[owner]
 	// If githubSender exists and has not expired, return it.

--- a/environment_test.go
+++ b/environment_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"os"
 	"strconv"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -141,4 +143,34 @@ func (s *EnvironmentSuite) TestInitSenders() {
 	for _, sender := range s.env.senders {
 		s.NotZero(sender.ErrorHandler(), "fallback error handler should be set")
 	}
+}
+
+func TestGetGitHubSenderConcurrentAccessShouldNotRace(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	e := &envState{
+		ctx:           ctx,
+		githubSenders: map[string]cachedGitHubSender{},
+	}
+	// Pre-populate an expired sender for the owner so every concurrent caller
+	// takes the cache-miss path that writes to the map.
+	e.githubSenders["owner"] = cachedGitHubSender{time: time.Now().Add(-2 * githubTokenTimeout)}
+
+	createToken := func(ctx context.Context, owner, repo string) (string, error) {
+		return "token", nil
+	}
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			sender, err := e.GetGitHubSender("owner", "repo", createToken)
+			assert.NoError(t, err)
+			assert.NotNil(t, sender)
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
DEVPROD-36693

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Adjusts the locking in `GetGitHubSender` so that the sender cache is accessed under proper synchronization. The cache is now guarded by a write lock for its full lifecycle, which corrects an inconsistency in how the shared map was accessed.

Also adds a regression test that exercises concurrent access to the cache and runs clean under the race detector.

### Testing

Tested with `RACE_DETECTOR=1 make test-evergreen RUN_TEST=GetGitHubSenderConcurrentAccess`



<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
