### PR TITLE
DEVPROD-38041: remove CLI login suggestion

### DIFF
--- a/config.go
+++ b/config.go
@@ -34,7 +34,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-07-28"
+	ClientVersion = "2026-07-29"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/http.go
+++ b/operations/http.go
@@ -53,12 +53,6 @@ func NewAPIError(resp *http.Response) APIError {
 	return APIError{bodyStr, resp.Status, resp.StatusCode}
 }
 
-func newAuthError(resp *http.Response) APIError {
-	apiError := NewAPIError(resp)
-	apiError.body = fmt.Sprintf("%s (%s)", apiError.body, client.AuthError)
-	return apiError
-}
-
 func newVPNError(resp *http.Response) APIError {
 	apiError := NewAPIError(resp)
 	apiError.body = fmt.Sprintf("%s (%s)", apiError.body, client.VPNError)
@@ -150,9 +144,6 @@ func (ac *legacyClient) modifyExisting(ctx context.Context, patchId, action stri
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return newAuthError(resp)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return newVPNError(resp)
 	}
@@ -178,9 +169,6 @@ func (ac *legacyClient) GetPatches(n int) ([]patch.Patch, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, newAuthError(resp)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, newVPNError(resp)
 	}
@@ -202,9 +190,6 @@ func (ac *legacyClient) GetRestPatch(patchId string) (*service.RestPatch, error)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, newAuthError(resp)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, newVPNError(resp)
 	}
@@ -226,9 +211,6 @@ func (ac *legacyClient) GetPatch(patchId string) (*patch.Patch, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, newAuthError(resp)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, newVPNError(resp)
 	}
@@ -254,9 +236,6 @@ func (ac *legacyClient) GetProjectRef(projectId string) (*model.ProjectRef, erro
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, newAuthError(resp)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, newVPNError(resp)
 	}
@@ -278,9 +257,6 @@ func (ac *legacyClient) GetPatchedConfig(patchId string) (*model.Project, error)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, newAuthError(resp)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, newVPNError(resp)
 	}
@@ -307,9 +283,6 @@ func (ac *legacyClient) GetConfig(versionId string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, newAuthError(resp)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, newVPNError(resp)
 	}
@@ -332,9 +305,6 @@ func (ac *legacyClient) GetProject(versionId string) (*model.Project, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, newAuthError(resp)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, newVPNError(resp)
 	}
@@ -362,9 +332,6 @@ func (ac *legacyClient) GetLastGreen(project string, variants []string) (*model.
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, newAuthError(resp)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, newVPNError(resp)
 	}
@@ -386,9 +353,6 @@ func (ac *legacyClient) DeletePatchModule(patchId, module string) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return newAuthError(resp)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return newVPNError(resp)
 	}
@@ -433,9 +397,6 @@ func (ac *legacyClient) UpdatePatchModule(ctx context.Context, params UpdatePatc
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return newAuthError(resp)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return newVPNError(resp)
 	}
@@ -452,9 +413,6 @@ func (ac *legacyClient) ListProjects() ([]model.ProjectRef, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, newAuthError(resp)
-	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, NewAPIError(resp)
 	}
@@ -472,9 +430,6 @@ func (ac *legacyClient) ListTasks(project string) ([]model.ProjectTask, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, newAuthError(resp)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, newVPNError(resp)
 	}
@@ -495,9 +450,6 @@ func (ac *legacyClient) ListVariants(project string) ([]model.BuildVariant, erro
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, newAuthError(resp)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, newVPNError(resp)
 	}
@@ -585,9 +537,6 @@ func (ac *legacyClient) PutPatch(ctx context.Context, incomingPatch patchSubmiss
 		return nil, err
 	}
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, newAuthError(resp)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, newVPNError(resp)
 	}
@@ -616,9 +565,6 @@ func (ac *legacyClient) GetTask(taskId string) (*service.RestTask, error) {
 
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, nil
-	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, newAuthError(resp)
 	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, newVPNError(resp)
@@ -651,9 +597,6 @@ func (ac *legacyClient) GetTaskV2(taskId string, execution *int) (*restModel.API
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, nil
 	}
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, newAuthError(resp)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, newVPNError(resp)
 	}
@@ -676,9 +619,6 @@ func (ac *legacyClient) GetRecentVersions(projectID string) ([]string, error) {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, newAuthError(resp)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, newVPNError(resp)
 	}
@@ -719,9 +659,6 @@ func (ac *legacyClient) UpdateRole(role *gimlet.Role) error {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return newAuthError(resp)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return newVPNError(resp)
 	}

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -69,9 +69,6 @@ func (c *communicatorImpl) CreateSpawnHost(ctx context.Context, spawnRequest *mo
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -99,9 +96,6 @@ func (c *communicatorImpl) GetSpawnHost(ctx context.Context, hostId string) (*mo
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -129,9 +123,6 @@ func (c *communicatorImpl) GetProject(ctx context.Context, projectID string) (*m
 
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -160,9 +151,6 @@ func (c *communicatorImpl) ModifySpawnHost(ctx context.Context, hostID string, c
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}
@@ -193,9 +181,6 @@ func (c *communicatorImpl) StopSpawnHost(ctx context.Context, hostID string, sub
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}
@@ -222,9 +207,6 @@ func (c *communicatorImpl) AttachVolume(ctx context.Context, hostID string, opts
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}
@@ -250,9 +232,6 @@ func (c *communicatorImpl) DetachVolume(ctx context.Context, hostID, volumeID st
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}
@@ -275,9 +254,6 @@ func (c *communicatorImpl) CreateVolume(ctx context.Context, volume *host.Volume
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -304,9 +280,6 @@ func (c *communicatorImpl) DeleteVolume(ctx context.Context, volumeID string) er
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}
@@ -328,9 +301,6 @@ func (c *communicatorImpl) ModifyVolume(ctx context.Context, volumeID string, op
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}
@@ -353,9 +323,6 @@ func (c *communicatorImpl) GetVolume(ctx context.Context, volumeID string) (*mod
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -383,9 +350,6 @@ func (c *communicatorImpl) GetVolumesByUser(ctx context.Context) ([]model.APIVol
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -456,9 +420,6 @@ func (c *communicatorImpl) StartSpawnHost(ctx context.Context, hostID string, su
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}
@@ -497,9 +458,6 @@ func (c *communicatorImpl) waitForStatus(ctx context.Context, hostID, status str
 				return errors.Wrapf(err, "sending request to get info for host '%s'", hostID)
 			}
 			defer resp.Body.Close()
-			if resp.StatusCode == http.StatusUnauthorized {
-				return util.RespError(resp, AuthError)
-			}
 			if resp.StatusCode == http.StatusForbidden {
 				return util.RespError(resp, VPNError)
 			}
@@ -529,9 +487,6 @@ func (c *communicatorImpl) TerminateSpawnHost(ctx context.Context, hostID string
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}
@@ -556,9 +511,6 @@ func (c *communicatorImpl) ChangeSpawnHostPassword(ctx context.Context, hostID, 
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}
@@ -583,9 +535,6 @@ func (c *communicatorImpl) ExtendSpawnHostExpiration(ctx context.Context, hostID
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}
@@ -608,9 +557,6 @@ func (c *communicatorImpl) GetHosts(ctx context.Context, data model.APIHostParam
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -874,9 +820,6 @@ func (c *communicatorImpl) RevertSettings(ctx context.Context, guid string) erro
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}
@@ -899,9 +842,6 @@ func (c *communicatorImpl) GetServiceUsers(ctx context.Context) ([]model.APIDBUs
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -933,9 +873,6 @@ func (c *communicatorImpl) UpdateServiceUser(ctx context.Context, username, disp
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}
@@ -958,9 +895,6 @@ func (c *communicatorImpl) DeleteServiceUser(ctx context.Context, username strin
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}
@@ -983,9 +917,6 @@ func (c *communicatorImpl) GetDistrosList(ctx context.Context) ([]model.APIDistr
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -1014,9 +945,6 @@ func (c *communicatorImpl) GetCurrentUsersKeys(ctx context.Context) ([]model.API
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -1050,9 +978,6 @@ func (c *communicatorImpl) AddPublicKey(ctx context.Context, keyName, keyValue s
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}
@@ -1075,9 +1000,6 @@ func (c *communicatorImpl) DeletePublicKey(ctx context.Context, keyName string) 
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}
@@ -1102,9 +1024,6 @@ func (c *communicatorImpl) ListAliases(ctx context.Context, project string, incl
 		return nil, errors.Wrap(err, "sending request to list project aliases")
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -1139,9 +1058,6 @@ func (c *communicatorImpl) ListPatchTriggerAliases(ctx context.Context, project 
 		return nil, errors.Wrap(err, "sending request to list patch trigger aliases")
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -1168,9 +1084,6 @@ func (c *communicatorImpl) GetClientConfig(ctx context.Context) (*evergreen.Clie
 		return nil, errors.Wrap(err, "sending request to get latest CLI version information")
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -1201,9 +1114,6 @@ func (c *communicatorImpl) GetParameters(ctx context.Context, project string) ([
 		return nil, errors.Wrapf(err, "sending request to get patch parameters for project '%s'", project)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -1229,9 +1139,6 @@ func (c *communicatorImpl) GetSubscriptions(ctx context.Context) ([]event.Subscr
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -1277,9 +1184,6 @@ func (c *communicatorImpl) SendSlackNotification(ctx context.Context, data *mode
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}
@@ -1302,9 +1206,6 @@ func (c *communicatorImpl) SendEmailNotification(ctx context.Context, data *mode
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}
@@ -1326,9 +1227,6 @@ func (c *communicatorImpl) GetManifestByTask(ctx context.Context, taskId string)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -1360,9 +1258,6 @@ func (c *communicatorImpl) StartHostProcesses(ctx context.Context, hostIDs []str
 			}
 			defer resp.Body.Close()
 
-			if resp.StatusCode == http.StatusUnauthorized {
-				return nil, util.RespError(resp, AuthError)
-			}
 			if resp.StatusCode == http.StatusForbidden {
 				return nil, util.RespError(resp, VPNError)
 			}
@@ -1404,9 +1299,6 @@ func (c *communicatorImpl) GetHostProcessOutput(ctx context.Context, hostProcess
 			}
 			defer resp.Body.Close()
 
-			if resp.StatusCode == http.StatusUnauthorized {
-				return nil, util.RespError(resp, AuthError)
-			}
 			if resp.StatusCode == http.StatusForbidden {
 				return nil, util.RespError(resp, VPNError)
 			}
@@ -1456,9 +1348,6 @@ func (c *communicatorImpl) GetRecentVersionsForProject(ctx context.Context, proj
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -1486,9 +1375,6 @@ func (c *communicatorImpl) GetBuildsForVersion(ctx context.Context, versionID st
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -1526,9 +1412,6 @@ func (c *communicatorImpl) GetTasksForBuild(ctx context.Context, buildID string,
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -1669,9 +1552,6 @@ func (c *communicatorImpl) FindHostByIpAddress(ctx context.Context, ip string) (
 		return nil, errors.Wrapf(err, "sending request to find host by IP address")
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -1699,9 +1579,6 @@ func (c *communicatorImpl) GetRawPatchWithModules(ctx context.Context, patchId s
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -1736,9 +1613,6 @@ func (c *communicatorImpl) GetManifestForVersion(ctx context.Context, versionID 
 		return nil, errors.Wrapf(err, "sending request to get version manifest")
 	}
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -1793,9 +1667,6 @@ func (c *communicatorImpl) GetTaskLogs(ctx context.Context, opts GetTaskLogsOpti
 		return nil, errors.Wrapf(err, "sending request to get task logs")
 	}
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -1852,9 +1723,6 @@ func (c *communicatorImpl) GetTestLogs(ctx context.Context, opts GetTestLogsOpti
 		return nil, errors.Wrapf(err, "sending request to get test logs")
 	}
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return nil, util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return nil, util.RespError(resp, VPNError)
 	}
@@ -1938,9 +1806,6 @@ func (c *communicatorImpl) SendPanicReport(ctx context.Context, details *model.P
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusUnauthorized {
-		return util.RespError(resp, AuthError)
-	}
 	if resp.StatusCode == http.StatusForbidden {
 		return util.RespError(resp, VPNError)
 	}

--- a/rest/client/request.go
+++ b/rest/client/request.go
@@ -24,9 +24,6 @@ type requestInfo struct {
 }
 
 var (
-	// AuthError is a special error when the CLI receives 401 Unauthorized to
-	// suggest logging in again as a possible solution to the error.
-	AuthError = "Possibly user credentials are expired, try logging in again via the Evergreen web UI."
 	// VPNError is a special error when the CLI receives 403 Forbidden to
 	// suggest checking VPN connection as a possible solution to the error.
 	VPNError = "VPN connection required: please make sure you're on the VPN and have access to Evergreen."
@@ -141,9 +138,7 @@ func (c *communicatorImpl) retryRequest(ctx context.Context, info requestInfo, d
 		},
 	})
 	// We return the response intentionally so that callers can read the body.
-	if resp != nil && resp.StatusCode == http.StatusUnauthorized {
-		return resp, util.RespError(resp, AuthError)
-	} else if resp != nil && resp.StatusCode == http.StatusForbidden {
+	if resp != nil && resp.StatusCode == http.StatusForbidden {
 		return resp, util.RespError(resp, VPNError)
 	} else if err != nil {
 		return resp, err


### PR DESCRIPTION
DEVPROD-38041

### Description

Noticed in [this thread](https://mongodb.slack.com/archives/C69UXN1CP/p1785265977631479), the CLI has switched to using Kanopy OAuth for a while, so the suggestion about logging into the web UI again won't help if a user hits a 401. Removing it since it's no longer helpful advice.

### Testing

* Code compiles.
* Tested locally to verify that 401s don't get the "try logging in again" message anymore.