### PR TITLE
 DEVPROD-37898 Cache results for generate tasks estimations

### DIFF
--- a/model/task/expected_duration.go
+++ b/model/task/expected_duration.go
@@ -3,14 +3,34 @@ package task
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/mongodb/anser/bsonutil"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
+
+// estimateCacheMaxSize bounds the shared historical-estimate caches. Keys are
+// active (project, build variant, task name) tuples, so this is far above the
+// working set of a busy app server.
+const estimateCacheMaxSize = 10000
+
+// expectedDurationCache shares the historical duration aggregate across sibling
+// tasks. Task.DurationPrediction already caches this value, but it's keyed by
+// task document, so every newly created task re-ran the identical seven-day
+// aggregate; a high-throughput generator recomputed it dozens of times a
+// minute. The TTL matches the per-task one, so this introduces no new
+// staleness, only a coarser cache key.
+var expectedDurationCache = expirable.NewLRU[string, util.DurationStats](estimateCacheMaxSize, nil, predictionTTL)
+
+func estimateCacheKey(project, buildVariant, displayName string) string {
+	return strings.Join([]string{project, buildVariant, displayName}, "\x00")
+}
 
 var TaskHistoricalDataIndex = bson.D{
 	{Key: ProjectKey, Value: 1},

--- a/model/task/expected_duration.go
+++ b/model/task/expected_duration.go
@@ -15,30 +15,13 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-// estimateCacheMaxSize bounds each shared historical-estimate cache to roughly
-// 12MB, at ~250 bytes per (project, build variant, task name) entry. Peak live
-// entries over a 24-hour slow log were ~700 for durations and ~3.8k for
-// generate estimations, and that undersamples projects fast enough to stay out
-// of the log. Overflowing costs a recompute, not correctness.
-const estimateCacheMaxSize = 50000
-
-// expectedDurationCache shares the historical duration aggregate across sibling
-// tasks, which Task.DurationPrediction cannot do because it is keyed by task
-// document.
-//
-// Adopting a shared entry restarts the task's own predictionTTL clock, so the
-// estimate a task holds can be up to 2*predictionTTL old rather than
-// predictionTTL. That is acceptable because the underlying value is a
-// seven-day trailing average, which barely moves over a day.
 var expectedDurationCache = expirable.NewLRU[string, util.DurationStats](estimateCacheMaxSize, nil, predictionTTL)
 
 func estimateCacheKey(project, buildVariant, displayName string) string {
 	return strings.Join([]string{project, buildVariant, displayName}, "\x00")
 }
 
-// ClearEstimateCaches drops the process-local historical-estimate caches. It's
-// exported for tests in other packages that assert on estimates computed from
-// task history, since a stale shared entry would make them order-dependent.
+// ClearEstimateCaches drops the process-local historical-estimate caches.
 func ClearEstimateCaches() {
 	expectedDurationCache.Purge()
 	generateTasksEstimationCache.Purge()

--- a/model/task/expected_duration.go
+++ b/model/task/expected_duration.go
@@ -15,21 +15,33 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-// estimateCacheMaxSize bounds the shared historical-estimate caches. Keys are
-// active (project, build variant, task name) tuples, so this is far above the
-// working set of a busy app server.
-const estimateCacheMaxSize = 10000
+// estimateCacheMaxSize bounds each shared historical-estimate cache to roughly
+// 12MB, at ~250 bytes per (project, build variant, task name) entry. Peak live
+// entries over a 24-hour slow log were ~700 for durations and ~3.8k for
+// generate estimations, and that undersamples projects fast enough to stay out
+// of the log. Overflowing costs a recompute, not correctness.
+const estimateCacheMaxSize = 50000
 
 // expectedDurationCache shares the historical duration aggregate across sibling
-// tasks. Task.DurationPrediction already caches this value, but it's keyed by
-// task document, so every newly created task re-ran the identical seven-day
-// aggregate; a high-throughput generator recomputed it dozens of times a
-// minute. The TTL matches the per-task one, so this introduces no new
-// staleness, only a coarser cache key.
+// tasks, which Task.DurationPrediction cannot do because it is keyed by task
+// document.
+//
+// Adopting a shared entry restarts the task's own predictionTTL clock, so the
+// estimate a task holds can be up to 2*predictionTTL old rather than
+// predictionTTL. That is acceptable because the underlying value is a
+// seven-day trailing average, which barely moves over a day.
 var expectedDurationCache = expirable.NewLRU[string, util.DurationStats](estimateCacheMaxSize, nil, predictionTTL)
 
 func estimateCacheKey(project, buildVariant, displayName string) string {
 	return strings.Join([]string{project, buildVariant, displayName}, "\x00")
+}
+
+// ClearEstimateCaches drops the process-local historical-estimate caches. It's
+// exported for tests in other packages that assert on estimates computed from
+// task history, since a stale shared entry would make them order-dependent.
+func ClearEstimateCaches() {
+	expectedDurationCache.Purge()
+	generateTasksEstimationCache.Purge()
 }
 
 var TaskHistoricalDataIndex = bson.D{

--- a/model/task/expected_duration.go
+++ b/model/task/expected_duration.go
@@ -3,7 +3,6 @@ package task
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -15,16 +14,13 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-var expectedDurationCache = expirable.NewLRU[string, util.DurationStats](estimateCacheMaxSize, nil, predictionTTL)
+var expectedDurationCache = expirable.NewLRU[estimateCacheKey, util.DurationStats](estimateCacheMaxSize, nil, estimateCacheTTL)
 
-func estimateCacheKey(project, buildVariant, displayName string) string {
-	return strings.Join([]string{project, buildVariant, displayName}, "\x00")
-}
-
-// ClearEstimateCaches drops the process-local historical-estimate caches.
-func ClearEstimateCaches() {
-	expectedDurationCache.Purge()
-	generateTasksEstimationCache.Purge()
+// estimateCacheKey identifies the family of tasks that share a historical estimate.
+type estimateCacheKey struct {
+	project         string
+	buildVariant    string
+	taskDisplayName string
 }
 
 var TaskHistoricalDataIndex = bson.D{

--- a/model/task/expected_duration_test.go
+++ b/model/task/expected_duration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExpectedDuration(t *testing.T) {
@@ -67,4 +68,41 @@ func TestExpectedDuration(t *testing.T) {
 	//nolint:testifylint // We expect it to be exactly equal.
 	assert.EqualValues(25*time.Minute, results[0].ExpectedDuration)
 	assert.InDelta(9.35*float64(time.Minute), results[0].StdDev, 0.01*float64(time.Minute))
+}
+
+func TestFetchExpectedDurationSharesEstimateBetweenSiblingTasks(t *testing.T) {
+	require.NoError(t, db.ClearCollections(Collection))
+	expectedDurationCache.Purge()
+	t.Cleanup(expectedDurationCache.Purge)
+	_, err := evergreen.GetEnvironment().DB().Collection(Collection).Indexes().CreateOne(t.Context(), mongo.IndexModel{Keys: TaskHistoricalDataIndex})
+	require.NoError(t, err)
+
+	now := time.Now()
+	history := Task{
+		Id:           "history",
+		DisplayName:  "compile",
+		BuildVariant: "bv",
+		Project:      "proj",
+		Status:       evergreen.TaskSucceeded,
+		StartTime:    now.Add(-20 * time.Minute),
+		FinishTime:   now,
+		TimeTaken:    20 * time.Minute,
+	}
+	require.NoError(t, history.Insert(t.Context()))
+
+	newTask := func(id string) *Task {
+		tsk := &Task{Id: id, DisplayName: "compile", BuildVariant: "bv", Project: "proj"}
+		require.NoError(t, tsk.Insert(t.Context()))
+		return tsk
+	}
+
+	assert.Equal(t, 20*time.Minute, newTask("first").FetchExpectedDuration(t.Context()).Average)
+
+	// Dropping the history proves the sibling reused the cached estimate rather
+	// than re-running the aggregate.
+	require.NoError(t, db.ClearCollections(Collection))
+	assert.Equal(t, 20*time.Minute, newTask("sibling").FetchExpectedDuration(t.Context()).Average)
+
+	expectedDurationCache.Purge()
+	assert.Equal(t, defaultTaskDuration, newTask("afterExpiry").FetchExpectedDuration(t.Context()).Average)
 }

--- a/model/task/expected_duration_test.go
+++ b/model/task/expected_duration_test.go
@@ -70,12 +70,13 @@ func TestExpectedDuration(t *testing.T) {
 	assert.InDelta(9.35*float64(time.Minute), results[0].StdDev, 0.01*float64(time.Minute))
 }
 
-// clearTasksAndEstimateCaches resets the task collection and the process-local estimate caches, which are
-// package-level and would otherwise leak between tests in this package.
+// clearTasksAndEstimateCaches resets the task collection and the package-level caches, which otherwise leak between tests.
 func clearTasksAndEstimateCaches(t *testing.T) {
 	reset := func() {
 		require.NoError(t, db.ClearCollections(Collection))
 		expectedDurationCache.Purge()
+		generateTasksEstimationCache.Purge()
+		noGenerateTasksHistoryCache.Purge()
 	}
 	reset()
 	t.Cleanup(reset)
@@ -116,9 +117,7 @@ func TestFetchExpectedDurationSharesEstimateBetweenSiblingTasks(t *testing.T) {
 	insertHistory("history", 20*time.Minute)
 	assert.Equal(t, 20*time.Minute, newTask("first").FetchExpectedDuration(t.Context()).Average)
 
-	// Replacing the history with a different duration proves the sibling served
-	// the estimate from the cache rather than re-running the aggregate, and that
-	// the next task after a reset picks up the new value.
+	// A different history proves the sibling came from the cache, and that the next task after a reset sees the new value.
 	require.NoError(t, db.ClearCollections(Collection))
 	insertHistory("newHistory", 30*time.Minute)
 	assert.Equal(t, 20*time.Minute, newTask("sibling").FetchExpectedDuration(t.Context()).Average)

--- a/model/task/expected_duration_test.go
+++ b/model/task/expected_duration_test.go
@@ -75,6 +75,8 @@ func clearTasksAndEstimateCaches(t *testing.T) {
 	reset := func() {
 		require.NoError(t, db.ClearCollections(Collection))
 		expectedDurationCache.Purge()
+		generateTasksEstimationCache.Purge()
+		noGenerateTasksHistoryCache.Purge()
 	}
 	reset()
 	t.Cleanup(reset)

--- a/model/task/expected_duration_test.go
+++ b/model/task/expected_duration_test.go
@@ -75,8 +75,6 @@ func clearTasksAndEstimateCaches(t *testing.T) {
 	reset := func() {
 		require.NoError(t, db.ClearCollections(Collection))
 		expectedDurationCache.Purge()
-		generateTasksEstimationCache.Purge()
-		noGenerateTasksHistoryCache.Purge()
 	}
 	reset()
 	t.Cleanup(reset)

--- a/model/task/expected_duration_test.go
+++ b/model/task/expected_duration_test.go
@@ -70,10 +70,25 @@ func TestExpectedDuration(t *testing.T) {
 	assert.InDelta(9.35*float64(time.Minute), results[0].StdDev, 0.01*float64(time.Minute))
 }
 
+// clearTasksAndEstimateCaches resets the task collection and the process-local estimate caches, which are
+// package-level and would otherwise leak between tests in this package.
+func clearTasksAndEstimateCaches(t *testing.T) {
+	reset := func() {
+		require.NoError(t, db.ClearCollections(Collection))
+		expectedDurationCache.Purge()
+	}
+	reset()
+	t.Cleanup(reset)
+}
+
 func TestFetchExpectedDurationSharesEstimateBetweenSiblingTasks(t *testing.T) {
-	require.NoError(t, db.ClearCollections(Collection))
-	expectedDurationCache.Purge()
-	t.Cleanup(expectedDurationCache.Purge)
+	const (
+		project      = "proj"
+		buildVariant = "bv"
+		displayName  = "compile"
+	)
+
+	clearTasksAndEstimateCaches(t)
 	_, err := evergreen.GetEnvironment().DB().Collection(Collection).Indexes().CreateOne(t.Context(), mongo.IndexModel{Keys: TaskHistoricalDataIndex})
 	require.NoError(t, err)
 
@@ -81,9 +96,9 @@ func TestFetchExpectedDurationSharesEstimateBetweenSiblingTasks(t *testing.T) {
 	insertHistory := func(id string, timeTaken time.Duration) {
 		history := Task{
 			Id:           id,
-			DisplayName:  "compile",
-			BuildVariant: "bv",
-			Project:      "proj",
+			DisplayName:  displayName,
+			BuildVariant: buildVariant,
+			Project:      project,
 			Status:       evergreen.TaskSucceeded,
 			StartTime:    now.Add(-timeTaken),
 			FinishTime:   now,
@@ -93,7 +108,7 @@ func TestFetchExpectedDurationSharesEstimateBetweenSiblingTasks(t *testing.T) {
 	}
 
 	newTask := func(id string) *Task {
-		tsk := &Task{Id: id, DisplayName: "compile", BuildVariant: "bv", Project: "proj"}
+		tsk := &Task{Id: id, DisplayName: displayName, BuildVariant: buildVariant, Project: project}
 		require.NoError(t, tsk.Insert(t.Context()))
 		return tsk
 	}

--- a/model/task/expected_duration_test.go
+++ b/model/task/expected_duration_test.go
@@ -78,17 +78,19 @@ func TestFetchExpectedDurationSharesEstimateBetweenSiblingTasks(t *testing.T) {
 	require.NoError(t, err)
 
 	now := time.Now()
-	history := Task{
-		Id:           "history",
-		DisplayName:  "compile",
-		BuildVariant: "bv",
-		Project:      "proj",
-		Status:       evergreen.TaskSucceeded,
-		StartTime:    now.Add(-20 * time.Minute),
-		FinishTime:   now,
-		TimeTaken:    20 * time.Minute,
+	insertHistory := func(id string, timeTaken time.Duration) {
+		history := Task{
+			Id:           id,
+			DisplayName:  "compile",
+			BuildVariant: "bv",
+			Project:      "proj",
+			Status:       evergreen.TaskSucceeded,
+			StartTime:    now.Add(-timeTaken),
+			FinishTime:   now,
+			TimeTaken:    timeTaken,
+		}
+		require.NoError(t, history.Insert(t.Context()))
 	}
-	require.NoError(t, history.Insert(t.Context()))
 
 	newTask := func(id string) *Task {
 		tsk := &Task{Id: id, DisplayName: "compile", BuildVariant: "bv", Project: "proj"}
@@ -96,13 +98,16 @@ func TestFetchExpectedDurationSharesEstimateBetweenSiblingTasks(t *testing.T) {
 		return tsk
 	}
 
+	insertHistory("history", 20*time.Minute)
 	assert.Equal(t, 20*time.Minute, newTask("first").FetchExpectedDuration(t.Context()).Average)
 
-	// Dropping the history proves the sibling reused the cached estimate rather
-	// than re-running the aggregate.
+	// Replacing the history with a different duration proves the sibling served
+	// the estimate from the cache rather than re-running the aggregate, and that
+	// the next task after a reset picks up the new value.
 	require.NoError(t, db.ClearCollections(Collection))
+	insertHistory("newHistory", 30*time.Minute)
 	assert.Equal(t, 20*time.Minute, newTask("sibling").FetchExpectedDuration(t.Context()).Average)
 
 	expectedDurationCache.Purge()
-	assert.Equal(t, defaultTaskDuration, newTask("afterExpiry").FetchExpectedDuration(t.Context()).Average)
+	assert.Equal(t, 30*time.Minute, newTask("afterExpiry").FetchExpectedDuration(t.Context()).Average)
 }

--- a/model/task/generate_tasks_estimations.go
+++ b/model/task/generate_tasks_estimations.go
@@ -17,7 +17,14 @@ const (
 	lookBackTime = 7 * 24 * time.Hour // one week
 )
 
-var generateTasksEstimationCache = expirable.NewLRU[string, GenerateTasksEstimation](estimateCacheMaxSize, nil, predictionTTL)
+var (
+	generateTasksEstimationCache = expirable.NewLRU[estimateCacheKey, GenerateTasksEstimation](estimateCacheMaxSize, nil, estimateCacheTTL)
+
+	// Generators with no successful run in the look-back window get their own cache so they can expire far
+	// sooner than a real estimate. Without it the batched aggregate re-runs for every generator in the build,
+	// since one generator missing from the results puts the whole batch back on the uncached path.
+	noGenerateTasksHistoryCache = expirable.NewLRU[estimateCacheKey, struct{}](estimateCacheMaxSize, nil, noHistoryCacheTTL)
+)
 
 // GenerateTasksEstimation holds estimation results for a single generator task.
 type GenerateTasksEstimation struct {
@@ -42,17 +49,20 @@ func GetBatchedGenerateTasksEstimations(ctx context.Context, project, buildVaria
 
 	uncached := make([]string, 0, len(displayNames))
 	for _, name := range displayNames {
-		est, ok := generateTasksEstimationCache.Get(estimateCacheKey(project, buildVariant, name))
-		if !ok {
-			uncached = append(uncached, name)
+		key := estimateCacheKey{project: project, buildVariant: buildVariant, taskDisplayName: name}
+		if est, ok := generateTasksEstimationCache.Get(key); ok {
+			result[name] = est
 			continue
 		}
-		// A cached zero records that the generator has no history, which the
-		// uncached path reports by omitting the name entirely.
-		if est != (GenerateTasksEstimation{}) {
-			result[name] = est
+		if _, ok := noGenerateTasksHistoryCache.Get(key); ok {
+			continue
 		}
+		uncached = append(uncached, name)
 	}
+	span.SetAttributes(
+		attribute.Int("evergreen.task.num_cached_generators", len(displayNames)-len(uncached)),
+		attribute.Int("evergreen.task.num_uncached_generators", len(uncached)),
+	)
 	if len(uncached) == 0 {
 		return result, nil
 	}
@@ -68,15 +78,14 @@ func GetBatchedGenerateTasksEstimations(ctx context.Context, project, buildVaria
 			EstimatedNumActivatedGeneratedTasks: int(math.Round(r.EstimatedActivated)),
 		}
 		result[r.DisplayName] = est
-		generateTasksEstimationCache.Add(estimateCacheKey(project, buildVariant, r.DisplayName), est)
+		generateTasksEstimationCache.Add(estimateCacheKey{project: project, buildVariant: buildVariant, taskDisplayName: r.DisplayName}, est)
 	}
 
-	// Generators with no successful run in the look-back window are absent from
-	// the results. Cache the zero estimate the caller would have defaulted to
-	// anyway, otherwise they will re-run the aggregate on every build creation.
+	// Absence from the results is how this function reports that a generator has no history, so record it
+	// separately rather than caching an estimate that would be indistinguishable from a real zero.
 	for _, name := range uncached {
 		if _, ok := result[name]; !ok {
-			generateTasksEstimationCache.Add(estimateCacheKey(project, buildVariant, name), GenerateTasksEstimation{})
+			noGenerateTasksHistoryCache.Add(estimateCacheKey{project: project, buildVariant: buildVariant, taskDisplayName: name}, struct{}{})
 		}
 	}
 

--- a/model/task/generate_tasks_estimations.go
+++ b/model/task/generate_tasks_estimations.go
@@ -46,25 +46,25 @@ func GetBatchedGenerateTasksEstimations(ctx context.Context, project, buildVaria
 	))
 	defer span.End()
 
-	numCached, numNoHistory := 0, 0
+	numHits, numNegativeHits := 0, 0
 	uncached := make([]string, 0, len(displayNames))
 	for _, name := range displayNames {
 		key := estimateCacheKey{project: project, buildVariant: buildVariant, taskDisplayName: name}
 		if est, ok := generateTasksEstimationCache.Get(key); ok {
 			result[name] = est
-			numCached++
+			numHits++
 			continue
 		}
 		if _, ok := noGenerateTasksHistoryCache.Get(key); ok {
-			numNoHistory++
+			numNegativeHits++
 			continue
 		}
 		uncached = append(uncached, name)
 	}
 	span.SetAttributes(
-		attribute.Int("evergreen.task.num_cached_generators", numCached),
-		attribute.Int("evergreen.task.num_no_history_generators", numNoHistory),
-		attribute.Int("evergreen.task.num_uncached_generators", len(uncached)),
+		attribute.Int("evergreen.task.num_cache_hits", numHits),
+		attribute.Int("evergreen.task.num_negative_cache_hits", numNegativeHits),
+		attribute.Int("evergreen.task.num_cache_misses", len(uncached)),
 		attribute.Int("evergreen.task.generate_tasks_estimation_cache_size", generateTasksEstimationCache.Len()),
 		attribute.Int("evergreen.task.no_generate_tasks_history_cache_size", noGenerateTasksHistoryCache.Len()),
 	)

--- a/model/task/generate_tasks_estimations.go
+++ b/model/task/generate_tasks_estimations.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/utility"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -15,6 +16,12 @@ import (
 const (
 	lookBackTime = 7 * 24 * time.Hour // one week
 )
+
+// generateTasksEstimationCache shares estimations across builds that create the
+// same generator tasks, which otherwise re-ran this aggregate on every build
+// creation. Like the expected-duration cache it's keyed by the (project, build
+// variant, task name) tuple the estimate is derived from.
+var generateTasksEstimationCache = expirable.NewLRU[string, GenerateTasksEstimation](estimateCacheMaxSize, nil, predictionTTL)
 
 // GenerateTasksEstimation holds estimation results for a single generator task.
 type GenerateTasksEstimation struct {
@@ -37,16 +44,30 @@ func GetBatchedGenerateTasksEstimations(ctx context.Context, project, buildVaria
 	))
 	defer span.End()
 
-	results, err := getBatchedGenerateTasksEstimations(ctx, project, buildVariant, displayNames, lookBackTime)
+	uncached := make([]string, 0, len(displayNames))
+	for _, name := range displayNames {
+		if est, ok := generateTasksEstimationCache.Get(estimateCacheKey(project, buildVariant, name)); ok {
+			result[name] = est
+			continue
+		}
+		uncached = append(uncached, name)
+	}
+	if len(uncached) == 0 {
+		return result, nil
+	}
+
+	results, err := getBatchedGenerateTasksEstimations(ctx, project, buildVariant, uncached, lookBackTime)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting generate tasks estimations")
 	}
 
 	for _, r := range results {
-		result[r.DisplayName] = GenerateTasksEstimation{
+		est := GenerateTasksEstimation{
 			EstimatedNumGeneratedTasks:          int(math.Round(r.EstimatedCreated)),
 			EstimatedNumActivatedGeneratedTasks: int(math.Round(r.EstimatedActivated)),
 		}
+		result[r.DisplayName] = est
+		generateTasksEstimationCache.Add(estimateCacheKey(project, buildVariant, r.DisplayName), est)
 	}
 
 	return result, nil

--- a/model/task/generate_tasks_estimations.go
+++ b/model/task/generate_tasks_estimations.go
@@ -46,25 +46,28 @@ func GetBatchedGenerateTasksEstimations(ctx context.Context, project, buildVaria
 	))
 	defer span.End()
 
-	numHits, numNegativeHits := 0, 0
+	hitNames := make([]string, 0, len(displayNames))
+	negativeHitNames := make([]string, 0, len(displayNames))
 	uncached := make([]string, 0, len(displayNames))
 	for _, name := range displayNames {
 		key := estimateCacheKey{project: project, buildVariant: buildVariant, taskDisplayName: name}
 		if est, ok := generateTasksEstimationCache.Get(key); ok {
 			result[name] = est
-			numHits++
+			hitNames = append(hitNames, name)
 			continue
 		}
 		if _, ok := noGenerateTasksHistoryCache.Get(key); ok {
-			numNegativeHits++
+			negativeHitNames = append(negativeHitNames, name)
 			continue
 		}
 		uncached = append(uncached, name)
 	}
 	span.SetAttributes(
-		attribute.Int("evergreen.task.num_cache_hits", numHits),
-		attribute.Int("evergreen.task.num_negative_cache_hits", numNegativeHits),
+		attribute.Int("evergreen.task.num_cache_hits", len(hitNames)),
+		attribute.Int("evergreen.task.num_negative_cache_hits", len(negativeHitNames)),
 		attribute.Int("evergreen.task.num_cache_misses", len(uncached)),
+		attribute.StringSlice("evergreen.task.cache_hit_names", hitNames),
+		attribute.StringSlice("evergreen.task.negative_cache_hit_names", negativeHitNames),
 		attribute.Int("evergreen.task.generate_tasks_estimation_cache_size", generateTasksEstimationCache.Len()),
 		attribute.Int("evergreen.task.no_generate_tasks_history_cache_size", noGenerateTasksHistoryCache.Len()),
 	)

--- a/model/task/generate_tasks_estimations.go
+++ b/model/task/generate_tasks_estimations.go
@@ -20,9 +20,8 @@ const (
 var (
 	generateTasksEstimationCache = expirable.NewLRU[estimateCacheKey, GenerateTasksEstimation](estimateCacheMaxSize, nil, estimateCacheTTL)
 
-	// Generators with no successful run in the look-back window get their own cache so they can expire far
-	// sooner than a real estimate. Without it the batched aggregate re-runs for every generator in the build,
-	// since one generator missing from the results puts the whole batch back on the uncached path.
+	// Generators with no history get their own cache so they expire sooner than a real estimate. Without it, one
+	// generator missing from the results puts the whole batch back on the uncached path.
 	noGenerateTasksHistoryCache = expirable.NewLRU[estimateCacheKey, struct{}](estimateCacheMaxSize, nil, noHistoryCacheTTL)
 )
 
@@ -47,21 +46,27 @@ func GetBatchedGenerateTasksEstimations(ctx context.Context, project, buildVaria
 	))
 	defer span.End()
 
+	numCached, numNoHistory := 0, 0
 	uncached := make([]string, 0, len(displayNames))
 	for _, name := range displayNames {
 		key := estimateCacheKey{project: project, buildVariant: buildVariant, taskDisplayName: name}
 		if est, ok := generateTasksEstimationCache.Get(key); ok {
 			result[name] = est
+			numCached++
 			continue
 		}
 		if _, ok := noGenerateTasksHistoryCache.Get(key); ok {
+			numNoHistory++
 			continue
 		}
 		uncached = append(uncached, name)
 	}
 	span.SetAttributes(
-		attribute.Int("evergreen.task.num_cached_generators", len(displayNames)-len(uncached)),
+		attribute.Int("evergreen.task.num_cached_generators", numCached),
+		attribute.Int("evergreen.task.num_no_history_generators", numNoHistory),
 		attribute.Int("evergreen.task.num_uncached_generators", len(uncached)),
+		attribute.Int("evergreen.task.generate_tasks_estimation_cache_size", generateTasksEstimationCache.Len()),
+		attribute.Int("evergreen.task.no_generate_tasks_history_cache_size", noGenerateTasksHistoryCache.Len()),
 	)
 	if len(uncached) == 0 {
 		return result, nil
@@ -81,8 +86,7 @@ func GetBatchedGenerateTasksEstimations(ctx context.Context, project, buildVaria
 		generateTasksEstimationCache.Add(estimateCacheKey{project: project, buildVariant: buildVariant, taskDisplayName: r.DisplayName}, est)
 	}
 
-	// Absence from the results is how this function reports that a generator has no history, so record it
-	// separately rather than caching an estimate that would be indistinguishable from a real zero.
+	// Absence from the results means no history. Caching it as an estimate would be indistinguishable from a real zero.
 	for _, name := range uncached {
 		if _, ok := result[name]; !ok {
 			noGenerateTasksHistoryCache.Add(estimateCacheKey{project: project, buildVariant: buildVariant, taskDisplayName: name}, struct{}{})

--- a/model/task/generate_tasks_estimations.go
+++ b/model/task/generate_tasks_estimations.go
@@ -46,11 +46,16 @@ func GetBatchedGenerateTasksEstimations(ctx context.Context, project, buildVaria
 
 	uncached := make([]string, 0, len(displayNames))
 	for _, name := range displayNames {
-		if est, ok := generateTasksEstimationCache.Get(estimateCacheKey(project, buildVariant, name)); ok {
-			result[name] = est
+		est, ok := generateTasksEstimationCache.Get(estimateCacheKey(project, buildVariant, name))
+		if !ok {
+			uncached = append(uncached, name)
 			continue
 		}
-		uncached = append(uncached, name)
+		// A cached zero records that the generator has no history, which the
+		// uncached path reports by omitting the name entirely.
+		if est != (GenerateTasksEstimation{}) {
+			result[name] = est
+		}
 	}
 	if len(uncached) == 0 {
 		return result, nil
@@ -68,6 +73,16 @@ func GetBatchedGenerateTasksEstimations(ctx context.Context, project, buildVaria
 		}
 		result[r.DisplayName] = est
 		generateTasksEstimationCache.Add(estimateCacheKey(project, buildVariant, r.DisplayName), est)
+	}
+
+	// Generators with no successful run in the look-back window are absent from
+	// the results. Cache the zero estimate the caller would have defaulted to
+	// anyway, otherwise these are exactly the names that re-run the aggregate on
+	// every build creation.
+	for _, name := range uncached {
+		if _, ok := result[name]; !ok {
+			generateTasksEstimationCache.Add(estimateCacheKey(project, buildVariant, name), GenerateTasksEstimation{})
+		}
 	}
 
 	return result, nil

--- a/model/task/generate_tasks_estimations.go
+++ b/model/task/generate_tasks_estimations.go
@@ -17,10 +17,6 @@ const (
 	lookBackTime = 7 * 24 * time.Hour // one week
 )
 
-// generateTasksEstimationCache shares estimations across builds that create the
-// same generator tasks, which otherwise re-ran this aggregate on every build
-// creation. Like the expected-duration cache it's keyed by the (project, build
-// variant, task name) tuple the estimate is derived from.
 var generateTasksEstimationCache = expirable.NewLRU[string, GenerateTasksEstimation](estimateCacheMaxSize, nil, predictionTTL)
 
 // GenerateTasksEstimation holds estimation results for a single generator task.
@@ -77,8 +73,7 @@ func GetBatchedGenerateTasksEstimations(ctx context.Context, project, buildVaria
 
 	// Generators with no successful run in the look-back window are absent from
 	// the results. Cache the zero estimate the caller would have defaulted to
-	// anyway, otherwise these are exactly the names that re-run the aggregate on
-	// every build creation.
+	// anyway, otherwise they will re-run the aggregate on every build creation.
 	for _, name := range uncached {
 		if _, ok := result[name]; !ok {
 			generateTasksEstimationCache.Add(estimateCacheKey(project, buildVariant, name), GenerateTasksEstimation{})

--- a/model/task/generate_tasks_estimations_test.go
+++ b/model/task/generate_tasks_estimations_test.go
@@ -15,9 +15,7 @@ import (
 func TestGenerateTasksEstimationsOnlyIncludesSucceeded(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	assert.NoError(db.ClearCollections(Collection))
-	generateTasksEstimationCache.Purge()
-	t.Cleanup(generateTasksEstimationCache.Purge)
+	clearTasksAndEstimateCaches(t)
 
 	ctx := t.Context()
 
@@ -86,9 +84,7 @@ func TestGenerateTasksEstimationsNoPreviousTasks(t *testing.T) {
 func TestGetBatchedGenerateTasksEstimations(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
-	assert.NoError(db.ClearCollections(Collection))
-	generateTasksEstimationCache.Purge()
-	t.Cleanup(generateTasksEstimationCache.Purge)
+	clearTasksAndEstimateCaches(t)
 
 	ctx := t.Context()
 
@@ -164,50 +160,62 @@ func TestGetBatchedGenerateTasksEstimations(t *testing.T) {
 }
 
 func TestGetBatchedGenerateTasksEstimationsSharesEstimatesAcrossBuilds(t *testing.T) {
-	require.NoError(t, db.ClearCollections(Collection))
-	generateTasksEstimationCache.Purge()
-	t.Cleanup(generateTasksEstimationCache.Purge)
+	const (
+		project      = "proj"
+		buildVariant = "bv"
+	)
+
+	clearTasksAndEstimateCaches(t)
 
 	ctx := t.Context()
 	_, err := evergreen.GetEnvironment().DB().Collection(Collection).Indexes().CreateOne(ctx, mongo.IndexModel{Keys: TaskHistoricalDataIndex})
 	require.NoError(t, err)
 
 	insertHistory := func(id, displayName string, generated, activated int) {
-		require.NoError(t, (&Task{
+		history := &Task{
 			Id:                         id,
 			DisplayName:                displayName,
-			BuildVariant:               "bv",
-			Project:                    "proj",
+			BuildVariant:               buildVariant,
+			Project:                    project,
 			Status:                     evergreen.TaskSucceeded,
 			NumGeneratedTasks:          generated,
 			NumActivatedGeneratedTasks: activated,
 			StartTime:                  time.Now().Add(-2 * time.Hour),
 			FinishTime:                 time.Now().Add(-1 * time.Hour),
 			GeneratedTasks:             true,
-		}).Insert(ctx))
+		}
+		require.NoError(t, history.Insert(ctx))
 	}
 
 	insertHistory("h1", "gen_a", 10, 8)
-	results, err := GetBatchedGenerateTasksEstimations(ctx, "proj", "bv", []string{"gen_a", "gen_none"})
+	// gen_zero succeeded without generating anything, so its real estimate is zero. It must stay
+	// distinguishable from gen_none, which has no history at all.
+	insertHistory("h2", "gen_zero", 0, 0)
+	results, err := GetBatchedGenerateTasksEstimations(ctx, project, buildVariant, []string{"gen_a", "gen_zero", "gen_none"})
 	require.NoError(t, err)
 	require.Contains(t, results, "gen_a")
 	assert.Equal(t, 10, results["gen_a"].EstimatedNumGeneratedTasks)
+	require.Contains(t, results, "gen_zero")
+	assert.Equal(t, 0, results["gen_zero"].EstimatedNumGeneratedTasks)
 	assert.NotContains(t, results, "gen_none")
 
-	// Replacing the history proves gen_a is served from the cache while gen_b,
-	// which was never queried, is computed fresh. gen_none stays absent from the
-	// cached no-history entry rather than re-running the aggregate.
+	// Replacing the history proves gen_a and gen_zero are served from the cache while gen_b, which was never
+	// queried, is computed fresh. gen_none stays absent from its no-history entry rather than re-running the
+	// aggregate, and gen_zero stays present, since a real zero is not a no-history marker.
 	require.NoError(t, db.ClearCollections(Collection))
-	insertHistory("h2", "gen_b", 20, 16)
-	insertHistory("h3", "gen_none", 99, 99)
+	insertHistory("h3", "gen_b", 20, 16)
+	insertHistory("h4", "gen_none", 99, 99)
+	insertHistory("h5", "gen_zero", 99, 99)
 
-	results, err = GetBatchedGenerateTasksEstimations(ctx, "proj", "bv", []string{"gen_a", "gen_b", "gen_none"})
+	results, err = GetBatchedGenerateTasksEstimations(ctx, project, buildVariant, []string{"gen_a", "gen_b", "gen_zero", "gen_none"})
 	require.NoError(t, err)
 	require.Contains(t, results, "gen_a")
 	assert.Equal(t, 10, results["gen_a"].EstimatedNumGeneratedTasks)
 	assert.Equal(t, 8, results["gen_a"].EstimatedNumActivatedGeneratedTasks)
 	require.Contains(t, results, "gen_b")
 	assert.Equal(t, 20, results["gen_b"].EstimatedNumGeneratedTasks)
+	require.Contains(t, results, "gen_zero")
+	assert.Equal(t, 0, results["gen_zero"].EstimatedNumGeneratedTasks)
 	assert.NotContains(t, results, "gen_none")
 }
 

--- a/model/task/generate_tasks_estimations_test.go
+++ b/model/task/generate_tasks_estimations_test.go
@@ -16,6 +16,8 @@ func TestGenerateTasksEstimationsOnlyIncludesSucceeded(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	assert.NoError(db.ClearCollections(Collection))
+	generateTasksEstimationCache.Purge()
+	t.Cleanup(generateTasksEstimationCache.Purge)
 
 	ctx := t.Context()
 
@@ -85,6 +87,8 @@ func TestGetBatchedGenerateTasksEstimations(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	assert.NoError(db.ClearCollections(Collection))
+	generateTasksEstimationCache.Purge()
+	t.Cleanup(generateTasksEstimationCache.Purge)
 
 	ctx := t.Context()
 

--- a/model/task/generate_tasks_estimations_test.go
+++ b/model/task/generate_tasks_estimations_test.go
@@ -188,8 +188,7 @@ func TestGetBatchedGenerateTasksEstimationsSharesEstimatesAcrossBuilds(t *testin
 	}
 
 	insertHistory("h1", "gen_a", 10, 8)
-	// gen_zero succeeded without generating anything, so its real estimate is zero. It must stay
-	// distinguishable from gen_none, which has no history at all.
+	// gen_zero's real estimate is zero; it must stay distinguishable from gen_none, which has no history.
 	insertHistory("h2", "gen_zero", 0, 0)
 	results, err := GetBatchedGenerateTasksEstimations(ctx, project, buildVariant, []string{"gen_a", "gen_zero", "gen_none"})
 	require.NoError(t, err)
@@ -199,9 +198,8 @@ func TestGetBatchedGenerateTasksEstimationsSharesEstimatesAcrossBuilds(t *testin
 	assert.Equal(t, 0, results["gen_zero"].EstimatedNumGeneratedTasks)
 	assert.NotContains(t, results, "gen_none")
 
-	// Replacing the history proves gen_a and gen_zero are served from the cache while gen_b, which was never
-	// queried, is computed fresh. gen_none stays absent from its no-history entry rather than re-running the
-	// aggregate, and gen_zero stays present, since a real zero is not a no-history marker.
+	// Replacing the history proves gen_a and gen_zero come from the cache while gen_b, never queried, is computed
+	// fresh. gen_none stays absent from its no-history entry, and gen_zero stays present.
 	require.NoError(t, db.ClearCollections(Collection))
 	insertHistory("h3", "gen_b", 20, 16)
 	insertHistory("h4", "gen_none", 99, 99)

--- a/model/task/generate_tasks_estimations_test.go
+++ b/model/task/generate_tasks_estimations_test.go
@@ -163,6 +163,54 @@ func TestGetBatchedGenerateTasksEstimations(t *testing.T) {
 	assert.NotContains(results, "gen_c")
 }
 
+func TestGetBatchedGenerateTasksEstimationsSharesEstimatesAcrossBuilds(t *testing.T) {
+	require.NoError(t, db.ClearCollections(Collection))
+	generateTasksEstimationCache.Purge()
+	t.Cleanup(generateTasksEstimationCache.Purge)
+
+	ctx := t.Context()
+	_, err := evergreen.GetEnvironment().DB().Collection(Collection).Indexes().CreateOne(ctx, mongo.IndexModel{Keys: TaskHistoricalDataIndex})
+	require.NoError(t, err)
+
+	insertHistory := func(id, displayName string, generated, activated int) {
+		require.NoError(t, (&Task{
+			Id:                         id,
+			DisplayName:                displayName,
+			BuildVariant:               "bv",
+			Project:                    "proj",
+			Status:                     evergreen.TaskSucceeded,
+			NumGeneratedTasks:          generated,
+			NumActivatedGeneratedTasks: activated,
+			StartTime:                  time.Now().Add(-2 * time.Hour),
+			FinishTime:                 time.Now().Add(-1 * time.Hour),
+			GeneratedTasks:             true,
+		}).Insert(ctx))
+	}
+
+	insertHistory("h1", "gen_a", 10, 8)
+	results, err := GetBatchedGenerateTasksEstimations(ctx, "proj", "bv", []string{"gen_a", "gen_none"})
+	require.NoError(t, err)
+	require.Contains(t, results, "gen_a")
+	assert.Equal(t, 10, results["gen_a"].EstimatedNumGeneratedTasks)
+	assert.NotContains(t, results, "gen_none")
+
+	// Replacing the history proves gen_a is served from the cache while gen_b,
+	// which was never queried, is computed fresh. gen_none stays absent from the
+	// cached no-history entry rather than re-running the aggregate.
+	require.NoError(t, db.ClearCollections(Collection))
+	insertHistory("h2", "gen_b", 20, 16)
+	insertHistory("h3", "gen_none", 99, 99)
+
+	results, err = GetBatchedGenerateTasksEstimations(ctx, "proj", "bv", []string{"gen_a", "gen_b", "gen_none"})
+	require.NoError(t, err)
+	require.Contains(t, results, "gen_a")
+	assert.Equal(t, 10, results["gen_a"].EstimatedNumGeneratedTasks)
+	assert.Equal(t, 8, results["gen_a"].EstimatedNumActivatedGeneratedTasks)
+	require.Contains(t, results, "gen_b")
+	assert.Equal(t, 20, results["gen_b"].EstimatedNumGeneratedTasks)
+	assert.NotContains(t, results, "gen_none")
+}
+
 func TestGetBatchedGenerateTasksEstimationsEmpty(t *testing.T) {
 	ctx := t.Context()
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -71,18 +71,16 @@ const (
 	// dependency resolution.
 	dependencyResolutionTimeout = 10 * time.Minute
 
-	// estimateCacheTTL bounds how stale a process-local historical estimate may be. It is much shorter than
-	// predictionTTL because a task document that inherits a cached estimate records it as freshly collected,
-	// so the two lifetimes compound, and the estimate feeds the per-user scheduling limit.
+	// estimateCacheTTL bounds how stale a process-local estimate may be. It is far shorter than predictionTTL
+	// because a task document that inherits a cached estimate stamps it as freshly collected, so the two compound.
 	estimateCacheTTL = time.Hour
 
-	// noHistoryCacheTTL bounds how long a generator is remembered as having no history. A generator's first
-	// successful run flips its estimate from nothing to its full size, so this must not outlive a build's
-	// turnaround by much.
+	// noHistoryCacheTTL bounds how long a generator is remembered as having no history. Its first successful run
+	// flips the estimate from nothing to full size, so this must not outlive a build's turnaround by much.
 	noHistoryCacheTTL = 5 * time.Minute
 
-	// estimateCacheMaxSize caps each estimate cache at roughly the number of distinct
-	// (project, build variant, task display name) triples seen within estimateCacheTTL.
+	// estimateCacheMaxSize caps each cache at roughly the distinct
+	// (project, build variant, display name) triples seen within estimateCacheTTL.
 	estimateCacheMaxSize = 50000
 )
 
@@ -3523,7 +3521,18 @@ func (t *Task) FetchExpectedDuration(ctx context.Context) util.DurationStats {
 
 	cacheKey := estimateCacheKey{project: t.Project, buildVariant: t.BuildVariant, taskDisplayName: t.DisplayName}
 	refresher := func(previous util.DurationStats) (util.DurationStats, bool) {
+		// Only cache consultations get a span. A task whose persisted prediction is still valid never runs this.
+		ctx, span := tracer.Start(ctx, "refresh-expected-duration")
+		defer span.End()
+		record := func(outcome string) {
+			span.SetAttributes(
+				attribute.String("evergreen.task.expected_duration_cache_outcome", outcome),
+				attribute.Int("evergreen.task.expected_duration_cache_size", expectedDurationCache.Len()),
+			)
+		}
+
 		if stats, ok := expectedDurationCache.Get(cacheKey); ok {
+			record("hit")
 			return stats, true
 		}
 
@@ -3538,10 +3547,13 @@ func (t *Task) FetchExpectedDuration(ctx context.Context) util.DurationStats {
 			"operation": "fetching expected duration, expect stale scheduling data",
 		}))
 		if err != nil {
+			record("query_error")
 			return defaultVal, false
 		}
 
+		// Nothing gets cached without usable history, so these keys miss on every lookup.
 		if len(vals) != 1 {
+			record("no_history")
 			if previous.Average == 0 {
 				return defaultVal, true
 			}
@@ -3551,11 +3563,13 @@ func (t *Task) FetchExpectedDuration(ctx context.Context) util.DurationStats {
 
 		avg := time.Duration(vals[0].ExpectedDuration)
 		if avg == 0 {
+			record("no_history")
 			return defaultVal, true
 		}
 		stdDev := time.Duration(vals[0].StdDev)
 		stats := util.DurationStats{Average: avg, StdDev: stdDev}
 		expectedDurationCache.Add(cacheKey, stats)
+		record("miss")
 		return stats, true
 	}
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3507,7 +3507,12 @@ func (t *Task) FetchExpectedDuration(ctx context.Context) util.DurationStats {
 		return util.DurationStats{Average: t.ExpectedDuration, StdDev: t.ExpectedDurationStdDev}
 	}
 
+	cacheKey := estimateCacheKey(t.Project, t.BuildVariant, t.DisplayName)
 	refresher := func(previous util.DurationStats) (util.DurationStats, bool) {
+		if stats, ok := expectedDurationCache.Get(cacheKey); ok {
+			return stats, true
+		}
+
 		defaultVal := util.DurationStats{Average: defaultTaskDuration, StdDev: 0}
 		vals, err := getExpectedDurationsForWindow(ctx, t.DisplayName, t.Project, t.BuildVariant,
 			time.Now().Add(-taskCompletionEstimateWindow), time.Now())
@@ -3535,7 +3540,9 @@ func (t *Task) FetchExpectedDuration(ctx context.Context) util.DurationStats {
 			return defaultVal, true
 		}
 		stdDev := time.Duration(vals[0].StdDev)
-		return util.DurationStats{Average: avg, StdDev: stdDev}, true
+		stats := util.DurationStats{Average: avg, StdDev: stdDev}
+		expectedDurationCache.Add(cacheKey, stats)
+		return stats, true
 	}
 
 	grip.Error(ctx, message.WrapError(t.DurationPrediction.SetRefresher(refresher), message.Fields{

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -71,7 +71,18 @@ const (
 	// dependency resolution.
 	dependencyResolutionTimeout = 10 * time.Minute
 
-	// estimateCacheMaxSize was calculated to fit an estimated number of values over the set cache TTL.
+	// estimateCacheTTL bounds how stale a process-local historical estimate may be. It is much shorter than
+	// predictionTTL because a task document that inherits a cached estimate records it as freshly collected,
+	// so the two lifetimes compound, and the estimate feeds the per-user scheduling limit.
+	estimateCacheTTL = time.Hour
+
+	// noHistoryCacheTTL bounds how long a generator is remembered as having no history. A generator's first
+	// successful run flips its estimate from nothing to its full size, so this must not outlive a build's
+	// turnaround by much.
+	noHistoryCacheTTL = 5 * time.Minute
+
+	// estimateCacheMaxSize caps each estimate cache at roughly the number of distinct
+	// (project, build variant, task display name) triples seen within estimateCacheTTL.
 	estimateCacheMaxSize = 50000
 )
 
@@ -3510,7 +3521,7 @@ func (t *Task) FetchExpectedDuration(ctx context.Context) util.DurationStats {
 		return util.DurationStats{Average: t.ExpectedDuration, StdDev: t.ExpectedDurationStdDev}
 	}
 
-	cacheKey := estimateCacheKey(t.Project, t.BuildVariant, t.DisplayName)
+	cacheKey := estimateCacheKey{project: t.Project, buildVariant: t.BuildVariant, taskDisplayName: t.DisplayName}
 	refresher := func(previous util.DurationStats) (util.DurationStats, bool) {
 		if stats, ok := expectedDurationCache.Get(cacheKey); ok {
 			return stats, true

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3528,6 +3528,9 @@ func (t *Task) FetchExpectedDuration(ctx context.Context) util.DurationStats {
 			span.SetAttributes(
 				attribute.String("evergreen.task.expected_duration_cache_outcome", outcome),
 				attribute.Int("evergreen.task.expected_duration_cache_size", expectedDurationCache.Len()),
+				attribute.String(evergreen.ProjectIdentifierOtelAttribute, cacheKey.project),
+				attribute.String(evergreen.BuildNameOtelAttribute, cacheKey.buildVariant),
+				attribute.String(evergreen.TaskNameOtelAttribute, cacheKey.taskDisplayName),
 			)
 		}
 

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -70,6 +70,9 @@ const (
 	// dependencyResolutionTimeout is the maximum time allowed for recursive
 	// dependency resolution.
 	dependencyResolutionTimeout = 10 * time.Minute
+
+	// estimateCacheMaxSize was calculated to fit an estimated number of values over the set cache TTL.
+	estimateCacheMaxSize = 50000
 )
 
 // maxDependencyDepth is the maximum recursion depth for dependency traversal.


### PR DESCRIPTION
DEVPROD-37898


### Description

create a new cache for duration estimation and generate tasks estimation because they were using up a lot of the read tickets and causing the db to be slow


### Testing

unit tests

made sure everything worked on staging with no notable increase in memory usage

task aggregation count with(1630) vs without(17) my change
<img width="617" height="325" alt="image" src="https://github.com/user-attachments/assets/04f6d05a-8f0a-4a83-a8a2-ed0e85f0cc95" />