### PR TITLE
DEVPROD-37938: Speed up generate.tasks build inserts and drop redundant task fetch

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -1467,6 +1467,7 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 	}
 
 	newBuildIds := make([]string, 0)
+	newBuilds := build.Builds{}
 	newActivatedTaskIds := make([]string, 0)
 	newActivatedTasks := []task.Task{}
 	newBuildStatuses := make([]VersionBuildStatus, 0)
@@ -1540,9 +1541,7 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 		}
 
 		allTasks = append(allTasks, tasks...)
-		if err = build.Insert(ctx); err != nil {
-			return nil, nil, errors.Wrapf(err, "inserting build '%s'", build.Id)
-		}
+		newBuilds = append(newBuilds, build)
 		newBuildIds = append(newBuildIds, build.Id)
 
 		batchTimeTasksToIds := map[string]string{}
@@ -1588,6 +1587,9 @@ func addNewBuilds(ctx context.Context, creationInfo TaskCreationInfo, existingBu
 				},
 			},
 		)
+	}
+	if err = newBuilds.InsertMany(ctx, false); err != nil {
+		return nil, nil, errors.Wrap(err, "inserting builds")
 	}
 	SetNumDependents(allTasks)
 	if err = allTasks.InsertUnordered(ctx); err != nil {

--- a/rest/data/generate.go
+++ b/rest/data/generate.go
@@ -11,20 +11,21 @@ import (
 	"github.com/pkg/errors"
 )
 
-// GenerateTasks parses JSON files for `generate.tasks` and creates the new builds and tasks.
-func GenerateTasks(ctx context.Context, settings *evergreen.Settings, taskID string, jsonFiles []json.RawMessage) error {
+// GenerateTasks parses JSON files for `generate.tasks` and stores them for the generate tasks job to
+// process. It returns the task the JSON was stored for so the caller can avoid re-fetching it.
+func GenerateTasks(ctx context.Context, settings *evergreen.Settings, taskID string, jsonFiles []json.RawMessage) (*task.Task, error) {
 	t, err := task.FindOneIdWithGeneratedJSON(ctx, taskID)
 	if err != nil {
-		return errors.Wrapf(err, "finding task '%s'", taskID)
+		return nil, errors.Wrapf(err, "finding task '%s'", taskID)
 	}
 	if t == nil {
-		return errors.Errorf("task '%s' not found", taskID)
+		return nil, errors.Errorf("task '%s' not found", taskID)
 	}
 
 	// Don't continue if the generator has already run
 	// Return status code 400 to prevent retries
 	if t.GeneratedTasks {
-		return gimlet.ErrorResponse{
+		return nil, gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
 			Message:    evergreen.TasksAlreadyGeneratedError,
 		}
@@ -35,10 +36,10 @@ func GenerateTasks(ctx context.Context, settings *evergreen.Settings, taskID str
 		files = append(files, string(f))
 	}
 	if _, err := task.GeneratedJSONInsertWithS3Fallback(ctx, settings, t, files, evergreen.ProjectStorageMethodDB); err != nil {
-		return errors.Wrapf(err, "inserting generated JSON files for task '%s'", t.Id)
+		return nil, errors.Wrapf(err, "inserting generated JSON files for task '%s'", t.Id)
 	}
 
-	return nil
+	return t, nil
 }
 
 // GeneratePoll checks to see if a `generate.tasks` job has finished.

--- a/rest/route/task_generate.go
+++ b/rest/route/task_generate.go
@@ -68,17 +68,11 @@ func validateFileSize(files []json.RawMessage, maxSizeInMB int) error {
 }
 
 func (h *generateHandler) Run(ctx context.Context) gimlet.Responder {
-	if err := data.GenerateTasks(ctx, h.env.Settings(), h.taskID, h.files); err != nil {
+	t, err := data.GenerateTasks(ctx, h.env.Settings(), h.taskID, h.files)
+	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "generating tasks for task '%s'", h.taskID))
 	}
 
-	t, err := task.FindOneId(ctx, h.taskID)
-	if err != nil {
-		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting task '%s'", h.taskID))
-	}
-	if t == nil {
-		return gimlet.MakeJSONErrorResponder(errors.Errorf("task '%s' not found", h.taskID))
-	}
 	grip.Warning(ctx, message.WrapError(units.CreateAndEnqueueGenerateTasks(ctx, h.env, []task.Task{*t}, utility.RoundPartOfMinute(1).Format(units.TSFormat)), message.Fields{
 		"message": "could not enqueue generate tasks job",
 		"version": t.Version,


### PR DESCRIPTION
DEVPROD-37938

### Description

Two low-risk performance improvements for `generate.tasks`, which is slow on large generated task sets.

1. **Batch build inserts** (`model/lifecycle.go`, `addNewBuilds`): builds were inserted one-at-a-time inside the per-variant loop (up to ~200 sequential inserts). They're now collected and inserted in a single `InsertMany` call, matching how the tasks below are already batch-inserted. Applies to all callers of `addNewBuilds` (including regular version creation), not just generate.tasks.

2. **Drop redundant task fetch** (`rest/data/generate.go` + `rest/route/task_generate.go`): the `generate` POST handler re-fetched the task via `FindOneId` right after `data.GenerateTasks` had already fetched it. `GenerateTasks` now returns the task it fetched, removing one DB read per request.


### Testing


