### PR TITLE
DEVPROD-38261 Update agents.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,7 @@ Evergreen uses `make` for building/testing/linting. Read the makefile as needed 
 ### Building
 
 ```bash
-make build          # Compile binary for local system (→ clients/<goos>_<goarch>/evergreen)
 make gqlgen         # Regenerate GraphQL code after schema changes
-make mod-tidy       # Tidy Go module dependencies
 ```
 
 ### Testing
@@ -43,12 +41,6 @@ RUN_COUNT=5         # Run tests N times.
 
 ### Linting
 
-```bash
-make lint            # Lint all packages.
-make lint-<package>  # Lint a specific package.
-make lint-evergreen  # Lint the top-level evergreen package (special case).
-```
-
 After making changes, run `make lint-<package>` for each affected package and verify there are no new errors beyond any pre-existing golangci-lint toolchain crashes.
 
 Adding a `ServiceFlags` field requires running `make test-service-graphql`.
@@ -63,6 +55,30 @@ are multiple changes on the same day.
 
 The Evergreen codebase has automated tests defined in `self-tests.yml`, which itself runs in Evergreen. For most tasks in
 `self-tests.yml`, there's a roughly 1:1 relationship between Makefile targets and Evergreen self-test tasks.
+
+## Architecture
+
+### Package Organization
+
+| Package        | Description                                                                                               |
+|----------------|-----------------------------------------------------------------------------------------------------------|
+| `agent/`       | Contains the logic to run the agent. Runs tasks on hosts; receives tasks to run from the app server.      |
+| `apimodels/`   | Shared models used across REST API boundaries for the agent.                                              |
+| `auth/`        | Authentication backends (naive, GitHub, Okta).                                                            |
+| `cloud/`       | Cloud provider integrations (AWS EC2, Docker, etc).                                                       |
+| `db/`          | MongoDB interaction layer.                                                                                |
+| `graphql/`     | GraphQL backend.                                                                                          |
+| `model/`       | Core data models; task, host, build, patch, distro, etc. are in subpackages.                              |
+| `operations/`  | CLI command implementations. Also provides an entry point for the app server/agent.                       |
+| `repotracker/` | Tracks GitHub repos for new commits and PRs.                                                              |
+| `rest/`        | REST API: `route/` (handlers), `data/` (data connectors), `model/` (API models), `client/` (CLI clients). |
+| `scheduler/`   | Orders tasks in distro queues.                                                                            |
+| `service/`     | HTTP server wiring; UI and legacy REST endpoints.                                                         |
+| `thirdparty/`  | Other third-party integrations (GitHub, Jira, etc).                                                       |
+| `trigger/`     | Logic to trigger notifications from CI system events.                                                     |
+| `units/`       | Background job definitions using the Amboy job framework.                                                 |
+| `util/`        | Common utility functions.                                                                                 |
+| `validator/`   | Validates project YAML configs and distro settings.                                                       |
 
 ## Go Coding Conventions
 
@@ -88,11 +104,7 @@ expectations.
 `makeAwsConfig` (should be `makeAWSConfig`)
 `UserId` (should be `UserID`)
 
-### Formatting
-* In Go, when a block of variable declarations or struct fields is vertically aligned (e.g., all the type keywords or `=` signs line up), new entries must maintain that alignment within the same block. A blank line or a comment header (e.g., `// Notification Flags`) starts a new block with its own independent alignment; do not align across block boundaries.
-
 ### Code Readability and Comments
-* Write self-documenting code through clear naming and structure (such as helper functions for modularity).
 * Inline code comments should be full sentences and express complete thoughts. Use proper grammar, punctuation, and
   capitalization.
 * Inline code comments should be used intentionally. Do not write a comment if it just explains exactly what the code is
@@ -100,16 +112,6 @@ expectations.
 * Documentation comments should focus on high-level information relevant to usage, such as intent, expected
   inputs/outputs, behavior. It is also valid to highlight hazardous gotchas to be careful about, if any. It should not
   describe implementation details; those should be left to inline comments.
-
-**Good use of comments:**
-* Documentation for exported structs, functions, fields, and methods.
-* Explaining broader context that can't be understood easily from the immediate implementation.
-* Explaining why the code has to do something non-obvious.
-* Explaining unusual but necessary implementation decisions.
-
-**Avoid:**
-* Comments that simply restate what the code is doing.
-* Redundant comments that add clutter or maintenance burden.
 
 ### Errors
 * When adding context to an error with `errors.Wrap`/`errors.Wrapf`, describe the operation that was being performed.
@@ -157,10 +159,7 @@ return errors.Wrapf(err, "unable to create file '%s'", name)
     * The environment is only needed to obtain a DB handle for a query (no admin-settings mutation is involved).
 
 ### AI-Generated Code
-AI-assisted code is welcome, but the author is responsible for the final result. Treat generated code with the same
-scrutiny as code you wrote yourself.
-* Read and fully understand any generated code before committing it. You should be able to defend its correctness,
-  performance, and security as if you'd written it.
+AI-assisted code is welcome, but the author is responsible for the final result.
 * Be skeptical of new external dependencies the AI introduces — adding a library is often a sign that the AI has
   "lost the plot" on a problem that should be solved with existing code. Read the library's docs before adopting it.
 * Remove the AI's explanatory comments unless the comment genuinely captures a non-obvious "why". Generated code tends

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,30 +64,6 @@ are multiple changes on the same day.
 The Evergreen codebase has automated tests defined in `self-tests.yml`, which itself runs in Evergreen. For most tasks in
 `self-tests.yml`, there's a roughly 1:1 relationship between Makefile targets and Evergreen self-test tasks.
 
-## Architecture
-
-### Package Organization
-
-| Package        | Description                                                                                               |
-|----------------|-----------------------------------------------------------------------------------------------------------|
-| `agent/`       | Contains the logic to run the agent. Runs tasks on hosts; receives tasks to run from the app server.      |
-| `apimodels/`   | Shared models used across REST API boundaries for the agent.                                              |
-| `auth/`        | Authentication backends (naive, GitHub, Okta).                                                            |
-| `cloud/`       | Cloud provider integrations (AWS EC2, Docker, etc).                                                       |
-| `db/`          | MongoDB interaction layer.                                                                                |
-| `graphql/`     | GraphQL backend.                                                                                          |
-| `model/`       | Core data models; task, host, build, patch, distro, etc. are in subpackages.                              |
-| `operations/`  | CLI command implementations. Also provides an entry point for the app server/agent.                       |
-| `repotracker/` | Tracks GitHub repos for new commits and PRs.                                                              |
-| `rest/`        | REST API: `route/` (handlers), `data/` (data connectors), `model/` (API models), `client/` (CLI clients). |
-| `scheduler/`   | Orders tasks in distro queues.                                                                            |
-| `service/`     | HTTP server wiring; UI and legacy REST endpoints.                                                         |
-| `thirdparty/`  | Other third-party integrations (GitHub, Jira, etc).                                                       |
-| `trigger/`     | Logic to trigger notifications from CI system events.                                                     |
-| `units/`       | Background job definitions using the Amboy job framework.                                                 |
-| `util/`        | Common utility functions.                                                                                 |
-| `validator/`   | Validates project YAML configs and distro settings.                                                       |
-
 ## Go Coding Conventions
 
 The conventions below are a distilled, agent-readable summary of the team's full style guide,


### PR DESCRIPTION
DEVPROD-38261


### Description

There's new research saying that too much context provided can make the newer, smarter models perform worse than without them. I ran the new /doctor command they release to help with bloat and applied the recommendations! 

**Removed**                                                                                                                                                                                                                                                                                                             
  - `### Formatting` (whole section) — the vertical-alignment rule describes what gofmt                                                                                                                                                                                                                                   
    already does. `goimports` is enabled in `.golangci.yml`, so `make lint` enforces this                                                                                                                                                                                                                                 
    mechanically; the prose can't drift out of sync with the formatter if it isn't there.                                                                                                                                                                                                                                 
  - `### Building` — dropped `make build` and `make mod-tidy`. Self-describing makefile                                                                                                                                                                                                                                   
    targets. Kept `make gqlgen`, since "after schema changes" is a workflow gotcha rather                                                                                                                                                                                                                                 
    than a command description.                                                                                                                                                                                                                                                                                           
  - `### Linting` — dropped the three `make lint*` invocations; they follow the same                                                                                                                                                                                                                                      
    `make <target>-<package>` pattern documented directly above under Testing. Kept the                                                                                                                                                                                                                                   
    note about pre-existing golangci-lint toolchain crashes.                                                                                                                                                                                                                                                              
  - `### Code Readability and Comments` — dropped the "write self-documenting code" bullet                                                                                                                                                                                                                                
    (generic) and the **Good use of comments** / **Avoid** lists, which restated the three                                                                                                                                                                                                                                
    bullets immediately above them and overlapped `### AI-Generated Code`.                                                                                                                                                                                                                                                
  - `### AI-Generated Code` — dropped the preamble and the "read and fully understand any                                                                                                                                                                                                                                 
    generated code before committing" bullet. Both address a human reviewer; the five                                                                                                                                                                                                                                     
    actionable bullets are unchanged.