### PR TITLE
DEVPROD-36277 Clear s3 cost for tasks without hosts

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2131,8 +2131,17 @@ func (t *Task) MarkEnd(ctx context.Context, finishTime time.Time, detail *apimod
 		}
 	}
 
-	// Calculate EC2 runtime costs now that we have the actual runtime.
-	t.UpdateTaskCost(ctx)
+	if t.HostId == "" {
+		t.TaskCost.OnDemandEC2Cost = 0
+		t.TaskCost.AdjustedEC2Cost = 0
+		t.TaskCost.OnDemandEBSThroughputCost = 0
+		t.TaskCost.AdjustedEBSThroughputCost = 0
+		t.TaskCost.OnDemandEBSStorageCost = 0
+		t.TaskCost.AdjustedEBSStorageCost = 0
+	} else {
+		// Calculate EC2 runtime costs now that we have the actual runtime.
+		t.UpdateTaskCost(ctx)
+	}
 
 	// record that the task has finished, in memory and in the db
 	t.Status = detail.Status
@@ -2347,6 +2356,8 @@ func resetTaskUpdate(t *Task, caller string, prediction *CostPredictionResult) [
 		t.CanReset = false
 		t.IsAutomaticRestart = false
 		t.HasAnnotations = false
+		t.TaskCost = cost.Cost{}
+		t.S3Usage = s3usage.S3Usage{}
 		if prediction != nil {
 			t.SetPredictedCost(prediction.PredictedCost)
 		}
@@ -2391,6 +2402,8 @@ func resetTaskUpdate(t *Task, caller string, prediction *CostPredictionResult) [
 				OverrideDependenciesKey,
 				CanResetKey,
 				HasAnnotationsKey,
+				TaskCostKey,
+				S3UsageKey,
 			},
 		},
 		addDisplayStatusCache,

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1098,6 +1098,72 @@ func TestEndingTask(t *testing.T) {
 	})
 }
 
+func TestMarkEnd(t *testing.T) {
+	ctx := t.Context()
+	t.Cleanup(func() {
+		require.NoError(t, db.ClearCollections(Collection, distro.Collection, evergreen.ConfigCollection))
+	})
+
+	require.NoError(t, (&evergreen.CostConfig{
+		FinanceFormula:      0.6,
+		SavingsPlanDiscount: 0.5,
+		OnDemandDiscount:    0.04,
+	}).Set(ctx))
+	require.NoError(t, (&distro.Distro{
+		Id: "test_distro",
+		CostData: distro.CostData{
+			OnDemandRate:    0.20,
+			SavingsPlanRate: 0.10,
+		},
+	}).Insert(ctx))
+
+	t.Run("HostTaskHasRuntimeCost", func(t *testing.T) {
+		require.NoError(t, db.Clear(Collection))
+		now := time.Now()
+		tsk := Task{
+			Id:        "host_task",
+			HostId:    "host",
+			DistroId:  "test_distro",
+			StartTime: now.Add(-time.Hour),
+		}
+		require.NoError(t, tsk.Insert(ctx))
+
+		require.NoError(t, tsk.MarkEnd(ctx, now, &apimodels.TaskEndDetail{Status: evergreen.TaskSucceeded}))
+
+		dbTask, err := FindOneId(ctx, tsk.Id)
+		require.NoError(t, err)
+		require.NotNil(t, dbTask)
+		assert.Positive(t, dbTask.TaskCost.OnDemandEC2Cost)
+		assert.Positive(t, dbTask.TaskCost.AdjustedEC2Cost)
+	})
+
+	t.Run("TaskWithoutHostHasNoRuntimeCost", func(t *testing.T) {
+		require.NoError(t, db.Clear(Collection))
+		now := time.Now()
+		tsk := Task{
+			Id:        "task_without_host",
+			DistroId:  "test_distro",
+			StartTime: now.Add(-time.Hour),
+			TaskCost: cost.Cost{
+				OnDemandEC2Cost:           1,
+				AdjustedEC2Cost:           1,
+				OnDemandEBSThroughputCost: 1,
+				AdjustedEBSThroughputCost: 1,
+				OnDemandEBSStorageCost:    1,
+				AdjustedEBSStorageCost:    1,
+			},
+		}
+		require.NoError(t, tsk.Insert(ctx))
+
+		require.NoError(t, tsk.MarkEnd(ctx, now, &apimodels.TaskEndDetail{Status: evergreen.TaskFailed}))
+
+		dbTask, err := FindOneId(ctx, tsk.Id)
+		require.NoError(t, err)
+		require.NotNil(t, dbTask)
+		assert.True(t, dbTask.TaskCost.IsZero())
+	})
+}
+
 func TestTaskResultOutcome(t *testing.T) {
 	assert := assert.New(t)
 
@@ -4643,6 +4709,8 @@ func TestReset(t *testing.T) {
 			HostCreateDetails:          []HostCreateDetail{{HostId: "h"}},
 			NumNextTaskDispatches:      3,
 			NumQuarantinedTestsSkipped: 2,
+			TaskCost:                   cost.Cost{OnDemandEC2Cost: 1, AdjustedS3ArtifactPutCost: 1},
+			S3Usage:                    s3usage.S3Usage{Artifacts: s3usage.ArtifactMetrics{S3UploadMetrics: s3usage.S3UploadMetrics{PutRequests: 1}}},
 		}
 		assert.NoError(t, t0.Insert(t.Context()))
 
@@ -4664,6 +4732,10 @@ func TestReset(t *testing.T) {
 		assert.Empty(t, dbTask.Details)
 		assert.Zero(t, dbTask.NumNextTaskDispatches)
 		assert.Zero(t, dbTask.NumQuarantinedTestsSkipped)
+		assert.True(t, dbTask.TaskCost.IsZero())
+		assert.True(t, dbTask.S3Usage.IsZero())
+		assert.True(t, t0.TaskCost.IsZero())
+		assert.True(t, t0.S3Usage.IsZero())
 
 	})
 
@@ -4732,6 +4804,26 @@ func TestResetTasks(t *testing.T) {
 		dbTask, err := FindOneId(ctx, t0.Id)
 		assert.NoError(t, err)
 		assert.False(t, dbTask.UnattainableDependency)
+	})
+
+	t.Run("ClearsExecutionCostAndUsage", func(t *testing.T) {
+		require.NoError(t, db.Clear(Collection))
+
+		t0 := Task{
+			Id:       "t0",
+			Status:   evergreen.TaskSucceeded,
+			CanReset: true,
+			TaskCost: cost.Cost{OnDemandEC2Cost: 1, AdjustedS3ArtifactPutCost: 1},
+			S3Usage:  s3usage.S3Usage{Logs: s3usage.LogMetrics{S3UploadMetrics: s3usage.S3UploadMetrics{PutRequests: 1}}},
+		}
+		require.NoError(t, t0.Insert(t.Context()))
+
+		require.NoError(t, ResetTasks(ctx, []Task{t0}, "user"))
+		dbTask, err := FindOneId(ctx, t0.Id)
+		require.NoError(t, err)
+		require.NotNil(t, dbTask)
+		assert.True(t, dbTask.TaskCost.IsZero())
+		assert.True(t, dbTask.S3Usage.IsZero())
 	})
 }
 


### PR DESCRIPTION
DEVPROD-36277

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->
To keep cost consistency, a task without a host should not keep over it's cost estimate. 

### Testing

<!--add a description of how you tested it-->
Unit tests