### PR TITLE
DEVPROD-36683 Bind debug daemon to localhost

### DIFF
--- a/operations/local_daemon_rest.go
+++ b/operations/local_daemon_rest.go
@@ -54,7 +54,7 @@ func (d *localDaemonREST) Start() error {
 	}
 
 	grip.Infof(context.Background(), "Starting REST daemon on port %d", d.port)
-	return http.ListenAndServe(fmt.Sprintf(":%d", d.port), router)
+	return http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", d.port), router)
 }
 
 // handleHealth checks if the daemon is running


### PR DESCRIPTION
DEVPROD-36683

### Description

The debug daemon's HTTP listener was binding to all network interfaces, making it reachable from other hosts on the network despite only being used locally. This restricts it to localhost, which is how the client already connects.
### Testing

Existing tests and ran a debug task in staging.
