### PR TITLE
DEVPROD-36652: validate topics for SNS webhooks

### DIFF
--- a/config_cloud.go
+++ b/config_cloud.go
@@ -83,9 +83,9 @@ type AWSConfig struct {
 	// elastic IPs enabled being assigned an elastic IP address.
 	ElasticIPUsageRate float64 `bson:"elastic_ip_usage_rate" json:"elastic_ip_usage_rate" yaml:"elastic_ip_usage_rate"`
 
-	// SNSTopicARNs are the ARNs of the AWS SNS topics that Evergreen accepts
-	// incoming SNS notifications from.
-	SNSTopicARNs []string `bson:"sns_topic_arns" json:"sns_topic_arns" yaml:"sns_topic_arns"`
+	// AllowedSNSTopicARNs are the ARNs of the AWS SNS topics that Evergreen
+	// accepts incoming SNS notifications from.
+	AllowedSNSTopicARNs []string `bson:"allowed_sns_topic_arns" json:"allowed_sns_topic_arns" yaml:"allowed_sns_topic_arns"`
 }
 
 // AccountRoleMapping is a mapping of an AWS account to the role that needs to

--- a/config_cloud.go
+++ b/config_cloud.go
@@ -82,6 +82,10 @@ type AWSConfig struct {
 	// ElasticIPUsageRate is the probability (out of 1) of a host that has
 	// elastic IPs enabled being assigned an elastic IP address.
 	ElasticIPUsageRate float64 `bson:"elastic_ip_usage_rate" json:"elastic_ip_usage_rate" yaml:"elastic_ip_usage_rate"`
+
+	// SNSTopicARNs are the ARNs of the AWS SNS topics that Evergreen accepts
+	// incoming SNS notifications from.
+	SNSTopicARNs []string `bson:"sns_topic_arns" json:"sns_topic_arns" yaml:"sns_topic_arns"`
 }
 
 // AccountRoleMapping is a mapping of an AWS account to the role that needs to

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -126,13 +126,13 @@ type ComplexityRoot struct {
 		AlertableInstanceTypes func(childComplexity int) int
 		AllowedInstanceTypes   func(childComplexity int) int
 		AllowedRegions         func(childComplexity int) int
+		AllowedSNSTopicARNs    func(childComplexity int) int
 		DefaultSecurityGroup   func(childComplexity int) int
 		ElasticIPUsageRate     func(childComplexity int) int
 		IPAMPoolID             func(childComplexity int) int
 		MaxVolumeSizePerUser   func(childComplexity int) int
 		ParserProject          func(childComplexity int) int
 		PersistentDNS          func(childComplexity int) int
-		SNSTopicARNs           func(childComplexity int) int
 		Subnets                func(childComplexity int) int
 	}
 
@@ -2961,6 +2961,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.AWSConfig.AllowedRegions(childComplexity), true
+	case "AWSConfig.allowedSNSTopicARNs":
+		if e.complexity.AWSConfig.AllowedSNSTopicARNs == nil {
+			break
+		}
+
+		return e.complexity.AWSConfig.AllowedSNSTopicARNs(childComplexity), true
 	case "AWSConfig.defaultSecurityGroup":
 		if e.complexity.AWSConfig.DefaultSecurityGroup == nil {
 			break
@@ -2997,12 +3003,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.AWSConfig.PersistentDNS(childComplexity), true
-	case "AWSConfig.snsTopicARNs":
-		if e.complexity.AWSConfig.SNSTopicARNs == nil {
-			break
-		}
-
-		return e.complexity.AWSConfig.SNSTopicARNs(childComplexity), true
 	case "AWSConfig.subnets":
 		if e.complexity.AWSConfig.Subnets == nil {
 			break
@@ -17864,14 +17864,14 @@ func (ec *executionContext) fieldContext_AWSConfig_elasticIPUsageRate(_ context.
 	return fc, nil
 }
 
-func (ec *executionContext) _AWSConfig_snsTopicARNs(ctx context.Context, field graphql.CollectedField, obj *model.APIAWSConfig) (ret graphql.Marshaler) {
+func (ec *executionContext) _AWSConfig_allowedSNSTopicARNs(ctx context.Context, field graphql.CollectedField, obj *model.APIAWSConfig) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
-		ec.fieldContext_AWSConfig_snsTopicARNs,
+		ec.fieldContext_AWSConfig_allowedSNSTopicARNs,
 		func(ctx context.Context) (any, error) {
-			return obj.SNSTopicARNs, nil
+			return obj.AllowedSNSTopicARNs, nil
 		},
 		nil,
 		ec.marshalNString2ᚕᚖstringᚄ,
@@ -17880,7 +17880,7 @@ func (ec *executionContext) _AWSConfig_snsTopicARNs(ctx context.Context, field g
 	)
 }
 
-func (ec *executionContext) fieldContext_AWSConfig_snsTopicARNs(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+func (ec *executionContext) fieldContext_AWSConfig_allowedSNSTopicARNs(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "AWSConfig",
 		Field:      field,
@@ -24111,8 +24111,8 @@ func (ec *executionContext) fieldContext_CloudProviderConfig_aws(_ context.Conte
 				return ec.fieldContext_AWSConfig_ipamPoolID(ctx, field)
 			case "elasticIPUsageRate":
 				return ec.fieldContext_AWSConfig_elasticIPUsageRate(ctx, field)
-			case "snsTopicARNs":
-				return ec.fieldContext_AWSConfig_snsTopicARNs(ctx, field)
+			case "allowedSNSTopicARNs":
+				return ec.fieldContext_AWSConfig_allowedSNSTopicARNs(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AWSConfig", field.Name)
 		},
@@ -79946,7 +79946,7 @@ func (ec *executionContext) unmarshalInputAWSConfigInput(ctx context.Context, ob
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"subnets", "parserProject", "persistentDNS", "defaultSecurityGroup", "allowedInstanceTypes", "alertableInstanceTypes", "allowedRegions", "maxVolumeSizePerUser", "accountRoles", "ipamPoolID", "elasticIPUsageRate", "snsTopicARNs"}
+	fieldsInOrder := [...]string{"subnets", "parserProject", "persistentDNS", "defaultSecurityGroup", "allowedInstanceTypes", "alertableInstanceTypes", "allowedRegions", "maxVolumeSizePerUser", "accountRoles", "ipamPoolID", "elasticIPUsageRate", "allowedSNSTopicARNs"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -80085,13 +80085,13 @@ func (ec *executionContext) unmarshalInputAWSConfigInput(ctx context.Context, ob
 				return it, err
 			}
 			it.ElasticIPUsageRate = data
-		case "snsTopicARNs":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("snsTopicARNs"))
+		case "allowedSNSTopicARNs":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("allowedSNSTopicARNs"))
 			data, err := ec.unmarshalNString2ᚕᚖstringᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}
-			it.SNSTopicARNs = data
+			it.AllowedSNSTopicARNs = data
 		}
 	}
 
@@ -91459,8 +91459,8 @@ func (ec *executionContext) _AWSConfig(ctx context.Context, sel ast.SelectionSet
 			out.Values[i] = ec._AWSConfig_ipamPoolID(ctx, field, obj)
 		case "elasticIPUsageRate":
 			out.Values[i] = ec._AWSConfig_elasticIPUsageRate(ctx, field, obj)
-		case "snsTopicARNs":
-			out.Values[i] = ec._AWSConfig_snsTopicARNs(ctx, field, obj)
+		case "allowedSNSTopicARNs":
+			out.Values[i] = ec._AWSConfig_allowedSNSTopicARNs(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -132,6 +132,7 @@ type ComplexityRoot struct {
 		MaxVolumeSizePerUser   func(childComplexity int) int
 		ParserProject          func(childComplexity int) int
 		PersistentDNS          func(childComplexity int) int
+		SNSTopicARNs           func(childComplexity int) int
 		Subnets                func(childComplexity int) int
 	}
 
@@ -2996,6 +2997,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.AWSConfig.PersistentDNS(childComplexity), true
+	case "AWSConfig.snsTopicARNs":
+		if e.complexity.AWSConfig.SNSTopicARNs == nil {
+			break
+		}
+
+		return e.complexity.AWSConfig.SNSTopicARNs(childComplexity), true
 	case "AWSConfig.subnets":
 		if e.complexity.AWSConfig.Subnets == nil {
 			break
@@ -17857,6 +17864,35 @@ func (ec *executionContext) fieldContext_AWSConfig_elasticIPUsageRate(_ context.
 	return fc, nil
 }
 
+func (ec *executionContext) _AWSConfig_snsTopicARNs(ctx context.Context, field graphql.CollectedField, obj *model.APIAWSConfig) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AWSConfig_snsTopicARNs,
+		func(ctx context.Context) (any, error) {
+			return obj.SNSTopicARNs, nil
+		},
+		nil,
+		ec.marshalNString2ᚕᚖstringᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_AWSConfig_snsTopicARNs(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AWSConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _AWSVPCConfig_subnets(ctx context.Context, field graphql.CollectedField, obj *model.APIAWSVPCConfig) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -24075,6 +24111,8 @@ func (ec *executionContext) fieldContext_CloudProviderConfig_aws(_ context.Conte
 				return ec.fieldContext_AWSConfig_ipamPoolID(ctx, field)
 			case "elasticIPUsageRate":
 				return ec.fieldContext_AWSConfig_elasticIPUsageRate(ctx, field)
+			case "snsTopicARNs":
+				return ec.fieldContext_AWSConfig_snsTopicARNs(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type AWSConfig", field.Name)
 		},
@@ -79908,7 +79946,7 @@ func (ec *executionContext) unmarshalInputAWSConfigInput(ctx context.Context, ob
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"subnets", "parserProject", "persistentDNS", "defaultSecurityGroup", "allowedInstanceTypes", "alertableInstanceTypes", "allowedRegions", "maxVolumeSizePerUser", "accountRoles", "ipamPoolID", "elasticIPUsageRate"}
+	fieldsInOrder := [...]string{"subnets", "parserProject", "persistentDNS", "defaultSecurityGroup", "allowedInstanceTypes", "alertableInstanceTypes", "allowedRegions", "maxVolumeSizePerUser", "accountRoles", "ipamPoolID", "elasticIPUsageRate", "snsTopicARNs"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -80047,6 +80085,13 @@ func (ec *executionContext) unmarshalInputAWSConfigInput(ctx context.Context, ob
 				return it, err
 			}
 			it.ElasticIPUsageRate = data
+		case "snsTopicARNs":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("snsTopicARNs"))
+			data, err := ec.unmarshalNString2ᚕᚖstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SNSTopicARNs = data
 		}
 	}
 
@@ -91414,6 +91459,11 @@ func (ec *executionContext) _AWSConfig(ctx context.Context, sel ast.SelectionSet
 			out.Values[i] = ec._AWSConfig_ipamPoolID(ctx, field, obj)
 		case "elasticIPUsageRate":
 			out.Values[i] = ec._AWSConfig_elasticIPUsageRate(ctx, field, obj)
+		case "snsTopicARNs":
+			out.Values[i] = ec._AWSConfig_snsTopicARNs(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/schema/types/adminSettings/providers.graphql
+++ b/graphql/schema/types/adminSettings/providers.graphql
@@ -20,7 +20,7 @@ input AWSConfigInput {
   accountRoles: [AWSAccountRoleMappingInput!]! @redactSecrets
   ipamPoolID: String
   elasticIPUsageRate: Float
-  snsTopicARNs: [String!]!
+  allowedSNSTopicARNs: [String!]!
 }
 
 type AWSConfig {
@@ -35,7 +35,7 @@ type AWSConfig {
   accountRoles: [AWSAccountRoleMapping!]! @requireAdmin
   ipamPoolID: String
   elasticIPUsageRate: Float
-  snsTopicARNs: [String!]!
+  allowedSNSTopicARNs: [String!]!
 }
 
 input AWSVPCConfigInput {

--- a/graphql/schema/types/adminSettings/providers.graphql
+++ b/graphql/schema/types/adminSettings/providers.graphql
@@ -20,6 +20,7 @@ input AWSConfigInput {
   accountRoles: [AWSAccountRoleMappingInput!]! @redactSecrets
   ipamPoolID: String
   elasticIPUsageRate: Float
+  snsTopicARNs: [String!]!
 }
 
 type AWSConfig {
@@ -34,6 +35,7 @@ type AWSConfig {
   accountRoles: [AWSAccountRoleMapping!]! @requireAdmin
   ipamPoolID: String
   elasticIPUsageRate: Float
+  snsTopicARNs: [String!]!
 }
 
 input AWSVPCConfigInput {

--- a/graphql/tests/mutation/saveAdminSettings/queries/providers.graphql
+++ b/graphql/tests/mutation/saveAdminSettings/queries/providers.graphql
@@ -33,6 +33,7 @@ mutation SaveAdminSettings {
         ]
         ipamPoolID: "pool-id"
         elasticIPUsageRate: 0.5
+        allowedSNSTopicARNs: ["arn:aws:sns:us-east-1:012345678901:topic"]
       }
       docker: {
         apiVersion: "1.40"
@@ -96,6 +97,7 @@ mutation SaveAdminSettings {
         }
         ipamPoolID
         elasticIPUsageRate
+        allowedSNSTopicARNs
       }
       docker {
         apiVersion

--- a/graphql/tests/mutation/saveAdminSettings/results.json
+++ b/graphql/tests/mutation/saveAdminSettings/results.json
@@ -479,7 +479,8 @@
                   }
                 ],
                 "ipamPoolID": "pool-id",
-                "elasticIPUsageRate": 0.5
+                "elasticIPUsageRate": 0.5,
+                "allowedSNSTopicARNs": ["arn:aws:sns:us-east-1:012345678901:topic"]
               },
               "docker": {
                 "apiVersion": "1.40"

--- a/graphql/tests/query/adminSettings/data.json
+++ b/graphql/tests/query/adminSettings/data.json
@@ -450,7 +450,8 @@
           }
         ],
         "ipam_pool_id": "ipam-pool-12345678",
-        "elastic_ip_usage_rate": 0.8
+        "elastic_ip_usage_rate": 0.8,
+        "allowed_sns_topic_arns": ["arn:aws:sns:us-east-1:012345678901:topic"]
       },
       "docker": {
         "api_version": "1.40"

--- a/graphql/tests/query/adminSettings/queries/providers.graphql
+++ b/graphql/tests/query/adminSettings/queries/providers.graphql
@@ -41,6 +41,7 @@ query Providers {
         }
         ipamPoolID
         elasticIPUsageRate
+        allowedSNSTopicARNs
       }
       docker {
         apiVersion

--- a/graphql/tests/query/adminSettings/results.json
+++ b/graphql/tests/query/adminSettings/results.json
@@ -553,7 +553,8 @@
                   }
                 ],
                 "ipamPoolID": "ipam-pool-12345678",
-                "elasticIPUsageRate": 0.8
+                "elasticIPUsageRate": 0.8,
+                "allowedSNSTopicARNs": ["arn:aws:sns:us-east-1:012345678901:topic"]
               },
               "docker": {
                 "apiVersion": "1.40"

--- a/rest/data/admin_test.go
+++ b/rest/data/admin_test.go
@@ -174,7 +174,7 @@ func (s *AdminDataSuite) TestSetAndGetSettings() {
 	}
 	s.Equal(testSettings.Providers.AWS.IPAMPoolID, settingsFromConnector.Providers.AWS.IPAMPoolID)
 	s.Equal(testSettings.Providers.AWS.ElasticIPUsageRate, settingsFromConnector.Providers.AWS.ElasticIPUsageRate)
-	s.Equal(testSettings.Providers.AWS.SNSTopicARNs, settingsFromConnector.Providers.AWS.SNSTopicARNs)
+	s.Equal(testSettings.Providers.AWS.AllowedSNSTopicARNs, settingsFromConnector.Providers.AWS.AllowedSNSTopicARNs)
 	s.EqualValues(testSettings.Providers.Docker.APIVersion, settingsFromConnector.Providers.Docker.APIVersion)
 	s.EqualValues(testSettings.RepoTracker.MaxConcurrentRequests, settingsFromConnector.RepoTracker.MaxConcurrentRequests)
 	s.EqualValues(testSettings.ReleaseMode.DistroMaxHostsFactor, settingsFromConnector.ReleaseMode.DistroMaxHostsFactor)

--- a/rest/data/admin_test.go
+++ b/rest/data/admin_test.go
@@ -174,6 +174,7 @@ func (s *AdminDataSuite) TestSetAndGetSettings() {
 	}
 	s.Equal(testSettings.Providers.AWS.IPAMPoolID, settingsFromConnector.Providers.AWS.IPAMPoolID)
 	s.Equal(testSettings.Providers.AWS.ElasticIPUsageRate, settingsFromConnector.Providers.AWS.ElasticIPUsageRate)
+	s.Equal(testSettings.Providers.AWS.SNSTopicARNs, settingsFromConnector.Providers.AWS.SNSTopicARNs)
 	s.EqualValues(testSettings.Providers.Docker.APIVersion, settingsFromConnector.Providers.Docker.APIVersion)
 	s.EqualValues(testSettings.RepoTracker.MaxConcurrentRequests, settingsFromConnector.RepoTracker.MaxConcurrentRequests)
 	s.EqualValues(testSettings.ReleaseMode.DistroMaxHostsFactor, settingsFromConnector.ReleaseMode.DistroMaxHostsFactor)

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1706,6 +1706,7 @@ type APIAWSConfig struct {
 	AccountRoles           []APIAWSAccountRoleMapping `json:"account_roles"`
 	IPAMPoolID             *string                    `json:"ipam_pool_id"`
 	ElasticIPUsageRate     *float64                   `json:"elastic_ip_usage_rate"`
+	SNSTopicARNs           []*string                  `json:"sns_topic_arns"`
 }
 
 func (a *APIAWSConfig) BuildFromService(h any) error {
@@ -1746,6 +1747,7 @@ func (a *APIAWSConfig) BuildFromService(h any) error {
 		a.AccountRoles = roleMappings
 		a.IPAMPoolID = utility.ToStringPtr(v.IPAMPoolID)
 		a.ElasticIPUsageRate = utility.ToFloat64Ptr(v.ElasticIPUsageRate)
+		a.SNSTopicARNs = utility.ToStringPtrSlice(v.SNSTopicARNs)
 	default:
 		return errors.Errorf("programmatic error: expected AWS config but got type %T", h)
 	}
@@ -1819,6 +1821,7 @@ func (a *APIAWSConfig) ToService() (any, error) {
 
 	config.IPAMPoolID = utility.FromStringPtr(a.IPAMPoolID)
 	config.ElasticIPUsageRate = utility.FromFloat64Ptr(a.ElasticIPUsageRate)
+	config.SNSTopicARNs = utility.FromStringPtrSlice(a.SNSTopicARNs)
 
 	return config, nil
 }

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1706,7 +1706,7 @@ type APIAWSConfig struct {
 	AccountRoles           []APIAWSAccountRoleMapping `json:"account_roles"`
 	IPAMPoolID             *string                    `json:"ipam_pool_id"`
 	ElasticIPUsageRate     *float64                   `json:"elastic_ip_usage_rate"`
-	SNSTopicARNs           []*string                  `json:"sns_topic_arns"`
+	AllowedSNSTopicARNs    []*string                  `json:"allowed_sns_topic_arns"`
 }
 
 func (a *APIAWSConfig) BuildFromService(h any) error {
@@ -1747,7 +1747,7 @@ func (a *APIAWSConfig) BuildFromService(h any) error {
 		a.AccountRoles = roleMappings
 		a.IPAMPoolID = utility.ToStringPtr(v.IPAMPoolID)
 		a.ElasticIPUsageRate = utility.ToFloat64Ptr(v.ElasticIPUsageRate)
-		a.SNSTopicARNs = utility.ToStringPtrSlice(v.SNSTopicARNs)
+		a.AllowedSNSTopicARNs = utility.ToStringPtrSlice(v.AllowedSNSTopicARNs)
 	default:
 		return errors.Errorf("programmatic error: expected AWS config but got type %T", h)
 	}
@@ -1821,7 +1821,7 @@ func (a *APIAWSConfig) ToService() (any, error) {
 
 	config.IPAMPoolID = utility.FromStringPtr(a.IPAMPoolID)
 	config.ElasticIPUsageRate = utility.FromFloat64Ptr(a.ElasticIPUsageRate)
-	config.SNSTopicARNs = utility.FromStringPtrSlice(a.SNSTopicARNs)
+	config.AllowedSNSTopicARNs = utility.FromStringPtrSlice(a.AllowedSNSTopicARNs)
 
 	return config, nil
 }

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -180,6 +180,7 @@ func TestModelConversion(t *testing.T) {
 		assert.Equal(ar.Account, utility.FromStringPtr(apiSettings.Providers.AWS.AccountRoles[i].Account))
 		assert.Equal(ar.Role, utility.FromStringPtr(apiSettings.Providers.AWS.AccountRoles[i].Role))
 	}
+	assert.EqualValues(testSettings.Providers.AWS.SNSTopicARNs, utility.FromStringPtrSlice(apiSettings.Providers.AWS.SNSTopicARNs))
 	assert.EqualValues(testSettings.Providers.Docker.APIVersion, utility.FromStringPtr(apiSettings.Providers.Docker.APIVersion))
 	assert.EqualValues(testSettings.RepoTracker.MaxConcurrentRequests, apiSettings.RepoTracker.MaxConcurrentRequests)
 	assert.EqualValues(testSettings.Scheduler.TaskFinder, utility.FromStringPtr(apiSettings.Scheduler.TaskFinder))

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -180,7 +180,7 @@ func TestModelConversion(t *testing.T) {
 		assert.Equal(ar.Account, utility.FromStringPtr(apiSettings.Providers.AWS.AccountRoles[i].Account))
 		assert.Equal(ar.Role, utility.FromStringPtr(apiSettings.Providers.AWS.AccountRoles[i].Role))
 	}
-	assert.EqualValues(testSettings.Providers.AWS.SNSTopicARNs, utility.FromStringPtrSlice(apiSettings.Providers.AWS.SNSTopicARNs))
+	assert.EqualValues(testSettings.Providers.AWS.AllowedSNSTopicARNs, utility.FromStringPtrSlice(apiSettings.Providers.AWS.AllowedSNSTopicARNs))
 	assert.EqualValues(testSettings.Providers.Docker.APIVersion, utility.FromStringPtr(apiSettings.Providers.Docker.APIVersion))
 	assert.EqualValues(testSettings.RepoTracker.MaxConcurrentRequests, apiSettings.RepoTracker.MaxConcurrentRequests)
 	assert.EqualValues(testSettings.Scheduler.TaskFinder, utility.FromStringPtr(apiSettings.Scheduler.TaskFinder))

--- a/rest/route/admin_test.go
+++ b/rest/route/admin_test.go
@@ -204,6 +204,7 @@ func (s *AdminRouteSuite) TestAdminRoute() {
 	}
 	s.EqualValues(testSettings.Providers.AWS.IPAMPoolID, settings.Providers.AWS.IPAMPoolID)
 	s.EqualValues(testSettings.Providers.AWS.ElasticIPUsageRate, settings.Providers.AWS.ElasticIPUsageRate)
+	s.EqualValues(testSettings.Providers.AWS.SNSTopicARNs, settings.Providers.AWS.SNSTopicARNs)
 	s.EqualValues(testSettings.Providers.Docker.APIVersion, settings.Providers.Docker.APIVersion)
 	s.EqualValues(testSettings.RepoTracker.MaxConcurrentRequests, settings.RepoTracker.MaxConcurrentRequests)
 	s.EqualValues(testSettings.Scheduler.TaskFinder, settings.Scheduler.TaskFinder)

--- a/rest/route/admin_test.go
+++ b/rest/route/admin_test.go
@@ -204,7 +204,7 @@ func (s *AdminRouteSuite) TestAdminRoute() {
 	}
 	s.EqualValues(testSettings.Providers.AWS.IPAMPoolID, settings.Providers.AWS.IPAMPoolID)
 	s.EqualValues(testSettings.Providers.AWS.ElasticIPUsageRate, settings.Providers.AWS.ElasticIPUsageRate)
-	s.EqualValues(testSettings.Providers.AWS.SNSTopicARNs, settings.Providers.AWS.SNSTopicARNs)
+	s.EqualValues(testSettings.Providers.AWS.AllowedSNSTopicARNs, settings.Providers.AWS.AllowedSNSTopicARNs)
 	s.EqualValues(testSettings.Providers.Docker.APIVersion, settings.Providers.Docker.APIVersion)
 	s.EqualValues(testSettings.RepoTracker.MaxConcurrentRequests, settings.RepoTracker.MaxConcurrentRequests)
 	s.EqualValues(testSettings.Scheduler.TaskFinder, settings.Scheduler.TaskFinder)

--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -55,6 +55,22 @@ func (bsns *baseSNS) Parse(ctx context.Context, r *http.Request) error {
 		}
 	}
 
+	// The SNS signature only proves that AWS signed the message, not that it
+	// came from one of Evergreen's own topics, so the topic must be checked
+	// against the allowed topics before acting on the message.
+	if !utility.StringSliceContains(bsns.env.Settings().Providers.AWS.SNSTopicARNs, payload.TopicArn) {
+		grip.Warning(ctx, message.Fields{
+			"message":      "rejecting SNS message from disallowed topic",
+			"topic_arn":    payload.TopicArn,
+			"message_id":   payload.MessageId,
+			"message_type": bsns.messageType,
+		})
+		return gimlet.ErrorResponse{
+			StatusCode: http.StatusUnauthorized,
+			Message:    fmt.Sprintf("SNS topic ARN '%s' is not allowed", payload.TopicArn),
+		}
+	}
+
 	bsns.payload = payload
 
 	return nil

--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -55,9 +55,7 @@ func (bsns *baseSNS) Parse(ctx context.Context, r *http.Request) error {
 		}
 	}
 
-	// The SNS signature only proves that AWS signed the message, not that it
-	// came from one of Evergreen's own topics, so the topic must be checked
-	// against the allowed topics before acting on the message.
+	// Validate that the SNS message came from one of Evergreen's own topics.
 	if !utility.StringSliceContains(bsns.env.Settings().Providers.AWS.SNSTopicARNs, payload.TopicArn) {
 		grip.Warning(ctx, message.Fields{
 			"message":      "rejecting SNS message from disallowed topic",

--- a/rest/route/sns.go
+++ b/rest/route/sns.go
@@ -56,7 +56,7 @@ func (bsns *baseSNS) Parse(ctx context.Context, r *http.Request) error {
 	}
 
 	// Validate that the SNS message came from one of Evergreen's own topics.
-	if !utility.StringSliceContains(bsns.env.Settings().Providers.AWS.SNSTopicARNs, payload.TopicArn) {
+	if !utility.StringSliceContains(bsns.env.Settings().Providers.AWS.AllowedSNSTopicARNs, payload.TopicArn) {
 		grip.Warning(ctx, message.Fields{
 			"message":      "rejecting SNS message from disallowed topic",
 			"topic_arn":    payload.TopicArn,

--- a/rest/route/sns_test.go
+++ b/rest/route/sns_test.go
@@ -101,7 +101,7 @@ func TestBaseSNSParse(t *testing.T) {
 			ctx := t.Context()
 			env := &mock.Environment{}
 			require.NoError(t, env.Configure(ctx))
-			env.EvergreenSettings.Providers.AWS.SNSTopicARNs = tCase.topicARNs
+			env.EvergreenSettings.Providers.AWS.AllowedSNSTopicARNs = tCase.topicARNs
 
 			payload := sns.Payload{
 				TopicArn:  tCase.payloadTopic,

--- a/rest/route/sns_test.go
+++ b/rest/route/sns_test.go
@@ -75,6 +75,61 @@ func TestBaseSNSRoute(t *testing.T) {
 	}
 }
 
+func TestBaseSNSParse(t *testing.T) {
+	const allowedTopicARN = "arn:aws:sns:us-east-1:1234567890:some-aws-topic"
+
+	for tName, tCase := range map[string]struct {
+		topicARNs      []string
+		payloadTopic   string
+		expectedStatus int
+	}{
+		"SucceedsWithAnyAllowedTopicARN": {
+			topicARNs:    []string{"arn:aws:sns:us-east-1:1234567890:other-topic", allowedTopicARN},
+			payloadTopic: allowedTopicARN,
+		},
+		"FailsWithDisallowedTopicARN": {
+			topicARNs:      []string{allowedTopicARN},
+			payloadTopic:   "arn:aws:sns:us-east-1:9876543210:bad-topic",
+			expectedStatus: http.StatusUnauthorized,
+		},
+		"FailsWithNoExplicitlyAllowedTopicARNs": {
+			payloadTopic:   allowedTopicARN,
+			expectedStatus: http.StatusUnauthorized,
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx := t.Context()
+			env := &mock.Environment{}
+			require.NoError(t, env.Configure(ctx))
+			env.EvergreenSettings.Providers.AWS.SNSTopicARNs = tCase.topicARNs
+
+			payload := sns.Payload{
+				TopicArn:  tCase.payloadTopic,
+				MessageId: "message_id",
+			}
+			req, err := http.NewRequest(http.MethodPost, "https://example.com/rest/v2/hooks/aws", nil)
+			require.NoError(t, err)
+			req.Header.Set("x-amz-sns-message-type", messageTypeNotification)
+			req = setSNSPayload(req, payload)
+
+			bsns := makeBaseSNS(env, env.LocalQueue())
+			err = bsns.Parse(ctx, req)
+
+			if tCase.expectedStatus == 0 {
+				assert.NoError(t, err)
+				assert.Equal(t, payload, bsns.payload)
+				return
+			}
+
+			require.Error(t, err)
+			resp, ok := err.(gimlet.ErrorResponse)
+			require.True(t, ok)
+			assert.Equal(t, tCase.expectedStatus, resp.StatusCode)
+			assert.Zero(t, bsns.payload)
+		})
+	}
+}
+
 func TestHandleEC2SNSNotification(t *testing.T) {
 	ctx := t.Context()
 	assert.NoError(t, db.Clear(host.Collection))

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -339,6 +339,7 @@ func MockConfig() *evergreen.Settings {
 				},
 				IPAMPoolID:         "pool_id",
 				ElasticIPUsageRate: 0.3,
+				SNSTopicARNs:       []string{"arn:aws:sns:us-east-1:012345678901:topic"},
 			},
 			Docker: evergreen.DockerConfig{
 				APIVersion: "docker_version",

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -337,9 +337,9 @@ func MockConfig() *evergreen.Settings {
 						Role:    "role",
 					},
 				},
-				IPAMPoolID:         "pool_id",
-				ElasticIPUsageRate: 0.3,
-				SNSTopicARNs:       []string{"arn:aws:sns:us-east-1:012345678901:topic"},
+				IPAMPoolID:          "pool_id",
+				ElasticIPUsageRate:  0.3,
+				AllowedSNSTopicARNs: []string{"arn:aws:sns:us-east-1:012345678901:topic"},
 			},
 			Docker: evergreen.DockerConfig{
 				APIVersion: "docker_version",


### PR DESCRIPTION
DEVPROD-36652

### Description

Current SNS middleware only validates that the payload came from AWS, it doesn't check that it specifically came from a topic that we set up. Added an admin setting to list out the allowed SNS topic ARNs that can be processed by Evergreen.

Before this commit is deployed, I'm going to set the allowed SNS topics to ensure that SNS requests continue to succeed post-deploy.

* Create admin setting for allowed set of SNS topics.
* Validate that the SNS topic comes from one in the allowed set.

[UI PR](https://github.com/evergreen-ci/ui/pull/1829)

### Testing

* Added unit tests.
* Tested in staging to verify that if no SNS topics are allowed, all SNS webhooks are rejected with 401. After adding the SNS topic that staging uses, the SNS webhooks started succeeding again.