### PR TITLE
DEVPROD-28848 Fix EC2 instance metadata optimization for task hosts

### DIFF
--- a/agent/util/ec2.go
+++ b/agent/util/ec2.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -116,51 +115,9 @@ func getEC2InstanceStartTime(ctx context.Context) (time.Time, error) {
 	})
 }
 
-// getEC2BlockDeviceMappings returns all block device mappings from the metadata endpoint.
-func getEC2BlockDeviceMappings(ctx context.Context) ([]host.VolumeAttachment, error) {
-	deviceList, err := getEC2Metadata(ctx, "block-device-mapping/", readBodyAsString)
-	if err != nil {
-		return nil, nil
-	}
-
-	deviceNames := strings.Fields(deviceList)
-	if len(deviceNames) == 0 {
-		return nil, nil
-	}
-
-	var volumes []host.VolumeAttachment
-	for _, deviceName := range deviceNames {
-		if strings.HasPrefix(deviceName, "ephemeral") {
-			continue
-		}
-		volumeID, err := getEC2Metadata(ctx, fmt.Sprintf("block-device-mapping/%s", deviceName), func(resp *http.Response) (string, error) {
-			body, err := readBodyAsString(resp)
-			if err != nil {
-				return "", err
-			}
-			return body, nil
-		})
-		if err != nil {
-			continue
-		}
-		// Only include valid EBS volume IDs (which start with "vol-").
-		// The EC2 metadata API can return device names like "sda1" for certain
-		// block device mapping entries (e.g., "ami", "root"), which are not
-		// actual EBS volume IDs and should not be tagged.
-		if !strings.HasPrefix(volumeID, "vol-") {
-			continue
-		}
-		volumes = append(volumes, host.VolumeAttachment{
-			VolumeID:   volumeID,
-			DeviceName: deviceName,
-		})
-	}
-
-	return volumes, nil
-}
-
-// GetEC2Metadata fetches necessary EC2 metadata needed for the needed for
-// the /hosts/{host_id}/is_up endpoint.
+// GetEC2Metadata fetches necessary EC2 metadata needed for the
+// /hosts/{host_id}/is_up endpoint. Volume IDs are not available from
+// the instance metadata endpoint, so they are not included.
 func GetEC2Metadata(ctx context.Context) (host.HostMetadataOptions, error) {
 	metadata := host.HostMetadataOptions{}
 
@@ -199,12 +156,6 @@ func GetEC2Metadata(ctx context.Context) (host.HostMetadataOptions, error) {
 		return metadata, errors.Wrapf(err, "fetching EC2 ipv6")
 	}
 	metadata.IPv6 = ipv6
-
-	volumes, err := getEC2BlockDeviceMappings(ctx)
-	if err != nil {
-		return metadata, errors.Wrapf(err, "fetching EC2 volume attachments")
-	}
-	metadata.Volumes = volumes
 
 	startTime, err := getEC2InstanceStartTime(ctx)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-08-04"
+	AgentVersion = "2026-08-05"
 )
 
 const (

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -1379,12 +1379,19 @@ func buildEC2MetadataUpdate(hostname, zone, publicIPv4, privateIPv4, ipv6 string
 	return setFields
 }
 
-// numMetadataFields is the number of fields required from EC2 in order
-// to have fully-populated a host's EC2 metadata
+// numMetadataFields is the number of metadata fields that can be set
+// from EC2 data (hostname, zone, start time, public IPv4, private
+// IPv4, IPv6, and volumes).
 const numMetadataFields = 7
 
+// numMetadataFieldsWithoutVolumes is the number of metadata fields
+// excluding volume attachments. Task hosts don't need volume tracking
+// because their EBS volumes are auto-deleted on termination.
+const numMetadataFieldsWithoutVolumes = numMetadataFields - 1
+
 // SetEC2Metadata updates the EC2 metadata for a given host. Only non-zero
-// fields will be set.
+// fields will be set. For task hosts, metadata can be set without volume
+// information since task hosts don't require volume tracking.
 func (h *Host) SetEC2Metadata(ctx context.Context, params HostMetadataOptions) error {
 	setFields := buildEC2MetadataUpdate(
 		params.PublicDNS,
@@ -1396,8 +1403,12 @@ func (h *Host) SetEC2Metadata(ctx context.Context, params HostMetadataOptions) e
 		params.Volumes,
 	)
 
-	// If there is any missing data in setFields, no-op.
-	if len(setFields) < numMetadataFields {
+	requiredFields := numMetadataFields
+	if h.StartedBy == evergreen.User {
+		requiredFields = numMetadataFieldsWithoutVolumes
+	}
+
+	if len(setFields) < requiredFields {
 		return nil
 	}
 

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -560,6 +560,87 @@ func TestHostSetDNSName(t *testing.T) {
 	assert.Equal(t, newHostname, dbHost.Host, "existing hostname should be retained even if an empty string is passed")
 }
 
+func TestSetEC2Metadata(t *testing.T) {
+	metadataWithoutVolumes := CloudProviderData{
+		PublicDNS:   "hostname",
+		Zone:        "us-east-1a",
+		PublicIPv4:  "1.2.3.4",
+		PrivateIPv4: "10.0.0.1",
+		IPv6:        "::1",
+		StartedAt:   time.Now(),
+	}
+	metadataWithVolumes := metadataWithoutVolumes
+	metadataWithVolumes.Volumes = []VolumeAttachment{{VolumeID: "vol-123", DeviceName: "/dev/sda1"}}
+
+	for tName, tCase := range map[string]func(t *testing.T){
+		"TaskHostSetsMetadataWithoutVolumes": func(t *testing.T) {
+			ctx := t.Context()
+			h := &Host{
+				Id:        "task-host",
+				StartedBy: evergreen.User,
+			}
+			require.NoError(t, h.Insert(ctx))
+
+			require.NoError(t, h.SetEC2Metadata(ctx, HostMetadataOptions{CloudProviderData: metadataWithoutVolumes}))
+
+			assert.Equal(t, "hostname", h.Host)
+			assert.Equal(t, "us-east-1a", h.Zone)
+			assert.Equal(t, "1.2.3.4", h.PublicIPv4)
+
+			dbHost, err := FindOneId(ctx, h.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+			assert.Equal(t, "hostname", dbHost.Host)
+			assert.True(t, dbHost.Provisioned)
+		},
+		"SpawnHostNoOpsWithoutVolumes": func(t *testing.T) {
+			ctx := t.Context()
+			h := &Host{
+				Id:        "spawn-host",
+				StartedBy: "user",
+			}
+			require.NoError(t, h.Insert(ctx))
+
+			require.NoError(t, h.SetEC2Metadata(ctx, HostMetadataOptions{CloudProviderData: metadataWithoutVolumes}))
+
+			assert.Empty(t, h.Host, "spawn host should not set metadata without volumes")
+
+			dbHost, err := FindOneId(ctx, h.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+			assert.Empty(t, dbHost.Host)
+			assert.False(t, dbHost.Provisioned)
+		},
+		"SpawnHostSetsMetadataWithVolumes": func(t *testing.T) {
+			ctx := t.Context()
+			h := &Host{
+				Id:        "spawn-host",
+				StartedBy: "user",
+			}
+			require.NoError(t, h.Insert(ctx))
+
+			require.NoError(t, h.SetEC2Metadata(ctx, HostMetadataOptions{CloudProviderData: metadataWithVolumes}))
+
+			assert.Equal(t, "hostname", h.Host)
+			assert.Len(t, h.Volumes, 1)
+
+			dbHost, err := FindOneId(ctx, h.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbHost)
+			assert.Equal(t, "hostname", dbHost.Host)
+			assert.True(t, dbHost.Provisioned)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(Collection))
+			t.Cleanup(func() {
+				assert.NoError(t, db.ClearCollections(Collection))
+			})
+			tCase(t)
+		})
+	}
+}
+
 func TestMarkReachable(t *testing.T) {
 	defer func() {
 		assert.NoError(t, db.ClearCollections(Collection, event.EventCollection))


### PR DESCRIPTION
DEVPROD-28848

### Description

The EC2 instance metadata optimization from DEVPROD-15331 let hosts self-report their EC2 data (hostname, IP, etc.) via the instance metadata endpoint during provisioning, so they don't have to wait for the set-cloud-hosts-ready job to poll AWS for the same info.

DEVPROD-27041 introduced an issue to this because the metadata endpoint doesn't return EBS volume IDs, and since we require all metadata fields including volumes, the whole update no-ops.

Task hosts don't actually need volume tracking (EBS volumes are auto-deleted on termination), so we can remove the requirement for them. Spawn hosts still require volumes, so those go through the existing path unchanged.

### Testing
Added unit tests