### PR TITLE
DEVPROD-40853: Prevent stale display task restarts from failing newer executions

### DIFF
--- a/graphql/tests/mutation/restartTask/data.json
+++ b/graphql/tests/mutation/restartTask/data.json
@@ -5,11 +5,13 @@
       "build_id": "build1",
       "status": "success",
       "version": "version1",
+      "latest_parent_execution": 0,
       "branch": "sandbox_project_id"
     },
     {
       "_id": "task2",
       "status": "success",
+      "latest_parent_execution": 0,
       "branch": "sandbox_project_id"
     },
     {
@@ -19,6 +21,7 @@
       "status": "success",
       "display_only": true,
       "execution": 0,
+      "latest_parent_execution": 0,
       "execution_tasks": ["execution_task_1", "execution_task_2"],
       "branch": "sandbox_project_id"
     },
@@ -41,6 +44,7 @@
       "build_id": "build1",
       "status": "success",
       "version": "version1",
+      "latest_parent_execution": 0,
       "branch": "evergreen"
     }
   ],

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2189,7 +2189,16 @@ func (t *Task) MarkEnd(ctx context.Context, finishTime time.Time, detail *apimod
 		TaskOutputInfoKey:     t.TaskOutputInfo,
 	}
 	ec2EBSSetFields(TaskCostKey, t.TaskCost, setFields)
-	return UpdateOne(ctx, bson.M{IdKey: t.Id}, bson.M{"$set": setFields})
+	query := ByIdAndExecution(t.Id, t.Execution)
+	if t.DisplayTaskId == nil {
+		query["$or"] = []bson.M{
+			{LatestParentExecutionKey: t.LatestParentExecution},
+			{LatestParentExecutionKey: bson.M{"$exists": false}},
+		}
+	} else if utility.FromStringPtr(t.DisplayTaskId) != "" {
+		query[LatestParentExecutionKey] = t.LatestParentExecution
+	}
+	return UpdateOne(ctx, query, bson.M{"$set": setFields})
 }
 
 // GetDisplayStatus finds and sets DisplayStatus to the task. It should reflect
@@ -3200,19 +3209,31 @@ func (t *Task) GetTestResultsTasks(ctx context.Context) ([]Task, error) {
 // SetResetWhenFinished requests that a display task or single-host task group
 // reset itself when finished. Will mark itself as system failed.
 func (t *Task) SetResetWhenFinished(ctx context.Context, caller string) error {
+	return t.setResetWhenFinished(ctx, caller, nil)
+}
+
+// SetResetWhenFinishedAtExecution requests a reset only if the task is at the expected execution.
+func (t *Task) SetResetWhenFinishedAtExecution(ctx context.Context, caller string, execution int) error {
+	return t.setResetWhenFinished(ctx, caller, &execution)
+}
+
+func (t *Task) setResetWhenFinished(ctx context.Context, caller string, execution *int) error {
 	if t.ResetWhenFinished {
+		if execution != nil {
+			return UpdateOne(ctx, bson.M{IdKey: t.Id, ExecutionKey: *execution}, bson.M{"$set": bson.M{ResetWhenFinishedKey: true}})
+		}
 		return nil
 	}
 	if err := updateSchedulingLimitForResetWhenFinished(ctx, t, caller); err != nil {
 		return errors.Wrapf(err, "updating user '%s' patch task scheduling limit", caller)
 	}
-	t.ResetFailedWhenFinished = false
-	t.ResetWhenFinished = true
-	return UpdateOne(
+	query := bson.M{IdKey: t.Id}
+	if execution != nil {
+		query[ExecutionKey] = *execution
+	}
+	err := UpdateOne(
 		ctx,
-		bson.M{
-			IdKey: t.Id,
-		},
+		query,
 		bson.M{
 			"$unset": bson.M{
 				ResetFailedWhenFinishedKey: 1,
@@ -3222,6 +3243,12 @@ func (t *Task) SetResetWhenFinished(ctx context.Context, caller string) error {
 			},
 		},
 	)
+	if err != nil {
+		return err
+	}
+	t.ResetFailedWhenFinished = false
+	t.ResetWhenFinished = true
+	return nil
 }
 
 // SetResetWhenFinishedWithInc requests that a task (that was marked to
@@ -3261,19 +3288,31 @@ func (t *Task) SetResetWhenFinishedWithInc(ctx context.Context) error {
 // SetResetFailedWhenFinished requests that a display task
 // only restarts failed tasks.
 func (t *Task) SetResetFailedWhenFinished(ctx context.Context, caller string) error {
+	return t.setResetFailedWhenFinished(ctx, caller, nil)
+}
+
+// SetResetFailedWhenFinishedAtExecution requests a failed-only reset if the task is at the expected execution.
+func (t *Task) SetResetFailedWhenFinishedAtExecution(ctx context.Context, caller string, execution int) error {
+	return t.setResetFailedWhenFinished(ctx, caller, &execution)
+}
+
+func (t *Task) setResetFailedWhenFinished(ctx context.Context, caller string, execution *int) error {
 	if t.ResetFailedWhenFinished {
+		if execution != nil {
+			return UpdateOne(ctx, bson.M{IdKey: t.Id, ExecutionKey: *execution}, bson.M{"$set": bson.M{ResetFailedWhenFinishedKey: true}})
+		}
 		return nil
 	}
 	if err := updateSchedulingLimitForResetWhenFinished(ctx, t, caller); err != nil {
 		return errors.Wrapf(err, "updating user '%s' patch task scheduling limit", caller)
 	}
-	t.ResetWhenFinished = false
-	t.ResetFailedWhenFinished = true
-	return UpdateOne(
+	query := bson.M{IdKey: t.Id}
+	if execution != nil {
+		query[ExecutionKey] = *execution
+	}
+	err := UpdateOne(
 		ctx,
-		bson.M{
-			IdKey: t.Id,
-		},
+		query,
 		bson.M{
 			"$unset": bson.M{
 				ResetWhenFinishedKey: 1,
@@ -3283,6 +3322,12 @@ func (t *Task) SetResetFailedWhenFinished(ctx context.Context, caller string) er
 			},
 		},
 	)
+	if err != nil {
+		return err
+	}
+	t.ResetWhenFinished = false
+	t.ResetFailedWhenFinished = true
+	return nil
 }
 
 func updateSchedulingLimitForResetWhenFinished(ctx context.Context, t *Task, caller string) error {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2189,8 +2189,12 @@ func (t *Task) MarkEnd(ctx context.Context, finishTime time.Time, detail *apimod
 		TaskOutputInfoKey:     t.TaskOutputInfo,
 	}
 	ec2EBSSetFields(TaskCostKey, t.TaskCost, setFields)
+	// End-task requests can race with display-task resets, so constrain the update
+	// to the execution and parent generation that issued it.
 	query := ByIdAndExecution(t.Id, t.Execution)
 	if t.DisplayTaskId == nil {
+		// A nil display task ID is ambiguous for legacy tasks, so allow documents
+		// with no parent generation while still guarding those that have one.
 		query["$or"] = []bson.M{
 			{LatestParentExecutionKey: t.LatestParentExecution},
 			{LatestParentExecutionKey: bson.M{"$exists": false}},
@@ -3220,6 +3224,8 @@ func (t *Task) SetResetWhenFinishedAtExecution(ctx context.Context, caller strin
 func (t *Task) setResetWhenFinished(ctx context.Context, caller string, execution *int) error {
 	if t.ResetWhenFinished {
 		if execution != nil {
+			// Validate idempotent requests against the database so a stale display
+			// generation cannot reset the current one.
 			return UpdateOne(ctx, bson.M{IdKey: t.Id, ExecutionKey: *execution}, bson.M{"$set": bson.M{ResetWhenFinishedKey: true}})
 		}
 		return nil
@@ -3299,6 +3305,8 @@ func (t *Task) SetResetFailedWhenFinishedAtExecution(ctx context.Context, caller
 func (t *Task) setResetFailedWhenFinished(ctx context.Context, caller string, execution *int) error {
 	if t.ResetFailedWhenFinished {
 		if execution != nil {
+			// Validate idempotent requests against the database so a stale display
+			// generation cannot reset the current one.
 			return UpdateOne(ctx, bson.M{IdKey: t.Id, ExecutionKey: *execution}, bson.M{"$set": bson.M{ResetFailedWhenFinishedKey: true}})
 		}
 		return nil

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2192,16 +2192,7 @@ func (t *Task) MarkEnd(ctx context.Context, finishTime time.Time, detail *apimod
 	// End-task requests can race with display-task resets, so constrain the update
 	// to the execution and parent generation that issued it.
 	query := ByIdAndExecution(t.Id, t.Execution)
-	if t.DisplayTaskId == nil {
-		// A nil display task ID is ambiguous for legacy tasks, so allow documents
-		// with no parent generation while still guarding those that have one.
-		query["$or"] = []bson.M{
-			{LatestParentExecutionKey: t.LatestParentExecution},
-			{LatestParentExecutionKey: bson.M{"$exists": false}},
-		}
-	} else if utility.FromStringPtr(t.DisplayTaskId) != "" {
-		query[LatestParentExecutionKey] = t.LatestParentExecution
-	}
+	query[LatestParentExecutionKey] = t.LatestParentExecution
 	return UpdateOne(ctx, query, bson.M{"$set": setFields})
 }
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1164,6 +1164,32 @@ func TestMarkEnd(t *testing.T) {
 	})
 }
 
+func TestMarkEndStaleDisplayGenerationDoesNotEndCurrentTask(t *testing.T) {
+	ctx := t.Context()
+	t.Cleanup(func() {
+		require.NoError(t, db.Clear(Collection))
+	})
+
+	current := Task{
+		Id:                    "execution_task",
+		Execution:             0,
+		LatestParentExecution: 2,
+		Status:                evergreen.TaskUndispatched,
+	}
+	require.NoError(t, current.Insert(ctx))
+
+	stale := current
+	stale.LatestParentExecution = 1
+	err := stale.MarkEnd(ctx, time.Now(), &apimodels.TaskEndDetail{Status: evergreen.TaskFailed})
+	require.Error(t, err)
+
+	dbTask, err := FindOneId(ctx, current.Id)
+	require.NoError(t, err)
+	require.NotNil(t, dbTask)
+	assert.Equal(t, evergreen.TaskUndispatched, dbTask.Status)
+	assert.True(t, utility.IsZeroTime(dbTask.FinishTime))
+}
+
 func TestTaskResultOutcome(t *testing.T) {
 	assert := assert.New(t)
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -273,6 +273,14 @@ func resetManyTasks(ctx context.Context, tasks []task.Task, caller string) error
 // reset an execution task, the given task ID must be that of its parent display
 // task.
 func TryResetTask(ctx context.Context, settings *evergreen.Settings, taskId, user, origin string, detail *apimodels.TaskEndDetail) error {
+	return tryResetTask(ctx, settings, taskId, user, origin, detail, nil)
+}
+
+func tryResetDisplayTask(ctx context.Context, settings *evergreen.Settings, taskId, user, origin string, detail *apimodels.TaskEndDetail, expectedExecution int) error {
+	return tryResetTask(ctx, settings, taskId, user, origin, detail, &expectedExecution)
+}
+
+func tryResetTask(ctx context.Context, settings *evergreen.Settings, taskId, user, origin string, detail *apimodels.TaskEndDetail, expectedExecution *int) error {
 	t, err := task.FindOneId(ctx, taskId)
 	if err != nil {
 		return errors.WithStack(err)
@@ -282,6 +290,9 @@ func TryResetTask(ctx context.Context, settings *evergreen.Settings, taskId, use
 	}
 	if t.IsPartOfDisplay(ctx) {
 		return errors.Errorf("cannot restart execution task '%s' because it is part of a display task", t.Id)
+	}
+	if expectedExecution != nil && t.Execution != *expectedExecution {
+		return nil
 	}
 
 	var execTask *task.Task
@@ -305,7 +316,13 @@ func TryResetTask(ctx context.Context, settings *evergreen.Settings, taskId, use
 						if err != nil {
 							return errors.Wrap(err, "finding execution task")
 						}
+						if execTask.Execution != t.Execution || execTask.LatestParentExecution != t.Execution {
+							continue
+						}
 						if err = MarkEnd(ctx, settings, execTask, origin, time.Now(), detail); err != nil {
+							if adb.ResultsNotFound(err) {
+								continue
+							}
 							return errors.Wrap(err, "marking execution task as ended")
 						}
 					}
@@ -2617,7 +2634,9 @@ func endAndResetSystemFailedTask(ctx context.Context, settings *evergreen.Settin
 // Marks display tasks as reset when finished and then check if it can be reset immediately.
 func ResetTaskOrDisplayTask(ctx context.Context, settings *evergreen.Settings, t *task.Task, user, origin string, failedOnly bool, detail *apimodels.TaskEndDetail) error {
 	taskToReset := *t
+	expectedDisplayExecution := taskToReset.Execution
 	if taskToReset.IsPartOfDisplay(ctx) { // if given an execution task, attempt to restart the full display task
+		expectedDisplayExecution = taskToReset.LatestParentExecution
 		dt, err := taskToReset.GetDisplayTask(ctx)
 		if err != nil {
 			return errors.Wrap(err, "getting display task")
@@ -2628,11 +2647,17 @@ func ResetTaskOrDisplayTask(ctx context.Context, settings *evergreen.Settings, t
 	}
 	if taskToReset.DisplayOnly {
 		if failedOnly {
-			if err := taskToReset.SetResetFailedWhenFinished(ctx, user); err != nil {
+			if err := taskToReset.SetResetFailedWhenFinishedAtExecution(ctx, user, expectedDisplayExecution); err != nil {
+				if adb.ResultsNotFound(err) {
+					return nil
+				}
 				return errors.Wrap(err, "marking display task for reset")
 			}
 		} else {
-			if err := taskToReset.SetResetWhenFinished(ctx, user); err != nil {
+			if err := taskToReset.SetResetWhenFinishedAtExecution(ctx, user, expectedDisplayExecution); err != nil {
+				if adb.ResultsNotFound(err) {
+					return nil
+				}
 				return errors.Wrap(err, "marking display task for reset")
 			}
 		}
@@ -2900,7 +2925,7 @@ func checkResetDisplayTask(ctx context.Context, setting *evergreen.Settings, use
 	if t.IsAutomaticRestart {
 		user = evergreen.AutoRestartActivator
 	}
-	return errors.Wrap(TryResetTask(ctx, setting, t.Id, user, origin, details), "resetting display task")
+	return errors.Wrap(tryResetDisplayTask(ctx, setting, t.Id, user, origin, details, t.Execution), "resetting display task")
 }
 
 // HandleEndTaskForGithubMergeQueueTask stops running GitHub merge queue tasks as soon as one task is finished.

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -5149,6 +5149,104 @@ func TestDisplayTaskUpdatesAreConcurrencySafe(t *testing.T) {
 	assert.Equal(t, event.TaskFinished, latestEvents[0].EventType, "should have logged event for display task finished")
 }
 
+func TestTryResetDisplayTask(t *testing.T) {
+	ctx := t.Context()
+	t.Cleanup(func() {
+		require.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection, VersionCollection, ProjectRefCollection, ParserProjectCollection))
+	})
+
+	const displayTaskID = "display_task"
+	execTask := task.Task{
+		Id:                    "execution_task",
+		DisplayTaskId:         utility.ToStringPtr(displayTaskID),
+		Execution:             2,
+		LatestParentExecution: 2,
+		Activated:             true,
+		Status:                evergreen.TaskUndispatched,
+	}
+	displayTask := task.Task{
+		Id:             displayTaskID,
+		DisplayTaskId:  utility.ToStringPtr(""),
+		DisplayOnly:    true,
+		ExecutionTasks: []string{execTask.Id},
+		Execution:      2,
+		Activated:      true,
+		Status:         evergreen.TaskStarted,
+	}
+	require.NoError(t, execTask.Insert(ctx))
+	require.NoError(t, displayTask.Insert(ctx))
+
+	detail := &apimodels.TaskEndDetail{Status: evergreen.TaskFailed, Type: evergreen.CommandTypeSystem}
+	staleExecTask := execTask
+	staleExecTask.LatestParentExecution = 1
+	require.NoError(t, ResetTaskOrDisplayTask(ctx, testutil.TestConfig(), &staleExecTask, evergreen.User, evergreen.MonitorPackage, true, detail))
+
+	dbDisplayTask, err := task.FindOneId(ctx, displayTask.Id)
+	require.NoError(t, err)
+	require.NotNil(t, dbDisplayTask)
+	assert.False(t, dbDisplayTask.ResetWhenFinished)
+	assert.False(t, dbDisplayTask.ResetFailedWhenFinished)
+	require.NoError(t, task.UpdateOne(ctx, bson.M{task.IdKey: displayTask.Id}, bson.M{"$set": bson.M{task.ResetFailedWhenFinishedKey: true}}))
+	require.NoError(t, ResetTaskOrDisplayTask(ctx, testutil.TestConfig(), &staleExecTask, evergreen.User, evergreen.MonitorPackage, true, detail))
+	dbExecTask, err := task.FindOneId(ctx, execTask.Id)
+	require.NoError(t, err)
+	require.NotNil(t, dbExecTask)
+	assert.Equal(t, evergreen.TaskUndispatched, dbExecTask.Status)
+	assert.True(t, utility.IsZeroTime(dbExecTask.FinishTime))
+
+	require.NoError(t, tryResetDisplayTask(ctx, testutil.TestConfig(), displayTask.Id, evergreen.User, evergreen.MonitorPackage, detail, 1))
+
+	dbExecTask, err = task.FindOneId(ctx, execTask.Id)
+	require.NoError(t, err)
+	require.NotNil(t, dbExecTask)
+	assert.Equal(t, evergreen.TaskUndispatched, dbExecTask.Status)
+	assert.True(t, utility.IsZeroTime(dbExecTask.FinishTime))
+
+	dbDisplayTask, err = task.FindOneId(ctx, displayTask.Id)
+	require.NoError(t, err)
+	require.NotNil(t, dbDisplayTask)
+	assert.Equal(t, 2, dbDisplayTask.Execution)
+	assert.Equal(t, evergreen.TaskStarted, dbDisplayTask.Status)
+
+	require.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection, VersionCollection, ProjectRefCollection, ParserProjectCollection))
+	const (
+		buildID   = "build"
+		versionID = "version"
+		projectID = "project"
+	)
+	sparseExecTask := task.Task{
+		Id:                    "sparse_execution_task",
+		DisplayTaskId:         utility.ToStringPtr(displayTaskID),
+		BuildId:               buildID,
+		Version:               versionID,
+		Project:               projectID,
+		Execution:             0,
+		LatestParentExecution: 1,
+		Activated:             true,
+		Status:                evergreen.TaskSucceeded,
+	}
+	displayTask.Execution = 1
+	displayTask.Status = evergreen.TaskStarted
+	displayTask.ExecutionTasks = []string{sparseExecTask.Id}
+	displayTask.BuildId = buildID
+	displayTask.Version = versionID
+	displayTask.Project = projectID
+	require.NoError(t, (&ProjectRef{Id: projectID}).Insert(ctx))
+	require.NoError(t, (&ParserProject{Id: versionID, Identifier: utility.ToStringPtr(projectID)}).Insert(ctx))
+	require.NoError(t, (&build.Build{Id: buildID, Version: versionID, Status: evergreen.BuildStarted}).Insert(ctx))
+	require.NoError(t, (&Version{Id: versionID, Identifier: projectID, Status: evergreen.VersionStarted}).Insert(ctx))
+	require.NoError(t, sparseExecTask.Insert(ctx))
+	require.NoError(t, displayTask.Insert(ctx))
+
+	require.NoError(t, TryResetTask(ctx, testutil.TestConfig(), displayTask.Id, evergreen.User, evergreen.MonitorPackage, detail))
+
+	dbSparseExecTask, err := task.FindOneId(ctx, sparseExecTask.Id)
+	require.NoError(t, err)
+	require.NotNil(t, dbSparseExecTask)
+	assert.Equal(t, evergreen.TaskSucceeded, dbSparseExecTask.Status)
+	assert.Equal(t, 0, dbSparseExecTask.Execution)
+}
+
 func TestAbortedTaskDelayedRestart(t *testing.T) {
 	ctx := t.Context()
 


### PR DESCRIPTION
DEVPROD-40853

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->
Fixes a race where stale display task restart handling can mark a newly reset execution task as system-failed before it dispatches.

Display task completion paths can run concurrently. After a display task advances to a new execution, handling from the previous execution could still set reset flags or finalize children. Since `MarkEnd` previously updated by task ID alone, this could modify the newer child execution.

This scopes restart handling to the expected display execution and parent generation. It also preserves successful sparse child executions when applying the retry cap.

### Testing

<!--add a description of how you tested it-->
Unit tests