### PR TITLE
Post per-variant ignored status on early return when all variants are filtered out

### DIFF
--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -372,6 +372,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	// If all variants were filtered out, send success messages and don't create the patch.
 	if len(patchDoc.VariantsTasks) == 0 && len(ignoredVariants) > 0 {
 		j.sendGitHubSuccessMessages(ctx, patchDoc, pref)
+		j.sendGitHubSuccessMessageForIgnoredVariants(ctx, patchDoc, ignoredVariants)
 		return nil
 	}
 


### PR DESCRIPTION
## Problem

When path filtering excludes **all** variants from a GitHub PR patch, `finishPatch` takes an early return (`units/patch_intent.go:373`) that calls `sendGitHubSuccessMessages` (posting `"all patched files are ignored"` to the 12 required-check rule contexts) but never calls `sendGitHubSuccessMessageForIgnoredVariants`. This means no per-variant commit status (e.g. `evergreen/e2e_nds_local_smoke_tests`) is posted at all.

When only **some** variants are filtered out, the code at line 445 does call `sendGitHubSuccessMessageForIgnoredVariants`, posting `"variant ignored due to path filtering"` to each filtered variant context. The early-return path is the only case where per-variant statuses are missing.

This breaks GitHub Actions workflows that poll for a specific `evergreen/<variant>` commit status to bridge it into the GitHub Checks API. When the status never appears, the bridge either times out and fails (blocking the PR) or has to match the Evergreen variant path filter exactly (creating a dual-filter sync problem).

## Fix

Add `j.sendGitHubSuccessMessageForIgnoredVariants(ctx, patchDoc, ignoredVariants)` before the early return, so per-variant `"variant ignored due to path filtering"` statuses are posted regardless of whether all or only some variants were filtered out.

## Change

One line added:

```go
 if len(patchDoc.VariantsTasks) == 0 && len(ignoredVariants) > 0 {
     j.sendGitHubSuccessMessages(ctx, patchDoc, pref)
+    j.sendGitHubSuccessMessageForIgnoredVariants(ctx, patchDoc, ignoredVariants)
     return nil
 }
```

## Impact

Every GitHub PR where all variants are path-filtered out will now receive per-variant `evergreen/<variant>` success statuses with description `"variant ignored due to path filtering"`, in addition to the existing 12 required-check `"all patched files are ignored"` statuses. This is the same message already posted for partially-filtered patches.

Downstream consumers that poll for a specific `evergreen/<variant>` context (e.g. the `mms-nds-local-smoke-required-pr` GHA workflow) will find the status immediately and exit green, instead of timing out or requiring a path filter that must be kept in sync with the Evergreen variant filter.