### PR TITLE
DEVPROD-32852: create admin settings for subnet discovery

### DIFF
--- a/config_cloud.go
+++ b/config_cloud.go
@@ -40,6 +40,8 @@ func (c *CloudProviders) ValidateAndDefault() error {
 	for i, m := range c.AWS.AccountRoles {
 		catcher.Wrapf(m.Validate(), "invalid account role mapping at index %d", i)
 	}
+	catcher.NewWhen(c.AWS.SubnetTagName == "" && c.AWS.SubnetTagValue != "", "must specify a subnet tag name if a subnet tag value is set")
+	catcher.NewWhen(c.AWS.SubnetTagName != "" && c.AWS.SubnetTagValue == "", "must specify a subnet tag value if a subnet tag name is set")
 	return catcher.Resolve()
 }
 
@@ -58,6 +60,13 @@ type Subnet struct {
 // AWSConfig stores auth info for Amazon Web Services.
 type AWSConfig struct {
 	Subnets []Subnet `bson:"subnets" json:"subnets" yaml:"subnets"`
+
+	// SubnetTagName is the name of the tag that marks a subnet as usable by
+	// Evergreen.
+	SubnetTagName string `bson:"subnet_tag_name" json:"subnet_tag_name" yaml:"subnet_tag_name"`
+	// SubnetTagValue is the value the tag must have for a subnet that Evergreen
+	// can use.
+	SubnetTagValue string `bson:"subnet_tag_value" json:"subnet_tag_value" yaml:"subnet_tag_value"`
 
 	// ParserProject is configuration for storing and accessing parser projects
 	// in S3.

--- a/config_test.go
+++ b/config_test.go
@@ -420,7 +420,8 @@ func (s *AdminSuite) TestAWSConfigSubnetTagValidation() {
 				s.NoError(err)
 				return
 			}
-			s.Contains(err, tCase.expectedErr)
+			s.Require().Error(err)
+			s.Contains(err.Error(), tCase.expectedErr)
 		})
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -387,6 +387,44 @@ func (s *AdminSuite) TestProvidersConfig() {
 	s.Equal(config, settings.Providers)
 }
 
+func (s *AdminSuite) TestAWSConfigSubnetTagValidation() {
+	for tName, tCase := range map[string]struct {
+		tagName     string
+		tagValue    string
+		expectedErr string
+	}{
+		"BothSetShouldPass": {
+			tagName:  "name",
+			tagValue: "value",
+		},
+		"NeitherSetShouldPass": {},
+		"TagNameWithoutTagValueShouldError": {
+			tagName:     "name",
+			expectedErr: "must specify a subnet tag value if a subnet tag name is set",
+		},
+		"TagValueWithoutTagNameShouldError": {
+			tagValue:    "value",
+			expectedErr: "must specify a subnet tag name if a subnet tag value is set",
+		},
+	} {
+		s.Run(tName, func() {
+			config := CloudProviders{
+				AWS: AWSConfig{
+					SubnetTagName:  tCase.tagName,
+					SubnetTagValue: tCase.tagValue,
+				},
+			}
+
+			err := config.ValidateAndDefault()
+			if tCase.expectedErr == "" {
+				s.NoError(err)
+				return
+			}
+			s.Contains(err, tCase.expectedErr)
+		})
+	}
+}
+
 func (s *AdminSuite) TestRepotrackerConfig() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -133,6 +133,8 @@ type ComplexityRoot struct {
 		MaxVolumeSizePerUser   func(childComplexity int) int
 		ParserProject          func(childComplexity int) int
 		PersistentDNS          func(childComplexity int) int
+		SubnetTagName          func(childComplexity int) int
+		SubnetTagValue         func(childComplexity int) int
 		Subnets                func(childComplexity int) int
 	}
 
@@ -3003,6 +3005,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.AWSConfig.PersistentDNS(childComplexity), true
+	case "AWSConfig.subnetTagName":
+		if e.complexity.AWSConfig.SubnetTagName == nil {
+			break
+		}
+
+		return e.complexity.AWSConfig.SubnetTagName(childComplexity), true
+	case "AWSConfig.subnetTagValue":
+		if e.complexity.AWSConfig.SubnetTagValue == nil {
+			break
+		}
+
+		return e.complexity.AWSConfig.SubnetTagValue(childComplexity), true
 	case "AWSConfig.subnets":
 		if e.complexity.AWSConfig.Subnets == nil {
 			break
@@ -17528,6 +17542,64 @@ func (ec *executionContext) fieldContext_AWSConfig_subnets(_ context.Context, fi
 	return fc, nil
 }
 
+func (ec *executionContext) _AWSConfig_subnetTagName(ctx context.Context, field graphql.CollectedField, obj *model.APIAWSConfig) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AWSConfig_subnetTagName,
+		func(ctx context.Context) (any, error) {
+			return obj.SubnetTagName, nil
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_AWSConfig_subnetTagName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AWSConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AWSConfig_subnetTagValue(ctx context.Context, field graphql.CollectedField, obj *model.APIAWSConfig) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_AWSConfig_subnetTagValue,
+		func(ctx context.Context) (any, error) {
+			return obj.SubnetTagValue, nil
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_AWSConfig_subnetTagValue(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AWSConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _AWSConfig_parserProject(ctx context.Context, field graphql.CollectedField, obj *model.APIAWSConfig) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -24108,6 +24180,10 @@ func (ec *executionContext) fieldContext_CloudProviderConfig_aws(_ context.Conte
 			switch field.Name {
 			case "subnets":
 				return ec.fieldContext_AWSConfig_subnets(ctx, field)
+			case "subnetTagName":
+				return ec.fieldContext_AWSConfig_subnetTagName(ctx, field)
+			case "subnetTagValue":
+				return ec.fieldContext_AWSConfig_subnetTagValue(ctx, field)
 			case "parserProject":
 				return ec.fieldContext_AWSConfig_parserProject(ctx, field)
 			case "persistentDNS":
@@ -79975,7 +80051,7 @@ func (ec *executionContext) unmarshalInputAWSConfigInput(ctx context.Context, ob
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"subnets", "parserProject", "persistentDNS", "defaultSecurityGroup", "allowedInstanceTypes", "alertableInstanceTypes", "allowedRegions", "maxVolumeSizePerUser", "accountRoles", "ipamPoolID", "elasticIPUsageRate", "allowedSNSTopicARNs"}
+	fieldsInOrder := [...]string{"subnets", "subnetTagName", "subnetTagValue", "parserProject", "persistentDNS", "defaultSecurityGroup", "allowedInstanceTypes", "alertableInstanceTypes", "allowedRegions", "maxVolumeSizePerUser", "accountRoles", "ipamPoolID", "elasticIPUsageRate", "allowedSNSTopicARNs"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -79989,6 +80065,20 @@ func (ec *executionContext) unmarshalInputAWSConfigInput(ctx context.Context, ob
 				return it, err
 			}
 			it.Subnets = data
+		case "subnetTagName":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("subnetTagName"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SubnetTagName = data
+		case "subnetTagValue":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("subnetTagValue"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SubnetTagValue = data
 		case "parserProject":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("parserProject"))
 			directive0 := func(ctx context.Context) (any, error) {
@@ -91487,6 +91577,10 @@ func (ec *executionContext) _AWSConfig(ctx context.Context, sel ast.SelectionSet
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "subnetTagName":
+			out.Values[i] = ec._AWSConfig_subnetTagName(ctx, field, obj)
+		case "subnetTagValue":
+			out.Values[i] = ec._AWSConfig_subnetTagValue(ctx, field, obj)
 		case "parserProject":
 			out.Values[i] = ec._AWSConfig_parserProject(ctx, field, obj)
 		case "persistentDNS":

--- a/graphql/schema/types/adminSettings/providers.graphql
+++ b/graphql/schema/types/adminSettings/providers.graphql
@@ -10,6 +10,8 @@ type AWSAccountRoleMapping {
 
 input AWSConfigInput {
   subnets: [SubnetInput!]!
+  subnetTagName: String
+  subnetTagValue: String
   parserProject: ParserProjectS3ConfigInput @redactSecrets
   persistentDNS: PersistentDNSConfigInput
   defaultSecurityGroup: String @redactSecrets
@@ -25,6 +27,8 @@ input AWSConfigInput {
 
 type AWSConfig {
   subnets: [Subnet!]!
+  subnetTagName: String
+  subnetTagValue: String
   parserProject: ParserProjectS3Config @requireAdmin
   persistentDNS: PersistentDNSConfig
   defaultSecurityGroup: String @requireAdmin

--- a/rest/data/admin_test.go
+++ b/rest/data/admin_test.go
@@ -168,6 +168,8 @@ func (s *AdminDataSuite) TestSetAndGetSettings() {
 	s.Equal(testSettings.Providers.AWS.ParserProject.GeneratedJSONPrefix, settingsFromConnector.Providers.AWS.ParserProject.GeneratedJSONPrefix)
 	s.Equal(testSettings.Providers.AWS.PersistentDNS.HostedZoneID, settingsFromConnector.Providers.AWS.PersistentDNS.HostedZoneID)
 	s.Equal(testSettings.Providers.AWS.PersistentDNS.Domain, settingsFromConnector.Providers.AWS.PersistentDNS.Domain)
+	s.Equal(testSettings.Providers.AWS.SubnetTagName, settingsFromConnector.Providers.AWS.SubnetTagName)
+	s.Equal(testSettings.Providers.AWS.SubnetTagValue, settingsFromConnector.Providers.AWS.SubnetTagValue)
 	s.Require().Len(testSettings.Providers.AWS.AccountRoles, len(settingsFromConnector.Providers.AWS.AccountRoles))
 	for i := range testSettings.Providers.AWS.AccountRoles {
 		s.Equal(testSettings.Providers.AWS.AccountRoles[i], settingsFromConnector.Providers.AWS.AccountRoles[i])
@@ -345,6 +347,8 @@ func (s *AdminDataSuite) TestSetAndGetSettings() {
 	s.Equal(testSettings.Providers.AWS.ParserProject.GeneratedJSONPrefix, settingsFromConnector.Providers.AWS.ParserProject.GeneratedJSONPrefix)
 	s.Equal(testSettings.Providers.AWS.PersistentDNS.HostedZoneID, settingsFromConnector.Providers.AWS.PersistentDNS.HostedZoneID)
 	s.Equal(testSettings.Providers.AWS.PersistentDNS.Domain, settingsFromConnector.Providers.AWS.PersistentDNS.Domain)
+	s.Equal(testSettings.Providers.AWS.SubnetTagName, settingsFromConnector.Providers.AWS.SubnetTagName)
+	s.Equal(testSettings.Providers.AWS.SubnetTagValue, settingsFromConnector.Providers.AWS.SubnetTagValue)
 	s.EqualValues(testSettings.Providers.Docker.APIVersion, settingsFromConnector.Providers.Docker.APIVersion)
 	s.EqualValues(testSettings.RepoTracker.MaxConcurrentRequests, settingsFromConnector.RepoTracker.MaxConcurrentRequests)
 	s.EqualValues(testSettings.Scheduler.TaskFinder, settingsFromConnector.Scheduler.TaskFinder)

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -1696,6 +1696,8 @@ func (a *APISubnet) ToService() (any, error) {
 
 type APIAWSConfig struct {
 	Subnets                []APISubnet                `json:"subnets"`
+	SubnetTagName          *string                    `json:"subnet_tag_name"`
+	SubnetTagValue         *string                    `json:"subnet_tag_value"`
 	ParserProject          *APIParserProjectS3Config  `json:"parser_project"`
 	PersistentDNS          *APIPersistentDNSConfig    `json:"persistent_dns"`
 	DefaultSecurityGroup   *string                    `json:"default_security_group"`
@@ -1719,6 +1721,8 @@ func (a *APIAWSConfig) BuildFromService(h any) error {
 			}
 			a.Subnets = append(a.Subnets, apiSubnet)
 		}
+		a.SubnetTagName = utility.ToStringPtr(v.SubnetTagName)
+		a.SubnetTagValue = utility.ToStringPtr(v.SubnetTagValue)
 
 		parserProject := &APIParserProjectS3Config{}
 		if err := parserProject.BuildFromService(v.ParserProject); err != nil {
@@ -1808,6 +1812,8 @@ func (a *APIAWSConfig) ToService() (any, error) {
 		}
 		config.Subnets = append(config.Subnets, subnet)
 	}
+	config.SubnetTagName = utility.FromStringPtr(a.SubnetTagName)
+	config.SubnetTagValue = utility.FromStringPtr(a.SubnetTagValue)
 
 	config.AllowedInstanceTypes = utility.FromStringPtrSlice(a.AllowedInstanceTypes)
 	config.AlertableInstanceTypes = utility.FromStringPtrSlice(a.AlertableInstanceTypes)

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -175,6 +175,8 @@ func TestModelConversion(t *testing.T) {
 	assert.EqualValues(testSettings.Providers.AWS.ParserProject.GeneratedJSONPrefix, utility.FromStringPtr(apiSettings.Providers.AWS.ParserProject.GeneratedJSONPrefix))
 	assert.EqualValues(testSettings.Providers.AWS.PersistentDNS.HostedZoneID, utility.FromStringPtr(apiSettings.Providers.AWS.PersistentDNS.HostedZoneID))
 	assert.EqualValues(testSettings.Providers.AWS.PersistentDNS.Domain, utility.FromStringPtr(apiSettings.Providers.AWS.PersistentDNS.Domain))
+	assert.EqualValues(testSettings.Providers.AWS.SubnetTagName, utility.FromStringPtr(apiSettings.Providers.AWS.SubnetTagName))
+	assert.EqualValues(testSettings.Providers.AWS.SubnetTagValue, utility.FromStringPtr(apiSettings.Providers.AWS.SubnetTagValue))
 	require.Len(apiSettings.Providers.AWS.AccountRoles, len(testSettings.Providers.AWS.AccountRoles))
 	for i, ar := range testSettings.Providers.AWS.AccountRoles {
 		assert.Equal(ar.Account, utility.FromStringPtr(apiSettings.Providers.AWS.AccountRoles[i].Account))

--- a/rest/route/admin_test.go
+++ b/rest/route/admin_test.go
@@ -198,6 +198,8 @@ func (s *AdminRouteSuite) TestAdminRoute() {
 	s.EqualValues(testSettings.ParameterStore.Prefix, settings.ParameterStore.Prefix)
 	s.EqualValues(testSettings.Providers.AWS.PersistentDNS.HostedZoneID, settings.Providers.AWS.PersistentDNS.HostedZoneID)
 	s.EqualValues(testSettings.Providers.AWS.PersistentDNS.Domain, settings.Providers.AWS.PersistentDNS.Domain)
+	s.EqualValues(testSettings.Providers.AWS.SubnetTagName, settings.Providers.AWS.SubnetTagName)
+	s.EqualValues(testSettings.Providers.AWS.SubnetTagValue, settings.Providers.AWS.SubnetTagValue)
 	s.Require().Len(testSettings.Providers.AWS.AccountRoles, len(settings.Providers.AWS.AccountRoles))
 	for i := range testSettings.Providers.AWS.AccountRoles {
 		s.Equal(testSettings.Providers.AWS.AccountRoles[i], settings.Providers.AWS.AccountRoles[i])

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -321,6 +321,8 @@ func MockConfig() *evergreen.Settings {
 			AWS: evergreen.AWSConfig{
 				DefaultSecurityGroup: "test_security_group",
 				MaxVolumeSizePerUser: 200,
+				SubnetTagName:        "subnet_tag_name",
+				SubnetTagValue:       "subnet_tag_value",
 				ParserProject: evergreen.ParserProjectS3Config{
 					S3Credentials: evergreen.S3Credentials{
 						Bucket: "parser_project_bucket",


### PR DESCRIPTION
DEVPROD-32852

### Description

Evergreen has logic to try different availability zones (AZs) in case some of them have insufficient capacity. The issue is that we currently have a list of subnets in the admin settings (each is tied to a specific AZ so they determine what AZs an instance can be spawned in), but those subnets are set only for the default AWS account. For distros that are using non-default accounts, their subnets were not added, so they're using the one subnet (i.e. the one AZ) in the distro provider settings.

Talked with infra to come up with this solution. They said that as they add more non-default accounts, rather than listing more and more subnets for each account (and having to make sure they all stay correct/consistent), they'd prefer that Evergreen dynamically discovers what subnets are available by looking up subnets matching a tag in the AWS API. That tag indicates to Evergreen that it's usable for running hosts.

This PR adds support for the tag key/value admin settings. Going to open a follow-up PR to actually implement the subnet discovery logic.

[UI PR](https://github.com/evergreen-ci/ui/pull/1837)

### Testing

* Tested locally to confirm that the subnet tag admin settings worked.
* Added unit tests.