### PR TITLE
DEVPROD-37839 Stagger fifteen second cron jobs

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-07-24"
+	ClientVersion = "2026-07-28"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/service.go
+++ b/operations/service.go
@@ -96,7 +96,7 @@ func startSystemCronJobs(ctx context.Context, env evergreen.Environment, tracer 
 	weekInterval := 7 * 24 * time.Hour
 	monthInterval := 30 * 24 * time.Hour
 
-	amboy.IntervalQueueOperation(ctx, populateQueue, 15*time.Second, utility.RoundPartOfMinute(0), opts, func(ctx context.Context, queue amboy.Queue) error {
+	amboy.IntervalQueueOperation(ctx, populateQueue, units.FifteenSecondCronInterval, utility.RoundPartOfMinute(0), opts, func(ctx context.Context, queue amboy.Queue) error {
 		return errors.WithStack(queue.Put(ctx, units.NewCronRemoteFifteenSecondJob()))
 	})
 	amboy.IntervalQueueOperation(ctx, populateQueue, time.Minute, utility.RoundPartOfMinute(0), opts, func(ctx context.Context, queue amboy.Queue) error {

--- a/units/crons_remote_fifteen_second.go
+++ b/units/crons_remote_fifteen_second.go
@@ -3,6 +3,7 @@ package units
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/utility"
@@ -14,7 +15,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-const cronsRemoteFifteenSecondJobName = "crons-remote-fifteen-second"
+const (
+	cronsRemoteFifteenSecondJobName = "crons-remote-fifteen-second"
+
+	FifteenSecondCronInterval = 15 * time.Second
+)
 
 func init() {
 	registry.AddJobType(cronsRemoteFifteenSecondJobName, NewCronRemoteFifteenSecondJob)
@@ -45,27 +50,36 @@ func (j *cronsRemoteFifteenSecondJob) Run(ctx context.Context) {
 		j.env = evergreen.GetEnvironment()
 	}
 
-	ops := map[string]cronJobFactory{
-		"scheduler":            schedulerJobs,
-		"alias scheduler":      aliasSchedulerJobs,
-		"host allocator":       hostAllocatorJobs,
-		"idle host":            idleHostJobs,
-		"agent deploy":         agentDeployJobs,
-		"agent monitor deploy": agentMonitorDeployJobs,
+	// Use array to not randomize order every time.
+	ops := []struct {
+		name    string
+		factory cronJobFactory
+	}{
+		{"scheduler", schedulerJobs},
+		{"alias scheduler", aliasSchedulerJobs},
+		{"host allocator", hostAllocatorJobs},
+		{"idle host", idleHostJobs},
+		{"agent deploy", agentDeployJobs},
+		{"agent monitor deploy", agentMonitorDeployJobs},
 	}
+	stagger := FifteenSecondCronInterval / time.Duration(len(ops))
 
 	var allJobs []amboy.Job
 	catcher := grip.NewBasicCatcher()
 	ts := utility.RoundPartOfMinute(15)
-	for name, op := range ops {
+	for i, op := range ops {
 		if ctx.Err() != nil {
 			j.AddError(errors.New("operation aborted"))
 			return
 		}
-		jobs, err := op(ctx, j.env, ts)
+		jobs, err := op.factory(ctx, j.env, ts)
 		if err != nil {
-			catcher.Wrapf(err, "getting '%s' jobs", name)
+			catcher.Wrapf(err, "getting '%s' jobs", op.name)
 			continue
+		}
+		waitUntil := ts.Add(time.Duration(i) * stagger)
+		for _, cronJob := range jobs {
+			cronJob.UpdateTimeInfo(amboy.JobTimeInfo{WaitUntil: waitUntil})
 		}
 		allJobs = append(allJobs, jobs...)
 	}

--- a/units/crons_remote_fifteen_second.go
+++ b/units/crons_remote_fifteen_second.go
@@ -62,12 +62,10 @@ func (j *cronsRemoteFifteenSecondJob) Run(ctx context.Context) {
 		{"agent deploy", agentDeployJobs},
 		{"agent monitor deploy", agentMonitorDeployJobs},
 	}
-	stagger := FifteenSecondCronInterval / time.Duration(len(ops))
-
 	var allJobs []amboy.Job
 	catcher := grip.NewBasicCatcher()
 	ts := utility.RoundPartOfMinute(15)
-	for i, op := range ops {
+	for _, op := range ops {
 		if ctx.Err() != nil {
 			j.AddError(errors.New("operation aborted"))
 			return
@@ -77,11 +75,16 @@ func (j *cronsRemoteFifteenSecondJob) Run(ctx context.Context) {
 			catcher.Wrapf(err, "getting '%s' jobs", op.name)
 			continue
 		}
-		waitUntil := ts.Add(time.Duration(i) * stagger)
-		for _, cronJob := range jobs {
-			cronJob.UpdateTimeInfo(amboy.JobTimeInfo{WaitUntil: waitUntil})
-		}
 		allJobs = append(allJobs, jobs...)
+	}
+
+	// Spread each job's dispatch eligibility evenly across the cron interval so
+	// the queue sees a steady trickle of work instead of one burst per tick.
+	if len(allJobs) > 0 {
+		stagger := FifteenSecondCronInterval / time.Duration(len(allJobs))
+		for i, cronJob := range allJobs {
+			cronJob.UpdateTimeInfo(amboy.JobTimeInfo{WaitUntil: ts.Add(time.Duration(i) * stagger)})
+		}
 	}
 	catcher.Wrap(amboy.EnqueueManyUniqueJobs(ctx, j.env.RemoteQueue(), allJobs), "populating main queue")
 


### PR DESCRIPTION
DEVPROD-37839 


### Description
stagger the 15 sec cron jobs because they were all hitting the DB at the same time causing latency spikes

will be monitoring the DB stats after deploy


### Testing

tested on staging to make sure jobs are running still 

looked at one of the jobs that are still running 4 times a minute
<img width="1336" height="268" alt="image" src="https://github.com/user-attachments/assets/683d732b-61d2-4077-b90b-2f7b323766b6" />
