### PR TITLE
DEVPROD-38094 Post per-variant ignored status on early return when all variants are filtered out

### DIFF
--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -372,6 +372,7 @@ func (j *patchIntentProcessor) finishPatch(ctx context.Context, patchDoc *patch.
 	// If all variants were filtered out, send success messages and don't create the patch.
 	if len(patchDoc.VariantsTasks) == 0 && len(ignoredVariants) > 0 {
 		j.sendGitHubSuccessMessages(ctx, patchDoc, pref)
+		j.sendGitHubSuccessMessageForIgnoredVariants(ctx, patchDoc, ignoredVariants)
 		return nil
 	}
 


### PR DESCRIPTION
[DEVPROD-38094](https://jira.mongodb.org/browse/DEVPROD-38094)

When evergreen path filtering excludes **all** variants from a GitHub PR patch, no per-variant commit status (e.g. `evergreen/e2e_nds_local_smoke_tests`) is posted at all. Instead, I'd like all variants that would have triggered but were ignored to be posted, so that a tool that looks for success for a particular variant can still determine that the check "succeeded" because it was path filtered out.

Currently, this breaks GitHub Actions workflows that poll for a specific `evergreen/<variant>` commit status to bridge it into the GitHub Checks API. When the status never appears, the bridge either times out and fails (blocking the PR) or has to match the Evergreen variant path filter exactly (creating a dual-filter sync problem).