### PR TITLE
DEVPROD-38227 Add GraphQL query complexity limit extension

### DIFF
--- a/graphql/http_handler.go
+++ b/graphql/http_handler.go
@@ -60,12 +60,13 @@ func Handler(apiURL string, allowMutations bool, env evergreen.Environment) func
 		),
 	))
 
-	cfg := env.Settings()
-	complexityLimit := cfg.RateLimit.GraphQLComplexityLimit
-	limitDisabled := cfg.ServiceFlags.GraphQLComplexityLimiterDisabled
+	ctx, cancel := env.Context()
+	defer cancel()
+	flags, _ := evergreen.GetServiceFlags(ctx)
+	complexityLimit := env.Settings().RateLimit.GraphQLComplexityLimit
 
 	// Reject queries that exceed the enabled complexity limit
-	if !limitDisabled && complexityLimit > 0 {
+	if !flags.GraphQLComplexityLimiterDisabled && complexityLimit > 0 {
 		srv.Use(extension.FixedComplexityLimit(complexityLimit))
 	}
 

--- a/graphql/http_handler.go
+++ b/graphql/http_handler.go
@@ -64,6 +64,7 @@ func Handler(apiURL string, allowMutations bool, env evergreen.Environment) func
 	complexityLimit := cfg.RateLimit.GraphQLComplexityLimit
 	limitDisabled := cfg.ServiceFlags.GraphQLComplexityLimiterDisabled
 
+	// Reject queries that exceed the enabled complexity limit
 	if !limitDisabled && complexityLimit > 0 {
 		srv.Use(extension.FixedComplexityLimit(complexityLimit))
 	}

--- a/graphql/http_handler.go
+++ b/graphql/http_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/99designs/gqlgen/graphql/handler/extension"
 	"github.com/99designs/gqlgen/graphql/handler/lru"
 	"github.com/99designs/gqlgen/graphql/handler/transport"
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/graphql/loaders"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/mongodb/grip"
@@ -24,7 +25,7 @@ import (
 )
 
 // Handler returns a gimlet http handler func used as the gql route handler
-func Handler(apiURL string, allowMutations bool) func(w http.ResponseWriter, r *http.Request) {
+func Handler(apiURL string, allowMutations bool, env evergreen.Environment) func(w http.ResponseWriter, r *http.Request) {
 	schema := NewExecutableSchema(New(apiURL))
 	srv := handler.New(schema)
 
@@ -58,6 +59,14 @@ func Handler(apiURL string, allowMutations bool) func(w http.ResponseWriter, r *
 			}),
 		),
 	))
+
+	cfg := env.Settings()
+	complexityLimit := cfg.RateLimit.GraphQLComplexityLimit
+	limitDisabled := cfg.ServiceFlags.GraphQLComplexityLimiterDisabled
+
+	if !limitDisabled && complexityLimit > 0 {
+		srv.Use(extension.FixedComplexityLimit(complexityLimit))
+	}
 
 	// Log graphql requests to splunk
 	srv.Use(MakeSplunkTracing(schema))

--- a/service/ui.go
+++ b/service/ui.go
@@ -182,7 +182,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	app.AddRoute("/graphql/query").
 		Wrap(allowsCORS, needsLoginNoRedirect, rateLimit).
 		Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			handlers.CompressHandler(http.HandlerFunc(graphql.Handler(uis.Settings.Api.URL, true))).ServeHTTP(w, r)
+			handlers.CompressHandler(http.HandlerFunc(graphql.Handler(uis.Settings.Api.URL, true, uis.env))).ServeHTTP(w, r)
 		})).
 		Post().Get()
 
@@ -190,7 +190,7 @@ func (uis *UIServer) GetServiceApp() *gimlet.APIApp {
 	app.AddRoute("/mcp/graphql/query").
 		Wrap(allowsCORS, requireSage, wrapUserForMCP, rateLimit).
 		Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			handlers.CompressHandler(http.HandlerFunc(graphql.Handler(uis.Settings.Api.URL, false))).ServeHTTP(w, r)
+			handlers.CompressHandler(http.HandlerFunc(graphql.Handler(uis.Settings.Api.URL, false, uis.env))).ServeHTTP(w, r)
 		})).
 		Post().Get()
 


### PR DESCRIPTION
DEVPROD-38227

### Description

Adds a GraphQL extension to the HTTP handler that reject GraphQL queries whose computed complexity score exceeds the configured limit, or only warns by setting the appropriate headers if the limit is disabled. 

### Testing

Tested locally via the UI - verified that GQL queries are blocked when their complexity exceeds the configured limit, disabling the limit via the service flags allows the requests to proceed with headers set, the 1000 proposed limit allows all UI queries, and setting the limit to 0 allows queries to proceed without setting any headers.
