### PR TITLE
DEVPROD-38039 Do not run check vulnerabilities task in PRs

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -678,7 +678,7 @@ tasks:
       - func: verify-swaggo-fmt
   - name: check-go-vulnerabilities
     tags: ["linter"]
-    allowed_requesters: ["patch", "commit"]
+    allowed_requesters: ["patch"]
     commands:
       - func: get-project-and-modules
       - command: subprocess.exec

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -678,6 +678,7 @@ tasks:
       - func: verify-swaggo-fmt
   - name: check-go-vulnerabilities
     tags: ["linter"]
+    allowed_requesters: ["patch", "commit"]
     commands:
       - func: get-project-and-modules
       - command: subprocess.exec


### PR DESCRIPTION
DEVPROD-38039

### Description
Removes this task from our PR checks while still allowing it to be in the waterfall and tested manually via the CLI.