### PR TITLE
DEVPROD-41058 Add observability for rate limiting

### DIFF
--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -860,19 +860,19 @@ func (m *rateLimitMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request,
 	settings := m.env.Settings()
 	cfg := settings.RateLimit
 
-	// Exempt users bypass rate limiting entirely.
-	if slices.Contains(cfg.ExemptUserIDs, u.Username()) {
-		next(rw, r)
-		return
-	}
-
 	perHour, burst := limitsFor(&cfg, m.surface, isService)
 
 	// Handle elevated users - 2x normal limits.
-	if slices.Contains(cfg.ElevatedUserIDs, u.Username()) {
+	elevated := slices.Contains(cfg.ElevatedUserIDs, u.Username())
+	if elevated {
 		perHour *= 2
 		burst *= 2
 	}
+
+	// Exempt users are never limited and get no rate limit headers, but they still
+	// consume from their bucket so their usage against the limit they would
+	// otherwise have is reported.
+	exempt := slices.Contains(cfg.ExemptUserIDs, u.Username())
 
 	limiter, err := ratelimit.NewRateLimiter(m.env.RedisClient())
 
@@ -899,23 +899,44 @@ func (m *rateLimitMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request,
 	}
 
 	if res != nil {
-		rw.Header().Set(evergreen.RateLimitLimitHeader, fmt.Sprintf("%d", perHour))
-		rw.Header().Set(evergreen.RateLimitBurstHeader, fmt.Sprintf("%d", burst))
-		rw.Header().Set(evergreen.RateLimitRemainingHeader, fmt.Sprintf("%d", res.Remaining))
-		resetTimestamp := time.Now().Add(res.ResetAfter).Unix()
-		rw.Header().Set(evergreen.RateLimitResetHeader, fmt.Sprintf("%d", resetTimestamp))
-
-		if res.Allowed == 0 {
-			rw.Header().Set(evergreen.RateLimitExceededHeader, "true")
+		exceeded := res.Allowed == 0
+		enforced := false
+		if exceeded && !exempt {
 			flags, _ := evergreen.GetServiceFlags(ctx)
-			if flags != nil && !flags.APIRateLimiterDisabled {
-				// Retry-After is a standard HTTP header that indicates how long the user should wait before making another request.
-				rw.Header().Set(evergreen.RetryAfterHeader, fmt.Sprintf("%d", int(res.RetryAfter.Seconds())))
-				gimlet.WriteResponse(ctx, rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
-					StatusCode: http.StatusTooManyRequests,
-					Message:    "rate limit exceeded",
-				}))
-				return
+			enforced = flags != nil && !flags.APIRateLimiterDisabled
+		}
+
+		// Annotate the request's "completed" log message so limit usage is attributable
+		// per request, including for requests that were never blocked.
+		gimlet.AddLoggingAnnotation(r, "rate_limit", message.Fields{
+			"surface":   m.surface,
+			"per_hour":  perHour,
+			"burst":     burst,
+			"remaining": res.Remaining,
+			"exceeded":  exceeded,
+			"enforced":  enforced,
+			"exempt":    exempt,
+			"elevated":  elevated,
+		})
+
+		if !exempt {
+			rw.Header().Set(evergreen.RateLimitLimitHeader, fmt.Sprintf("%d", perHour))
+			rw.Header().Set(evergreen.RateLimitBurstHeader, fmt.Sprintf("%d", burst))
+			rw.Header().Set(evergreen.RateLimitRemainingHeader, fmt.Sprintf("%d", res.Remaining))
+			resetTimestamp := time.Now().Add(res.ResetAfter).Unix()
+			rw.Header().Set(evergreen.RateLimitResetHeader, fmt.Sprintf("%d", resetTimestamp))
+
+			if exceeded {
+				rw.Header().Set(evergreen.RateLimitExceededHeader, "true")
+				if enforced {
+					// Retry-After is a standard HTTP header that indicates how long the user should wait before making another request.
+					rw.Header().Set(evergreen.RetryAfterHeader, fmt.Sprintf("%d", int(res.RetryAfter.Seconds())))
+					gimlet.WriteResponse(ctx, rw, gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{
+						StatusCode: http.StatusTooManyRequests,
+						Message:    "rate limit exceeded",
+					}))
+					return
+				}
 			}
 		}
 	}

--- a/rest/route/middleware.go
+++ b/rest/route/middleware.go
@@ -905,25 +905,22 @@ func (m *rateLimitMiddleware) ServeHTTP(rw http.ResponseWriter, r *http.Request,
 			flags, _ := evergreen.GetServiceFlags(ctx)
 			enforced = flags != nil && !flags.APIRateLimiterDisabled
 		}
+		resetTimestamp := time.Now().Add(res.ResetAfter).Unix()
 
 		// Annotate the request's "completed" log message so limit usage is attributable
 		// per request, including for requests that were never blocked.
 		gimlet.AddLoggingAnnotation(r, "rate_limit", message.Fields{
-			"surface":   m.surface,
-			"per_hour":  perHour,
-			"burst":     burst,
-			"remaining": res.Remaining,
-			"exceeded":  exceeded,
-			"enforced":  enforced,
-			"exempt":    exempt,
-			"elevated":  elevated,
+			"surface":    m.surface,
+			"remaining":  res.Remaining,
+			"reset_time": resetTimestamp,
+			"per_hour":   perHour,
+			"burst":      burst,
 		})
 
 		if !exempt {
 			rw.Header().Set(evergreen.RateLimitLimitHeader, fmt.Sprintf("%d", perHour))
 			rw.Header().Set(evergreen.RateLimitBurstHeader, fmt.Sprintf("%d", burst))
 			rw.Header().Set(evergreen.RateLimitRemainingHeader, fmt.Sprintf("%d", res.Remaining))
-			resetTimestamp := time.Now().Add(res.ResetAfter).Unix()
 			rw.Header().Set(evergreen.RateLimitResetHeader, fmt.Sprintf("%d", resetTimestamp))
 
 			if exceeded {

--- a/rest/route/ratelimit_test.go
+++ b/rest/route/ratelimit_test.go
@@ -15,6 +15,10 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/negroni"
+	"github.com/mongodb/grip/logging"
+	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/send"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -387,6 +391,72 @@ func TestRateLimitMiddlewareSurfacesHaveIndependentBuckets(t *testing.T) {
 	rw, ran = runRateLimit(t, restMW, "/rest/v2/hosts", u)
 	assert.True(t, ran, "REST bucket should be independent from the exhausted GraphQL bucket")
 	assert.Equal(t, http.StatusOK, rw.Code)
+}
+
+// runRateLimitLogged runs the middleware inside gimlet's request logger, which is what
+// emits the "completed" log message that rate limit annotations are attached to, and
+// returns that message's fields.
+func runRateLimitLogged(t *testing.T, mw gimlet.Middleware, surfacePath string, u *user.DBUser) message.Fields {
+	sender := send.MakeInternalLogger()
+	r, err := http.NewRequest(http.MethodGet, surfacePath, nil)
+	require.NoError(t, err)
+	r = r.WithContext(gimlet.AttachUser(t.Context(), u))
+
+	rw := negroni.NewResponseWriter(httptest.NewRecorder())
+	gimlet.NewRecoveryLogger(logging.MakeGrip(sender)).ServeHTTP(rw, r, func(rw http.ResponseWriter, r *http.Request) {
+		mw.ServeHTTP(rw, r, func(rw http.ResponseWriter, _ *http.Request) { rw.WriteHeader(http.StatusOK) })
+	})
+
+	require.True(t, sender.HasMessage())
+	fields, ok := sender.GetMessage().Message.Raw().(message.Fields)
+	require.True(t, ok)
+	require.Equal(t, "completed", fields["action"])
+	return fields
+}
+
+func TestRateLimitMiddlewareAnnotatesCompletedLogWhenOverLimit(t *testing.T) {
+	env := setupRateLimitEnv(t, evergreen.RateLimitConfig{RESTUserPerHour: 100, RESTUserBurst: 1})
+	mw := NewRateLimitMiddleware(env, evergreen.RateLimitSurfaceREST)
+	u := &user.DBUser{Id: "u"}
+
+	fields := runRateLimitLogged(t, mw, "/rest/v2/hosts", u)
+	require.Equal(t, message.Fields{
+		"surface": evergreen.RateLimitSurfaceREST, "per_hour": 100, "burst": 1, "remaining": 0,
+		"exceeded": false, "enforced": false, "exempt": false, "elevated": false,
+	}, fields["rate_limit"])
+
+	fields = runRateLimitLogged(t, mw, "/rest/v2/hosts", u)
+	assert.Equal(t, http.StatusTooManyRequests, fields["status"])
+	assert.Equal(t, message.Fields{
+		"surface": evergreen.RateLimitSurfaceREST, "per_hour": 100, "burst": 1, "remaining": 0,
+		"exceeded": true, "enforced": true, "exempt": false, "elevated": false,
+	}, fields["rate_limit"])
+}
+
+// Verifies that an exempt user's usage is still reported even though they are never
+// blocked, so that an exempt user exceeding the limit they would otherwise have is
+// visible in the logs.
+func TestRateLimitMiddlewareAnnotatesCompletedLogForExemptUser(t *testing.T) {
+	env := setupRateLimitEnv(t, evergreen.RateLimitConfig{
+		RESTUserPerHour: 100,
+		RESTUserBurst:   1,
+		ExemptUserIDs:   []string{"exempt"},
+	})
+	mw := NewRateLimitMiddleware(env, evergreen.RateLimitSurfaceREST)
+	u := &user.DBUser{Id: "exempt"}
+
+	fields := runRateLimitLogged(t, mw, "/rest/v2/hosts", u)
+	require.Equal(t, message.Fields{
+		"surface": evergreen.RateLimitSurfaceREST, "per_hour": 100, "burst": 1, "remaining": 0,
+		"exceeded": false, "enforced": false, "exempt": true, "elevated": false,
+	}, fields["rate_limit"])
+
+	fields = runRateLimitLogged(t, mw, "/rest/v2/hosts", u)
+	assert.Equal(t, http.StatusOK, fields["status"], "exempt user should not be blocked")
+	assert.Equal(t, message.Fields{
+		"surface": evergreen.RateLimitSurfaceREST, "per_hour": 100, "burst": 1, "remaining": 0,
+		"exceeded": true, "enforced": false, "exempt": true, "elevated": false,
+	}, fields["rate_limit"])
 }
 
 // Verifies that if Redis becomes unavailable after the limiter is already initialized,

--- a/rest/route/ratelimit_test.go
+++ b/rest/route/ratelimit_test.go
@@ -15,10 +15,6 @@ import (
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/gimlet"
-	"github.com/evergreen-ci/negroni"
-	"github.com/mongodb/grip/logging"
-	"github.com/mongodb/grip/message"
-	"github.com/mongodb/grip/send"
 	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -391,72 +387,6 @@ func TestRateLimitMiddlewareSurfacesHaveIndependentBuckets(t *testing.T) {
 	rw, ran = runRateLimit(t, restMW, "/rest/v2/hosts", u)
 	assert.True(t, ran, "REST bucket should be independent from the exhausted GraphQL bucket")
 	assert.Equal(t, http.StatusOK, rw.Code)
-}
-
-// runRateLimitLogged runs the middleware inside gimlet's request logger, which is what
-// emits the "completed" log message that rate limit annotations are attached to, and
-// returns that message's fields.
-func runRateLimitLogged(t *testing.T, mw gimlet.Middleware, surfacePath string, u *user.DBUser) message.Fields {
-	sender := send.MakeInternalLogger()
-	r, err := http.NewRequest(http.MethodGet, surfacePath, nil)
-	require.NoError(t, err)
-	r = r.WithContext(gimlet.AttachUser(t.Context(), u))
-
-	rw := negroni.NewResponseWriter(httptest.NewRecorder())
-	gimlet.NewRecoveryLogger(logging.MakeGrip(sender)).ServeHTTP(rw, r, func(rw http.ResponseWriter, r *http.Request) {
-		mw.ServeHTTP(rw, r, func(rw http.ResponseWriter, _ *http.Request) { rw.WriteHeader(http.StatusOK) })
-	})
-
-	require.True(t, sender.HasMessage())
-	fields, ok := sender.GetMessage().Message.Raw().(message.Fields)
-	require.True(t, ok)
-	require.Equal(t, "completed", fields["action"])
-	return fields
-}
-
-func TestRateLimitMiddlewareAnnotatesCompletedLogWhenOverLimit(t *testing.T) {
-	env := setupRateLimitEnv(t, evergreen.RateLimitConfig{RESTUserPerHour: 100, RESTUserBurst: 1})
-	mw := NewRateLimitMiddleware(env, evergreen.RateLimitSurfaceREST)
-	u := &user.DBUser{Id: "u"}
-
-	fields := runRateLimitLogged(t, mw, "/rest/v2/hosts", u)
-	require.Equal(t, message.Fields{
-		"surface": evergreen.RateLimitSurfaceREST, "per_hour": 100, "burst": 1, "remaining": 0,
-		"exceeded": false, "enforced": false, "exempt": false, "elevated": false,
-	}, fields["rate_limit"])
-
-	fields = runRateLimitLogged(t, mw, "/rest/v2/hosts", u)
-	assert.Equal(t, http.StatusTooManyRequests, fields["status"])
-	assert.Equal(t, message.Fields{
-		"surface": evergreen.RateLimitSurfaceREST, "per_hour": 100, "burst": 1, "remaining": 0,
-		"exceeded": true, "enforced": true, "exempt": false, "elevated": false,
-	}, fields["rate_limit"])
-}
-
-// Verifies that an exempt user's usage is still reported even though they are never
-// blocked, so that an exempt user exceeding the limit they would otherwise have is
-// visible in the logs.
-func TestRateLimitMiddlewareAnnotatesCompletedLogForExemptUser(t *testing.T) {
-	env := setupRateLimitEnv(t, evergreen.RateLimitConfig{
-		RESTUserPerHour: 100,
-		RESTUserBurst:   1,
-		ExemptUserIDs:   []string{"exempt"},
-	})
-	mw := NewRateLimitMiddleware(env, evergreen.RateLimitSurfaceREST)
-	u := &user.DBUser{Id: "exempt"}
-
-	fields := runRateLimitLogged(t, mw, "/rest/v2/hosts", u)
-	require.Equal(t, message.Fields{
-		"surface": evergreen.RateLimitSurfaceREST, "per_hour": 100, "burst": 1, "remaining": 0,
-		"exceeded": false, "enforced": false, "exempt": true, "elevated": false,
-	}, fields["rate_limit"])
-
-	fields = runRateLimitLogged(t, mw, "/rest/v2/hosts", u)
-	assert.Equal(t, http.StatusOK, fields["status"], "exempt user should not be blocked")
-	assert.Equal(t, message.Fields{
-		"surface": evergreen.RateLimitSurfaceREST, "per_hour": 100, "burst": 1, "remaining": 0,
-		"exceeded": true, "enforced": false, "exempt": true, "elevated": false,
-	}, fields["rate_limit"])
 }
 
 // Verifies that if Redis becomes unavailable after the limiter is already initialized,


### PR DESCRIPTION
DEVPROD-41058

### Description 

add rate limit field to our normal rest route completed logs 


### Testing

on staging 

<img width="471" height="528" alt="image" src="https://github.com/user-attachments/assets/31729263-1229-4f17-818a-9b126a1fcfc0" />
