### PR TITLE
DEVPROD-38173 Check that debug spawn hosts are enabled before returning task expansions

### DIFF
--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -382,6 +382,12 @@ func (h *getExpansionsAndVarsHandler) Run(ctx context.Context) gimlet.Responder 
 			Message:    fmt.Sprintf("project ref '%s' not found", t.Project),
 		})
 	}
+	if isUserRequest && !pRef.IsDebugSpawnHostsEnabled() {
+		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+			StatusCode: http.StatusForbidden,
+			Message:    fmt.Sprintf("debug spawn hosts are disabled for project '%s'", pRef.Id),
+		})
+	}
 	knownHosts := h.settings.Expansions[evergreen.GithubKnownHosts]
 	e, err := model.PopulateExpansions(ctx, t, foundHost, knownHosts)
 	if err != nil {

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -251,6 +251,29 @@ func TestExpansionsAndVarsHostOwnership(t *testing.T) {
 	require.NoError(t, nonDebugHost.Insert(t.Context()))
 	require.NoError(t, wrongTaskDebugHost.Insert(t.Context()))
 
+	t.Run("UserRequestRejectsDebugSpawnHostsDisabledProject", func(t *testing.T) {
+		disabled := true
+		disabledPRef := model.ProjectRef{
+			Id:                      "disabled_project",
+			Owner:                   "evergreen-ci",
+			Repo:                    "sample",
+			DebugSpawnHostsDisabled: &disabled,
+		}
+		disabledTask := task.Task{
+			Id:      "t_disabled",
+			Project: "disabled_project",
+			Version: "aaaaaaaaaaff001122334455",
+		}
+		require.NoError(t, disabledPRef.Insert(t.Context()))
+		require.NoError(t, disabledTask.Insert(t.Context()))
+
+		userCtx := gimlet.AttachUser(t.Context(), &user.DBUser{Id: "test_user"})
+		rh := &getExpansionsAndVarsHandler{settings: env.Settings(), taskID: "t_disabled", hostID: "debug_host"}
+		resp := rh.Run(userCtx)
+		require.NotZero(t, resp)
+		assert.Equal(t, http.StatusForbidden, resp.Status())
+	})
+
 	t.Run("UserRequestRejectsNonDebugHost", func(t *testing.T) {
 		userCtx := gimlet.AttachUser(t.Context(), &user.DBUser{Id: "test_user"})
 		rh := &getExpansionsAndVarsHandler{settings: env.Settings(), taskID: "t1", hostID: "non_debug_host"}

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -203,9 +203,10 @@ func TestExpansionsAndVarsHostOwnership(t *testing.T) {
 		Version: "aaaaaaaaaaff001122334455",
 	}
 	pRef := model.ProjectRef{
-		Id:    "p1",
-		Owner: "evergreen-ci",
-		Repo:  "sample",
+		Id:                      "p1",
+		Owner:                   "evergreen-ci",
+		Repo:                    "sample",
+		DebugSpawnHostsDisabled: utility.FalsePtr(),
 	}
 	vars := &model.ProjectVars{
 		Id:          "p1",


### PR DESCRIPTION
DEVPROD-38173

### Description

The debug spawn host feature necessitates that on some level a user-authed request can fetch expansions. This is an explicitly [opt](https://docs.devprod.prod.corp.mongodb.com/evergreen/Hosts/Debug-Spawn-Hosts#for-project-admins) in risk that must be acknowledged before enabling the feature, that Will signed off on.

The route currently requires you pass in a debug spawn host ID as a header but that can be spoofed. Add another check to verify the task ID comes from a project with the feature enabled.
### Testing

### Testing

Added a unit test.