### PR TITLE
DEVPROD-37998 Add CLI message for rate limited REST requests

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-07-29b"
+	ClientVersion = "2026-07-31"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-07-29a"
+	ClientVersion = "2026-07-29b"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/http.go
+++ b/operations/http.go
@@ -50,6 +50,11 @@ func NewAPIError(resp *http.Response) APIError {
 	defer resp.Body.Close()
 	bodyBytes, _ := io.ReadAll(resp.Body) // ignore error, request has already failed anyway
 	bodyStr := string(bodyBytes)
+	// If the response is a 429 (rate limit exceeded), replace the response body
+	// with the rate limit metadata from the response headers.
+	if resp.StatusCode == http.StatusTooManyRequests {
+		bodyStr = client.RateLimitMessage(resp.Header)
+	}
 	return APIError{bodyStr, resp.Status, resp.StatusCode}
 }
 

--- a/operations/http_test.go
+++ b/operations/http_test.go
@@ -2,10 +2,15 @@ package operations
 
 import (
 	"context"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -20,6 +25,35 @@ const testApiServer = "http://example.invalid"
 
 func TestCliHttpTestSuite(t *testing.T) {
 	suite.Run(t, new(CliHttpTestSuite))
+}
+
+func TestNewAPIErrorTooManyRequestsShouldReportRateLimitInfo(t *testing.T) {
+	header := http.Header{}
+	header.Set(evergreen.RateLimitLimitHeader, "5000")
+	header.Set(evergreen.RetryAfterHeader, "7")
+	resp := &http.Response{
+		StatusCode: http.StatusTooManyRequests,
+		Status:     "429 Too Many Requests",
+		Header:     header,
+		Body:       io.NopCloser(strings.NewReader(`{"status":429,"message":"rate limit exceeded"}`)),
+	}
+
+	err := NewAPIError(resp)
+	assert.Contains(t, err.Error(), "rate limit exceeded")
+	assert.Contains(t, err.Error(), "5000")
+	assert.Contains(t, err.Error(), "7")
+}
+
+func TestNewAPIErrorNonRateLimitStatusShouldReportResponseBody(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: http.StatusNotFound,
+		Status:     "404 Not Found",
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader("no such project")),
+	}
+
+	err := NewAPIError(resp)
+	assert.Contains(t, err.Error(), "no such project")
 }
 
 // sets up the global settings file

--- a/operations/model.go
+++ b/operations/model.go
@@ -295,6 +295,7 @@ func (s *ClientSettings) setupRestCommunicator(ctx context.Context, printMessage
 	}
 	if printMessages {
 		printUserMessages(ctx, c, !s.AutoUpgradeCLI)
+		printRateLimitWarning(ctx, c, s.User)
 	}
 
 	return c, nil

--- a/operations/model.go
+++ b/operations/model.go
@@ -295,7 +295,6 @@ func (s *ClientSettings) setupRestCommunicator(ctx context.Context, printMessage
 	}
 	if printMessages {
 		printUserMessages(ctx, c, !s.AutoUpgradeCLI)
-		printRateLimitWarning(ctx, c, s.User)
 	}
 
 	return c, nil

--- a/ratelimit/ratelimit.go
+++ b/ratelimit/ratelimit.go
@@ -33,8 +33,8 @@ func (l *Limiter) AllowN(ctx context.Context, userID string, surface evergreen.R
 	if !slices.Contains(evergreen.ValidRateLimitSurfaces, surface) {
 		return nil, errors.Errorf("invalid rate limit surface '%s'", surface)
 	}
-	if n < 1 {
-		return nil, errors.Errorf("cost %d must be at least 1", n)
+	if n < 0 {
+		return nil, errors.Errorf("cost %d must be at least 0", n)
 	}
 	// Skip limiting if limits are not set by returning a nil Result.
 	if reqPerHour == 0 { // Burst is guaranteed to also be 0 by validation in config.
@@ -45,4 +45,9 @@ func (l *Limiter) AllowN(ctx context.Context, userID string, surface evergreen.R
 	limit := redis_rate.PerHour(reqPerHour)
 	limit.Burst = burst // Override default burst, which is equal to hourly limit
 	return l.limiter.AllowN(ctx, key, limit, n)
+}
+
+// Peek reports the current rate limit status for a give userId, surface, and set of limits without consuming any tokens.
+func (l *Limiter) Peek(ctx context.Context, userID string, surface evergreen.RateLimitSurface, reqPerHour int, burst int) (*redis_rate.Result, error) {
+	return l.AllowN(ctx, userID, surface, reqPerHour, burst, 0)
 }

--- a/ratelimit/ratelimit_test.go
+++ b/ratelimit/ratelimit_test.go
@@ -68,11 +68,34 @@ func TestAllowNCostExceedingBurstShouldDeny(t *testing.T) {
 	assert.Equal(t, 0, res.Allowed)
 }
 
-func TestAllowNCostLessThanOneShouldError(t *testing.T) {
+func TestAllowNCostLessThanZeroShouldError(t *testing.T) {
 	l := newRedisTestLimiter(t)
-	res, err := l.AllowN(t.Context(), "user", evergreen.RateLimitSurfaceComplexity, 100, 10, 0)
+	res, err := l.AllowN(t.Context(), "user", evergreen.RateLimitSurfaceComplexity, 100, 10, -1)
 	assert.ErrorContains(t, err, "cost")
 	assert.Nil(t, res)
+}
+
+func TestPeekDoesNotConsumeTokens(t *testing.T) {
+	l := newRedisTestLimiter(t)
+	ctx := t.Context()
+
+	// Peek at the user's rate limit without consuming any tokens.
+	res, err := l.Peek(ctx, "user", evergreen.RateLimitSurfaceREST, 100, 1)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, 1, res.Remaining)
+
+	// After peeking, the user should still be allowed to make a request.
+	res, err = l.Allow(ctx, "user", evergreen.RateLimitSurfaceREST, 100, 1)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, 1, res.Allowed)
+
+	// The user's remaining tokens should now be 0.
+	res, err = l.Peek(ctx, "user", evergreen.RateLimitSurfaceREST, 100, 1)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, 0, res.Remaining)
 }
 
 func TestAllowNZeroReqPerHourSkipsLimiting(t *testing.T) {
@@ -81,15 +104,6 @@ func TestAllowNZeroReqPerHourSkipsLimiting(t *testing.T) {
 	// zero), so the request passes through with a nil Result rather than being rejected.
 	res, err := l.AllowN(t.Context(), "user", evergreen.RateLimitSurfaceREST, 0, 0, 1)
 	assert.NoError(t, err)
-	assert.Nil(t, res)
-}
-
-func TestAllowNInvalidCostErrorsWhenLimitingDisabled(t *testing.T) {
-	l := newRedisTestLimiter(t)
-	// Cost is validated before the unset-limit short-circuit, so an invalid cost is reported even
-	// when limiting is disabled.
-	res, err := l.AllowN(t.Context(), "user", evergreen.RateLimitSurfaceREST, 0, 0, 0)
-	assert.ErrorContains(t, err, "cost")
 	assert.Nil(t, res)
 }
 

--- a/rest/client/request.go
+++ b/rest/client/request.go
@@ -92,15 +92,15 @@ func (c *communicatorImpl) request(ctx context.Context, info requestInfo, data a
 	}
 	// Return a custom CLI response when a request fails due to rate limiting.
 	if resp.StatusCode == http.StatusTooManyRequests {
-		return resp, util.RespError(resp, rateLimitMessage(resp.Header))
+		return resp, util.RespError(resp, RateLimitMessage(resp.Header))
 	}
 
 	return resp, nil
 }
 
-// rateLimitMessage summarizes the rate limit metadata that the server sets
+// RateLimitMessage summarizes the rate limit metadata that the server sets
 // alongside a 429 response.
-func rateLimitMessage(header http.Header) string {
+func RateLimitMessage(header http.Header) string {
 	msg := "API rate limit exceeded"
 
 	var details []string
@@ -110,10 +110,10 @@ func rateLimitMessage(header http.Header) string {
 	if retryAfter := header.Get(evergreen.RetryAfterHeader); retryAfter != "" {
 		details = append(details, fmt.Sprintf("retry in %s seconds", retryAfter))
 	}
-	details = append(details, "GET /rest/v2/users/{user_id}/rate_limit to check your current rate limit status")
 	if len(details) > 0 {
 		msg += fmt.Sprintf(" (%s)", strings.Join(details, ", "))
 	}
+	msg += "\nGET /rest/v2/users/{user_id}/rate_limit to check your current rate limit status."
 
 	return msg
 }

--- a/rest/client/request.go
+++ b/rest/client/request.go
@@ -90,8 +90,32 @@ func (c *communicatorImpl) request(ctx context.Context, info requestInfo, data a
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
+	// Return a custom CLI response when a request fails due to rate limiting.
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return resp, util.RespError(resp, rateLimitMessage(resp.Header))
+	}
 
 	return resp, nil
+}
+
+// rateLimitMessage summarizes the rate limit metadata that the server sets
+// alongside a 429 response.
+func rateLimitMessage(header http.Header) string {
+	msg := "API rate limit exceeded"
+
+	var details []string
+	if limit := header.Get(evergreen.RateLimitLimitHeader); limit != "" {
+		details = append(details, fmt.Sprintf("refills at %s requests/hour", limit))
+	}
+	if retryAfter := header.Get(evergreen.RetryAfterHeader); retryAfter != "" {
+		details = append(details, fmt.Sprintf("retry in %s seconds", retryAfter))
+	}
+	details = append(details, "GET /rest/v2/users/{user_id}/rate_limit to check your current rate limit status")
+	if len(details) > 0 {
+		msg += fmt.Sprintf(" (%s)", strings.Join(details, ", "))
+	}
+
+	return msg
 }
 
 func (c *communicatorImpl) doRequest(ctx context.Context, r *http.Request) (*http.Response, error) {

--- a/rest/client/request_test.go
+++ b/rest/client/request_test.go
@@ -2,10 +2,13 @@ package client
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -25,6 +28,75 @@ func (s *RequestTestSuite) SetupTest() {
 		timeoutMax:   time.Minute * 10,
 		serverURL:    "url",
 	}
+}
+
+func TestRateLimitMessage(t *testing.T) {
+	// The rate limit header names aren't in canonical MIME form, so they must be
+	// set with Set rather than assigned directly into the header map.
+	newHeader := func(kv map[string]string) http.Header {
+		h := http.Header{}
+		for k, v := range kv {
+			h.Set(k, v)
+		}
+		return h
+	}
+
+	for testName, testCase := range map[string]struct {
+		header           http.Header
+		expectedContains []string
+		expectedOmits    []string
+	}{
+		"AllHeadersShouldBeIncluded": {
+			header: newHeader(map[string]string{
+				evergreen.RateLimitLimitHeader: "5000",
+				evergreen.RetryAfterHeader:     "7",
+			}),
+			expectedContains: []string{"5000", "7", "/rest/v2/users/{user_id}/rate_limit"},
+		},
+		"MissingRetryAfterShouldOnlyReportLimit": {
+			header: newHeader(map[string]string{
+				evergreen.RateLimitLimitHeader: "5000",
+			}),
+			expectedContains: []string{"5000"},
+			expectedOmits:    []string{"retry in"},
+		},
+		"MissingLimitShouldOnlyReportRetryAfter": {
+			header: newHeader(map[string]string{
+				evergreen.RetryAfterHeader: "7",
+			}),
+			expectedContains: []string{"7"},
+			expectedOmits:    []string{"refills"},
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			msg := rateLimitMessage(testCase.header)
+			assert.Contains(t, msg, "rate limit exceeded")
+			for _, contains := range testCase.expectedContains {
+				assert.Contains(t, msg, contains)
+			}
+			for _, omits := range testCase.expectedOmits {
+				assert.NotContains(t, msg, omits)
+			}
+		})
+	}
+}
+
+func TestRequestTooManyRequestsShouldErrorWithRateLimitInfo(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.Header().Set(evergreen.RateLimitLimitHeader, "5000")
+		rw.Header().Set(evergreen.RetryAfterHeader, "7")
+		rw.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := &communicatorImpl{serverURL: srv.URL, httpClient: srv.Client()}
+	resp, err := c.request(t.Context(), requestInfo{method: http.MethodGet, path: "path"}, nil)
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	assert.Contains(t, err.Error(), "rate limit exceeded")
+	assert.Contains(t, err.Error(), "5000")
+	assert.Contains(t, err.Error(), "7")
 }
 
 func (s *RequestTestSuite) TestNewRequest() {

--- a/rest/client/request_test.go
+++ b/rest/client/request_test.go
@@ -69,7 +69,7 @@ func TestRateLimitMessage(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			msg := rateLimitMessage(testCase.header)
+			msg := RateLimitMessage(testCase.header)
 			assert.Contains(t, msg, "rate limit exceeded")
 			for _, contains := range testCase.expectedContains {
 				assert.Contains(t, msg, contains)

--- a/rest/model/rate_limit.go
+++ b/rest/model/rate_limit.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"github.com/go-redis/redis_rate/v10"
+)
+
+type APIRateLimitStatus struct {
+	Limit             int `json:"hourly_limit"`
+	Burst             int `json:"burst_limit"`
+	Remaining         int `json:"remaining"`
+	ResetAfterSeconds int `json:"reset_after_seconds"`
+}
+
+// BuildFromService converts a redis_rate.Result into an APIRateLimitStatus.
+func (s *APIRateLimitStatus) BuildFromService(result *redis_rate.Result) {
+	if result == nil {
+		return
+	}
+	s.Limit = result.Limit.Rate
+	s.Burst = result.Limit.Burst
+	s.Remaining = result.Remaining
+	s.ResetAfterSeconds = int(result.ResetAfter.Seconds())
+}

--- a/rest/route/rate_limit_status.go
+++ b/rest/route/rate_limit_status.go
@@ -1,0 +1,102 @@
+package route
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"slices"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/ratelimit"
+	restmodel "github.com/evergreen-ci/evergreen/rest/model"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/pkg/errors"
+)
+
+////////////////////////////////////////////////////////////////////////
+//
+// GET /rest/v2/users/{user_id}/rate_limit
+
+type userRateLimitGetHandler struct {
+	env    evergreen.Environment
+	userID string
+}
+
+func makeUserRateLimitGetHandler(env evergreen.Environment) gimlet.RouteHandler {
+	return &userRateLimitGetHandler{env: env}
+}
+
+// Factory creates an instance of the handler.
+//
+//	@Summary		Get a user's REST rate limit status
+//	@Description	Get the caller's current REST rate limit status. Callers may only check their own rate limit. Returns a 503 if rate limiting is disabled globally or for the caller's user type.
+//	@Tags			users
+//	@Router			/users/{user_id}/rate_limit [get]
+//	@Security		Api-User || Api-Key
+//	@Param			user_id	path		string	true	"User ID"
+//	@Success		200		{object}	model.APIRateLimitStatus
+func (h *userRateLimitGetHandler) Factory() gimlet.RouteHandler {
+	return &userRateLimitGetHandler{env: h.env}
+}
+
+func (h *userRateLimitGetHandler) Parse(ctx context.Context, r *http.Request) error {
+	h.userID = gimlet.GetVars(r)["user_id"]
+	return nil
+}
+
+func (h *userRateLimitGetHandler) Run(ctx context.Context) gimlet.Responder {
+	u := MustHaveUser(ctx)
+	if u.Username() != h.userID {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusForbidden,
+			Message:    fmt.Sprintf("users may only check their own rate limit %s", u.Username()),
+		})
+	}
+
+	flags, err := evergreen.GetServiceFlags(ctx)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "checking rate limit status"))
+	}
+	if flags.APIRateLimiterDisabled {
+		return rateLimitingDisabledResponder()
+	}
+
+	cfg := h.env.Settings().RateLimit
+	perHour, burst := limitsFor(&cfg, evergreen.RateLimitSurfaceREST, u.OnlyAPI)
+	if perHour == 0 {
+		// No limit configured for this user's tier is functionally the same as the
+		// limiter being disabled from this caller's perspective.
+		return rateLimitingDisabledResponder()
+	}
+	if slices.Contains(cfg.ElevatedUserIDs, u.Username()) {
+		perHour *= 2
+		burst *= 2
+	}
+
+	limiter, err := ratelimit.NewRateLimiter(h.env.RedisClient())
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "checking rate limit status"))
+	}
+	if limiter == nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.New("nil rate limiter returned for rate limit status check"))
+	}
+	// Check the user's REST rate limit without consuming any tokens.
+	result, err := limiter.Peek(ctx, u.Username(), evergreen.RateLimitSurfaceREST, perHour, burst)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "checking rate limit status"))
+	}
+
+	status := &restmodel.APIRateLimitStatus{}
+	status.BuildFromService(result)
+	return gimlet.NewJSONResponse(status)
+}
+
+// rateLimitingDisabledResponder is returned whenever there's no limit enforced
+// against the caller, whether because the limiter is disabled globally or
+// because their user type has no configured limit.
+func rateLimitingDisabledResponder() gimlet.Responder {
+	return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+		StatusCode: http.StatusConflict,
+		Message:    "rate limiting is currently disabled",
+	})
+}

--- a/rest/route/rate_limit_status_test.go
+++ b/rest/route/rate_limit_status_test.go
@@ -1,0 +1,93 @@
+package route
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/user"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runUserRateLimitHandler parses and runs the handler for a GET on
+// /users/{userID}/rate_limit, authenticated as userID.
+func runUserRateLimitHandler(t *testing.T, env evergreen.Environment, userID string) gimlet.Responder {
+	req, err := http.NewRequest(http.MethodGet, "http://example.com/api/rest/v2/users/"+userID+"/rate_limit", nil)
+	require.NoError(t, err)
+	req = gimlet.SetURLVars(req, map[string]string{"user_id": userID})
+
+	handler := makeUserRateLimitGetHandler(env)
+	require.NoError(t, handler.Parse(t.Context(), req))
+
+	ctx := gimlet.AttachUser(t.Context(), &user.DBUser{Id: userID})
+	return handler.Run(ctx)
+}
+
+func TestUserRateLimitGetHandlerSelfOnly(t *testing.T) {
+	for testName, testCase := range map[string]func(t *testing.T){
+		"MismatchedUserIDIsForbidden": func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, "http://example.com/api/rest/v2/users/other_user/rate_limit", nil)
+			require.NoError(t, err)
+			req = gimlet.SetURLVars(req, map[string]string{"user_id": "other_user"})
+
+			handler := makeUserRateLimitGetHandler(nil)
+			require.NoError(t, handler.Parse(t.Context(), req))
+
+			ctx := gimlet.AttachUser(t.Context(), &user.DBUser{Id: "me"})
+			resp := handler.Run(ctx)
+			assert.Equal(t, http.StatusForbidden, resp.Status())
+		},
+		"MatchingUserIDIsAllowed": func(t *testing.T) {
+			env := setupRateLimitEnv(t, evergreen.RateLimitConfig{RESTUserPerHour: 100, RESTUserBurst: 5})
+
+			resp := runUserRateLimitHandler(t, env, "me")
+			assert.Equal(t, http.StatusOK, resp.Status())
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			testCase(t)
+		})
+	}
+}
+
+// TestUserRateLimitGetHandlerDisabledReportsServiceUnavailable verifies that
+// there being no limit enforced against the caller -- whether because the
+// limiter is disabled globally or because their user type has no configured
+// limit -- is reported as a 503, so it's visible without being confused with a
+// genuine internal error (a 500, see
+// TestUserRateLimitGetHandlerInternalErrorReturns500).
+func TestUserRateLimitGetHandlerDisabledReportsServiceUnavailable(t *testing.T) {
+	for testName, testCase := range map[string]func(t *testing.T){
+		"GlobalFlagDisabled": func(t *testing.T) {
+			env := setupRateLimitEnv(t, evergreen.RateLimitConfig{RESTUserPerHour: 100, RESTUserBurst: 5})
+			require.NoError(t, (&evergreen.ServiceFlags{APIRateLimiterDisabled: true}).Set(t.Context()))
+
+			resp := runUserRateLimitHandler(t, env, "me")
+			assert.Equal(t, http.StatusConflict, resp.Status())
+		},
+		"UnconfiguredRESTLimit": func(t *testing.T) {
+			env := setupRateLimitEnv(t, evergreen.RateLimitConfig{}) // all zero
+
+			resp := runUserRateLimitHandler(t, env, "me")
+			assert.Equal(t, http.StatusConflict, resp.Status())
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			testCase(t)
+		})
+	}
+}
+
+// TestUserRateLimitGetHandlerInternalErrorReturns500 verifies that a genuine
+// failure to determine the caller's rate limit (as opposed to there being no
+// limit to report) surfaces as a visible 500, rather than being silently
+// swallowed as a 200 with no data.
+func TestUserRateLimitGetHandlerInternalErrorReturns500(t *testing.T) {
+	env := setupRateLimitEnv(t, evergreen.RateLimitConfig{RESTUserPerHour: 100, RESTUserBurst: 5})
+	env.SetRedisClient(nil) // NewRateLimiter will fail.
+
+	resp := runUserRateLimitHandler(t, env, "me")
+	assert.Equal(t, http.StatusInternalServerError, resp.Status())
+}

--- a/rest/route/service.go
+++ b/rest/route/service.go
@@ -251,8 +251,11 @@ func AttachHandler(app *gimlet.APIApp, opts HandlerOpts) {
 	app.AddRoute("/tasks/{task_id}/github_dynamic_access_tokens").Version(2).Delete().Wrap(requireUser, viewTasks, rateLimit).RouteHandler(makeDeleteGitHubDynamicAccessTokens())
 	app.AddRoute("/user/settings").Version(2).Get().Wrap(requireUser, rateLimit).RouteHandler(makeFetchUserConfig())
 	app.AddRoute("/user/settings").Version(2).Post().Wrap(requireUser, rateLimit).RouteHandler(makeSetUserConfig())
-	app.AddRoute("/users/{user_id}").Version(2).Get().Wrap(requireUser, rateLimit).RouteHandler(makeGetUserHandler())
+	// No rate-limit middleware: called at the beginning of CLI commands to resolve user details.
+	app.AddRoute("/users/{user_id}").Version(2).Get().Wrap(requireUser).RouteHandler(makeGetUserHandler())
 	app.AddRoute("/users/{user_id}/hosts").Version(2).Get().Wrap(requireUser, rateLimit).RouteHandler(makeFetchHosts())
+	// No rate-limit middleware: this endpoint reports the caller's rate-limit status and must remain available even once the caller's limit is exhausted.
+	app.AddRoute("/users/{user_id}/rate_limit").Version(2).Get().Wrap(requireUser).RouteHandler(makeUserRateLimitGetHandler(env))
 	app.AddRoute("/users/{user_id}/patches").Version(2).Get().Wrap(requireUser, rateLimit).RouteHandler(makeUserPatchHandler())
 	app.AddRoute("/users/offboard_user").Version(2).Post().Wrap(requireUser, editRoles, rateLimit).RouteHandler(makeOffboardUser(env))
 	app.AddRoute("/users/rename_user").Version(2).Post().Wrap(requireUser, editRoles, rateLimit).RouteHandler(makeRenameUser(env))


### PR DESCRIPTION
DEVPROD-37998

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
- When a 429 response is returned by a REST request, the CLI reads the rate limit headers on the response and constructs a message to indicate when the user should retry the request, and the REST route they can hit to monitor their rate limit status.
- Removes rateLimit middleware from the `/user/{user_id}` route because CLI commands call it to resolve user details, like whether the user is a service user
- Adds a new v2 REST route that reports the user's rate limit state `/users/{user_id}/rate_limit`

The response looks like this:
```
{
  "hourly_limit": 20,
  "burst_limit": 2,
  "remaining": 0,
  "reset_after_seconds": 214
}
```
It returns a 409 response when there are no rate limits for REST enabled (either disabled by service flag or set to 0 for the user tier).

### Testing

Tested with staging + local binary, message is correctly printed when the limit is hit, and not printed if limiting is not in place or hit
