### PR TITLE
Revert "Revert "DEVPROD-36693: Fix GitHub sender cache synchronization without self-deadlock""

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -335,6 +335,7 @@ type envState struct {
 	closers                 []closerOp
 	senders                 map[SenderKey]send.Sender
 	githubSenders           map[string]cachedGitHubSender
+	githubSendersMu         sync.Mutex
 	roleManager             gimlet.RoleManager
 	userManager             gimlet.UserManager
 	userManagerInfo         UserManagerInfo
@@ -1377,8 +1378,12 @@ type CreateInstallationTokenFunc func(ctx context.Context, owner, repo string) (
 // In case of GitHub app errors, the function returns the legacy GitHub sender with a global token attached.
 // The senders are only unique to orgs, not repos, but the repo name is needed to generate a token if necessary.
 func (e *envState) GetGitHubSender(owner, repo string, createInstallationToken CreateInstallationTokenFunc) (send.Sender, error) {
-	e.mu.RLock()
-	defer e.mu.RUnlock()
+	// Lock the cache with its own lock, held across the whole function so the
+	// cache-miss path can safely write to e.githubSenders. The
+	// createInstallationToken call below reads from the environment and grabs
+	// e.mu, so the cache uses a separate lock to keep that call safe.
+	e.githubSendersMu.Lock()
+	defer e.githubSendersMu.Unlock()
 
 	githubSender, ok := e.githubSenders[owner]
 	// If githubSender exists and has not expired, return it.

--- a/environment_test.go
+++ b/environment_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"os"
 	"strconv"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -141,4 +143,36 @@ func (s *EnvironmentSuite) TestInitSenders() {
 	for _, sender := range s.env.senders {
 		s.NotZero(sender.ErrorHandler(), "fallback error handler should be set")
 	}
+}
+
+func TestGetGitHubSenderConcurrentAccessShouldNotRace(t *testing.T) {
+	e := &envState{
+		ctx:           t.Context(),
+		githubSenders: map[string]cachedGitHubSender{},
+	}
+	// Pre-populate an expired sender for the owner so every concurrent caller
+	// takes the cache-miss path that writes to the map.
+	e.githubSenders["owner"] = cachedGitHubSender{time: time.Now().Add(-2 * githubTokenTimeout)}
+
+	// Grab e.mu here to mimic the real token-creation path, which reads from
+	// the environment. This makes the test freeze if GetGitHubSender ever locks
+	// the cache with e.mu instead of its own lock.
+	createToken := func(ctx context.Context, owner, repo string) (string, error) {
+		e.mu.RLock()
+		defer e.mu.RUnlock()
+		return "token", nil
+	}
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			sender, err := e.GetGitHubSender("owner", "repo", createToken)
+			assert.NoError(t, err)
+			assert.NotNil(t, sender)
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
Reverts evergreen-ci/evergreen#10590

This undoes the revert because it's not needed in the end. 