### PR TITLE
PLATFORMS-2447: Add the distro container-isolation model and kill switch

### DIFF
--- a/config_db.go
+++ b/config_db.go
@@ -101,7 +101,7 @@ var (
 	backgroundCommandFailureEnabledKey    = bsonutil.MustHaveTag(ServiceFlags{}, "BackgroundCommandFailureEnabled")
 	apiRateLimiterDisabledKey             = bsonutil.MustHaveTag(ServiceFlags{}, "APIRateLimiterDisabled")
 	graphqlComplexityLimiterDisabledKey   = bsonutil.MustHaveTag(ServiceFlags{}, "GraphQLComplexityLimiterDisabled")
-	containerIsolationDisabledKey         = bsonutil.MustHaveTag(ServiceFlags{}, "ContainerIsolationDisabled")
+	containerIsolationEnabledKey          = bsonutil.MustHaveTag(ServiceFlags{}, "ContainerIsolationEnabled")
 
 	// DiagnosticsConfig keys
 	diagnosticsS3BucketNameKey = bsonutil.MustHaveTag(DiagnosticsConfig{}, "S3BucketName")

--- a/config_db.go
+++ b/config_db.go
@@ -101,6 +101,7 @@ var (
 	backgroundCommandFailureEnabledKey    = bsonutil.MustHaveTag(ServiceFlags{}, "BackgroundCommandFailureEnabled")
 	apiRateLimiterDisabledKey             = bsonutil.MustHaveTag(ServiceFlags{}, "APIRateLimiterDisabled")
 	graphqlComplexityLimiterDisabledKey   = bsonutil.MustHaveTag(ServiceFlags{}, "GraphQLComplexityLimiterDisabled")
+	containerIsolationDisabledKey         = bsonutil.MustHaveTag(ServiceFlags{}, "ContainerIsolationDisabled")
 
 	// DiagnosticsConfig keys
 	diagnosticsS3BucketNameKey = bsonutil.MustHaveTag(DiagnosticsConfig{}, "S3BucketName")

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -44,10 +44,11 @@ type ServiceFlags struct {
 	PodDiagnosticsDisabled             bool `bson:"pod_diagnostics_disabled" json:"pod_diagnostics_disabled"`
 	RetryFailedLogMoveEnabled          bool `bson:"retry_failed_log_move_enabled" json:"retry_failed_log_move_enabled"`
 	ProjectTranslationCacheEnabled     bool `bson:"project_translation_cache_enabled" json:"project_translation_cache_enabled"`
-	// ContainerIsolationDisabled is a fleet-wide kill switch that converts
-	// every distro to host-mode immediately, regardless of per-distro
-	// container isolation settings.
-	ContainerIsolationDisabled bool `bson:"container_isolation_disabled" json:"container_isolation_disabled"`
+	// ContainerIsolationEnabled is a fleet-wide flag that controls whether
+	// per-distro container isolation settings are honored. When false,
+	// every distro runs in host mode regardless of its container isolation
+	// configuration.
+	ContainerIsolationEnabled bool `bson:"container_isolation_enabled" json:"container_isolation_enabled"`
 
 	// Notification Flags
 	EventProcessingDisabled      bool `bson:"event_processing_disabled" json:"event_processing_disabled"`
@@ -117,7 +118,7 @@ func (c *ServiceFlags) Set(ctx context.Context) error {
 			backgroundCommandFailureEnabledKey:    c.BackgroundCommandFailureEnabled,
 			apiRateLimiterDisabledKey:             c.APIRateLimiterDisabled,
 			graphqlComplexityLimiterDisabledKey:   c.GraphQLComplexityLimiterDisabled,
-			containerIsolationDisabledKey:         c.ContainerIsolationDisabled,
+			containerIsolationEnabledKey:          c.ContainerIsolationEnabled,
 		}}), "updating config section '%s'", c.SectionId(),
 	)
 }

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -44,6 +44,10 @@ type ServiceFlags struct {
 	PodDiagnosticsDisabled             bool `bson:"pod_diagnostics_disabled" json:"pod_diagnostics_disabled"`
 	RetryFailedLogMoveEnabled          bool `bson:"retry_failed_log_move_enabled" json:"retry_failed_log_move_enabled"`
 	ProjectTranslationCacheEnabled     bool `bson:"project_translation_cache_enabled" json:"project_translation_cache_enabled"`
+	// ContainerIsolationDisabled is a fleet-wide kill switch that converts
+	// every distro to host-mode immediately, regardless of per-distro
+	// container isolation settings.
+	ContainerIsolationDisabled bool `bson:"container_isolation_disabled" json:"container_isolation_disabled"`
 
 	// Notification Flags
 	EventProcessingDisabled      bool `bson:"event_processing_disabled" json:"event_processing_disabled"`
@@ -113,6 +117,7 @@ func (c *ServiceFlags) Set(ctx context.Context) error {
 			backgroundCommandFailureEnabledKey:    c.BackgroundCommandFailureEnabled,
 			apiRateLimiterDisabledKey:             c.APIRateLimiterDisabled,
 			graphqlComplexityLimiterDisabledKey:   c.GraphQLComplexityLimiterDisabled,
+			containerIsolationDisabledKey:         c.ContainerIsolationDisabled,
 		}}), "updating config section '%s'", c.SectionId(),
 	)
 }

--- a/graphql/tests/mutation/setServiceFlags/results.json
+++ b/graphql/tests/mutation/setServiceFlags/results.json
@@ -55,6 +55,7 @@
             { "name": "pod_diagnostics_disabled", "enabled": false },
             { "name": "retry_failed_log_move_enabled", "enabled": false },
             { "name": "project_translation_cache_enabled", "enabled": false },
+            { "name": "container_isolation_disabled", "enabled": false },
             { "name": "event_processing_disabled", "enabled": false },
             { "name": "jira_notifications_disabled", "enabled": false },
             { "name": "slack_notifications_disabled", "enabled": false },

--- a/graphql/tests/mutation/setServiceFlags/results.json
+++ b/graphql/tests/mutation/setServiceFlags/results.json
@@ -55,7 +55,7 @@
             { "name": "pod_diagnostics_disabled", "enabled": false },
             { "name": "retry_failed_log_move_enabled", "enabled": false },
             { "name": "project_translation_cache_enabled", "enabled": false },
-            { "name": "container_isolation_disabled", "enabled": false },
+            { "name": "container_isolation_enabled", "enabled": false },
             { "name": "event_processing_disabled", "enabled": false },
             { "name": "jira_notifications_disabled", "enabled": false },
             { "name": "slack_notifications_disabled", "enabled": false },

--- a/graphql/tests/query/adminSettings/results.json
+++ b/graphql/tests/query/adminSettings/results.json
@@ -611,6 +611,7 @@
               { "name": "pod_diagnostics_disabled", "enabled": false },
               { "name": "retry_failed_log_move_enabled", "enabled": false },
               { "name": "project_translation_cache_enabled", "enabled": false },
+              { "name": "container_isolation_disabled", "enabled": false },
               { "name": "event_processing_disabled", "enabled": false },
               { "name": "jira_notifications_disabled", "enabled": false },
               { "name": "slack_notifications_disabled", "enabled": false },

--- a/graphql/tests/query/adminSettings/results.json
+++ b/graphql/tests/query/adminSettings/results.json
@@ -611,7 +611,7 @@
               { "name": "pod_diagnostics_disabled", "enabled": false },
               { "name": "retry_failed_log_move_enabled", "enabled": false },
               { "name": "project_translation_cache_enabled", "enabled": false },
-              { "name": "container_isolation_disabled", "enabled": false },
+              { "name": "container_isolation_enabled", "enabled": false },
               { "name": "event_processing_disabled", "enabled": false },
               { "name": "jira_notifications_disabled", "enabled": false },
               { "name": "slack_notifications_disabled", "enabled": false },

--- a/model/distro/distro.go
+++ b/model/distro/distro.go
@@ -129,9 +129,10 @@ type BootstrapSettings struct {
 	Communication string `bson:"communication,omitempty" json:"communication,omitempty" mapstructure:"communication,omitempty"`
 
 	// Optional
-	Env                 []EnvVar             `bson:"env,omitempty" json:"env,omitempty" mapstructure:"env,omitempty"`
-	ResourceLimits      ResourceLimits       `bson:"resource_limits,omitempty" json:"resource_limits" mapstructure:"resource_limits,omitempty"`
-	PreconditionScripts []PreconditionScript `bson:"precondition_scripts,omitempty" json:"precondition_scripts,omitempty" mapstructure:"precondition_scripts,omitempty"`
+	Env                 []EnvVar                   `bson:"env,omitempty" json:"env,omitempty" mapstructure:"env,omitempty"`
+	ResourceLimits      ResourceLimits             `bson:"resource_limits,omitempty" json:"resource_limits" mapstructure:"resource_limits,omitempty"`
+	ContainerIsolation  ContainerIsolationSettings `bson:"container_isolation,omitempty" json:"container_isolation,omitempty" mapstructure:"container_isolation,omitempty"`
+	PreconditionScripts []PreconditionScript       `bson:"precondition_scripts,omitempty" json:"precondition_scripts,omitempty" mapstructure:"precondition_scripts,omitempty"`
 
 	// Required for new provisioning
 	ClientDir             string `bson:"client_dir,omitempty" json:"client_dir,omitempty" mapstructure:"client_dir,omitempty"`
@@ -163,6 +164,21 @@ type ResourceLimits struct {
 	NumTasks        int `bson:"num_tasks,omitempty" json:"num_tasks,omitempty" mapstructure:"num_tasks,omitempty"`
 	LockedMemoryKB  int `bson:"locked_memory,omitempty" json:"locked_memory,omitempty" mapstructure:"locked_memory,omitempty"`
 	VirtualMemoryKB int `bson:"virtual_memory,omitempty" json:"virtual_memory,omitempty" mapstructure:"virtual_memory,omitempty"`
+}
+
+// ContainerIsolationSettings controls per-task container isolation.
+// When enabled, task commands (subprocess.exec, shell.exec) run inside
+// an ephemeral Docker container. The task working directory is bind-mounted
+// from the host into the container.
+type ContainerIsolationSettings struct {
+	Enabled  bool   `bson:"enabled" json:"enabled" mapstructure:"enabled"`
+	Image    string `bson:"image" json:"image" mapstructure:"image"`
+	MemoryMB int64  `bson:"memory_mb,omitempty" json:"memory_mb,omitempty" mapstructure:"memory_mb,omitempty"`
+	CPUs     int64  `bson:"cpus,omitempty" json:"cpus,omitempty" mapstructure:"cpus,omitempty"`
+	// RequireIsolation opts into fail-closed behavior. When true, container
+	// creation or image-pull failure fails the task immediately rather than
+	// degrading to host-mode. Default (false) is fail-open.
+	RequireIsolation bool `bson:"require_isolation,omitempty" json:"require_isolation,omitempty" mapstructure:"require_isolation,omitempty"`
 }
 
 type HomeVolumeSettings struct {
@@ -255,6 +271,14 @@ func (d *Distro) ValidateBootstrapSettings() error {
 	catcher.NewWhen(d.IsLinux() && d.BootstrapSettings.ResourceLimits.NumTasks < -1, "max number of tasks should be a positive number or -1")
 	catcher.NewWhen(d.IsLinux() && d.BootstrapSettings.ResourceLimits.LockedMemoryKB < -1, "max locked memory should be a positive number or -1")
 	catcher.NewWhen(d.IsLinux() && d.BootstrapSettings.ResourceLimits.VirtualMemoryKB < -1, "max virtual memory should be a positive number or -1")
+
+	if ci := d.BootstrapSettings.ContainerIsolation; ci.Enabled {
+		catcher.NewWhen(!d.IsLinux(), "container isolation is only supported on Linux")
+		catcher.NewWhen(ci.Image == "", "container image cannot be empty when container isolation is enabled")
+		catcher.NewWhen(d.ExecUser == "", "container isolation requires ExecUser to be set; it is used to scope between-task process cleanup inside the container's PID namespace")
+	} else if d.BootstrapSettings.ContainerIsolation.RequireIsolation {
+		catcher.New("require_isolation has no effect when container isolation is not enabled")
+	}
 
 	return catcher.Resolve()
 }

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -750,3 +750,109 @@ func TestCostData(t *testing.T) {
 	assert.Equal(t, 0.0, found2.CostData.OnDemandRate)
 	assert.Equal(t, 0.0, found2.CostData.SavingsPlanRate)
 }
+
+func TestContainerIsolationSettingsValidation(t *testing.T) {
+	t.Run("ValidLinuxConfig", func(t *testing.T) {
+		d := Distro{
+			Id:       "test-distro",
+			Arch:     "linux_amd64",
+			ExecUser: "mci-exec",
+			BootstrapSettings: BootstrapSettings{
+				Method:                BootstrapMethodSSH,
+				Communication:         CommunicationMethodSSH,
+				ClientDir:             "/home/agent",
+				JasperBinaryDir:       "/home/agent",
+				JasperCredentialsPath: "/home/agent/creds",
+				ShellPath:             "/bin/bash",
+				ContainerIsolation: ContainerIsolationSettings{
+					Enabled: true,
+					Image:   "ubuntu:22.04",
+				},
+			},
+		}
+		assert.NoError(t, d.ValidateBootstrapSettings())
+	})
+
+	t.Run("EnabledWithRequireIsolationAndMissingExecUserRejected", func(t *testing.T) {
+		// Ensures both ExecUser and RequireIsolation validations fire together
+		// on the most security-sensitive configuration (fail-closed isolation).
+		d := Distro{
+			Id:   "test-distro",
+			Arch: "linux_amd64",
+			BootstrapSettings: BootstrapSettings{
+				Method:                BootstrapMethodSSH,
+				Communication:         CommunicationMethodSSH,
+				ClientDir:             "/home/agent",
+				JasperBinaryDir:       "/home/agent",
+				JasperCredentialsPath: "/home/agent/creds",
+				ShellPath:             "/bin/bash",
+				ContainerIsolation: ContainerIsolationSettings{
+					Enabled:          true,
+					Image:            "ubuntu:22.04",
+					RequireIsolation: true,
+					// ExecUser deliberately absent
+				},
+			},
+		}
+		assert.ErrorContains(t, d.ValidateBootstrapSettings(), "ExecUser")
+	})
+
+	t.Run("RequireIsolationWithoutEnabledRejected", func(t *testing.T) {
+		d := Distro{
+			Id:   "test-distro",
+			Arch: "linux_amd64",
+			BootstrapSettings: BootstrapSettings{
+				Method:                BootstrapMethodSSH,
+				Communication:         CommunicationMethodSSH,
+				ClientDir:             "/home/agent",
+				JasperBinaryDir:       "/home/agent",
+				JasperCredentialsPath: "/home/agent/creds",
+				ShellPath:             "/bin/bash",
+				ContainerIsolation: ContainerIsolationSettings{
+					Enabled:          false,
+					RequireIsolation: true,
+				},
+			},
+		}
+		assert.ErrorContains(t, d.ValidateBootstrapSettings(), "require_isolation has no effect")
+	})
+
+	t.Run("ContainerIsolationWithoutExecUserRejected", func(t *testing.T) {
+		d := Distro{
+			Id:   "test-distro",
+			Arch: "linux_amd64",
+			BootstrapSettings: BootstrapSettings{
+				Method:                BootstrapMethodSSH,
+				Communication:         CommunicationMethodSSH,
+				ClientDir:             "/home/agent",
+				JasperBinaryDir:       "/home/agent",
+				JasperCredentialsPath: "/home/agent/creds",
+				ShellPath:             "/bin/bash",
+				ContainerIsolation: ContainerIsolationSettings{
+					Enabled: true,
+					Image:   "ubuntu:22.04",
+				},
+			},
+		}
+		assert.ErrorContains(t, d.ValidateBootstrapSettings(), "ExecUser")
+	})
+
+	t.Run("EnabledWithoutImage", func(t *testing.T) {
+		d := Distro{
+			Id:   "test-distro",
+			Arch: "linux_amd64",
+			BootstrapSettings: BootstrapSettings{
+				Method:                BootstrapMethodSSH,
+				Communication:         CommunicationMethodSSH,
+				ClientDir:             "/home/agent",
+				JasperBinaryDir:       "/home/agent",
+				JasperCredentialsPath: "/home/agent/creds",
+				ShellPath:             "/bin/bash",
+				ContainerIsolation: ContainerIsolationSettings{
+					Enabled: true,
+				},
+			},
+		}
+		assert.Error(t, d.ValidateBootstrapSettings())
+	})
+}

--- a/model/distro/distro_test.go
+++ b/model/distro/distro_test.go
@@ -790,7 +790,6 @@ func TestContainerIsolationSettingsValidation(t *testing.T) {
 					Enabled:          true,
 					Image:            "ubuntu:22.04",
 					RequireIsolation: true,
-					// ExecUser deliberately absent
 				},
 			},
 		}

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2129,7 +2129,7 @@ type APIServiceFlags struct {
 	PodDiagnosticsDisabled             bool `json:"pod_diagnostics_disabled"`
 	RetryFailedLogMoveEnabled          bool `json:"retry_failed_log_move_enabled"`
 	ProjectTranslationCacheEnabled     bool `json:"project_translation_cache_enabled"`
-	ContainerIsolationDisabled         bool `json:"container_isolation_disabled"`
+	ContainerIsolationEnabled          bool `json:"container_isolation_enabled"`
 
 	// Notifications Flags
 	EventProcessingDisabled      bool `json:"event_processing_disabled"`
@@ -2592,7 +2592,7 @@ func (as *APIServiceFlags) BuildFromService(h any) error {
 		as.PodDiagnosticsDisabled = v.PodDiagnosticsDisabled
 		as.RetryFailedLogMoveEnabled = v.RetryFailedLogMoveEnabled
 		as.ProjectTranslationCacheEnabled = v.ProjectTranslationCacheEnabled
-		as.ContainerIsolationDisabled = v.ContainerIsolationDisabled
+		as.ContainerIsolationEnabled = v.ContainerIsolationEnabled
 		as.BackgroundCommandFailureEnabled = v.BackgroundCommandFailureEnabled
 		as.APIRateLimiterDisabled = v.APIRateLimiterDisabled
 		as.GraphQLComplexityLimiterDisabled = v.GraphQLComplexityLimiterDisabled
@@ -2646,7 +2646,7 @@ func (as *APIServiceFlags) ToService() (any, error) {
 		RetryFailedLogMoveEnabled:          as.RetryFailedLogMoveEnabled,
 		ProjectTranslationCacheEnabled:     as.ProjectTranslationCacheEnabled,
 		BackgroundCommandFailureEnabled:    as.BackgroundCommandFailureEnabled,
-		ContainerIsolationDisabled:         as.ContainerIsolationDisabled,
+		ContainerIsolationEnabled:          as.ContainerIsolationEnabled,
 		APIRateLimiterDisabled:             as.APIRateLimiterDisabled,
 		GraphQLComplexityLimiterDisabled:   as.GraphQLComplexityLimiterDisabled,
 	}, nil

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2129,6 +2129,7 @@ type APIServiceFlags struct {
 	PodDiagnosticsDisabled             bool `json:"pod_diagnostics_disabled"`
 	RetryFailedLogMoveEnabled          bool `json:"retry_failed_log_move_enabled"`
 	ProjectTranslationCacheEnabled     bool `json:"project_translation_cache_enabled"`
+	ContainerIsolationDisabled         bool `json:"container_isolation_disabled"`
 
 	// Notifications Flags
 	EventProcessingDisabled      bool `json:"event_processing_disabled"`
@@ -2591,6 +2592,7 @@ func (as *APIServiceFlags) BuildFromService(h any) error {
 		as.PodDiagnosticsDisabled = v.PodDiagnosticsDisabled
 		as.RetryFailedLogMoveEnabled = v.RetryFailedLogMoveEnabled
 		as.ProjectTranslationCacheEnabled = v.ProjectTranslationCacheEnabled
+		as.ContainerIsolationDisabled = v.ContainerIsolationDisabled
 		as.BackgroundCommandFailureEnabled = v.BackgroundCommandFailureEnabled
 		as.APIRateLimiterDisabled = v.APIRateLimiterDisabled
 		as.GraphQLComplexityLimiterDisabled = v.GraphQLComplexityLimiterDisabled
@@ -2644,6 +2646,7 @@ func (as *APIServiceFlags) ToService() (any, error) {
 		RetryFailedLogMoveEnabled:          as.RetryFailedLogMoveEnabled,
 		ProjectTranslationCacheEnabled:     as.ProjectTranslationCacheEnabled,
 		BackgroundCommandFailureEnabled:    as.BackgroundCommandFailureEnabled,
+		ContainerIsolationDisabled:         as.ContainerIsolationDisabled,
 		APIRateLimiterDisabled:             as.APIRateLimiterDisabled,
 		GraphQLComplexityLimiterDisabled:   as.GraphQLComplexityLimiterDisabled,
 	}, nil

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -173,17 +173,59 @@ func (s *APIDispatcherSettings) ToService() distro.DispatcherSettings {
 // APIBootstrapSettings is the model to be returned by the API whenever distro.BootstrapSettings are fetched
 
 type APIBootstrapSettings struct {
-	Method                *string                 `json:"method"`
-	Communication         *string                 `json:"communication"`
-	ClientDir             *string                 `json:"client_dir"`
-	JasperBinaryDir       *string                 `json:"jasper_binary_dir"`
-	JasperCredentialsPath *string                 `json:"jasper_credentials_path"`
-	ServiceUser           *string                 `json:"service_user"`
-	ShellPath             *string                 `json:"shell_path"`
-	RootDir               *string                 `json:"root_dir"`
-	Env                   []APIEnvVar             `json:"env"`
-	ResourceLimits        APIResourceLimits       `json:"resource_limits"`
-	PreconditionScripts   []APIPreconditionScript `json:"precondition_scripts"`
+	Method                *string                       `json:"method"`
+	Communication         *string                       `json:"communication"`
+	ClientDir             *string                       `json:"client_dir"`
+	JasperBinaryDir       *string                       `json:"jasper_binary_dir"`
+	JasperCredentialsPath *string                       `json:"jasper_credentials_path"`
+	ServiceUser           *string                       `json:"service_user"`
+	ShellPath             *string                       `json:"shell_path"`
+	RootDir               *string                       `json:"root_dir"`
+	Env                   []APIEnvVar                   `json:"env"`
+	ResourceLimits        APIResourceLimits             `json:"resource_limits"`
+	PreconditionScripts   []APIPreconditionScript       `json:"precondition_scripts"`
+	ContainerIsolation    APIContainerIsolationSettings `json:"container_isolation"`
+}
+
+// APIContainerIsolationSettings is the API model for per-task container isolation
+// configuration on a distro. When Enabled is true, task subprocess calls
+// (shell.exec, subprocess.exec) are wrapped in an ephemeral Docker container.
+//
+// PATCH semantics note: the distro PATCH handler merges the request body over
+// the existing model at the JSON-key level, so a partial container_isolation
+// object (e.g. only {"enabled":true}) keeps old values for any omitted keys.
+// Send the full block to avoid unintentional merging.
+type APIContainerIsolationSettings struct {
+	Enabled  bool    `json:"enabled"`
+	Image    *string `json:"image,omitempty"`
+	MemoryMB int64   `json:"memory_mb,omitempty"`
+	CPUs     int64   `json:"cpus,omitempty"`
+	// RequireIsolation has no omitempty so that an explicit false is
+	// serialized and the fail-closed flag is never silently dropped
+	// when a client round-trips the full block.
+	RequireIsolation bool `json:"require_isolation"`
+}
+
+func (s *APIContainerIsolationSettings) BuildFromService(ci distro.ContainerIsolationSettings) {
+	s.Enabled = ci.Enabled
+	// Only set Image pointer when non-empty so omitempty correctly omits it
+	// in GET responses for distros with no image configured.
+	if ci.Image != "" {
+		s.Image = utility.ToStringPtr(ci.Image)
+	}
+	s.MemoryMB = ci.MemoryMB
+	s.CPUs = ci.CPUs
+	s.RequireIsolation = ci.RequireIsolation
+}
+
+func (s *APIContainerIsolationSettings) ToService() distro.ContainerIsolationSettings {
+	return distro.ContainerIsolationSettings{
+		Enabled:          s.Enabled,
+		Image:            utility.FromStringPtr(s.Image),
+		MemoryMB:         s.MemoryMB,
+		CPUs:             s.CPUs,
+		RequireIsolation: s.RequireIsolation,
+	}
 }
 
 type APIEnvVar struct {
@@ -268,6 +310,7 @@ func (s *APIBootstrapSettings) BuildFromService(settings distro.BootstrapSetting
 	s.ResourceLimits.NumTasks = settings.ResourceLimits.NumTasks
 	s.ResourceLimits.LockedMemoryKB = settings.ResourceLimits.LockedMemoryKB
 	s.ResourceLimits.VirtualMemoryKB = settings.ResourceLimits.VirtualMemoryKB
+	s.ContainerIsolation.BuildFromService(settings.ContainerIsolation)
 }
 
 // ToService returns a service layer distro.BootstrapSettings using the data
@@ -299,6 +342,7 @@ func (s *APIBootstrapSettings) ToService() distro.BootstrapSettings {
 	settings.ResourceLimits.NumTasks = s.ResourceLimits.NumTasks
 	settings.ResourceLimits.LockedMemoryKB = s.ResourceLimits.LockedMemoryKB
 	settings.ResourceLimits.VirtualMemoryKB = s.ResourceLimits.VirtualMemoryKB
+	settings.ContainerIsolation = s.ContainerIsolation.ToService()
 
 	return settings
 }

--- a/rest/model/distro.go
+++ b/rest/model/distro.go
@@ -187,14 +187,8 @@ type APIBootstrapSettings struct {
 	ContainerIsolation    APIContainerIsolationSettings `json:"container_isolation"`
 }
 
-// APIContainerIsolationSettings is the API model for per-task container isolation
-// configuration on a distro. When Enabled is true, task subprocess calls
-// (shell.exec, subprocess.exec) are wrapped in an ephemeral Docker container.
-//
-// PATCH semantics note: the distro PATCH handler merges the request body over
-// the existing model at the JSON-key level, so a partial container_isolation
-// object (e.g. only {"enabled":true}) keeps old values for any omitted keys.
-// Send the full block to avoid unintentional merging.
+// APIContainerIsolationSettings is the API model for per-task container
+// isolation configuration on a distro.
 type APIContainerIsolationSettings struct {
 	Enabled  bool    `json:"enabled"`
 	Image    *string `json:"image,omitempty"`


### PR DESCRIPTION
PLATFORMS-2447: Add the distro container-isolation model and kill switch

PLATFORMS-2447

**Stack: PR 1 of 9 — no dependency, first in stack.**

This PR is safe to merge alone because it only introduces configuration and model plumbing; no execution path consumes it yet.

### Description

Adds distro isolation configuration, validation, REST conversion, and the persisted fleet-wide service flag. This establishes the configuration contract without changing agent execution.

### Documentation

No user-facing documentation changes are required in this slice. Stack ordering and cross-PR links are maintained separately.
