### PR TITLE
DEVPROD-37682: Remove legacy Okta username fallback

### DIFF
--- a/auth/okta.go
+++ b/auth/okta.go
@@ -57,14 +57,15 @@ func NewOktaUserManager(conf *evergreen.OktaConfig, evgURL, loginDomain string) 
 
 // makeReconciliateID maps a validated email to a username, stripping the domain
 // only for allow-listed domains so accounts sharing a local-part across domains
-// cannot collide. An empty allow-list strips unconditionally (legacy behavior).
+// cannot collide. Emails from any other domain, including when the allow-list is
+// empty, keep their full address as the username.
 func makeReconciliateID(expectedEmailDomains []string) func(string) string {
 	return func(id string) string {
 		emailDomainStart := strings.LastIndex(id, "@")
 		if emailDomainStart == -1 {
 			return id
 		}
-		if len(expectedEmailDomains) > 0 && !domainInAllowList(expectedEmailDomains, id[emailDomainStart+1:]) {
+		if !domainInAllowList(expectedEmailDomains, id[emailDomainStart+1:]) {
 			return id
 		}
 		return id[:emailDomainStart]

--- a/auth/okta_test.go
+++ b/auth/okta_test.go
@@ -12,10 +12,10 @@ func TestMakeReconciliateID(t *testing.T) {
 		id                   string
 		expected             string
 	}{
-		"StripsDomainWhenNoAllowListConfigured": {
+		"KeepsFullEmailWhenNoAllowListConfigured": {
 			expectedEmailDomains: nil,
 			id:                   "alice@a.com",
-			expected:             "alice",
+			expected:             "alice@a.com",
 		},
 		"StripsDomainWhenInAllowList": {
 			expectedEmailDomains: []string{"a.com"},

--- a/config_auth.go
+++ b/config_auth.go
@@ -44,8 +44,8 @@ type OktaConfig struct {
 	ExpireAfterMinutes int      `bson:"expire_after_minutes" json:"expire_after_minutes" yaml:"expire_after_minutes"`
 	// ExpectedEmailDomains is the allow-list of email domains whose local-part may
 	// be used as the username. Emails from other domains keep their full address,
-	// so accounts sharing a local-part across domains cannot collide. Empty strips
-	// the domain unconditionally (legacy behavior).
+	// so accounts sharing a local-part across domains cannot collide. If it's
+	// empty, every email keeps its full address as the username.
 	ExpectedEmailDomains []string `bson:"expected_email_domains" json:"expected_email_domains" yaml:"expected_email_domains"`
 }
 


### PR DESCRIPTION
DEVPROD-37682

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Now that `ExpectedEmailDomains` is configured, this removes the `len(expectedEmailDomains) > 0` clause from `makeReconciliateID` in `auth/okta.go`, which was the one remaining path back to the username collision [DEVPROD-36680](https://jira.mongodb.org/browse/DEVPROD-36680) fixed. 

### Testing

Updated existing tests 



<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
