### PR TITLE
DEVPROD-36689: Redact UserData in EC2 AWS request logging

### DIFF
--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"time"
 
@@ -1542,10 +1543,50 @@ func makeAWSLogMessage(name, client string, args any) message.Fields {
 
 	argMap := make(map[string]any)
 	if err := mapstructure.Decode(args, &argMap); err == nil {
+		redactAWSUserData(argMap)
 		msg["args"] = argMap
 	} else {
 		msg["args"] = fmt.Sprintf("%+v", args)
 	}
 
 	return msg
+}
+
+// redactAWSUserData recursively redacts any UserData field in a decoded AWS
+// request. Nested structs are decoded into fresh maps so the caller's original
+// request is never mutated.
+func redactAWSUserData(argMap map[string]any) {
+	for k, v := range argMap {
+		if k == "UserData" {
+			argMap[k] = "{REDACTED}"
+			continue
+		}
+		if nested := decodeAWSStruct(v); nested != nil {
+			redactAWSUserData(nested)
+			argMap[k] = nested
+		}
+	}
+}
+
+// decodeAWSStruct decodes a struct or pointer-to-struct value into a fresh map
+// so it can be recursively redacted. It returns nil for any other kind of value.
+func decodeAWSStruct(v any) map[string]any {
+	if v == nil {
+		return nil
+	}
+	rv := reflect.ValueOf(v)
+	for rv.Kind() == reflect.Ptr {
+		if rv.IsNil() {
+			return nil
+		}
+		rv = rv.Elem()
+	}
+	if rv.Kind() != reflect.Struct {
+		return nil
+	}
+	m := make(map[string]any)
+	if err := mapstructure.Decode(rv.Interface(), &m); err != nil {
+		return nil
+	}
+	return m
 }

--- a/cloud/ec2_client_test.go
+++ b/cloud/ec2_client_test.go
@@ -1,0 +1,44 @@
+package cloud
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeAWSLogMessageRedactsUserData(t *testing.T) {
+	const secretUserData = "c29tZS1ob3N0LXNlY3JldA==" //nolint:gosec // Not a real secret.
+
+	t.Run("NestedUserDataInLaunchTemplateIsRedacted", func(t *testing.T) {
+		input := &ec2.CreateLaunchTemplateInput{
+			LaunchTemplateName: aws.String("template"),
+			LaunchTemplateData: &types.RequestLaunchTemplateData{
+				UserData: aws.String(secretUserData),
+			},
+		}
+		msg := makeAWSLogMessage("CreateLaunchTemplate", "client", input)
+
+		args, ok := msg["args"].(map[string]any)
+		require.True(t, ok)
+		launchTemplateData, ok := args["LaunchTemplateData"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "{REDACTED}", launchTemplateData["UserData"])
+		require.Contains(t, args, "LaunchTemplateName")
+	})
+
+	t.Run("TopLevelUserDataInRunInstancesIsRedacted", func(t *testing.T) {
+		input := &ec2.RunInstancesInput{
+			UserData:     aws.String(secretUserData),
+			InstanceType: types.InstanceTypeT2Micro,
+		}
+		msg := makeAWSLogMessage("RunInstances", "client", input)
+
+		args, ok := msg["args"].(map[string]any)
+		require.True(t, ok)
+		require.Equal(t, "{REDACTED}", args["UserData"])
+		require.Contains(t, args, "InstanceType")
+	})
+}


### PR DESCRIPTION
DEVPROD-36689

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Redacts the UserData field from EC2 AWS API request logs. Covers both RunInstances and CreateLaunchTemplate inputs.

  
### Testing
Added a unit test verifying redaction for top-level and nested UserData fields.




<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
