### PR TITLE
Revert "DEVPROD-37017: use OTel instrumentation for HTTP clients by d…

### DIFF
--- a/cloud/docker_client.go
+++ b/cloud/docker_client.go
@@ -136,30 +136,35 @@ func (c *dockerClientImpl) createClient(h *host.Host, httpClient *http.Client, t
 func (c *dockerClientImpl) Init(apiVersion string) error {
 	c.apiVersion = apiVersion
 
-	c.httpClient = c.getHTTPClient(0)
+	var err error
+	c.httpClient, err = c.getHTTPClient(0)
+	if err != nil {
+		return errors.Wrap(err, "creating HTTP client")
+	}
 
 	// Create HTTP client for importing images with higher timeout.
-	c.importHTTPClient = c.getHTTPClient(imageImportTimeout)
+	c.importHTTPClient, err = c.getHTTPClient(imageImportTimeout)
+	if err != nil {
+		return errors.Wrap(err, "creating HTTP client for importing images")
+	}
 
 	return nil
 }
 
-// getHTTPClient returns an HTTP client for Docker. The transport is left as a
-// plain *http.Transport (rather than being wrapped with otelhttp instrumentation
-// like the utility HTTP client pool) because the Docker client inspects the
-// transport to detect that it must communicate over TLS. Wrapping the transport
-// hides it from the Docker client, which then sends plain HTTP requests to the
-// TLS Docker daemon.
-func (c *dockerClientImpl) getHTTPClient(timeout time.Duration) *http.Client {
-	transport := utility.DefaultTransport()
-	transport.TLSClientConfig.InsecureSkipVerify = true
+// getHTTPClient returns an HTTP client for Docker.
+func (c *dockerClientImpl) getHTTPClient(timeout time.Duration) (*http.Client, error) {
+	client := utility.GetHTTPClient()
 
-	client := utility.DefaultHttpClient(transport)
 	if timeout > 0 {
 		client.Timeout = timeout
 	}
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		return client, errors.New("type assertion failed: transport is not an *http.Transport")
+	}
+	transport.TLSClientConfig.InsecureSkipVerify = true
 
-	return client
+	return client, nil
 }
 
 // EnsureImageDownloaded checks if the image in s3 specified by the URL already exists,

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/evergreen-ci/pail v0.0.0-20260618132147-c9bcc0488a7f
 	github.com/evergreen-ci/poplar v0.0.0-20260330180450-c8cf511d1bd6
 	github.com/evergreen-ci/shrub v0.0.0-20251017154811-4d3ed1599154
-	github.com/evergreen-ci/utility v0.0.0-20260721175728-1efbb3c9cac1
+	github.com/evergreen-ci/utility v0.0.0-20260116164328-250718d590d2
 	github.com/gonzojive/httpcache v0.0.0-20220509000156-e80a5e6a69fe
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gorilla/mux v1.8.1
@@ -33,7 +33,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mongodb/amboy v0.0.0-20260326190628-51c8dde3a7f5
 	github.com/mongodb/anser v0.0.0-20260326191204-f2d0a92e3f0a
-	github.com/mongodb/grip v0.0.0-20260722151137-692eb0583f05
+	github.com/mongodb/grip v0.0.0-20260721180657-45243b88445c
 	github.com/pkg/errors v0.9.1
 	github.com/ravilushqa/otelgqlgen v0.19.0
 	github.com/robbiet480/go.sns v0.0.0-20210223081447-c7c9eb6836cb

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/evergreen-ci/shrub v0.0.0-20251017154811-4d3ed1599154 h1:YO1VY9Qj68Kj
 github.com/evergreen-ci/shrub v0.0.0-20251017154811-4d3ed1599154/go.mod h1:nDQB46oIkI/BmvuNKkHdJekvXuGm8lvfUBcbbjekMZM=
 github.com/evergreen-ci/test-selection-client v0.0.0-20260409173604-004964bcf728 h1:7dFa0fx1u5BwUg3Kbf71iaglBsyQJfkYLFd3CfVHxUA=
 github.com/evergreen-ci/test-selection-client v0.0.0-20260409173604-004964bcf728/go.mod h1:0iD20pmczefJcyBCIuYuwfq9J3cqWOM5v61znyqcAwY=
-github.com/evergreen-ci/utility v0.0.0-20260721175728-1efbb3c9cac1 h1:sxnClHN9nFejto80mQBjp4ltOLZV+12BzNF10/Srkls=
-github.com/evergreen-ci/utility v0.0.0-20260721175728-1efbb3c9cac1/go.mod h1:A03U7o6F4PDMNz+lD9mktDgy53wWJHgfR6Bk1fndBJc=
+github.com/evergreen-ci/utility v0.0.0-20260116164328-250718d590d2 h1:p5kFLuoZu3SuP5AnmmLT58pSSxq8S0wNDEvjZHVcg2I=
+github.com/evergreen-ci/utility v0.0.0-20260116164328-250718d590d2/go.mod h1:Al1Mt6zmPNfdvH/Zd99nrjNoSyHK5g4zE/1tv9MiWQU=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -323,8 +323,8 @@ github.com/mongodb/anser v0.0.0-20260326191204-f2d0a92e3f0a h1:aerBBPXwQOo+s1BR7
 github.com/mongodb/anser v0.0.0-20260326191204-f2d0a92e3f0a/go.mod h1:y5tT5wIiax8QSqifu02lYQcumwsvAwAYb2PmpguRyfE=
 github.com/mongodb/ftdc v0.0.0-20251208183831-018e343a1aac h1:KL3+DC+q8yS+QmdPAvnJiMHNU9VcYD3+4+0U1F+Crzo=
 github.com/mongodb/ftdc v0.0.0-20251208183831-018e343a1aac/go.mod h1:iaQJgZ9mNDQzR9Y8BY6D/Y6i8IzadyjY91a20xE5sOE=
-github.com/mongodb/grip v0.0.0-20260722151137-692eb0583f05 h1:Cv0u/BjKVPg6EWurKHoQfFtCdbwv2yXM/AzjU5aRwUc=
-github.com/mongodb/grip v0.0.0-20260722151137-692eb0583f05/go.mod h1:NtYrBFAm5EkpnHUOUSKMnJbL6Ojr6Cza8ZdBQHNYZkw=
+github.com/mongodb/grip v0.0.0-20260721180657-45243b88445c h1:JU7R1E7tJxl30MmO9YwbXCc5KWmO2F3679IxrVtqRIU=
+github.com/mongodb/grip v0.0.0-20260721180657-45243b88445c/go.mod h1:nIxXGOFRWYjuwlgZlhj7BvCE6MjPuOFr3xbe9IcbKDo=
 github.com/mongodb/jasper v0.0.0-20260330133616-5411573646d1 h1:SSUZlMk2YvlnqB8o8BxdQzEBACZ/m0/Biu8uljAYCTc=
 github.com/mongodb/jasper v0.0.0-20260330133616-5411573646d1/go.mod h1:dNPRgqt6EwehE2ADcYPuvtVy+3/RbgY956R+R6Ln58s=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=


### PR DESCRIPTION
…efault (#10561)"

This reverts commit 3787788e396d65acf1ba3515ab0ab8f48236b6e0.

Reverting because [the OTel collectors can't handle the load from adding more spans](https://mongodb.slack.com/archives/C0BKS6LT65P/p1784933188005429).