### PR TITLE
DEVPROD-37016: add OTel tracing for GitHub app installation client

### DIFF
--- a/model/githubapp/github_app_installation.go
+++ b/model/githubapp/github_app_installation.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -119,7 +120,7 @@ func getGitHubClientForAuth(authFields *GithubAppAuth) (*GitHubClient, error) {
 		return nil, errors.Wrap(err, "parsing private key")
 	}
 
-	itr := ghinstallation.NewAppsTransportFromPrivateKey(utility.DefaultTransport(), authFields.AppID, key)
+	itr := ghinstallation.NewAppsTransportFromPrivateKey(otelhttp.NewTransport(utility.DefaultTransport()), authFields.AppID, key)
 	httpClient := utility.GetCustomHTTPRetryableClientWithTransport(itr, githubClientShouldRetry(), utility.RetryHTTPDelay(utility.RetryOptions{
 		MinDelay:    GitHubRetryMinDelay,
 		MaxDelay:    GitHubRetryMaxDelay,


### PR DESCRIPTION
DEVPROD-37016

### Description

Add OTel tracing so we can tell what HTTP requests are made to GitHub for GitHub app installations.

### Testing

Tested in staging to verify that `github.generate_token` still works and adds spans for GitHub app installations requests ([example](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/m2fov6ifGQ5/trace/FNBzLZMDiYG?fields[]=s_name&fields[]=s_serviceName&span=f488320385520438)).