### PR TITLE
DEVPROD-38097: disable vuln task

### DIFF
--- a/self-tests.yml
+++ b/self-tests.yml
@@ -677,6 +677,8 @@ tasks:
           include_expansions_in_env: ["GOROOT"]
       - func: verify-swaggo-fmt
   - name: check-go-vulnerabilities
+    tags: ["linter"]
+    disable: true
     commands:
       - func: get-project-and-modules
       - command: subprocess.exec

--- a/self-tests.yml
+++ b/self-tests.yml
@@ -677,7 +677,6 @@ tasks:
           include_expansions_in_env: ["GOROOT"]
       - func: verify-swaggo-fmt
   - name: check-go-vulnerabilities
-    tags: ["linter"]
     commands:
       - func: get-project-and-modules
       - command: subprocess.exec


### PR DESCRIPTION
DEVPROD-XXXX

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Remove vuln; I think it might make sense to revisit having this task work after we upgrade to 1.25 since so many updates are blocked, so I'm just marking it as inactive entirely rather than removing it just from the PR tags, but please let me know if you disagree.