### PR TITLE
PLATFORMS-2447: Expose effective isolation settings through DistroView

### DIFF
--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -353,9 +353,18 @@ type GeneratePollResponse struct {
 // DistroView represents the view of data that the agent uses from the distro
 // it is running on.
 type DistroView struct {
-	DisableShallowClone bool     `json:"disable_shallow_clone"`
-	Mountpoints         []string `json:"mountpoints"`
-	ExecUser            string   `json:"exec_user"`
+	DisableShallowClone bool                        `json:"disable_shallow_clone"`
+	Mountpoints         []string                    `json:"mountpoints"`
+	ExecUser            string                      `json:"exec_user"`
+	ContainerIsolation  *ContainerIsolationSettings `json:"container_isolation,omitempty"`
+}
+
+// ContainerIsolationSettings is the agent-facing view of container isolation config.
+type ContainerIsolationSettings struct {
+	Image            string `json:"image"`
+	MemoryMB         int64  `json:"memory_mb,omitempty"`
+	CPUs             int64  `json:"cpus,omitempty"`
+	RequireIsolation bool   `json:"require_isolation,omitempty"`
 }
 
 // HostView includes a relevant subset of information the agent's own host.

--- a/config.go
+++ b/config.go
@@ -38,7 +38,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-07-22"
+	AgentVersion = "2026-07-29"
 )
 
 const (

--- a/model/distro/db.go
+++ b/model/distro/db.go
@@ -26,6 +26,7 @@ var (
 	SetupKey                 = bsonutil.MustHaveTag(Distro{}, "Setup")
 	AuthorizedKeysFileKey    = bsonutil.MustHaveTag(Distro{}, "AuthorizedKeysFile")
 	UserKey                  = bsonutil.MustHaveTag(Distro{}, "User")
+	ExecUserKey              = bsonutil.MustHaveTag(Distro{}, "ExecUser")
 	SSHOptionsKey            = bsonutil.MustHaveTag(Distro{}, "SSHOptions")
 	BootstrapSettingsKey     = bsonutil.MustHaveTag(Distro{}, "BootstrapSettings")
 	DispatcherSettingsKey    = bsonutil.MustHaveTag(Distro{}, "DispatcherSettings")
@@ -114,6 +115,17 @@ func HasAnyByIdOrAlias(ctx context.Context, ids []string) (bool, error) {
 		return false, errors.Wrap(err, "finding distro by ID or alias")
 	}
 	return d != nil, nil
+}
+
+// FindOneForDistroView returns a Distro containing only the fields needed by
+// the distro_view agent endpoint (bootstrap settings and exec user). Using a
+// projection avoids deserializing the full document — which can be large for
+// EC2 distros — on every agent task start.
+func FindOneForDistroView(ctx context.Context, id string) (*Distro, error) {
+	return FindOne(ctx, ById(id), options.FindOne().SetProjection(bson.M{
+		BootstrapSettingsKey: 1,
+		ExecUserKey:          1,
+	}))
 }
 
 func FindOne(ctx context.Context, query bson.M, options ...*options.FindOneOptions) (*Distro, error) {

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -16,6 +16,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/artifact"
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/githubapp"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -586,14 +587,15 @@ func (h *getParserProjectHandler) Run(ctx context.Context) gimlet.Responder {
 type getDistroViewHandler struct {
 	taskID string
 	hostID string
+	env    evergreen.Environment
 }
 
-func makeGetDistroView() gimlet.RouteHandler {
-	return &getDistroViewHandler{}
+func makeGetDistroView(env evergreen.Environment) gimlet.RouteHandler {
+	return &getDistroViewHandler{env: env}
 }
 
 func (h *getDistroViewHandler) Factory() gimlet.RouteHandler {
-	return &getDistroViewHandler{}
+	return &getDistroViewHandler{env: h.env}
 }
 
 func (h *getDistroViewHandler) Parse(ctx context.Context, r *http.Request) error {
@@ -632,6 +634,70 @@ func (h *getDistroViewHandler) Run(ctx context.Context) gimlet.Responder {
 		DisableShallowClone: foundHost.Distro.DisableShallowClone,
 		Mountpoints:         foundHost.Distro.Mountpoints,
 		ExecUser:            foundHost.Distro.ExecUser,
+	}
+	// Prefer live distro settings over the embedded snapshot for fields that
+	// affect task isolation. Hosts provisioned before container isolation was
+	// configured carry a stale snapshot; a live lookup ensures they pick up
+	// the current distro config. ExecUser is also refreshed because the distro
+	// validator couples it to ContainerIsolation.Enabled — they must be
+	// consistent or between-task process cleanup will be skipped.
+	//
+	// The live lookup is skipped when: (a) the host has no distro ID, or
+	// (b) the service-level kill switch is on (no isolation is active anywhere).
+	// This avoids an unconditional per-task-start DB round-trip on fleets where
+	// container isolation has not been enabled.
+	ci := foundHost.Distro.BootstrapSettings.ContainerIsolation
+	killSwitchOn := h.env != nil && !h.env.Settings().ServiceFlags.ContainerIsolationEnabled
+	if foundHost.Distro.Id == "" {
+		grip.Warning(ctx, message.Fields{
+			"message": "host has no distro ID; skipping live distro lookup for container isolation",
+			"host_id": h.hostID,
+		})
+	} else if killSwitchOn {
+		// Kill switch is active — no live lookup needed; ci stays as embedded snapshot.
+	} else if liveDistro, err := distro.FindOneForDistroView(ctx, foundHost.Distro.Id); err != nil {
+		grip.Warning(ctx, message.WrapError(err, message.Fields{
+			"message": "falling back to embedded distro snapshot for container isolation settings",
+			"host_id": h.hostID,
+			"distro":  foundHost.Distro.Id,
+		}))
+	} else if liveDistro != nil {
+		ci = liveDistro.BootstrapSettings.ContainerIsolation
+		if liveDistro.ExecUser != "" {
+			dv.ExecUser = liveDistro.ExecUser
+		}
+	} else {
+		grip.Warning(ctx, message.Fields{
+			"message": "distro not found in live collection; using embedded snapshot for container isolation",
+			"host_id": h.hostID,
+			"distro":  foundHost.Distro.Id,
+		})
+	}
+
+	// Populate container isolation only when the distro has it enabled and
+	// the fleet-wide container isolation flag is enabled.
+	if ci.Enabled {
+		if h.env != nil && !h.env.Settings().ServiceFlags.ContainerIsolationEnabled {
+			// Kill switch wins over per-distro settings, including RequireIsolation.
+			// Log a warning when the kill switch suppresses a fail-closed distro so
+			// the override is visible and operators can correlate host-mode tasks
+			// with the kill switch being active.
+			if ci.RequireIsolation {
+				grip.Warning(ctx, message.Fields{
+					"message": "container isolation kill switch is overriding a require_isolation distro; tasks will run in host-mode",
+					"host_id": h.hostID,
+					"distro":  foundHost.Distro.Id,
+					"image":   ci.Image,
+				})
+			}
+		} else {
+			dv.ContainerIsolation = &apimodels.ContainerIsolationSettings{
+				Image:            ci.Image,
+				MemoryMB:         ci.MemoryMB,
+				CPUs:             ci.CPUs,
+				RequireIsolation: ci.RequireIsolation,
+			}
+		}
 	}
 	return gimlet.NewJSONResponse(dv)
 }

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -635,26 +635,19 @@ func (h *getDistroViewHandler) Run(ctx context.Context) gimlet.Responder {
 		Mountpoints:         foundHost.Distro.Mountpoints,
 		ExecUser:            foundHost.Distro.ExecUser,
 	}
-	// Prefer live distro settings over the embedded snapshot for fields that
-	// affect task isolation. Hosts provisioned before container isolation was
-	// configured carry a stale snapshot; a live lookup ensures they pick up
-	// the current distro config. ExecUser is also refreshed because the distro
-	// validator couples it to ContainerIsolation.Enabled — they must be
-	// consistent or between-task process cleanup will be skipped.
-	//
-	// The live lookup is skipped when: (a) the host has no distro ID, or
-	// (b) the service-level kill switch is on (no isolation is active anywhere).
-	// This avoids an unconditional per-task-start DB round-trip on fleets where
-	// container isolation has not been enabled.
+	// Return the embedded snapshot without container isolation when the
+	// fleet-wide flag is off.
+	if h.env != nil && !h.env.Settings().ServiceFlags.ContainerIsolationEnabled {
+		return gimlet.NewJSONResponse(dv)
+	}
+	// Refresh container isolation and ExecUser from the live distro config to
+	// pick up changes made after the host was provisioned.
 	ci := foundHost.Distro.BootstrapSettings.ContainerIsolation
-	killSwitchOn := h.env != nil && !h.env.Settings().ServiceFlags.ContainerIsolationEnabled
 	if foundHost.Distro.Id == "" {
 		grip.Warning(ctx, message.Fields{
 			"message": "host has no distro ID; skipping live distro lookup for container isolation",
 			"host_id": h.hostID,
 		})
-	} else if killSwitchOn {
-		// Kill switch is active — no live lookup needed; ci stays as embedded snapshot.
 	} else if liveDistro, err := distro.FindOneForDistroView(ctx, foundHost.Distro.Id); err != nil {
 		grip.Warning(ctx, message.WrapError(err, message.Fields{
 			"message": "falling back to embedded distro snapshot for container isolation settings",
@@ -673,30 +666,12 @@ func (h *getDistroViewHandler) Run(ctx context.Context) gimlet.Responder {
 			"distro":  foundHost.Distro.Id,
 		})
 	}
-
-	// Populate container isolation only when the distro has it enabled and
-	// the fleet-wide container isolation flag is enabled.
 	if ci.Enabled {
-		if h.env != nil && !h.env.Settings().ServiceFlags.ContainerIsolationEnabled {
-			// Kill switch wins over per-distro settings, including RequireIsolation.
-			// Log a warning when the kill switch suppresses a fail-closed distro so
-			// the override is visible and operators can correlate host-mode tasks
-			// with the kill switch being active.
-			if ci.RequireIsolation {
-				grip.Warning(ctx, message.Fields{
-					"message": "container isolation kill switch is overriding a require_isolation distro; tasks will run in host-mode",
-					"host_id": h.hostID,
-					"distro":  foundHost.Distro.Id,
-					"image":   ci.Image,
-				})
-			}
-		} else {
-			dv.ContainerIsolation = &apimodels.ContainerIsolationSettings{
-				Image:            ci.Image,
-				MemoryMB:         ci.MemoryMB,
-				CPUs:             ci.CPUs,
-				RequireIsolation: ci.RequireIsolation,
-			}
+		dv.ContainerIsolation = &apimodels.ContainerIsolationSettings{
+			Image:            ci.Image,
+			MemoryMB:         ci.MemoryMB,
+			CPUs:             ci.CPUs,
+			RequireIsolation: ci.RequireIsolation,
 		}
 	}
 	return gimlet.NewJSONResponse(dv)

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -1772,6 +1772,7 @@ func TestGetDistroView(t *testing.T) {
 			}
 			require.NoError(t, liveDistro.Insert(ctx))
 
+			ctx = context.WithValue(ctx, model.ApiHostKey, &h)
 			resp := rh.Run(ctx)
 			require.Equal(t, http.StatusOK, resp.Status())
 			data, ok := resp.Data().(apimodels.DistroView)
@@ -1802,6 +1803,7 @@ func TestGetDistroView(t *testing.T) {
 			// Live distro has CI disabled.
 			require.NoError(t, (&distro.Distro{Id: "rhel80"}).Insert(ctx))
 
+			ctx = context.WithValue(ctx, model.ApiHostKey, &h)
 			resp := rh.Run(ctx)
 			require.Equal(t, http.StatusOK, resp.Status())
 			data, ok := resp.Data().(apimodels.DistroView)
@@ -1828,6 +1830,7 @@ func TestGetDistroView(t *testing.T) {
 			require.NoError(t, h.Insert(ctx))
 			// Intentionally do not insert a live distro document for "rhel80-missing".
 
+			ctx = context.WithValue(ctx, model.ApiHostKey, &h)
 			resp := rh.Run(ctx)
 			require.Equal(t, http.StatusOK, resp.Status())
 			data, ok := resp.Data().(apimodels.DistroView)
@@ -1857,6 +1860,7 @@ func TestGetDistroView(t *testing.T) {
 			}
 			require.NoError(t, liveDistro.Insert(ctx))
 
+			ctx = context.WithValue(ctx, model.ApiHostKey, &h)
 			resp := rh.Run(ctx)
 			require.Equal(t, http.StatusOK, resp.Status())
 			data, ok := resp.Data().(apimodels.DistroView)

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/s3lifecycle"
 	"github.com/evergreen-ci/evergreen/model/s3usage"
 	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
@@ -98,8 +100,7 @@ func TestAgentGetExpansionsAndVars(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			env := &mock.Environment{}
 			require.NoError(t, env.Configure(ctx))
@@ -518,8 +519,7 @@ func TestMarkTaskForReset(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			require.NoError(t, db.ClearCollections(task.Collection, model.ProjectRefCollection))
 			settings := &evergreen.Settings{
@@ -623,8 +623,7 @@ func TestAgentSetup(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			s := &evergreen.Settings{
 				Splunk: evergreen.SplunkConfig{
@@ -648,8 +647,7 @@ func TestAgentSetup(t *testing.T) {
 }
 
 func TestDownstreamParams(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	require.NoError(t, db.ClearCollections(patch.Collection, task.Collection, host.Collection))
 	parameters := []patch.Parameter{
@@ -720,8 +718,7 @@ func TestDownstreamParams(t *testing.T) {
 }
 
 func TestAgentGetProjectRef(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	require.NoError(t, db.ClearCollections(task.Collection, model.ProjectRefCollection))
 	defer func() {
@@ -824,8 +821,7 @@ func TestCreateInstallationToken(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			env := &mock.Environment{}
 			require.NoError(t, env.Configure(ctx))
@@ -839,8 +835,7 @@ func TestCreateInstallationToken(t *testing.T) {
 }
 
 func TestUpsertCheckRunParse(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	require.NoError(t, db.ClearCollections(task.Collection, patch.Collection))
 
@@ -1231,8 +1226,7 @@ func TestCreateGitHubDynamicAccessToken(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			env := &mock.Environment{}
 			require.NoError(t, env.Configure(ctx))
@@ -1297,8 +1291,7 @@ func TestRevokeGitHubDynamicAccessToken(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			env := &mock.Environment{}
 			require.NoError(t, env.Configure(ctx))
@@ -1454,8 +1447,7 @@ func TestStartTaskWithOtelMetadata(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			require.NoError(t, db.ClearCollections(task.Collection, host.Collection))
 
@@ -1661,6 +1653,101 @@ func TestLogLookupClosureUsesAdminBucketsConfig(t *testing.T) {
 	})
 }
 
+func TestGitServePatchFile(t *testing.T) {
+	ctx := t.Context()
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+	testutil.ConfigureIntegrationTest(t, env.Settings())
+
+	require.NoError(t, db.ClearCollections(task.Collection, patch.Collection))
+
+	const patchFileID = "patchfile123"
+	const otherPatchFileID = "patchfile456"
+	const taskID = "task1"
+	const versionID = "aaaaaaaaaaff001122334455"
+
+	tsk := task.Task{
+		Id:      taskID,
+		Version: versionID,
+	}
+	require.NoError(t, tsk.Insert(ctx))
+
+	p := patch.Patch{
+		Id:      mgobson.NewObjectId(),
+		Version: versionID,
+		Patches: []patch.ModulePatch{
+			{
+				ModuleName: "",
+				PatchSet: patch.PatchSet{
+					PatchFileId: patchFileID,
+				},
+			},
+		},
+	}
+	require.NoError(t, p.Insert(ctx))
+
+	require.NoError(t, db.WriteGridFile(ctx, patch.GridFSPrefix, patchFileID, strings.NewReader("diff --git a/file")))
+
+	t.Run("ValidPatchFileIDReturnsContents", func(t *testing.T) {
+		h := &gitServePatchFileHandler{taskID: taskID, patchID: patchFileID}
+		resp := h.Run(ctx)
+		require.NotNil(t, resp)
+		assert.Equal(t, http.StatusOK, resp.Status())
+	})
+
+	t.Run("PatchFileIDBelongingToOtherPatchReturnsNotFound", func(t *testing.T) {
+		h := &gitServePatchFileHandler{taskID: taskID, patchID: otherPatchFileID}
+		resp := h.Run(ctx)
+		require.NotNil(t, resp)
+		assert.Equal(t, http.StatusNotFound, resp.Status())
+	})
+}
+
+func TestAttachTestResultsHandlerRun(t *testing.T) {
+	const (
+		authedTaskID = "authed_task"
+		victimTaskID = "victim_task"
+	)
+	authedTask := &task.Task{Id: authedTaskID, Execution: 1}
+
+	makeHandler := func(body apimodels.AttachTestResultsRequest) *attachTestResultsHandler {
+		return &attachTestResultsHandler{taskID: authedTaskID, body: body}
+	}
+	matchingInfo := testresult.TestResultsInfo{TaskID: authedTaskID, Execution: 1}
+
+	t.Run("MismatchedTaskIDIsRejected", func(t *testing.T) {
+		h := makeHandler(apimodels.AttachTestResultsRequest{
+			Info: testresult.TestResultsInfo{TaskID: victimTaskID, Execution: 1},
+		})
+		ctx := context.WithValue(t.Context(), model.ApiTaskKey, authedTask)
+		assert.Equal(t, http.StatusForbidden, h.Run(ctx).Status())
+	})
+	t.Run("MismatchedExecutionIsRejected", func(t *testing.T) {
+		h := makeHandler(apimodels.AttachTestResultsRequest{
+			Info: testresult.TestResultsInfo{TaskID: authedTaskID, Execution: 2},
+		})
+		ctx := context.WithValue(t.Context(), model.ApiTaskKey, authedTask)
+		assert.Equal(t, http.StatusForbidden, h.Run(ctx).Status())
+	})
+	t.Run("NegativeFailedCountIsRejected", func(t *testing.T) {
+		h := makeHandler(apimodels.AttachTestResultsRequest{
+			Info:  matchingInfo,
+			Stats: testresult.TaskTestResultsStats{FailedCount: -1, TotalCount: 1},
+		})
+		ctx := context.WithValue(t.Context(), model.ApiTaskKey, authedTask)
+		assert.Equal(t, http.StatusBadRequest, h.Run(ctx).Status())
+	})
+	t.Run("NegativeTotalCountIsRejected", func(t *testing.T) {
+		h := makeHandler(apimodels.AttachTestResultsRequest{
+			Info:  matchingInfo,
+			Stats: testresult.TaskTestResultsStats{FailedCount: 0, TotalCount: -1},
+		})
+		ctx := context.WithValue(t.Context(), model.ApiTaskKey, authedTask)
+		assert.Equal(t, http.StatusBadRequest, h.Run(ctx).Status())
+	})
+}
+
 func TestGetDistroView(t *testing.T) {
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, rh *getDistroViewHandler){
 		"LiveDistroEnablesContainerIsolationForStaleHost": func(ctx context.Context, t *testing.T, rh *getDistroViewHandler) {
@@ -1794,25 +1881,4 @@ func TestGetDistroView(t *testing.T) {
 			tCase(ctx, t, rh)
 		})
 	}
-}
-
-func TestFindExpirationDaysForFileKey(t *testing.T) {
-	days90 := 90
-	cfg := &evergreen.BucketsConfig{
-		LogBucket: evergreen.BucketConfig{Name: "log-bucket", ExpirationDays: &days90},
-	}
-	logLookup := func(_ context.Context, bucket, _ string) (int, bool) {
-		return cfg.LogBucketExpirationDays(bucket)
-	}
-
-	t.Run("KnownLogBucketReturnsDays", func(t *testing.T) {
-		days, ok := logLookup(t.Context(), "log-bucket", "")
-		assert.True(t, ok)
-		assert.Equal(t, 90, days)
-	})
-
-	t.Run("UnknownBucketReturnsFalse", func(t *testing.T) {
-		_, ok := logLookup(t.Context(), "artifact-bucket", "")
-		assert.False(t, ok)
-	})
 }

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -25,7 +24,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/s3lifecycle"
 	"github.com/evergreen-ci/evergreen/model/s3usage"
 	"github.com/evergreen-ci/evergreen/model/task"
-	"github.com/evergreen-ci/evergreen/model/testresult"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/gimlet"
@@ -100,7 +98,8 @@ func TestAgentGetExpansionsAndVars(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			ctx := t.Context()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			env := &mock.Environment{}
 			require.NoError(t, env.Configure(ctx))
@@ -519,7 +518,8 @@ func TestMarkTaskForReset(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			ctx := t.Context()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			require.NoError(t, db.ClearCollections(task.Collection, model.ProjectRefCollection))
 			settings := &evergreen.Settings{
@@ -623,7 +623,8 @@ func TestAgentSetup(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			ctx := t.Context()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			s := &evergreen.Settings{
 				Splunk: evergreen.SplunkConfig{
@@ -647,7 +648,8 @@ func TestAgentSetup(t *testing.T) {
 }
 
 func TestDownstreamParams(t *testing.T) {
-	ctx := t.Context()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	require.NoError(t, db.ClearCollections(patch.Collection, task.Collection, host.Collection))
 	parameters := []patch.Parameter{
@@ -718,7 +720,8 @@ func TestDownstreamParams(t *testing.T) {
 }
 
 func TestAgentGetProjectRef(t *testing.T) {
-	ctx := t.Context()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	require.NoError(t, db.ClearCollections(task.Collection, model.ProjectRefCollection))
 	defer func() {
@@ -821,7 +824,8 @@ func TestCreateInstallationToken(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			ctx := t.Context()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			env := &mock.Environment{}
 			require.NoError(t, env.Configure(ctx))
@@ -835,7 +839,8 @@ func TestCreateInstallationToken(t *testing.T) {
 }
 
 func TestUpsertCheckRunParse(t *testing.T) {
-	ctx := t.Context()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	require.NoError(t, db.ClearCollections(task.Collection, patch.Collection))
 
@@ -1226,7 +1231,8 @@ func TestCreateGitHubDynamicAccessToken(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			ctx := t.Context()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			env := &mock.Environment{}
 			require.NoError(t, env.Configure(ctx))
@@ -1291,7 +1297,8 @@ func TestRevokeGitHubDynamicAccessToken(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			ctx := t.Context()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			env := &mock.Environment{}
 			require.NoError(t, env.Configure(ctx))
@@ -1447,7 +1454,8 @@ func TestStartTaskWithOtelMetadata(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := t.Context()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			require.NoError(t, db.ClearCollections(task.Collection, host.Collection))
 
@@ -1653,97 +1661,158 @@ func TestLogLookupClosureUsesAdminBucketsConfig(t *testing.T) {
 	})
 }
 
-func TestGitServePatchFile(t *testing.T) {
-	ctx := t.Context()
-
-	env := &mock.Environment{}
-	require.NoError(t, env.Configure(ctx))
-	testutil.ConfigureIntegrationTest(t, env.Settings())
-
-	require.NoError(t, db.ClearCollections(task.Collection, patch.Collection))
-
-	const patchFileID = "patchfile123"
-	const otherPatchFileID = "patchfile456"
-	const taskID = "task1"
-	const versionID = "aaaaaaaaaaff001122334455"
-
-	tsk := task.Task{
-		Id:      taskID,
-		Version: versionID,
-	}
-	require.NoError(t, tsk.Insert(ctx))
-
-	p := patch.Patch{
-		Id:      mgobson.NewObjectId(),
-		Version: versionID,
-		Patches: []patch.ModulePatch{
-			{
-				ModuleName: "",
-				PatchSet: patch.PatchSet{
-					PatchFileId: patchFileID,
+func TestGetDistroView(t *testing.T) {
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, rh *getDistroViewHandler){
+		"LiveDistroEnablesContainerIsolationForStaleHost": func(ctx context.Context, t *testing.T, rh *getDistroViewHandler) {
+			// The host's embedded distro has no container isolation, but the
+			// live distro in the DB has it enabled. The handler should return CI.
+			h := host.Host{
+				Id:     "host_id",
+				Distro: distro.Distro{Id: "rhel80"},
+			}
+			require.NoError(t, h.Insert(ctx))
+			liveDistro := &distro.Distro{
+				Id:       "rhel80",
+				ExecUser: "taskuser",
+				BootstrapSettings: distro.BootstrapSettings{
+					ContainerIsolation: distro.ContainerIsolationSettings{
+						Enabled:  true,
+						Image:    "my-image:latest",
+						MemoryMB: 1024,
+						CPUs:     2,
+					},
 				},
-			},
+			}
+			require.NoError(t, liveDistro.Insert(ctx))
+
+			resp := rh.Run(ctx)
+			require.Equal(t, http.StatusOK, resp.Status())
+			data, ok := resp.Data().(apimodels.DistroView)
+			require.True(t, ok)
+			require.NotNil(t, data.ContainerIsolation)
+			assert.Equal(t, "my-image:latest", data.ContainerIsolation.Image)
+			assert.Equal(t, int64(1024), data.ContainerIsolation.MemoryMB)
+			assert.Equal(t, int64(2), data.ContainerIsolation.CPUs)
+			assert.Equal(t, "taskuser", data.ExecUser, "ExecUser should be refreshed from live distro")
 		},
+		"LiveDistroDisablesContainerIsolationOverEmbedded": func(ctx context.Context, t *testing.T, rh *getDistroViewHandler) {
+			// The host's embedded distro has CI enabled, but the live distro
+			// does not. The live distro's settings should win.
+			h := host.Host{
+				Id: "host_id",
+				Distro: distro.Distro{
+					Id:       "rhel80",
+					ExecUser: "taskuser",
+					BootstrapSettings: distro.BootstrapSettings{
+						ContainerIsolation: distro.ContainerIsolationSettings{
+							Enabled: true,
+							Image:   "stale-image:v1",
+						},
+					},
+				},
+			}
+			require.NoError(t, h.Insert(ctx))
+			// Live distro has CI disabled.
+			require.NoError(t, (&distro.Distro{Id: "rhel80"}).Insert(ctx))
+
+			resp := rh.Run(ctx)
+			require.Equal(t, http.StatusOK, resp.Status())
+			data, ok := resp.Data().(apimodels.DistroView)
+			require.True(t, ok)
+			assert.Nil(t, data.ContainerIsolation)
+			assert.Equal(t, "taskuser", data.ExecUser, "snapshot ExecUser preserved when live distro has none")
+		},
+		"MissingLiveDistroFallsBackToEmbeddedSnapshot": func(ctx context.Context, t *testing.T, rh *getDistroViewHandler) {
+			// No live distro document exists; the handler falls back to the
+			// host's embedded distro snapshot which has CI enabled.
+			h := host.Host{
+				Id: "host_id",
+				Distro: distro.Distro{
+					Id:       "rhel80-missing",
+					ExecUser: "snapshotuser",
+					BootstrapSettings: distro.BootstrapSettings{
+						ContainerIsolation: distro.ContainerIsolationSettings{
+							Enabled: true,
+							Image:   "embedded-image:v1",
+						},
+					},
+				},
+			}
+			require.NoError(t, h.Insert(ctx))
+			// Intentionally do not insert a live distro document for "rhel80-missing".
+
+			resp := rh.Run(ctx)
+			require.Equal(t, http.StatusOK, resp.Status())
+			data, ok := resp.Data().(apimodels.DistroView)
+			require.True(t, ok)
+			require.NotNil(t, data.ContainerIsolation)
+			assert.Equal(t, "embedded-image:v1", data.ContainerIsolation.Image)
+			assert.Equal(t, "snapshotuser", data.ExecUser, "snapshot ExecUser preserved when live distro missing")
+		},
+		"ContainerIsolationKillSwitchSuppressesCI": func(ctx context.Context, t *testing.T, rh *getDistroViewHandler) {
+			rh.env.Settings().ServiceFlags.ContainerIsolationEnabled = false
+
+			h := host.Host{
+				Id:     "host_id",
+				Distro: distro.Distro{Id: "rhel80"},
+			}
+			require.NoError(t, h.Insert(ctx))
+			liveDistro := &distro.Distro{
+				Id:       "rhel80",
+				ExecUser: "taskuser",
+				BootstrapSettings: distro.BootstrapSettings{
+					ContainerIsolation: distro.ContainerIsolationSettings{
+						Enabled:          true,
+						Image:            "my-image:latest",
+						RequireIsolation: true,
+					},
+				},
+			}
+			require.NoError(t, liveDistro.Insert(ctx))
+
+			resp := rh.Run(ctx)
+			require.Equal(t, http.StatusOK, resp.Status())
+			data, ok := resp.Data().(apimodels.DistroView)
+			require.True(t, ok)
+			assert.Nil(t, data.ContainerIsolation, "kill switch should suppress CI")
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx := t.Context()
+
+			env := &mock.Environment{}
+			require.NoError(t, env.Configure(ctx))
+			testutil.ConfigureIntegrationTest(t, env.Settings())
+
+			require.NoError(t, db.ClearCollections(host.Collection, distro.Collection))
+
+			rh, ok := makeGetDistroView(env).(*getDistroViewHandler)
+			require.True(t, ok)
+			rh.env.Settings().ServiceFlags.ContainerIsolationEnabled = true
+			rh.hostID = "host_id"
+
+			tCase(ctx, t, rh)
+		})
 	}
-	require.NoError(t, p.Insert(ctx))
-
-	require.NoError(t, db.WriteGridFile(ctx, patch.GridFSPrefix, patchFileID, strings.NewReader("diff --git a/file")))
-
-	t.Run("ValidPatchFileIDReturnsContents", func(t *testing.T) {
-		h := &gitServePatchFileHandler{taskID: taskID, patchID: patchFileID}
-		resp := h.Run(ctx)
-		require.NotNil(t, resp)
-		assert.Equal(t, http.StatusOK, resp.Status())
-	})
-
-	t.Run("PatchFileIDBelongingToOtherPatchReturnsNotFound", func(t *testing.T) {
-		h := &gitServePatchFileHandler{taskID: taskID, patchID: otherPatchFileID}
-		resp := h.Run(ctx)
-		require.NotNil(t, resp)
-		assert.Equal(t, http.StatusNotFound, resp.Status())
-	})
 }
 
-func TestAttachTestResultsHandlerRun(t *testing.T) {
-	const (
-		authedTaskID = "authed_task"
-		victimTaskID = "victim_task"
-	)
-	authedTask := &task.Task{Id: authedTaskID, Execution: 1}
-
-	makeHandler := func(body apimodels.AttachTestResultsRequest) *attachTestResultsHandler {
-		return &attachTestResultsHandler{taskID: authedTaskID, body: body}
+func TestFindExpirationDaysForFileKey(t *testing.T) {
+	days90 := 90
+	cfg := &evergreen.BucketsConfig{
+		LogBucket: evergreen.BucketConfig{Name: "log-bucket", ExpirationDays: &days90},
 	}
-	matchingInfo := testresult.TestResultsInfo{TaskID: authedTaskID, Execution: 1}
+	logLookup := func(_ context.Context, bucket, _ string) (int, bool) {
+		return cfg.LogBucketExpirationDays(bucket)
+	}
 
-	t.Run("MismatchedTaskIDIsRejected", func(t *testing.T) {
-		h := makeHandler(apimodels.AttachTestResultsRequest{
-			Info: testresult.TestResultsInfo{TaskID: victimTaskID, Execution: 1},
-		})
-		ctx := context.WithValue(t.Context(), model.ApiTaskKey, authedTask)
-		assert.Equal(t, http.StatusForbidden, h.Run(ctx).Status())
+	t.Run("KnownLogBucketReturnsDays", func(t *testing.T) {
+		days, ok := logLookup(t.Context(), "log-bucket", "")
+		assert.True(t, ok)
+		assert.Equal(t, 90, days)
 	})
-	t.Run("MismatchedExecutionIsRejected", func(t *testing.T) {
-		h := makeHandler(apimodels.AttachTestResultsRequest{
-			Info: testresult.TestResultsInfo{TaskID: authedTaskID, Execution: 2},
-		})
-		ctx := context.WithValue(t.Context(), model.ApiTaskKey, authedTask)
-		assert.Equal(t, http.StatusForbidden, h.Run(ctx).Status())
-	})
-	t.Run("NegativeFailedCountIsRejected", func(t *testing.T) {
-		h := makeHandler(apimodels.AttachTestResultsRequest{
-			Info:  matchingInfo,
-			Stats: testresult.TaskTestResultsStats{FailedCount: -1, TotalCount: 1},
-		})
-		ctx := context.WithValue(t.Context(), model.ApiTaskKey, authedTask)
-		assert.Equal(t, http.StatusBadRequest, h.Run(ctx).Status())
-	})
-	t.Run("NegativeTotalCountIsRejected", func(t *testing.T) {
-		h := makeHandler(apimodels.AttachTestResultsRequest{
-			Info:  matchingInfo,
-			Stats: testresult.TaskTestResultsStats{FailedCount: 0, TotalCount: -1},
-		})
-		ctx := context.WithValue(t.Context(), model.ApiTaskKey, authedTask)
-		assert.Equal(t, http.StatusBadRequest, h.Run(ctx).Status())
+
+	t.Run("UnknownBucketReturnsFalse", func(t *testing.T) {
+		_, ok := logLookup(t.Context(), "artifact-bucket", "")
+		assert.False(t, ok)
 	})
 }

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -82,7 +82,7 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/hosts/{task_id}/list").Version(2).Get().Wrap(requireTask, rateLimit).RouteHandler(makeHostListRouteManager())
 	app.AddRoute("/task/{task_id}/").Version(2).Get().Wrap(requireUserOrTask, rateLimit).RouteHandler(makeFetchTask())
 	app.AddRoute("/task/{task_id}/display_task").Version(2).Get().Wrap(requireTask, rateLimit).RouteHandler(makeGetDisplayTaskHandler())
-	app.AddRoute("/task/{task_id}/distro_view").Version(2).Get().Wrap(requireUserOrTask, rateLimit).RouteHandler(makeGetDistroView())
+	app.AddRoute("/task/{task_id}/distro_view").Version(2).Get().Wrap(requireUserOrTask, rateLimit).RouteHandler(makeGetDistroView(env))
 	app.AddRoute("/task/{task_id}/host_view").Version(2).Get().Wrap(requireTask, requireHost, rateLimit).RouteHandler(makeGetHostView())
 	app.AddRoute("/task/{task_id}/downstreamParams").Version(2).Post().Wrap(requireTask, rateLimit).RouteHandler(makeSetDownstreamParams())
 	app.AddRoute("/task/{task_id}/expansions_and_vars").Version(2).Get().Wrap(requireUserOrTask, rateLimit).RouteHandler(makeGetExpansionsAndVars(settings))


### PR DESCRIPTION
PLATFORMS-2447: Expose effective isolation settings through DistroView

PLATFORMS-2447

**Stack: PR 2 of 9 — depends on `pr01-distro-model` (`https://github.com/evergreen-ci/evergreen/pull/10581`).**

This PR is safe to merge alone because it only exposes configuration; no task execution path is activated.

### Description

Extends the agent-facing distro view with isolation settings and suppresses them when the fleet-wide kill switch is active.

### Documentation

No user-facing documentation changes are required in this slice. Stack ordering and cross-PR links are maintained separately.
