### PR TITLE
DEVPROD-40877 Honor the artifact AWS accounts without lifecycle rules list for key+secret uploads

### DIFF
--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -374,9 +374,9 @@ func (s3pc *s3put) Execute(ctx context.Context, comm client.Communicator, logger
 		}
 	}
 
-	// For key+secret uploads with no role ARN, resolve the AWS account ID via STS so that
-	// cost tracking can gate on devprod-owned accounts just like role-ARN uploads.
-	if s3pc.getRoleARN() == "" && s3pc.AwsKey != "" && len(conf.DevprodOwnedAWSAccountIDs) > 0 {
+	// For key+secret uploads with no role ARN, resolve the AWS account ID via STS so cost tracking and lifecycle rule discovery can gate on it.
+	needsAccountID := len(conf.DevprodOwnedAWSAccountIDs) > 0 || len(conf.ArtifactAWSAccountsWithoutLifecycleRules) > 0
+	if s3pc.getRoleARN() == "" && s3pc.AwsKey != "" && needsAccountID {
 		accountID, err := conf.GetOrSetCachedAWSAccountID(s3pc.AwsKey, func() (string, error) {
 			return resolveAWSAccountIDFromStaticCredentials(ctx, s3pc.AwsKey, s3pc.AwsSecret, s3pc.AwsSessionToken, s3pc.Region)
 		})

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -75,6 +75,9 @@ type TaskConfig struct {
 	// DevprodOwnedAWSAccountIDs contains the AWS account IDs of the accounts that are
 	// owned by Devprod that we want to calculate s3 costs for.
 	DevprodOwnedAWSAccountIDs []string
+	// ArtifactAWSAccountsWithoutLifecycleRules contains the AWS account IDs of the accounts that we
+	// calculate s3 costs for but cannot read lifecycle rules from.
+	ArtifactAWSAccountsWithoutLifecycleRules []string
 	// awsAccountIDByKey caches resolved AWS account IDs keyed by AWS access key ID,
 	// so repeated s3.put commands using the same key avoid redundant STS calls.
 	awsAccountIDByKey map[string]string
@@ -288,6 +291,7 @@ func NewTaskConfig(opts TaskConfigOptions) (*TaskConfig, error) {
 
 	if opts.ExpansionsAndVars != nil {
 		taskConfig.DevprodOwnedAWSAccountIDs = opts.ExpansionsAndVars.DevprodOwnedAWSAccountIDs
+		taskConfig.ArtifactAWSAccountsWithoutLifecycleRules = opts.ExpansionsAndVars.ArtifactAWSAccountsWithoutLifecycleRules
 	}
 
 	if opts.ExpansionsAndVars != nil && opts.ExpansionsAndVars.Expansions != nil {

--- a/agent/internal/task_config_test.go
+++ b/agent/internal/task_config_test.go
@@ -63,14 +63,16 @@ func TestNewTaskConfig(t *testing.T) {
 			PrivateVars: map[string]bool{
 				"aws_token": true,
 			},
-			RedactKeys:                []string{"pass", "secret", "token"},
-			DevprodOwnedAWSAccountIDs: []string{"123456789012"},
+			RedactKeys:                               []string{"pass", "secret", "token"},
+			DevprodOwnedAWSAccountIDs:                []string{"123456789012"},
+			ArtifactAWSAccountsWithoutLifecycleRules: []string{"210987654321"},
 		},
 	}
 	taskConfig, err := NewTaskConfig(tcOpts)
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{"123456789012"}, taskConfig.DevprodOwnedAWSAccountIDs)
+	assert.Equal(t, []string{"210987654321"}, taskConfig.ArtifactAWSAccountsWithoutLifecycleRules)
 	assert.Empty(t, taskConfig.DynamicExpansions)
 	assert.Empty(t, taskConfig.Expansions)
 	assert.ElementsMatch(t, []string{"aws_token", "my_pass_secret", "myPASSWORD", "mySecret", "git_token"}, taskConfig.Redacted)

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -392,6 +392,9 @@ type ExpansionsAndVars struct {
 	// DevprodOwnedAWSAccountIDs contains the AWS account IDs of the accounts that are
 	// owned by Devprod that we want to calculate s3 costs for.
 	DevprodOwnedAWSAccountIDs []string `json:"devprod_owned_aws_account_ids,omitempty"`
+	// ArtifactAWSAccountsWithoutLifecycleRules contains the AWS account IDs of the accounts that we
+	// calculate s3 costs for but cannot read lifecycle rules from.
+	ArtifactAWSAccountsWithoutLifecycleRules []string `json:"artifact_aws_accounts_without_lifecycle_rules,omitempty"`
 }
 
 // CheckRunOutput represents the output for a CheckRun.

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-08-03"
+	AgentVersion = "2026-08-04"
 )
 
 const (

--- a/model/s3lifecycle/s3_lifecycle.go
+++ b/model/s3lifecycle/s3_lifecycle.go
@@ -110,10 +110,12 @@ type S3LifecycleClient interface {
 // DiscoverAndCacheProjectBucket checks if we have lifecycle rules cached for a bucket and fetches them if not.
 // It returns true if rules were successfully cached (discovery succeeded), false if already cached, if the
 // bucket's account is in accountsWithoutLifecycleRules, or if discovery failed.
+// fallbackAccountID is used when the account cannot be derived from roleARN, which is the case for key+secret
+// uploads. Without it those buckets bypass the skip list entirely.
 // This is best-effort - errors are logged but not returned to avoid failing file uploads.
-func DiscoverAndCacheProjectBucket(ctx context.Context, bucketName, region string, roleARN *string, externalID *string, projectID string, accountsWithoutLifecycleRules []string, client S3LifecycleClient) bool {
+func DiscoverAndCacheProjectBucket(ctx context.Context, bucketName, region string, roleARN *string, externalID *string, fallbackAccountID, projectID string, accountsWithoutLifecycleRules []string, client S3LifecycleClient) bool {
 	// Derive the AWS account ID from the role ARN so we can check it against the skip list.
-	var awsAccountID string
+	awsAccountID := fallbackAccountID
 	if roleARN != nil {
 		if id, ok := util.AWSAccountIDFromIAMARN(*roleARN); ok {
 			awsAccountID = id

--- a/model/s3lifecycle/s3_lifecycle_test.go
+++ b/model/s3lifecycle/s3_lifecycle_test.go
@@ -310,7 +310,7 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 			},
 		}
 
-		discovered := DiscoverAndCacheProjectBucket(t.Context(), "test-bucket", "us-east-1", &roleARN, nil, "test-project", nil, mockClient)
+		discovered := DiscoverAndCacheProjectBucket(t.Context(), "test-bucket", "us-east-1", &roleARN, nil, "", "test-project", nil, mockClient)
 		assert.True(t, discovered, "should trigger discovery for new bucket")
 
 		rules, err := FindAllRulesForBucket(t.Context(), "test-bucket")
@@ -352,7 +352,7 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 			rules: []pail.LifecycleRule{{ID: "should-not-be-called"}},
 		}
 
-		discovered := DiscoverAndCacheProjectBucket(t.Context(), "cached-bucket", "us-east-1", nil, nil, "test-project", nil, mockClient)
+		discovered := DiscoverAndCacheProjectBucket(t.Context(), "cached-bucket", "us-east-1", nil, nil, "", "test-project", nil, mockClient)
 		assert.False(t, discovered, "should skip discovery for cached bucket")
 
 		rules, err := FindAllRulesForBucket(t.Context(), "cached-bucket")
@@ -368,7 +368,7 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 			err: errors.New("AWS API error"),
 		}
 
-		discovered := DiscoverAndCacheProjectBucket(t.Context(), "error-bucket", "us-east-1", nil, nil, "test-project", nil, mockClient)
+		discovered := DiscoverAndCacheProjectBucket(t.Context(), "error-bucket", "us-east-1", nil, nil, "", "test-project", nil, mockClient)
 		assert.False(t, discovered, "should return false when AWS call fails")
 
 		rules, err := FindAllRulesForBucket(t.Context(), "error-bucket")
@@ -383,7 +383,7 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 			rules: []pail.LifecycleRule{},
 		}
 
-		discovered := DiscoverAndCacheProjectBucket(t.Context(), "empty-bucket", "us-east-1", nil, nil, "test-project", nil, mockClient)
+		discovered := DiscoverAndCacheProjectBucket(t.Context(), "empty-bucket", "us-east-1", nil, nil, "", "test-project", nil, mockClient)
 		assert.True(t, discovered, "should trigger discovery even if no rules returned")
 
 		rules, err := FindAllRulesForBucket(t.Context(), "empty-bucket")
@@ -400,7 +400,7 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 			rules: []pail.LifecycleRule{{ID: "should-not-be-called"}},
 		}
 
-		discovered := DiscoverAndCacheProjectBucket(t.Context(), "restricted-bucket", "us-east-1", &roleARN, nil, "test-project", accountsWithoutLifecycleRules, mockClient)
+		discovered := DiscoverAndCacheProjectBucket(t.Context(), "restricted-bucket", "us-east-1", &roleARN, nil, "", "test-project", accountsWithoutLifecycleRules, mockClient)
 		assert.False(t, discovered, "should skip discovery for buckets in accounts without lifecycle rules access")
 
 		rules, err := FindAllRulesForBucket(t.Context(), "restricted-bucket")
@@ -409,28 +409,62 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 		assert.Zero(t, mockClient.callCount, "should not have called AWS")
 	})
 
-	t.Run("NoRoleARNSkipsAccountCheck", func(t *testing.T) {
-		require.NoError(t, db.Clear(Collection))
+	roleARN := "arn:aws:iam::111111111111:role/my-role"
+	for _, tc := range []struct {
+		name              string
+		bucket            string
+		roleARN           *string
+		fallbackAccountID string
+		withoutRules      []string
+		wantDiscovered    bool
+		wantAccountID     string
+	}{
+		{
+			name:           "UnknownAccountCannotBeCheckedAgainstList",
+			bucket:         "key-secret-bucket",
+			withoutRules:   []string{"999999999999"},
+			wantDiscovered: true,
+		},
+		{
+			name:              "ListedFallbackAccountIDSkipsDiscovery",
+			bucket:            "restricted-key-secret-bucket",
+			fallbackAccountID: "999999999999",
+			withoutRules:      []string{"999999999999"},
+		},
+		{
+			name:              "UnlistedFallbackAccountIDIsCached",
+			bucket:            "allowed-key-secret-bucket",
+			fallbackAccountID: "222222222222",
+			withoutRules:      []string{"999999999999"},
+			wantDiscovered:    true,
+			wantAccountID:     "222222222222",
+		},
+		{
+			name:              "RoleARNTakesPrecedenceOverFallback",
+			bucket:            "mixed-bucket",
+			roleARN:           &roleARN,
+			fallbackAccountID: "222222222222",
+			withoutRules:      []string{"111111111111"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, db.Clear(Collection))
+			mockClient := &mockS3LifecycleClient{
+				rules: []pail.LifecycleRule{{ID: "rule1", Status: "Enabled", ExpirationDays: ptr(int32(30))}},
+			}
 
-		accountsWithoutLifecycleRules := []string{"999999999999"}
-		mockClient := &mockS3LifecycleClient{
-			rules: []pail.LifecycleRule{
-				{
-					ID:             "rule1",
-					Prefix:         "",
-					Status:         "Enabled",
-					ExpirationDays: ptr(int32(30)),
-				},
-			},
-		}
+			discovered := DiscoverAndCacheProjectBucket(t.Context(), tc.bucket, "us-east-1", tc.roleARN, nil, tc.fallbackAccountID, "test-project", tc.withoutRules, mockClient)
+			assert.Equal(t, tc.wantDiscovered, discovered)
 
-		// Without a role ARN we cannot determine the account ID, so discovery should proceed.
-		discovered := DiscoverAndCacheProjectBucket(t.Context(), "key-secret-bucket", "us-east-1", nil, nil, "test-project", accountsWithoutLifecycleRules, mockClient)
-		assert.True(t, discovered, "should proceed with discovery when no role ARN is present")
-
-		rules, err := FindAllRulesForBucket(t.Context(), "key-secret-bucket")
-		require.NoError(t, err)
-		assert.Len(t, rules, 1)
-		assert.Empty(t, rules[0].AWSAccountID, "account ID should be empty for key+secret auth buckets")
-	})
+			rules, err := FindAllRulesForBucket(t.Context(), tc.bucket)
+			require.NoError(t, err)
+			if !tc.wantDiscovered {
+				assert.Empty(t, rules)
+				assert.Zero(t, mockClient.callCount, "should not have called AWS")
+				return
+			}
+			require.Len(t, rules, 1)
+			assert.Equal(t, tc.wantAccountID, rules[0].AWSAccountID)
+		})
+	}
 }

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -794,7 +794,7 @@ func discoverAndCacheBucketLifecycleRules(ctx context.Context, t *task.Task, fil
 			externalID = &file.ExternalID
 		}
 
-		wasCached := s3lifecycle.DiscoverAndCacheProjectBucket(ctx, bucketName, region, roleARN, externalID, t.Project, costConfig.S3Cost.Storage.ArtifactAWSAccountsWithoutLifecycleRules, cloud.NewS3LifecycleClient())
+		wasCached := s3lifecycle.DiscoverAndCacheProjectBucket(ctx, bucketName, region, roleARN, externalID, file.AWSAccountID, t.Project, costConfig.S3Cost.Storage.ArtifactAWSAccountsWithoutLifecycleRules, cloud.NewS3LifecycleClient())
 		if wasCached {
 			cachedBuckets = append(cachedBuckets, bucketName)
 		}

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -447,6 +447,7 @@ func (h *getExpansionsAndVarsHandler) Run(ctx context.Context) gimlet.Responder 
 		grip.Error(ctx, errors.Wrap(err, "loading cost config for expansions_and_vars"))
 	} else {
 		res.DevprodOwnedAWSAccountIDs = costCfg.S3Cost.Storage.DevprodOwnedAWSAccountIDs
+		res.ArtifactAWSAccountsWithoutLifecycleRules = costCfg.S3Cost.Storage.ArtifactAWSAccountsWithoutLifecycleRules
 	}
 
 	return gimlet.NewJSONResponse(res)


### PR DESCRIPTION
DEVPROD-40877 

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Discovery of S3 lifecycle rules skipped the accounts-without-lifecycle-rules list entirely for s3.put uploads using a key and secret, because DiscoverAndCacheProjectBucket derived the account ID only from the role ARN and those uploads have none, so every attempt hit AWS and 403'd. This threads the already-resolved artifact.File.AWSAccountID through as a fallback, and resolves that account whenever either S3 cost account list is configured rather than only the devprod-owned one.

### Testing
Added tests 



<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
