### PR TITLE
DEVPROD-37994: Align version cost telemetry with the UI total

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -583,6 +583,14 @@ const (
 	VersionAdjustedCostOtelAttribute          = "evergreen.version.adjusted_cost"
 	VersionPredictedOnDemandCostOtelAttribute = "evergreen.version.predicted_on_demand_cost"
 	VersionPredictedAdjustedCostOtelAttribute = "evergreen.version.predicted_adjusted_cost"
+	// VersionTotalAdjustedCostOtelAttribute and VersionPredictedTotalAdjustedCostOtelAttribute are pre-summed
+	// totals of all adjusted cost components, matching the total the UI displays for the version.
+	VersionTotalAdjustedCostOtelAttribute          = "evergreen.version.total_adjusted_cost"
+	VersionPredictedTotalAdjustedCostOtelAttribute = "evergreen.version.predicted_total_adjusted_cost"
+	// VersionChildPatchesAdjustedCostOtelAttribute is the summed adjusted cost of the version's child patches,
+	// kept separate from the version's own total.
+	VersionChildPatchesAdjustedCostOtelAttribute = "evergreen.version.child_patches_adjusted_cost"
+	VersionParentPatchIDOtelAttribute            = "evergreen.version.parent_patch_id"
 
 	// EBS cost otel attributes — version-level (throughput)
 	VersionEBSOnDemandThroughputCostOtelAttribute = "evergreen.version.cost.ebs.on_demand_throughput_cost"

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/cost"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/patch"
@@ -1014,13 +1015,28 @@ func getVersionCtxForTracing(ctx context.Context, v *Version, project string, p 
 			attribute.Float64(evergreen.VersionAdjustedS3LogPutCostOtelAttribute, v.Cost.AdjustedS3LogPutCost),
 			attribute.Float64(evergreen.VersionOnDemandS3LogStorageCostOtelAttribute, v.Cost.OnDemandS3LogStorageCost),
 			attribute.Float64(evergreen.VersionAdjustedS3LogStorageCostOtelAttribute, v.Cost.AdjustedS3LogStorageCost),
+			attribute.Float64(evergreen.VersionTotalAdjustedCostOtelAttribute, v.Cost.AdjustedTotal()),
 		)
 	}
 	if !v.PredictedCost.IsZero() {
 		attrs = append(attrs,
 			attribute.Float64(evergreen.VersionPredictedOnDemandCostOtelAttribute, v.PredictedCost.OnDemandEC2Cost),
 			attribute.Float64(evergreen.VersionPredictedAdjustedCostOtelAttribute, v.PredictedCost.AdjustedEC2Cost),
+			attribute.Float64(evergreen.VersionPredictedTotalAdjustedCostOtelAttribute, v.PredictedCost.AdjustedTotal()),
 		)
+	}
+	if v.ParentPatchID != "" {
+		attrs = append(attrs, attribute.String(evergreen.VersionParentPatchIDOtelAttribute, v.ParentPatchID))
+	}
+	if p != nil && len(p.Triggers.ChildPatches) > 0 {
+		childVersions, err := VersionFind(ctx, db.Query(bson.M{VersionIdKey: bson.M{"$in": p.Triggers.ChildPatches}}).WithFields(VersionCostKey, VersionPredictedCostKey))
+		if err != nil {
+			return nil, errors.Wrap(err, "finding child versions for cost attributes")
+		}
+		childPatchesCost, _ := cost.SumPerChildVersionAdjustedTotals(len(childVersions), func(i int) (actual, predicted *cost.Cost) {
+			return &childVersions[i].Cost, &childVersions[i].PredictedCost
+		})
+		attrs = append(attrs, attribute.Float64(evergreen.VersionChildPatchesAdjustedCostOtelAttribute, childPatchesCost))
 	}
 	if !v.S3Usage.IsZero() {
 		var avgFilePutCost float64

--- a/model/version.go
+++ b/model/version.go
@@ -515,6 +515,15 @@ func (v *Version) UpdateAggregateTaskCosts(ctx context.Context) error {
 		return errors.Wrap(err, "updating version aggregated task costs")
 	}
 
+	total.OnDemandS3ArtifactPutCost = v.Cost.OnDemandS3ArtifactPutCost
+	total.AdjustedS3ArtifactPutCost = v.Cost.AdjustedS3ArtifactPutCost
+	total.OnDemandS3LogPutCost = v.Cost.OnDemandS3LogPutCost
+	total.AdjustedS3LogPutCost = v.Cost.AdjustedS3LogPutCost
+	total.OnDemandS3ArtifactStorageCost = v.Cost.OnDemandS3ArtifactStorageCost
+	total.AdjustedS3ArtifactStorageCost = v.Cost.AdjustedS3ArtifactStorageCost
+	total.OnDemandS3LogStorageCost = v.Cost.OnDemandS3LogStorageCost
+	total.AdjustedS3LogStorageCost = v.Cost.AdjustedS3LogStorageCost
+
 	v.Cost = total
 	v.PredictedCost = predicted
 	return nil

--- a/model/version_test.go
+++ b/model/version_test.go
@@ -863,6 +863,32 @@ func TestUpdateAggregateTaskCosts(t *testing.T) {
 		assert.InDelta(t, 0.24, v.Cost.AdjustedEBSStorageCost, 0.001)
 	})
 
+	t.Run("PreservesActualS3CostsNotInAggregationPipeline", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(VersionCollection, taskCollection))
+		// Actual S3 costs live only on the version, incremented per task by IncrementVersionS3CostAndUsage.
+		v := &Version{Id: "v6", Cost: cost.Cost{
+			AdjustedS3ArtifactPutCost:     0.42,
+			AdjustedS3ArtifactStorageCost: 4.61,
+			AdjustedS3LogPutCost:          2.07,
+			AdjustedS3LogStorageCost:      0.33,
+			OnDemandS3ArtifactPutCost:     0.50,
+		}}
+		require.NoError(t, v.Insert(ctx))
+
+		require.NoError(t, db.Insert(ctx, taskCollection, bson.M{
+			"_id": "t1", "version": "v6", "display_only": false,
+			"cost": bson.M{"adjusted_ec2_cost": 10.0, "adjusted_ebs_storage_cost": 1.0},
+		}))
+
+		require.NoError(t, v.UpdateAggregateTaskCosts(ctx))
+		assert.InDelta(t, 0.42, v.Cost.AdjustedS3ArtifactPutCost, 0.001)
+		assert.InDelta(t, 4.61, v.Cost.AdjustedS3ArtifactStorageCost, 0.001)
+		assert.InDelta(t, 2.07, v.Cost.AdjustedS3LogPutCost, 0.001)
+		assert.InDelta(t, 0.33, v.Cost.AdjustedS3LogStorageCost, 0.001)
+		assert.InDelta(t, 0.50, v.Cost.OnDemandS3ArtifactPutCost, 0.001)
+		// The in-memory total must match what the UI sums: EC2 + EBS + all actual S3 components.
+		assert.InDelta(t, 18.43, v.Cost.AdjustedTotal(), 0.001)
+	})
 }
 
 func TestIncrementVersionS3CostAndUsage(t *testing.T) {


### PR DESCRIPTION
DEVPROD-37994
<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Fixes UpdateAggregateTaskCosts in model/version.go discarding the version's actual S3 costs in memory, which made the version-completion span's total fall short of the cost the Spruce UI shows for the same patch. Also adds pre-summed total, child patch, and parent patch ID cost attributes to the span so Honeycomb can rank patches by cost without a formula.


### Testing

Tested on staging ([honeycomb link](https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen/result/9g1DDeeSk3B))