### PR TITLE
DEVPROD-37455: Require repo admin to attach a project to an existing repo

### DIFF
--- a/docs/Project-Configuration/Repo-Level-Settings.md
+++ b/docs/Project-Configuration/Repo-Level-Settings.md
@@ -8,7 +8,9 @@ Once a project is attached, any undefined fields will default to the repo's fiel
 
 ![repo_sidebar.png](../images/repo_sidebar.png)
 
-Changing the owner or repo for a branch project will result in it inheriting values from a different repo value, so there is a new operation "Move to New Repo".
+Attaching a project to a repo that already has a repo project requires admin permissions on that repo, since attaching gives the branch access to repo-wide settings. Being an admin of the branch project alone is not sufficient. If no repo project exists for the owner/repo yet, the user attaching the project becomes its first admin, so no additional permissions are needed.
+
+Changing the owner or repo for a branch project will result in it inheriting values from a different repo value, so there is a new operation "Move to New Repo". This also requires admin permissions on the target repo if a repo project already exists for it.
 
 ![detach_from_repo.png](../images/detach_from_repo.png)
 

--- a/graphql/attach_project_to_new_repo_test.go
+++ b/graphql/attach_project_to_new_repo_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/gimlet"
@@ -16,7 +17,8 @@ import (
 )
 
 // TestAttachProjectToNewRepoRequiresTargetRepoAdmin verifies that project admin access alone is not
-// sufficient to move a project onto a repo the user does not administer.
+// sufficient to move a project onto a repo the user does not administer, and that the same request
+// succeeds once the user is an admin of that repo.
 func TestAttachProjectToNewRepoRequiresTargetRepoAdmin(t *testing.T) {
 	setupPermissions(t)
 
@@ -89,4 +91,49 @@ func TestAttachProjectToNewRepoRequiresTargetRepoAdmin(t *testing.T) {
 	assert.Equal(t, originRepoRef.Owner, projectFromDB.Owner)
 	assert.Equal(t, originRepoRef.Repo, projectFromDB.Repo)
 	assert.Equal(t, originRepoRef.Id, projectFromDB.RepoRefId)
+
+	// Making the user an admin of the target repo allows the same request to succeed.
+	rm := evergreen.GetEnvironment().RoleManager()
+	for _, repoRefID := range []string{originRepoRef.Id, targetRepoRef.Id} {
+		require.NoError(t, rm.AddScope(t.Context(), gimlet.Scope{
+			ID:        model.GetRepoAdminScope(repoRefID),
+			Type:      evergreen.ProjectResourceType,
+			Resources: []string{repoRefID},
+		}))
+		require.NoError(t, rm.AddScope(t.Context(), gimlet.Scope{
+			ID:        model.GetUnrestrictedBranchProjectsScope(repoRefID),
+			Type:      evergreen.ProjectResourceType,
+			Resources: []string{repoRefID},
+		}))
+	}
+	require.NoError(t, rm.UpdateRole(t.Context(), gimlet.Role{
+		ID:          model.GetRepoAdminRole(targetRepoRef.Id),
+		Scope:       model.GetRepoAdminScope(targetRepoRef.Id),
+		Permissions: gimlet.Permissions{evergreen.PermissionProjectSettings: evergreen.ProjectSettingsEdit.Value},
+	}))
+	require.NoError(t, usr.AddRole(t.Context(), model.GetRepoAdminRole(targetRepoRef.Id)))
+
+	// AttachToNewRepo validates the new owner against the cached environment settings.
+	settings := evergreen.GetEnvironment().Settings()
+	originalOrgs := settings.GithubOrgs
+	settings.GithubOrgs = []string{originRepoRef.Owner, targetRepoRef.Owner}
+	t.Cleanup(func() { settings.GithubOrgs = originalOrgs })
+
+	req = httptest.NewRequest(http.MethodPost, "/graphql/query", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(gimlet.AttachUser(req.Context(), usr))
+	recorder = httptest.NewRecorder()
+	handler.NewDefaultServer(NewExecutableSchema(New("/graphql"))).ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	response.Errors = nil
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	require.Empty(t, response.Errors, "response body: %s", recorder.Body.String())
+
+	projectFromDB, err = model.FindBranchProjectRef(t.Context(), projectRef.Id)
+	require.NoError(t, err)
+	require.NotNil(t, projectFromDB)
+	assert.Equal(t, targetRepoRef.Owner, projectFromDB.Owner)
+	assert.Equal(t, targetRepoRef.Repo, projectFromDB.Repo)
+	assert.Equal(t, targetRepoRef.Id, projectFromDB.RepoRefId)
 }

--- a/graphql/attach_project_to_new_repo_test.go
+++ b/graphql/attach_project_to_new_repo_test.go
@@ -1,0 +1,92 @@
+package graphql
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/99designs/gqlgen/graphql/handler"
+	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/user"
+	"github.com/evergreen-ci/gimlet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAttachProjectToNewRepoRequiresTargetRepoAdmin verifies that project admin access alone is not
+// sufficient to move a project onto a repo the user does not administer.
+func TestAttachProjectToNewRepoRequiresTargetRepoAdmin(t *testing.T) {
+	setupPermissions(t)
+
+	usr := &user.DBUser{
+		Id:          testUser,
+		SystemRoles: []string{"admin_project"},
+	}
+	require.NoError(t, usr.Insert(t.Context()))
+
+	originRepoRef := model.RepoRef{ProjectRef: model.ProjectRef{
+		Id:    "origin_repo_id",
+		Owner: "old-owner",
+		Repo:  "old-repo",
+	}}
+	require.NoError(t, originRepoRef.Replace(t.Context()))
+
+	targetRepoRef := model.RepoRef{ProjectRef: model.ProjectRef{
+		Id:    "target_repo_id",
+		Owner: "new-owner",
+		Repo:  "new-repo",
+	}}
+	require.NoError(t, targetRepoRef.Replace(t.Context()))
+
+	projectRef := model.ProjectRef{
+		Id:         "project_id",
+		Identifier: "project_identifier",
+		Owner:      originRepoRef.Owner,
+		Repo:       originRepoRef.Repo,
+		Branch:     "main",
+		RepoRefId:  originRepoRef.Id,
+	}
+	require.NoError(t, projectRef.Insert(t.Context()))
+
+	payload, err := json.Marshal(map[string]any{
+		"operationName": "AttachProjectToNewRepo",
+		"query": `mutation AttachProjectToNewRepo($project: MoveProjectInput!) {
+			attachProjectToNewRepo(project: $project) {
+				id
+			}
+		}`,
+		"variables": map[string]any{
+			"project": map[string]any{
+				"projectId": projectRef.Id,
+				"newOwner":  targetRepoRef.Owner,
+				"newRepo":   targetRepoRef.Repo,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/graphql/query", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req = req.WithContext(gimlet.AttachUser(req.Context(), usr))
+	recorder := httptest.NewRecorder()
+	handler.NewDefaultServer(NewExecutableSchema(New("/graphql"))).ServeHTTP(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code)
+	var response struct {
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	require.Len(t, response.Errors, 1)
+	assert.Contains(t, response.Errors[0].Message, "is not an admin of repo 'new-owner/new-repo'")
+
+	projectFromDB, err := model.FindBranchProjectRef(t.Context(), projectRef.Id)
+	require.NoError(t, err)
+	require.NotNil(t, projectFromDB)
+	assert.Equal(t, originRepoRef.Owner, projectFromDB.Owner)
+	assert.Equal(t, originRepoRef.Repo, projectFromDB.Repo)
+	assert.Equal(t, originRepoRef.Id, projectFromDB.RepoRefId)
+}

--- a/graphql/integration_atomic_test_util.go
+++ b/graphql/integration_atomic_test_util.go
@@ -216,6 +216,7 @@ func setupUsers(t *testing.T) {
 			"project_sandbox",
 			"project_evergreen",
 			"repo_sandbox",
+			"repo_different",
 		},
 	}
 	assert.NoError(t, adminUsr.Insert(t.Context()))
@@ -524,6 +525,24 @@ func setupScopesAndRoles(t *testing.T, state *AtomicGraphQLState) {
 		Permissions: projectPermissions,
 	}
 	err = roleManager.UpdateRole(t.Context(), repoSandboxRole)
+	require.NoError(t, err)
+
+	repoDifferentScope := gimlet.Scope{
+		ID:        "repo_different_scope",
+		Name:      "repo_different",
+		Type:      evergreen.ProjectResourceType,
+		Resources: []string{"different"},
+	}
+	err = roleManager.AddScope(t.Context(), repoDifferentScope)
+	require.NoError(t, err)
+
+	repoDifferentRole := gimlet.Role{
+		ID:          "repo_different",
+		Name:        "repo_different",
+		Scope:       repoDifferentScope.ID,
+		Permissions: projectPermissions,
+	}
+	err = roleManager.UpdateRole(t.Context(), repoDifferentRole)
 	require.NoError(t, err)
 
 	directorySpecificTestSetup(t, *state)

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -449,6 +449,9 @@ func (r *mutationResolver) AttachProjectToNewRepo(ctx context.Context, project M
 	pRef.Repo = project.NewRepo
 
 	if err = pRef.AttachToNewRepo(ctx, usr); err != nil {
+		if werrors.Is(err, model.ErrRepoRefUnauthorized) {
+			return nil, Forbidden.Send(ctx, fmt.Sprintf("user '%s' is not an admin of repo '%s/%s'", usr.Username(), project.NewOwner, project.NewRepo))
+		}
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("updating owner/repo for project '%s': %s", project.ProjectID, err.Error()))
 	}
 

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -1002,7 +1002,7 @@ func (p *ProjectRef) checkExistingRepoRefAdmin(ctx context.Context, u *user.DBUs
 		RequiredLevel: evergreen.ProjectSettingsEdit.Value,
 	})
 	if !isRepoAdmin {
-		return errors.Wrapf(ErrRepoRefUnauthorized, "user '%s' cannot attach project '%s' to repo '%s/%s'", u.Id, p.Id, p.Owner, p.Repo)
+		return errors.Wrapf(ErrRepoRefUnauthorized, "user '%s' cannot attach project '%s' to repo '%s' ('%s/%s')", u.Id, p.Id, repoRef.Id, p.Owner, p.Repo)
 	}
 	return nil
 }

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -980,26 +980,39 @@ func (p *ProjectRef) DetachFromRepo(ctx context.Context, u *user.DBUser) error {
 	return catcher.Resolve()
 }
 
+// ErrRepoRefUnauthorized indicates that the user is not an admin of the repo ref they're
+// trying to attach a project to.
+var ErrRepoRefUnauthorized = errors.New("user is not an admin of the repo")
+
+// checkExistingRepoRefAdmin verifies that the user is allowed to attach the project to the repo ref
+// matching the project's current owner/repo. If no such repo ref exists yet, there is nothing to
+// authorize against, since the user will become its admin.
+func (p *ProjectRef) checkExistingRepoRefAdmin(ctx context.Context, u *user.DBUser) error {
+	repoRef, err := FindRepoRefByOwnerAndRepo(ctx, p.Owner, p.Repo)
+	if err != nil {
+		return errors.Wrapf(err, "finding repo ref for '%s/%s'", p.Owner, p.Repo)
+	}
+	if repoRef == nil {
+		return nil
+	}
+	isRepoAdmin := u.HasPermission(ctx, gimlet.PermissionOpts{
+		Resource:      repoRef.Id,
+		ResourceType:  evergreen.ProjectResourceType,
+		Permission:    evergreen.PermissionProjectSettings,
+		RequiredLevel: evergreen.ProjectSettingsEdit.Value,
+	})
+	if !isRepoAdmin {
+		return errors.Wrapf(ErrRepoRefUnauthorized, "user '%s' cannot attach project '%s' to repo '%s/%s'", u.Id, p.Id, p.Owner, p.Repo)
+	}
+	return nil
+}
+
 // AttachToRepo adds the branch to the relevant repo scopes, and updates the project to point to the repo.
 // Any values that previously were unset will now use the repo value, unless this would introduce
 // a GitHub project conflict. If no repo ref currently exists, the user attaching it will be added as the repo ref admin.
 func (p *ProjectRef) AttachToRepo(ctx context.Context, u *user.DBUser) error {
-	// If repo project exists, only allow repo admins to attach to a project.
-	repoRef, err := FindRepoRefByOwnerAndRepo(ctx, p.Owner, p.Repo)
-	if err != nil {
-		return errors.Wrapf(err, "finding repo ref '%s'", p.RepoRefId)
-	}
-	if repoRef != nil {
-		isRepoAdmin := u.HasPermission(ctx, gimlet.PermissionOpts{
-			Resource:      repoRef.Id,
-			ResourceType:  evergreen.ProjectResourceType,
-			Permission:    evergreen.PermissionProjectSettings,
-			RequiredLevel: evergreen.ProjectSettingsEdit.Value,
-		})
-
-		if !isRepoAdmin {
-			return errors.Errorf("user '%s' does not have permission to attach project '%s' to repo '%s'", u.Id, p.Id, p.Repo)
-		}
+	if err := p.checkExistingRepoRefAdmin(ctx, u); err != nil {
+		return err
 	}
 
 	// Before allowing a project to attach to a repo, verify that this is a valid GitHub organization.
@@ -1035,6 +1048,13 @@ func (p *ProjectRef) AttachToRepo(ctx context.Context, u *user.DBUser) error {
 // updates the project to point to the new repo. Any Github project conflicts are disabled.
 // If no repo ref currently exists for the new repo, the user attaching it will be added as the repo ref admin.
 func (p *ProjectRef) AttachToNewRepo(ctx context.Context, u *user.DBUser) error {
+	// Moving to a repo that already has a repo ref requires the same authorization as AttachToRepo.
+	if p.UseRepoSettings() {
+		if err := p.checkExistingRepoRefAdmin(ctx, u); err != nil {
+			return err
+		}
+	}
+
 	before, err := GetProjectSettingsById(ctx, p.Id, false)
 	if err != nil {
 		return errors.Wrap(err, "getting before project settings event")

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/evergreen-ci/gimlet"
 	"github.com/evergreen-ci/utility"
 	"github.com/google/go-github/v70/github"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
@@ -1067,6 +1068,11 @@ func TestAttachToNewRepo(t *testing.T) {
 	assert.NoError(t, pRef.Insert(t.Context()))
 	pRef.Owner = "newOwner"
 	pRef.Repo = "newRepo"
+	// Reload the user so it carries the admin role it gained for the new repo above, as a real
+	// request would.
+	u, err = user.FindOneById(t.Context(), "me")
+	require.NoError(t, err)
+	require.NotNil(t, u)
 	assert.NoError(t, pRef.AttachToNewRepo(t.Context(), u))
 	assert.True(t, pRef.UseRepoSettings())
 	assert.NotEmpty(t, pRef.RepoRefId)
@@ -1081,6 +1087,110 @@ func TestAttachToNewRepo(t *testing.T) {
 	assert.False(t, pRefFromDB.IsPRTestingEnabled())
 	assert.True(t, pRefFromDB.IsGithubChecksEnabled())
 
+}
+
+// TestAttachToNewRepoExistingRepoRefPermissions checks the permissions required to move a project
+// onto an owner/repo that already has a repo ref.
+func TestAttachToNewRepoExistingRepoRefPermissions(t *testing.T) {
+	setup := func(t *testing.T, userRoles ...string) (ProjectRef, RepoRef, *user.DBUser) {
+		ctx := t.Context()
+		require.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection, ProjectVarsCollection, fakeparameter.Collection,
+			evergreen.ScopeCollection, evergreen.RoleCollection, user.Collection, evergreen.ConfigCollection, githubapp.GitHubAppCollection))
+		require.NoError(t, db.CreateCollections(evergreen.ScopeCollection))
+
+		targetRepoRef := RepoRef{ProjectRef{
+			Id:    "targetRepoRef",
+			Owner: "newOwner",
+			Repo:  "new-repo",
+		}}
+		require.NoError(t, targetRepoRef.Replace(ctx))
+		targetRepoVars := ProjectVars{
+			Id:            targetRepoRef.Id,
+			Vars:          map[string]string{"target_repo_var": "target_repo_value"},
+			PrivateVars:   map[string]bool{"target_repo_var": true},
+			AdminOnlyVars: map[string]bool{"target_repo_var": true},
+		}
+		require.NoError(t, targetRepoVars.Insert(ctx))
+
+		originRepoRef := RepoRef{ProjectRef{
+			Id:    "originRepoRef",
+			Owner: "old-owner",
+			Repo:  "old-repo",
+		}}
+		require.NoError(t, originRepoRef.Replace(ctx))
+
+		pRef := ProjectRef{
+			Id:        "myProject",
+			Owner:     "old-owner",
+			Repo:      "old-repo",
+			Branch:    "main",
+			Admins:    []string{"me"},
+			RepoRefId: originRepoRef.Id,
+			Enabled:   true,
+		}
+		require.NoError(t, pRef.Insert(ctx))
+		pRefVars := ProjectVars{
+			Id:   pRef.Id,
+			Vars: map[string]string{"my_var": "my_value"},
+		}
+		require.NoError(t, pRefVars.Insert(ctx))
+
+		u := &user.DBUser{Id: "me", SystemRoles: userRoles}
+		require.NoError(t, u.Insert(ctx))
+
+		pRef.Owner = targetRepoRef.Owner
+		pRef.Repo = targetRepoRef.Repo
+		return pRef, targetRepoRef, u
+	}
+
+	t.Run("NonRepoAdminShouldError", func(t *testing.T) {
+		ctx := t.Context()
+		pRef, _, u := setup(t)
+
+		err := pRef.AttachToNewRepo(ctx, u)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrRepoRefUnauthorized), "expected an authorization error, got '%s'", err)
+
+		pRefFromDB, err := FindBranchProjectRef(ctx, pRef.Id)
+		require.NoError(t, err)
+		require.NotNil(t, pRefFromDB)
+		assert.Equal(t, "old-owner", pRefFromDB.Owner)
+		assert.Equal(t, "old-repo", pRefFromDB.Repo)
+		assert.Equal(t, "originRepoRef", pRefFromDB.RepoRefId)
+
+		// A rejected move must leave the project's variables untouched.
+		mergedVars, err := FindMergedProjectVars(ctx, pRef.Id)
+		require.NoError(t, err)
+		require.NotNil(t, mergedVars)
+		assert.NotContains(t, mergedVars.Vars, "target_repo_var")
+		assert.NotContains(t, mergedVars.AdminOnlyVars, "target_repo_var")
+	})
+
+	t.Run("RepoAdminShouldSucceed", func(t *testing.T) {
+		ctx := t.Context()
+		pRef, targetRepoRef, u := setup(t, GetRepoAdminRole("targetRepoRef"))
+
+		rm := testutil.NewEnvironment(ctx, t).RoleManager()
+		require.NoError(t, rm.AddScope(ctx, gimlet.Scope{
+			ID:        GetRepoAdminScope(targetRepoRef.Id),
+			Type:      evergreen.ProjectResourceType,
+			Resources: []string{targetRepoRef.Id},
+		}))
+		require.NoError(t, rm.UpdateRole(ctx, gimlet.Role{
+			ID:          GetRepoAdminRole(targetRepoRef.Id),
+			Scope:       GetRepoAdminScope(targetRepoRef.Id),
+			Permissions: gimlet.Permissions{evergreen.PermissionProjectSettings: evergreen.ProjectSettingsEdit.Value},
+		}))
+
+		require.NoError(t, pRef.AttachToNewRepo(ctx, u))
+
+		pRefFromDB, err := FindBranchProjectRef(ctx, pRef.Id)
+		require.NoError(t, err)
+		require.NotNil(t, pRefFromDB)
+		assert.Equal(t, targetRepoRef.Owner, pRefFromDB.Owner)
+		assert.Equal(t, targetRepoRef.Repo, pRefFromDB.Repo)
+		assert.Equal(t, targetRepoRef.Id, pRefFromDB.RepoRefId)
+	})
 }
 
 func checkRepoAttachmentEventLog(t *testing.T, project ProjectRef, attachmentType string) {


### PR DESCRIPTION
DEVPROD-37455

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

`AttachToRepo` in `model/project_ref.go` requires `project_settings:edit` on the target owner/repo's repo ref when one already exists, but `AttachToNewRepo` did not, so the two entry points enforced different permissions. This extracts the check into `checkExistingRepoRefAdmin`, calls it from both, and has `AttachProjectToNewRepo` return `Forbidden` rather than `InternalServerError` for it.

### Testing
Added tests 

### Documentation

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
