### PR TITLE
DEVPROD-38266 Allow task history GET options in query parameters

### DIFF
--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -1015,7 +1016,7 @@ func (h *modifyProjectVersionsHandler) Run(ctx context.Context) gimlet.Responder
 
 ////////////////////////////////////////////////////////////////////////
 //
-// GET /rest/v2/projects/{project_id}/tasks/{task_id}
+// GET /rest/v2/projects/{project_id}/tasks/{task_name}
 
 type getProjectTasksHandler struct {
 	projectName string
@@ -1031,14 +1032,18 @@ func makeGetProjectTasksHandler() gimlet.RouteHandler {
 // Factory creates an instance of the handler.
 //
 //	@Summary		Get tasks for a project
-//	@Description	Returns the last set number of completed tasks that exist for a given project. Parameters should be passed into the JSON body. Ensure that a task name rather than a task ID is passed into the URL.
+//	@Description	Returns the last set number of completed tasks that exist for a given project. Parameters can be passed as query parameters or in the JSON body. Query parameters override body parameters. Ensure that a task name rather than a task ID is passed into the URL.
 //	@Tags			tasks
 //	@Router			/projects/{project_id}/tasks/{task_name} [get]
 //	@Security		Api-User || Api-Key
-//	@Param			project_id	path	string						true	"the project ID"
-//	@Param			task_name	path	string						true	"the task name"
-//	@Param			{object}	body	model.GetProjectTasksOpts	false	"parameters"
-//	@Success		200			{array}	model.APITask
+//	@Param			project_id		path	string						true	"the project ID"
+//	@Param			task_name		path	string						true	"the task name"
+//	@Param			num_versions	query	int							false	"The number of versions to search. Defaults to 5."
+//	@Param			build_variant	query	string						false	"Only return tasks for this build variant."
+//	@Param			start_at		query	int							false	"The revision order number to start at."
+//	@Param			requesters		query	[]string					false	"Only return tasks for these requester types. Can be comma-separated or specified multiple times."	collectionFormat(multi)
+//	@Param			{object}		body	model.GetProjectTasksOpts	false	"parameters"
+//	@Success		200				{array}	model.APITask
 func (h *getProjectTasksHandler) Factory() gimlet.RouteHandler {
 	return &getProjectTasksHandler{}
 }
@@ -1046,11 +1051,35 @@ func (h *getProjectTasksHandler) Factory() gimlet.RouteHandler {
 func (h *getProjectTasksHandler) Parse(ctx context.Context, r *http.Request) error {
 	h.projectName = gimlet.GetVars(r)["project_id"]
 	h.taskName = gimlet.GetVars(r)["task_name"]
+	params := r.URL.Query()
 	// body is optional
 	b, _ := io.ReadAll(r.Body)
 	if len(b) > 0 {
 		if err := json.Unmarshal(b, &h.opts); err != nil {
 			return errors.Wrap(err, "reading project task options from JSON request body")
+		}
+	}
+	if limitStr := params.Get("num_versions"); limitStr != "" {
+		limit, err := strconv.Atoi(limitStr)
+		if err != nil {
+			return errors.Wrap(err, "invalid num_versions query parameter")
+		}
+		h.opts.Limit = limit
+	}
+	if buildVariant, ok := params["build_variant"]; ok {
+		h.opts.BuildVariant = buildVariant[0]
+	}
+	if startAtStr := params.Get("start_at"); startAtStr != "" {
+		startAt, err := strconv.Atoi(startAtStr)
+		if err != nil {
+			return errors.Wrap(err, "invalid start_at query parameter")
+		}
+		h.opts.StartAt = startAt
+	}
+	if requesters, ok := params["requesters"]; ok {
+		h.opts.Requesters = nil
+		for _, requester := range requesters {
+			h.opts.Requesters = append(h.opts.Requesters, strings.Split(requester, ",")...)
 		}
 	}
 	if h.opts.Limit < 0 {

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -904,6 +904,85 @@ func TestGetProjectTasks(t *testing.T) {
 	assert.Len(resp.Data(), 21)
 }
 
+func TestGetProjectTasksParse(t *testing.T) {
+	ctx := t.Context()
+
+	for testName, testCase := range map[string]func(*testing.T){
+		"DefaultsWhenNoOptionsSpecified": func(t *testing.T) {
+			h := &getProjectTasksHandler{}
+			req, err := http.NewRequest(http.MethodGet, "https://example.com/rest/v2/projects/proj/tasks/task", http.NoBody)
+			require.NoError(t, err)
+			req = gimlet.SetURLVars(req, map[string]string{"project_id": "proj", "task_name": "task"})
+			require.NoError(t, h.Parse(ctx, req))
+			assert.Equal(t, defaultVersionLimit, h.opts.Limit)
+		},
+		"AcceptsBodyOptions": func(t *testing.T) {
+			h := &getProjectTasksHandler{}
+			req, err := http.NewRequest(http.MethodGet, "https://example.com/rest/v2/projects/proj/tasks/task", bytes.NewBufferString(`{"num_versions":10,"build_variant":"variant","start_at":20,"requesters":["ad_hoc"]}`))
+			require.NoError(t, err)
+			req = gimlet.SetURLVars(req, map[string]string{"project_id": "proj", "task_name": "task"})
+			require.NoError(t, h.Parse(ctx, req))
+			assert.Equal(t, model.GetProjectTasksOpts{
+				Limit:        10,
+				BuildVariant: "variant",
+				StartAt:      20,
+				Requesters:   []string{evergreen.AdHocRequester},
+			}, h.opts)
+		},
+		"AcceptsQueryOptions": func(t *testing.T) {
+			h := &getProjectTasksHandler{}
+			req, err := http.NewRequest(http.MethodGet, "https://example.com/rest/v2/projects/proj/tasks/task?num_versions=10&build_variant=variant&start_at=20&requesters=ad_hoc&requesters=gitter_request", http.NoBody)
+			require.NoError(t, err)
+			req = gimlet.SetURLVars(req, map[string]string{"project_id": "proj", "task_name": "task"})
+			require.NoError(t, h.Parse(ctx, req))
+			assert.Equal(t, model.GetProjectTasksOpts{
+				Limit:        10,
+				BuildVariant: "variant",
+				StartAt:      20,
+				Requesters:   []string{evergreen.AdHocRequester, evergreen.RepotrackerVersionRequester},
+			}, h.opts)
+		},
+		"AcceptsCommaSeparatedRequesters": func(t *testing.T) {
+			h := &getProjectTasksHandler{}
+			req, err := http.NewRequest(http.MethodGet, "https://example.com/rest/v2/projects/proj/tasks/task?requesters=ad_hoc,gitter_request", http.NoBody)
+			require.NoError(t, err)
+			req = gimlet.SetURLVars(req, map[string]string{"project_id": "proj", "task_name": "task"})
+			require.NoError(t, h.Parse(ctx, req))
+			assert.Equal(t, []string{evergreen.AdHocRequester, evergreen.RepotrackerVersionRequester}, h.opts.Requesters)
+		},
+		"QueryOptionsOverrideBodyOptions": func(t *testing.T) {
+			h := &getProjectTasksHandler{}
+			req, err := http.NewRequest(http.MethodGet, "https://example.com/rest/v2/projects/proj/tasks/task?num_versions=10&build_variant=query_variant&start_at=20&requesters=gitter_request", bytes.NewBufferString(`{"num_versions":5,"build_variant":"body_variant","start_at":10,"requesters":["ad_hoc"]}`))
+			require.NoError(t, err)
+			req = gimlet.SetURLVars(req, map[string]string{"project_id": "proj", "task_name": "task"})
+			require.NoError(t, h.Parse(ctx, req))
+			assert.Equal(t, model.GetProjectTasksOpts{
+				Limit:        10,
+				BuildVariant: "query_variant",
+				StartAt:      20,
+				Requesters:   []string{evergreen.RepotrackerVersionRequester},
+			}, h.opts)
+		},
+		"RejectsInvalidQueryOptions": func(t *testing.T) {
+			for _, query := range []string{
+				"num_versions=not_an_int",
+				"num_versions=-1",
+				"start_at=not_an_int",
+				"start_at=-1",
+				"requesters=invalid",
+			} {
+				h := &getProjectTasksHandler{}
+				req, err := http.NewRequest(http.MethodGet, "https://example.com/rest/v2/projects/proj/tasks/task?"+query, http.NoBody)
+				require.NoError(t, err)
+				req = gimlet.SetURLVars(req, map[string]string{"project_id": "proj", "task_name": "task"})
+				assert.Error(t, h.Parse(ctx, req))
+			}
+		},
+	} {
+		t.Run(testName, testCase)
+	}
+}
+
 func TestGetProjectVersions(t *testing.T) {
 	assert := assert.New(t)
 	ctx := t.Context()


### PR DESCRIPTION
[DEVPROD-38266](https://jira.mongodb.org/browse/DEVPROD-38266)

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->

Adds query parameters to our task history route, it currently only supports an object body.

### Testing

<!--add a description of how you tested it-->
Unit tests

### Documentation


Updated our documentation.
<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
