### PR TITLE
DEVPROD-37017: use OTel instrumentation for HTTP clients by default

### DIFF
--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -23,7 +23,6 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // The DockerClient interface wraps the Docker dockerClient interaction.
@@ -145,12 +144,17 @@ func (c *dockerClientImpl) Init(apiVersion string) error {
 	return nil
 }
 
-// getHTTPClient returns an HTTP client for Docker.
+// getHTTPClient returns an HTTP client for Docker. The transport is left as a
+// plain *http.Transport (rather than being wrapped with otelhttp instrumentation
+// like the utility HTTP client pool) because the Docker client inspects the
+// transport to detect that it must communicate over TLS. Wrapping the transport
+// hides it from the Docker client, which then sends plain HTTP requests to the
+// TLS Docker daemon.
 func (c *dockerClientImpl) getHTTPClient(timeout time.Duration) *http.Client {
 	transport := utility.DefaultTransport()
 	transport.TLSClientConfig.InsecureSkipVerify = true
 
-	client := utility.DefaultHttpClient(otelhttp.NewTransport(transport))
+	client := utility.DefaultHttpClient(transport)
 	if timeout > 0 {
 		client.Timeout = timeout
 	}

--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -23,6 +23,7 @@ import (
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
 // The DockerClient interface wraps the Docker dockerClient interaction.
@@ -136,35 +137,25 @@ func (c *dockerClientImpl) createClient(h *host.Host, httpClient *http.Client, t
 func (c *dockerClientImpl) Init(apiVersion string) error {
 	c.apiVersion = apiVersion
 
-	var err error
-	c.httpClient, err = c.getHTTPClient(0)
-	if err != nil {
-		return errors.Wrap(err, "creating HTTP client")
-	}
+	c.httpClient = c.getHTTPClient(0)
 
 	// Create HTTP client for importing images with higher timeout.
-	c.importHTTPClient, err = c.getHTTPClient(imageImportTimeout)
-	if err != nil {
-		return errors.Wrap(err, "creating HTTP client for importing images")
-	}
+	c.importHTTPClient = c.getHTTPClient(imageImportTimeout)
 
 	return nil
 }
 
 // getHTTPClient returns an HTTP client for Docker.
-func (c *dockerClientImpl) getHTTPClient(timeout time.Duration) (*http.Client, error) {
-	client := utility.GetHTTPClient()
+func (c *dockerClientImpl) getHTTPClient(timeout time.Duration) *http.Client {
+	transport := utility.DefaultTransport()
+	transport.TLSClientConfig.InsecureSkipVerify = true
 
+	client := utility.DefaultHttpClient(otelhttp.NewTransport(transport))
 	if timeout > 0 {
 		client.Timeout = timeout
 	}
-	transport, ok := client.Transport.(*http.Transport)
-	if !ok {
-		return client, errors.New("type assertion failed: transport is not an *http.Transport")
-	}
-	transport.TLSClientConfig.InsecureSkipVerify = true
 
-	return client, nil
+	return client
 }
 
 // EnsureImageDownloaded checks if the image in s3 specified by the URL already exists,

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-07-21"
+	AgentVersion = "2026-07-22"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/evergreen-ci/pail v0.0.0-20260618132147-c9bcc0488a7f
 	github.com/evergreen-ci/poplar v0.0.0-20260330180450-c8cf511d1bd6
 	github.com/evergreen-ci/shrub v0.0.0-20251017154811-4d3ed1599154
-	github.com/evergreen-ci/utility v0.0.0-20260116164328-250718d590d2
+	github.com/evergreen-ci/utility v0.0.0-20260721175728-1efbb3c9cac1
 	github.com/gonzojive/httpcache v0.0.0-20220509000156-e80a5e6a69fe
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gorilla/mux v1.8.1
@@ -33,7 +33,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mongodb/amboy v0.0.0-20260326190628-51c8dde3a7f5
 	github.com/mongodb/anser v0.0.0-20260326191204-f2d0a92e3f0a
-	github.com/mongodb/grip v0.0.0-20260721180657-45243b88445c
+	github.com/mongodb/grip v0.0.0-20260722151137-692eb0583f05
 	github.com/pkg/errors v0.9.1
 	github.com/ravilushqa/otelgqlgen v0.19.0
 	github.com/robbiet480/go.sns v0.0.0-20210223081447-c7c9eb6836cb

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/evergreen-ci/shrub v0.0.0-20251017154811-4d3ed1599154 h1:YO1VY9Qj68Kj
 github.com/evergreen-ci/shrub v0.0.0-20251017154811-4d3ed1599154/go.mod h1:nDQB46oIkI/BmvuNKkHdJekvXuGm8lvfUBcbbjekMZM=
 github.com/evergreen-ci/test-selection-client v0.0.0-20260409173604-004964bcf728 h1:7dFa0fx1u5BwUg3Kbf71iaglBsyQJfkYLFd3CfVHxUA=
 github.com/evergreen-ci/test-selection-client v0.0.0-20260409173604-004964bcf728/go.mod h1:0iD20pmczefJcyBCIuYuwfq9J3cqWOM5v61znyqcAwY=
-github.com/evergreen-ci/utility v0.0.0-20260116164328-250718d590d2 h1:p5kFLuoZu3SuP5AnmmLT58pSSxq8S0wNDEvjZHVcg2I=
-github.com/evergreen-ci/utility v0.0.0-20260116164328-250718d590d2/go.mod h1:Al1Mt6zmPNfdvH/Zd99nrjNoSyHK5g4zE/1tv9MiWQU=
+github.com/evergreen-ci/utility v0.0.0-20260721175728-1efbb3c9cac1 h1:sxnClHN9nFejto80mQBjp4ltOLZV+12BzNF10/Srkls=
+github.com/evergreen-ci/utility v0.0.0-20260721175728-1efbb3c9cac1/go.mod h1:A03U7o6F4PDMNz+lD9mktDgy53wWJHgfR6Bk1fndBJc=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -323,8 +323,8 @@ github.com/mongodb/anser v0.0.0-20260326191204-f2d0a92e3f0a h1:aerBBPXwQOo+s1BR7
 github.com/mongodb/anser v0.0.0-20260326191204-f2d0a92e3f0a/go.mod h1:y5tT5wIiax8QSqifu02lYQcumwsvAwAYb2PmpguRyfE=
 github.com/mongodb/ftdc v0.0.0-20251208183831-018e343a1aac h1:KL3+DC+q8yS+QmdPAvnJiMHNU9VcYD3+4+0U1F+Crzo=
 github.com/mongodb/ftdc v0.0.0-20251208183831-018e343a1aac/go.mod h1:iaQJgZ9mNDQzR9Y8BY6D/Y6i8IzadyjY91a20xE5sOE=
-github.com/mongodb/grip v0.0.0-20260721180657-45243b88445c h1:JU7R1E7tJxl30MmO9YwbXCc5KWmO2F3679IxrVtqRIU=
-github.com/mongodb/grip v0.0.0-20260721180657-45243b88445c/go.mod h1:nIxXGOFRWYjuwlgZlhj7BvCE6MjPuOFr3xbe9IcbKDo=
+github.com/mongodb/grip v0.0.0-20260722151137-692eb0583f05 h1:Cv0u/BjKVPg6EWurKHoQfFtCdbwv2yXM/AzjU5aRwUc=
+github.com/mongodb/grip v0.0.0-20260722151137-692eb0583f05/go.mod h1:NtYrBFAm5EkpnHUOUSKMnJbL6Ojr6Cza8ZdBQHNYZkw=
 github.com/mongodb/jasper v0.0.0-20260330133616-5411573646d1 h1:SSUZlMk2YvlnqB8o8BxdQzEBACZ/m0/Biu8uljAYCTc=
 github.com/mongodb/jasper v0.0.0-20260330133616-5411573646d1/go.mod h1:dNPRgqt6EwehE2ADcYPuvtVy+3/RbgY956R+R6Ln58s=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=


### PR DESCRIPTION
DEVPROD-37017

### Description

This adds instrumentation by default for all HTTP clients retrieved from `utility.GetHTTPClient`. With this, we can more easily see requests made from Evergreen and the agent. We also get instrumentation automatically whenever a new caller uses an HTTP client from the pool.

* Bump utility to get the OTel instrumentation by default (https://github.com/evergreen-ci/utility/pull/85)
* Bump grip to deduplicate OTel instrumentation (https://github.com/mongodb/grip/pull/178).
~* Set up OTel tracing for Docker container pool client.~ (Apparently this is not possible because Docker detects that the transport will use HTTPS if using the OTel wrapper.)

### Testing

Tested in personal staging to confirm the instrumentation works as expected:
* Pre-change, traces don't show detailed HTTP request breakdowns sometimes unless explicitly instrumented (e.g. [this s3.put](https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen-agent/result/dakwFPubWzj/trace/gVHdJJdNTTJ?fields[]=s_name&span=cf7fbc8948f1e153) doesn't show any info about the requests made to S3). 
* Post-change, traces now show individual HTTP requests by default (e.g. [this s3.put](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen-agent/result/8LhUe2RN7j9/trace/4NwbLP6HEAW?fields[]=s_name&fields[]=s_serviceName&span=28d490f8d336a8ba) shows a HEAD/PUT to S3, followed by a POST back to Evergreen for the artifacts).