### PR TITLE
DEVPROD-36672: Harden git file restore against unsafe include filenames

### DIFF
--- a/thirdparty/git.go
+++ b/thirdparty/git.go
@@ -411,7 +411,9 @@ func GitRestoreFile(ctx context.Context, owner, repo, revision, gitDir string, f
 		return nil, errors.Wrapf(err, "validating file path '%s' is within git repo directory", fileName)
 	}
 
-	cmd := exec.CommandContext(ctx, "git", "restore", "--source=HEAD", fileName)
+	// Pass "--" so git never interprets the user-provided filename as an option,
+	// and use a literal pathspec so leading ':' cannot invoke pathspec magic.
+	cmd := exec.CommandContext(ctx, "git", "restore", "--source=HEAD", "--", ":(literal)"+fileName)
 	cmd.Dir = gitDir
 	cmd.WaitDelay = gitOperationWaitDelay
 	var stdout, stderr strings.Builder
@@ -459,6 +461,15 @@ func GitRestoreFile(ctx context.Context, owner, repo, revision, gitDir string, f
 func validateFileIsWithinDirectory(dir, file string) error {
 	// Normalize the path (e.g. removes redundant separators, resolves ".").
 	cleanPath := filepath.Clean(file)
+
+	// Reject values that git could interpret as an option or a magic pathspec
+	// rather than a literal filename.
+	if strings.HasPrefix(cleanPath, "-") {
+		return errors.Errorf("file '%s' cannot begin with '-'", file)
+	}
+	if strings.HasPrefix(file, ":") {
+		return errors.Errorf("file '%s' cannot begin with ':'", file)
+	}
 
 	if filepath.IsAbs(cleanPath) {
 		return errors.Errorf("file '%s' must be a relative path, not absolute", file)

--- a/thirdparty/git_test.go
+++ b/thirdparty/git_test.go
@@ -224,6 +224,26 @@ func TestValidateFileIsWithinDirectory(t *testing.T) {
 		err := validateFileIsWithinDirectory(parentDir, "src/../etc/../../passwd")
 		assert.Error(t, err)
 	})
+
+	t.Run("LeadingDashDisallowed", func(t *testing.T) {
+		err := validateFileIsWithinDirectory(parentDir, "--pathspec-from-file=/etc/hostname")
+		assert.Error(t, err)
+	})
+
+	t.Run("ShortOptionDisallowed", func(t *testing.T) {
+		err := validateFileIsWithinDirectory(parentDir, "-p")
+		assert.Error(t, err)
+	})
+
+	t.Run("LeadingColonDisallowed", func(t *testing.T) {
+		err := validateFileIsWithinDirectory(parentDir, ":/")
+		assert.Error(t, err)
+	})
+
+	t.Run("MagicPathspecDisallowed", func(t *testing.T) {
+		err := validateFileIsWithinDirectory(parentDir, ":(exclude)foo")
+		assert.Error(t, err)
+	})
 }
 
 func TestValidateFileIsNotSymlink(t *testing.T) {


### PR DESCRIPTION
DEVPROD-36672

### Description

Adds input hardening to the app-server git file-restore path used when resolving project include files. Filenames are now passed to git in a way that ensures they are always treated as literal paths, and the path validator rejects a class of unsafe values it previously allowed.

No behavior change for valid file paths; the GitHub API fallback and file-not-found handling are unaffected.

### Testing

Added a test 



<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
