### PR TITLE
DEVPROD-37863 Activate crons and batchtime versions with run every mainline commit

### DIFF
--- a/model/version_activation.go
+++ b/model/version_activation.go
@@ -51,9 +51,9 @@ func activateMostRecentNonIgnoredCommitForProject(ctx context.Context, projectRe
 	return nil, nil
 }
 
-// activateEveryRecentMainlineCommitForProject activates all unactivated non-ignored versions
-// up to the limit specified, runEveryMainlineCommitLimit or up to the last activated version,
-// whichever is less.
+// activateEveryRecentMainlineCommitForProject activates all elapsed builds and tasks for
+// non-ignored versions up to the limit specified, runEveryMainlineCommitLimit or back to the last
+// activated version, whichever is less.
 func activateEveryRecentMainlineCommitForProject(ctx context.Context, projectRef *ProjectRef, ts time.Time) ([]string, error) {
 	lastActivatedVersion, err := VersionFindOne(ctx, VersionByMostRecentActivated(projectRef.Id, ts))
 	if err != nil {
@@ -69,10 +69,12 @@ func activateEveryRecentMainlineCommitForProject(ctx context.Context, projectRef
 			return nil, errors.Wrapf(err, "finding all unactivated non-ignored versions")
 		}
 	} else {
-		// If there is a last activated version, activate only versions since that one.
-		activateVersions, err = VersionFind(ctx, VersionsUnactivatedSinceLastActivated(projectRef.Id, ts, lastActivatedVersion.RevisionOrderNumber, runEveryMainlineCommitLimit))
+		// If there is a last activated version, only consider versions since that one. The last
+		// activated version itself is included because its batchtime and cron build variants and
+		// tasks may not have elapsed yet when it was first activated.
+		activateVersions, err = VersionFind(ctx, VersionsSinceLastActivated(projectRef.Id, ts, lastActivatedVersion.RevisionOrderNumber, runEveryMainlineCommitLimit))
 		if err != nil {
-			return nil, errors.Wrapf(err, "finding unactivated versions since last activated version '%s'", lastActivatedVersion.Id)
+			return nil, errors.Wrapf(err, "finding versions since last activated version '%s'", lastActivatedVersion.Id)
 		}
 	}
 

--- a/model/version_activation.go
+++ b/model/version_activation.go
@@ -69,9 +69,11 @@ func activateEveryRecentMainlineCommitForProject(ctx context.Context, projectRef
 			return nil, errors.Wrapf(err, "finding all unactivated non-ignored versions")
 		}
 	} else {
-		// If there is a last activated version, only consider versions since that one. The last
-		// activated version itself is included because its batchtime and cron build variants and
-		// tasks may not have elapsed yet when it was first activated.
+		// If there is a last activated version, only consider versions since that one. Versions that
+		// are already activated are still considered, including the last activated version itself,
+		// because a version is marked activated as soon as any of its build variants activates. Its
+		// remaining batchtime and cron build variants and tasks may still be waiting for their
+		// activation time to elapse.
 		activateVersions, err = VersionFind(ctx, VersionsSinceLastActivated(projectRef.Id, ts, lastActivatedVersion.RevisionOrderNumber, runEveryMainlineCommitLimit))
 		if err != nil {
 			return nil, errors.Wrapf(err, "finding versions since last activated version '%s'", lastActivatedVersion.Id)

--- a/model/version_activation_test.go
+++ b/model/version_activation_test.go
@@ -339,6 +339,65 @@ func (s *VersionActivationSuite) TestDoProjectActivationMultipleUnactivatedCommi
 	require.True(utility.FromBoolPtr(updatedActivatedVersion.Activated))
 }
 
+func (s *VersionActivationSuite) TestDoProjectActivationActivatesElapsedCronVariantOnAlreadyActivatedVersion() {
+	t := s.T()
+	require := require.New(t)
+
+	projectID := "test-project-cron"
+	now := time.Now()
+
+	projectRef := &ProjectRef{
+		Id:                     projectID,
+		RunEveryMainlineCommit: utility.TruePtr(),
+	}
+	require.NoError(projectRef.Insert(s.ctx))
+
+	// The version is already marked activated because its non-cron variant activated on a previous
+	// run, but its cron variant's activation time has only just elapsed.
+	version := &Version{
+		Id:                  "version-with-cron",
+		Identifier:          projectID,
+		Requester:           evergreen.RepotrackerVersionRequester,
+		CreateTime:          now.Add(-10 * time.Minute),
+		Revision:            "cron123",
+		RevisionOrderNumber: 1,
+		Activated:           utility.ToBoolPtr(true),
+		BuildVariants: []VersionBuildStatus{
+			{
+				BuildVariant: "regular-variant",
+				BuildId:      "build-regular",
+				ActivationStatus: ActivationStatus{
+					Activated:  true,
+					ActivateAt: now.Add(-10 * time.Minute),
+				},
+			},
+			{
+				BuildVariant: "cron-variant",
+				BuildId:      "build-cron",
+				ActivationStatus: ActivationStatus{
+					Activated:  false,
+					ActivateAt: now.Add(-1 * time.Minute),
+				},
+			},
+		},
+	}
+	require.NoError(version.Insert(s.ctx))
+
+	activated, err := DoProjectActivation(s.ctx, projectRef, now)
+	require.NoError(err)
+	require.Len(activated, 1)
+	assert.Equal(t, "version-with-cron", activated[0])
+
+	updatedVersion, err := VersionFindOneId(s.ctx, version.Id)
+	require.NoError(err)
+	require.NotNil(updatedVersion)
+	_, err = updatedVersion.GetBuildVariants(s.ctx)
+	require.NoError(err)
+	require.Len(updatedVersion.BuildVariants, 2)
+	assert.True(t, updatedVersion.BuildVariants[0].Activated)
+	assert.True(t, updatedVersion.BuildVariants[1].Activated, "cron variant should activate once its activation time elapses")
+}
+
 func (s *VersionActivationSuite) TestDoProjectActivationNewProject() {
 	t := s.T()
 	require := require.New(t)
@@ -491,7 +550,7 @@ func (s *VersionActivationSuite) TestDoProjectActivationSingleCommitBehaviorPres
 	require.True(updatedVersion.BuildVariants[0].Activated, "Single version should be activated")
 }
 
-func (s *VersionActivationSuite) TestVersionsUnactivatedSinceLastActivated() {
+func (s *VersionActivationSuite) TestVersionsSinceLastActivated() {
 	t := s.T()
 	require := require.New(t)
 
@@ -534,19 +593,19 @@ func (s *VersionActivationSuite) TestVersionsUnactivatedSinceLastActivated() {
 		require.NoError(version.Insert(s.ctx))
 	}
 
-	// Test the query to find unactivated versions since last activated
-	unactivatedVersions, err := VersionFind(s.ctx, VersionsUnactivatedSinceLastActivated(projectID, now, 1, 1000))
+	// Test the query to find versions since last activated
+	versionsSinceLastActivated, err := VersionFind(s.ctx, VersionsSinceLastActivated(projectID, now, 1, 1000))
 	require.NoError(err)
-	require.Len(unactivatedVersions, 2, "Should find 2 unactivated versions after the activated one")
+	require.Len(versionsSinceLastActivated, 3, "Should find the activated version and the 2 versions after it")
 
 	// Verify the correct versions were returned
 	foundIds := make(map[string]bool)
-	for _, v := range unactivatedVersions {
+	for _, v := range versionsSinceLastActivated {
 		foundIds[v.Id] = true
 	}
 	require.True(foundIds["unactivated-1"], "Should include unactivated-1")
 	require.True(foundIds["unactivated-2"], "Should include unactivated-2")
-	require.False(foundIds["activated-version"], "Should not include activated version")
+	require.True(foundIds["activated-version"], "Should include the activated version so its pending batchtime and cron work is reconsidered")
 }
 
 func (s *VersionActivationSuite) TestDoProjectActivationNoVersionsToActivate() {

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -259,11 +259,9 @@ func VersionBySystemRequesterOrdered(projectId string, startOrder int) db.Q {
 	return db.Query(q).Sort([]string{"-" + VersionRevisionOrderNumberKey})
 }
 
-// VersionsSinceLastActivated finds all non-ignored versions that are at least as new as the most
-// recently activated version for a project. Already-activated versions are included because a
-// version is marked activated as soon as any of its build variants activates, while its remaining
-// batchtime and cron build variants and tasks may still be waiting for their activation time to
-// elapse.
+// VersionsSinceLastActivated finds all non-ignored mainline commit versions within a project that
+// are at least as new as the given revision order number, ordered by most recently created to
+// oldest. Versions are included regardless of whether they're already activated.
 func VersionsSinceLastActivated(projectId string, ts time.Time, lastActivatedOrderNum, limit int) db.Q {
 	return db.Query(
 		bson.M{

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -259,18 +259,19 @@ func VersionBySystemRequesterOrdered(projectId string, startOrder int) db.Q {
 	return db.Query(q).Sort([]string{"-" + VersionRevisionOrderNumberKey})
 }
 
-// VersionsUnactivatedSinceLastActivated finds all unactivated, non-ignored versions
-// that are newer than the most recently activated version for a project.
-// This ensures that all commits since the last activation get activated together.
-func VersionsUnactivatedSinceLastActivated(projectId string, ts time.Time, lastActivatedOrderNum, limit int) db.Q {
+// VersionsSinceLastActivated finds all non-ignored versions that are at least as new as the most
+// recently activated version for a project. Already-activated versions are included because a
+// version is marked activated as soon as any of its build variants activates, while its remaining
+// batchtime and cron build variants and tasks may still be waiting for their activation time to
+// elapse.
+func VersionsSinceLastActivated(projectId string, ts time.Time, lastActivatedOrderNum, limit int) db.Q {
 	return db.Query(
 		bson.M{
 			VersionRequesterKey:           evergreen.RepotrackerVersionRequester,
 			VersionIdentifierKey:          projectId,
 			VersionIgnoredKey:             bson.M{"$ne": true},
 			VersionCreateTimeKey:          bson.M{"$lte": ts},
-			VersionActivatedKey:           bson.M{"$ne": true},                  // Only unactivated versions
-			VersionRevisionOrderNumberKey: bson.M{"$gt": lastActivatedOrderNum}, // Newer than last activated
+			VersionRevisionOrderNumberKey: bson.M{"$gte": lastActivatedOrderNum},
 		},
 	).Sort([]string{"-" + VersionRevisionOrderNumberKey}).Limit(limit)
 }

--- a/model/version_db_test.go
+++ b/model/version_db_test.go
@@ -478,7 +478,7 @@ func TestRemoveGitTagFromVersions(t *testing.T) {
 	}
 }
 
-func TestVersionsUnactivatedSinceLastActivated(t *testing.T) {
+func TestVersionsSinceLastActivated(t *testing.T) {
 	require.NoError(t, db.ClearCollections(VersionCollection))
 	ts := time.Now()
 
@@ -534,14 +534,15 @@ func TestVersionsUnactivatedSinceLastActivated(t *testing.T) {
 
 	require.NoError(t, db.InsertMany(t.Context(), VersionCollection, v1, v2, v3, v4, v5, v6))
 
-	// Test finding unactivated versions since last activated (order number 1).
-	versions, err := VersionFind(t.Context(), VersionsUnactivatedSinceLastActivated("proj", ts, 1, 5000))
+	// Test finding versions since last activated (order number 1).
+	versions, err := VersionFind(t.Context(), VersionsSinceLastActivated("proj", ts, 1, 5000))
 	require.NoError(t, err)
-	require.Len(t, versions, 2, "Should find 2 unactivated versions after the activated one (excluding future version)")
+	require.Len(t, versions, 3, "Should find the activated version and the 2 versions after it (excluding future version)")
 
 	// Should be ordered by most recent first (highest order number first).
 	assert.Equal(t, "unactivated-2", versions[0].Id)
 	assert.Equal(t, "unactivated-1", versions[1].Id)
+	assert.Equal(t, "activated", versions[2].Id, "already-activated version should be reconsidered for elapsed batchtime and cron work")
 
 	// Verify that future version (created after ts) is NOT included.
 	foundIds := make(map[string]bool)


### PR DESCRIPTION
DEVPROD-37863

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->
Fixes a bug where cron and batchtime controlled variants never activate if a project has run every mainline commit enabled. 

That setting replaced our repotracker activation logic with one that only looks at unactivated versions.

Cron and batchtime work lives on versions that are already activated, since we flag a version activated as soon as any one of its variants activates, so those versions have to go through the activation function again for their tasks to ever get activated.

Looking at activated versions is safe because `ActivateElapsedBuildsAndTasks` is idempotent and no-ops without writing when nothing has elapsed. It's also what our normal (non run every mainline commit) path has always done.

### Testing

<!--add a description of how you tested it-->
Unit tests. Deployed to staging with the setting enabled and a cron setup, it scheduled the cron as it should