### PR TITLE
DEVPROD-37845: Count real max hosts when using task tags

### DIFF
--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -1861,11 +1861,6 @@ func evaluateTaskUnits(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, v
 			Timeout:                  ptg.Timeout,
 			ShareProcs:               ptg.ShareProcs,
 		}
-		if tg.MaxHosts == -1 {
-			tg.MaxHosts = len(ptg.Tasks)
-		} else if tg.MaxHosts < 1 {
-			tg.MaxHosts = 1
-		}
 		// expand, validate that tasks defined in a group are listed in the project tasks
 		var taskNames []string
 		for _, taskName := range ptg.Tasks {
@@ -1879,6 +1874,14 @@ func evaluateTaskUnits(tse *taskSelectorEvaluator, tgse *tagSelectorEvaluator, v
 			taskNames = append(taskNames, names...)
 		}
 		tg.Tasks = taskNames
+		// Max hosts has to be resolved after the task selectors are expanded so
+		// that -1 counts the actual tasks in the group rather than the number of
+		// selectors that produced them.
+		if tg.MaxHosts == -1 {
+			tg.MaxHosts = len(tg.Tasks)
+		} else if tg.MaxHosts < 1 {
+			tg.MaxHosts = 1
+		}
 		groups = append(groups, tg)
 	}
 	return tasks, groups, evalErrs

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -1611,6 +1611,40 @@ buildvariants:
 		assert.Equal(t, "example_task_group", proj.TaskGroups[0].Name)
 		assert.Len(t, proj.TaskGroups[0].Tasks, proj.TaskGroups[0].MaxHosts)
 	})
+
+	t.Run("UnlimitedMaxHostsForTaskGroupWithTagSelectorsCountsExpandedTasks", func(t *testing.T) {
+		tagMaxHostYml := `
+tasks:
+- name: build_1
+  tags: [ "build" ]
+- name: build_2
+  tags: [ "build" ]
+- name: test_1
+  tags: [ "test" ]
+- name: test_2
+  tags: [ "test" ]
+- name: test_3
+  tags: [ "test" ]
+task_groups:
+- name: example_task_group
+  max_hosts: -1
+  tasks:
+  - .build
+  - .test
+buildvariants:
+- name: bv
+  display_name: "bv_display"
+  tasks:
+  - name: example_task_group
+`
+		proj := &Project{}
+		_, err := LoadProjectInto(ctx, []byte(tagMaxHostYml), nil, "id", proj)
+		require.NotNil(t, proj)
+		assert.NoError(t, err)
+		require.Len(t, proj.TaskGroups, 1)
+		require.Len(t, proj.TaskGroups[0].Tasks, 5)
+		assert.Equal(t, 5, proj.TaskGroups[0].MaxHosts)
+	})
 }
 
 func TestTaskGroupWithDisplayTask(t *testing.T) {


### PR DESCRIPTION
DEVPROD-37845

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->
This fixes a bug where we weren't counting the real max hosts when the task group selected task tags

### Testing

<!--add a description of how you tested it-->
Unit test, fails on main but passes with the change.