### PR TITLE
DEVPROD-40761: Presign signed artifacts with the project's current AWS credentials 

### DIFF
--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -252,31 +252,12 @@ func (s3pc *s3put) validate() error {
 	return catcher.Resolve()
 }
 
-// expansionVarName returns the expansion name if value is exactly one expansion
-// reference.
-func expansionVarName(value string) string {
-	if !strings.HasPrefix(value, "${") || !strings.HasSuffix(value, "}") {
-		return ""
-	}
-
-	name := value[2 : len(value)-1]
-	// An expansion may supply a fallback as ${var|default}.
-	if idx := strings.Index(name, "|"); idx >= 0 {
-		name = name[:idx]
-	}
-	if name == "" || strings.ContainsAny(name, "${}") {
-		return ""
-	}
-
-	return name
-}
-
 // Apply the expansions from the relevant task config
 // to all appropriate fields of the s3put.
 func (s3pc *s3put) expandParams(conf *internal.TaskConfig) error {
 	s3pc.remoteFile = s3pc.RemoteFile
-	s3pc.awsKeyVarName = expansionVarName(s3pc.AwsKey)
-	s3pc.awsSecretVarName = expansionVarName(s3pc.AwsSecret)
+	s3pc.awsKeyVarName = util.ExpansionVarName(s3pc.AwsKey)
+	s3pc.awsSecretVarName = util.ExpansionVarName(s3pc.AwsSecret)
 
 	var err error
 	if err = util.ExpandValues(s3pc, &conf.Expansions); err != nil {

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -169,6 +169,11 @@ type s3put struct {
 	// the "assumedRoleARN".
 	externalID string
 
+	// awsKeyVarName and awsSecretVarName are the expansion names behind AwsKey and
+	// AwsSecret, captured before expansion overwrites them.
+	awsKeyVarName    string
+	awsSecretVarName string
+
 	bucket pail.Bucket
 
 	taskData client.TaskData
@@ -247,10 +252,31 @@ func (s3pc *s3put) validate() error {
 	return catcher.Resolve()
 }
 
+// expansionVarName returns the expansion name if value is exactly one expansion
+// reference.
+func expansionVarName(value string) string {
+	if !strings.HasPrefix(value, "${") || !strings.HasSuffix(value, "}") {
+		return ""
+	}
+
+	name := value[2 : len(value)-1]
+	// An expansion may supply a fallback as ${var|default}.
+	if idx := strings.Index(name, "|"); idx >= 0 {
+		name = name[:idx]
+	}
+	if name == "" || strings.ContainsAny(name, "${}") {
+		return ""
+	}
+
+	return name
+}
+
 // Apply the expansions from the relevant task config
 // to all appropriate fields of the s3put.
 func (s3pc *s3put) expandParams(conf *internal.TaskConfig) error {
 	s3pc.remoteFile = s3pc.RemoteFile
+	s3pc.awsKeyVarName = expansionVarName(s3pc.AwsKey)
+	s3pc.awsSecretVarName = expansionVarName(s3pc.AwsSecret)
 
 	var err error
 	if err = util.ExpandValues(s3pc, &conf.Expansions); err != nil {
@@ -639,27 +665,31 @@ func (s3pc *s3put) attachFiles(ctx context.Context, comm client.Communicator, up
 		bucket := s3pc.Bucket
 		fileKey := remoteFileName
 
-		var key, secret string
+		var key, secret, keyVarName, secretVarName string
 		if s3pc.Visibility == artifact.Signed {
 			key = s3pc.AwsKey
 			secret = s3pc.AwsSecret
+			keyVarName = s3pc.awsKeyVarName
+			secretVarName = s3pc.awsSecretVarName
 		}
 
 		files = append(files, &artifact.File{
-			Name:            displayName,
-			Link:            fileLink,
-			Visibility:      s3pc.Visibility,
-			AWSKey:          key,
-			AWSSecret:       secret,
-			AWSRoleARN:      s3pc.getRoleARN(),
-			AWSAccountID:    s3pc.resolvedAWSAccountID,
-			ExternalID:      s3pc.externalID,
-			Bucket:          bucket,
-			FileKey:         fileKey,
-			ContentType:     s3pc.ContentType,
-			FileSize:        uploadInfo.FileSizeBytes,
-			PutRequests:     uploadInfo.PutRequests,
-			AssociatedLinks: s3pc.associatedLinks,
+			Name:             displayName,
+			Link:             fileLink,
+			Visibility:       s3pc.Visibility,
+			AWSKey:           key,
+			AWSSecret:        secret,
+			AWSKeyVarName:    keyVarName,
+			AWSSecretVarName: secretVarName,
+			AWSRoleARN:       s3pc.getRoleARN(),
+			AWSAccountID:     s3pc.resolvedAWSAccountID,
+			ExternalID:       s3pc.externalID,
+			Bucket:           bucket,
+			FileKey:          fileKey,
+			ContentType:      s3pc.ContentType,
+			FileSize:         uploadInfo.FileSizeBytes,
+			PutRequests:      uploadInfo.PutRequests,
+			AssociatedLinks:  s3pc.associatedLinks,
 		})
 	}
 

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -1095,23 +1095,6 @@ func TestPutWithRetryAccumulatesPutsAcrossRetries(t *testing.T) {
 	assert.Equal(t, 9, conf.S3Usage.Artifacts.ArtifactWithMinPutRequests)
 }
 
-func TestExpansionVarName(t *testing.T) {
-	for name, testCase := range map[string]struct {
-		value    string
-		expected string
-	}{
-		"SingleExpansionReturnsName":              {value: "${aws_key}", expected: "aws_key"},
-		"ExpansionWithDefaultReturnsName":         {value: "${aws_key|fallback}", expected: "aws_key"},
-		"LiteralReturnsEmpty":                     {value: "AKIAFAKEKEY", expected: ""},
-		"ExpansionWithSurroundingTextIsNotSingle": {value: "prefix-${aws_key}", expected: ""},
-		"UnclosedExpansionReturnsEmpty":           {value: "${aws_key", expected: ""},
-	} {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, testCase.expected, expansionVarName(testCase.value))
-		})
-	}
-}
-
 func TestAttachFilesRecordsCredentialVarNames(t *testing.T) {
 	const keyVar = "artifact_aws_key"
 	const secretVar = "artifact_aws_secret"

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -1094,3 +1094,79 @@ func TestPutWithRetryAccumulatesPutsAcrossRetries(t *testing.T) {
 	assert.Equal(t, 9, conf.S3Usage.Artifacts.ArtifactWithMaxPutRequests)
 	assert.Equal(t, 9, conf.S3Usage.Artifacts.ArtifactWithMinPutRequests)
 }
+
+func TestExpansionVarName(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		value    string
+		expected string
+	}{
+		"SingleExpansionReturnsName":              {value: "${aws_key}", expected: "aws_key"},
+		"ExpansionWithDefaultReturnsName":         {value: "${aws_key|fallback}", expected: "aws_key"},
+		"LiteralReturnsEmpty":                     {value: "AKIAFAKEKEY", expected: ""},
+		"ExpansionWithSurroundingTextIsNotSingle": {value: "prefix-${aws_key}", expected: ""},
+		"UnclosedExpansionReturnsEmpty":           {value: "${aws_key", expected: ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, expansionVarName(testCase.value))
+		})
+	}
+}
+
+func TestAttachFilesRecordsCredentialVarNames(t *testing.T) {
+	const keyVar = "artifact_aws_key"
+	const secretVar = "artifact_aws_secret"
+
+	newCmd := func() *s3put {
+		return &s3put{
+			AwsKey:      fmt.Sprintf("${%s}", keyVar),
+			AwsSecret:   fmt.Sprintf("${%s}", secretVar),
+			Bucket:      "bucket",
+			RemoteFile:  "remote/file",
+			LocalFile:   "local_file",
+			Visibility:  artifact.Signed,
+			ContentType: "application/octet-stream",
+			Permissions: "private",
+		}
+	}
+	conf := &internal.TaskConfig{
+		Expansions: *util.NewExpansions(map[string]string{
+			keyVar:    "resolved-key",
+			secretVar: "resolved-secret",
+		}),
+		WorkDir: "/tmp",
+	}
+
+	attach := func(t *testing.T, cmd *s3put) *artifact.File {
+		require.NoError(t, cmd.expandParams(conf))
+		comm := client.NewMock("http://localhost.com")
+		cmd.taskData = client.TaskData{ID: "task", Secret: "secret"}
+		require.NoError(t, cmd.attachFiles(t.Context(), comm, []s3usage.FileMetrics{{
+			LocalPath:  "local_file",
+			RemotePath: "remote/file",
+		}}))
+		attached := comm.AttachedFiles[cmd.taskData.ID]
+		require.Len(t, attached, 1)
+		return attached[0]
+	}
+
+	t.Run("SignedFileStoresVarNamesAlongsideResolvedValues", func(t *testing.T) {
+		file := attach(t, newCmd())
+		assert.Equal(t, keyVar, file.AWSKeyVarName)
+		assert.Equal(t, secretVar, file.AWSSecretVarName)
+		// The resolved values stay as the fallback for presigning.
+		assert.Equal(t, "resolved-key", file.AWSKey)
+		assert.Equal(t, "resolved-secret", file.AWSSecret)
+	})
+
+	t.Run("RoleARNKeepsKeyAndSecretEmptyPerValidate", func(t *testing.T) {
+		cmd := newCmd()
+		cmd.AwsKey = ""
+		cmd.AwsSecret = ""
+		cmd.RoleARN = "arn:aws:iam::000000000000:role/fake-role"
+		require.NoError(t, cmd.validate())
+		file := attach(t, cmd)
+		assert.Empty(t, file.AWSKeyVarName)
+		assert.Empty(t, file.AWSSecretVarName)
+		assert.Equal(t, "arn:aws:iam::000000000000:role/fake-role", file.AWSRoleARN)
+	})
+}

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-07-29"
+	AgentVersion = "2026-08-03"
 )
 
 const (

--- a/config_db.go
+++ b/config_db.go
@@ -101,6 +101,7 @@ var (
 	backgroundCommandFailureEnabledKey    = bsonutil.MustHaveTag(ServiceFlags{}, "BackgroundCommandFailureEnabled")
 	apiRateLimiterDisabledKey             = bsonutil.MustHaveTag(ServiceFlags{}, "APIRateLimiterDisabled")
 	graphqlComplexityLimiterDisabledKey   = bsonutil.MustHaveTag(ServiceFlags{}, "GraphQLComplexityLimiterDisabled")
+	liveArtifactCredentialsDisabledKey    = bsonutil.MustHaveTag(ServiceFlags{}, "LiveArtifactCredentialsDisabled")
 	containerIsolationEnabledKey          = bsonutil.MustHaveTag(ServiceFlags{}, "ContainerIsolationEnabled")
 
 	// DiagnosticsConfig keys

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -44,6 +44,9 @@ type ServiceFlags struct {
 	PodDiagnosticsDisabled             bool `bson:"pod_diagnostics_disabled" json:"pod_diagnostics_disabled"`
 	RetryFailedLogMoveEnabled          bool `bson:"retry_failed_log_move_enabled" json:"retry_failed_log_move_enabled"`
 	ProjectTranslationCacheEnabled     bool `bson:"project_translation_cache_enabled" json:"project_translation_cache_enabled"`
+	// LiveArtifactCredentialsDisabled makes presigning use only the credentials
+	// stored on each artifact.
+	LiveArtifactCredentialsDisabled bool `bson:"live_artifact_credentials_disabled" json:"live_artifact_credentials_disabled"`
 	// ContainerIsolationEnabled is a fleet-wide flag that controls whether
 	// per-distro container isolation settings are honored. When false,
 	// every distro runs in host mode regardless of its container isolation
@@ -119,6 +122,7 @@ func (c *ServiceFlags) Set(ctx context.Context) error {
 			apiRateLimiterDisabledKey:             c.APIRateLimiterDisabled,
 			graphqlComplexityLimiterDisabledKey:   c.GraphQLComplexityLimiterDisabled,
 			containerIsolationEnabledKey:          c.ContainerIsolationEnabled,
+			liveArtifactCredentialsDisabledKey:    c.LiveArtifactCredentialsDisabled,
 		}}), "updating config section '%s'", c.SectionId(),
 	)
 }

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1570,6 +1570,9 @@ Parameters:
   the presigned url.
   Note: This parameter does \_not* affect the underlying permissions of the file
   on S3, only the visibility in the Evergreen UI. To change the permissions of the file on S3, use the `permissions` parameter.
+  See [Rotating AWS credentials for signed artifacts](#rotating-aws-credentials-for-signed-artifacts)
+  for how presigning picks up rotated credentials, and how to repair links for artifacts
+  uploaded before that.
 - `patchable`: defaults to true. If set to false, the command will
   no-op for patches (i.e. continue without performing the s3 put).
 - `patch_only`: defaults to false. If set to true, the command will
@@ -1594,6 +1597,41 @@ Parameters:
     }
   ]
   ```
+
+### Rotating AWS credentials for signed artifacts
+
+A presigned URL for a `visibility: signed` artifact is generated when someone opens
+the file, not when the file is uploaded, so it has to be signed with credentials that
+are still valid. When `aws_key` and `aws_secret` are given as single expansions, as in
+`aws_key: ${aws_key}`, Evergreen records the expansion names alongside the artifact and
+re-reads those project variables each time it presigns. Rotating the credentials is
+therefore enough to fix links for artifacts uploaded that way, with no need to keep the
+retired key pair around.
+
+Artifacts uploaded before Evergreen started recording those names have no names to
+re-read. For those, name the project variables once at the project level and Evergreen
+will use them for any signed artifact in the project that has none of its own:
+
+```bash
+curl -X PATCH \
+  -H "Authorization: Bearer $(evergreen client get-oauth-token)" \
+  -H "Content-Type: application/json" \
+  https://evergreen.mongodb.com/rest/v2/projects/<project> \
+  -d '{"artifact_credentials": {"aws_key_var_name": "name_of_your_aws_key_variable", "aws_secret_var_name": "name_of_your_aws_secret_variable"}}'
+```
+
+`aws_key_var_name` and `aws_secret_var_name` are the **names** of the project variables
+holding the credentials, not the credentials themselves. They must be set together, and
+the variables must exist in the project's variables. This setting is not editable from
+the project settings UI.
+
+`artifact_credentials` is unset by default and is only needed as a one-time backfill for
+those older artifacts.
+
+Artifacts uploaded with `role_arn` are unaffected by any of this. They are presigned by
+assuming that role each time, so rotating the role's credentials needs no action.
+Changing or deleting the role itself, however, breaks those links permanently, and
+`artifact_credentials` cannot repair them.
 
 ## s3.put with multiple files
 

--- a/graphql/tests/mutation/setServiceFlags/results.json
+++ b/graphql/tests/mutation/setServiceFlags/results.json
@@ -55,6 +55,7 @@
             { "name": "pod_diagnostics_disabled", "enabled": false },
             { "name": "retry_failed_log_move_enabled", "enabled": false },
             { "name": "project_translation_cache_enabled", "enabled": false },
+            { "name": "live_artifact_credentials_disabled", "enabled": false },
             { "name": "container_isolation_enabled", "enabled": false },
             { "name": "event_processing_disabled", "enabled": false },
             { "name": "jira_notifications_disabled", "enabled": false },

--- a/graphql/tests/query/adminSettings/results.json
+++ b/graphql/tests/query/adminSettings/results.json
@@ -611,6 +611,7 @@
               { "name": "pod_diagnostics_disabled", "enabled": false },
               { "name": "retry_failed_log_move_enabled", "enabled": false },
               { "name": "project_translation_cache_enabled", "enabled": false },
+              { "name": "live_artifact_credentials_disabled", "enabled": false },
               { "name": "container_isolation_enabled", "enabled": false },
               { "name": "event_processing_disabled", "enabled": false },
               { "name": "jira_notifications_disabled", "enabled": false },

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -11,6 +11,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/pail"
 	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -68,6 +69,10 @@ type File struct {
 	AWSSecret string `json:"aws_secret,omitempty" bson:"aws_secret,omitempty"`
 	// AWSRoleARN is the role ARN with which the file was uploaded to S3.
 	AWSRoleARN string `json:"aws_role_arn,omitempty" bson:"aws_role_arn,omitempty"`
+	// AWSKeyVarName is the name of the project variable that supplied AWSKey.
+	AWSKeyVarName string `json:"aws_key_var_name,omitempty" bson:"aws_key_var_name,omitempty"`
+	// AWSSecretVarName is the name of the project variable that supplied AWSSecret.
+	AWSSecretVarName string `json:"aws_secret_var_name,omitempty" bson:"aws_secret_var_name,omitempty"`
 	// AWSAccountID is the resolved account ID for key+secret uploads (empty when AWSRoleARN is set).
 	AWSAccountID string `json:"aws_account_id,omitempty" bson:"aws_account_id,omitempty"`
 	// ExternalID is the external ID with which the file was uploaded to S3.
@@ -100,8 +105,8 @@ func (f *File) validate() error {
 }
 
 // StripHiddenFiles is a helper for only showing users the files they are
-// allowed to see. It also pre-signs file URLs.
-func StripHiddenFiles(ctx context.Context, files []File, hasUser bool) ([]File, error) {
+// allowed to see. It also pre-signs file URLs. The resolver may be nil.
+func StripHiddenFiles(ctx context.Context, files []File, hasUser bool, resolver CredentialResolver) ([]File, error) {
 	publicFiles := []File{}
 	for _, file := range files {
 		switch {
@@ -110,7 +115,7 @@ func StripHiddenFiles(ctx context.Context, files []File, hasUser bool) ([]File, 
 		case (file.Visibility == Private || file.Visibility == Signed) && !hasUser:
 			continue
 		case file.Visibility == Signed && hasUser:
-			link, err := PresignFile(ctx, file)
+			link, err := PresignFile(ctx, file, resolver)
 			if err != nil {
 				return nil, errors.Wrapf(err, "presigning url for file '%s'", file.Name)
 			}
@@ -150,16 +155,55 @@ func StripHiddenFilesLazy(files []File, hasUser bool, baseURL string, taskID str
 	return publicFiles
 }
 
-// PresignFile generates a presigned S3 URL for the given artifact file.
-func PresignFile(ctx context.Context, file File) (string, error) {
+// Credentials are the static AWS credentials used to presign an artifact URL. A
+// file uploaded with a role ARN needs none, since STS mints credentials per
+// presign.
+type Credentials struct {
+	AWSKey    string
+	AWSSecret string
+}
+
+// CredentialResolver resolves the static credentials to presign a file with from
+// the owning project's current configuration. A nil result or an error means the
+// credentials stored on the artifact should be used. Resolvers cache per task, so
+// they must not be shared across requests.
+type CredentialResolver func(ctx context.Context, file File) (*Credentials, error)
+
+// credentialsForPresign prefers resolved credentials over the ones stored on the
+// artifact, and returns none at all for a file uploaded with a role ARN.
+func credentialsForPresign(ctx context.Context, file File, resolver CredentialResolver) Credentials {
+	if file.AWSRoleARN != "" {
+		return Credentials{}
+	}
+
+	creds := Credentials{
+		AWSKey:    file.AWSKey,
+		AWSSecret: file.AWSSecret,
+	}
+
+	if resolver != nil {
+		resolved, err := resolver(ctx, file)
+		grip.InfoWhen(ctx, err != nil, message.WrapError(err, message.Fields{
+			"message": "resolving current artifact credentials, falling back to the credentials stored on the artifact",
+			"bucket":  file.Bucket,
+			"file":    file.Name,
+		}))
+		if err == nil && resolved != nil {
+			creds = *resolved
+		}
+	}
+
+	return creds
+}
+
+// PresignFile generates a presigned S3 URL for the given artifact file. The
+// resolver may be nil, in which case the stored credentials are used.
+func PresignFile(ctx context.Context, file File, resolver CredentialResolver) (string, error) {
 	if err := file.validate(); err != nil {
 		return "", errors.Wrap(err, "file validation failed")
 	}
 
-	if file.AWSRoleARN != "" {
-		file.AWSKey = ""
-		file.AWSSecret = ""
-	}
+	creds := credentialsForPresign(ctx, file, resolver)
 
 	var externalID *string
 	if file.ExternalID != "" {
@@ -170,8 +214,8 @@ func PresignFile(ctx context.Context, file File) (string, error) {
 		Bucket:                file.Bucket,
 		FileKey:               file.FileKey,
 		SignatureExpiryWindow: evergreen.PresignMinimumValidTime,
-		AWSKey:                file.AWSKey,
-		AWSSecret:             file.AWSSecret,
+		AWSKey:                creds.AWSKey,
+		AWSSecret:             creds.AWSSecret,
 		AWSRoleARN:            file.AWSRoleARN,
 		ExternalID:            externalID,
 	}

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -105,7 +105,7 @@ func (f *File) validate() error {
 }
 
 // StripHiddenFiles is a helper for only showing users the files they are
-// allowed to see. It also pre-signs file URLs. The resolver may be nil.
+// allowed to see. It also pre-signs file URLs.
 func StripHiddenFiles(ctx context.Context, files []File, hasUser bool, resolver CredentialResolver) ([]File, error) {
 	publicFiles := []File{}
 	for _, file := range files {
@@ -166,7 +166,8 @@ type Credentials struct {
 // CredentialResolver resolves the static credentials to presign a file with from
 // the owning project's current configuration. A nil result or an error means the
 // credentials stored on the artifact should be used. Resolvers cache per task, so
-// they must not be shared across requests.
+// they must not be shared across requests. Use
+// model.NewArtifactCredentialResolver to construct one.
 type CredentialResolver func(ctx context.Context, file File) (*Credentials, error)
 
 // credentialsForPresign prefers resolved credentials over the ones stored on the
@@ -181,23 +182,20 @@ func credentialsForPresign(ctx context.Context, file File, resolver CredentialRe
 		AWSSecret: file.AWSSecret,
 	}
 
-	if resolver != nil {
-		resolved, err := resolver(ctx, file)
-		grip.InfoWhen(ctx, err != nil, message.WrapError(err, message.Fields{
-			"message": "resolving current artifact credentials, falling back to the credentials stored on the artifact",
-			"bucket":  file.Bucket,
-			"file":    file.Name,
-		}))
-		if err == nil && resolved != nil {
-			creds = *resolved
-		}
+	resolved, err := resolver(ctx, file)
+	grip.InfoWhen(ctx, err != nil, message.WrapError(err, message.Fields{
+		"message": "resolving current artifact credentials, falling back to the credentials stored on the artifact",
+		"bucket":  file.Bucket,
+		"file":    file.Name,
+	}))
+	if err == nil && resolved != nil {
+		creds = *resolved
 	}
 
 	return creds
 }
 
-// PresignFile generates a presigned S3 URL for the given artifact file. The
-// resolver may be nil, in which case the stored credentials are used.
+// PresignFile generates a presigned S3 URL for the given artifact file.
 func PresignFile(ctx context.Context, file File, resolver CredentialResolver) (string, error) {
 	if err := file.validate(); err != nil {
 		return "", errors.Wrap(err, "file validation failed")

--- a/model/artifact/artifact_file_test.go
+++ b/model/artifact/artifact_file_test.go
@@ -1,11 +1,14 @@
 package artifact
 
 import (
+	"context"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen/db"
 	_ "github.com/evergreen-ci/evergreen/testutil"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -317,4 +320,89 @@ func TestStripHiddenFilesLazy(t *testing.T) {
 		assert.Len(t, result, 1)
 		assert.Equal(t, "https://example.com/private", result[0].Link)
 	})
+}
+
+func TestCredentialsForPresign(t *testing.T) {
+	storedFile := File{
+		Name:       "Binaries",
+		Bucket:     "bucket",
+		FileKey:    "key",
+		Visibility: Signed,
+		AWSKey:     "AKIAFAKESTOREDKEY",
+		AWSSecret:  "fake-stored-secret",
+	}
+
+	for name, testCase := range map[string]struct {
+		file     File
+		resolver CredentialResolver
+		expected Credentials
+	}{
+		"ResolvedKeyAndSecretWinOverStored": {
+			file: storedFile,
+			resolver: func(context.Context, File) (*Credentials, error) {
+				return &Credentials{AWSKey: "AKIAFAKELIVEKEY", AWSSecret: "fake-live-secret"}, nil
+			},
+			expected: Credentials{AWSKey: "AKIAFAKELIVEKEY", AWSSecret: "fake-live-secret"},
+		},
+		"NoResolutionFallsBackToStored": {
+			file: storedFile,
+			resolver: func(context.Context, File) (*Credentials, error) {
+				return nil, nil
+			},
+			expected: Credentials{AWSKey: "AKIAFAKESTOREDKEY", AWSSecret: "fake-stored-secret"},
+		},
+		"ResolutionErrorFallsBackToStoredInsteadOfFailing": {
+			file: storedFile,
+			resolver: func(context.Context, File) (*Credentials, error) {
+				return nil, errors.New("parameter store is down")
+			},
+			expected: Credentials{AWSKey: "AKIAFAKESTOREDKEY", AWSSecret: "fake-stored-secret"},
+		},
+		// A role ARN on the artifact must suppress the key pair, including a
+		// resolved one, so that presigning goes through STS.
+		"StoredRoleARNSuppressesEveryKeyPair": {
+			file: File{
+				Bucket:     "bucket",
+				FileKey:    "key",
+				AWSKey:     "AKIAFAKESTOREDKEY",
+				AWSSecret:  "fake-stored-secret",
+				AWSRoleARN: "arn:aws:iam::000000000000:role/fake-stored-role",
+			},
+			resolver: func(context.Context, File) (*Credentials, error) {
+				return &Credentials{AWSKey: "AKIAFAKELIVEKEY", AWSSecret: "fake-live-secret"}, nil
+			},
+			expected: Credentials{},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, credentialsForPresign(t.Context(), testCase.file, testCase.resolver))
+		})
+	}
+}
+
+func TestPresignFileDoesNotWriteToDB(t *testing.T) {
+	require.NoError(t, db.ClearCollections(Collection))
+
+	entry := Entry{
+		TaskId: "task", BuildId: "build",
+		Files: []File{{
+			Name: "Binaries", Bucket: "bucket", FileKey: "key", Visibility: Signed,
+			AWSKey: "AKIAFAKESTOREDKEY", AWSSecret: "fake-stored-secret",
+		}},
+	}
+	require.NoError(t, entry.Upsert(t.Context()))
+
+	resolver := func(context.Context, File) (*Credentials, error) {
+		return &Credentials{AWSKey: "AKIAFAKELIVEKEY", AWSSecret: "fake-live-secret"}, nil
+	}
+	url, err := PresignFile(t.Context(), entry.Files[0], resolver)
+	require.NoError(t, err)
+	// Presigning must not persist the resolved credential.
+	assert.Contains(t, url, "AKIAFAKELIVEKEY")
+	assert.NotContains(t, url, "AKIAFAKESTOREDKEY")
+
+	after, err := FindAll(t.Context(), ByTaskIdAndExecution("task", 0))
+	require.NoError(t, err)
+	require.Len(t, after, 1)
+	assert.Equal(t, "AKIAFAKESTOREDKEY", after[0].Files[0].AWSKey)
 }

--- a/model/artifact_credentials.go
+++ b/model/artifact_credentials.go
@@ -1,0 +1,115 @@
+package model
+
+import (
+	"context"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model/artifact"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/pkg/errors"
+)
+
+// ArtifactCredentialSettings names where to find a project's current AWS artifact
+// credentials, as the names of the project variables holding them.
+type ArtifactCredentialSettings struct {
+	// AWSKeyVarName is the name of the project variable holding the AWS access key ID.
+	AWSKeyVarName string `bson:"aws_key_var_name,omitempty" json:"aws_key_var_name,omitempty" yaml:"aws_key_var_name,omitempty"`
+	// AWSSecretVarName is the name of the project variable holding the AWS secret key.
+	AWSSecretVarName string `bson:"aws_secret_var_name,omitempty" json:"aws_secret_var_name,omitempty" yaml:"aws_secret_var_name,omitempty"`
+}
+
+// Validate rejects settings that cannot resolve, such as half of the static pair.
+func (s ArtifactCredentialSettings) Validate() error {
+	if (s.AWSKeyVarName == "") != (s.AWSSecretVarName == "") {
+		return errors.New("AWS key and secret variable names must be set together")
+	}
+
+	return nil
+}
+
+// artifactCredentialResolver resolves credentials for one task, caching its
+// project lookups.
+type artifactCredentialResolver struct {
+	taskID string
+
+	loaded      bool
+	loadErr     error
+	settings    ArtifactCredentialSettings
+	projectVars map[string]string
+}
+
+// NewArtifactCredentialResolver returns a resolver for the given task's project.
+// It caches, so it must not be shared across requests.
+func NewArtifactCredentialResolver(taskID string) artifact.CredentialResolver {
+	r := &artifactCredentialResolver{taskID: taskID}
+	return r.resolve
+}
+
+func (r *artifactCredentialResolver) resolve(ctx context.Context, file artifact.File) (*artifact.Credentials, error) {
+	flags, err := evergreen.GetServiceFlags(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting service flags")
+	}
+	if flags.LiveArtifactCredentialsDisabled {
+		return nil, nil
+	}
+
+	if err := r.load(ctx); err != nil {
+		return nil, err
+	}
+
+	// Names on the artifact are more specific than the project-wide defaults.
+	keyVar, secretVar := file.AWSKeyVarName, file.AWSSecretVarName
+	if keyVar == "" || secretVar == "" {
+		keyVar, secretVar = r.settings.AWSKeyVarName, r.settings.AWSSecretVarName
+	}
+	if keyVar == "" || secretVar == "" {
+		return nil, nil
+	}
+
+	key, secret := r.projectVars[keyVar], r.projectVars[secretVar]
+	if key == "" || secret == "" {
+		return nil, errors.Errorf("project variables '%s' and '%s' for task '%s' did not both resolve to a value", keyVar, secretVar, r.taskID)
+	}
+
+	return &artifact.Credentials{AWSKey: key, AWSSecret: secret}, nil
+}
+
+// load fetches and caches the task's project settings and variables.
+func (r *artifactCredentialResolver) load(ctx context.Context) error {
+	if r.loaded {
+		return r.loadErr
+	}
+	r.loaded = true
+	r.loadErr = r.loadUncached(ctx)
+	return r.loadErr
+}
+
+func (r *artifactCredentialResolver) loadUncached(ctx context.Context) error {
+	t, err := task.FindOneIdWithFields(ctx, r.taskID, task.ProjectKey, task.VersionKey)
+	if err != nil {
+		return errors.Wrapf(err, "finding task '%s'", r.taskID)
+	}
+	if t == nil {
+		return errors.Errorf("task '%s' not found", r.taskID)
+	}
+
+	pRef, err := FindMergedProjectRef(ctx, t.Project, t.Version, false)
+	if err != nil {
+		return errors.Wrapf(err, "finding project ref for project '%s'", t.Project)
+	}
+	if pRef == nil {
+		return errors.Errorf("project ref for project '%s' not found", t.Project)
+	}
+	r.settings = pRef.ArtifactCredentials
+
+	vars, err := FindMergedProjectVars(ctx, t.Project)
+	if err != nil {
+		return errors.Wrapf(err, "finding project variables for project '%s'", t.Project)
+	}
+	if vars != nil {
+		r.projectVars = vars.Vars
+	}
+
+	return nil
+}

--- a/model/artifact_credentials_test.go
+++ b/model/artifact_credentials_test.go
@@ -1,0 +1,119 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/cloud/parameterstore/fakeparameter"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/artifact"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testProjectID    = "project"
+	testTaskID       = "task"
+	testKeyVar       = "artifact_aws_key"
+	testSecretVar    = "artifact_aws_secret"
+	testSettingsKey  = "project_settings_aws_key"
+	testSettingsSecr = "project_settings_aws_secret"
+)
+
+func setupArtifactCredentials(t *testing.T, settings ArtifactCredentialSettings) {
+	require.NoError(t, db.ClearCollections(ProjectRefCollection, ProjectVarsCollection,
+		fakeparameter.Collection, task.Collection, evergreen.ConfigCollection))
+
+	pRef := ProjectRef{Id: testProjectID, ArtifactCredentials: settings}
+	require.NoError(t, pRef.Insert(t.Context()))
+
+	vars := ProjectVars{Id: testProjectID, Vars: map[string]string{
+		testKeyVar:       "AKIAFAKEVARKEY",
+		testSecretVar:    "fake-var-secret",
+		testSettingsKey:  "AKIAFAKESETTINGSKEY",
+		testSettingsSecr: "fake-settings-secret",
+	}}
+	_, err := vars.Upsert(t.Context())
+	require.NoError(t, err)
+
+	tsk := task.Task{Id: testTaskID, Project: testProjectID, Version: "version"}
+	require.NoError(t, tsk.Insert(t.Context()))
+}
+
+func TestArtifactCredentialResolver(t *testing.T) {
+	staticFile := artifact.File{
+		Name: "Binaries", Bucket: "bucket", FileKey: "key", Visibility: artifact.Signed,
+		AWSKey: "AKIAFAKESTOREDKEY", AWSSecret: "fake-stored-secret",
+	}
+	varNameFile := staticFile
+	varNameFile.AWSKeyVarName, varNameFile.AWSSecretVarName = testKeyVar, testSecretVar
+
+	unresolvableFile := staticFile
+	unresolvableFile.AWSKeyVarName, unresolvableFile.AWSSecretVarName = "nonexistent", "also_nonexistent"
+
+	staticSettings := ArtifactCredentialSettings{AWSKeyVarName: testSettingsKey, AWSSecretVarName: testSettingsSecr}
+
+	// A nil expectation means the resolver found no source, so presigning falls back
+	// to the credentials stored on the artifact.
+	for name, testCase := range map[string]struct {
+		settings ArtifactCredentialSettings
+		file     artifact.File
+		expected *artifact.Credentials
+		hasErr   bool
+	}{
+		"VarNamesOnTheArtifactBeatProjectSettingsVarNames": {
+			settings: staticSettings,
+			file:     varNameFile,
+			expected: &artifact.Credentials{AWSKey: "AKIAFAKEVARKEY", AWSSecret: "fake-var-secret"},
+		},
+		"ProjectSettingsVarNamesResolveArtifactsWithoutTheirOwn": {
+			settings: staticSettings,
+			file:     staticFile,
+			expected: &artifact.Credentials{AWSKey: "AKIAFAKESETTINGSKEY", AWSSecret: "fake-settings-secret"},
+		},
+		"NoConfiguredSourceResolvesToNothing": {
+			file: staticFile,
+		},
+		"UnresolvableVarNameErrors": {
+			file:   unresolvableFile,
+			hasErr: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			setupArtifactCredentials(t, testCase.settings)
+
+			creds, err := NewArtifactCredentialResolver(testTaskID)(t.Context(), testCase.file)
+			if testCase.hasErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, testCase.expected, creds)
+		})
+	}
+
+	t.Run("DisablingFlagStopsResolutionEntirely", func(t *testing.T) {
+		setupArtifactCredentials(t, staticSettings)
+		flags := evergreen.ServiceFlags{LiveArtifactCredentialsDisabled: true}
+		require.NoError(t, flags.Set(t.Context()))
+
+		creds, err := NewArtifactCredentialResolver(testTaskID)(t.Context(), staticFile)
+		require.NoError(t, err)
+		assert.Nil(t, creds)
+	})
+
+	t.Run("ResolutionIsCachedAcrossFilesOnTheSameTask", func(t *testing.T) {
+		setupArtifactCredentials(t, staticSettings)
+		resolver := NewArtifactCredentialResolver(testTaskID)
+		creds, err := resolver(t.Context(), staticFile)
+		require.NoError(t, err)
+
+		// A second lookup would fail, so resolving again proves it was cached.
+		require.NoError(t, db.ClearCollections(ProjectRefCollection))
+
+		cachedCreds, err := resolver(t.Context(), staticFile)
+		require.NoError(t, err)
+		assert.Equal(t, creds, cachedCreds)
+	})
+}

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -114,7 +114,7 @@ type ProjectRef struct {
 	PerfEnabled        *bool                        `bson:"perf_enabled,omitempty" json:"perf_enabled,omitempty" yaml:"perf_enabled,omitempty"`
 
 	// ArtifactCredentials names the source of the AWS credentials used to presign
-	// this project's signed artifacts. Not editable from the settings UI.
+	// this project's signed artifacts.
 	ArtifactCredentials ArtifactCredentialSettings `bson:"artifact_credentials,omitempty" json:"artifact_credentials,omitempty" yaml:"artifact_credentials,omitempty"`
 
 	// RepoRefId is the repo ref id that this project ref tracks, if any.

--- a/model/project_ref.go
+++ b/model/project_ref.go
@@ -113,6 +113,10 @@ type ProjectRef struct {
 	BuildBaronSettings evergreen.BuildBaronSettings `bson:"build_baron_settings,omitempty" json:"build_baron_settings" yaml:"build_baron_settings,omitempty"`
 	PerfEnabled        *bool                        `bson:"perf_enabled,omitempty" json:"perf_enabled,omitempty" yaml:"perf_enabled,omitempty"`
 
+	// ArtifactCredentials names the source of the AWS credentials used to presign
+	// this project's signed artifacts. Not editable from the settings UI.
+	ArtifactCredentials ArtifactCredentialSettings `bson:"artifact_credentials,omitempty" json:"artifact_credentials,omitempty" yaml:"artifact_credentials,omitempty"`
+
 	// RepoRefId is the repo ref id that this project ref tracks, if any.
 	RepoRefId string `bson:"repo_ref_id" json:"repo_ref_id" yaml:"repo_ref_id"`
 

--- a/model/project_ref_test.go
+++ b/model/project_ref_test.go
@@ -4082,3 +4082,31 @@ func TestUserHasRepoViewPermission(t *testing.T) {
 		})
 	}
 }
+
+// The settings UI never sends artifact credentials, so no section write may include them.
+func TestArtifactCredentialsSurviveProjectSettingsWrites(t *testing.T) {
+	credentials := ArtifactCredentialSettings{AWSKeyVarName: "aws_key", AWSSecretVarName: "aws_secret"}
+
+	// A nil update is how defaulting a section to the repo saves it.
+	for name, update := range map[string]*ProjectRef{
+		"SavingTheGeneralSection":           {Id: "project_id", Identifier: "project_identifier", Owner: "owner", Repo: "repo", Enabled: true, BatchTime: 20},
+		"DefaultingTheGeneralSectionToRepo": nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(ProjectRefCollection, RepoRefCollection, evergreen.ConfigCollection))
+			pRef := ProjectRef{
+				Id: "project_id", Identifier: "project_identifier", Owner: "owner", Repo: "repo",
+				Branch: "main", Enabled: true, BatchTime: 10, ArtifactCredentials: credentials,
+			}
+			require.NoError(t, pRef.Insert(t.Context()))
+
+			_, err := SaveProjectPageForSection(t.Context(), "project_id", update, ProjectPageGeneralSection, false)
+			require.NoError(t, err)
+
+			saved, err := FindBranchProjectRef(t.Context(), "project_identifier")
+			require.NoError(t, err)
+			require.NotNil(t, saved)
+			assert.Equal(t, credentials, saved.ArtifactCredentials)
+		})
+	}
+}

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2130,6 +2130,7 @@ type APIServiceFlags struct {
 	RetryFailedLogMoveEnabled          bool `json:"retry_failed_log_move_enabled"`
 	ProjectTranslationCacheEnabled     bool `json:"project_translation_cache_enabled"`
 	ContainerIsolationEnabled          bool `json:"container_isolation_enabled"`
+	LiveArtifactCredentialsDisabled    bool `json:"live_artifact_credentials_disabled"`
 
 	// Notifications Flags
 	EventProcessingDisabled      bool `json:"event_processing_disabled"`
@@ -2593,6 +2594,7 @@ func (as *APIServiceFlags) BuildFromService(h any) error {
 		as.RetryFailedLogMoveEnabled = v.RetryFailedLogMoveEnabled
 		as.ProjectTranslationCacheEnabled = v.ProjectTranslationCacheEnabled
 		as.ContainerIsolationEnabled = v.ContainerIsolationEnabled
+		as.LiveArtifactCredentialsDisabled = v.LiveArtifactCredentialsDisabled
 		as.BackgroundCommandFailureEnabled = v.BackgroundCommandFailureEnabled
 		as.APIRateLimiterDisabled = v.APIRateLimiterDisabled
 		as.GraphQLComplexityLimiterDisabled = v.GraphQLComplexityLimiterDisabled
@@ -2647,6 +2649,7 @@ func (as *APIServiceFlags) ToService() (any, error) {
 		ProjectTranslationCacheEnabled:     as.ProjectTranslationCacheEnabled,
 		BackgroundCommandFailureEnabled:    as.BackgroundCommandFailureEnabled,
 		ContainerIsolationEnabled:          as.ContainerIsolationEnabled,
+		LiveArtifactCredentialsDisabled:    as.LiveArtifactCredentialsDisabled,
 		APIRateLimiterDisabled:             as.APIRateLimiterDisabled,
 		GraphQLComplexityLimiterDisabled:   as.GraphQLComplexityLimiterDisabled,
 	}, nil

--- a/rest/model/project.go
+++ b/rest/model/project.go
@@ -528,6 +528,9 @@ type APIProjectRef struct {
 	BuildBaronSettings APIBuildBaronSettings `json:"build_baron_settings"`
 	// Enable the performance plugin.
 	PerfEnabled *bool `json:"perf_enabled"`
+	// Source of the AWS credentials used to presign signed artifacts. Not editable
+	// from the project settings UI.
+	ArtifactCredentials APIArtifactCredentialSettings `json:"artifact_credentials"`
 	// Whether or not the project can be seen in the UI. Cannot be modified by
 	// users.
 	Hidden *bool `json:"hidden"`
@@ -632,6 +635,7 @@ func (p *APIProjectRef) ToService() (*model.ProjectRef, error) {
 		BuildBaronSettings:               p.BuildBaronSettings.ToService(),
 		TaskAnnotationSettings:           p.TaskAnnotationSettings.ToService(),
 		PerfEnabled:                      utility.BoolPtrCopy(p.PerfEnabled),
+		ArtifactCredentials:              p.ArtifactCredentials.ToService(),
 		Hidden:                           utility.BoolPtrCopy(p.Hidden),
 		PatchingDisabled:                 utility.BoolPtrCopy(p.PatchingDisabled),
 		RepotrackerDisabled:              utility.BoolPtrCopy(p.RepotrackerDisabled),
@@ -741,6 +745,7 @@ func (p *APIProjectRef) BuildPublicFields(ctx context.Context, projectRef model.
 	p.UseRepoSettings = utility.ToBoolPtr(projectRef.UseRepoSettings())
 	p.RepoRefId = utility.ToStringPtr(projectRef.RepoRefId)
 	p.PerfEnabled = utility.BoolPtrCopy(projectRef.PerfEnabled)
+	p.ArtifactCredentials.BuildFromService(projectRef.ArtifactCredentials)
 	p.Hidden = utility.BoolPtrCopy(projectRef.Hidden)
 	p.PatchingDisabled = utility.BoolPtrCopy(projectRef.PatchingDisabled)
 	p.RepotrackerDisabled = utility.BoolPtrCopy(projectRef.RepotrackerDisabled)
@@ -922,4 +927,25 @@ type GetProjectTasksOpts struct {
 	BuildVariant string   `json:"build_variant"`
 	StartAt      int      `json:"start_at"`
 	Requesters   []string `json:"requesters"`
+}
+
+// APIArtifactCredentialSettings names the source of a project's artifact AWS
+// credentials. Credentials are variable names, never values.
+type APIArtifactCredentialSettings struct {
+	// Name of the project variable holding the AWS access key ID.
+	AWSKeyVarName *string `json:"aws_key_var_name"`
+	// Name of the project variable holding the AWS secret access key.
+	AWSSecretVarName *string `json:"aws_secret_var_name"`
+}
+
+func (s *APIArtifactCredentialSettings) BuildFromService(settings model.ArtifactCredentialSettings) {
+	s.AWSKeyVarName = utility.ToStringPtr(settings.AWSKeyVarName)
+	s.AWSSecretVarName = utility.ToStringPtr(settings.AWSSecretVarName)
+}
+
+func (s *APIArtifactCredentialSettings) ToService() model.ArtifactCredentialSettings {
+	return model.ArtifactCredentialSettings{
+		AWSKeyVarName:    utility.FromStringPtr(s.AWSKeyVarName),
+		AWSSecretVarName: utility.FromStringPtr(s.AWSSecretVarName),
+	}
 }

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -686,7 +686,7 @@ func (at *APITask) getArtifacts(ctx context.Context, baseURL string) error {
 		if baseURL != "" && len(artifactSignSecret) > 0 {
 			strippedFiles = artifact.StripHiddenFilesLazy(entry.Files, true, baseURL, entry.TaskId, entry.Execution, artifactSignSecret)
 		} else {
-			strippedFiles, err = artifact.StripHiddenFiles(ctx, entry.Files, true)
+			strippedFiles, err = artifact.StripHiddenFiles(ctx, entry.Files, true, model.NewArtifactCredentialResolver(entry.TaskId))
 			if err != nil {
 				return err
 			}

--- a/rest/route/artifact_sign.go
+++ b/rest/route/artifact_sign.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/artifact"
 	"github.com/evergreen-ci/gimlet"
 )
@@ -78,7 +79,7 @@ func artifactSignHandler() http.HandlerFunc {
 			return
 		}
 
-		presignedURL, err := artifact.PresignFile(ctx, *found)
+		presignedURL, err := artifact.PresignFile(ctx, *found, model.NewArtifactCredentialResolver(taskID))
 		if err != nil {
 			http.Error(w, "presigning artifact URL", http.StatusInternalServerError)
 			return

--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -399,6 +399,10 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "validating build baron config"))
 	}
 
+	if err = h.newProjectRef.ArtifactCredentials.Validate(); err != nil {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{StatusCode: http.StatusBadRequest, Message: errors.Wrap(err, "invalid artifact credentials").Error()})
+	}
+
 	newRevision := utility.FromStringPtr(h.apiNewProjectRef.Revision)
 	if newRevision != "" {
 		if err = dbModel.UpdateLastRevision(ctx, h.project, newRevision); err != nil {

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -121,6 +121,41 @@ func (s *ProjectPatchByIDSuite) TestParse() {
 	s.NotNil(s.rm.(*projectIDPatchHandler).user)
 }
 
+// Artifact credentials are settable here but not in the project settings UI, and
+// this route replaces the whole document, so a later patch must not drop them.
+func (s *ProjectPatchByIDSuite) TestRunSetsAndPreservesArtifactCredentials() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "Test1"})
+
+	patch := func(body string) gimlet.Responder {
+		req, _ := http.NewRequest(http.MethodPatch, "http://example.com/api/rest/v2/projects/dimoxinil", bytes.NewBufferString(body))
+		req = gimlet.SetURLVars(req, map[string]string{"project_id": "dimoxinil"})
+		s.Require().NoError(s.rm.Parse(ctx, req))
+		return s.rm.Run(ctx)
+	}
+	credentials := serviceModel.ArtifactCredentialSettings{AWSKeyVarName: "aws_key", AWSSecretVarName: "aws_secret"}
+
+	resp := patch(`{"artifact_credentials": {"aws_key_var_name": "aws_key", "aws_secret_var_name": "aws_secret"}}`)
+	s.Equal(http.StatusOK, resp.Status())
+	pRef, err := serviceModel.FindBranchProjectRef(ctx, "dimoxinil")
+	s.NoError(err)
+	s.Require().NotNil(pRef)
+	s.Equal(credentials, pRef.ArtifactCredentials)
+
+	resp = patch(`{"batch_time": 55}`)
+	s.Equal(http.StatusOK, resp.Status())
+	pRef, err = serviceModel.FindBranchProjectRef(ctx, "dimoxinil")
+	s.NoError(err)
+	s.Require().NotNil(pRef)
+	s.Equal(credentials, pRef.ArtifactCredentials)
+	s.Equal(55, pRef.BatchTime)
+
+	// Half a pair resolves to nothing, leaving artifacts on stale stored credentials.
+	resp = patch(`{"artifact_credentials": {"aws_key_var_name": "only_key", "aws_secret_var_name": ""}}`)
+	s.Equal(http.StatusBadRequest, resp.Status())
+}
+
 func (s *ProjectPatchByIDSuite) TestRunInvalidIdentifierChange() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/service/rest_task.go
+++ b/service/rest_task.go
@@ -168,7 +168,7 @@ func (restapi restAPI) getTaskInfo(w http.ResponseWriter, r *http.Request) {
 
 	}
 	for _, entry := range entries {
-		strippedFiles, err := artifact.StripHiddenFiles(r.Context(), entry.Files, true)
+		strippedFiles, err := artifact.StripHiddenFiles(r.Context(), entry.Files, true, model.NewArtifactCredentialResolver(entry.TaskId))
 		if err != nil {
 			msg := fmt.Sprintf("Error getting artifact files for task '%s'", srcTask.Id)
 			grip.Error(r.Context(), message.WrapError(err, message.Fields{

--- a/service/task.go
+++ b/service/task.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen/apimodels"
+	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/artifact"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/log"
@@ -188,7 +189,7 @@ func (uis *UIServer) taskFileRaw(w http.ResponseWriter, r *http.Request) {
 		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrapf(err, "finding artifacts for task '%s'", projCtx.Task.Id))
 		return
 	}
-	taskFiles, err = artifact.StripHiddenFiles(r.Context(), taskFiles, true)
+	taskFiles, err = artifact.StripHiddenFiles(r.Context(), taskFiles, true, model.NewArtifactCredentialResolver(projCtx.Task.Id))
 	if err != nil {
 		uis.LoggedError(w, r, http.StatusInternalServerError, errors.Wrapf(err, "stripping hidden files for task '%s'", projCtx.Task.Id))
 		return

--- a/util/expand_params.go
+++ b/util/expand_params.go
@@ -181,3 +181,24 @@ func IsExpandable(param string) bool {
 	endIndex := strings.Index(param, pluginExpandEndTag)
 	return startIndex >= 0 && endIndex >= 0 && endIndex > startIndex
 }
+
+// ExpansionVarName returns the expansion name if the value is exactly one
+// expansion reference, such as "${aws_key}", and the empty string otherwise.
+func ExpansionVarName(value string) string {
+	if !strings.HasPrefix(value, pluginExpandStartTag) || !strings.HasSuffix(value, pluginExpandEndTag) {
+		return ""
+	}
+
+	name := value[len(pluginExpandStartTag) : len(value)-len(pluginExpandEndTag)]
+	// An expansion may supply a fallback as ${var|default}.
+	if idx := strings.Index(name, "|"); idx >= 0 {
+		name = name[:idx]
+	}
+	// The outer tags are already stripped, so any remaining tag character means
+	// the value was not a single reference (e.g. "${a}${b}" or "${a${b}").
+	if name == "" || strings.ContainsAny(name, pluginExpandStartTag+pluginExpandEndTag) {
+		return ""
+	}
+
+	return name
+}

--- a/util/expand_params_test.go
+++ b/util/expand_params_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsExpandable(t *testing.T) {
@@ -280,4 +281,24 @@ func TestExpandValues(t *testing.T) {
 			So(testmap["A"]["deep"], ShouldEqual, "C")
 		})
 	})
+}
+
+func TestExpansionVarName(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		value    string
+		expected string
+	}{
+		"SingleExpansionReturnsName":              {value: "${aws_key}", expected: "aws_key"},
+		"ExpansionWithDefaultReturnsName":         {value: "${aws_key|fallback}", expected: "aws_key"},
+		"LiteralReturnsEmpty":                     {value: "AKIAFAKEKEY", expected: ""},
+		"ExpansionWithSurroundingTextIsNotSingle": {value: "prefix-${aws_key}", expected: ""},
+		"UnclosedExpansionReturnsEmpty":           {value: "${aws_key", expected: ""},
+		"AdjacentExpansionsReturnEmpty":           {value: "${aws_key}${aws_secret}", expected: ""},
+		"NestedExpansionReturnsEmpty":             {value: "${aws_${key}}", expected: ""},
+		"EmptyExpansionReturnsEmpty":              {value: "${}", expected: ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, ExpansionVarName(testCase.value))
+		})
+	}
 }


### PR DESCRIPTION
DEVPROD-40761

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Before this change, we created signed urls by storing the literal `aws_key` and `aws_secret` values copied onto the `artifact.File` document at upload time. Those values are frozen at upload, so rotating a project's AWS credentials silently breaks every previously uploaded signed artifact. 

This change does two things: 

1. It changes `s3.put` to record the names of the project variables of the key and secret rather than the values and it re-reads those variables through when signing the url. This way starting from when this is merged, files won't break if credentials are rotate. 
2. To fix files that were uploaded before this change, a project can set (only via the api) 

`  https://evergreen.mongodb.com/rest/v2/projects/<project> \
    -d '{"artifact_credentials": {"aws_key_var_name": "aws_key_var_name", "aws_secret_var_name": "aws_secret_var_name"}}'` 

with the names of the project variables holding their current AWS key and secret, and presigning will falls back to it for any artifact that have no variable names set on it. 

### Testing

I tested this on staging [with this task](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu2204_generate_api_docs_presigned_key_patch_d964d5bc4d62fab7ed3456020767c3e12df9dfe7_6a710f8e425a800007874d57_26_08_03_22_01_10/files?execution=0) by uploading a file with an aws key and secret, editing those to "fake" in the db, setting artifact_credentials, and making sure that it still signs them. 

### Documentation
Added documentation explaining how they are set with this change, how they were set before and how to fix old broken links. 