### PR TITLE
DEVPROD-37748 Fix check-modernize regression in environment_test.go

### DIFF
--- a/environment_test.go
+++ b/environment_test.go
@@ -146,8 +146,7 @@ func (s *EnvironmentSuite) TestInitSenders() {
 }
 
 func TestGetGitHubSenderConcurrentAccessShouldNotRace(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	e := &envState{
 		ctx:           ctx,
@@ -164,7 +163,7 @@ func TestGetGitHubSenderConcurrentAccessShouldNotRace(t *testing.T) {
 	const goroutines = 20
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
 			sender, err := e.GetGitHubSender("owner", "repo", createToken)


### PR DESCRIPTION
DEVPROD-37748

### Description

`check-modernize` is failing on main. Two modernize findings were introduced in `environment_test.go` by DEVPROD-36693 (#10555):

- `TestGetGitHubSenderConcurrentAccessShouldNotRace` used `context.WithCancel(context.Background())` + `defer cancel()` instead of `t.Context()` (testingcontext).
- A `for i := 0; i < goroutines; i++` loop that can `range` over an int (rangeint).

This applies the modernize-suggested fixes so the check passes.

### Testing

- `make modernize` now passes.
- `go test -run TestGetGitHubSenderConcurrentAccessShouldNotRace ./` passes.