### PR TITLE
DEVPROD-36674: narrow distro permission check

### DIFF
--- a/model/host/db.go
+++ b/model/host/db.go
@@ -1298,17 +1298,6 @@ func updateAllVolumes(ctx context.Context, query bson.M, update bson.M) error {
 	return errors.Wrap(err, "updating volumes")
 }
 
-func FindDistroForHost(ctx context.Context, hostID string) (string, error) {
-	h, err := FindOne(ctx, ById(hostID))
-	if err != nil {
-		return "", err
-	}
-	if h == nil {
-		return "", errors.New("host not found")
-	}
-	return h.Distro.Id, nil
-}
-
 func findVolumes(ctx context.Context, q bson.M) ([]Volume, error) {
 	volumes := []Volume{}
 	return volumes, db.FindAllQ(ctx, VolumesCollection, db.Query(q), &volumes)

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -585,59 +585,25 @@ func urlVarsToProjectScopes(r *http.Request) ([]string, int, error) {
 	return res, http.StatusOK, nil
 }
 
-// urlVarsToDistroScopes returns all distros being requested for access and the
-// HTTP status code.
+// urlVarsToDistroScopes returns the distro being requested for access and the
+// HTTP status code. The distro is matched by ID only, not by distro alias,
+// because the routes that check distro permissions all act on a distro looked
+// up by its exact ID.
 func urlVarsToDistroScopes(r *http.Request) ([]string, int, error) {
-	var err error
-	vars := gimlet.GetVars(r)
-	query := r.URL.Query()
-
-	resourceType := strings.ToUpper(util.CoalesceStrings(query["resource_type"], vars["resource_type"]))
-	if resourceType != "" {
-		switch resourceType {
-		case event.ResourceTypeDistro:
-			vars["distro_id"] = vars["resource_id"]
-		case event.ResourceTypeHost:
-			vars["host_id"] = vars["resource_id"]
-		}
-	}
-
-	distroID := util.CoalesceStrings(append(query["distro_id"], query["distroId"]...), vars["distro_id"], vars["distroId"])
-
-	hostID := util.CoalesceStrings(append(query["host_id"], query["hostId"]...), vars["host_id"], vars["hostId"])
-	if distroID == "" && hostID != "" {
-		distroID, err = host.FindDistroForHost(r.Context(), hostID)
-		if err != nil {
-			return nil, http.StatusNotFound, errors.Wrapf(err, "finding distro for host '%s'", hostID)
-		}
-	}
-
-	// no distro found - return a 404
+	distroID := gimlet.GetVars(r)["distro_id"]
 	if distroID == "" {
 		return nil, http.StatusNotFound, errors.New("no distro found")
 	}
 
-	dat, err := distro.NewDistroAliasesLookupTable(r.Context())
+	d, err := distro.FindOneId(r.Context(), distroID)
 	if err != nil {
-		return nil, http.StatusInternalServerError, errors.Wrap(err, "getting distro lookup table")
+		return nil, http.StatusInternalServerError, errors.Wrapf(err, "finding distro '%s'", distroID)
 	}
-	distroIDs := dat.Expand([]string{distroID})
-	if len(distroIDs) == 0 {
-		return nil, http.StatusNotFound, errors.Errorf("distro '%s' did not match any existing distros", distroID)
-	}
-	// Verify that all the concrete distros that this request is accessing
-	// exist.
-	for _, resolvedDistroID := range distroIDs {
-		d, err := distro.FindOneId(r.Context(), resolvedDistroID)
-		if err != nil {
-			return nil, http.StatusInternalServerError, errors.Wrapf(err, "finding distro '%s'", resolvedDistroID)
-		}
-		if d == nil {
-			return nil, http.StatusNotFound, errors.Errorf("distro '%s' does not exist", resolvedDistroID)
-		}
+	if d == nil {
+		return nil, http.StatusNotFound, errors.Errorf("distro '%s' does not exist", distroID)
 	}
 
-	return distroIDs, http.StatusOK, nil
+	return []string{distroID}, http.StatusOK, nil
 }
 
 func superUserResource(_ *http.Request) ([]string, int, error) {

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -586,9 +586,7 @@ func urlVarsToProjectScopes(r *http.Request) ([]string, int, error) {
 }
 
 // urlVarsToDistroScopes returns the distro being requested for access and the
-// HTTP status code. The distro is matched by ID only, not by distro alias,
-// because the routes that check distro permissions all act on a distro looked
-// up by its exact ID.
+// HTTP status code.
 func urlVarsToDistroScopes(r *http.Request) ([]string, int, error) {
 	distroID := gimlet.GetVars(r)["distro_id"]
 	if distroID == "" {

--- a/rest/route/middleware_test.go
+++ b/rest/route/middleware_test.go
@@ -2,6 +2,7 @@ package route
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -596,16 +597,14 @@ func TestURLVarsToDistroScopes(t *testing.T) {
 		assert.NoError(t, db.ClearCollections(distro.Collection))
 	})
 
-	authorized := distro.Distro{
-		Id:      "authorized-distro",
-		Aliases: []string{"shared-alias"},
+	targetDistro := distro.Distro{
+		Id: "distro",
 	}
-	require.NoError(t, authorized.Insert(t.Context()))
-	victim := distro.Distro{
-		Id:      "victim-distro",
-		Aliases: []string{"shared-alias"},
+	require.NoError(t, targetDistro.Insert(t.Context()))
+	otherDistro := distro.Distro{
+		Id: "other-distro",
 	}
-	require.NoError(t, victim.Insert(t.Context()))
+	require.NoError(t, otherDistro.Insert(t.Context()))
 
 	for tName, tCase := range map[string]struct {
 		pathVars           map[string]string
@@ -614,28 +613,18 @@ func TestURLVarsToDistroScopes(t *testing.T) {
 		expectedStatusCode int
 	}{
 		"ResolvesDistroFromPath": {
-			pathVars:           map[string]string{"distro_id": "victim-distro"},
-			expectedDistroIDs:  []string{"victim-distro"},
+			pathVars:           map[string]string{"distro_id": targetDistro.Id},
+			expectedDistroIDs:  []string{targetDistro.Id},
 			expectedStatusCode: http.StatusOK,
 		},
 		"IgnoresQueryStringDistroWhenPathHasDistro": {
-			pathVars:           map[string]string{"distro_id": "victim-distro"},
-			queryString:        "distro_id=authorized-distro&distroId=authorized-distro",
-			expectedDistroIDs:  []string{"victim-distro"},
+			pathVars:           map[string]string{"distro_id": targetDistro.Id},
+			queryString:        fmt.Sprintf("distro_id=%s", otherDistro.Id),
+			expectedDistroIDs:  []string{targetDistro.Id},
 			expectedStatusCode: http.StatusOK,
-		},
-		"IgnoresQueryStringHostWhenPathHasDistro": {
-			pathVars:           map[string]string{"distro_id": "victim-distro"},
-			queryString:        "host_id=authorized-host&resource_type=DISTRO&resource_id=authorized-distro",
-			expectedDistroIDs:  []string{"victim-distro"},
-			expectedStatusCode: http.StatusOK,
-		},
-		"DistroAliasInPathIsNotFound": {
-			pathVars:           map[string]string{"distro_id": "shared-alias"},
-			expectedStatusCode: http.StatusNotFound,
 		},
 		"QueryStringOnlyDistroIsNotFound": {
-			queryString:        "distro_id=authorized-distro",
+			queryString:        fmt.Sprintf("distro_id=%s", otherDistro.Id),
 			expectedStatusCode: http.StatusNotFound,
 		},
 		"NonexistentDistroInPathIsNotFound": {

--- a/rest/route/middleware_test.go
+++ b/rest/route/middleware_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -587,4 +588,83 @@ func TestProjectViewPermission(t *testing.T) {
 	authHandler.ServeHTTP(rw, req, checkPermission)
 	assert.Equal(http.StatusOK, rw.Code)
 	assert.Equal(1, counter)
+}
+
+func TestURLVarsToDistroScopes(t *testing.T) {
+	require.NoError(t, db.ClearCollections(distro.Collection))
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(distro.Collection))
+	})
+
+	authorized := distro.Distro{
+		Id:      "authorized-distro",
+		Aliases: []string{"shared-alias"},
+	}
+	require.NoError(t, authorized.Insert(t.Context()))
+	victim := distro.Distro{
+		Id:      "victim-distro",
+		Aliases: []string{"shared-alias"},
+	}
+	require.NoError(t, victim.Insert(t.Context()))
+
+	for tName, tCase := range map[string]struct {
+		pathVars           map[string]string
+		queryString        string
+		expectedDistroIDs  []string
+		expectedStatusCode int
+	}{
+		"ResolvesDistroFromPath": {
+			pathVars:           map[string]string{"distro_id": "victim-distro"},
+			expectedDistroIDs:  []string{"victim-distro"},
+			expectedStatusCode: http.StatusOK,
+		},
+		"IgnoresQueryStringDistroWhenPathHasDistro": {
+			pathVars:           map[string]string{"distro_id": "victim-distro"},
+			queryString:        "distro_id=authorized-distro&distroId=authorized-distro",
+			expectedDistroIDs:  []string{"victim-distro"},
+			expectedStatusCode: http.StatusOK,
+		},
+		"IgnoresQueryStringHostWhenPathHasDistro": {
+			pathVars:           map[string]string{"distro_id": "victim-distro"},
+			queryString:        "host_id=authorized-host&resource_type=DISTRO&resource_id=authorized-distro",
+			expectedDistroIDs:  []string{"victim-distro"},
+			expectedStatusCode: http.StatusOK,
+		},
+		"DistroAliasInPathIsNotFound": {
+			pathVars:           map[string]string{"distro_id": "shared-alias"},
+			expectedStatusCode: http.StatusNotFound,
+		},
+		"QueryStringOnlyDistroIsNotFound": {
+			queryString:        "distro_id=authorized-distro",
+			expectedStatusCode: http.StatusNotFound,
+		},
+		"NonexistentDistroInPathIsNotFound": {
+			pathVars:           map[string]string{"distro_id": "nonexistent-distro"},
+			expectedStatusCode: http.StatusNotFound,
+		},
+		"NoDistroIsNotFound": {
+			expectedStatusCode: http.StatusNotFound,
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			url := "/rest/v2/distros/some-distro"
+			if tCase.queryString != "" {
+				url += "?" + tCase.queryString
+			}
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, nil)
+			require.NoError(t, err)
+			req = gimlet.SetURLVars(req, tCase.pathVars)
+
+			distroIDs, statusCode, err := urlVarsToDistroScopes(req)
+
+			assert.Equal(t, tCase.expectedStatusCode, statusCode)
+			if tCase.expectedStatusCode != http.StatusOK {
+				assert.Error(t, err)
+				assert.Empty(t, distroIDs)
+				return
+			}
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tCase.expectedDistroIDs, distroIDs)
+		})
+	}
 }


### PR DESCRIPTION
DEVPROD-36674

### Description

It seems like the distro permission check is overly permissive and can check permissions against a different distro than the route is actually accessing (e.g. by passing a different distro ID in the query parameters). Because route handlers only access the distro specified by `distro_id`, we can significantly simply down the check - it only needs to check distro permissions against the `distro_id` in the path.

### Testing

* Manually audited all the routes that check distro permissions to confirm that they only ever access the distro specified by `distro_id`.
* Added unit tests.