### PR TITLE
DEVPROD-37017: use OTel wrapper for HTTP clients

### DIFF
--- a/auth/okta.go
+++ b/auth/okta.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"time"
 
@@ -29,7 +30,7 @@ func NewOktaUserManager(conf *evergreen.OktaConfig, evgURL, loginDomain string) 
 		LoginCookieTTL:       evergreen.LoginCookieTTL,
 		AllowReauthorization: true,
 		ReconciliateID:       makeReconciliateID(conf.ExpectedEmailDomains),
-		GetHTTPClient:        utility.GetHTTPClient,
+		GetHTTPClient:        func() *http.Client { return utility.GetHTTPClient() },
 		PutHTTPClient:        utility.PutHTTPClient,
 		ExternalCache: &usercache.ExternalOptions{
 			PutUserGetToken: user.PutLoginCache,

--- a/auth/okta.go
+++ b/auth/okta.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"net/http"
 	"strings"
 	"time"
 
@@ -30,7 +29,7 @@ func NewOktaUserManager(conf *evergreen.OktaConfig, evgURL, loginDomain string) 
 		LoginCookieTTL:       evergreen.LoginCookieTTL,
 		AllowReauthorization: true,
 		ReconciliateID:       makeReconciliateID(conf.ExpectedEmailDomains),
-		GetHTTPClient:        func() *http.Client { return utility.GetHTTPClient() },
+		GetHTTPClient:        utility.GetHTTPClient,
 		PutHTTPClient:        utility.PutHTTPClient,
 		ExternalCache: &usercache.ExternalOptions{
 			PutUserGetToken: user.PutLoginCache,

--- a/config_api.go
+++ b/config_api.go
@@ -29,7 +29,7 @@ type ClientConfig struct {
 }
 
 func (c *ClientConfig) populateClientBinaries(ctx context.Context, s3URLPrefix string) {
-	client := utility.GetHTTPClient()
+	client := utility.WithOTelTracing(utility.GetHTTPClient())
 	defer utility.PutHTTPClient(client)
 
 	// We assume that all valid OS/arch combinations listed in Evergreen

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/evergreen-ci/pail v0.0.0-20260618132147-c9bcc0488a7f
 	github.com/evergreen-ci/poplar v0.0.0-20260330180450-c8cf511d1bd6
 	github.com/evergreen-ci/shrub v0.0.0-20251017154811-4d3ed1599154
-	github.com/evergreen-ci/utility v0.0.0-20260116164328-250718d590d2
+	github.com/evergreen-ci/utility v0.0.0-20260727185913-06cd8a26cd5e
 	github.com/gonzojive/httpcache v0.0.0-20220509000156-e80a5e6a69fe
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gorilla/mux v1.8.1
@@ -33,7 +33,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mongodb/amboy v0.0.0-20260326190628-51c8dde3a7f5
 	github.com/mongodb/anser v0.0.0-20260326191204-f2d0a92e3f0a
-	github.com/mongodb/grip v0.0.0-20260721180657-45243b88445c
+	github.com/mongodb/grip v0.0.0-20260728153343-09a3a7fc4c49
 	github.com/pkg/errors v0.9.1
 	github.com/ravilushqa/otelgqlgen v0.19.0
 	github.com/robbiet480/go.sns v0.0.0-20210223081447-c7c9eb6836cb

--- a/go.sum
+++ b/go.sum
@@ -177,8 +177,8 @@ github.com/evergreen-ci/shrub v0.0.0-20251017154811-4d3ed1599154 h1:YO1VY9Qj68Kj
 github.com/evergreen-ci/shrub v0.0.0-20251017154811-4d3ed1599154/go.mod h1:nDQB46oIkI/BmvuNKkHdJekvXuGm8lvfUBcbbjekMZM=
 github.com/evergreen-ci/test-selection-client v0.0.0-20260409173604-004964bcf728 h1:7dFa0fx1u5BwUg3Kbf71iaglBsyQJfkYLFd3CfVHxUA=
 github.com/evergreen-ci/test-selection-client v0.0.0-20260409173604-004964bcf728/go.mod h1:0iD20pmczefJcyBCIuYuwfq9J3cqWOM5v61znyqcAwY=
-github.com/evergreen-ci/utility v0.0.0-20260116164328-250718d590d2 h1:p5kFLuoZu3SuP5AnmmLT58pSSxq8S0wNDEvjZHVcg2I=
-github.com/evergreen-ci/utility v0.0.0-20260116164328-250718d590d2/go.mod h1:Al1Mt6zmPNfdvH/Zd99nrjNoSyHK5g4zE/1tv9MiWQU=
+github.com/evergreen-ci/utility v0.0.0-20260727185913-06cd8a26cd5e h1:9Ad/RzvKJLRjI4epzBTCx3+nEZS1dyNwDAmMQ01mtyU=
+github.com/evergreen-ci/utility v0.0.0-20260727185913-06cd8a26cd5e/go.mod h1:A03U7o6F4PDMNz+lD9mktDgy53wWJHgfR6Bk1fndBJc=
 github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -323,8 +323,8 @@ github.com/mongodb/anser v0.0.0-20260326191204-f2d0a92e3f0a h1:aerBBPXwQOo+s1BR7
 github.com/mongodb/anser v0.0.0-20260326191204-f2d0a92e3f0a/go.mod h1:y5tT5wIiax8QSqifu02lYQcumwsvAwAYb2PmpguRyfE=
 github.com/mongodb/ftdc v0.0.0-20251208183831-018e343a1aac h1:KL3+DC+q8yS+QmdPAvnJiMHNU9VcYD3+4+0U1F+Crzo=
 github.com/mongodb/ftdc v0.0.0-20251208183831-018e343a1aac/go.mod h1:iaQJgZ9mNDQzR9Y8BY6D/Y6i8IzadyjY91a20xE5sOE=
-github.com/mongodb/grip v0.0.0-20260721180657-45243b88445c h1:JU7R1E7tJxl30MmO9YwbXCc5KWmO2F3679IxrVtqRIU=
-github.com/mongodb/grip v0.0.0-20260721180657-45243b88445c/go.mod h1:nIxXGOFRWYjuwlgZlhj7BvCE6MjPuOFr3xbe9IcbKDo=
+github.com/mongodb/grip v0.0.0-20260728153343-09a3a7fc4c49 h1:/s5If9JUis71QMB/6Ik3alNFSfElvY0JNt4gqR0tOaU=
+github.com/mongodb/grip v0.0.0-20260728153343-09a3a7fc4c49/go.mod h1:8C/dvHEa6ydNcHnlO3BWg5eUqkrKQnP6MI0HQ31rNSc=
 github.com/mongodb/jasper v0.0.0-20260330133616-5411573646d1 h1:SSUZlMk2YvlnqB8o8BxdQzEBACZ/m0/Biu8uljAYCTc=
 github.com/mongodb/jasper v0.0.0-20260330133616-5411573646d1/go.mod h1:dNPRgqt6EwehE2ADcYPuvtVy+3/RbgY956R+R6Ln58s=
 github.com/montanaflynn/stats v0.7.1 h1:etflOAAHORrCC44V+aR6Ftzort912ZU+YLiSTuV8eaE=

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -756,7 +756,7 @@ func (r *taskResolver) TaskOwnerTeam(ctx context.Context, obj *restModel.APITask
 	if fwsBaseURL == "" {
 		return nil, InternalServerError.Send(ctx, "Foliage Web Services URL not set")
 	}
-	httpClient := utility.GetHTTPClient()
+	httpClient := utility.WithOTelTracing(utility.GetHTTPClient())
 	defer utility.PutHTTPClient(httpClient)
 
 	cfg := fws.NewConfiguration()

--- a/rest/data/build_baron.go
+++ b/rest/data/build_baron.go
@@ -96,7 +96,7 @@ func fileTicketCustomHook(context context.Context, taskId string, execution int,
 		req.Header.Add(evergreen.APIKeyHeader, webHook.Secret)
 	}
 
-	client := utility.GetHTTPClient()
+	client := utility.WithOTelTracing(utility.GetHTTPClient())
 	defer utility.PutHTTPClient(client)
 	resp, err := client.Do(req)
 	if err != nil {

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -903,7 +903,7 @@ func shouldSkipCIForGraphite(ctx context.Context, owner, repo string, prNumber i
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := utility.GetHTTPClient()
+	client := utility.WithOTelTracing(utility.GetHTTPClient())
 	defer utility.PutHTTPClient(client)
 
 	resp, err := client.Do(req)

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -962,7 +962,7 @@ func githubRequest(ctx context.Context, method string, url string, oauthToken st
 
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")
-	client := utility.GetHTTPClient()
+	client := utility.WithOTelTracing(utility.GetHTTPClient())
 	defer utility.PutHTTPClient(client)
 
 	return client.Do(req)

--- a/thirdparty/jira.go
+++ b/thirdparty/jira.go
@@ -109,7 +109,7 @@ func (jiraHandler *JiraHandler) JQLSearch(ctx context.Context, query string, sta
 }
 
 func NewJiraHandler(opts send.JiraOptions) (JiraHandler, error) {
-	httpClient := utility.GetHTTPClient()
+	httpClient := utility.WithOTelTracing(utility.GetHTTPClient())
 	if opts.PersonalAccessTokenOpts.Token != "" {
 		transport := jira.BearerAuthTransport{
 			Token:     opts.PersonalAccessTokenOpts.Token,

--- a/thirdparty/okta.go
+++ b/thirdparty/okta.go
@@ -148,7 +148,7 @@ func discoverOAuthASMetadata(ctx context.Context, issuer string) (*oauthASMetada
 	}
 	req.Header.Set("Accept", "application/json")
 
-	httpClient := utility.GetHTTPClient()
+	httpClient := utility.WithOTelTracing(utility.GetHTTPClient())
 	defer utility.PutHTTPClient(httpClient)
 
 	resp, err := httpClient.Do(req)
@@ -197,7 +197,7 @@ func doTokenExchange(ctx context.Context, tokenURL string, opts OktaTokenExchang
 	req.Header.Set("Accept", "application/json")
 	req.SetBasicAuth(opts.ClientID, opts.ClientSecret)
 
-	httpClient := utility.GetHTTPClient()
+	httpClient := utility.WithOTelTracing(utility.GetHTTPClient())
 	defer utility.PutHTTPClient(httpClient)
 
 	resp, err := httpClient.Do(req)
@@ -356,7 +356,7 @@ func ExchangeAuthCodeForToken(ctx context.Context, opts AuthCodeExchangeOptions)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	httpClient := utility.GetHTTPClient()
+	httpClient := utility.WithOTelTracing(utility.GetHTTPClient())
 	defer utility.PutHTTPClient(httpClient)
 
 	resp, err := httpClient.Do(req)

--- a/thirdparty/sage.go
+++ b/thirdparty/sage.go
@@ -19,7 +19,7 @@ func NewSageClient(baseURL string) (*SageClient, error) {
 		return nil, errors.New("Sage base URL is not configured")
 	}
 	return &SageClient{
-		httpClient: utility.GetHTTPClient(),
+		httpClient: utility.WithOTelTracing(utility.GetHTTPClient()),
 		baseURL:    baseURL,
 	}, nil
 }

--- a/util/webhook_grip.go
+++ b/util/webhook_grip.go
@@ -147,7 +147,7 @@ func (w *evergreenWebhookLogger) send(m message.Composer) error {
 
 	client := w.client
 	if client == nil {
-		client = utility.GetHTTPClient()
+		client = utility.WithOTelTracing(utility.GetHTTPClient())
 		defer utility.PutHTTPClient(client)
 	}
 	return utility.Retry(context.Background(), func() (bool, error) {


### PR DESCRIPTION
DEVPROD-37017

### Description

This is pretty much #10561 but instrumenting the HTTP clients in the app server explicitly rather than by default. The only behavioral change from #10561 is only the app server gets the extra tracing. The agent HTTP clients can't use it because the S3 SDK makes too many HTTP requests.

### Testing

Tested in personal staging to verify that the GitHub client (which uses OTel tracing) is working and creates spans for HTTP requests.