### PR TITLE
PLATFORMS-2440: Add container command wrapping and process cleanup

### DIFF
--- a/agent/util/container.go
+++ b/agent/util/container.go
@@ -1,0 +1,136 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/mongodb/grip"
+	"github.com/mongodb/jasper/options"
+	"github.com/pkg/errors"
+)
+
+const (
+	// containerEnvFileName is the name of the env-file written to the tmpfs dir.
+	containerEnvFileName = ".evg-env"
+)
+
+// WrapWithContainer prepends `docker exec <containerID>` to opts.Args,
+// routing command execution into the specified Docker container. It also:
+//   - adds `--workdir=<workdir>` if workdir is non-empty
+//   - writes opts.Environment to <envFileHostDir>/.evg-env (mode 0600) and adds
+//     `--env-file=<path>` if envFileHostDir is non-empty
+//   - prepends `nice -n <DefaultNice>` to the in-container argv so workload
+//     processes run at DefaultNice on standard EC2 hosts where the Docker daemon
+//     runs at nice 0. POSIX fork inheritance of nice breaks at the container
+//     boundary (docker exec starts the process via the daemon rather than
+//     inheriting from the agent's pre-fork nice reset); the prefix is the
+//     workaround. See inline comment for the known daemon-nice-offset caveat.
+//
+// Note: Docker's --env-file parser does not strip surrounding quotes from
+// values, so a value like "-Xmx1g" reaches the container with quotes intact.
+// Expansion values with literal surrounding quotes should be set without them.
+//
+// It is a no-op if containerID is empty.
+func WrapWithContainer(ctx context.Context, opts *options.Create, containerID, workdir, envFileHostDir string) error {
+	if containerID == "" {
+		return nil
+	}
+
+	// -i keeps stdin open so the container process receives it. Without this,
+	// docker exec closes the container process's stdin immediately, causing
+	// shell.exec commands that pass the script via stdin (the default mode) to
+	// get no input and exit 0 silently rather than running the script.
+	args := []string{"docker", "exec", "-i"}
+
+	if workdir != "" {
+		args = append(args, "--workdir="+workdir)
+	}
+
+	if envFileHostDir != "" {
+		// Pass the host-env file first (contains PATH, GOROOT, etc.
+		// captured from the host's profile scripts). The per-command
+		// env-file is passed second so its values override the host-env
+		// for command-specific variables. Docker applies --env-file args
+		// in order; later entries override earlier ones.
+		hostEnvPath := filepath.Join(envFileHostDir, ".evg-host-env")
+		if _, err := os.Stat(hostEnvPath); err == nil {
+			args = append(args, "--env-file="+hostEnvPath)
+		}
+
+		envFilePath := filepath.Join(envFileHostDir, containerEnvFileName)
+		if err := writeEnvFile(ctx, envFilePath, opts.Environment); err != nil {
+			return errors.Wrap(err, "writing container env file")
+		}
+		args = append(args, "--env-file="+envFilePath)
+	}
+
+	// If the command was wrapped with `sudo -u <user>` to run as exec_user,
+	// strip that prefix and use `docker exec --user` instead. Docker handles
+	// the user switch natively, removing the need for sudo to be installed
+	// inside the container image. This matches the format emitted by Jasper's
+	// SudoAs: ["sudo", "-u", user, ...rest]. Plain Sudo(true) without a user
+	// (which emits ["sudo", ...rest]) is not handled here and would be forwarded
+	// into the container as-is; in practice Evergreen only uses SudoAs for
+	// container-eligible commands.
+	if len(opts.Args) >= 3 && opts.Args[0] == "sudo" && opts.Args[1] == "-u" {
+		args = append(args, "--user="+opts.Args[2])
+		opts.Args = opts.Args[3:]
+	}
+
+	args = append(args, containerID)
+	// Reset the in-container process nice via `nice -n DefaultNice`. The agent
+	// runs at AgentNice and resets to DefaultNice before forking host
+	// subprocesses, but that reset does not propagate across the container
+	// boundary (Docker daemon starts the in-container process independently).
+	// `nice -n N` is a relative increment: it adjusts the current process's
+	// niceness by N. On standard EC2 hosts the Docker daemon runs at nice 0,
+	// so `nice -n 0` results in nice 0 (DefaultNice). If the daemon runs at a
+	// non-zero nice, the increment preserves that offset; we accept this as a
+	// known limitation for Phase 0 where all target hosts use system-managed
+	// Docker daemons at default nice.
+	args = append(args, "nice", "-n", fmt.Sprintf("%d", DefaultNice))
+	opts.Args = append(args, opts.Args...)
+	return nil
+}
+
+// writeEnvFile serializes env as KEY=VALUE lines to path with mode 0600.
+// The write is atomic (temp file + rename) to prevent concurrent docker exec
+// invocations from observing a partially-written file.
+// Values that contain newlines are skipped because the Docker env-file format
+// does not support multi-line values; a warning is logged for each dropped var.
+func writeEnvFile(ctx context.Context, path string, env map[string]string) error {
+	var sb strings.Builder
+	for k, v := range env {
+		if strings.ContainsAny(v, "\n\r") {
+			grip.Warningf(ctx, "skipping expansion '%s' in container env file: value contains a newline and cannot be forwarded via docker exec --env-file", k)
+			continue
+		}
+		fmt.Fprintf(&sb, "%s=%s\n", k, v)
+	}
+
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".evg-env-tmp-")
+	if err != nil {
+		return errors.Wrapf(err, "creating temp env file in '%s'", dir)
+	}
+	tmpPath := tmp.Name()
+
+	_, writeErr := tmp.WriteString(sb.String())
+	closeErr := tmp.Close()
+	if writeErr != nil || closeErr != nil {
+		_ = os.Remove(tmpPath)
+		if writeErr != nil {
+			return errors.Wrap(writeErr, "writing temp env file")
+		}
+		return errors.Wrap(closeErr, "closing temp env file")
+	}
+
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return errors.Wrapf(err, "installing env file at '%s'", path)
+	}
+	return nil
+}

--- a/agent/util/container.go
+++ b/agent/util/container.go
@@ -81,10 +81,15 @@ func WrapWithContainer(ctx context.Context, opts *options.Create, containerID, w
 	args = append(args, containerID)
 	// The agent resets its nice to DefaultNice before forking host subprocesses,
 	// but that does not cross the container boundary because the Docker daemon
-	// starts the in-container process independently. `nice -n N` is a relative
-	// increment, so this only lands on DefaultNice when the daemon itself runs at
-	// nice 0, which holds for the system-managed daemons on all target hosts.
-	args = append(args, "nice", "-n", strconv.Itoa(DefaultNice))
+	// starts the in-container process independently, so re-apply it in the
+	// container. `nice -n N` is a relative increment, so this only lands on
+	// DefaultNice when the daemon itself runs at nice 0, which holds for the
+	// system-managed daemons on all target hosts. The prefix is skipped when it
+	// would be a no-op, since it would otherwise require every task image to
+	// provide nice.
+	if DefaultNice != 0 {
+		args = append(args, "nice", "-n", strconv.Itoa(DefaultNice))
+	}
 	opts.Args = append(args, opts.Args...)
 	return nil
 }

--- a/agent/util/container.go
+++ b/agent/util/container.go
@@ -60,8 +60,8 @@ func WrapWithContainer(ctx context.Context, opts *options.Create, containerID, w
 			args = append(args, "--env-file="+hostEnvPath)
 		}
 
-		envFilePath := filepath.Join(envFileHostDir, containerEnvFileName)
-		if err := writeEnvFile(ctx, envFilePath, opts.Environment); err != nil {
+		envFilePath, err := writeEnvFile(ctx, envFileHostDir, opts.Environment)
+		if err != nil {
 			return errors.Wrap(err, "writing container env file")
 		}
 		args = append(args, "--env-file="+envFilePath)
@@ -96,12 +96,13 @@ func WrapWithContainer(ctx context.Context, opts *options.Create, containerID, w
 	return nil
 }
 
-// writeEnvFile serializes env as KEY=VALUE lines to path with mode 0600.
-// The write is atomic (temp file + rename) to prevent concurrent docker exec
-// invocations from observing a partially-written file.
+// writeEnvFile serializes env as KEY=VALUE lines to a unique file in dir with
+// mode 0600. A unique file keeps concurrent command wrappers from replacing
+// each other's environment before docker exec reads it. The file is owned by
+// the container's env tmpfs and is removed when that tmpfs is torn down.
 // Values that contain newlines are skipped because the Docker env-file format
 // does not support multi-line values; a warning is logged for each dropped var.
-func writeEnvFile(ctx context.Context, path string, env map[string]string) error {
+func writeEnvFile(ctx context.Context, dir string, env map[string]string) (string, error) {
 	var sb strings.Builder
 	for k, v := range env {
 		if strings.ContainsAny(v, "\n\r") {
@@ -111,26 +112,21 @@ func writeEnvFile(ctx context.Context, path string, env map[string]string) error
 		fmt.Fprintf(&sb, "%s=%s\n", k, v)
 	}
 
-	dir := filepath.Dir(path)
-	tmp, err := os.CreateTemp(dir, ".evg-env-tmp-")
+	tmp, err := os.CreateTemp(dir, containerEnvFileName+"-")
 	if err != nil {
-		return errors.Wrapf(err, "creating temp env file in '%s'", dir)
+		return "", errors.Wrapf(err, "creating env file in '%s'", dir)
 	}
-	tmpPath := tmp.Name()
+	path := tmp.Name()
 
 	_, writeErr := tmp.WriteString(sb.String())
 	closeErr := tmp.Close()
 	if writeErr != nil || closeErr != nil {
-		_ = os.Remove(tmpPath)
+		_ = os.Remove(path)
 		if writeErr != nil {
-			return errors.Wrap(writeErr, "writing temp env file")
+			return "", errors.Wrap(writeErr, "writing env file")
 		}
-		return errors.Wrap(closeErr, "closing temp env file")
+		return "", errors.Wrap(closeErr, "closing env file")
 	}
 
-	if err := os.Rename(tmpPath, path); err != nil {
-		_ = os.Remove(tmpPath)
-		return errors.Wrapf(err, "installing env file at '%s'", path)
-	}
-	return nil
+	return path, nil
 }

--- a/agent/util/container.go
+++ b/agent/util/container.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/mongodb/grip"
@@ -13,27 +14,22 @@ import (
 )
 
 const (
-	// containerEnvFileName is the name of the env-file written to the tmpfs dir.
+	// containerEnvFileName is the prefix for the per-command env-file written to
+	// the tmpfs dir.
 	containerEnvFileName = ".evg-env"
+	// containerHostEnvFileName is the env-file capturing the host's profile
+	// environment (PATH, GOROOT, etc.), written during container setup.
+	containerHostEnvFileName = ".evg-host-env"
 )
 
-// WrapWithContainer prepends `docker exec <containerID>` to opts.Args,
-// routing command execution into the specified Docker container. It also:
-//   - adds `--workdir=<workdir>` if workdir is non-empty
-//   - writes opts.Environment to <envFileHostDir>/.evg-env (mode 0600) and adds
-//     `--env-file=<path>` if envFileHostDir is non-empty
-//   - prepends `nice -n <DefaultNice>` to the in-container argv so workload
-//     processes run at DefaultNice on standard EC2 hosts where the Docker daemon
-//     runs at nice 0. POSIX fork inheritance of nice breaks at the container
-//     boundary (docker exec starts the process via the daemon rather than
-//     inheriting from the agent's pre-fork nice reset); the prefix is the
-//     workaround. See inline comment for the known daemon-nice-offset caveat.
+// WrapWithContainer rewrites opts.Args to run the command inside the given
+// Docker container via `docker exec`, applying workdir, environment, exec user,
+// and nice settings. It is a no-op if containerID is empty.
 //
-// Note: Docker's --env-file parser does not strip surrounding quotes from
-// values, so a value like "-Xmx1g" reaches the container with quotes intact.
-// Expansion values with literal surrounding quotes should be set without them.
-//
-// It is a no-op if containerID is empty.
+// If envFileHostDir is non-empty, opts.Environment is written there as an
+// env-file readable only by the agent's user. Docker's --env-file parser does
+// not strip surrounding quotes from values, so expansions must be set without
+// literal surrounding quotes or they reach the container with the quotes intact.
 func WrapWithContainer(ctx context.Context, opts *options.Create, containerID, workdir, envFileHostDir string) error {
 	if containerID == "" {
 		return nil
@@ -50,58 +46,55 @@ func WrapWithContainer(ctx context.Context, opts *options.Create, containerID, w
 	}
 
 	if envFileHostDir != "" {
-		// Pass the host-env file first (contains PATH, GOROOT, etc.
-		// captured from the host's profile scripts). The per-command
-		// env-file is passed second so its values override the host-env
-		// for command-specific variables. Docker applies --env-file args
-		// in order; later entries override earlier ones.
-		hostEnvPath := filepath.Join(envFileHostDir, ".evg-host-env")
-		if _, err := os.Stat(hostEnvPath); err == nil {
+		// Docker applies --env-file args in order, so the host-env file goes
+		// first and the per-command file second in order to let command-specific
+		// values override the host's.
+		hostEnvPath := filepath.Join(envFileHostDir, containerHostEnvFileName)
+		switch _, err := os.Stat(hostEnvPath); {
+		case err == nil:
 			args = append(args, "--env-file="+hostEnvPath)
+		case !os.IsNotExist(err):
+			// The file exists but is unreadable, so the container would silently
+			// lose PATH and surface it later as a command-not-found failure.
+			grip.Warningf(ctx, "checking container host env file '%s', continuing without it: %s", hostEnvPath, err)
 		}
 
-		envFilePath, err := writeEnvFile(ctx, envFileHostDir, opts.Environment)
-		if err != nil {
-			return errors.Wrap(err, "writing container env file")
+		if len(opts.Environment) > 0 {
+			envFilePath, err := writeEnvFile(ctx, envFileHostDir, opts.Environment)
+			if err != nil {
+				return errors.Wrap(err, "writing container env file")
+			}
+			args = append(args, "--env-file="+envFilePath)
 		}
-		args = append(args, "--env-file="+envFilePath)
 	}
 
-	// If the command was wrapped with `sudo -u <user>` to run as exec_user,
-	// strip that prefix and use `docker exec --user` instead. Docker handles
-	// the user switch natively, removing the need for sudo to be installed
-	// inside the container image. This matches the format emitted by Jasper's
-	// SudoAs: ["sudo", "-u", user, ...rest]. Plain Sudo(true) without a user
-	// (which emits ["sudo", ...rest]) is not handled here and would be forwarded
-	// into the container as-is; in practice Evergreen only uses SudoAs for
-	// container-eligible commands.
-	if len(opts.Args) >= 3 && opts.Args[0] == "sudo" && opts.Args[1] == "-u" {
+	// Translate the `sudo -u <user>` prefix that Jasper's SudoAs emits into
+	// `docker exec --user`, so the container image does not need sudo installed.
+	// Plain Sudo(true) emits ["sudo", ...rest] with no user and is forwarded into
+	// the container as-is; Evergreen only uses SudoAs for container-eligible
+	// commands.
+	if len(opts.Args) > 3 && opts.Args[0] == "sudo" && opts.Args[1] == "-u" {
 		args = append(args, "--user="+opts.Args[2])
 		opts.Args = opts.Args[3:]
 	}
 
 	args = append(args, containerID)
-	// Reset the in-container process nice via `nice -n DefaultNice`. The agent
-	// runs at AgentNice and resets to DefaultNice before forking host
-	// subprocesses, but that reset does not propagate across the container
-	// boundary (Docker daemon starts the in-container process independently).
-	// `nice -n N` is a relative increment: it adjusts the current process's
-	// niceness by N. On standard EC2 hosts the Docker daemon runs at nice 0,
-	// so `nice -n 0` results in nice 0 (DefaultNice). If the daemon runs at a
-	// non-zero nice, the increment preserves that offset; we accept this as a
-	// known limitation for Phase 0 where all target hosts use system-managed
-	// Docker daemons at default nice.
-	args = append(args, "nice", "-n", fmt.Sprintf("%d", DefaultNice))
+	// The agent resets its nice to DefaultNice before forking host subprocesses,
+	// but that does not cross the container boundary because the Docker daemon
+	// starts the in-container process independently. `nice -n N` is a relative
+	// increment, so this only lands on DefaultNice when the daemon itself runs at
+	// nice 0, which holds for the system-managed daemons on all target hosts.
+	args = append(args, "nice", "-n", strconv.Itoa(DefaultNice))
 	opts.Args = append(args, opts.Args...)
 	return nil
 }
 
 // writeEnvFile serializes env as KEY=VALUE lines to a unique file in dir with
-// mode 0600. A unique file keeps concurrent command wrappers from replacing
-// each other's environment before docker exec reads it. The file is owned by
-// the container's env tmpfs and is removed when that tmpfs is torn down.
-// Values that contain newlines are skipped because the Docker env-file format
-// does not support multi-line values; a warning is logged for each dropped var.
+// mode 0600. Each command gets its own file so that concurrent wrappers cannot
+// replace each other's environment before docker exec reads it; the files live
+// on the container's env tmpfs and are removed when it is torn down. Values
+// containing newlines are dropped with a warning because the Docker env-file
+// format cannot represent them.
 func writeEnvFile(ctx context.Context, dir string, env map[string]string) (string, error) {
 	var sb strings.Builder
 	for k, v := range env {

--- a/agent/util/container.go
+++ b/agent/util/container.go
@@ -70,28 +70,41 @@ func WrapWithContainer(ctx context.Context, opts *options.Create, containerID, w
 
 	// Translate the `sudo -u <user>` prefix that Jasper's SudoAs emits into
 	// `docker exec --user`, so the container image does not need sudo installed.
-	// Plain Sudo(true) emits ["sudo", ...rest] with no user and is forwarded into
-	// the container as-is; Evergreen only uses SudoAs for container-eligible
-	// commands.
+	//
+	// This is coupled to how Jasper builds that prefix: Command.sudoCmd()
+	// (jasper/command.go:31) emits ["sudo"] when only Sudo(true) is set and
+	// ["sudo", "-u", <user>] when SudoAs sets a user, then prepends it to
+	// opts.Args in jasper/command.go:711. Re-check both if the Jasper pin moves.
+	// The user-less form is forwarded into the container as-is, since Evergreen
+	// only uses SudoAs for container-eligible commands.
+	//
+	// This must stay below the env-file write above: stripping the prefix mutates
+	// opts.Args, and doing it first would leave opts partially rewritten if the
+	// write failed.
 	if len(opts.Args) > 3 && opts.Args[0] == "sudo" && opts.Args[1] == "-u" {
 		args = append(args, "--user="+opts.Args[2])
 		opts.Args = opts.Args[3:]
 	}
 
 	args = append(args, containerID)
-	// The agent resets its nice to DefaultNice before forking host subprocesses,
-	// but that does not cross the container boundary because the Docker daemon
-	// starts the in-container process independently, so re-apply it in the
-	// container. `nice -n N` is a relative increment, so this only lands on
-	// DefaultNice when the daemon itself runs at nice 0, which holds for the
-	// system-managed daemons on all target hosts. The prefix is skipped when it
-	// would be a no-op, since it would otherwise require every task image to
-	// provide nice.
-	if DefaultNice != 0 {
-		args = append(args, "nice", "-n", strconv.Itoa(DefaultNice))
-	}
+	args = append(args, containerNiceArgs(DefaultNice)...)
 	opts.Args = append(args, opts.Args...)
 	return nil
+}
+
+// containerNiceArgs returns the argv prefix that re-applies nice to the
+// in-container process. The agent resets its nice before forking host
+// subprocesses, but that does not cross the container boundary because the
+// Docker daemon starts the in-container process independently. `nice -n N` is a
+// relative increment, so it only lands on nice when the daemon itself runs at
+// nice 0, which holds for the system-managed daemons on all target hosts. A
+// zero increment yields no prefix, since it would be a no-op that still forced
+// every task image to provide nice.
+func containerNiceArgs(nice int) []string {
+	if nice == 0 {
+		return nil
+	}
+	return []string{"nice", "-n", strconv.Itoa(nice)}
 }
 
 // writeEnvFile serializes env as KEY=VALUE lines to a unique file in dir with

--- a/agent/util/container_test.go
+++ b/agent/util/container_test.go
@@ -1,0 +1,187 @@
+package util
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mongodb/jasper/options"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWrapWithContainer(t *testing.T) {
+	baseArgs := []string{"/bin/bash", "-c", "echo hello"}
+
+	makeOpts := func() *options.Create {
+		return &options.Create{Args: append([]string{}, baseArgs...)}
+	}
+
+	t.Run("EmptyContainerID", func(t *testing.T) {
+		opts := makeOpts()
+		require.NoError(t, WrapWithContainer(t.Context(), opts, "", "", ""))
+		assert.Equal(t, baseArgs, opts.Args)
+	})
+
+	t.Run("ContainerIDOnly", func(t *testing.T) {
+		opts := makeOpts()
+		require.NoError(t, WrapWithContainer(t.Context(), opts, "abc123def", "", ""))
+		require.GreaterOrEqual(t, len(opts.Args), len(baseArgs)+4)
+		assert.Equal(t, "docker", opts.Args[0])
+		assert.Equal(t, "exec", opts.Args[1])
+		assert.Equal(t, "-i", opts.Args[2])
+		assert.Equal(t, "abc123def", opts.Args[3])
+		assert.Equal(t, baseArgs, opts.Args[len(opts.Args)-len(baseArgs):])
+	})
+
+	t.Run("WithWorkdir", func(t *testing.T) {
+		opts := makeOpts()
+		require.NoError(t, WrapWithContainer(t.Context(), opts, "abc123", "/data/mci/task1", ""))
+		assert.Equal(t, "docker", opts.Args[0])
+		assert.Equal(t, "exec", opts.Args[1])
+		assert.Equal(t, "-i", opts.Args[2])
+		assert.Equal(t, "--workdir=/data/mci/task1", opts.Args[3])
+		assert.Equal(t, "abc123", opts.Args[4])
+		assert.Equal(t, baseArgs, opts.Args[len(opts.Args)-len(baseArgs):])
+	})
+
+	t.Run("WithEnvFile", func(t *testing.T) {
+		dir := t.TempDir()
+		opts := makeOpts()
+		opts.Environment = map[string]string{"FOO": "bar", "SECRET": "s3cr3t"}
+		require.NoError(t, WrapWithContainer(t.Context(), opts, "abc123", "", dir))
+
+		// docker exec args include --env-file flag
+		var envFileArg string
+		for _, arg := range opts.Args {
+			if len(arg) > 11 && arg[:11] == "--env-file=" {
+				envFileArg = arg[11:]
+			}
+		}
+		require.NotEmpty(t, envFileArg, "expected --env-file argument in docker exec args")
+
+		// env file should exist and be readable
+		content, err := os.ReadFile(envFileArg)
+		require.NoError(t, err)
+		body := string(content)
+		assert.Contains(t, body, "FOO=bar\n")
+		assert.Contains(t, body, "SECRET=s3cr3t\n")
+	})
+
+	t.Run("WithWorkdirAndEnvFile", func(t *testing.T) {
+		dir := t.TempDir()
+		opts := makeOpts()
+		opts.Environment = map[string]string{"K": "v"}
+		require.NoError(t, WrapWithContainer(t.Context(), opts, "cid", "/work", dir))
+
+		assert.Equal(t, "docker", opts.Args[0])
+		assert.Equal(t, "exec", opts.Args[1])
+		assert.Equal(t, "-i", opts.Args[2])
+		assert.Equal(t, "--workdir=/work", opts.Args[3])
+		hasEnvFile := false
+		for _, arg := range opts.Args {
+			if len(arg) > 11 && arg[:11] == "--env-file=" {
+				hasEnvFile = true
+			}
+		}
+		assert.True(t, hasEnvFile, "expected --env-file argument")
+		assert.Equal(t, baseArgs, opts.Args[len(opts.Args)-len(baseArgs):])
+	})
+
+	t.Run("NicePrefixInContainerArgv", func(t *testing.T) {
+		opts := makeOpts()
+		require.NoError(t, WrapWithContainer(t.Context(), opts, "cid", "", ""))
+		// nice -n 0 must appear between the containerID and the original command.
+		niceIdx := -1
+		for i, arg := range opts.Args {
+			if arg == "nice" {
+				niceIdx = i
+				break
+			}
+		}
+		require.NotEqual(t, -1, niceIdx, "expected 'nice' in docker exec args")
+		require.Less(t, niceIdx+2, len(opts.Args), "expected '-n' and '0' after 'nice'")
+		assert.Equal(t, "-n", opts.Args[niceIdx+1])
+		assert.Equal(t, fmt.Sprintf("%d", DefaultNice), opts.Args[niceIdx+2])
+		assert.Equal(t, baseArgs, opts.Args[len(opts.Args)-len(baseArgs):])
+	})
+
+	t.Run("SudoPrefixStrippedAndUserFlagAdded", func(t *testing.T) {
+		// Jasper's SudoAs prepends ["sudo", "-u", user] to opts.Args before
+		// WrapWithContainer is called. Verify the prefix is stripped and
+		// --user=<user> is added to the docker exec flags instead.
+		opts := &options.Create{Args: append([]string{"sudo", "-u", "ubuntu"}, baseArgs...)}
+		require.NoError(t, WrapWithContainer(t.Context(), opts, "cid", "", ""))
+
+		assert.Equal(t, "docker", opts.Args[0])
+		assert.Equal(t, "exec", opts.Args[1])
+
+		hasUser := false
+		for _, arg := range opts.Args {
+			assert.NotEqual(t, "sudo", arg, "sudo should not appear in final args")
+			if arg == "--user=ubuntu" {
+				hasUser = true
+			}
+		}
+		assert.True(t, hasUser, "expected --user=ubuntu in docker exec args")
+		assert.Equal(t, baseArgs, opts.Args[len(opts.Args)-len(baseArgs):])
+	})
+
+	t.Run("PreservesOriginalArgs", func(t *testing.T) {
+		opts := makeOpts()
+		original := append([]string{}, opts.Args...)
+		require.NoError(t, WrapWithContainer(t.Context(), opts, "xyz789", "", ""))
+		assert.Equal(t, original, opts.Args[len(opts.Args)-len(original):])
+	})
+
+	t.Run("EnvFileMode0600", func(t *testing.T) {
+		dir := t.TempDir()
+		opts := makeOpts()
+		opts.Environment = map[string]string{"KEY": "value"}
+		require.NoError(t, WrapWithContainer(t.Context(), opts, "cid", "", dir))
+
+		envFilePath := filepath.Join(dir, containerEnvFileName)
+		fi, err := os.Stat(envFilePath)
+		require.NoError(t, err)
+		assert.Equal(t, os.FileMode(0600), fi.Mode().Perm())
+	})
+}
+
+func TestWriteEnvFile(t *testing.T) {
+	t.Run("WritesKeyValuePairs", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, ".evg-env")
+		env := map[string]string{"A": "1", "B": "hello world"}
+		require.NoError(t, writeEnvFile(t.Context(), path, env))
+
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		body := string(data)
+		assert.Contains(t, body, "A=1\n")
+		assert.Contains(t, body, "B=hello world\n")
+	})
+
+	t.Run("SkipsMultilineValues", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, ".evg-env")
+		env := map[string]string{"GOOD": "ok", "BAD": "line1\nline2"}
+		require.NoError(t, writeEnvFile(t.Context(), path, env))
+
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		body := string(data)
+		assert.Contains(t, body, "GOOD=ok\n")
+		assert.NotContains(t, body, "BAD=")
+	})
+
+	t.Run("EmptyEnv", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, ".evg-env")
+		require.NoError(t, writeEnvFile(t.Context(), path, nil))
+
+		data, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Empty(t, string(data))
+	})
+}

--- a/agent/util/container_test.go
+++ b/agent/util/container_test.go
@@ -3,7 +3,6 @@ package util
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/mongodb/jasper/options"
@@ -141,19 +140,57 @@ func TestWrapWithContainer(t *testing.T) {
 		opts.Environment = map[string]string{"KEY": "value"}
 		require.NoError(t, WrapWithContainer(t.Context(), opts, "cid", "", dir))
 
-		envFilePath := filepath.Join(dir, containerEnvFileName)
+		envFilePath := ""
+		for _, arg := range opts.Args {
+			if len(arg) > 11 && arg[:11] == "--env-file=" {
+				envFilePath = arg[11:]
+			}
+		}
+		require.NotEmpty(t, envFilePath)
 		fi, err := os.Stat(envFilePath)
 		require.NoError(t, err)
 		assert.Equal(t, os.FileMode(0600), fi.Mode().Perm())
+	})
+
+	t.Run("SeparateCommandsRetainTheirEnvironment", func(t *testing.T) {
+		dir := t.TempDir()
+		firstOpts := makeOpts()
+		firstOpts.Environment = map[string]string{"COMMAND": "first"}
+		require.NoError(t, WrapWithContainer(t.Context(), firstOpts, "cid", "", dir))
+
+		firstEnvFile := ""
+		for _, arg := range firstOpts.Args {
+			if len(arg) > 11 && arg[:11] == "--env-file=" {
+				firstEnvFile = arg[11:]
+			}
+		}
+		require.NotEmpty(t, firstEnvFile)
+
+		secondOpts := makeOpts()
+		secondOpts.Environment = map[string]string{"COMMAND": "second"}
+		require.NoError(t, WrapWithContainer(t.Context(), secondOpts, "cid", "", dir))
+		secondEnvFile := ""
+		for _, arg := range secondOpts.Args {
+			if len(arg) > 11 && arg[:11] == "--env-file=" {
+				secondEnvFile = arg[11:]
+			}
+		}
+		require.NotEmpty(t, secondEnvFile)
+		assert.NotEqual(t, firstEnvFile, secondEnvFile)
+
+		data, err := os.ReadFile(firstEnvFile)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), "COMMAND=first\n")
+		assert.NotContains(t, string(data), "COMMAND=second\n")
 	})
 }
 
 func TestWriteEnvFile(t *testing.T) {
 	t.Run("WritesKeyValuePairs", func(t *testing.T) {
 		dir := t.TempDir()
-		path := filepath.Join(dir, ".evg-env")
 		env := map[string]string{"A": "1", "B": "hello world"}
-		require.NoError(t, writeEnvFile(t.Context(), path, env))
+		path, err := writeEnvFile(t.Context(), dir, env)
+		require.NoError(t, err)
 
 		data, err := os.ReadFile(path)
 		require.NoError(t, err)
@@ -164,9 +201,9 @@ func TestWriteEnvFile(t *testing.T) {
 
 	t.Run("SkipsMultilineValues", func(t *testing.T) {
 		dir := t.TempDir()
-		path := filepath.Join(dir, ".evg-env")
 		env := map[string]string{"GOOD": "ok", "BAD": "line1\nline2"}
-		require.NoError(t, writeEnvFile(t.Context(), path, env))
+		path, err := writeEnvFile(t.Context(), dir, env)
+		require.NoError(t, err)
 
 		data, err := os.ReadFile(path)
 		require.NoError(t, err)
@@ -177,8 +214,8 @@ func TestWriteEnvFile(t *testing.T) {
 
 	t.Run("EmptyEnv", func(t *testing.T) {
 		dir := t.TempDir()
-		path := filepath.Join(dir, ".evg-env")
-		require.NoError(t, writeEnvFile(t.Context(), path, nil))
+		path, err := writeEnvFile(t.Context(), dir, nil)
+		require.NoError(t, err)
 
 		data, err := os.ReadFile(path)
 		require.NoError(t, err)

--- a/agent/util/container_test.go
+++ b/agent/util/container_test.go
@@ -3,13 +3,27 @@ package util
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
+	"slices"
+	"strings"
 	"testing"
 
 	"github.com/mongodb/jasper/options"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// envFilePaths returns the values of every --env-file flag in args, in order.
+func envFilePaths(args []string) []string {
+	var paths []string
+	for _, arg := range args {
+		if path, ok := strings.CutPrefix(arg, "--env-file="); ok {
+			paths = append(paths, path)
+		}
+	}
+	return paths
+}
 
 func TestWrapWithContainer(t *testing.T) {
 	baseArgs := []string{"/bin/bash", "-c", "echo hello"}
@@ -52,17 +66,10 @@ func TestWrapWithContainer(t *testing.T) {
 		opts.Environment = map[string]string{"FOO": "bar", "SECRET": "s3cr3t"}
 		require.NoError(t, WrapWithContainer(t.Context(), opts, "abc123", "", dir))
 
-		// docker exec args include --env-file flag
-		var envFileArg string
-		for _, arg := range opts.Args {
-			if len(arg) > 11 && arg[:11] == "--env-file=" {
-				envFileArg = arg[11:]
-			}
-		}
-		require.NotEmpty(t, envFileArg, "expected --env-file argument in docker exec args")
+		paths := envFilePaths(opts.Args)
+		require.Len(t, paths, 1)
 
-		// env file should exist and be readable
-		content, err := os.ReadFile(envFileArg)
+		content, err := os.ReadFile(paths[0])
 		require.NoError(t, err)
 		body := string(content)
 		assert.Contains(t, body, "FOO=bar\n")
@@ -79,13 +86,7 @@ func TestWrapWithContainer(t *testing.T) {
 		assert.Equal(t, "exec", opts.Args[1])
 		assert.Equal(t, "-i", opts.Args[2])
 		assert.Equal(t, "--workdir=/work", opts.Args[3])
-		hasEnvFile := false
-		for _, arg := range opts.Args {
-			if len(arg) > 11 && arg[:11] == "--env-file=" {
-				hasEnvFile = true
-			}
-		}
-		assert.True(t, hasEnvFile, "expected --env-file argument")
+		assert.Len(t, envFilePaths(opts.Args), 1)
 		assert.Equal(t, baseArgs, opts.Args[len(opts.Args)-len(baseArgs):])
 	})
 
@@ -117,15 +118,59 @@ func TestWrapWithContainer(t *testing.T) {
 		assert.Equal(t, "docker", opts.Args[0])
 		assert.Equal(t, "exec", opts.Args[1])
 
-		hasUser := false
-		for _, arg := range opts.Args {
-			assert.NotEqual(t, "sudo", arg, "sudo should not appear in final args")
-			if arg == "--user=ubuntu" {
-				hasUser = true
-			}
-		}
-		assert.True(t, hasUser, "expected --user=ubuntu in docker exec args")
+		assert.NotContains(t, opts.Args, "sudo")
+		userIdx := slices.Index(opts.Args, "--user=ubuntu")
+		require.NotEqual(t, -1, userIdx, "expected --user=ubuntu in docker exec args")
+		// The flag has to precede the container ID or docker parses it as an
+		// argument to the in-container command instead.
+		assert.Less(t, userIdx, slices.Index(opts.Args, "cid"))
 		assert.Equal(t, baseArgs, opts.Args[len(opts.Args)-len(baseArgs):])
+	})
+
+	t.Run("HostEnvFilePrecedesPerCommandEnvFile", func(t *testing.T) {
+		dir := t.TempDir()
+		hostEnvPath := filepath.Join(dir, containerHostEnvFileName)
+		require.NoError(t, os.WriteFile(hostEnvPath, []byte("PATH=/usr/bin\n"), 0600))
+
+		opts := makeOpts()
+		opts.Environment = map[string]string{"K": "v"}
+		require.NoError(t, WrapWithContainer(t.Context(), opts, "cid", "", dir))
+
+		// Docker applies --env-file args in order, so the per-command file must
+		// come second for its values to win.
+		paths := envFilePaths(opts.Args)
+		require.Len(t, paths, 2)
+		assert.Equal(t, hostEnvPath, paths[0])
+		assert.NotEqual(t, hostEnvPath, paths[1])
+	})
+
+	t.Run("MissingHostEnvFileIsOmitted", func(t *testing.T) {
+		dir := t.TempDir()
+		opts := makeOpts()
+		opts.Environment = map[string]string{"K": "v"}
+		require.NoError(t, WrapWithContainer(t.Context(), opts, "cid", "", dir))
+
+		paths := envFilePaths(opts.Args)
+		require.Len(t, paths, 1)
+		assert.NotEqual(t, filepath.Join(dir, containerHostEnvFileName), paths[0])
+	})
+
+	t.Run("EmptyEnvironmentWritesNoEnvFile", func(t *testing.T) {
+		dir := t.TempDir()
+		opts := makeOpts()
+		require.NoError(t, WrapWithContainer(t.Context(), opts, "cid", "", dir))
+
+		assert.Empty(t, envFilePaths(opts.Args))
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		assert.Empty(t, entries, "no env file should be created for an empty environment")
+	})
+
+	t.Run("EnvFileFailureLeavesArgsUnmodified", func(t *testing.T) {
+		opts := makeOpts()
+		opts.Environment = map[string]string{"K": "v"}
+		require.Error(t, WrapWithContainer(t.Context(), opts, "cid", "", filepath.Join(t.TempDir(), "missing")))
+		assert.Equal(t, baseArgs, opts.Args)
 	})
 
 	t.Run("PreservesOriginalArgs", func(t *testing.T) {
@@ -146,14 +191,9 @@ func TestWrapWithContainer(t *testing.T) {
 		opts.Environment = map[string]string{"KEY": "value"}
 		require.NoError(t, WrapWithContainer(t.Context(), opts, "cid", "", dir))
 
-		envFilePath := ""
-		for _, arg := range opts.Args {
-			if len(arg) > 11 && arg[:11] == "--env-file=" {
-				envFilePath = arg[11:]
-			}
-		}
-		require.NotEmpty(t, envFilePath)
-		fi, err := os.Stat(envFilePath)
+		paths := envFilePaths(opts.Args)
+		require.Len(t, paths, 1)
+		fi, err := os.Stat(paths[0])
 		require.NoError(t, err)
 		assert.Equal(t, os.FileMode(0600), fi.Mode().Perm())
 	})
@@ -164,27 +204,17 @@ func TestWrapWithContainer(t *testing.T) {
 		firstOpts.Environment = map[string]string{"COMMAND": "first"}
 		require.NoError(t, WrapWithContainer(t.Context(), firstOpts, "cid", "", dir))
 
-		firstEnvFile := ""
-		for _, arg := range firstOpts.Args {
-			if len(arg) > 11 && arg[:11] == "--env-file=" {
-				firstEnvFile = arg[11:]
-			}
-		}
-		require.NotEmpty(t, firstEnvFile)
+		firstPaths := envFilePaths(firstOpts.Args)
+		require.Len(t, firstPaths, 1)
 
 		secondOpts := makeOpts()
 		secondOpts.Environment = map[string]string{"COMMAND": "second"}
 		require.NoError(t, WrapWithContainer(t.Context(), secondOpts, "cid", "", dir))
-		secondEnvFile := ""
-		for _, arg := range secondOpts.Args {
-			if len(arg) > 11 && arg[:11] == "--env-file=" {
-				secondEnvFile = arg[11:]
-			}
-		}
-		require.NotEmpty(t, secondEnvFile)
-		assert.NotEqual(t, firstEnvFile, secondEnvFile)
+		secondPaths := envFilePaths(secondOpts.Args)
+		require.Len(t, secondPaths, 1)
+		assert.NotEqual(t, firstPaths[0], secondPaths[0])
 
-		data, err := os.ReadFile(firstEnvFile)
+		data, err := os.ReadFile(firstPaths[0])
 		require.NoError(t, err)
 		assert.Contains(t, string(data), "COMMAND=first\n")
 		assert.NotContains(t, string(data), "COMMAND=second\n")
@@ -226,5 +256,10 @@ func TestWriteEnvFile(t *testing.T) {
 		data, err := os.ReadFile(path)
 		require.NoError(t, err)
 		assert.Empty(t, string(data))
+	})
+
+	t.Run("NonexistentDirErrors", func(t *testing.T) {
+		_, err := writeEnvFile(t.Context(), filepath.Join(t.TempDir(), "missing"), map[string]string{"A": "1"})
+		assert.Error(t, err)
 	})
 }

--- a/agent/util/container_test.go
+++ b/agent/util/container_test.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -90,16 +89,11 @@ func TestWrapWithContainer(t *testing.T) {
 		assert.Equal(t, baseArgs, opts.Args[len(opts.Args)-len(baseArgs):])
 	})
 
-	t.Run("NicePrefixAppliedOnlyWhenItChangesPriority", func(t *testing.T) {
+	t.Run("NicePrefixMatchesDefaultNice", func(t *testing.T) {
 		opts := makeOpts()
 		require.NoError(t, WrapWithContainer(t.Context(), opts, "cid", "", ""))
 
-		// A `nice -n 0` prefix would be a no-op that forces every task image to
-		// provide nice, so it is only emitted when DefaultNice is non-zero.
-		expected := baseArgs
-		if DefaultNice != 0 {
-			expected = append([]string{"nice", "-n", strconv.Itoa(DefaultNice)}, baseArgs...)
-		}
+		expected := append(containerNiceArgs(DefaultNice), baseArgs...)
 		require.Len(t, opts.Args, 4+len(expected))
 		assert.Equal(t, expected, opts.Args[4:])
 	})
@@ -258,4 +252,19 @@ func TestWriteEnvFile(t *testing.T) {
 		_, err := writeEnvFile(t.Context(), filepath.Join(t.TempDir(), "missing"), map[string]string{"A": "1"})
 		assert.Error(t, err)
 	})
+}
+
+func TestContainerNiceArgs(t *testing.T) {
+	for testName, testCase := range map[string]struct {
+		nice     int
+		expected []string
+	}{
+		"ZeroYieldsNoPrefixToAvoidRequiringNiceInTheImage": {nice: 0, expected: nil},
+		"NegativeNiceRaisesPriority":                       {nice: -10, expected: []string{"nice", "-n", "-10"}},
+		"PositiveNiceLowersPriority":                       {nice: 5, expected: []string{"nice", "-n", "5"}},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			assert.Equal(t, testCase.expected, containerNiceArgs(testCase.nice))
+		})
+	}
 }

--- a/agent/util/container_test.go
+++ b/agent/util/container_test.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/mongodb/jasper/options"
@@ -135,6 +136,11 @@ func TestWrapWithContainer(t *testing.T) {
 	})
 
 	t.Run("EnvFileMode0600", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			// Windows does not support POSIX permission bits and reports writable files with the default 0666 mode.
+			t.Skip("Windows does not support POSIX permission bits")
+		}
+
 		dir := t.TempDir()
 		opts := makeOpts()
 		opts.Environment = map[string]string{"KEY": "value"}

--- a/agent/util/container_test.go
+++ b/agent/util/container_test.go
@@ -1,11 +1,11 @@
 package util
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -90,22 +90,18 @@ func TestWrapWithContainer(t *testing.T) {
 		assert.Equal(t, baseArgs, opts.Args[len(opts.Args)-len(baseArgs):])
 	})
 
-	t.Run("NicePrefixInContainerArgv", func(t *testing.T) {
+	t.Run("NicePrefixAppliedOnlyWhenItChangesPriority", func(t *testing.T) {
 		opts := makeOpts()
 		require.NoError(t, WrapWithContainer(t.Context(), opts, "cid", "", ""))
-		// nice -n 0 must appear between the containerID and the original command.
-		niceIdx := -1
-		for i, arg := range opts.Args {
-			if arg == "nice" {
-				niceIdx = i
-				break
-			}
+
+		// A `nice -n 0` prefix would be a no-op that forces every task image to
+		// provide nice, so it is only emitted when DefaultNice is non-zero.
+		expected := baseArgs
+		if DefaultNice != 0 {
+			expected = append([]string{"nice", "-n", strconv.Itoa(DefaultNice)}, baseArgs...)
 		}
-		require.NotEqual(t, -1, niceIdx, "expected 'nice' in docker exec args")
-		require.Less(t, niceIdx+2, len(opts.Args), "expected '-n' and '0' after 'nice'")
-		assert.Equal(t, "-n", opts.Args[niceIdx+1])
-		assert.Equal(t, fmt.Sprintf("%d", DefaultNice), opts.Args[niceIdx+2])
-		assert.Equal(t, baseArgs, opts.Args[len(opts.Args)-len(baseArgs):])
+		require.Len(t, opts.Args, 4+len(expected))
+		assert.Equal(t, expected, opts.Args[4:])
 	})
 
 	t.Run("SudoPrefixStrippedAndUserFlagAdded", func(t *testing.T) {

--- a/agent/util/subtree.go
+++ b/agent/util/subtree.go
@@ -10,7 +10,14 @@ const (
 	MarkerInEvergreen = "IN_EVERGREEN"
 )
 
-var ErrPSTimeout = errors.New("ps timeout")
+var (
+	ErrPSTimeout = errors.New("ps timeout")
+	// ErrContainerExecUnavailable is returned by KillSpawnedProcsInContainer
+	// when docker exec fails at the daemon level (exit 125): the container is
+	// not running, paused, or unreachable. Callers should warn rather than
+	// treat this as a hard kill failure.
+	ErrContainerExecUnavailable = errors.New("container exec unavailable")
+)
 
 const (
 	// minNice is the minimum nice value (i.e. highest priority).

--- a/agent/util/subtree.go
+++ b/agent/util/subtree.go
@@ -12,10 +12,9 @@ const (
 
 var (
 	ErrPSTimeout = errors.New("ps timeout")
-	// ErrContainerExecUnavailable is returned by KillSpawnedProcsInContainer
-	// when docker exec fails at the daemon level (exit 125): the container is
-	// not running, paused, or unreachable. Callers should warn rather than
-	// treat this as a hard kill failure.
+	// ErrContainerExecUnavailable indicates the container could not be reached
+	// to clean up its processes. Callers should warn rather than treat this as a
+	// hard kill failure, since failing here would mask the task's own failure.
 	ErrContainerExecUnavailable = errors.New("container exec unavailable")
 )
 

--- a/agent/util/subtree_unix.go
+++ b/agent/util/subtree_unix.go
@@ -81,6 +81,50 @@ func killUserProcesses(ctx context.Context, execUser string) error {
 	return nil
 }
 
+const (
+	// dockerExecContainerNotRunningExitCode is returned by `docker exec` when
+	// the exec invocation itself fails at the daemon level — most commonly
+	// because the container is not running, but also for a paused container,
+	// a transient daemon error, or an invalid container reference. We treat
+	// this as a benign no-op for the kill use case: if we cannot exec into the
+	// container, we cannot know whether processes are leaking, but failing hard
+	// here would mask the original task failure with a cleanup error. Callers
+	// should log a warning so the dead-container state is visible in agent logs.
+	dockerExecContainerNotRunningExitCode = 125
+)
+
+// KillSpawnedProcsInContainer kills all processes owned by execUser inside a
+// running isolation container. This is the container-mode equivalent of the
+// host-side killUserProcesses: it runs pkill inside the container's PID
+// namespace via docker exec so that PID 1 (sleep infinity, running as root)
+// is preserved while user-owned processes from the previous task are cleaned up.
+func KillSpawnedProcsInContainer(ctx context.Context, containerID, execUser string) error {
+	if containerID == "" {
+		return errors.New("containerID cannot be empty")
+	}
+	if execUser == "" {
+		return errors.New("execUser cannot be empty")
+	}
+	cmd := jasper.NewCommand().Add([]string{"docker", "exec", containerID, "pkill", "-SIGKILL", "-U", execUser})
+	if err := cmd.Run(ctx); err != nil {
+		exitCode, _ := cmd.Wait(ctx)
+		switch exitCode {
+		case pkillNoMatchingProcessesExitCode:
+			// No user processes found — nothing to kill, not an error.
+		case dockerExecContainerNotRunningExitCode:
+			// docker exec failed at the daemon level (container not running,
+			// paused, invalid reference, or transient daemon error). Return a
+			// sentinel error so callers can log a warning — we cannot kill
+			// processes we cannot reach, but we also do not want to mask the
+			// original task failure with a cleanup error.
+			return ErrContainerExecUnavailable
+		default:
+			return errors.Wrapf(err, "killing processes for user '%s' in container '%s'", execUser, containerID)
+		}
+	}
+	return nil
+}
+
 func getPIDsToKill(ctx context.Context, key, workingDir string, logger grip.Journaler) ([]int, error) {
 	var pidsToKill []int
 

--- a/agent/util/subtree_unix.go
+++ b/agent/util/subtree_unix.go
@@ -82,22 +82,16 @@ func killUserProcesses(ctx context.Context, execUser string) error {
 }
 
 const (
-	// dockerExecContainerNotRunningExitCode is returned by `docker exec` when
-	// the exec invocation itself fails at the daemon level — most commonly
-	// because the container is not running, but also for a paused container,
-	// a transient daemon error, or an invalid container reference. We treat
-	// this as a benign no-op for the kill use case: if we cannot exec into the
-	// container, we cannot know whether processes are leaking, but failing hard
-	// here would mask the original task failure with a cleanup error. Callers
-	// should log a warning so the dead-container state is visible in agent logs.
-	dockerExecContainerNotRunningExitCode = 125
+	// dockerExecDaemonFailureExitCode is returned by `docker exec` when the exec
+	// invocation fails at the daemon level, which covers a stopped or paused
+	// container, an invalid container reference, and transient daemon errors.
+	dockerExecDaemonFailureExitCode = 125
 )
 
-// KillSpawnedProcsInContainer kills all processes owned by execUser inside a
-// running isolation container. This is the container-mode equivalent of the
-// host-side killUserProcesses: it runs pkill inside the container's PID
-// namespace via docker exec so that PID 1 (sleep infinity, running as root)
-// is preserved while user-owned processes from the previous task are cleaned up.
+// KillSpawnedProcsInContainer is the container-mode equivalent of
+// killUserProcesses: it kills the processes owned by execUser inside a running
+// isolation container, leaving the container's PID 1 intact. It returns an error
+// matching ErrContainerExecUnavailable if the container could not be reached.
 func KillSpawnedProcsInContainer(ctx context.Context, containerID, execUser string) error {
 	if containerID == "" {
 		return errors.New("containerID cannot be empty")
@@ -110,14 +104,9 @@ func KillSpawnedProcsInContainer(ctx context.Context, containerID, execUser stri
 		exitCode, _ := cmd.Wait(ctx)
 		switch exitCode {
 		case pkillNoMatchingProcessesExitCode:
-			// No user processes found — nothing to kill, not an error.
-		case dockerExecContainerNotRunningExitCode:
-			// docker exec failed at the daemon level (container not running,
-			// paused, invalid reference, or transient daemon error). Return a
-			// sentinel error so callers can log a warning — we cannot kill
-			// processes we cannot reach, but we also do not want to mask the
-			// original task failure with a cleanup error.
-			return ErrContainerExecUnavailable
+			// pkill found no matching processes, so there is nothing to kill.
+		case dockerExecDaemonFailureExitCode:
+			return errors.Wrapf(ErrContainerExecUnavailable, "killing processes for user '%s' in container '%s': %s", execUser, containerID, err)
 		default:
 			return errors.Wrapf(err, "killing processes for user '%s' in container '%s'", execUser, containerID)
 		}

--- a/agent/util/subtree_unix.go
+++ b/agent/util/subtree_unix.go
@@ -99,9 +99,23 @@ func KillSpawnedProcsInContainer(ctx context.Context, containerID, execUser stri
 	if execUser == "" {
 		return errors.New("execUser cannot be empty")
 	}
+	// Unlike killUserProcesses, this needs no sudo. The agent already reaches the
+	// Docker socket unprivileged, and docker exec runs as the image's default
+	// user (normally root), so the in-container pkill can signal execUser's
+	// processes directly. Sudo is only required host-side, where the agent user
+	// cannot signal another user's processes.
 	cmd := jasper.NewCommand().Add([]string{"docker", "exec", containerID, "pkill", "-SIGKILL", "-U", execUser})
 	if err := cmd.Run(ctx); err != nil {
+		// Wait's error is discarded because Run already wraps it; only the exit
+		// code is new information.
 		exitCode, _ := cmd.Wait(ctx)
+		// A cancelled or timed-out context can terminate docker exec with an exit
+		// code that collides with the benign cases below, which would report a
+		// cleanup that never happened as a success, so the code is only
+		// trustworthy while the context is live.
+		if ctx.Err() != nil {
+			return errors.Wrapf(err, "killing processes for user '%s' in container '%s'", execUser, containerID)
+		}
 		switch exitCode {
 		case pkillNoMatchingProcessesExitCode:
 			// pkill found no matching processes, so there is nothing to kill.

--- a/agent/util/subtree_unix_test.go
+++ b/agent/util/subtree_unix_test.go
@@ -157,4 +157,15 @@ func TestKillSpawnedProcsInContainer(t *testing.T) {
 		err := KillSpawnedProcsInContainer(ctx, "somecontainer", "someuser")
 		assert.NoError(t, err)
 	})
+
+	t.Run("CancelledContextErrorsRatherThanReportingBenignExit", func(t *testing.T) {
+		// With no usable exit code, the benign exit-1 and exit-125 branches must
+		// not be reachable, or a cancelled cleanup would look successful.
+		fakeDocker(t, 1)
+		cancelledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+		err := KillSpawnedProcsInContainer(cancelledCtx, "somecontainer", "someuser")
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, ErrContainerExecUnavailable)
+	})
 }

--- a/agent/util/subtree_unix_test.go
+++ b/agent/util/subtree_unix_test.go
@@ -4,7 +4,10 @@ package util
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -13,6 +16,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// fakeDocker installs a stub `docker` binary in a temp dir that exits with
+// the given exit code, and prepends that dir to PATH so jasper resolves it.
+func fakeDocker(t *testing.T, exitCode int) {
+	t.Helper()
+	dir := t.TempDir()
+	script := fmt.Sprintf("#!/bin/sh\nexit %d\n", exitCode)
+	path := filepath.Join(dir, "docker")
+	require.NoError(t, os.WriteFile(path, []byte(script), 0755))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
 
 func TestKillSpawnedProcs(t *testing.T) {
 	for testName, test := range map[string]func(ctx context.Context, t *testing.T){
@@ -97,4 +111,50 @@ func TestParsePs(t *testing.T) {
 	for psOutput, processes := range cases {
 		assert.Equal(t, processes, parsePs(psOutput))
 	}
+}
+
+func TestKillSpawnedProcsInContainer(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("EmptyContainerIDReturnsError", func(t *testing.T) {
+		err := KillSpawnedProcsInContainer(ctx, "", "someuser")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "containerID cannot be empty")
+	})
+
+	t.Run("EmptyExecUserReturnsError", func(t *testing.T) {
+		err := KillSpawnedProcsInContainer(ctx, "somecontainer", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "execUser cannot be empty")
+	})
+
+	t.Run("ExitOneIsNilNoProcsBenign", func(t *testing.T) {
+		// exit 1 = pkill found no matching processes — not an error.
+		fakeDocker(t, 1)
+		err := KillSpawnedProcsInContainer(ctx, "somecontainer", "someuser")
+		assert.NoError(t, err)
+	})
+
+	t.Run("ExitOneTwentyFiveReturnsErrContainerExecUnavailable", func(t *testing.T) {
+		// exit 125 = docker exec daemon-level failure (container not running, etc.)
+		fakeDocker(t, 125)
+		err := KillSpawnedProcsInContainer(ctx, "somecontainer", "someuser")
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrContainerExecUnavailable)
+	})
+
+	t.Run("NonZeroNonBenignExitReturnsWrappedError", func(t *testing.T) {
+		// exit 2 = generic pkill error — should surface as a real failure.
+		fakeDocker(t, 2)
+		err := KillSpawnedProcsInContainer(ctx, "somecontainer", "someuser")
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, ErrContainerExecUnavailable)
+	})
+
+	t.Run("ZeroExitIsNilProcessesKilled", func(t *testing.T) {
+		// exit 0 = pkill found and killed at least one process — success.
+		fakeDocker(t, 0)
+		err := KillSpawnedProcsInContainer(ctx, "somecontainer", "someuser")
+		assert.NoError(t, err)
+	})
 }

--- a/agent/util/subtree_windows.go
+++ b/agent/util/subtree_windows.go
@@ -369,6 +369,12 @@ func (we *WindowsError) Error() string {
 	return fmt.Sprintf("gowin32: %s failed: %v", we.functionName, we.innerError)
 }
 
+// KillSpawnedProcsInContainer is a no-op on Windows; container isolation is
+// Linux-only.
+func KillSpawnedProcsInContainer(_ context.Context, _, _ string) error {
+	return nil
+}
+
 // GetNice is a no-op in Windows and returns the default nice.
 func GetNice(int) (int, error) {
 	return DefaultNice, nil

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-08-03"
+	AgentVersion = "2026-08-04"
 )
 
 const (


### PR DESCRIPTION
PLATFORMS-2440: Add container command wrapping and process cleanup

PLATFORMS-2440

**Stack: PR 4 of 9 — depends on `pr03-container-package` (`https://github.com/evergreen-ci/evergreen/pull/10613`).**

This PR is safe to merge alone because the helpers have no callers outside `agent/util` at this position.

### Description

Adds utilities that translate eligible host commands into Docker execution, safely create per-command environment files, and clean process subtrees inside containers.

### Where these get wired up

Both exported helpers are intentionally caller-free in this slice; the next slice in the stack adds the call sites:

- `WrapWithContainer` is called from `agent/command/exec.go` and `agent/command/shell.go`, wrapping the existing `options.Create` before the command runs.
- `KillSpawnedProcsInContainer` is called from `agent/agent.go` during task cleanup, alongside the existing host-side `KillSpawnedProcs`.
- The `.evg-host-env` file that `WrapWithContainer` looks for is written in `agent/container.go` when the container's env tmpfs is set up, which also lands in that slice. Until then the lookup finds nothing and is skipped, which is the tested `MissingHostEnvFileIsOmitted` case.

Splitting them this way keeps this PR reviewable in isolation; happy to fold it into the caller PR instead if you would rather review them together.

### Documentation

No user-facing documentation changes are required in this slice. Stack ordering and cross-PR links are maintained separately.
