### PR TITLE
PLATFORMS-2444: Add agent container lifecycle orchestration

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -72,16 +72,13 @@ type Agent struct {
 	otelGrpcConn        *grpc.ClientConn
 	closers             []closerOp
 	// currentContainer holds the active task-group isolation container, if any.
-	// Created at task-group setup, reused across tasks in the group, and
-	// destroyed in runTeardownGroupCommands. Set/cleared by
-	// maybeStartContainer/destroyContainer.
+	// Set/cleared by ensureContainer/destroyContainer.
 	currentContainer ContainerHandle
 	// containerFactory creates new isolation containers. Defaults to
 	// defaultContainerFactory; replaced in tests with a stub that avoids Docker.
 	containerFactory containerFactoryFunc
 	// retainContainerUntil, when non-zero, causes destroyContainer to skip
-	// actual removal and leave the container running for on-call inspection.
-	// Set by the task failure handler when ContainerRetainOnFailureSecs > 0.
+	// removal and leave the container running for on-call inspection.
 	retainContainerUntil time.Time
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -108,11 +108,7 @@ type Options struct {
 	SingleTaskDistro           bool
 	// ContainerRetainOnFailureSecs is how long an isolation container is kept
 	// alive after a task failure so on-call can docker exec into it for
-	// post-mortem inspection. Default is 300s during Phase 0/1; set to 0 to
-	// disable retention once container.failure_snapshot coverage is trusted.
-	// Note: the CLI flag default is 300, but the zero value of this field is 0
-	// (no retention). Code that constructs Options{} directly (e.g. tests)
-	// gets zero — retention disabled — unless explicitly set.
+	// post-mortem inspection. Zero disables retention.
 	ContainerRetainOnFailureSecs int
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -71,6 +71,18 @@ type Agent struct {
 	tracer              trace.Tracer
 	otelGrpcConn        *grpc.ClientConn
 	closers             []closerOp
+	// currentContainer holds the active task-group isolation container, if any.
+	// Created at task-group setup, reused across tasks in the group, and
+	// destroyed in runTeardownGroupCommands. Set/cleared by
+	// maybeStartContainer/destroyContainer.
+	currentContainer ContainerHandle
+	// containerFactory creates new isolation containers. Defaults to
+	// defaultContainerFactory; replaced in tests with a stub that avoids Docker.
+	containerFactory containerFactoryFunc
+	// retainContainerUntil, when non-zero, causes destroyContainer to skip
+	// actual removal and leave the container running for on-call inspection.
+	// Set by the task failure handler when ContainerRetainOnFailureSecs > 0.
+	retainContainerUntil time.Time
 }
 
 // Options contains startup options for an Agent.
@@ -94,6 +106,14 @@ type Options struct {
 	SendTaskLogsToGlobalSender bool
 	HomeDirectory              string
 	SingleTaskDistro           bool
+	// ContainerRetainOnFailureSecs is how long an isolation container is kept
+	// alive after a task failure so on-call can docker exec into it for
+	// post-mortem inspection. Default is 300s during Phase 0/1; set to 0 to
+	// disable retention once container.failure_snapshot coverage is trusted.
+	// Note: the CLI flag default is 300, but the zero value of this field is 0
+	// (no retention). Code that constructs Options{} directly (e.g. tests)
+	// gets zero — retention disabled — unless explicitly set.
+	ContainerRetainOnFailureSecs int
 }
 
 // AddLoggableInfo is a helper to add relevant information about the agent

--- a/agent/container.go
+++ b/agent/container.go
@@ -1,0 +1,580 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	dockercontainer "github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+	"github.com/evergreen-ci/evergreen"
+	agentcontainer "github.com/evergreen-ci/evergreen/agent/container"
+	"github.com/evergreen-ci/evergreen/agent/globals"
+	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/evergreen/apimodels"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/recovery"
+	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+)
+
+// ContainerHandle is the interface through which the agent manages an active
+// task isolation container. Using an interface lets unit tests inject a fake
+// without requiring a live Docker daemon.
+type ContainerHandle interface {
+	GetID() string
+	GetName() string
+	GetEnvFileHostDir() string
+	Close()
+	Destroy(ctx context.Context) error
+}
+
+// containerFactory creates and starts a new isolation container. The default
+// implementation calls agentcontainer.CreateAndStart; tests replace it with a
+// stub that returns a fake ContainerHandle without Docker.
+type containerFactoryFunc func(ctx context.Context, cfg agentcontainer.Config) (ContainerHandle, error)
+
+func defaultContainerFactory(ctx context.Context, cfg agentcontainer.Config) (ContainerHandle, error) {
+	return agentcontainer.CreateAndStart(ctx, cfg)
+}
+
+// tryReapOrphanContainers removes any evergreen-task-* containers left behind
+// by a prior agent crash or host reboot. Called once at agent startup when
+// the --cleanup flag is set, before any tasks are dispatched. Best-effort:
+// if Docker is not running (non-container-enabled host) the function returns
+// silently; individual removal failures are warned but do not block startup.
+// reaperTimeout bounds the total time the orphan-container reaper spends
+// connecting to Docker, listing containers, and removing them. Using a
+// background-derived context (not the agent's Start ctx) ensures that a
+// shutdown signal arriving during the --cleanup phase doesn't silently skip
+// the reap entirely: the agent ctx would be cancelled before any Docker call
+// completes, leaving orphans on the host.
+const reaperTimeout = 30 * time.Second //nolint:unused
+
+func (a *Agent) tryReapOrphanContainers(ctx context.Context) { //nolint:unused
+	defer recovery.LogStackTraceAndContinue("reap orphan containers")
+
+	// Use a bounded background context so the reaper completes even if the
+	// parent ctx is cancelled during a shutdown race. The parent ctx is still
+	// used for mid-loop cancellation checks so a clean agent shutdown during
+	// removal doesn't log spurious warnings.
+	reaperCtx, cancel := context.WithTimeout(context.Background(), reaperTimeout)
+	defer cancel()
+
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		grip.Infof(ctx, "Orphan container reaper: Docker client unavailable, skipping: %s", err)
+		return
+	}
+	defer cli.Close()
+
+	if _, err := cli.Info(reaperCtx); err != nil {
+		grip.Infof(ctx, "Orphan container reaper: Docker daemon not reachable, skipping: %s", err)
+		return
+	}
+
+	// The name filter is a substring match. GOAL-279 containers are named
+	// evergreen-task-<task-id>, a prefix distinctive enough that accidental
+	// collisions with human-created containers are unlikely. A label-based
+	// filter would be more precise but requires labelling containers at
+	// creation time (a larger change deferred to Phase 1).
+	containers, err := cli.ContainerList(reaperCtx, dockercontainer.ListOptions{
+		All:     true,
+		Filters: filters.NewArgs(filters.KeyValuePair{Key: "name", Value: "evergreen-task-"}),
+	})
+	if err != nil {
+		grip.Warningf(ctx, "Orphan container reaper: could not list containers: %s", err)
+		return
+	}
+
+	for _, c := range containers {
+		shortID := c.ID
+		if len(shortID) > 12 {
+			shortID = shortID[:12]
+		}
+		names := containerNames(c.Names)
+		if err := cli.ContainerRemove(reaperCtx, c.ID, dockercontainer.RemoveOptions{Force: true}); err != nil {
+			if ctx.Err() != nil {
+				// Context cancelled during shutdown — not a real removal failure.
+				return
+			}
+			grip.Warningf(ctx, "Orphan container reaper: could not remove container '%s' (%s): %s", shortID, names, err)
+		} else {
+			grip.Infof(ctx, "Orphan container reaper: removed stale container '%s' (%s).", shortID, names)
+		}
+	}
+}
+
+// containerNames strips the leading '/' that the Docker API prepends to
+// container names and joins them for display.
+func containerNames(names []string) string { //nolint:unused
+	clean := make([]string, len(names))
+	for i, n := range names {
+		clean[i] = strings.TrimPrefix(n, "/")
+	}
+	return strings.Join(clean, ",")
+}
+
+// maybeStartContainer ensures a Docker container is running for task isolation
+// when the distro has container isolation enabled. It sets conf.ContainerID so
+// commands know to route execution through `docker exec`.
+//
+// Container lifecycle is task-group-scoped, not per-task. If a container is
+// already running for this task group (a.currentContainer != nil), the existing
+// container's identity is wired into conf without creating a new one. A new
+// container is only created at the start of a task group (when a.currentContainer
+// is nil). The container is destroyed in runTeardownGroupCommands.
+func (a *Agent) maybeStartContainer(ctx context.Context, conf *internal.TaskConfig, log grip.Journaler) error {
+	if conf.Distro == nil || conf.Distro.ContainerIsolation == nil {
+		return nil
+	}
+
+	if a.currentContainer != nil {
+		// Reuse the container that was started for the first task in this group.
+		conf.ContainerID = a.currentContainer.GetID()
+		conf.EnvFileHostDir = a.currentContainer.GetEnvFileHostDir()
+		return nil
+	}
+
+	// The task workdir is created by the agent (root) with mode 0755 due to
+	// the process umask. The exec_user inside the container (typically uid=1000)
+	// cannot write to a root-owned 0755 directory. Explicitly chmod to 0777 so
+	// the container process can write task output to the workdir via the
+	// same-path bind mount. This is safe: the workdir is per-task and ephemeral.
+	if conf.WorkDir != "" {
+		if err := os.Chmod(conf.WorkDir, 0777); err != nil {
+			grip.Warningf(ctx, "Could not chmod task workdir '%s' for container isolation: %s", conf.WorkDir, err)
+		}
+	}
+
+	// The task tmp directory (WorkDir/tmp) has the same umask problem —
+	// MkdirAll creates it with 0777 but the umask strips group/other write
+	// bits, leaving the container user unable to write temp files (cgo,
+	// gcc, etc.). Chmod it the same way as the workdir.
+	if conf.WorkDir != "" {
+		tmpDir := filepath.Join(conf.WorkDir, "tmp")
+		if err := os.Chmod(tmpDir, 0777); err != nil {
+			grip.Warningf(ctx, "Could not chmod task tmp dir '%s' for container isolation: %s", tmpDir, err)
+		}
+	}
+
+	ci := conf.Distro.ContainerIsolation
+	ctx, span := a.tracer.Start(ctx, "container.create_and_start")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("container.image", ci.Image),
+		attribute.String("container.task_id", conf.Task.Id),
+		attribute.String("container.distro_id", conf.Task.DistroId),
+	)
+
+	// Build the extra mounts. /opt is bind-mounted read-only so toolchains
+	// (mongodbtoolchain, golang, java, ruby) installed at AMI provisioning
+	// are visible inside the container without baking them into the image.
+	// Skip the mount if /opt does not exist on the host — Docker rejects
+	// bind-mount sources that don't exist, which would fail container
+	// creation entirely.
+	//
+	// Security: /opt must contain only toolchains, never secrets. Read-only
+	// mounts still allow reading and exfiltration, so any credential
+	// material placed under /opt would be visible to every containerized
+	// task. AMI provisioning scripts for container-isolated distros must
+	// not write SSH keys, tokens, or other secrets to /opt.
+	var extraMounts []agentcontainer.Mount
+	if _, err := os.Stat("/opt"); err == nil {
+		extraMounts = append(extraMounts, agentcontainer.Mount{
+			Source: "/opt", Target: "/opt", ReadOnly: true,
+		})
+	} else {
+		grip.Warningf(ctx, "Host /opt not found, skipping toolchain bind mount for task '%s'", conf.Task.Id)
+	}
+
+	factory := a.containerFactory
+	if factory == nil {
+		factory = defaultContainerFactory
+	}
+	tc, err := factory(ctx, agentcontainer.Config{
+		Image:       ci.Image,
+		WorkDir:     conf.WorkDir,
+		TaskID:      conf.Task.Id,
+		MemoryMB:    ci.MemoryMB,
+		CPUs:        ci.CPUs,
+		ExtraMounts: extraMounts,
+		Logger:      log,
+	})
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		if ci.RequireIsolation {
+			return errors.Wrap(err, "starting isolation container (fail-closed: require_isolation is set)")
+		}
+		if log != nil {
+			log.Warning(ctx, message.WrapError(err, message.Fields{
+				"message": "container_isolation_degraded",
+				"task_id": conf.Task.Id,
+				"image":   ci.Image,
+				"note":    "task will run without container isolation",
+			}))
+		}
+		return nil
+	}
+	span.SetAttributes(
+		attribute.String("container.id", tc.GetID()),
+		attribute.String("container.name", tc.GetName()),
+	)
+	conf.ContainerID = tc.GetID()
+	conf.EnvFileHostDir = tc.GetEnvFileHostDir()
+	a.currentContainer = tc
+
+	// Write a static host-env file in the env tmpfs containing PATH and
+	// known toolchain env vars from the host. docker exec does not source
+	// /etc/profile.d/*.sh, so toolchain paths set by those scripts (e.g.
+	// /opt/golang/go1.24.13/bin added to PATH) are missing inside the
+	// container. WrapWithContainer passes this as a second --env-file so
+	// these vars reach every docker exec invocation. Per-command env vars
+	// (from the command's own env map) are written to a separate env-file
+	// and override these since Docker applies --env-file args in order.
+	if conf.EnvFileHostDir != "" {
+		hostEnvPath := filepath.Join(conf.EnvFileHostDir, ".evg-host-env")
+		if err := writeHostEnvFile(hostEnvPath); err != nil {
+			grip.Warningf(ctx, "Could not write host env file for container isolation: %s", err)
+		}
+	}
+
+	grip.Infof(ctx, "Started isolation container '%s' (image=%s) for task group starting with task '%s'.", tc.GetName(), ci.Image, conf.Task.Id)
+	return nil
+}
+
+// destroyContainer tears down the isolation container and clears the agent's
+// container reference. conf may be nil (e.g. when called from the loop-exit
+// defer before any task has run), in which case conf fields are not cleared.
+// The container is identified by its name in logs rather than the task ID,
+// since the container was created for the first task in the group and its name
+// does not change across task-group members.
+//
+// If a.retainContainerUntil is in the future, the container is intentionally
+// left running for on-call post-mortem inspection (retain_on_failure_secs).
+// The agent reference is cleared so subsequent task dispatch is unaffected;
+// the reaper removes the container at next startup.
+//
+// Static-host note: the retention window is checked only when destroyContainer
+// fires (at group teardown). If teardown fires within the window the container
+// is left running until the orphan reaper at next agent restart — there is no
+// background timer that removes it after the window elapses. On dynamic EC2
+// hosts (the Phase 0 target) the host recycles before accumulation becomes a
+// concern. Static hosts running many task groups should set
+// container_retain_on_failure_secs=0 until a deadline-based sweep is added.
+func (a *Agent) destroyContainer(ctx context.Context, conf *internal.TaskConfig) {
+	if a.currentContainer == nil {
+		a.retainContainerUntil = time.Time{}
+		return
+	}
+	containerName := a.currentContainer.GetName()
+
+	ctx, span := a.tracer.Start(ctx, "container.destroy")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("container.id", a.currentContainer.GetID()),
+		attribute.String("container.name", containerName),
+	)
+
+	if !a.retainContainerUntil.IsZero() && time.Now().Before(a.retainContainerUntil) {
+		grip.Infof(ctx, "Retaining isolation container '%s' until %s for on-call inspection (retain_on_failure_secs). The orphan reaper will remove it at next agent startup.",
+			containerName, a.retainContainerUntil.Format(time.RFC3339))
+		// Close the Docker client connection (it is no longer needed for
+		// lifecycle management) but do NOT remove the container or its tmpfs.
+		// The tmpfs remains mounted inside the container so on-call can read
+		// the env-file; the container itself is left running for docker exec.
+		// The orphan reaper at next agent startup handles the final cleanup.
+		a.currentContainer.Close()
+		a.currentContainer = nil
+		a.retainContainerUntil = time.Time{}
+		if conf != nil {
+			conf.ContainerID = ""
+			conf.EnvFileHostDir = ""
+		}
+		return
+	}
+
+	if err := a.currentContainer.Destroy(ctx); err != nil {
+		grip.Warningf(ctx, "Failed to destroy isolation container '%s': %s", containerName, err)
+	}
+	a.currentContainer = nil
+	a.retainContainerUntil = time.Time{}
+	if conf != nil {
+		conf.ContainerID = ""
+		conf.EnvFileHostDir = ""
+	}
+}
+
+// checkContainerOOM uses docker inspect to read the OOMKilled flag from the
+// container state. Returns (true, nil) when the container was OOM-killed,
+// (false, nil) when it was not, and (false, err) when inspect fails.
+func checkContainerOOM(ctx context.Context, containerID string) (bool, error) { //nolint:unused
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return false, fmt.Errorf("creating Docker client for OOM check: %w", err)
+	}
+	defer cli.Close()
+
+	inspectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	info, err := cli.ContainerInspect(inspectCtx, containerID)
+	if err != nil {
+		return false, fmt.Errorf("inspecting container '%s': %w", containerID, err)
+	}
+	if info.State == nil {
+		return false, nil
+	}
+	return info.State.OOMKilled, nil
+}
+
+// scheduleContainerRetention sets the retention window on the agent when a
+// task fails with an active isolation container. The container is kept alive
+// for ContainerRetainOnFailureSecs seconds after the task ends so on-call can
+// docker exec into it for post-mortem inspection.
+//
+// Timing note: the window is measured from task failure time, not from when
+// destroyContainer actually fires (which is at group teardown, potentially
+// seconds to minutes later). For task groups where teardown fires within the
+// window, the container is left running until the reaper; for teardown after
+// the window, normal destroy runs. Both outcomes are acceptable for Phase 0
+// on-call use: the container is either available or cleanly removed.
+func (a *Agent) scheduleContainerRetention(ctx context.Context, containerName string) { //nolint:unused
+	if a.opts.ContainerRetainOnFailureSecs <= 0 || a.currentContainer == nil {
+		return
+	}
+	a.retainContainerUntil = time.Now().Add(time.Duration(a.opts.ContainerRetainOnFailureSecs) * time.Second)
+	grip.Infof(ctx, "Task failed with isolation container '%s' active; scheduling retention until %s (retain_on_failure_secs=%d). Use `docker exec -it %s bash` for inspection.",
+		containerName, a.retainContainerUntil.Format(time.RFC3339),
+		a.opts.ContainerRetainOnFailureSecs, containerName)
+}
+
+// augmentOOMTrackerWithContainerSignal supplements the existing dmesg-based
+// OOM report with the container-native OOMKilled signal from docker inspect.
+// This is more reliable than dmesg under containers because dmesg PIDs are
+// host-side (not matching container-namespaced PIDs) and the dmesg buffer can
+// accumulate messages from prior containers.
+//
+// This check is intentionally independent of tc.oomTrackerEnabled(cloudProvider).
+// That gate controls the dmesg-based report (a project-level setting for host
+// processes). The container OOMKilled signal is a container-specific fact from
+// docker inspect, always worth surfacing when a container is active regardless
+// of project OOM-tracker preferences.
+// emitContainerFailureSnapshot collects post-mortem forensics from the active
+// isolation container and emits them as a container.failure_snapshot OTel span.
+// It is called on non-zero task exit while the container is still running (before
+// destroyContainer fires at group teardown). All string fields are run through
+// the task config's redactor so secrets never appear in Honeycomb.
+func (a *Agent) emitContainerFailureSnapshot(ctx context.Context, tc *taskContext, detail *apimodels.TaskEndDetail) { //nolint:unused
+	if a.currentContainer == nil || tc == nil {
+		return
+	}
+	containerID := a.currentContainer.GetID()
+	image := ""
+	if tc.taskConfig != nil && tc.taskConfig.Distro != nil && tc.taskConfig.Distro.ContainerIsolation != nil {
+		image = tc.taskConfig.Distro.ContainerIsolation.Image
+	}
+
+	ctx, span := a.tracer.Start(ctx, "container.failure_snapshot")
+	defer span.End()
+	span.SetAttributes(
+		attribute.String("container.id", containerID),
+		attribute.String("container.image", image),
+		attribute.String("container.task_status", detail.Status),
+		attribute.Bool("container.oom_killed", detail.OOMTracker != nil && detail.OOMTracker.Detected),
+	)
+	if detail.Status == evergreen.TaskFailed || detail.TimedOut {
+		span.SetStatus(codes.Error, detail.Status)
+	}
+
+	// docker inspect JSON.
+	if inspectJSON, err := containerInspectJSON(ctx, containerID); err == nil {
+		span.SetAttributes(attribute.String("container.inspect_json", redactForSnapshot(inspectJSON, tc)))
+	}
+
+	// ps -ef inside the container. Capture output even on non-zero exit — a
+	// container whose processes have all died is exactly the case where we
+	// want "no processes found" in Honeycomb rather than a missing attribute.
+	if psOut, _ := containerExec(ctx, containerID, "ps", "-ef"); psOut != "" {
+		span.SetAttributes(attribute.String("container.ps_output", redactForSnapshot(psOut, tc)))
+	}
+
+	// Env-file contents (the per-task tmpfs written by WrapWithContainer).
+	if tc.taskConfig != nil && tc.taskConfig.EnvFileHostDir != "" {
+		envFile := filepath.Join(tc.taskConfig.EnvFileHostDir, ".evg-env")
+		if data, err := os.ReadFile(envFile); err == nil {
+			span.SetAttributes(attribute.String("container.env_file", redactForSnapshot(string(data), tc)))
+		}
+	}
+
+	// Task log tail (stdout/stderr) is an accepted deviation from the
+	// design doc's original "last 200 lines of stdout/stderr" requirement.
+	// Task output flows through Jasper senders to the remote Evergreen log
+	// service, not to a local file or container stdout. `docker logs` does
+	// not help because the container's PID 1 is `sleep infinity` — the
+	// actual task commands run via `docker exec` and their output is
+	// captured by Jasper, not by the Docker logging driver. The design doc
+	// (technical-design-agent-container-lifecycle.md and phase-0-plan.md)
+	// has been updated to reflect this deviation. Closing the gap would
+	// require a ring buffer in the logger infrastructure, deferred to
+	// Phase 1 if post-mortem finds the existing log pipeline insufficient.
+}
+
+// containerInspectJSON returns the full JSON from docker inspect for a container.
+func containerInspectJSON(ctx context.Context, containerID string) (string, error) { //nolint:unused
+	inspectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	if err != nil {
+		return "", errors.Wrap(err, "creating Docker client for inspect")
+	}
+	defer cli.Close()
+
+	info, err := cli.ContainerInspect(inspectCtx, containerID)
+	if err != nil {
+		return "", errors.Wrapf(err, "inspecting container '%s'", containerID)
+	}
+	data, err := json.Marshal(info)
+	if err != nil {
+		return "", errors.Wrap(err, "marshalling inspect result")
+	}
+	return string(data), nil
+}
+
+// containerExec runs a command inside a container and returns its combined output.
+// This failure-snapshot path uses the docker CLI (not the SDK) because it is
+// called only on task failure and the credential-helper flow for ECR is handled
+// by host_provision.go (which also uses the CLI for the same reason). The SDK
+// path for the main lifecycle (CreateAndStart, Destroy) is intentional and
+// unrelated; the CLI is used here for the forensic path to keep its footprint
+// simple and aligned with other CLI callers.
+func containerExec(ctx context.Context, containerID string, args ...string) (string, error) { //nolint:unused
+	execCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	cmdArgs := append([]string{"exec", containerID}, args...)
+	out, err := exec.CommandContext(execCtx, "docker", cmdArgs...).CombinedOutput()
+	return strings.TrimSpace(string(out)), err
+}
+
+// redactForSnapshot applies the task's expansion redactions to s so that
+// secrets never appear in Honeycomb attributes. Values are applied
+// longest-first (matching the canonical redacting_sender order) to prevent a
+// shorter secret that is a prefix of a longer one from producing a partial
+// substitution that leaks the suffix.
+func redactForSnapshot(s string, tc *taskContext) string {
+	if tc == nil || tc.taskConfig == nil {
+		return s
+	}
+	conf := tc.taskConfig
+
+	type kv struct{ key, val string }
+	var all []kv
+
+	for _, info := range conf.NewExpansions.GetRedacted() {
+		if info.Value != "" {
+			all = append(all, kv{info.Key, info.Value})
+		}
+	}
+	// Use a fresh slice to avoid aliasing conf.Redacted's backing array.
+	allToRedact := append([]string(nil), conf.Redacted...)
+	allToRedact = append(allToRedact, globals.ExpansionsToRedact...)
+	for _, name := range allToRedact {
+		if val := conf.NewExpansions.Get(name); val != "" {
+			all = append(all, kv{name, val})
+		}
+	}
+	conf.InternalRedactions.Range(func(k, v string) bool {
+		if v != "" {
+			all = append(all, kv{k, v})
+		}
+		return true
+	})
+
+	// Sort longest value first to prevent prefix-substitution leaks.
+	sort.Slice(all, func(i, j int) bool { return len(all[i].val) > len(all[j].val) })
+
+	for _, entry := range all {
+		s = strings.ReplaceAll(s, entry.val, fmt.Sprintf("<REDACTED:%s>", entry.key))
+	}
+	return s
+}
+
+func (a *Agent) augmentOOMTrackerWithContainerSignal(ctx context.Context, tc *taskContext, detail *apimodels.TaskEndDetail) { //nolint:unused
+	if a.currentContainer == nil {
+		return
+	}
+	oomKilled, err := checkContainerOOM(ctx, a.currentContainer.GetID())
+	if err != nil {
+		tc.logger.Execution().Warningf(ctx, "Could not check container OOM status via docker inspect: %s", err)
+		return
+	}
+	if !oomKilled {
+		tc.logger.Execution().Debugf(ctx, "docker inspect: container '%s' OOMKilled=false.", a.currentContainer.GetName())
+		return
+	}
+	tc.logger.Execution().Infof(ctx, "docker inspect: container '%s' OOMKilled=true; task was OOM-killed.", a.currentContainer.GetName())
+	if detail.OOMTracker == nil {
+		detail.OOMTracker = &apimodels.OOMTrackerInfo{}
+	}
+	detail.OOMTracker.Detected = true
+}
+
+// hostEnvVars are environment variables set by /etc/profile.d/*.sh on the host
+// that configure toolchain access. docker exec does not source profile scripts,
+// so these vars must be explicitly forwarded into the container.
+var hostEnvVars = []string{
+	"PATH",
+	"GOROOT",
+	"JAVA_HOME",
+	"ANT_HOME",
+	"LD_LIBRARY_PATH",
+	"PKG_CONFIG_PATH",
+	"PYTHONPATH",
+	"NODE_PATH",
+	"CPATH",
+	"LIBRARY_PATH",
+}
+
+// writeHostEnvFile captures the host's toolchain-related env vars and writes
+// them to path in KEY=VALUE format. This file is passed as a --env-file to
+// docker exec so containerized processes can find toolchains installed at
+// /opt/golang, /opt/mongodbtoolchain, etc. without sourcing profile scripts.
+//
+// The agent runs as a systemd service whose PATH does not include toolchain
+// directories set by /etc/profile.d/*.sh. To capture the effective PATH and
+// toolchain vars that a login shell would have, we run `bash -l -c` to source
+// the profile scripts and print the env vars.
+func writeHostEnvFile(path string) error {
+	// Build a shell command that sources profile scripts and prints the
+	// vars we care about in KEY=VALUE format.
+	var cmdParts []string
+	for _, key := range hostEnvVars {
+		cmdParts = append(cmdParts, fmt.Sprintf("[ -n \"$%s\" ] && echo '%s='$%s", key, key, key))
+	}
+	shellCmd := strings.Join(cmdParts, "\n")
+
+	out, err := exec.Command("bash", "-l", "-c", shellCmd).Output()
+	if err != nil {
+		// Fall back to the agent process's own env vars if the login shell
+		// fails (e.g. bash not available). This won't have toolchain paths
+		// but preserves the base PATH.
+		var sb strings.Builder
+		for _, key := range hostEnvVars {
+			if val := os.Getenv(key); val != "" {
+				fmt.Fprintf(&sb, "%s=%s\n", key, val)
+			}
+		}
+		return os.WriteFile(path, []byte(sb.String()), 0600)
+	}
+	return os.WriteFile(path, out, 0600)
+}

--- a/agent/container.go
+++ b/agent/container.go
@@ -40,9 +40,8 @@ type ContainerHandle interface {
 	Destroy(ctx context.Context) error
 }
 
-// containerFactory creates and starts a new isolation container. The default
-// implementation calls agentcontainer.CreateAndStart; tests replace it with a
-// stub that returns a fake ContainerHandle without Docker.
+// containerFactoryFunc creates and starts a new isolation container. Tests
+// replace it with a stub that avoids Docker.
 type containerFactoryFunc func(ctx context.Context, cfg agentcontainer.Config) (ContainerHandle, error)
 
 func defaultContainerFactory(ctx context.Context, cfg agentcontainer.Config) (ContainerHandle, error) {
@@ -51,7 +50,7 @@ func defaultContainerFactory(ctx context.Context, cfg agentcontainer.Config) (Co
 
 // reaperTimeout bounds the total time the orphan-container reaper spends
 // connecting to Docker, listing containers, and removing them.
-const reaperTimeout = 30 * time.Second //nolint:unused
+const reaperTimeout = 30 * time.Second
 
 const (
 	containerEnvFilePrefix  = ".evg-env-"
@@ -60,10 +59,11 @@ const (
 )
 
 // tryReapOrphanContainers removes isolation containers left behind by a prior
-// agent crash or host reboot. Called once at agent startup when the --cleanup
-// flag is set, before any tasks are dispatched. Best-effort: if Docker is not
-// running the function returns silently, and individual removal failures are
-// warned but do not block startup.
+// agent exit (crash, OOM kill, systemd restart, host reboot, or Docker daemon
+// restart where the agent loses track but containers survive). Called once at
+// agent startup when the --cleanup flag is set, before any tasks are dispatched.
+// Best-effort: if Docker is not running the function returns silently, and
+// individual removal failures are warned but do not block startup.
 //
 // The reaper runs on a background-derived context so that a shutdown signal
 // arriving during the --cleanup phase does not cancel every Docker call and
@@ -116,16 +116,10 @@ func (a *Agent) tryReapOrphanContainers(ctx context.Context) { //nolint:unused
 }
 
 // isAgentOwnedContainer reports whether the reaper may remove a container.
-//
-// An explicit owner label is authoritative in both directions: it claims
-// containers this agent created and protects containers owned by anything
-// else. Containers with no owner label at all are matched on an anchored name
-// prefix, so containers created before ownership labels existed are still
-// reaped rather than stranded on the host across an agent rollout.
-//
-// The prefix is checked here rather than in the Docker filter because Docker's
-// name filter is an unanchored substring match, which would also match a
-// container a human named something like "my-evergreen-task-debug".
+// An explicit owner label is authoritative in both directions. Containers with
+// no owner label are matched on an anchored name prefix so pre-label containers
+// are still reaped. The prefix is checked client-side because Docker's name
+// filter is an unanchored substring match.
 func isAgentOwnedContainer(labels map[string]string, names []string) bool {
 	if owner, ok := labels[agentcontainer.OwnerLabel]; ok {
 		return owner == agentcontainer.OwnerLabelValue
@@ -148,16 +142,11 @@ func containerNames(names []string) string {
 	return strings.Join(clean, ",")
 }
 
-// maybeStartContainer ensures a Docker container is running for task isolation
-// when the distro has container isolation enabled. It sets conf.ContainerID so
-// commands know to route execution through `docker exec`.
-//
-// Container lifecycle is task-group-scoped, not per-task. If a container is
-// already running for this task group (a.currentContainer != nil), the existing
-// container's identity is wired into conf without creating a new one. A new
-// container is only created at the start of a task group (when a.currentContainer
-// is nil). The container is destroyed in runTeardownGroupCommands.
-func (a *Agent) maybeStartContainer(ctx context.Context, conf *internal.TaskConfig, log grip.Journaler) error {
+// ensureContainer starts a Docker container for task isolation when the distro
+// has container isolation enabled, or reuses the existing container for the
+// current task group. It sets conf.ContainerID so commands route execution
+// through `docker exec`. The container is destroyed in runTeardownGroupCommands.
+func (a *Agent) ensureContainer(ctx context.Context, conf *internal.TaskConfig, log grip.Journaler) error {
 	if conf.Distro == nil || conf.Distro.ContainerIsolation == nil {
 		return nil
 	}
@@ -189,28 +178,33 @@ func (a *Agent) maybeStartContainer(ctx context.Context, conf *internal.TaskConf
 			span.SetStatus(codes.Error, err.Error())
 			return errors.Wrap(err, "preparing task directories for isolation container (fail-closed: require_isolation is set)")
 		}
-		grip.Warningf(ctx, "Could not prepare task directories for container isolation: %s", err)
+		if log != nil {
+			log.Warningf(ctx, "Could not prepare task directories for container isolation: %s", err)
+		}
 	}
 	if fellBack {
 		span.SetAttributes(attribute.Bool("container.workdir_permissive_fallback", true))
-		grip.Warningf(ctx, "Task directories for task '%s' are world-writable because ownership could not be transferred to exec user '%s'; the container can write to them, but so can any other local user on this host.",
-			conf.Task.Id, conf.Distro.ExecUser)
+		if log != nil {
+			log.Warningf(ctx, "Task directories for task '%s' are world-writable because ownership could not be transferred to exec user '%s'; the container can write to them, but so can any other local user on this host.",
+				conf.Task.Id, conf.Distro.ExecUser)
+		}
 	}
 
-	extraMounts := toolchainMounts(ctx, conf.Task.Id)
+	extraMounts := toolchainMounts(ctx, conf.Task.Id, log)
 
 	factory := a.containerFactory
 	if factory == nil {
 		factory = defaultContainerFactory
 	}
 	tc, err := factory(ctx, agentcontainer.Config{
-		Image:       ci.Image,
-		WorkDir:     conf.WorkDir,
-		TaskID:      conf.Task.Id,
-		MemoryMB:    ci.MemoryMB,
-		CPUs:        ci.CPUs,
-		ExtraMounts: extraMounts,
-		Logger:      log,
+		Image:         ci.Image,
+		WorkDir:       conf.WorkDir,
+		TaskID:        conf.Task.Id,
+		TaskExecution: conf.Task.Execution,
+		MemoryMB:      ci.MemoryMB,
+		CPUs:          ci.CPUs,
+		ExtraMounts:   extraMounts,
+		Logger:        log,
 	})
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
@@ -246,11 +240,15 @@ func (a *Agent) maybeStartContainer(ctx context.Context, conf *internal.TaskConf
 	if conf.EnvFileHostDir != "" {
 		hostEnvPath := filepath.Join(conf.EnvFileHostDir, ".evg-host-env")
 		if err := writeHostEnvFile(ctx, hostEnvPath); err != nil {
-			grip.Warningf(ctx, "Could not write host env file for container isolation: %s", err)
+			if log != nil {
+				log.Warningf(ctx, "Could not write host env file for container isolation: %s", err)
+			}
 		}
 	}
 
-	grip.Infof(ctx, "Started isolation container '%s' (image=%s) for task group starting with task '%s'.", tc.GetName(), ci.Image, conf.Task.Id)
+	if log != nil {
+		log.Infof(ctx, "Started isolation container '%s' (image=%s) for task group starting with task '%s'.", tc.GetName(), ci.Image, conf.Task.Id)
+	}
 	return nil
 }
 
@@ -283,7 +281,7 @@ var containerToolchainDirs = []string{
 // toolchainMounts returns read-only mounts for the toolchain directories that
 // exist on the host. Nonexistent sources are skipped because Docker rejects
 // bind mounts whose source is missing, which would fail container creation.
-func toolchainMounts(ctx context.Context, taskID string) []agentcontainer.Mount {
+func toolchainMounts(ctx context.Context, taskID string, log grip.Journaler) []agentcontainer.Mount {
 	var mounts []agentcontainer.Mount
 	for _, dir := range containerToolchainDirs {
 		if _, err := os.Stat(dir); err != nil {
@@ -291,29 +289,19 @@ func toolchainMounts(ctx context.Context, taskID string) []agentcontainer.Mount 
 		}
 		mounts = append(mounts, agentcontainer.Mount{Source: dir, Target: dir, ReadOnly: true})
 	}
-	if len(mounts) == 0 {
-		grip.Warningf(ctx, "No host toolchain directories found; container for task '%s' will only see image-provided toolchains.", taskID)
+	if len(mounts) == 0 && log != nil {
+		log.Warningf(ctx, "No host toolchain directories found; container for task '%s' will only see image-provided toolchains.", taskID)
 	}
 	return mounts
 }
 
 // secureContainerDirs prepares the task working directory and its tmp
-// subdirectory for use by the container's exec user, which must be able to
-// write to them through the same-path bind mount.
-//
-// The preferred path transfers ownership to the exec user and applies a mode
-// that is not world-writable. When ownership cannot be reconciled — the user
-// does not resolve on the host, or the agent cannot chown — the directories
-// fall back to a permissive mode so the task still runs, and fellBack reports
-// the weaker posture so the caller can log it.
-//
-// Bind mounts are enforced by numeric uid, while `docker exec --user` resolves
-// the exec user against the image's own passwd database. A host uid that
-// disagrees with the image's uid for the same name is therefore not detectable
-// here and surfaces as a write failure inside the container.
-//
-// When the distro has no exec user, docker exec runs as root inside the
-// container and can already write to the agent-owned directories.
+// subdirectory for the container's exec user. Ownership transfer is preferred;
+// when that fails, a permissive mode is applied so the task still runs, and
+// fellBack reports the weaker posture. Bind mounts use numeric uid while
+// docker exec resolves the user against the image's passwd database, so a
+// uid mismatch is not detectable here and surfaces as a write failure inside
+// the container.
 func secureContainerDirs(workDir, execUser string) (fellBack bool, err error) {
 	if workDir == "" || execUser == "" {
 		return false, nil
@@ -411,16 +399,10 @@ func verifyRealDir(dir string) error {
 }
 
 // destroyContainer tears down the isolation container and clears the agent's
-// container reference. conf may be nil (e.g. when called from the loop-exit
-// defer before any task has run), in which case conf fields are not cleared.
-// The container is identified by its name in logs rather than the task ID,
-// since the container was created for the first task in the group and its name
-// does not change across task-group members.
+// reference. conf may be nil; in that case conf fields are not cleared.
 //
-// If a.retainContainerUntil is in the future, container ownership transfers to
-// a bounded background cleanup. The container remains available for inspection
-// until the retention deadline, or until the agent context is canceled during
-// shutdown. The agent reference is cleared so subsequent dispatch is unaffected.
+// If retainContainerUntil is in the future, the container is handed off to a
+// background goroutine that destroys it at the deadline or on agent shutdown.
 func (a *Agent) destroyContainer(ctx context.Context, conf *internal.TaskConfig) {
 	if a.currentContainer == nil {
 		a.retainContainerUntil = time.Time{}
@@ -528,32 +510,28 @@ func checkContainerOOM(ctx context.Context, containerID string) (bool, error) { 
 // for ContainerRetainOnFailureSecs seconds after the task ends so on-call can
 // docker exec into it for post-mortem inspection.
 //
-// Timing note: the window is measured from task failure time, not from when
-// destroyContainer actually fires (which is at group teardown, potentially
-// seconds to minutes later). For task groups where teardown fires within the
-// window, the container is left running until the reaper; for teardown after
-// the window, normal destroy runs. Both outcomes are acceptable for Phase 0
-// on-call use: the container is either available or cleanly removed.
-func (a *Agent) scheduleContainerRetention(ctx context.Context, containerName string) { //nolint:unused
+// The window is measured from task failure time, not from when destroyContainer
+// actually fires (which is at group teardown, potentially seconds to minutes
+// later). The retention goroutine destroys the container at the deadline; if
+// the agent exits before the deadline, the reaper cleans it up at next startup.
+func (a *Agent) scheduleContainerRetention(ctx context.Context, containerName string, log grip.Journaler) { //nolint:unused
 	if a.opts.ContainerRetainOnFailureSecs <= 0 || a.currentContainer == nil {
 		return
 	}
 	a.retainContainerUntil = time.Now().Add(time.Duration(a.opts.ContainerRetainOnFailureSecs) * time.Second)
-	grip.Infof(ctx, "Task failed with isolation container '%s' active; scheduling retention until %s (retain_on_failure_secs=%d). Use `docker exec -it %s bash` for inspection.",
-		containerName, a.retainContainerUntil.Format(time.RFC3339),
-		a.opts.ContainerRetainOnFailureSecs, containerName)
+	if log != nil {
+		log.Infof(ctx, "Task failed with isolation container '%s' active; scheduling retention until %s (retain_on_failure_secs=%d). Use `docker exec -it %s bash` for inspection.",
+			containerName, a.retainContainerUntil.Format(time.RFC3339),
+			a.opts.ContainerRetainOnFailureSecs, containerName)
+	}
 }
 
 // emitContainerFailureSnapshot collects post-mortem forensics from the active
 // isolation container and emits them as a container.failure_snapshot OTel span.
-// It is called on non-zero task exit while the container is still running
-// (before destroyContainer fires at group teardown).
-//
-// Only allowlisted fields are exported, and every exported string is passed
-// through redactForSnapshot, which fails closed. The raw inspect document and
-// raw env-file values are never exported because both carry credentials.
+// Only allowlisted fields are exported; every exported string passes through
+// redactForSnapshot. Raw env-file values are never exported.
 func (a *Agent) emitContainerFailureSnapshot(ctx context.Context, tc *taskContext, detail *apimodels.TaskEndDetail) { //nolint:unused
-	if a.currentContainer == nil || tc == nil {
+	if a.currentContainer == nil || tc == nil || detail == nil {
 		return
 	}
 	containerID := a.currentContainer.GetID()
@@ -576,13 +554,6 @@ func (a *Agent) emitContainerFailureSnapshot(ctx context.Context, tc *taskContex
 
 	if summary, err := containerInspectSummaryJSON(ctx, containerID); err == nil {
 		span.SetAttributes(attribute.String("container.inspect_summary", redactForSnapshot(summary, tc)))
-	}
-
-	// Capture ps output even on non-zero exit: a container whose processes
-	// have all died is exactly the case where "no processes found" is the
-	// useful signal rather than a missing attribute.
-	if psOut, _ := containerExec(ctx, containerID, "ps", "-ef"); psOut != "" {
-		span.SetAttributes(attribute.String("container.ps_output", redactForSnapshot(psOut, tc)))
 	}
 
 	// Only the env-file key names are exported. The values are the task's
@@ -746,14 +717,9 @@ func redactForSnapshot(s string, tc *taskContext) string {
 
 // augmentOOMTrackerWithContainerSignal supplements the dmesg-based OOM report
 // with the container-native OOMKilled signal from docker inspect, which is
-// more reliable under containers because dmesg PIDs are host-side and the
-// buffer can carry messages from prior containers.
-//
-// This is deliberately independent of tc.oomTrackerEnabled(cloudProvider):
-// that gate controls the dmesg report for host processes, whereas OOMKilled is
-// a container-specific fact worth surfacing whenever a container is active.
+// more reliable under containers where dmesg PIDs are host-side.
 func (a *Agent) augmentOOMTrackerWithContainerSignal(ctx context.Context, tc *taskContext, detail *apimodels.TaskEndDetail) { //nolint:unused
-	if a.currentContainer == nil {
+	if a.currentContainer == nil || tc == nil || detail == nil {
 		return
 	}
 	oomKilled, err := checkContainerOOM(ctx, a.currentContainer.GetID())

--- a/agent/container.go
+++ b/agent/container.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -282,6 +283,10 @@ func toolchainMounts(ctx context.Context, taskID string) []agentcontainer.Mount 
 // container and can already write to the agent-owned directories, so there is
 // nothing to do.
 func secureContainerDirs(workDir, execUser string) error {
+	if runtime.GOOS == "windows" {
+		// Container isolation is Linux/Docker-only, and Windows ACLs cannot be expressed as POSIX UID/GID ownership.
+		return nil
+	}
 	if workDir == "" || execUser == "" {
 		return nil
 	}

--- a/agent/container.go
+++ b/agent/container.go
@@ -283,10 +283,6 @@ func toolchainMounts(ctx context.Context, taskID string) []agentcontainer.Mount 
 // container and can already write to the agent-owned directories, so there is
 // nothing to do.
 func secureContainerDirs(workDir, execUser string) error {
-	if runtime.GOOS == "windows" {
-		// Container isolation is Linux/Docker-only, and Windows ACLs cannot be expressed as POSIX UID/GID ownership.
-		return nil
-	}
 	if workDir == "" || execUser == "" {
 		return nil
 	}
@@ -294,6 +290,12 @@ func secureContainerDirs(workDir, execUser string) error {
 	usr, err := user.Lookup(execUser)
 	if err != nil {
 		return errors.Wrapf(err, "looking up exec user '%s'", execUser)
+	}
+	if runtime.GOOS == "windows" {
+		// Container isolation is Linux/Docker-only; Windows cannot express ownership as
+		// a POSIX numeric UID/GID, and ACL-based equivalents are out of scope. The
+		// lookup above still validates the exec user so isolation fails closed consistently.
+		return nil
 	}
 	uid, err := strconv.Atoi(usr.Uid)
 	if err != nil {

--- a/agent/container.go
+++ b/agent/container.go
@@ -560,7 +560,7 @@ func containerEnvFileKeys(dir string) ([]string, error) {
 	}
 
 	var keys []string
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		key, _, found := strings.Cut(line, "=")
 		if !found || key == "" {
 			continue
@@ -759,7 +759,7 @@ func parseHostEnv(out []byte) []string {
 	}
 
 	var entries []string
-	for _, record := range strings.Split(after, "\x00") {
+	for record := range strings.SplitSeq(after, "\x00") {
 		key, value, found := strings.Cut(record, "=")
 		if !found || key == "" || strings.ContainsAny(value, "\n\r") {
 			continue

--- a/agent/container.go
+++ b/agent/container.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -25,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // ContainerHandle is the interface through which the agent manages an active
@@ -34,7 +37,6 @@ type ContainerHandle interface {
 	GetID() string
 	GetName() string
 	GetEnvFileHostDir() string
-	Close()
 	Destroy(ctx context.Context) error
 }
 
@@ -47,17 +49,8 @@ func defaultContainerFactory(ctx context.Context, cfg agentcontainer.Config) (Co
 	return agentcontainer.CreateAndStart(ctx, cfg)
 }
 
-// tryReapOrphanContainers removes any evergreen-task-* containers left behind
-// by a prior agent crash or host reboot. Called once at agent startup when
-// the --cleanup flag is set, before any tasks are dispatched. Best-effort:
-// if Docker is not running (non-container-enabled host) the function returns
-// silently; individual removal failures are warned but do not block startup.
 // reaperTimeout bounds the total time the orphan-container reaper spends
-// connecting to Docker, listing containers, and removing them. Using a
-// background-derived context (not the agent's Start ctx) ensures that a
-// shutdown signal arriving during the --cleanup phase doesn't silently skip
-// the reap entirely: the agent ctx would be cancelled before any Docker call
-// completes, leaving orphans on the host.
+// connecting to Docker, listing containers, and removing them.
 const reaperTimeout = 30 * time.Second //nolint:unused
 
 const (
@@ -66,13 +59,18 @@ const (
 	hostEnvCommandWaitDelay = time.Second
 )
 
+// tryReapOrphanContainers removes isolation containers left behind by a prior
+// agent crash or host reboot. Called once at agent startup when the --cleanup
+// flag is set, before any tasks are dispatched. Best-effort: if Docker is not
+// running the function returns silently, and individual removal failures are
+// warned but do not block startup.
+//
+// The reaper runs on a background-derived context so that a shutdown signal
+// arriving during the --cleanup phase does not cancel every Docker call and
+// silently skip the reap, leaving orphans on the host.
 func (a *Agent) tryReapOrphanContainers(ctx context.Context) { //nolint:unused
 	defer recovery.LogStackTraceAndContinue("reap orphan containers")
 
-	// Use a bounded background context so the reaper completes even if the
-	// parent ctx is cancelled during a shutdown race. The parent ctx is still
-	// used for mid-loop cancellation checks so a clean agent shutdown during
-	// removal doesn't log spurious warnings.
 	reaperCtx, cancel := context.WithTimeout(context.Background(), reaperTimeout)
 	defer cancel()
 
@@ -88,14 +86,13 @@ func (a *Agent) tryReapOrphanContainers(ctx context.Context) { //nolint:unused
 		return
 	}
 
-	// The name filter is a substring match. GOAL-279 containers are named
-	// evergreen-task-<task-id>, a prefix distinctive enough that accidental
-	// collisions with human-created containers are unlikely. A label-based
-	// filter would be more precise but requires labelling containers at
-	// creation time (a larger change deferred to Phase 1).
+	// Select by ownership label, not by name. Removal is destructive and
+	// irreversible, so a container must positively identify itself as owned
+	// by the agent before it is eligible.
+	ownerFilter := fmt.Sprintf("%s=%s", agentcontainer.OwnerLabel, agentcontainer.OwnerLabelValue)
 	containers, err := cli.ContainerList(reaperCtx, dockercontainer.ListOptions{
 		All:     true,
-		Filters: filters.NewArgs(filters.KeyValuePair{Key: "name", Value: "evergreen-task-"}),
+		Filters: filters.NewArgs(filters.KeyValuePair{Key: "label", Value: ownerFilter}),
 	})
 	if err != nil {
 		grip.Warningf(ctx, "Orphan container reaper: could not list containers: %s", err)
@@ -103,6 +100,11 @@ func (a *Agent) tryReapOrphanContainers(ctx context.Context) { //nolint:unused
 	}
 
 	for _, c := range containers {
+		// Re-check ownership on the returned document rather than trusting
+		// the server-side filter alone.
+		if !isAgentOwnedContainer(c.Labels) {
+			continue
+		}
 		shortID := c.ID
 		if len(shortID) > 12 {
 			shortID = shortID[:12]
@@ -110,7 +112,6 @@ func (a *Agent) tryReapOrphanContainers(ctx context.Context) { //nolint:unused
 		names := containerNames(c.Names)
 		if err := cli.ContainerRemove(reaperCtx, c.ID, dockercontainer.RemoveOptions{Force: true}); err != nil {
 			if ctx.Err() != nil {
-				// Context cancelled during shutdown — not a real removal failure.
 				return
 			}
 			grip.Warningf(ctx, "Orphan container reaper: could not remove container '%s' (%s): %s", shortID, names, err)
@@ -120,9 +121,16 @@ func (a *Agent) tryReapOrphanContainers(ctx context.Context) { //nolint:unused
 	}
 }
 
+// isAgentOwnedContainer reports whether a container carries this agent's
+// ownership label. Removal is irreversible, so a container must positively
+// identify itself as agent-owned before the reaper will touch it.
+func isAgentOwnedContainer(labels map[string]string) bool {
+	return labels[agentcontainer.OwnerLabel] == agentcontainer.OwnerLabelValue
+}
+
 // containerNames strips the leading '/' that the Docker API prepends to
 // container names and joins them for display.
-func containerNames(names []string) string { //nolint:unused
+func containerNames(names []string) string {
 	clean := make([]string, len(names))
 	for i, n := range names {
 		clean[i] = strings.TrimPrefix(n, "/")
@@ -151,28 +159,6 @@ func (a *Agent) maybeStartContainer(ctx context.Context, conf *internal.TaskConf
 		return nil
 	}
 
-	// The task workdir is created by the agent (root) with mode 0755 due to
-	// the process umask. The exec_user inside the container (typically uid=1000)
-	// cannot write to a root-owned 0755 directory. Explicitly chmod to 0777 so
-	// the container process can write task output to the workdir via the
-	// same-path bind mount. This is safe: the workdir is per-task and ephemeral.
-	if conf.WorkDir != "" {
-		if err := os.Chmod(conf.WorkDir, 0777); err != nil {
-			grip.Warningf(ctx, "Could not chmod task workdir '%s' for container isolation: %s", conf.WorkDir, err)
-		}
-	}
-
-	// The task tmp directory (WorkDir/tmp) has the same umask problem —
-	// MkdirAll creates it with 0777 but the umask strips group/other write
-	// bits, leaving the container user unable to write temp files (cgo,
-	// gcc, etc.). Chmod it the same way as the workdir.
-	if conf.WorkDir != "" {
-		tmpDir := filepath.Join(conf.WorkDir, "tmp")
-		if err := os.Chmod(tmpDir, 0777); err != nil {
-			grip.Warningf(ctx, "Could not chmod task tmp dir '%s' for container isolation: %s", tmpDir, err)
-		}
-	}
-
 	ci := conf.Distro.ContainerIsolation
 	ctx, span := a.tracer.Start(ctx, "container.create_and_start")
 	defer span.End()
@@ -182,26 +168,20 @@ func (a *Agent) maybeStartContainer(ctx context.Context, conf *internal.TaskConf
 		attribute.String("container.distro_id", conf.Task.DistroId),
 	)
 
-	// Build the extra mounts. /opt is bind-mounted read-only so toolchains
-	// (mongodbtoolchain, golang, java, ruby) installed at AMI provisioning
-	// are visible inside the container without baking them into the image.
-	// Skip the mount if /opt does not exist on the host — Docker rejects
-	// bind-mount sources that don't exist, which would fail container
-	// creation entirely.
-	//
-	// Security: /opt must contain only toolchains, never secrets. Read-only
-	// mounts still allow reading and exfiltration, so any credential
-	// material placed under /opt would be visible to every containerized
-	// task. AMI provisioning scripts for container-isolated distros must
-	// not write SSH keys, tokens, or other secrets to /opt.
-	var extraMounts []agentcontainer.Mount
-	if _, err := os.Stat("/opt"); err == nil {
-		extraMounts = append(extraMounts, agentcontainer.Mount{
-			Source: "/opt", Target: "/opt", ReadOnly: true,
-		})
-	} else {
-		grip.Warningf(ctx, "Host /opt not found, skipping toolchain bind mount for task '%s'", conf.Task.Id)
+	// The task workdir and its tmp subdirectory are created by the agent and
+	// are not writable by the container's exec user. Access is granted by
+	// transferring ownership rather than by widening the mode, so the
+	// directories never become world-writable on a host shared with other
+	// local users.
+	if err := secureContainerDirs(conf.WorkDir, conf.Distro.ExecUser); err != nil {
+		if ci.RequireIsolation {
+			span.SetStatus(codes.Error, err.Error())
+			return errors.Wrap(err, "preparing task directories for isolation container (fail-closed: require_isolation is set)")
+		}
+		grip.Warningf(ctx, "Could not prepare task directories for container isolation: %s", err)
 	}
+
+	extraMounts := toolchainMounts(ctx, conf.Task.Id)
 
 	factory := a.containerFactory
 	if factory == nil {
@@ -258,6 +238,94 @@ func (a *Agent) maybeStartContainer(ctx context.Context, conf *internal.TaskConf
 	return nil
 }
 
+// containerDirMode is the mode applied to task directories shared with the
+// isolation container. The container's exec user is granted write access
+// through ownership, so these directories are never world-writable.
+const containerDirMode = 0755
+
+// containerToolchainDirs are the host toolchain directories bind-mounted
+// read-only into the container. Toolchains are installed at AMI provisioning
+// rather than baked into the image. Only these paths are mounted; the whole
+// of /opt is not, because a read-only mount still lets a task read (and
+// exfiltrate) anything beneath it.
+var containerToolchainDirs = []string{
+	"/opt/mongodbtoolchain",
+	"/opt/golang",
+	"/opt/java",
+	"/opt/ruby",
+	"/opt/node",
+	"/opt/python",
+}
+
+// toolchainMounts returns read-only mounts for the toolchain directories that
+// exist on the host. Nonexistent sources are skipped because Docker rejects
+// bind mounts whose source is missing, which would fail container creation.
+func toolchainMounts(ctx context.Context, taskID string) []agentcontainer.Mount {
+	var mounts []agentcontainer.Mount
+	for _, dir := range containerToolchainDirs {
+		if _, err := os.Stat(dir); err != nil {
+			continue
+		}
+		mounts = append(mounts, agentcontainer.Mount{Source: dir, Target: dir, ReadOnly: true})
+	}
+	if len(mounts) == 0 {
+		grip.Warningf(ctx, "No host toolchain directories found; container for task '%s' will only see image-provided toolchains.", taskID)
+	}
+	return mounts
+}
+
+// secureContainerDirs transfers ownership of the task working directory and
+// its tmp subdirectory to the distro's exec user so containerized processes
+// can write to them through the same-path bind mount.
+//
+// When the distro has no exec user, docker exec runs as root inside the
+// container and can already write to the agent-owned directories, so there is
+// nothing to do.
+func secureContainerDirs(workDir, execUser string) error {
+	if workDir == "" || execUser == "" {
+		return nil
+	}
+
+	usr, err := user.Lookup(execUser)
+	if err != nil {
+		return errors.Wrapf(err, "looking up exec user '%s'", execUser)
+	}
+	uid, err := strconv.Atoi(usr.Uid)
+	if err != nil {
+		return errors.Wrapf(err, "parsing uid for exec user '%s'", execUser)
+	}
+	gid, err := strconv.Atoi(usr.Gid)
+	if err != nil {
+		return errors.Wrapf(err, "parsing gid for exec user '%s'", execUser)
+	}
+
+	catcher := grip.NewBasicCatcher()
+	for _, dir := range []string{workDir, filepath.Join(workDir, "tmp")} {
+		catcher.Wrapf(chownContainerDir(dir, uid, gid), "securing '%s'", dir)
+	}
+	return catcher.Resolve()
+}
+
+// chownContainerDir transfers ownership of dir to uid/gid. It refuses to act
+// on a symlink so that a local user cannot redirect the ownership change at a
+// path they do not own.
+func chownContainerDir(dir string, uid, gid int) error {
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return errors.Wrap(err, "stating directory")
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return errors.New("refusing to modify a symlink")
+	}
+	if !info.IsDir() {
+		return errors.New("path is not a directory")
+	}
+	if err := os.Lchown(dir, uid, gid); err != nil {
+		return errors.Wrap(err, "changing ownership")
+	}
+	return errors.Wrap(os.Chmod(dir, containerDirMode), "setting permissions")
+}
+
 // destroyContainer tears down the isolation container and clears the agent's
 // container reference. conf may be nil (e.g. when called from the loop-exit
 // defer before any task has run), in which case conf fields are not cleared.
@@ -294,7 +362,7 @@ func (a *Agent) destroyContainer(ctx context.Context, conf *internal.TaskConfig)
 			conf.ContainerID = ""
 			conf.EnvFileHostDir = ""
 		}
-		go destroyRetainedContainer(ctx, retainedContainer, containerName, retainedUntil)
+		go destroyRetainedContainer(ctx, a.tracer, retainedContainer, containerName, retainedUntil)
 		return
 	}
 
@@ -309,7 +377,13 @@ func (a *Agent) destroyContainer(ctx context.Context, conf *internal.TaskConfig)
 	}
 }
 
-func destroyRetainedContainer(ctx context.Context, container ContainerHandle, containerName string, retainUntil time.Time) {
+// destroyRetainedContainer waits for the retention deadline to pass or the
+// agent to shut down, then removes the container. It runs detached from its
+// caller, so it must recover from panics: an unrecovered panic in a goroutine
+// terminates the entire agent process.
+func destroyRetainedContainer(ctx context.Context, tracer trace.Tracer, container ContainerHandle, containerName string, retainUntil time.Time) {
+	defer recovery.LogStackTraceAndContinue("destroy retained container")
+
 	timer := time.NewTimer(time.Until(retainUntil))
 	defer timer.Stop()
 
@@ -318,31 +392,48 @@ func destroyRetainedContainer(ctx context.Context, container ContainerHandle, co
 	case <-timer.C:
 	}
 
+	// Detach from the caller so shutdown cancellation cannot bypass removal.
+	// The span starts here so its duration covers the removal itself rather
+	// than the caller's already-completed teardown.
 	destroyCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), reaperTimeout)
 	defer cancel()
+	destroyCtx, span := tracer.Start(destroyCtx, "container.destroy_retained")
+	defer span.End()
+	span.SetAttributes(attribute.String("container.name", containerName))
+
 	if err := container.Destroy(destroyCtx); err != nil {
+		span.SetStatus(codes.Error, err.Error())
 		grip.Warningf(destroyCtx, "Failed to destroy retained isolation container '%s': %s", containerName, err)
 	}
 }
 
-// checkContainerOOM uses docker inspect to read the OOMKilled flag from the
-// container state. Returns (true, nil) when the container was OOM-killed,
-// (false, nil) when it was not, and (false, err) when inspect fails.
-func checkContainerOOM(ctx context.Context, containerID string) (bool, error) { //nolint:unused
+// inspectContainerTimeout bounds a single docker inspect call.
+const inspectContainerTimeout = 10 * time.Second //nolint:unused
+
+// inspectContainer returns the Docker inspect document for a container.
+func inspectContainer(ctx context.Context, containerID string) (dockercontainer.InspectResponse, error) { //nolint:unused
+	inspectCtx, cancel := context.WithTimeout(ctx, inspectContainerTimeout)
+	defer cancel()
+
 	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
-		return false, fmt.Errorf("creating Docker client for OOM check: %w", err)
+		return dockercontainer.InspectResponse{}, errors.Wrap(err, "creating Docker client")
 	}
 	defer cli.Close()
 
-	inspectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
 	info, err := cli.ContainerInspect(inspectCtx, containerID)
+	return info, errors.Wrapf(err, "inspecting container '%s'", containerID)
+}
+
+// checkContainerOOM reads the container-native OOMKilled flag from docker
+// inspect. Returns (true, nil) when the container was OOM-killed, (false, nil)
+// when it was not, and (false, err) when inspect fails.
+func checkContainerOOM(ctx context.Context, containerID string) (bool, error) { //nolint:unused
+	info, err := inspectContainer(ctx, containerID)
 	if err != nil {
-		return false, fmt.Errorf("inspecting container '%s': %w", containerID, err)
+		return false, err
 	}
-	if info.State == nil {
+	if info.ContainerJSONBase == nil || info.State == nil {
 		return false, nil
 	}
 	return info.State.OOMKilled, nil
@@ -369,22 +460,14 @@ func (a *Agent) scheduleContainerRetention(ctx context.Context, containerName st
 		a.opts.ContainerRetainOnFailureSecs, containerName)
 }
 
-// augmentOOMTrackerWithContainerSignal supplements the existing dmesg-based
-// OOM report with the container-native OOMKilled signal from docker inspect.
-// This is more reliable than dmesg under containers because dmesg PIDs are
-// host-side (not matching container-namespaced PIDs) and the dmesg buffer can
-// accumulate messages from prior containers.
-//
-// This check is intentionally independent of tc.oomTrackerEnabled(cloudProvider).
-// That gate controls the dmesg-based report (a project-level setting for host
-// processes). The container OOMKilled signal is a container-specific fact from
-// docker inspect, always worth surfacing when a container is active regardless
-// of project OOM-tracker preferences.
 // emitContainerFailureSnapshot collects post-mortem forensics from the active
 // isolation container and emits them as a container.failure_snapshot OTel span.
-// It is called on non-zero task exit while the container is still running (before
-// destroyContainer fires at group teardown). All string fields are run through
-// the task config's redactor so secrets never appear in Honeycomb.
+// It is called on non-zero task exit while the container is still running
+// (before destroyContainer fires at group teardown).
+//
+// Only allowlisted fields are exported, and every exported string is passed
+// through redactForSnapshot, which fails closed. The raw inspect document and
+// raw env-file values are never exported because both carry credentials.
 func (a *Agent) emitContainerFailureSnapshot(ctx context.Context, tc *taskContext, detail *apimodels.TaskEndDetail) { //nolint:unused
 	if a.currentContainer == nil || tc == nil {
 		return
@@ -407,36 +490,85 @@ func (a *Agent) emitContainerFailureSnapshot(ctx context.Context, tc *taskContex
 		span.SetStatus(codes.Error, detail.Status)
 	}
 
-	// docker inspect JSON.
-	if inspectJSON, err := containerInspectJSON(ctx, containerID); err == nil {
-		span.SetAttributes(attribute.String("container.inspect_json", redactForSnapshot(inspectJSON, tc)))
+	if summary, err := containerInspectSummaryJSON(ctx, containerID); err == nil {
+		span.SetAttributes(attribute.String("container.inspect_summary", redactForSnapshot(summary, tc)))
 	}
 
-	// ps -ef inside the container. Capture output even on non-zero exit — a
-	// container whose processes have all died is exactly the case where we
-	// want "no processes found" in Honeycomb rather than a missing attribute.
+	// Capture ps output even on non-zero exit: a container whose processes
+	// have all died is exactly the case where "no processes found" is the
+	// useful signal rather than a missing attribute.
 	if psOut, _ := containerExec(ctx, containerID, "ps", "-ef"); psOut != "" {
 		span.SetAttributes(attribute.String("container.ps_output", redactForSnapshot(psOut, tc)))
 	}
 
-	// Env-file contents (the per-task tmpfs written by WrapWithContainer).
+	// Only the env-file key names are exported. The values are the task's
+	// environment, which routinely holds credentials, and the key list is
+	// enough to diagnose a missing or malformed variable.
 	if tc.taskConfig != nil && tc.taskConfig.EnvFileHostDir != "" {
-		if data, err := readLatestContainerEnvFile(tc.taskConfig.EnvFileHostDir); err == nil {
-			span.SetAttributes(attribute.String("container.env_file", redactForSnapshot(string(data), tc)))
+		if keys, err := containerEnvFileKeys(tc.taskConfig.EnvFileHostDir); err == nil {
+			span.SetAttributes(attribute.StringSlice("container.env_file_keys", keys))
 		}
 	}
 
-	// Task log tail (stdout/stderr) is an accepted deviation from the
-	// design doc's original "last 200 lines of stdout/stderr" requirement.
-	// Task output flows through Jasper senders to the remote Evergreen log
-	// service, not to a local file or container stdout. `docker logs` does
-	// not help because the container's PID 1 is `sleep infinity` — the
-	// actual task commands run via `docker exec` and their output is
-	// captured by Jasper, not by the Docker logging driver. The design doc
-	// (technical-design-agent-container-lifecycle.md and phase-0-plan.md)
-	// has been updated to reflect this deviation. Closing the gap would
-	// require a ring buffer in the logger infrastructure, deferred to
-	// Phase 1 if post-mortem finds the existing log pipeline insufficient.
+	// Task stdout/stderr is not captured here: it flows through Jasper to the
+	// remote log service, and `docker logs` only sees PID 1 (`sleep infinity`).
+}
+
+// containerInspectSummary is the allowlisted subset of docker inspect output
+// that may be exported to telemetry. The full document is deliberately
+// excluded because it embeds the container's environment and image config.
+type containerInspectSummary struct { //nolint:unused
+	Status       string `json:"status"`
+	ExitCode     int    `json:"exit_code"`
+	OOMKilled    bool   `json:"oom_killed"`
+	Error        string `json:"error"`
+	StartedAt    string `json:"started_at"`
+	FinishedAt   string `json:"finished_at"`
+	RestartCount int    `json:"restart_count"`
+}
+
+// containerInspectSummaryJSON returns the allowlisted inspect fields as JSON.
+func containerInspectSummaryJSON(ctx context.Context, containerID string) (string, error) { //nolint:unused
+	info, err := inspectContainer(ctx, containerID)
+	if err != nil {
+		return "", err
+	}
+
+	var summary containerInspectSummary
+	if info.ContainerJSONBase != nil {
+		summary.RestartCount = info.RestartCount
+		if info.State != nil {
+			summary.Status = info.State.Status
+			summary.ExitCode = info.State.ExitCode
+			summary.OOMKilled = info.State.OOMKilled
+			summary.Error = info.State.Error
+			summary.StartedAt = info.State.StartedAt
+			summary.FinishedAt = info.State.FinishedAt
+		}
+	}
+
+	data, err := json.Marshal(summary)
+	return string(data), errors.Wrap(err, "marshalling inspect summary")
+}
+
+// containerEnvFileKeys returns the sorted key names present in the newest
+// container env file. Values are intentionally discarded.
+func containerEnvFileKeys(dir string) ([]string, error) {
+	data, err := readLatestContainerEnvFile(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var keys []string
+	for _, line := range strings.Split(string(data), "\n") {
+		key, _, found := strings.Cut(line, "=")
+		if !found || key == "" {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys, nil
 }
 
 func readLatestContainerEnvFile(dir string) ([]byte, error) {
@@ -468,35 +600,10 @@ func readLatestContainerEnvFile(dir string) ([]byte, error) {
 	return data, errors.Wrap(err, "reading latest container env file")
 }
 
-// containerInspectJSON returns the full JSON from docker inspect for a container.
-func containerInspectJSON(ctx context.Context, containerID string) (string, error) { //nolint:unused
-	inspectCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-
-	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
-	if err != nil {
-		return "", errors.Wrap(err, "creating Docker client for inspect")
-	}
-	defer cli.Close()
-
-	info, err := cli.ContainerInspect(inspectCtx, containerID)
-	if err != nil {
-		return "", errors.Wrapf(err, "inspecting container '%s'", containerID)
-	}
-	data, err := json.Marshal(info)
-	if err != nil {
-		return "", errors.Wrap(err, "marshalling inspect result")
-	}
-	return string(data), nil
-}
-
-// containerExec runs a command inside a container and returns its combined output.
-// This failure-snapshot path uses the docker CLI (not the SDK) because it is
-// called only on task failure and the credential-helper flow for ECR is handled
-// by host_provision.go (which also uses the CLI for the same reason). The SDK
-// path for the main lifecycle (CreateAndStart, Destroy) is intentional and
-// unrelated; the CLI is used here for the forensic path to keep its footprint
-// simple and aligned with other CLI callers.
+// containerExec runs a command inside a container and returns its combined
+// output. This forensic path uses the docker CLI rather than the SDK to keep
+// its footprint small; the main lifecycle (CreateAndStart, Destroy) uses the
+// SDK.
 func containerExec(ctx context.Context, containerID string, args ...string) (string, error) { //nolint:unused
 	execCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
 	defer cancel()
@@ -505,6 +612,11 @@ func containerExec(ctx context.Context, containerID string, args ...string) (str
 	return strings.TrimSpace(string(out)), err
 }
 
+// redactionUnavailable replaces snapshot content when the task config needed
+// to redact secrets is missing. Exporting the raw value instead would risk
+// leaking credentials into telemetry, so redaction fails closed.
+const redactionUnavailable = "<REDACTION_UNAVAILABLE>"
+
 // redactForSnapshot applies the task's expansion redactions to s so that
 // secrets never appear in Honeycomb attributes. Values are applied
 // longest-first (matching the canonical redacting_sender order) to prevent a
@@ -512,7 +624,7 @@ func containerExec(ctx context.Context, containerID string, args ...string) (str
 // substitution that leaks the suffix.
 func redactForSnapshot(s string, tc *taskContext) string {
 	if tc == nil || tc.taskConfig == nil {
-		return s
+		return redactionUnavailable
 	}
 	conf := tc.taskConfig
 
@@ -548,6 +660,14 @@ func redactForSnapshot(s string, tc *taskContext) string {
 	return s
 }
 
+// augmentOOMTrackerWithContainerSignal supplements the dmesg-based OOM report
+// with the container-native OOMKilled signal from docker inspect, which is
+// more reliable under containers because dmesg PIDs are host-side and the
+// buffer can carry messages from prior containers.
+//
+// This is deliberately independent of tc.oomTrackerEnabled(cloudProvider):
+// that gate controls the dmesg report for host processes, whereas OOMKilled is
+// a container-specific fact worth surfacing whenever a container is active.
 func (a *Agent) augmentOOMTrackerWithContainerSignal(ctx context.Context, tc *taskContext, detail *apimodels.TaskEndDetail) { //nolint:unused
 	if a.currentContainer == nil {
 		return
@@ -584,40 +704,86 @@ var hostEnvVars = []string{
 	"LIBRARY_PATH",
 }
 
+// hostEnvSentinel marks the start of the env dump in the login shell's stdout.
+// A login shell also runs profile scripts, which may print banners; everything
+// before the sentinel is discarded so it cannot corrupt the env file.
+const hostEnvSentinel = "__EVG_HOST_ENV_BEGIN__"
+
 // writeHostEnvFile captures the host's toolchain-related env vars and writes
 // them to path in KEY=VALUE format. This file is passed as a --env-file to
 // docker exec so containerized processes can find toolchains installed at
 // /opt/golang, /opt/mongodbtoolchain, etc. without sourcing profile scripts.
 //
 // The agent runs as a systemd service whose PATH does not include toolchain
-// directories set by /etc/profile.d/*.sh. To capture the effective PATH and
-// toolchain vars that a login shell would have, we run `bash -l -c` to source
-// the profile scripts and print the env vars.
+// directories set by /etc/profile.d/*.sh, so values are captured from a login
+// shell. If that capture fails the agent's own environment is written instead
+// and the capture error is returned, because the result is degraded.
 func writeHostEnvFile(ctx context.Context, path string) error {
-	// Build a shell command that sources profile scripts and prints the
-	// vars we care about in KEY=VALUE format.
-	var cmdParts []string
-	for _, key := range hostEnvVars {
-		cmdParts = append(cmdParts, fmt.Sprintf("[ -n \"$%s\" ] && echo '%s='$%s", key, key, key))
-	}
-	shellCmd := strings.Join(cmdParts, "\n")
-
 	captureCtx, cancel := context.WithTimeout(ctx, hostEnvCaptureTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(captureCtx, "bash", "-l", "-c", shellCmd)
+
+	cmd := exec.CommandContext(captureCtx, "bash", "-l", "-c", hostEnvShellCommand())
 	cmd.WaitDelay = hostEnvCommandWaitDelay
 	out, err := cmd.Output()
 	if err != nil {
-		// Fall back to the agent process's own env vars if the login shell
-		// fails (e.g. bash not available). This won't have toolchain paths
-		// but preserves the base PATH.
-		var sb strings.Builder
-		for _, key := range hostEnvVars {
-			if val := os.Getenv(key); val != "" {
-				fmt.Fprintf(&sb, "%s=%s\n", key, val)
-			}
+		if writeErr := os.WriteFile(path, []byte(formatHostEnv(agentHostEnv())), 0600); writeErr != nil {
+			return errors.Wrap(writeErr, "writing fallback host env file")
 		}
-		return os.WriteFile(path, []byte(sb.String()), 0600)
+		return errors.Wrap(err, "capturing login shell environment, wrote agent environment instead")
 	}
-	return os.WriteFile(path, out, 0600)
+	return errors.Wrap(os.WriteFile(path, []byte(formatHostEnv(parseHostEnv(out))), 0600), "writing host env file")
+}
+
+// hostEnvShellCommand builds a script printing the wanted variables as
+// NUL-delimited KEY=VALUE records. Expansions are quoted so values containing
+// spaces or glob characters are neither word-split nor pathname-expanded, and
+// NUL delimiting stops a value containing a newline from being mistaken for a
+// record boundary.
+func hostEnvShellCommand() string {
+	parts := []string{fmt.Sprintf("printf '%%s\\0' '%s'", hostEnvSentinel)}
+	for _, key := range hostEnvVars {
+		parts = append(parts, fmt.Sprintf("[ -n \"$%s\" ] && printf '%%s=%%s\\0' '%s' \"$%s\"", key, key, key))
+	}
+	// A trailing true keeps the exit status zero when the final variable is unset.
+	parts = append(parts, "true")
+	return strings.Join(parts, "\n")
+}
+
+// parseHostEnv extracts KEY=VALUE records from the NUL-delimited capture. It
+// discards anything profile scripts printed before the sentinel and drops
+// values containing newlines, which an env file cannot represent.
+func parseHostEnv(out []byte) []string {
+	_, after, found := strings.Cut(string(out), hostEnvSentinel+"\x00")
+	if !found {
+		return nil
+	}
+
+	var entries []string
+	for _, record := range strings.Split(after, "\x00") {
+		key, value, found := strings.Cut(record, "=")
+		if !found || key == "" || strings.ContainsAny(value, "\n\r") {
+			continue
+		}
+		entries = append(entries, key+"="+value)
+	}
+	return entries
+}
+
+// agentHostEnv reads the wanted variables from the agent's own environment.
+// It lacks profile-set toolchain paths but preserves a usable base PATH.
+func agentHostEnv() []string {
+	var entries []string
+	for _, key := range hostEnvVars {
+		if val := os.Getenv(key); val != "" && !strings.ContainsAny(val, "\n\r") {
+			entries = append(entries, key+"="+val)
+		}
+	}
+	return entries
+}
+
+func formatHostEnv(entries []string) string {
+	if len(entries) == 0 {
+		return ""
+	}
+	return strings.Join(entries, "\n") + "\n"
 }

--- a/agent/container.go
+++ b/agent/container.go
@@ -60,6 +60,12 @@ func defaultContainerFactory(ctx context.Context, cfg agentcontainer.Config) (Co
 // completes, leaving orphans on the host.
 const reaperTimeout = 30 * time.Second //nolint:unused
 
+const (
+	containerEnvFilePrefix  = ".evg-env-"
+	hostEnvCaptureTimeout   = 30 * time.Second
+	hostEnvCommandWaitDelay = time.Second
+)
+
 func (a *Agent) tryReapOrphanContainers(ctx context.Context) { //nolint:unused
 	defer recovery.LogStackTraceAndContinue("reap orphan containers")
 
@@ -243,7 +249,7 @@ func (a *Agent) maybeStartContainer(ctx context.Context, conf *internal.TaskConf
 	// and override these since Docker applies --env-file args in order.
 	if conf.EnvFileHostDir != "" {
 		hostEnvPath := filepath.Join(conf.EnvFileHostDir, ".evg-host-env")
-		if err := writeHostEnvFile(hostEnvPath); err != nil {
+		if err := writeHostEnvFile(ctx, hostEnvPath); err != nil {
 			grip.Warningf(ctx, "Could not write host env file for container isolation: %s", err)
 		}
 	}
@@ -259,18 +265,10 @@ func (a *Agent) maybeStartContainer(ctx context.Context, conf *internal.TaskConf
 // since the container was created for the first task in the group and its name
 // does not change across task-group members.
 //
-// If a.retainContainerUntil is in the future, the container is intentionally
-// left running for on-call post-mortem inspection (retain_on_failure_secs).
-// The agent reference is cleared so subsequent task dispatch is unaffected;
-// the reaper removes the container at next startup.
-//
-// Static-host note: the retention window is checked only when destroyContainer
-// fires (at group teardown). If teardown fires within the window the container
-// is left running until the orphan reaper at next agent restart — there is no
-// background timer that removes it after the window elapses. On dynamic EC2
-// hosts (the Phase 0 target) the host recycles before accumulation becomes a
-// concern. Static hosts running many task groups should set
-// container_retain_on_failure_secs=0 until a deadline-based sweep is added.
+// If a.retainContainerUntil is in the future, container ownership transfers to
+// a bounded background cleanup. The container remains available for inspection
+// until the retention deadline, or until the agent context is canceled during
+// shutdown. The agent reference is cleared so subsequent dispatch is unaffected.
 func (a *Agent) destroyContainer(ctx context.Context, conf *internal.TaskConfig) {
 	if a.currentContainer == nil {
 		a.retainContainerUntil = time.Time{}
@@ -286,20 +284,17 @@ func (a *Agent) destroyContainer(ctx context.Context, conf *internal.TaskConfig)
 	)
 
 	if !a.retainContainerUntil.IsZero() && time.Now().Before(a.retainContainerUntil) {
-		grip.Infof(ctx, "Retaining isolation container '%s' until %s for on-call inspection (retain_on_failure_secs). The orphan reaper will remove it at next agent startup.",
+		grip.Infof(ctx, "Retaining isolation container '%s' until %s for on-call inspection (retain_on_failure_secs).",
 			containerName, a.retainContainerUntil.Format(time.RFC3339))
-		// Close the Docker client connection (it is no longer needed for
-		// lifecycle management) but do NOT remove the container or its tmpfs.
-		// The tmpfs remains mounted inside the container so on-call can read
-		// the env-file; the container itself is left running for docker exec.
-		// The orphan reaper at next agent startup handles the final cleanup.
-		a.currentContainer.Close()
+		retainedContainer := a.currentContainer
+		retainedUntil := a.retainContainerUntil
 		a.currentContainer = nil
 		a.retainContainerUntil = time.Time{}
 		if conf != nil {
 			conf.ContainerID = ""
 			conf.EnvFileHostDir = ""
 		}
+		go destroyRetainedContainer(ctx, retainedContainer, containerName, retainedUntil)
 		return
 	}
 
@@ -311,6 +306,22 @@ func (a *Agent) destroyContainer(ctx context.Context, conf *internal.TaskConfig)
 	if conf != nil {
 		conf.ContainerID = ""
 		conf.EnvFileHostDir = ""
+	}
+}
+
+func destroyRetainedContainer(ctx context.Context, container ContainerHandle, containerName string, retainUntil time.Time) {
+	timer := time.NewTimer(time.Until(retainUntil))
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+	case <-timer.C:
+	}
+
+	destroyCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), reaperTimeout)
+	defer cancel()
+	if err := container.Destroy(destroyCtx); err != nil {
+		grip.Warningf(destroyCtx, "Failed to destroy retained isolation container '%s': %s", containerName, err)
 	}
 }
 
@@ -410,8 +421,7 @@ func (a *Agent) emitContainerFailureSnapshot(ctx context.Context, tc *taskContex
 
 	// Env-file contents (the per-task tmpfs written by WrapWithContainer).
 	if tc.taskConfig != nil && tc.taskConfig.EnvFileHostDir != "" {
-		envFile := filepath.Join(tc.taskConfig.EnvFileHostDir, ".evg-env")
-		if data, err := os.ReadFile(envFile); err == nil {
+		if data, err := readLatestContainerEnvFile(tc.taskConfig.EnvFileHostDir); err == nil {
 			span.SetAttributes(attribute.String("container.env_file", redactForSnapshot(string(data), tc)))
 		}
 	}
@@ -427,6 +437,35 @@ func (a *Agent) emitContainerFailureSnapshot(ctx context.Context, tc *taskContex
 	// has been updated to reflect this deviation. Closing the gap would
 	// require a ring buffer in the logger infrastructure, deferred to
 	// Phase 1 if post-mortem finds the existing log pipeline insufficient.
+}
+
+func readLatestContainerEnvFile(dir string) ([]byte, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, errors.Wrap(err, "reading container env directory")
+	}
+
+	var latestName string
+	var latestModTime time.Time
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), containerEnvFilePrefix) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil, errors.Wrapf(err, "reading container env file info for '%s'", entry.Name())
+		}
+		if latestName == "" || info.ModTime().After(latestModTime) || (info.ModTime().Equal(latestModTime) && entry.Name() > latestName) {
+			latestName = entry.Name()
+			latestModTime = info.ModTime()
+		}
+	}
+	if latestName == "" {
+		return nil, errors.New("container env file not found")
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, latestName))
+	return data, errors.Wrap(err, "reading latest container env file")
 }
 
 // containerInspectJSON returns the full JSON from docker inspect for a container.
@@ -554,7 +593,7 @@ var hostEnvVars = []string{
 // directories set by /etc/profile.d/*.sh. To capture the effective PATH and
 // toolchain vars that a login shell would have, we run `bash -l -c` to source
 // the profile scripts and print the env vars.
-func writeHostEnvFile(path string) error {
+func writeHostEnvFile(ctx context.Context, path string) error {
 	// Build a shell command that sources profile scripts and prints the
 	// vars we care about in KEY=VALUE format.
 	var cmdParts []string
@@ -563,7 +602,11 @@ func writeHostEnvFile(path string) error {
 	}
 	shellCmd := strings.Join(cmdParts, "\n")
 
-	out, err := exec.Command("bash", "-l", "-c", shellCmd).Output()
+	captureCtx, cancel := context.WithTimeout(ctx, hostEnvCaptureTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(captureCtx, "bash", "-l", "-c", shellCmd)
+	cmd.WaitDelay = hostEnvCommandWaitDelay
+	out, err := cmd.Output()
 	if err != nil {
 		// Fall back to the agent process's own env vars if the login shell
 		// fails (e.g. bash not available). This won't have toolchain paths

--- a/agent/container.go
+++ b/agent/container.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	dockercontainer "github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/client"
 	"github.com/evergreen-ci/evergreen"
 	agentcontainer "github.com/evergreen-ci/evergreen/agent/container"
@@ -87,23 +86,17 @@ func (a *Agent) tryReapOrphanContainers(ctx context.Context) { //nolint:unused
 		return
 	}
 
-	// Select by ownership label, not by name. Removal is destructive and
-	// irreversible, so a container must positively identify itself as owned
-	// by the agent before it is eligible.
-	ownerFilter := fmt.Sprintf("%s=%s", agentcontainer.OwnerLabel, agentcontainer.OwnerLabelValue)
-	containers, err := cli.ContainerList(reaperCtx, dockercontainer.ListOptions{
-		All:     true,
-		Filters: filters.NewArgs(filters.KeyValuePair{Key: "label", Value: ownerFilter}),
-	})
+	// Ownership is decided client-side by isAgentOwnedContainer, because
+	// Docker's name filter cannot express an anchored prefix and a label
+	// filter alone would strand containers created before labels existed.
+	containers, err := cli.ContainerList(reaperCtx, dockercontainer.ListOptions{All: true})
 	if err != nil {
 		grip.Warningf(ctx, "Orphan container reaper: could not list containers: %s", err)
 		return
 	}
 
 	for _, c := range containers {
-		// Re-check ownership on the returned document rather than trusting
-		// the server-side filter alone.
-		if !isAgentOwnedContainer(c.Labels) {
+		if !isAgentOwnedContainer(c.Labels, c.Names) {
 			continue
 		}
 		shortID := c.ID
@@ -122,11 +115,27 @@ func (a *Agent) tryReapOrphanContainers(ctx context.Context) { //nolint:unused
 	}
 }
 
-// isAgentOwnedContainer reports whether a container carries this agent's
-// ownership label. Removal is irreversible, so a container must positively
-// identify itself as agent-owned before the reaper will touch it.
-func isAgentOwnedContainer(labels map[string]string) bool {
-	return labels[agentcontainer.OwnerLabel] == agentcontainer.OwnerLabelValue
+// isAgentOwnedContainer reports whether the reaper may remove a container.
+//
+// An explicit owner label is authoritative in both directions: it claims
+// containers this agent created and protects containers owned by anything
+// else. Containers with no owner label at all are matched on an anchored name
+// prefix, so containers created before ownership labels existed are still
+// reaped rather than stranded on the host across an agent rollout.
+//
+// The prefix is checked here rather than in the Docker filter because Docker's
+// name filter is an unanchored substring match, which would also match a
+// container a human named something like "my-evergreen-task-debug".
+func isAgentOwnedContainer(labels map[string]string, names []string) bool {
+	if owner, ok := labels[agentcontainer.OwnerLabel]; ok {
+		return owner == agentcontainer.OwnerLabelValue
+	}
+	for _, name := range names {
+		if strings.HasPrefix(strings.TrimPrefix(name, "/"), agentcontainer.ContainerNamePrefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // containerNames strips the leading '/' that the Docker API prepends to
@@ -174,12 +183,18 @@ func (a *Agent) maybeStartContainer(ctx context.Context, conf *internal.TaskConf
 	// transferring ownership rather than by widening the mode, so the
 	// directories never become world-writable on a host shared with other
 	// local users.
-	if err := secureContainerDirs(conf.WorkDir, conf.Distro.ExecUser); err != nil {
+	fellBack, err := secureContainerDirs(conf.WorkDir, conf.Distro.ExecUser)
+	if err != nil {
 		if ci.RequireIsolation {
 			span.SetStatus(codes.Error, err.Error())
 			return errors.Wrap(err, "preparing task directories for isolation container (fail-closed: require_isolation is set)")
 		}
 		grip.Warningf(ctx, "Could not prepare task directories for container isolation: %s", err)
+	}
+	if fellBack {
+		span.SetAttributes(attribute.Bool("container.workdir_permissive_fallback", true))
+		grip.Warningf(ctx, "Task directories for task '%s' are world-writable because ownership could not be transferred to exec user '%s'; the container can write to them, but so can any other local user on this host.",
+			conf.Task.Id, conf.Distro.ExecUser)
 	}
 
 	extraMounts := toolchainMounts(ctx, conf.Task.Id)
@@ -239,10 +254,17 @@ func (a *Agent) maybeStartContainer(ctx context.Context, conf *internal.TaskConf
 	return nil
 }
 
-// containerDirMode is the mode applied to task directories shared with the
-// isolation container. The container's exec user is granted write access
-// through ownership, so these directories are never world-writable.
-const containerDirMode = 0755
+const (
+	// containerDirMode is applied to task directories once they are owned by
+	// the container's exec user, so they are not world-writable.
+	containerDirMode = 0755
+
+	// containerDirPermissiveMode is the fallback applied when ownership cannot
+	// be reconciled with the exec user. It is world-writable, which is unsafe
+	// on a host shared with other local users, so it is only used to keep the
+	// task runnable and is always reported to the caller.
+	containerDirPermissiveMode = 0777
+)
 
 // containerToolchainDirs are the host toolchain directories bind-mounted
 // read-only into the container. Toolchains are installed at AMI provisioning
@@ -275,18 +297,49 @@ func toolchainMounts(ctx context.Context, taskID string) []agentcontainer.Mount 
 	return mounts
 }
 
-// secureContainerDirs transfers ownership of the task working directory and
-// its tmp subdirectory to the distro's exec user so containerized processes
-// can write to them through the same-path bind mount.
+// secureContainerDirs prepares the task working directory and its tmp
+// subdirectory for use by the container's exec user, which must be able to
+// write to them through the same-path bind mount.
+//
+// The preferred path transfers ownership to the exec user and applies a mode
+// that is not world-writable. When ownership cannot be reconciled — the user
+// does not resolve on the host, or the agent cannot chown — the directories
+// fall back to a permissive mode so the task still runs, and fellBack reports
+// the weaker posture so the caller can log it.
+//
+// Bind mounts are enforced by numeric uid, while `docker exec --user` resolves
+// the exec user against the image's own passwd database. A host uid that
+// disagrees with the image's uid for the same name is therefore not detectable
+// here and surfaces as a write failure inside the container.
 //
 // When the distro has no exec user, docker exec runs as root inside the
-// container and can already write to the agent-owned directories, so there is
-// nothing to do.
-func secureContainerDirs(workDir, execUser string) error {
+// container and can already write to the agent-owned directories.
+func secureContainerDirs(workDir, execUser string) (fellBack bool, err error) {
 	if workDir == "" || execUser == "" {
-		return nil
+		return false, nil
 	}
 
+	dirs := []string{workDir, filepath.Join(workDir, "tmp")}
+
+	ownershipErr := transferDirOwnership(dirs, execUser)
+	if ownershipErr == nil {
+		return false, nil
+	}
+
+	// Windows has no POSIX ownership to fall back from, so surface the error
+	// rather than implying a permissive mode resolved anything.
+	if runtime.GOOS == "windows" {
+		return false, ownershipErr
+	}
+
+	if fallbackErr := applyPermissiveDirMode(dirs); fallbackErr != nil {
+		return false, errors.Wrapf(fallbackErr, "falling back to permissive mode after ownership transfer failed (%s)", ownershipErr)
+	}
+	return true, nil
+}
+
+// transferDirOwnership hands dirs to the exec user and applies containerDirMode.
+func transferDirOwnership(dirs []string, execUser string) error {
 	usr, err := user.Lookup(execUser)
 	if err != nil {
 		return errors.Wrapf(err, "looking up exec user '%s'", execUser)
@@ -307,16 +360,43 @@ func secureContainerDirs(workDir, execUser string) error {
 	}
 
 	catcher := grip.NewBasicCatcher()
-	for _, dir := range []string{workDir, filepath.Join(workDir, "tmp")} {
+	for _, dir := range dirs {
 		catcher.Wrapf(chownContainerDir(dir, uid, gid), "securing '%s'", dir)
 	}
 	return catcher.Resolve()
 }
 
-// chownContainerDir transfers ownership of dir to uid/gid. It refuses to act
-// on a symlink so that a local user cannot redirect the ownership change at a
-// path they do not own.
+func applyPermissiveDirMode(dirs []string) error {
+	catcher := grip.NewBasicCatcher()
+	for _, dir := range dirs {
+		catcher.Wrapf(setContainerDirMode(dir, containerDirPermissiveMode), "setting fallback mode on '%s'", dir)
+	}
+	return catcher.Resolve()
+}
+
+// chownContainerDir transfers ownership of dir to uid/gid and tightens its mode.
 func chownContainerDir(dir string, uid, gid int) error {
+	if err := verifyRealDir(dir); err != nil {
+		return err
+	}
+	if err := os.Lchown(dir, uid, gid); err != nil {
+		return errors.Wrap(err, "changing ownership")
+	}
+	return errors.Wrap(os.Chmod(dir, containerDirMode), "setting permissions")
+}
+
+func setContainerDirMode(dir string, mode os.FileMode) error {
+	if err := verifyRealDir(dir); err != nil {
+		return err
+	}
+	return errors.Wrap(os.Chmod(dir, mode), "setting permissions")
+}
+
+// verifyRealDir refuses symlinks so a local user cannot redirect a permission
+// or ownership change at a path they do not own. This matters most on the
+// permissive fallback, where following a symlink would grant world-writable
+// access to the target.
+func verifyRealDir(dir string) error {
 	info, err := os.Lstat(dir)
 	if err != nil {
 		return errors.Wrap(err, "stating directory")
@@ -327,10 +407,7 @@ func chownContainerDir(dir string, uid, gid int) error {
 	if !info.IsDir() {
 		return errors.New("path is not a directory")
 	}
-	if err := os.Lchown(dir, uid, gid); err != nil {
-		return errors.Wrap(err, "changing ownership")
-	}
-	return errors.Wrap(os.Chmod(dir, containerDirMode), "setting permissions")
+	return nil
 }
 
 // destroyContainer tears down the isolation container and clears the agent's

--- a/agent/container/lifecycle.go
+++ b/agent/container/lifecycle.go
@@ -44,6 +44,18 @@ const (
 	containerCreateMaxAttempts = 6
 
 	containerCreateRetryDelay = 5 * time.Second
+
+	// OwnerLabel marks a container as agent-created for task isolation. The
+	// orphan reaper matches this label rather than the container name so it
+	// cannot remove containers owned by another agent or by a human.
+	OwnerLabel = "evergreen.owner"
+
+	// OwnerLabelValue is the value OwnerLabel carries.
+	OwnerLabelValue = "evergreen-agent-task-isolation"
+
+	// TaskIDLabel records the task a container was created for, so a leaked
+	// container can be attributed to its task.
+	TaskIDLabel = "evergreen.task_id"
 )
 
 // activeEnvFileBaseDir is the runtime base dir, defaulting to envFileBaseDir.
@@ -182,6 +194,10 @@ func CreateAndStart(ctx context.Context, cfg Config) (*TaskContainer, error) {
 		Cmd:        []string{"sleep", "infinity"},
 		WorkingDir: cfg.WorkDir,
 		Tty:        false,
+		Labels: map[string]string{
+			OwnerLabel:  OwnerLabelValue,
+			TaskIDLabel: cfg.TaskID,
+		},
 	}
 
 	mounts := []mount.Mount{
@@ -336,12 +352,6 @@ func (tc *TaskContainer) Destroy(ctx context.Context) error {
 		return removeErr
 	}
 	return envErr
-}
-
-// Close closes the Docker client connection. This is called by the agent
-// when a retained container's deadline expires or the agent shuts down.
-func (tc *TaskContainer) Close() {
-	_ = tc.cli.Close()
 }
 
 // imagePullTimeout caps the time allowed to pull a container image.

--- a/agent/container/lifecycle.go
+++ b/agent/container/lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/docker/docker/api/types/registry"
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -52,10 +54,6 @@ const (
 	// OwnerLabelValue is the value OwnerLabel carries.
 	OwnerLabelValue = "evergreen-agent-task-isolation"
 
-	// TaskIDLabel records the task a container was created for, so a leaked
-	// container can be attributed to its task.
-	TaskIDLabel = "evergreen.task_id"
-
 	// ContainerNamePrefix is the name prefix for agent-created isolation
 	// containers. The reaper matches it as an anchored prefix to identify
 	// containers created before ownership labels existed.
@@ -86,11 +84,12 @@ type Mount struct {
 
 // Config holds the parameters for creating a task isolation container.
 type Config struct {
-	Image    string
-	WorkDir  string // Host path to task working directory.
-	TaskID   string
-	MemoryMB int64 // 0 means no limit.
-	CPUs     int64 // 0 means no limit. In units of whole CPUs.
+	Image         string
+	WorkDir       string // Host path to task working directory.
+	TaskID        string
+	TaskExecution int
+	MemoryMB      int64 // 0 means no limit.
+	CPUs          int64 // 0 means no limit. In units of whole CPUs.
 
 	// ExtraMounts are additional host→container bind mounts layered on top
 	// of the workdir mount. Sources and targets must be absolute paths.
@@ -133,7 +132,7 @@ func (c Config) Validate() error {
 }
 
 func (c Config) containerName() string {
-	return ContainerNamePrefix + c.TaskID
+	return ContainerNamePrefix + c.TaskID + "-" + strconv.Itoa(c.TaskExecution)
 }
 
 // TaskContainer represents a running isolation container for a single task.
@@ -199,8 +198,9 @@ func CreateAndStart(ctx context.Context, cfg Config) (*TaskContainer, error) {
 		WorkingDir: cfg.WorkDir,
 		Tty:        false,
 		Labels: map[string]string{
-			OwnerLabel:  OwnerLabelValue,
-			TaskIDLabel: cfg.TaskID,
+			OwnerLabel:                 OwnerLabelValue,
+			evergreen.TagTaskID:        cfg.TaskID,
+			evergreen.TagTaskExecution: strconv.Itoa(cfg.TaskExecution),
 		},
 	}
 

--- a/agent/container/lifecycle.go
+++ b/agent/container/lifecycle.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
@@ -56,6 +55,11 @@ const (
 	// TaskIDLabel records the task a container was created for, so a leaked
 	// container can be attributed to its task.
 	TaskIDLabel = "evergreen.task_id"
+
+	// ContainerNamePrefix is the name prefix for agent-created isolation
+	// containers. The reaper matches it as an anchored prefix to identify
+	// containers created before ownership labels existed.
+	ContainerNamePrefix = "evergreen-task-"
 )
 
 // activeEnvFileBaseDir is the runtime base dir, defaulting to envFileBaseDir.
@@ -129,7 +133,7 @@ func (c Config) Validate() error {
 }
 
 func (c Config) containerName() string {
-	return fmt.Sprintf("evergreen-task-%s", c.TaskID)
+	return ContainerNamePrefix + c.TaskID
 }
 
 // TaskContainer represents a running isolation container for a single task.

--- a/agent/container/lifecycle.go
+++ b/agent/container/lifecycle.go
@@ -338,6 +338,12 @@ func (tc *TaskContainer) Destroy(ctx context.Context) error {
 	return envErr
 }
 
+// Close closes the Docker client connection. This is called by the agent
+// when a retained container's deadline expires or the agent shuts down.
+func (tc *TaskContainer) Close() {
+	_ = tc.cli.Close()
+}
+
 // imagePullTimeout caps the time allowed to pull a container image.
 const imagePullTimeout = 5 * time.Minute
 

--- a/agent/container_test.go
+++ b/agent/container_test.go
@@ -1,0 +1,461 @@
+package agent
+
+import (
+	"context"
+	"maps"
+	"os"
+	"testing"
+	"time"
+
+	agentcontainer "github.com/evergreen-ci/evergreen/agent/container"
+	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/evergreen/agent/internal/client"
+	agentutil "github.com/evergreen-ci/evergreen/agent/util"
+	"github.com/evergreen-ci/evergreen/apimodels"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/util"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+)
+
+// agentForKillTest returns a minimal Agent that passes the shouldKill guard.
+// shouldKill short-circuits to false when a.opts.Cleanup is false (added in
+// the upstream sync), so tests that want to reach the kill/cleanup logic must
+// set Cleanup: true.
+func agentForKillTest() *Agent {
+	return &Agent{opts: Options{Cleanup: true}}
+}
+
+// TestKillProcsContainerIsolationSkipsDockerCleanup verifies the A5 gate:
+// when ContainerIsolation is set, killProcs logs "Skipping Docker artifact
+// cleanup" and returns early without calling docker.Cleanup. The gate is
+// confirmed by the presence of that log line in the test output.
+func TestKillProcsContainerIsolationSkipsDockerCleanup(t *testing.T) {
+	ctx := t.Context()
+	a := agentForKillTest()
+
+	tc := &taskContext{
+		task: client.TaskData{ID: "test-task-1"},
+		taskConfig: &internal.TaskConfig{
+			// Empty ExecUser → takes the ps-based kill path (no sudo pkill),
+			// safe in a sandboxed test environment.
+			WorkDir: t.TempDir(),
+			Distro: &apimodels.DistroView{
+				ContainerIsolation: &apimodels.ContainerIsolationSettings{
+					Image: "ubuntu:22.04",
+				},
+			},
+		},
+	}
+
+	// shouldKill → true (Cleanup=true, task.ID set, TaskGroup nil).
+	// Process-kill block: ContainerID="" and ExecUser="" → ps path, no-op.
+	// docker.Cleanup gate: ContainerIsolation != nil → early return, nil.
+	err := a.killProcs(ctx, tc, true, "test")
+	assert.NoError(t, err, "killProcs must return nil on a container-isolation distro without invoking docker.Cleanup")
+}
+
+// TestKillProcsContainerRouting verifies that killProcs routes to the
+// in-container kill path when ContainerID is set, and the host-side
+// KillSpawnedProcs path when it is not.
+func TestKillProcsContainerRouting(t *testing.T) {
+	ctx := t.Context()
+	a := agentForKillTest()
+
+	t.Run("EmptyContainerIDTakesHostPath", func(t *testing.T) {
+		tc := &taskContext{
+			task: client.TaskData{ID: "test-task-1"},
+			taskConfig: &internal.TaskConfig{
+				WorkDir: t.TempDir(),
+				Distro:  &apimodels.DistroView{
+					// Empty ExecUser: takes the ps-based host path, which is
+					// safe without real sudo in a test environment.
+				},
+			},
+		}
+		// ContainerID="" → host-side KillSpawnedProcs (ps path, no sudo).
+		// No task-marker processes running → nil.
+		err := a.killProcs(ctx, tc, true, "test")
+		assert.NoError(t, err)
+	})
+
+	t.Run("NonEmptyContainerIDEmptyExecUserLogsWarningNoError", func(t *testing.T) {
+		tc := &taskContext{
+			task: client.TaskData{ID: "test-task-1"},
+			taskConfig: &internal.TaskConfig{
+				ContainerID: "some-container-id",
+				WorkDir:     t.TempDir(),
+				Distro: &apimodels.DistroView{
+					// ExecUser deliberately empty to hit the graceful-degradation
+					// branch (warning logged, no docker exec attempted).
+					ContainerIsolation: &apimodels.ContainerIsolationSettings{
+						Image: "ubuntu:22.04",
+					},
+				},
+			},
+		}
+		// ContainerID != "" but ExecUser == "" → warning logged, nil returned.
+		err := a.killProcs(ctx, tc, true, "test")
+		require.NoError(t, err)
+	})
+}
+
+func makeSnapshotTC(expansions map[string]string, redacted []string, secrets map[string]string) *taskContext {
+	exp := util.Expansions{}
+	maps.Copy(exp, expansions)
+	dynExp := agentutil.NewDynamicExpansions(exp)
+	internalExp := agentutil.NewDynamicExpansions(util.Expansions{})
+	for k, v := range secrets {
+		internalExp.Put(k, v)
+	}
+	return &taskContext{
+		taskConfig: &internal.TaskConfig{
+			NewExpansions:      dynExp,
+			Redacted:           redacted,
+			InternalRedactions: internalExp,
+		},
+	}
+}
+
+func TestRedactForSnapshot(t *testing.T) {
+	t.Run("NilTCReturnsUnchanged", func(t *testing.T) {
+		assert.Equal(t, "hello world", redactForSnapshot("hello world", nil))
+	})
+
+	t.Run("NilTaskConfigReturnsUnchanged", func(t *testing.T) {
+		assert.Equal(t, "secret", redactForSnapshot("secret", &taskContext{}))
+	})
+
+	t.Run("RedactsNamedExpansion", func(t *testing.T) {
+		tc := makeSnapshotTC(map[string]string{"my_key": "supersecret"}, []string{"my_key"}, nil)
+		result := redactForSnapshot("data contains supersecret value", tc)
+		assert.NotContains(t, result, "supersecret")
+		assert.Contains(t, result, "<REDACTED:my_key>")
+	})
+
+	t.Run("LongestFirstPreventsPartialLeak", func(t *testing.T) {
+		// "foo" is a prefix of "foobar". Without longest-first sort, replacing
+		// "foo" first would yield "<REDACTED:short>bar", leaking "bar".
+		tc := makeSnapshotTC(map[string]string{"short": "foo", "long": "foobar"}, []string{"short", "long"}, nil)
+		result := redactForSnapshot("the secret is foobar end", tc)
+		assert.NotContains(t, result, "foobar", "longer secret must be fully redacted")
+		assert.NotContains(t, result, "foo", "shorter secret must not appear even as a suffix")
+	})
+
+	t.Run("RedactsInternalSecrets", func(t *testing.T) {
+		tc := makeSnapshotTC(nil, nil, map[string]string{"host_secret": "abc123"})
+		result := redactForSnapshot("auth=abc123", tc)
+		assert.NotContains(t, result, "abc123")
+		assert.Contains(t, result, "<REDACTED:host_secret>")
+	})
+
+	t.Run("EmptyValueSkipped", func(t *testing.T) {
+		tc := makeSnapshotTC(map[string]string{"empty_key": ""}, []string{"empty_key"}, nil)
+		result := redactForSnapshot("nothing to redact", tc)
+		assert.Equal(t, "nothing to redact", result)
+	})
+}
+
+// fakeContainer is a test double for ContainerHandle that does not require
+// a live Docker daemon.
+type fakeContainer struct {
+	id             string
+	name           string
+	envFileHostDir string
+	destroyCalled  int
+	closeCalled    int
+	destroyErr     error
+}
+
+func (f *fakeContainer) GetID() string             { return f.id }
+func (f *fakeContainer) GetName() string           { return f.name }
+func (f *fakeContainer) GetEnvFileHostDir() string { return f.envFileHostDir }
+func (f *fakeContainer) Close()                    { f.closeCalled++ }
+func (f *fakeContainer) Destroy(_ context.Context) error {
+	f.destroyCalled++
+	return f.destroyErr
+}
+
+func agentForContainerTest() *Agent {
+	return &Agent{
+		opts:   Options{Cleanup: true},
+		tracer: otel.GetTracerProvider().Tracer("test"),
+	}
+}
+
+func makeAgentWithFakeContainer(fc *fakeContainer) *Agent {
+	a := agentForContainerTest()
+	a.currentContainer = fc
+	return a
+}
+
+func makeDistroWithIsolation(image string) *apimodels.DistroView {
+	return &apimodels.DistroView{
+		ContainerIsolation: &apimodels.ContainerIsolationSettings{
+			Image: image,
+		},
+	}
+}
+
+func TestMaybeStartContainerReusePath(t *testing.T) {
+	ctx := t.Context()
+	fc := &fakeContainer{id: "abc123", name: "evergreen-task-abc", envFileHostDir: "/tmp/env-abc"}
+	a := makeAgentWithFakeContainer(fc)
+	conf := &internal.TaskConfig{
+		Distro: makeDistroWithIsolation("ubuntu:22.04"),
+		Task:   task.Task{},
+	}
+
+	err := a.maybeStartContainer(ctx, conf, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "abc123", conf.ContainerID, "reuse path should wire ContainerID from existing container")
+	assert.Equal(t, "/tmp/env-abc", conf.EnvFileHostDir, "reuse path should wire EnvFileHostDir from existing container")
+	assert.Equal(t, fc, a.currentContainer, "existing container should not be replaced")
+}
+
+func TestMaybeStartContainerCreatePath(t *testing.T) {
+	ctx := t.Context()
+	a := agentForContainerTest()
+	created := &fakeContainer{id: "newid", name: "evergreen-task-new", envFileHostDir: "/tmp/env-new"}
+	a.containerFactory = func(_ context.Context, _ agentcontainer.Config) (ContainerHandle, error) {
+		return created, nil
+	}
+	conf := &internal.TaskConfig{
+		Distro: makeDistroWithIsolation("ubuntu:22.04"),
+		Task:   task.Task{Id: "task-1"},
+	}
+
+	err := a.maybeStartContainer(ctx, conf, nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "newid", conf.ContainerID)
+	assert.Equal(t, "/tmp/env-new", conf.EnvFileHostDir)
+	assert.Equal(t, created, a.currentContainer)
+}
+
+func TestMaybeStartContainerNilDistroIsNoop(t *testing.T) {
+	ctx := t.Context()
+	a := agentForContainerTest()
+	conf := &internal.TaskConfig{Distro: nil}
+
+	require.NoError(t, a.maybeStartContainer(ctx, conf, nil))
+	assert.Nil(t, a.currentContainer)
+}
+
+func TestMaybeStartContainerNilIsolationIsNoop(t *testing.T) {
+	ctx := t.Context()
+	a := agentForContainerTest()
+	conf := &internal.TaskConfig{Distro: &apimodels.DistroView{ContainerIsolation: nil}}
+
+	require.NoError(t, a.maybeStartContainer(ctx, conf, nil))
+	assert.Nil(t, a.currentContainer)
+}
+
+func TestDestroyContainerNilCurrentContainerIsNoop(t *testing.T) {
+	ctx := t.Context()
+	a := &Agent{}
+	conf := &internal.TaskConfig{}
+
+	// Should not panic and should leave everything unchanged.
+	a.destroyContainer(ctx, conf)
+	assert.Empty(t, conf.ContainerID)
+	assert.Empty(t, conf.EnvFileHostDir)
+}
+
+func TestDestroyContainerNilConfSafe(t *testing.T) {
+	ctx := t.Context()
+	fc := &fakeContainer{id: "abc", name: "ctr"}
+	a := makeAgentWithFakeContainer(fc)
+
+	// nil conf is explicitly supported (loop-exit defer has no conf).
+	a.destroyContainer(ctx, nil)
+	assert.Nil(t, a.currentContainer)
+	assert.Equal(t, 1, fc.destroyCalled)
+}
+
+func TestDestroyContainerClearsFields(t *testing.T) {
+	ctx := t.Context()
+	fc := &fakeContainer{id: "abc", name: "ctr", envFileHostDir: "/tmp/env"}
+	a := makeAgentWithFakeContainer(fc)
+	conf := &internal.TaskConfig{ContainerID: "abc", EnvFileHostDir: "/tmp/env"}
+
+	a.destroyContainer(ctx, conf)
+
+	assert.Nil(t, a.currentContainer, "currentContainer must be cleared after destroy")
+	assert.Empty(t, conf.ContainerID, "conf.ContainerID must be cleared")
+	assert.Empty(t, conf.EnvFileHostDir, "conf.EnvFileHostDir must be cleared")
+	assert.Equal(t, 1, fc.destroyCalled)
+}
+
+func TestDestroyContainerIdempotent(t *testing.T) {
+	ctx := t.Context()
+	fc := &fakeContainer{id: "abc", name: "ctr"}
+	a := makeAgentWithFakeContainer(fc)
+	conf := &internal.TaskConfig{ContainerID: "abc"}
+
+	a.destroyContainer(ctx, conf)
+	// Second call: currentContainer is already nil, should be a no-op.
+	a.destroyContainer(ctx, conf)
+
+	assert.Equal(t, 1, fc.destroyCalled, "Destroy should only be called once")
+}
+
+func TestMaybeStartContainerFailClosedPropagatesError(t *testing.T) {
+	ctx := t.Context()
+	a := agentForContainerTest()
+	a.containerFactory = func(_ context.Context, _ agentcontainer.Config) (ContainerHandle, error) {
+		return nil, errors.New("docker unavailable")
+	}
+	conf := &internal.TaskConfig{
+		Distro: &apimodels.DistroView{
+			ContainerIsolation: &apimodels.ContainerIsolationSettings{
+				Image:            "ubuntu:22.04",
+				RequireIsolation: true,
+			},
+		},
+		Task: task.Task{Id: "task-1"},
+	}
+
+	err := a.maybeStartContainer(ctx, conf, nil)
+	require.Error(t, err, "fail-closed: error should be returned when factory fails")
+	assert.Nil(t, a.currentContainer)
+	assert.Empty(t, conf.ContainerID)
+}
+
+func TestMaybeStartContainerFailOpenReturnsNil(t *testing.T) {
+	ctx := t.Context()
+	a := agentForContainerTest()
+	a.containerFactory = func(_ context.Context, _ agentcontainer.Config) (ContainerHandle, error) {
+		return nil, errors.New("docker unavailable")
+	}
+	conf := &internal.TaskConfig{
+		Distro: makeDistroWithIsolation("ubuntu:22.04"), // RequireIsolation defaults false
+		Task:   task.Task{Id: "task-1"},
+	}
+
+	err := a.maybeStartContainer(ctx, conf, nil)
+	require.NoError(t, err, "fail-open: error should be swallowed when RequireIsolation is false")
+	assert.Nil(t, a.currentContainer, "currentContainer must remain nil on fail-open")
+	assert.Empty(t, conf.ContainerID, "conf.ContainerID must not be set on fail-open")
+}
+
+func TestDestroyContainerRetentionCallsCloseNotDestroy(t *testing.T) {
+	ctx := t.Context()
+	fc := &fakeContainer{id: "abc", name: "ctr"}
+	a := makeAgentWithFakeContainer(fc)
+	// Set retention window far in the future so destroyContainer takes the retention path.
+	a.retainContainerUntil = time.Now().Add(5 * time.Minute)
+	conf := &internal.TaskConfig{ContainerID: "abc"}
+
+	a.destroyContainer(ctx, conf)
+
+	assert.Equal(t, 1, fc.closeCalled, "retention path must call Close() to release the Docker client")
+	assert.Equal(t, 0, fc.destroyCalled, "retention path must NOT call Destroy() — container must stay running for inspection")
+	assert.Nil(t, a.currentContainer, "currentContainer must be cleared even in retention path")
+	assert.Empty(t, conf.ContainerID, "conf.ContainerID must be cleared in retention path")
+}
+
+// TestMaybeStartContainerFailClosedErrorPropagatesFromRunTask verifies that
+// a non-nil error from maybeStartContainer causes runTask (via the caller) to
+// fail rather than silently continuing in host mode. The fail-closed contract
+// (require_isolation=true) must not be violated at the runTask call site.
+func TestMaybeStartContainerFailClosedPropagatesFromRunTask(t *testing.T) {
+	ctx := t.Context()
+	a := agentForContainerTest()
+	a.containerFactory = func(_ context.Context, _ agentcontainer.Config) (ContainerHandle, error) {
+		return nil, errors.New("container daemon unreachable")
+	}
+
+	conf := &internal.TaskConfig{
+		Distro: &apimodels.DistroView{
+			ContainerIsolation: &apimodels.ContainerIsolationSettings{
+				Image:            "ubuntu:22.04",
+				RequireIsolation: true,
+			},
+		},
+		Task: task.Task{Id: "task-1"},
+	}
+
+	err := a.maybeStartContainer(ctx, conf, nil)
+	require.Error(t, err, "fail-closed path must propagate error to runTask caller")
+	assert.Empty(t, conf.ContainerID, "ContainerID must not be set when container fails to start")
+	assert.Nil(t, a.currentContainer)
+}
+
+func TestMaybeStartContainerOptMountMatchesHostFilesystem(t *testing.T) {
+	ctx := t.Context()
+	a := agentForContainerTest()
+	created := &fakeContainer{id: "newid", name: "evergreen-task-new", envFileHostDir: "/tmp/env-new"}
+	var capturedCfg agentcontainer.Config
+	a.containerFactory = func(_ context.Context, cfg agentcontainer.Config) (ContainerHandle, error) {
+		capturedCfg = cfg
+		return created, nil
+	}
+	conf := &internal.TaskConfig{
+		Distro: makeDistroWithIsolation("ubuntu:22.04"),
+		Task:   task.Task{Id: "task-1"},
+	}
+
+	require.NoError(t, a.maybeStartContainer(ctx, conf, nil))
+
+	// The /opt mount is conditional on os.Stat("/opt") succeeding. On
+	// macOS/Linux test hosts /opt typically exists, but the test must not
+	// assume that — it verifies the mount is present iff /opt exists.
+	_, optExists := os.Stat("/opt")
+	found := false
+	for _, m := range capturedCfg.ExtraMounts {
+		if m.Source == "/opt" && m.Target == "/opt" && m.ReadOnly {
+			found = true
+		}
+	}
+	if optExists == nil {
+		assert.True(t, found, "ExtraMounts must contain /opt:ro when /opt exists on host")
+	} else {
+		assert.False(t, found, "ExtraMounts must not contain /opt when /opt does not exist on host")
+	}
+}
+
+func TestDestroyContainerCallsDestroyEvenWithCancelledContext(t *testing.T) {
+	ctx := t.Context()
+	fc := &fakeContainer{id: "abc", name: "ctr", envFileHostDir: "/tmp/env"}
+	a := makeAgentWithFakeContainer(fc)
+	conf := &internal.TaskConfig{ContainerID: "abc", EnvFileHostDir: "/tmp/env"}
+
+	// Cancel the context before calling destroyContainer to verify that
+	// Destroy is still called. The real TaskContainer.Destroy uses
+	// context.Background() internally so cleanup is not bypassed by caller
+	// cancellation. The fake ignores its context, so this test verifies
+	// the destroyContainer call site does not short-circuit on ctx.Err();
+	// integration testing against a real Docker daemon is needed to verify
+	// the internal context.Background() usage.
+	cancelledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	a.destroyContainer(cancelledCtx, conf)
+
+	assert.Equal(t, 1, fc.destroyCalled, "Destroy must be called even when context is cancelled")
+	assert.Nil(t, a.currentContainer)
+	assert.Empty(t, conf.ContainerID)
+}
+
+func TestDestroyContainerStillClearsReferenceOnDestroyError(t *testing.T) {
+	ctx := t.Context()
+	fc := &fakeContainer{
+		id:         "abc",
+		name:       "ctr",
+		destroyErr: errors.New("docker daemon unreachable"),
+	}
+	a := makeAgentWithFakeContainer(fc)
+	conf := &internal.TaskConfig{ContainerID: "abc"}
+
+	a.destroyContainer(ctx, conf)
+
+	// destroyContainer logs the warning but still clears the reference so
+	// the agent doesn't get stuck on a container it can't remove.
+	assert.Equal(t, 1, fc.destroyCalled, "Destroy must be called once")
+	assert.Nil(t, a.currentContainer, "currentContainer must be cleared even on Destroy error")
+	assert.Empty(t, conf.ContainerID)
+}

--- a/agent/container_test.go
+++ b/agent/container_test.go
@@ -264,10 +264,15 @@ func TestMaybeStartContainerFailOpenReturnsNil(t *testing.T) {
 }
 
 // TestMaybeStartContainerFailsClosedWhenDirsCannotBeSecured verifies that a
-// distro requiring isolation does not start a container whose task directories
-// could not be handed to the exec user, since the task would otherwise run
-// with the container unable to write its own workdir.
+// distro requiring isolation does not start a container when neither ownership
+// transfer nor the permissive fallback could be applied.
 func TestMaybeStartContainerFailsClosedWhenDirsCannotBeSecured(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Container isolation uses POSIX ownership and is not supported on Windows")
+	}
+	usr, err := user.Current()
+	require.NoError(t, err)
+
 	ctx := t.Context()
 	a := agentForContainerTest()
 	factoryCalled := false
@@ -276,7 +281,42 @@ func TestMaybeStartContainerFailsClosedWhenDirsCannotBeSecured(t *testing.T) {
 		return &fakeContainer{id: "id", name: "ctr"}, nil
 	}
 	conf := &internal.TaskConfig{
-		WorkDir: t.TempDir(),
+		// A workdir that does not exist defeats ownership transfer and the
+		// fallback alike.
+		WorkDir: filepath.Join(t.TempDir(), "absent"),
+		Distro: &apimodels.DistroView{
+			ExecUser: usr.Username,
+			ContainerIsolation: &apimodels.ContainerIsolationSettings{
+				Image:            "ubuntu:22.04",
+				RequireIsolation: true,
+			},
+		},
+		Task: task.Task{Id: "task-1"},
+	}
+
+	err = a.maybeStartContainer(ctx, conf, nil)
+	require.Error(t, err, "require_isolation must fail closed when task directories cannot be secured at all")
+	assert.False(t, factoryCalled, "container must not be created after directory preparation fails")
+	assert.Nil(t, a.currentContainer)
+}
+
+// TestMaybeStartContainerUsesPermissiveFallbackWhenOwnershipFails verifies the
+// task still runs when the exec user cannot be reconciled, which is the
+// behaviour the pre-review implementation had unconditionally.
+func TestMaybeStartContainerUsesPermissiveFallbackWhenOwnershipFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Container isolation uses POSIX ownership and is not supported on Windows")
+	}
+	ctx := t.Context()
+	a := agentForContainerTest()
+	created := &fakeContainer{id: "id", name: "ctr"}
+	a.containerFactory = func(_ context.Context, _ agentcontainer.Config) (ContainerHandle, error) {
+		return created, nil
+	}
+	workDir := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(workDir, "tmp"), 0700))
+	conf := &internal.TaskConfig{
+		WorkDir: workDir,
 		Distro: &apimodels.DistroView{
 			ExecUser: "evergreen-nonexistent-user",
 			ContainerIsolation: &apimodels.ContainerIsolationSettings{
@@ -287,30 +327,13 @@ func TestMaybeStartContainerFailsClosedWhenDirsCannotBeSecured(t *testing.T) {
 		Task: task.Task{Id: "task-1"},
 	}
 
-	err := a.maybeStartContainer(ctx, conf, nil)
-	require.Error(t, err, "require_isolation must fail closed when task directories cannot be secured")
-	assert.False(t, factoryCalled, "container must not be created after directory preparation fails")
-	assert.Nil(t, a.currentContainer)
-}
+	require.NoError(t, a.maybeStartContainer(ctx, conf, nil),
+		"an unreconcilable exec user must degrade rather than fail the task")
+	assert.Equal(t, created, a.currentContainer)
 
-func TestMaybeStartContainerFailsOpenWhenDirsCannotBeSecured(t *testing.T) {
-	ctx := t.Context()
-	a := agentForContainerTest()
-	created := &fakeContainer{id: "id", name: "ctr"}
-	a.containerFactory = func(_ context.Context, _ agentcontainer.Config) (ContainerHandle, error) {
-		return created, nil
-	}
-	conf := &internal.TaskConfig{
-		WorkDir: t.TempDir(),
-		Distro: &apimodels.DistroView{
-			ExecUser:           "evergreen-nonexistent-user",
-			ContainerIsolation: &apimodels.ContainerIsolationSettings{Image: "ubuntu:22.04"},
-		},
-		Task: task.Task{Id: "task-1"},
-	}
-
-	require.NoError(t, a.maybeStartContainer(ctx, conf, nil))
-	assert.Equal(t, created, a.currentContainer, "without require_isolation the task proceeds despite degraded directories")
+	info, err := os.Stat(workDir)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode().Perm()&0002, "the fallback must leave the workdir writable by the container")
 }
 
 func TestDestroyContainerRetentionWaitsForDeadline(t *testing.T) {
@@ -409,28 +432,36 @@ func TestDestroyContainerStillClearsReferenceOnDestroyError(t *testing.T) {
 }
 
 func TestIsAgentOwnedContainer(t *testing.T) {
-	t.Run("OwnedLabelMatches", func(t *testing.T) {
-		assert.True(t, isAgentOwnedContainer(map[string]string{
-			agentcontainer.OwnerLabel: agentcontainer.OwnerLabelValue,
-		}))
+	ownedLabels := map[string]string{agentcontainer.OwnerLabel: agentcontainer.OwnerLabelValue}
+
+	t.Run("OwnerLabelMatches", func(t *testing.T) {
+		assert.True(t, isAgentOwnedContainer(ownedLabels, nil))
 	})
 
-	t.Run("NoLabelsIsNotOwned", func(t *testing.T) {
-		assert.False(t, isAgentOwnedContainer(nil),
-			"an unlabelled container may belong to a human and must never be reaped")
+	t.Run("ForeignOwnerLabelIsProtectedEvenWithMatchingName", func(t *testing.T) {
+		// An explicit foreign owner must win over the name prefix, otherwise
+		// the reaper would destroy another system's container.
+		assert.False(t, isAgentOwnedContainer(
+			map[string]string{agentcontainer.OwnerLabel: "someone-else"},
+			[]string{"/" + agentcontainer.ContainerNamePrefix + "abc"},
+		))
 	})
 
-	t.Run("ForeignOwnerIsNotOwned", func(t *testing.T) {
-		assert.False(t, isAgentOwnedContainer(map[string]string{
-			agentcontainer.OwnerLabel: "someone-else",
-		}))
+	t.Run("UnlabelledContainerWithNamePrefixIsReaped", func(t *testing.T) {
+		// Containers created before ownership labels existed must still be
+		// reaped, or an agent rollout strands orphans on the host forever.
+		assert.True(t, isAgentOwnedContainer(nil, []string{"/" + agentcontainer.ContainerNamePrefix + "abc"}))
 	})
 
-	t.Run("EvergreenTaskNameWithoutLabelIsNotOwned", func(t *testing.T) {
-		// The previous implementation matched the name substring
-		// "evergreen-task-", which would have reaped another agent's
-		// container or a human's lookalike.
-		assert.False(t, isAgentOwnedContainer(map[string]string{"name": "evergreen-task-abc"}))
+	t.Run("NamePrefixIsAnchoredNotSubstring", func(t *testing.T) {
+		// Docker's own name filter is an unanchored substring match, which
+		// would have destroyed a container a human named this way.
+		assert.False(t, isAgentOwnedContainer(nil, []string{"/my-" + agentcontainer.ContainerNamePrefix + "debug"}))
+	})
+
+	t.Run("UnrelatedUnlabelledContainerIsNotReaped", func(t *testing.T) {
+		assert.False(t, isAgentOwnedContainer(nil, []string{"/postgres"}))
+		assert.False(t, isAgentOwnedContainer(nil, nil))
 	})
 }
 
@@ -466,17 +497,44 @@ func TestSecureContainerDirs(t *testing.T) {
 	}
 
 	t.Run("EmptyWorkDirIsNoop", func(t *testing.T) {
-		assert.NoError(t, secureContainerDirs("", "someuser"))
+		fellBack, err := secureContainerDirs("", "someuser")
+		assert.NoError(t, err)
+		assert.False(t, fellBack)
 	})
 
 	t.Run("EmptyExecUserIsNoop", func(t *testing.T) {
 		// Without an exec user, docker exec runs as root in the container and
 		// can already write to the agent-owned directories.
-		assert.NoError(t, secureContainerDirs(t.TempDir(), ""))
+		fellBack, err := secureContainerDirs(t.TempDir(), "")
+		assert.NoError(t, err)
+		assert.False(t, fellBack)
 	})
 
-	t.Run("UnknownExecUserErrors", func(t *testing.T) {
-		assert.Error(t, secureContainerDirs(t.TempDir(), "evergreen-nonexistent-user"))
+	t.Run("UnknownExecUserFallsBackToWritableDirs", func(t *testing.T) {
+		// The container must still be able to write its own workdir, so an
+		// unreconcilable exec user degrades rather than breaking the task.
+		workDir := t.TempDir()
+		require.NoError(t, os.Mkdir(filepath.Join(workDir, "tmp"), 0700))
+
+		fellBack, err := secureContainerDirs(workDir, "evergreen-nonexistent-user")
+
+		require.NoError(t, err)
+		assert.True(t, fellBack, "the caller must be told the directories are world-writable")
+		for _, dir := range []string{workDir, filepath.Join(workDir, "tmp")} {
+			info, statErr := os.Stat(dir)
+			require.NoError(t, statErr)
+			assert.NotZero(t, info.Mode().Perm()&0002, "the fallback must leave %s writable by the container", dir)
+		}
+	})
+
+	t.Run("NonexistentWorkDirErrorsRatherThanSilentlyDegrading", func(t *testing.T) {
+		usr, err := user.Current()
+		require.NoError(t, err)
+
+		fellBack, err := secureContainerDirs(filepath.Join(t.TempDir(), "absent"), usr.Username)
+
+		require.Error(t, err, "when neither ownership nor the fallback can be applied the caller must hear about it")
+		assert.False(t, fellBack)
 	})
 
 	t.Run("CurrentUserSetsNonWorldWritableMode", func(t *testing.T) {
@@ -486,13 +544,15 @@ func TestSecureContainerDirs(t *testing.T) {
 		workDir := t.TempDir()
 		require.NoError(t, os.Mkdir(filepath.Join(workDir, "tmp"), 0700))
 
-		require.NoError(t, secureContainerDirs(workDir, usr.Username))
+		fellBack, err := secureContainerDirs(workDir, usr.Username)
+		require.NoError(t, err)
+		assert.False(t, fellBack, "ownership transfer succeeded, so no fallback should be reported")
 
 		for _, dir := range []string{workDir, filepath.Join(workDir, "tmp")} {
-			info, err := os.Stat(dir)
-			require.NoError(t, err)
+			info, statErr := os.Stat(dir)
+			require.NoError(t, statErr)
 			assert.Equal(t, os.FileMode(containerDirMode), info.Mode().Perm(), "mode should be %o for %s", containerDirMode, dir)
-			assert.Zero(t, info.Mode().Perm()&0002, "task directories must never be world-writable")
+			assert.Zero(t, info.Mode().Perm()&0002, "task directories must not be world-writable when ownership succeeds")
 		}
 	})
 }

--- a/agent/container_test.go
+++ b/agent/container_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"maps"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -167,14 +168,18 @@ type fakeContainer struct {
 	destroyCalled  int
 	closeCalled    int
 	destroyErr     error
+	destroySignal  chan error
 }
 
 func (f *fakeContainer) GetID() string             { return f.id }
 func (f *fakeContainer) GetName() string           { return f.name }
 func (f *fakeContainer) GetEnvFileHostDir() string { return f.envFileHostDir }
 func (f *fakeContainer) Close()                    { f.closeCalled++ }
-func (f *fakeContainer) Destroy(_ context.Context) error {
+func (f *fakeContainer) Destroy(ctx context.Context) error {
 	f.destroyCalled++
+	if f.destroySignal != nil {
+		f.destroySignal <- ctx.Err()
+	}
 	return f.destroyErr
 }
 
@@ -342,20 +347,49 @@ func TestMaybeStartContainerFailOpenReturnsNil(t *testing.T) {
 	assert.Empty(t, conf.ContainerID, "conf.ContainerID must not be set on fail-open")
 }
 
-func TestDestroyContainerRetentionCallsCloseNotDestroy(t *testing.T) {
+func TestDestroyContainerRetentionExpiresWithinDeadline(t *testing.T) {
 	ctx := t.Context()
-	fc := &fakeContainer{id: "abc", name: "ctr"}
+	fc := &fakeContainer{
+		id:            "abc",
+		name:          "ctr",
+		destroySignal: make(chan error, 1),
+	}
 	a := makeAgentWithFakeContainer(fc)
-	// Set retention window far in the future so destroyContainer takes the retention path.
-	a.retainContainerUntil = time.Now().Add(5 * time.Minute)
+	a.retainContainerUntil = time.Now().Add(25 * time.Millisecond)
 	conf := &internal.TaskConfig{ContainerID: "abc"}
 
 	a.destroyContainer(ctx, conf)
 
-	assert.Equal(t, 1, fc.closeCalled, "retention path must call Close() to release the Docker client")
-	assert.Equal(t, 0, fc.destroyCalled, "retention path must NOT call Destroy() — container must stay running for inspection")
 	assert.Nil(t, a.currentContainer, "currentContainer must be cleared even in retention path")
 	assert.Empty(t, conf.ContainerID, "conf.ContainerID must be cleared in retention path")
+	select {
+	case destroyCtxErr := <-fc.destroySignal:
+		assert.NoError(t, destroyCtxErr, "retained container cleanup must not inherit cancellation")
+	case <-time.After(time.Second):
+		t.Fatal("retained container was not destroyed after its retention deadline")
+	}
+}
+
+func TestDestroyContainerRetentionEndsOnContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	fc := &fakeContainer{
+		id:            "abc",
+		name:          "ctr",
+		destroySignal: make(chan error, 1),
+	}
+	a := makeAgentWithFakeContainer(fc)
+	a.retainContainerUntil = time.Now().Add(5 * time.Minute)
+	conf := &internal.TaskConfig{ContainerID: "abc"}
+
+	a.destroyContainer(ctx, conf)
+	cancel()
+
+	select {
+	case destroyCtxErr := <-fc.destroySignal:
+		assert.NoError(t, destroyCtxErr, "shutdown cleanup must use a detached context")
+	case <-time.After(time.Second):
+		t.Fatal("retained container was not destroyed after context cancellation")
+	}
 }
 
 // TestMaybeStartContainerFailClosedErrorPropagatesFromRunTask verifies that
@@ -458,4 +492,31 @@ func TestDestroyContainerStillClearsReferenceOnDestroyError(t *testing.T) {
 	assert.Equal(t, 1, fc.destroyCalled, "Destroy must be called once")
 	assert.Nil(t, a.currentContainer, "currentContainer must be cleared even on Destroy error")
 	assert.Empty(t, conf.ContainerID)
+}
+
+func TestReadLatestContainerEnvFileReadsNewestUniqueFile(t *testing.T) {
+	dir := t.TempDir()
+	olderPath := filepath.Join(dir, ".evg-env-older")
+	newerPath := filepath.Join(dir, ".evg-env-newer")
+	require.NoError(t, os.WriteFile(olderPath, []byte("VALUE=older\n"), 0600))
+	require.NoError(t, os.WriteFile(newerPath, []byte("VALUE=newer\n"), 0600))
+	baseTime := time.Now().Add(-time.Minute)
+	require.NoError(t, os.Chtimes(olderPath, baseTime, baseTime))
+	require.NoError(t, os.Chtimes(newerPath, baseTime.Add(time.Second), baseTime.Add(time.Second)))
+
+	data, err := readLatestContainerEnvFile(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "VALUE=newer\n", string(data))
+}
+
+func TestWriteHostEnvFileStopsLoginShellWhenContextExpires(t *testing.T) {
+	dir := t.TempDir()
+	bashPath := filepath.Join(dir, "bash")
+	require.NoError(t, os.WriteFile(bashPath, []byte("#!/bin/sh\n/bin/sleep 2\n/bin/touch \"$0.finished\"\n"), 0700))
+	t.Setenv("PATH", dir)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	t.Cleanup(cancel)
+	require.NoError(t, writeHostEnvFile(ctx, filepath.Join(dir, "host-env")))
+	assert.NoFileExists(t, bashPath+".finished", "the timed-out login shell must not resume profile processing")
 }

--- a/agent/container_test.go
+++ b/agent/container_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"maps"
 	"os"
+	"os/user"
 	"path/filepath"
 	"testing"
 	"time"
 
 	agentcontainer "github.com/evergreen-ci/evergreen/agent/container"
 	"github.com/evergreen-ci/evergreen/agent/internal"
-	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	agentutil "github.com/evergreen-ci/evergreen/agent/util"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -20,88 +20,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 )
-
-// agentForKillTest returns a minimal Agent that passes the shouldKill guard.
-// shouldKill short-circuits to false when a.opts.Cleanup is false (added in
-// the upstream sync), so tests that want to reach the kill/cleanup logic must
-// set Cleanup: true.
-func agentForKillTest() *Agent {
-	return &Agent{opts: Options{Cleanup: true}}
-}
-
-// TestKillProcsContainerIsolationSkipsDockerCleanup verifies the A5 gate:
-// when ContainerIsolation is set, killProcs logs "Skipping Docker artifact
-// cleanup" and returns early without calling docker.Cleanup. The gate is
-// confirmed by the presence of that log line in the test output.
-func TestKillProcsContainerIsolationSkipsDockerCleanup(t *testing.T) {
-	ctx := t.Context()
-	a := agentForKillTest()
-
-	tc := &taskContext{
-		task: client.TaskData{ID: "test-task-1"},
-		taskConfig: &internal.TaskConfig{
-			// Empty ExecUser → takes the ps-based kill path (no sudo pkill),
-			// safe in a sandboxed test environment.
-			WorkDir: t.TempDir(),
-			Distro: &apimodels.DistroView{
-				ContainerIsolation: &apimodels.ContainerIsolationSettings{
-					Image: "ubuntu:22.04",
-				},
-			},
-		},
-	}
-
-	// shouldKill → true (Cleanup=true, task.ID set, TaskGroup nil).
-	// Process-kill block: ContainerID="" and ExecUser="" → ps path, no-op.
-	// docker.Cleanup gate: ContainerIsolation != nil → early return, nil.
-	err := a.killProcs(ctx, tc, true, "test")
-	assert.NoError(t, err, "killProcs must return nil on a container-isolation distro without invoking docker.Cleanup")
-}
-
-// TestKillProcsContainerRouting verifies that killProcs routes to the
-// in-container kill path when ContainerID is set, and the host-side
-// KillSpawnedProcs path when it is not.
-func TestKillProcsContainerRouting(t *testing.T) {
-	ctx := t.Context()
-	a := agentForKillTest()
-
-	t.Run("EmptyContainerIDTakesHostPath", func(t *testing.T) {
-		tc := &taskContext{
-			task: client.TaskData{ID: "test-task-1"},
-			taskConfig: &internal.TaskConfig{
-				WorkDir: t.TempDir(),
-				Distro:  &apimodels.DistroView{
-					// Empty ExecUser: takes the ps-based host path, which is
-					// safe without real sudo in a test environment.
-				},
-			},
-		}
-		// ContainerID="" → host-side KillSpawnedProcs (ps path, no sudo).
-		// No task-marker processes running → nil.
-		err := a.killProcs(ctx, tc, true, "test")
-		assert.NoError(t, err)
-	})
-
-	t.Run("NonEmptyContainerIDEmptyExecUserLogsWarningNoError", func(t *testing.T) {
-		tc := &taskContext{
-			task: client.TaskData{ID: "test-task-1"},
-			taskConfig: &internal.TaskConfig{
-				ContainerID: "some-container-id",
-				WorkDir:     t.TempDir(),
-				Distro: &apimodels.DistroView{
-					// ExecUser deliberately empty to hit the graceful-degradation
-					// branch (warning logged, no docker exec attempted).
-					ContainerIsolation: &apimodels.ContainerIsolationSettings{
-						Image: "ubuntu:22.04",
-					},
-				},
-			},
-		}
-		// ContainerID != "" but ExecUser == "" → warning logged, nil returned.
-		err := a.killProcs(ctx, tc, true, "test")
-		require.NoError(t, err)
-	})
-}
 
 func makeSnapshotTC(expansions map[string]string, redacted []string, secrets map[string]string) *taskContext {
 	exp := util.Expansions{}
@@ -121,12 +39,13 @@ func makeSnapshotTC(expansions map[string]string, redacted []string, secrets map
 }
 
 func TestRedactForSnapshot(t *testing.T) {
-	t.Run("NilTCReturnsUnchanged", func(t *testing.T) {
-		assert.Equal(t, "hello world", redactForSnapshot("hello world", nil))
+	t.Run("NilTCFailsClosed", func(t *testing.T) {
+		assert.Equal(t, redactionUnavailable, redactForSnapshot("hello world", nil),
+			"without a task config the redactor cannot know the secrets, so it must not emit the raw value")
 	})
 
-	t.Run("NilTaskConfigReturnsUnchanged", func(t *testing.T) {
-		assert.Equal(t, "secret", redactForSnapshot("secret", &taskContext{}))
+	t.Run("NilTaskConfigFailsClosed", func(t *testing.T) {
+		assert.Equal(t, redactionUnavailable, redactForSnapshot("secret", &taskContext{}))
 	})
 
 	t.Run("RedactsNamedExpansion", func(t *testing.T) {
@@ -166,7 +85,6 @@ type fakeContainer struct {
 	name           string
 	envFileHostDir string
 	destroyCalled  int
-	closeCalled    int
 	destroyErr     error
 	destroySignal  chan error
 }
@@ -174,7 +92,6 @@ type fakeContainer struct {
 func (f *fakeContainer) GetID() string             { return f.id }
 func (f *fakeContainer) GetName() string           { return f.name }
 func (f *fakeContainer) GetEnvFileHostDir() string { return f.envFileHostDir }
-func (f *fakeContainer) Close()                    { f.closeCalled++ }
 func (f *fakeContainer) Destroy(ctx context.Context) error {
 	f.destroyCalled++
 	if f.destroySignal != nil {
@@ -264,7 +181,6 @@ func TestDestroyContainerNilCurrentContainerIsNoop(t *testing.T) {
 	a := &Agent{}
 	conf := &internal.TaskConfig{}
 
-	// Should not panic and should leave everything unchanged.
 	a.destroyContainer(ctx, conf)
 	assert.Empty(t, conf.ContainerID)
 	assert.Empty(t, conf.EnvFileHostDir)
@@ -302,7 +218,6 @@ func TestDestroyContainerIdempotent(t *testing.T) {
 	conf := &internal.TaskConfig{ContainerID: "abc"}
 
 	a.destroyContainer(ctx, conf)
-	// Second call: currentContainer is already nil, should be a no-op.
 	a.destroyContainer(ctx, conf)
 
 	assert.Equal(t, 1, fc.destroyCalled, "Destroy should only be called once")
@@ -347,64 +262,22 @@ func TestMaybeStartContainerFailOpenReturnsNil(t *testing.T) {
 	assert.Empty(t, conf.ContainerID, "conf.ContainerID must not be set on fail-open")
 }
 
-func TestDestroyContainerRetentionExpiresWithinDeadline(t *testing.T) {
-	ctx := t.Context()
-	fc := &fakeContainer{
-		id:            "abc",
-		name:          "ctr",
-		destroySignal: make(chan error, 1),
-	}
-	a := makeAgentWithFakeContainer(fc)
-	a.retainContainerUntil = time.Now().Add(25 * time.Millisecond)
-	conf := &internal.TaskConfig{ContainerID: "abc"}
-
-	a.destroyContainer(ctx, conf)
-
-	assert.Nil(t, a.currentContainer, "currentContainer must be cleared even in retention path")
-	assert.Empty(t, conf.ContainerID, "conf.ContainerID must be cleared in retention path")
-	select {
-	case destroyCtxErr := <-fc.destroySignal:
-		assert.NoError(t, destroyCtxErr, "retained container cleanup must not inherit cancellation")
-	case <-time.After(time.Second):
-		t.Fatal("retained container was not destroyed after its retention deadline")
-	}
-}
-
-func TestDestroyContainerRetentionEndsOnContextCancellation(t *testing.T) {
-	ctx, cancel := context.WithCancel(t.Context())
-	fc := &fakeContainer{
-		id:            "abc",
-		name:          "ctr",
-		destroySignal: make(chan error, 1),
-	}
-	a := makeAgentWithFakeContainer(fc)
-	a.retainContainerUntil = time.Now().Add(5 * time.Minute)
-	conf := &internal.TaskConfig{ContainerID: "abc"}
-
-	a.destroyContainer(ctx, conf)
-	cancel()
-
-	select {
-	case destroyCtxErr := <-fc.destroySignal:
-		assert.NoError(t, destroyCtxErr, "shutdown cleanup must use a detached context")
-	case <-time.After(time.Second):
-		t.Fatal("retained container was not destroyed after context cancellation")
-	}
-}
-
-// TestMaybeStartContainerFailClosedErrorPropagatesFromRunTask verifies that
-// a non-nil error from maybeStartContainer causes runTask (via the caller) to
-// fail rather than silently continuing in host mode. The fail-closed contract
-// (require_isolation=true) must not be violated at the runTask call site.
-func TestMaybeStartContainerFailClosedPropagatesFromRunTask(t *testing.T) {
+// TestMaybeStartContainerFailsClosedWhenDirsCannotBeSecured verifies that a
+// distro requiring isolation does not start a container whose task directories
+// could not be handed to the exec user, since the task would otherwise run
+// with the container unable to write its own workdir.
+func TestMaybeStartContainerFailsClosedWhenDirsCannotBeSecured(t *testing.T) {
 	ctx := t.Context()
 	a := agentForContainerTest()
+	factoryCalled := false
 	a.containerFactory = func(_ context.Context, _ agentcontainer.Config) (ContainerHandle, error) {
-		return nil, errors.New("container daemon unreachable")
+		factoryCalled = true
+		return &fakeContainer{id: "id", name: "ctr"}, nil
 	}
-
 	conf := &internal.TaskConfig{
+		WorkDir: t.TempDir(),
 		Distro: &apimodels.DistroView{
+			ExecUser: "evergreen-nonexistent-user",
 			ContainerIsolation: &apimodels.ContainerIsolationSettings{
 				Image:            "ubuntu:22.04",
 				RequireIsolation: true,
@@ -414,41 +287,90 @@ func TestMaybeStartContainerFailClosedPropagatesFromRunTask(t *testing.T) {
 	}
 
 	err := a.maybeStartContainer(ctx, conf, nil)
-	require.Error(t, err, "fail-closed path must propagate error to runTask caller")
-	assert.Empty(t, conf.ContainerID, "ContainerID must not be set when container fails to start")
+	require.Error(t, err, "require_isolation must fail closed when task directories cannot be secured")
+	assert.False(t, factoryCalled, "container must not be created after directory preparation fails")
 	assert.Nil(t, a.currentContainer)
 }
 
-func TestMaybeStartContainerOptMountMatchesHostFilesystem(t *testing.T) {
+func TestMaybeStartContainerFailsOpenWhenDirsCannotBeSecured(t *testing.T) {
 	ctx := t.Context()
 	a := agentForContainerTest()
-	created := &fakeContainer{id: "newid", name: "evergreen-task-new", envFileHostDir: "/tmp/env-new"}
-	var capturedCfg agentcontainer.Config
-	a.containerFactory = func(_ context.Context, cfg agentcontainer.Config) (ContainerHandle, error) {
-		capturedCfg = cfg
+	created := &fakeContainer{id: "id", name: "ctr"}
+	a.containerFactory = func(_ context.Context, _ agentcontainer.Config) (ContainerHandle, error) {
 		return created, nil
 	}
 	conf := &internal.TaskConfig{
-		Distro: makeDistroWithIsolation("ubuntu:22.04"),
-		Task:   task.Task{Id: "task-1"},
+		WorkDir: t.TempDir(),
+		Distro: &apimodels.DistroView{
+			ExecUser:           "evergreen-nonexistent-user",
+			ContainerIsolation: &apimodels.ContainerIsolationSettings{Image: "ubuntu:22.04"},
+		},
+		Task: task.Task{Id: "task-1"},
 	}
 
 	require.NoError(t, a.maybeStartContainer(ctx, conf, nil))
+	assert.Equal(t, created, a.currentContainer, "without require_isolation the task proceeds despite degraded directories")
+}
 
-	// The /opt mount is conditional on os.Stat("/opt") succeeding. On
-	// macOS/Linux test hosts /opt typically exists, but the test must not
-	// assume that — it verifies the mount is present iff /opt exists.
-	_, optExists := os.Stat("/opt")
-	found := false
-	for _, m := range capturedCfg.ExtraMounts {
-		if m.Source == "/opt" && m.Target == "/opt" && m.ReadOnly {
-			found = true
-		}
+func TestDestroyContainerRetentionWaitsForDeadline(t *testing.T) {
+	ctx := t.Context()
+	fc := &fakeContainer{
+		id:            "abc",
+		name:          "ctr",
+		destroySignal: make(chan error, 1),
 	}
-	if optExists == nil {
-		assert.True(t, found, "ExtraMounts must contain /opt:ro when /opt exists on host")
-	} else {
-		assert.False(t, found, "ExtraMounts must not contain /opt when /opt does not exist on host")
+	a := makeAgentWithFakeContainer(fc)
+	a.retainContainerUntil = time.Now().Add(200 * time.Millisecond)
+	conf := &internal.TaskConfig{ContainerID: "abc"}
+
+	a.destroyContainer(ctx, conf)
+
+	assert.Nil(t, a.currentContainer, "currentContainer must be cleared even in retention path")
+	assert.Empty(t, conf.ContainerID, "conf.ContainerID must be cleared in retention path")
+
+	// The point of retention is that the container survives for inspection.
+	// Without this assertion the test would pass even if retention were ignored.
+	select {
+	case <-fc.destroySignal:
+		t.Fatal("container was destroyed before its retention deadline elapsed")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	select {
+	case destroyCtxErr := <-fc.destroySignal:
+		assert.NoError(t, destroyCtxErr, "retained container cleanup must not inherit cancellation")
+	case <-time.After(5 * time.Second):
+		t.Fatal("retained container was not destroyed after its retention deadline")
+	}
+}
+
+func TestDestroyContainerRetentionEndsOnContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	fc := &fakeContainer{
+		id:            "abc",
+		name:          "ctr",
+		destroySignal: make(chan error, 1),
+	}
+	a := makeAgentWithFakeContainer(fc)
+	a.retainContainerUntil = time.Now().Add(time.Hour)
+	conf := &internal.TaskConfig{ContainerID: "abc"}
+
+	a.destroyContainer(ctx, conf)
+
+	select {
+	case <-fc.destroySignal:
+		t.Fatal("container was destroyed before shutdown was signalled")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case destroyCtxErr := <-fc.destroySignal:
+		assert.NoError(t, destroyCtxErr, "shutdown cleanup must use a detached context")
+	case <-time.After(5 * time.Second):
+		t.Fatal("retained container was not destroyed after context cancellation")
 	}
 }
 
@@ -458,19 +380,12 @@ func TestDestroyContainerCallsDestroyEvenWithCancelledContext(t *testing.T) {
 	a := makeAgentWithFakeContainer(fc)
 	conf := &internal.TaskConfig{ContainerID: "abc", EnvFileHostDir: "/tmp/env"}
 
-	// Cancel the context before calling destroyContainer to verify that
-	// Destroy is still called. The real TaskContainer.Destroy uses
-	// context.Background() internally so cleanup is not bypassed by caller
-	// cancellation. The fake ignores its context, so this test verifies
-	// the destroyContainer call site does not short-circuit on ctx.Err();
-	// integration testing against a real Docker daemon is needed to verify
-	// the internal context.Background() usage.
 	cancelledCtx, cancel := context.WithCancel(ctx)
 	cancel()
 
 	a.destroyContainer(cancelledCtx, conf)
 
-	assert.Equal(t, 1, fc.destroyCalled, "Destroy must be called even when context is cancelled")
+	assert.Equal(t, 1, fc.destroyCalled, "the call site must not short-circuit on ctx.Err()")
 	assert.Nil(t, a.currentContainer)
 	assert.Empty(t, conf.ContainerID)
 }
@@ -487,17 +402,124 @@ func TestDestroyContainerStillClearsReferenceOnDestroyError(t *testing.T) {
 
 	a.destroyContainer(ctx, conf)
 
-	// destroyContainer logs the warning but still clears the reference so
-	// the agent doesn't get stuck on a container it can't remove.
 	assert.Equal(t, 1, fc.destroyCalled, "Destroy must be called once")
 	assert.Nil(t, a.currentContainer, "currentContainer must be cleared even on Destroy error")
 	assert.Empty(t, conf.ContainerID)
 }
 
+func TestIsAgentOwnedContainer(t *testing.T) {
+	t.Run("OwnedLabelMatches", func(t *testing.T) {
+		assert.True(t, isAgentOwnedContainer(map[string]string{
+			agentcontainer.OwnerLabel: agentcontainer.OwnerLabelValue,
+		}))
+	})
+
+	t.Run("NoLabelsIsNotOwned", func(t *testing.T) {
+		assert.False(t, isAgentOwnedContainer(nil),
+			"an unlabelled container may belong to a human and must never be reaped")
+	})
+
+	t.Run("ForeignOwnerIsNotOwned", func(t *testing.T) {
+		assert.False(t, isAgentOwnedContainer(map[string]string{
+			agentcontainer.OwnerLabel: "someone-else",
+		}))
+	})
+
+	t.Run("EvergreenTaskNameWithoutLabelIsNotOwned", func(t *testing.T) {
+		// The previous implementation matched the name substring
+		// "evergreen-task-", which would have reaped another agent's
+		// container or a human's lookalike.
+		assert.False(t, isAgentOwnedContainer(map[string]string{"name": "evergreen-task-abc"}))
+	})
+}
+
+func TestContainerNames(t *testing.T) {
+	assert.Equal(t, "a,b", containerNames([]string{"/a", "/b"}))
+	assert.Empty(t, containerNames(nil))
+}
+
+func TestContainerToolchainDirsDoesNotMountAllOfOpt(t *testing.T) {
+	assert.NotContains(t, containerToolchainDirs, "/opt",
+		"mounting all of /opt exposes anything provisioning writes there to every containerized task")
+}
+
+func TestToolchainMountsOnlyIncludesExistingDirsReadOnly(t *testing.T) {
+	existing := t.TempDir()
+	missing := filepath.Join(t.TempDir(), "absent")
+
+	original := containerToolchainDirs
+	t.Cleanup(func() { containerToolchainDirs = original })
+	containerToolchainDirs = []string{existing, missing}
+
+	mounts := toolchainMounts(t.Context(), "task-1")
+
+	require.Len(t, mounts, 1, "a nonexistent source would make Docker reject container creation")
+	assert.Equal(t, existing, mounts[0].Source)
+	assert.Equal(t, existing, mounts[0].Target)
+	assert.True(t, mounts[0].ReadOnly, "toolchain mounts must be read-only")
+}
+
+func TestSecureContainerDirs(t *testing.T) {
+	t.Run("EmptyWorkDirIsNoop", func(t *testing.T) {
+		assert.NoError(t, secureContainerDirs("", "someuser"))
+	})
+
+	t.Run("EmptyExecUserIsNoop", func(t *testing.T) {
+		// Without an exec user, docker exec runs as root in the container and
+		// can already write to the agent-owned directories.
+		assert.NoError(t, secureContainerDirs(t.TempDir(), ""))
+	})
+
+	t.Run("UnknownExecUserErrors", func(t *testing.T) {
+		assert.Error(t, secureContainerDirs(t.TempDir(), "evergreen-nonexistent-user"))
+	})
+
+	t.Run("CurrentUserSetsNonWorldWritableMode", func(t *testing.T) {
+		usr, err := user.Current()
+		require.NoError(t, err)
+
+		workDir := t.TempDir()
+		require.NoError(t, os.Mkdir(filepath.Join(workDir, "tmp"), 0700))
+
+		require.NoError(t, secureContainerDirs(workDir, usr.Username))
+
+		for _, dir := range []string{workDir, filepath.Join(workDir, "tmp")} {
+			info, err := os.Stat(dir)
+			require.NoError(t, err)
+			assert.Equal(t, os.FileMode(containerDirMode), info.Mode().Perm(), "mode should be %o for %s", containerDirMode, dir)
+			assert.Zero(t, info.Mode().Perm()&0002, "task directories must never be world-writable")
+		}
+	})
+}
+
+func TestChownContainerDirRefusesSymlink(t *testing.T) {
+	base := t.TempDir()
+	target := filepath.Join(base, "target")
+	link := filepath.Join(base, "link")
+	require.NoError(t, os.Mkdir(target, 0700))
+	require.NoError(t, os.Symlink(target, link))
+
+	err := chownContainerDir(link, os.Getuid(), os.Getgid())
+
+	require.Error(t, err, "following a symlink would let a local user redirect the chown")
+	assert.Contains(t, err.Error(), "symlink")
+
+	info, err := os.Stat(target)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0700), info.Mode().Perm(), "the symlink target must be untouched")
+}
+
+func TestChownContainerDirRefusesNonDirectory(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "file")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0600))
+
+	assert.Error(t, chownContainerDir(file, os.Getuid(), os.Getgid()))
+}
+
 func TestReadLatestContainerEnvFileReadsNewestUniqueFile(t *testing.T) {
 	dir := t.TempDir()
-	olderPath := filepath.Join(dir, ".evg-env-older")
-	newerPath := filepath.Join(dir, ".evg-env-newer")
+	olderPath := filepath.Join(dir, containerEnvFilePrefix+"older")
+	newerPath := filepath.Join(dir, containerEnvFilePrefix+"newer")
 	require.NoError(t, os.WriteFile(olderPath, []byte("VALUE=older\n"), 0600))
 	require.NoError(t, os.WriteFile(newerPath, []byte("VALUE=newer\n"), 0600))
 	baseTime := time.Now().Add(-time.Minute)
@@ -509,14 +531,121 @@ func TestReadLatestContainerEnvFileReadsNewestUniqueFile(t *testing.T) {
 	assert.Equal(t, "VALUE=newer\n", string(data))
 }
 
-func TestWriteHostEnvFileStopsLoginShellWhenContextExpires(t *testing.T) {
+func TestContainerEnvFileKeysOmitsValues(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, containerEnvFilePrefix+"1"),
+		[]byte("AWS_SECRET_ACCESS_KEY=supersecret\nPATH=/usr/bin\n"),
+		0600,
+	))
+
+	keys, err := containerEnvFileKeys(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"AWS_SECRET_ACCESS_KEY", "PATH"}, keys)
+	for _, key := range keys {
+		assert.NotContains(t, key, "supersecret", "env values must never reach telemetry")
+	}
+}
+
+func TestParseHostEnv(t *testing.T) {
+	sentinel := hostEnvSentinel + "\x00"
+
+	t.Run("DiscardsProfileOutputBeforeSentinel", func(t *testing.T) {
+		out := []byte("Welcome to the machine\nMOTD banner\n" + sentinel + "PATH=/usr/bin\x00")
+		assert.Equal(t, []string{"PATH=/usr/bin"}, parseHostEnv(out))
+	})
+
+	t.Run("PreservesSpacesAndGlobCharacters", func(t *testing.T) {
+		// The previous unquoted `echo '%s='$VAR` word-split and glob-expanded
+		// these values before they reached the env file.
+		out := []byte(sentinel + "PATH=/opt/my tools/bin:/usr/*\x00")
+		assert.Equal(t, []string{"PATH=/opt/my tools/bin:/usr/*"}, parseHostEnv(out))
+	})
+
+	t.Run("DropsValuesContainingNewlines", func(t *testing.T) {
+		out := []byte(sentinel + "GOOD=1\x00BAD=line1\nline2\x00")
+		assert.Equal(t, []string{"GOOD=1"}, parseHostEnv(out),
+			"an env file cannot represent a newline, and Docker rejects the whole file")
+	})
+
+	t.Run("NoSentinelYieldsNothing", func(t *testing.T) {
+		assert.Empty(t, parseHostEnv([]byte("PATH=/usr/bin\x00")))
+	})
+
+	t.Run("SkipsRecordsWithoutSeparatorOrKey", func(t *testing.T) {
+		out := []byte(sentinel + "novalue\x00=orphan\x00OK=1\x00")
+		assert.Equal(t, []string{"OK=1"}, parseHostEnv(out))
+	})
+}
+
+func TestHostEnvShellCommandQuotesExpansions(t *testing.T) {
+	cmd := hostEnvShellCommand()
+
+	assert.Contains(t, cmd, hostEnvSentinel, "the sentinel must be emitted so profile output can be discarded")
+	assert.Contains(t, cmd, `"$PATH"`, "expansions must be quoted to prevent word splitting and globbing")
+	assert.NotContains(t, cmd, "echo '", "echo with an unquoted expansion is what corrupted values")
+}
+
+func TestFormatHostEnv(t *testing.T) {
+	assert.Empty(t, formatHostEnv(nil))
+	assert.Equal(t, "A=1\nB=2\n", formatHostEnv([]string{"A=1", "B=2"}))
+}
+
+func TestAgentHostEnvDropsNewlineValues(t *testing.T) {
+	t.Setenv("GOROOT", "/opt/golang/go\nEVIL=1")
+	t.Setenv("JAVA_HOME", "/opt/java")
+
+	entries := agentHostEnv()
+
+	assert.Contains(t, entries, "JAVA_HOME=/opt/java")
+	for _, entry := range entries {
+		assert.NotContains(t, entry, "EVIL", "a newline in a value must not smuggle an extra env entry")
+	}
+}
+
+func TestWriteHostEnvFileReportsCaptureFailureAndWritesFallback(t *testing.T) {
 	dir := t.TempDir()
 	bashPath := filepath.Join(dir, "bash")
 	require.NoError(t, os.WriteFile(bashPath, []byte("#!/bin/sh\n/bin/sleep 2\n/bin/touch \"$0.finished\"\n"), 0700))
 	t.Setenv("PATH", dir)
+	t.Setenv("JAVA_HOME", "/opt/java")
 
+	envPath := filepath.Join(dir, "host-env")
 	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
 	t.Cleanup(cancel)
-	require.NoError(t, writeHostEnvFile(ctx, filepath.Join(dir, "host-env")))
+
+	err := writeHostEnvFile(ctx, envPath)
+
+	require.Error(t, err, "a swallowed capture failure hides a degraded container environment")
 	assert.NoFileExists(t, bashPath+".finished", "the timed-out login shell must not resume profile processing")
+
+	data, readErr := os.ReadFile(envPath)
+	require.NoError(t, readErr, "the fallback env file must still be written")
+	assert.Contains(t, string(data), "JAVA_HOME=/opt/java", "the fallback should carry the agent's own environment")
+}
+
+func TestWriteHostEnvFileParsesLoginShellOutput(t *testing.T) {
+	dir := t.TempDir()
+	bashPath := filepath.Join(dir, "bash")
+	// Stand in for a login shell whose profile scripts print a banner before
+	// the env dump, and whose PATH contains a space.
+	script := "#!/bin/sh\n" +
+		"printf 'MOTD banner\\n'\n" +
+		"printf '%s\\0' '" + hostEnvSentinel + "'\n" +
+		"printf '%s=%s\\0' 'PATH' '/opt/my tools/bin'\n"
+	require.NoError(t, os.WriteFile(bashPath, []byte(script), 0700))
+	t.Setenv("PATH", dir)
+
+	envPath := filepath.Join(dir, "host-env")
+	require.NoError(t, writeHostEnvFile(t.Context(), envPath))
+
+	data, err := os.ReadFile(envPath)
+	require.NoError(t, err)
+	assert.Equal(t, "PATH=/opt/my tools/bin\n", string(data),
+		"the banner must be discarded and the spaced value preserved verbatim")
+
+	info, err := os.Stat(envPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
 }

--- a/agent/container_test.go
+++ b/agent/container_test.go
@@ -122,7 +122,7 @@ func makeDistroWithIsolation(image string) *apimodels.DistroView {
 	}
 }
 
-func TestMaybeStartContainerReusePath(t *testing.T) {
+func TestEnsureContainerReusePath(t *testing.T) {
 	ctx := t.Context()
 	fc := &fakeContainer{id: "abc123", name: "evergreen-task-abc", envFileHostDir: "/tmp/env-abc"}
 	a := makeAgentWithFakeContainer(fc)
@@ -131,7 +131,7 @@ func TestMaybeStartContainerReusePath(t *testing.T) {
 		Task:   task.Task{},
 	}
 
-	err := a.maybeStartContainer(ctx, conf, nil)
+	err := a.ensureContainer(ctx, conf, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "abc123", conf.ContainerID, "reuse path should wire ContainerID from existing container")
@@ -139,7 +139,7 @@ func TestMaybeStartContainerReusePath(t *testing.T) {
 	assert.Equal(t, fc, a.currentContainer, "existing container should not be replaced")
 }
 
-func TestMaybeStartContainerCreatePath(t *testing.T) {
+func TestEnsureContainerCreatePath(t *testing.T) {
 	ctx := t.Context()
 	a := agentForContainerTest()
 	created := &fakeContainer{id: "newid", name: "evergreen-task-new", envFileHostDir: "/tmp/env-new"}
@@ -151,7 +151,7 @@ func TestMaybeStartContainerCreatePath(t *testing.T) {
 		Task:   task.Task{Id: "task-1"},
 	}
 
-	err := a.maybeStartContainer(ctx, conf, nil)
+	err := a.ensureContainer(ctx, conf, nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, "newid", conf.ContainerID)
@@ -159,21 +159,21 @@ func TestMaybeStartContainerCreatePath(t *testing.T) {
 	assert.Equal(t, created, a.currentContainer)
 }
 
-func TestMaybeStartContainerNilDistroIsNoop(t *testing.T) {
+func TestEnsureContainerNilDistroIsNoop(t *testing.T) {
 	ctx := t.Context()
 	a := agentForContainerTest()
 	conf := &internal.TaskConfig{Distro: nil}
 
-	require.NoError(t, a.maybeStartContainer(ctx, conf, nil))
+	require.NoError(t, a.ensureContainer(ctx, conf, nil))
 	assert.Nil(t, a.currentContainer)
 }
 
-func TestMaybeStartContainerNilIsolationIsNoop(t *testing.T) {
+func TestEnsureContainerNilIsolationIsNoop(t *testing.T) {
 	ctx := t.Context()
 	a := agentForContainerTest()
 	conf := &internal.TaskConfig{Distro: &apimodels.DistroView{ContainerIsolation: nil}}
 
-	require.NoError(t, a.maybeStartContainer(ctx, conf, nil))
+	require.NoError(t, a.ensureContainer(ctx, conf, nil))
 	assert.Nil(t, a.currentContainer)
 }
 
@@ -224,7 +224,7 @@ func TestDestroyContainerIdempotent(t *testing.T) {
 	assert.Equal(t, 1, fc.destroyCalled, "Destroy should only be called once")
 }
 
-func TestMaybeStartContainerFailClosedPropagatesError(t *testing.T) {
+func TestEnsureContainerFailClosedPropagatesError(t *testing.T) {
 	ctx := t.Context()
 	a := agentForContainerTest()
 	a.containerFactory = func(_ context.Context, _ agentcontainer.Config) (ContainerHandle, error) {
@@ -240,13 +240,13 @@ func TestMaybeStartContainerFailClosedPropagatesError(t *testing.T) {
 		Task: task.Task{Id: "task-1"},
 	}
 
-	err := a.maybeStartContainer(ctx, conf, nil)
+	err := a.ensureContainer(ctx, conf, nil)
 	require.Error(t, err, "fail-closed: error should be returned when factory fails")
 	assert.Nil(t, a.currentContainer)
 	assert.Empty(t, conf.ContainerID)
 }
 
-func TestMaybeStartContainerFailOpenReturnsNil(t *testing.T) {
+func TestEnsureContainerFailOpenReturnsNil(t *testing.T) {
 	ctx := t.Context()
 	a := agentForContainerTest()
 	a.containerFactory = func(_ context.Context, _ agentcontainer.Config) (ContainerHandle, error) {
@@ -257,16 +257,16 @@ func TestMaybeStartContainerFailOpenReturnsNil(t *testing.T) {
 		Task:   task.Task{Id: "task-1"},
 	}
 
-	err := a.maybeStartContainer(ctx, conf, nil)
+	err := a.ensureContainer(ctx, conf, nil)
 	require.NoError(t, err, "fail-open: error should be swallowed when RequireIsolation is false")
 	assert.Nil(t, a.currentContainer, "currentContainer must remain nil on fail-open")
 	assert.Empty(t, conf.ContainerID, "conf.ContainerID must not be set on fail-open")
 }
 
-// TestMaybeStartContainerFailsClosedWhenDirsCannotBeSecured verifies that a
+// TestEnsureContainerFailsClosedWhenDirsCannotBeSecured verifies that a
 // distro requiring isolation does not start a container when neither ownership
 // transfer nor the permissive fallback could be applied.
-func TestMaybeStartContainerFailsClosedWhenDirsCannotBeSecured(t *testing.T) {
+func TestEnsureContainerFailsClosedWhenDirsCannotBeSecured(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Container isolation uses POSIX ownership and is not supported on Windows")
 	}
@@ -294,16 +294,16 @@ func TestMaybeStartContainerFailsClosedWhenDirsCannotBeSecured(t *testing.T) {
 		Task: task.Task{Id: "task-1"},
 	}
 
-	err = a.maybeStartContainer(ctx, conf, nil)
+	err = a.ensureContainer(ctx, conf, nil)
 	require.Error(t, err, "require_isolation must fail closed when task directories cannot be secured at all")
 	assert.False(t, factoryCalled, "container must not be created after directory preparation fails")
 	assert.Nil(t, a.currentContainer)
 }
 
-// TestMaybeStartContainerUsesPermissiveFallbackWhenOwnershipFails verifies the
+// TestEnsureContainerUsesPermissiveFallbackWhenOwnershipFails verifies the
 // task still runs when the exec user cannot be reconciled, which is the
 // behaviour the pre-review implementation had unconditionally.
-func TestMaybeStartContainerUsesPermissiveFallbackWhenOwnershipFails(t *testing.T) {
+func TestEnsureContainerUsesPermissiveFallbackWhenOwnershipFails(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Container isolation uses POSIX ownership and is not supported on Windows")
 	}
@@ -327,7 +327,7 @@ func TestMaybeStartContainerUsesPermissiveFallbackWhenOwnershipFails(t *testing.
 		Task: task.Task{Id: "task-1"},
 	}
 
-	require.NoError(t, a.maybeStartContainer(ctx, conf, nil),
+	require.NoError(t, a.ensureContainer(ctx, conf, nil),
 		"an unreconcilable exec user must degrade rather than fail the task")
 	assert.Equal(t, created, a.currentContainer)
 
@@ -483,7 +483,7 @@ func TestToolchainMountsOnlyIncludesExistingDirsReadOnly(t *testing.T) {
 	t.Cleanup(func() { containerToolchainDirs = original })
 	containerToolchainDirs = []string{existing, missing}
 
-	mounts := toolchainMounts(t.Context(), "task-1")
+	mounts := toolchainMounts(t.Context(), "task-1", nil)
 
 	require.Len(t, mounts, 1, "a nonexistent source would make Docker reject container creation")
 	assert.Equal(t, existing, mounts[0].Source)

--- a/agent/container_test.go
+++ b/agent/container_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -460,6 +461,10 @@ func TestToolchainMountsOnlyIncludesExistingDirsReadOnly(t *testing.T) {
 }
 
 func TestSecureContainerDirs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Container isolation uses POSIX ownership and is not supported on Windows")
+	}
+
 	t.Run("EmptyWorkDirIsNoop", func(t *testing.T) {
 		assert.NoError(t, secureContainerDirs("", "someuser"))
 	})
@@ -506,6 +511,10 @@ func TestChownContainerDirRefusesSymlink(t *testing.T) {
 
 	info, err := os.Stat(target)
 	require.NoError(t, err)
+	if runtime.GOOS == "windows" {
+		assert.True(t, info.IsDir(), "the symlink target must remain a directory")
+		return
+	}
 	assert.Equal(t, os.FileMode(0700), info.Mode().Perm(), "the symlink target must be untouched")
 }
 
@@ -626,6 +635,10 @@ func TestWriteHostEnvFileReportsCaptureFailureAndWritesFallback(t *testing.T) {
 }
 
 func TestWriteHostEnvFileParsesLoginShellOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows cannot execute the extensionless shell script used by this integration test")
+	}
+
 	dir := t.TempDir()
 	bashPath := filepath.Join(dir, "bash")
 	// Stand in for a login shell whose profile scripts print a banner before

--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -98,6 +98,15 @@ type TaskConfig struct {
 	// BackgroundFailures is the send-only end of a channel for background command failures; the agent reads from the bidirectional end on taskContext.
 	BackgroundFailures chan<- error
 
+	// ContainerID is the Docker container ID for this task's isolation container.
+	// Empty if container isolation is not enabled for this task.
+	// Set by the agent before task commands run; read by exec.go and shell.go.
+	ContainerID string
+
+	// EnvFileHostDir is the host-side tmpfs directory for env-file forwarding.
+	// Set alongside ContainerID when container isolation is enabled.
+	EnvFileHostDir string
+
 	// PatchOrVersionDescription holds the description of a patch or
 	// message of a version to be used in the otel attributes.
 	PatchOrVersionDescription string

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-08-04"
+	AgentVersion = "2026-08-05"
 )
 
 const (


### PR DESCRIPTION
PLATFORMS-2444: Add agent container lifecycle orchestration

PLATFORMS-2444

**Stack: PR 5 of 9 — depends on `pr04-container-wrap` (`https://github.com/evergreen-ci/evergreen/pull/10623`).**

This PR is safe to merge alone because the orchestration has no production activation call sites.

### Description

Adds Agent-owned task/task-group binding, orphan reaping, failed-container retention, failure snapshots, and host-environment capture. It remains inactive until the next PR.

#### Pre-cut review fixes

- Retained containers now have deadline- and shutdown-driven cleanup.
- Snapshots select the newest unique command environment file.
- Login-shell environment capture honors cancellation and a bounded timeout. 

### Documentation

No user-facing documentation changes are required in this slice. Stack ordering and cross-PR links are maintained separately.
