### PR TITLE
 DEVPROD-36651: Shell-quote values in debug spawn-host setup script

### DIFF
--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -360,8 +360,8 @@ fi
 
 echo "Debug daemon started successfully."
 
-evergreen debug load "%s"
-evergreen debug select "%s" --variant "%s"
+evergreen debug load %s
+evergreen debug select %s --variant %s
 evergreen debug run-until %s
 
 if [ $? -eq 0 ]; then
@@ -369,7 +369,7 @@ if [ $? -eq 0 ]; then
 else
   echo "ERROR: Debug setup script failed during execution."
 fi
-`, configPath, t.DisplayName, t.BuildVariant, stepNum, stepNum), nil
+`, util.ShellQuote(configPath), util.ShellQuote(t.DisplayName), util.ShellQuote(t.BuildVariant), util.ShellQuote(stepNum), stepNum), nil
 }
 
 func CheckInstanceTypeValid(ctx context.Context, d distro.Distro, requestedType string, allowedTypes []string) error {

--- a/util/shell.go
+++ b/util/shell.go
@@ -7,3 +7,9 @@ import "strings"
 func PowerShellQuotedString(s string) string {
 	return "@'\n" + strings.Replace(strings.Replace(s, `\`, `\\`, -1), `"`, `""`, -1) + "\n'@"
 }
+
+// ShellQuote returns s quoted for safe use as a single literal argument in a
+// POSIX shell command.
+func ShellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/util/shell_test.go
+++ b/util/shell_test.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShellQuote(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input    string
+		expected string
+	}{
+		"PlainString":         {input: "my-task", expected: `'my-task'`},
+		"StringWithSpaces":    {input: "my task", expected: `'my task'`},
+		"EmptyString":         {input: "", expected: `''`},
+		"DoubleQuote":         {input: `a"b`, expected: `'a"b'`},
+		"SingleQuote":         {input: "a'b", expected: `'a'\''b'`},
+		"CommandSubstitution": {input: "$(cmd)", expected: `'$(cmd)'`},
+		"Backtick":            {input: "`cmd`", expected: "'`cmd`'"},
+		"Newline":             {input: "a\nb", expected: "'a\nb'"},
+		"Backslash":           {input: `a\b`, expected: `'a\b'`},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, ShellQuote(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
 DEVPROD-36651

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
The debug spawn-host setup script put the task name, variant name, and step number straight into shell commands. This quotes them with a new util.ShellQuote helper so they are treated as plain text.

### Testing

Added a test 


<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
