### PR TITLE
DEVPROD-41118: fix patch number alignment in patch output

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-07-31"
+	ClientVersion = "2026-08-07"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/patch_util.go
+++ b/operations/patch_util.go
@@ -33,7 +33,7 @@ const largeNumFinalizedTasksThreshold = 1000
 // This is the template used to render a patch's summary in a human-readable output format.
 var patchDisplayTemplate = template.Must(template.New("patch").Parse(`
          ID : {{.Patch.Id.Hex}}
-	 Number : {{.Patch.PatchNumber}}
+     Number : {{.Patch.PatchNumber}}
     Project : {{.ProjectIdentifier}}
     Created : {{.Patch.CreateTime.Local.String}}
 Description : {{if .Patch.Description}}{{.Patch.Description}}{{else}}<none>{{end}}


### PR DESCRIPTION
DEVPROD-41118

### Description

There's a tab character on the line for patch number in the `evergreen patch` output, which can be displayed as a differing amount of whitespace depending on your terminal settings. Changed it to use spaces like the other lines so it doesn't get misaligned.

### Testing

Before:
<img width="1040" height="204" alt="image" src="https://github.com/user-attachments/assets/3c5b8e2c-c3ec-4633-acb3-3b804cb6145f" />

After:
<img width="1038" height="220" alt="image" src="https://github.com/user-attachments/assets/1d43117b-7bba-477e-990e-e3a22a26a126" />