### PR TITLE
DEVPROD-28343: Refresh the GitHub App clone token on git.get_project retries

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -398,7 +398,7 @@ func (c *gitFetchProject) fetchSource(ctx context.Context, logger client.LoggerP
 	return c.retryFetch(ctx, logger, comm, conf, true, opts, func(opts cloneOpts) error {
 		attempt++
 		// Don't refresh c.Token because it is user supplied.
-		if attempt > 1 && c.Token == "" {
+		if attempt == gitFetchProjectRetries && c.Token == "" {
 			refreshed, err := refreshCloneToken(ctx, comm, conf, opts.owner, opts.repo)
 			if err != nil {
 				logger.Task().Warningf(ctx, "Refreshing clone token, retrying with the previous one: %s", err)
@@ -597,7 +597,7 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 	token := appToken
 	return c.retryFetch(ctx, logger, comm, conf, false, opts, func(opts cloneOpts) error {
 		attempt++
-		if attempt > 1 {
+		if attempt == gitFetchProjectRetries {
 			refreshed, err := refreshCloneToken(ctx, comm, conf, owner, tokenRepo)
 			if err != nil {
 				logger.Task().Warningf(ctx, "Refreshing clone token, retrying with the previous one: %s", err)

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -105,7 +105,7 @@ func getCloneToken(ctx context.Context, comm client.Communicator, conf *internal
 
 	owner := conf.ProjectRef.Owner
 	repo := conf.ProjectRef.Repo
-	appToken, err := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), owner, repo)
+	appToken, err := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), owner, repo, "")
 	if err != nil {
 		return "", errors.Wrap(err, "creating app token")
 	}
@@ -394,12 +394,19 @@ func (c *gitFetchProject) Execute(ctx context.Context, comm client.Communicator,
 
 func (c *gitFetchProject) fetchSource(ctx context.Context, logger client.LoggerProducer, comm client.Communicator, conf *internal.TaskConfig, opts cloneOpts) error {
 	attempt := 0
+	token := opts.token
 	return c.retryFetch(ctx, logger, comm, conf, true, opts, func(opts cloneOpts) error {
 		attempt++
+		// A user-supplied token is the user's to manage; only app tokens are ours to replace.
+		if attempt > 1 && c.Token == "" {
+			token = refreshCloneToken(ctx, comm, conf, logger, opts.owner, opts.repo, token)
+		}
+		opts.token = token
+
 		// On the second attempt, check if the merge queue ref was deleted before retrying.
 		if attempt == 2 && conf.Task.Requester == evergreen.GithubMergeRequester && conf.GithubMergeData.HeadBranch != "" {
 			ref := "heads/" + conf.GithubMergeData.HeadBranch
-			appToken, tokenErr := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), opts.owner, opts.repo)
+			appToken, tokenErr := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), opts.owner, opts.repo, "")
 			if tokenErr == nil && appToken != "" {
 				exists, checkErr := thirdparty.MergeQueueRefExists(ctx, opts.owner, opts.repo, ref, appToken)
 				if checkErr != nil {
@@ -446,6 +453,22 @@ func (c *gitFetchProject) fetchSource(ctx context.Context, logger client.LoggerP
 
 		return nil
 	})
+}
+
+// refreshCloneToken mints a replacement clone token for a retry, reporting the
+// previous one as rejected so the app server evicts it from its cache instead of
+// handing the same token back. GitHub invalidates outstanding installation
+// tokens when an app installation changes, and a retry that reuses a dead token
+// fails identically to the attempt before it. On failure it falls back to the
+// previous token, which is no worse than not refreshing at all.
+func refreshCloneToken(ctx context.Context, comm client.Communicator, conf *internal.TaskConfig, logger client.LoggerProducer, owner, repo, rejectedToken string) string {
+	token, err := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), owner, repo, rejectedToken)
+	if err != nil {
+		logger.Task().Warningf(ctx, "Refreshing clone token, retrying with the previous one: %s", err)
+		return rejectedToken
+	}
+	conf.NewExpansions.Redact(generatedTokenKey, token)
+	return token
 }
 
 func (c *gitFetchProject) retryFetch(ctx context.Context, logger client.LoggerProducer, comm client.Communicator, conf *internal.TaskConfig, isSource bool, opts cloneOpts, fetch func(cloneOpts) error) error {
@@ -547,7 +570,8 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 			" to https format. Please update your project config.", module.Repo)
 	}
 
-	appToken, err := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), owner, parentRepoForGitHubAppToken(repo))
+	tokenRepo := parentRepoForGitHubAppToken(repo)
+	appToken, err := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), owner, tokenRepo, "")
 	if err != nil {
 		return errors.Wrap(err, "creating app token")
 	}
@@ -566,15 +590,20 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 		modulePatch = p.FindModule(moduleName)
 	}
 
-	var moduleCmds []string
-	moduleCmds, err = c.buildModuleCloneCommand(conf, opts, revision, modulePatch)
-	if err != nil {
-		return err
-	}
-
 	attempt := 0
+	token := appToken
 	return c.retryFetch(ctx, logger, comm, conf, false, opts, func(opts cloneOpts) error {
 		attempt++
+		if attempt > 1 {
+			token = refreshCloneToken(ctx, comm, conf, logger, owner, tokenRepo, token)
+		}
+		opts.token = token
+
+		moduleCmds, err := c.buildModuleCloneCommand(conf, opts, revision, modulePatch)
+		if err != nil {
+			return err
+		}
+
 		ctx, span := getTracer().Start(ctx, "clone_module", trace.WithAttributes(
 			attribute.String(cloneModuleAttribute, module.Name),
 			attribute.String(cloneOwnerAttribute, opts.owner),

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -105,7 +105,7 @@ func getCloneToken(ctx context.Context, comm client.Communicator, conf *internal
 
 	owner := conf.ProjectRef.Owner
 	repo := conf.ProjectRef.Repo
-	appToken, err := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), owner, repo, "")
+	appToken, err := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), owner, repo, false)
 	if err != nil {
 		return "", errors.Wrap(err, "creating app token")
 	}
@@ -397,16 +397,26 @@ func (c *gitFetchProject) fetchSource(ctx context.Context, logger client.LoggerP
 	token := opts.token
 	return c.retryFetch(ctx, logger, comm, conf, true, opts, func(opts cloneOpts) error {
 		attempt++
-		// A user-supplied token is the user's to manage; only app tokens are ours to replace.
+		// Don't refresh c.Token because it is user supplied.
 		if attempt > 1 && c.Token == "" {
-			token = refreshCloneToken(ctx, comm, conf, logger, opts.owner, opts.repo, token)
+			refreshed, err := refreshCloneToken(ctx, comm, conf, opts.owner, opts.repo)
+			if err != nil {
+				logger.Task().Warningf(ctx, "Refreshing clone token, retrying with the previous one: %s", err)
+			} else {
+				token = refreshed
+			}
 		}
 		opts.token = token
 
 		// On the second attempt, check if the merge queue ref was deleted before retrying.
 		if attempt == 2 && conf.Task.Requester == evergreen.GithubMergeRequester && conf.GithubMergeData.HeadBranch != "" {
 			ref := "heads/" + conf.GithubMergeData.HeadBranch
-			appToken, tokenErr := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), opts.owner, opts.repo, "")
+			// A user-supplied clone token can't authenticate an app-scoped API call.
+			appToken := token
+			var tokenErr error
+			if c.Token != "" {
+				appToken, tokenErr = comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), opts.owner, opts.repo, false)
+			}
 			if tokenErr == nil && appToken != "" {
 				exists, checkErr := thirdparty.MergeQueueRefExists(ctx, opts.owner, opts.repo, ref, appToken)
 				if checkErr != nil {
@@ -455,20 +465,13 @@ func (c *gitFetchProject) fetchSource(ctx context.Context, logger client.LoggerP
 	})
 }
 
-// refreshCloneToken mints a replacement clone token for a retry, reporting the
-// previous one as rejected so the app server evicts it from its cache instead of
-// handing the same token back. GitHub invalidates outstanding installation
-// tokens when an app installation changes, and a retry that reuses a dead token
-// fails identically to the attempt before it. On failure it falls back to the
-// previous token, which is no worse than not refreshing at all.
-func refreshCloneToken(ctx context.Context, comm client.Communicator, conf *internal.TaskConfig, logger client.LoggerProducer, owner, repo, rejectedToken string) string {
-	token, err := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), owner, repo, rejectedToken)
+func refreshCloneToken(ctx context.Context, comm client.Communicator, conf *internal.TaskConfig, owner, repo string) (string, error) {
+	token, err := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), owner, repo, true)
 	if err != nil {
-		logger.Task().Warningf(ctx, "Refreshing clone token, retrying with the previous one: %s", err)
-		return rejectedToken
+		return "", errors.Wrap(err, "creating app token")
 	}
 	conf.NewExpansions.Redact(generatedTokenKey, token)
-	return token
+	return token, nil
 }
 
 func (c *gitFetchProject) retryFetch(ctx context.Context, logger client.LoggerProducer, comm client.Communicator, conf *internal.TaskConfig, isSource bool, opts cloneOpts, fetch func(cloneOpts) error) error {
@@ -571,7 +574,7 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 	}
 
 	tokenRepo := parentRepoForGitHubAppToken(repo)
-	appToken, err := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), owner, tokenRepo, "")
+	appToken, err := comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), owner, tokenRepo, false)
 	if err != nil {
 		return errors.Wrap(err, "creating app token")
 	}
@@ -595,7 +598,12 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 	return c.retryFetch(ctx, logger, comm, conf, false, opts, func(opts cloneOpts) error {
 		attempt++
 		if attempt > 1 {
-			token = refreshCloneToken(ctx, comm, conf, logger, owner, tokenRepo, token)
+			refreshed, err := refreshCloneToken(ctx, comm, conf, owner, tokenRepo)
+			if err != nil {
+				logger.Task().Warningf(ctx, "Refreshing clone token, retrying with the previous one: %s", err)
+			} else {
+				token = refreshed
+			}
 		}
 		opts.token = token
 

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -97,6 +97,8 @@ func (s *GitGetProjectSuite) SetupSuite() {
 func (s *GitGetProjectSuite) SetupTest() {
 	s.NoError(db.ClearCollections(patch.Collection, build.Collection, task.Collection,
 		model.VersionCollection, host.Collection))
+	// s.comm outlives the test, so its recorded calls have to be reset here.
+	s.comm.CreateInstallationTokenRejected = nil
 	var err error
 
 	configPath1 := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "plugin_clone.yml")

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -97,8 +97,7 @@ func (s *GitGetProjectSuite) SetupSuite() {
 func (s *GitGetProjectSuite) SetupTest() {
 	s.NoError(db.ClearCollections(patch.Collection, build.Collection, task.Collection,
 		model.VersionCollection, host.Collection))
-	// s.comm outlives the test, so its recorded calls have to be reset here.
-	s.comm.CreateInstallationTokenRejected = nil
+	s.comm.CreateInstallationTokenRefresh = nil
 	var err error
 
 	configPath1 := filepath.Join(testutil.GetDirectoryOfFile(), "testdata", "git", "plugin_clone.yml")
@@ -416,11 +415,11 @@ func (s *GitGetProjectSuite) TestCloneTokenIsRefreshedOnRetry() {
 	c.SetJasperManager(s.jasper)
 	s.Error(c.Execute(ctx, s.comm, logger, conf))
 
-	rejected := s.comm.GetCreateInstallationTokenRejected()
-	s.Require().Greater(len(rejected), 1, "the failing clone should have been retried")
-	s.Empty(rejected[0], "the initial token request has nothing to reject")
-	for _, token := range rejected[1:] {
-		s.Equal("token", token, "each retry should report the token it was handed as rejected")
+	refresh := s.comm.GetCreateInstallationTokenRefresh()
+	s.Require().Greater(len(refresh), 1, "the failing clone should have been retried")
+	s.False(refresh[0], "the initial token request has nothing to refresh")
+	for _, r := range refresh[1:] {
+		s.True(r, "each retry should ask for a refreshed token")
 	}
 }
 

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -399,6 +399,29 @@ func (s *GitGetProjectSuite) TestTokenIsRedactedWhenGenerated() {
 	})
 }
 
+func (s *GitGetProjectSuite) TestCloneTokenIsRefreshedOnRetry() {
+	conf := s.taskConfig1
+	conf.ProjectRef.Repo = "invalidRepo"
+	s.comm.CreateInstallationTokenResult = "token"
+	s.comm.CreateInstallationTokenFail = false
+
+	logger, err := s.comm.GetLoggerProducer(s.ctx, &conf.Task, nil)
+	s.Require().NoError(err)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := gitFetchProject{Directory: ""}
+	c.SetJasperManager(s.jasper)
+	s.Error(c.Execute(ctx, s.comm, logger, conf))
+
+	rejected := s.comm.GetCreateInstallationTokenRejected()
+	s.Require().Greater(len(rejected), 1, "the failing clone should have been retried")
+	s.Empty(rejected[0], "the initial token request has nothing to reject")
+	for _, token := range rejected[1:] {
+		s.Equal("token", token, "each retry should report the token it was handed as rejected")
+	}
+}
+
 func (s *GitGetProjectSuite) TestStdErrLogged() {
 	if os.Getenv("IS_DOCKER") == "true" {
 		s.T().Skip("TestStdErrLogged will not run on docker since it requires a SSH key")

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -400,7 +400,7 @@ func (s *GitGetProjectSuite) TestTokenIsRedactedWhenGenerated() {
 	})
 }
 
-func (s *GitGetProjectSuite) TestCloneTokenIsRefreshedOnRetry() {
+func (s *GitGetProjectSuite) TestCloneTokenIsRefreshedOnFinalAttempt() {
 	conf := s.taskConfig1
 	conf.ProjectRef.Repo = "invalidRepo"
 	s.comm.CreateInstallationTokenResult = "token"
@@ -417,9 +417,9 @@ func (s *GitGetProjectSuite) TestCloneTokenIsRefreshedOnRetry() {
 
 	refresh := s.comm.GetCreateInstallationTokenRefresh()
 	s.Require().Greater(len(refresh), 1, "the failing clone should have been retried")
-	s.False(refresh[0], "the initial token request has nothing to refresh")
-	for _, r := range refresh[1:] {
-		s.True(r, "each retry should ask for a refreshed token")
+	s.True(refresh[len(refresh)-1], "the final attempt should ask for a refreshed token")
+	for _, r := range refresh[:len(refresh)-1] {
+		s.False(r, "only the final attempt should refresh the token")
 	}
 }
 

--- a/agent/internal/client/client.go
+++ b/agent/internal/client/client.go
@@ -915,11 +915,14 @@ func (c *baseCommunicator) GetAdditionalPatches(ctx context.Context, patchId str
 	return patches, nil
 }
 
-func (c *baseCommunicator) CreateInstallationTokenForClone(ctx context.Context, td TaskData, owner, repo string) (string, error) {
+func (c *baseCommunicator) CreateInstallationTokenForClone(ctx context.Context, td TaskData, owner, repo, rejectedToken string) (string, error) {
 	info := requestInfo{
 		method:   http.MethodGet,
 		path:     fmt.Sprintf("task/%s/installation_token/%s/%s", td.ID, owner, repo),
 		taskData: &td,
+	}
+	if rejectedToken != "" {
+		info.headers = map[string]string{evergreen.RejectedGitHubTokenHeader: rejectedToken}
 	}
 	resp, err := c.retryRequest(ctx, info, nil)
 	if err != nil {

--- a/agent/internal/client/client.go
+++ b/agent/internal/client/client.go
@@ -915,14 +915,14 @@ func (c *baseCommunicator) GetAdditionalPatches(ctx context.Context, patchId str
 	return patches, nil
 }
 
-func (c *baseCommunicator) CreateInstallationTokenForClone(ctx context.Context, td TaskData, owner, repo, rejectedToken string) (string, error) {
+func (c *baseCommunicator) CreateInstallationTokenForClone(ctx context.Context, td TaskData, owner, repo string, refresh bool) (string, error) {
 	info := requestInfo{
 		method:   http.MethodGet,
 		path:     fmt.Sprintf("task/%s/installation_token/%s/%s", td.ID, owner, repo),
 		taskData: &td,
 	}
-	if rejectedToken != "" {
-		info.headers = map[string]string{evergreen.RejectedGitHubTokenHeader: rejectedToken}
+	if refresh {
+		info.headers = map[string]string{evergreen.RefreshGitHubTokenHeader: "true"}
 	}
 	resp, err := c.retryRequest(ctx, info, nil)
 	if err != nil {

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -122,12 +122,8 @@ type SharedCommunicator interface {
 	SelectTests(ctx context.Context, taskData TaskData, request restmodel.SelectTestsRequest) ([]string, error)
 
 	// CreateInstallationTokenForClone creates an installation token for the given owner and repo if there is a GitHub app installed.
-	// rejectedToken, if non-empty, is a token GitHub rejected; passing it evicts
-	// that token from the cache of the app server that serves the request, so a
-	// replacement is issued instead of the same dead token being served again.
-	// The cache is per-process, so this only helps if the request lands on the
-	// app server that issued rejectedToken.
-	CreateInstallationTokenForClone(ctx context.Context, td TaskData, owner, repo, rejectedToken string) (string, error)
+	// If refresh in true, the function creates a new token and replaces the one the app server has cached.
+	CreateInstallationTokenForClone(ctx context.Context, td TaskData, owner, repo string, refresh bool) (string, error)
 
 	// CreateGitHubDynamicAccessToken creates a dynamic access token using the task's project's GitHub app.
 	// It intersects the permissions requested with the permissions set in the project settings for the requester

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -122,7 +122,10 @@ type SharedCommunicator interface {
 	SelectTests(ctx context.Context, taskData TaskData, request restmodel.SelectTestsRequest) ([]string, error)
 
 	// CreateInstallationTokenForClone creates an installation token for the given owner and repo if there is a GitHub app installed.
-	CreateInstallationTokenForClone(ctx context.Context, td TaskData, owner, repo string) (string, error)
+	// rejectedToken, if non-empty, is a token GitHub rejected; passing it evicts
+	// that token from the app server's cache so a replacement is issued instead
+	// of the same dead token being served again.
+	CreateInstallationTokenForClone(ctx context.Context, td TaskData, owner, repo, rejectedToken string) (string, error)
 
 	// CreateGitHubDynamicAccessToken creates a dynamic access token using the task's project's GitHub app.
 	// It intersects the permissions requested with the permissions set in the project settings for the requester

--- a/agent/internal/client/interface.go
+++ b/agent/internal/client/interface.go
@@ -123,8 +123,10 @@ type SharedCommunicator interface {
 
 	// CreateInstallationTokenForClone creates an installation token for the given owner and repo if there is a GitHub app installed.
 	// rejectedToken, if non-empty, is a token GitHub rejected; passing it evicts
-	// that token from the app server's cache so a replacement is issued instead
-	// of the same dead token being served again.
+	// that token from the cache of the app server that serves the request, so a
+	// replacement is issued instead of the same dead token being served again.
+	// The cache is per-process, so this only helps if the request lands on the
+	// app server that issued rejectedToken.
 	CreateInstallationTokenForClone(ctx context.Context, td TaskData, owner, repo, rejectedToken string) (string, error)
 
 	// CreateGitHubDynamicAccessToken creates a dynamic access token using the task's project's GitHub app.

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -68,7 +68,7 @@ type Mock struct {
 	GetLoggerProducerShouldFail          bool
 	CreateInstallationTokenFail          bool
 	CreateInstallationTokenResult        string
-	CreateInstallationTokenRejected      []string
+	CreateInstallationTokenRefresh       []bool
 	CreateGitHubDynamicAccessTokenResult string
 	CreateGitHubDynamicAccessTokenFail   bool
 	RevokeGitHubDynamicAccessTokenFail   bool
@@ -570,9 +570,9 @@ func (c *Mock) GetAdditionalPatches(ctx context.Context, patchId string, td Task
 	return []string{"555555555555555555555555"}, nil
 }
 
-func (c *Mock) CreateInstallationTokenForClone(ctx context.Context, td TaskData, owner, repo, rejectedToken string) (string, error) {
+func (c *Mock) CreateInstallationTokenForClone(ctx context.Context, td TaskData, owner, repo string, refresh bool) (string, error) {
 	c.mu.Lock()
-	c.CreateInstallationTokenRejected = append(c.CreateInstallationTokenRejected, rejectedToken)
+	c.CreateInstallationTokenRefresh = append(c.CreateInstallationTokenRefresh, refresh)
 	c.mu.Unlock()
 
 	if c.CreateInstallationTokenFail {
@@ -581,12 +581,12 @@ func (c *Mock) CreateInstallationTokenForClone(ctx context.Context, td TaskData,
 	return c.CreateInstallationTokenResult, nil
 }
 
-// GetCreateInstallationTokenRejected returns the rejected tokens that have been
+// GetCreateInstallationTokenRefresh returns the refresh flags that have been
 // passed to CreateInstallationTokenForClone, in call order.
-func (c *Mock) GetCreateInstallationTokenRejected() []string {
+func (c *Mock) GetCreateInstallationTokenRefresh() []bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return slices.Clone(c.CreateInstallationTokenRejected)
+	return slices.Clone(c.CreateInstallationTokenRefresh)
 }
 
 func (c *Mock) CreateGitHubDynamicAccessToken(ctx context.Context, td TaskData, owner, repo string, permissions *github.InstallationPermissions) (string, *github.InstallationPermissions, error) {

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sync"
 	"time"
 
@@ -585,7 +586,7 @@ func (c *Mock) CreateInstallationTokenForClone(ctx context.Context, td TaskData,
 func (c *Mock) GetCreateInstallationTokenRejected() []string {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return append([]string{}, c.CreateInstallationTokenRejected...)
+	return slices.Clone(c.CreateInstallationTokenRejected)
 }
 
 func (c *Mock) CreateGitHubDynamicAccessToken(ctx context.Context, td TaskData, owner, repo string, permissions *github.InstallationPermissions) (string, *github.InstallationPermissions, error) {

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -67,6 +67,7 @@ type Mock struct {
 	GetLoggerProducerShouldFail          bool
 	CreateInstallationTokenFail          bool
 	CreateInstallationTokenResult        string
+	CreateInstallationTokenRejected      []string
 	CreateGitHubDynamicAccessTokenResult string
 	CreateGitHubDynamicAccessTokenFail   bool
 	RevokeGitHubDynamicAccessTokenFail   bool
@@ -568,11 +569,23 @@ func (c *Mock) GetAdditionalPatches(ctx context.Context, patchId string, td Task
 	return []string{"555555555555555555555555"}, nil
 }
 
-func (c *Mock) CreateInstallationTokenForClone(ctx context.Context, td TaskData, owner, repo string) (string, error) {
+func (c *Mock) CreateInstallationTokenForClone(ctx context.Context, td TaskData, owner, repo, rejectedToken string) (string, error) {
+	c.mu.Lock()
+	c.CreateInstallationTokenRejected = append(c.CreateInstallationTokenRejected, rejectedToken)
+	c.mu.Unlock()
+
 	if c.CreateInstallationTokenFail {
 		return "", errors.New("failed to create token")
 	}
 	return c.CreateInstallationTokenResult, nil
+}
+
+// GetCreateInstallationTokenRejected returns the rejected tokens that have been
+// passed to CreateInstallationTokenForClone, in call order.
+func (c *Mock) GetCreateInstallationTokenRejected() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return append([]string{}, c.CreateInstallationTokenRejected...)
 }
 
 func (c *Mock) CreateGitHubDynamicAccessToken(ctx context.Context, td TaskData, owner, repo string, permissions *github.InstallationPermissions) (string, *github.InstallationPermissions, error) {

--- a/agent/internal/client/request.go
+++ b/agent/internal/client/request.go
@@ -22,6 +22,9 @@ type requestInfo struct {
 	method   string
 	path     string
 	taskData *TaskData
+	// headers are request-specific headers, added on top of the communicator's
+	// standard ones.
+	headers map[string]string
 
 	retryOn413 bool
 }
@@ -76,6 +79,9 @@ func (c *baseCommunicator) createRequest(info requestInfo, data any) (*http.Requ
 	r, err := c.newRequest(info.method, info.path, taskID, secret, data)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating request")
+	}
+	for name, value := range info.headers {
+		r.Header.Add(name, value)
 	}
 
 	return r, nil

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-08-04"
+	AgentVersion = "2026-08-12"
 )
 
 const (

--- a/globals.go
+++ b/globals.go
@@ -687,10 +687,10 @@ const (
 	EnvironmentHeader    = "X-Evergreen-Environment"
 	GraphQLAIAgentHeader = "X-Graphql-Ai-Agent"
 
-	// RejectedGitHubTokenHeader carries an installation token that GitHub
-	// rejected, so that the token can be evicted from Evergreen's cache before a
-	// replacement is handed out.
-	RejectedGitHubTokenHeader = "X-Evergreen-Rejected-GitHub-Token"
+	// RefreshGitHubTokenHeader is set to "true" by callers whose installation
+	// token GitHub rejected, to mint a new one in place of whatever Evergreen has
+	// cached.
+	RefreshGitHubTokenHeader = "X-Evergreen-Refresh-GitHub-Token"
 
 	// Rate limiting response headers
 	RateLimitLimitHeader            = "X-RateLimit-Limit"             // Hourly request limit for the user.

--- a/globals.go
+++ b/globals.go
@@ -687,6 +687,11 @@ const (
 	EnvironmentHeader    = "X-Evergreen-Environment"
 	GraphQLAIAgentHeader = "X-Graphql-Ai-Agent"
 
+	// RejectedGitHubTokenHeader carries an installation token that GitHub
+	// rejected, so that the token can be evicted from Evergreen's cache before a
+	// replacement is handed out.
+	RejectedGitHubTokenHeader = "X-Evergreen-Rejected-GitHub-Token"
+
 	// Rate limiting response headers
 	RateLimitLimitHeader            = "X-RateLimit-Limit"             // Hourly request limit for the user.
 	RateLimitBurstHeader            = "X-RateLimit-Burst"             // Maximum number of requests that can be made in a short burst.

--- a/model/githubapp/github_app_auth.go
+++ b/model/githubapp/github_app_auth.go
@@ -98,6 +98,22 @@ func CreateCachedInstallationTokenWithDefaultOwnerRepo(ctx context.Context, sett
 // token returned from this method - revoking the token will cause other GitHub
 // operations reusing the same token to fail.
 func (g *GithubAppAuth) CreateCachedInstallationToken(ctx context.Context, owner, repo string, lifetime time.Duration, opts *github.InstallationTokenOptions) (string, error) {
+	return g.createCachedInstallationToken(ctx, owner, repo, lifetime, opts, "")
+}
+
+// RecreateCachedInstallationToken is CreateCachedInstallationToken for a caller
+// whose token GitHub already rejected. GitHub can invalidate an outstanding
+// installation token before it expires (e.g. when the app installation's repos
+// or permissions change), and the cache has no other way to learn that a token
+// it's still serving is dead. rejectedToken is only evicted if it's still what's
+// cached, so that many callers holding the same dead token don't each mint a
+// replacement and evict each other's: the first one repopulates the cache and
+// the rest see a different token and reuse it.
+func (g *GithubAppAuth) RecreateCachedInstallationToken(ctx context.Context, owner, repo string, lifetime time.Duration, opts *github.InstallationTokenOptions, rejectedToken string) (string, error) {
+	return g.createCachedInstallationToken(ctx, owner, repo, lifetime, opts, rejectedToken)
+}
+
+func (g *GithubAppAuth) createCachedInstallationToken(ctx context.Context, owner, repo string, lifetime time.Duration, opts *github.InstallationTokenOptions, rejectedToken string) (string, error) {
 	if lifetime >= MaxInstallationTokenLifetime {
 		lifetime = MaxInstallationTokenLifetime
 	}
@@ -119,7 +135,15 @@ func (g *GithubAppAuth) CreateCachedInstallationToken(ctx context.Context, owner
 	if err != nil {
 		return "", errors.Wrap(err, "creating cache ID")
 	}
-	if cachedToken, found := ghInstallationTokenCache.Get(ctx, id, lifetime); found {
+	cachedToken, found := ghInstallationTokenCache.Get(ctx, id, lifetime)
+	if found && rejectedToken != "" && cachedToken == rejectedToken {
+		// ponytail: nothing serializes the re-mint, so callers that race between
+		// the delete and the put each mint their own token. Add singleflight if
+		// GitHub starts rate limiting the app.
+		ghInstallationTokenCache.Delete(ctx, id)
+		found = false
+	}
+	if found {
 		return cachedToken, nil
 	}
 

--- a/model/githubapp/github_app_auth.go
+++ b/model/githubapp/github_app_auth.go
@@ -109,6 +109,11 @@ func (g *GithubAppAuth) CreateCachedInstallationToken(ctx context.Context, owner
 // cached, so that many callers holding the same dead token don't each mint a
 // replacement and evict each other's: the first one repopulates the cache and
 // the rest see a different token and reuse it.
+//
+// The cache is per-process, so this is best-effort: a caller routed to a
+// different app server than the one that issued rejectedToken sees that
+// process's own token instead, which is a different string and so evicts
+// nothing - and is equally dead if GitHub invalidated the whole installation.
 func (g *GithubAppAuth) RecreateCachedInstallationToken(ctx context.Context, owner, repo string, lifetime time.Duration, opts *github.InstallationTokenOptions, rejectedToken string) (string, error) {
 	return g.createCachedInstallationToken(ctx, owner, repo, lifetime, opts, rejectedToken)
 }
@@ -137,9 +142,8 @@ func (g *GithubAppAuth) createCachedInstallationToken(ctx context.Context, owner
 	}
 	cachedToken, found := ghInstallationTokenCache.Get(ctx, id, lifetime)
 	if found && rejectedToken != "" && cachedToken == rejectedToken {
-		// ponytail: nothing serializes the re-mint, so callers that race between
-		// the delete and the put each mint their own token. Add singleflight if
-		// GitHub starts rate limiting the app.
+		// Nothing serializes the re-mint, so callers that race between the delete
+		// and the put each mint their own token.
 		ghInstallationTokenCache.Delete(ctx, id)
 		found = false
 	}

--- a/model/githubapp/github_app_auth.go
+++ b/model/githubapp/github_app_auth.go
@@ -84,7 +84,7 @@ func CreateCachedInstallationTokenWithDefaultOwnerRepo(ctx context.Context, sett
 	if settings.AuthConfig.Github == nil || settings.AuthConfig.Github.DefaultOwner == "" || settings.AuthConfig.Github.DefaultRepo == "" {
 		return "", errors.Errorf("missing GitHub app configuration needed to create installation tokens")
 	}
-	return CreateGitHubAppAuth(settings).CreateCachedInstallationToken(ctx, settings.AuthConfig.Github.DefaultOwner, settings.AuthConfig.Github.DefaultRepo, lifetime, opts)
+	return CreateGitHubAppAuth(settings).CreateCachedInstallationToken(ctx, settings.AuthConfig.Github.DefaultOwner, settings.AuthConfig.Github.DefaultRepo, lifetime, opts, false)
 }
 
 // CreateCachedInstallationToken uses the owner/repo information to request an github app installation id
@@ -96,29 +96,10 @@ func CreateCachedInstallationTokenWithDefaultOwnerRepo(ctx context.Context, sett
 // for 45 minutes. However, if the cached token will expire in 5 minutes, it
 // will provide a freshly-generated token. Also take special care if revoking a
 // token returned from this method - revoking the token will cause other GitHub
-// operations reusing the same token to fail.
-func (g *GithubAppAuth) CreateCachedInstallationToken(ctx context.Context, owner, repo string, lifetime time.Duration, opts *github.InstallationTokenOptions) (string, error) {
-	return g.createCachedInstallationToken(ctx, owner, repo, lifetime, opts, "")
-}
-
-// RecreateCachedInstallationToken is CreateCachedInstallationToken for a caller
-// whose token GitHub already rejected. GitHub can invalidate an outstanding
-// installation token before it expires (e.g. when the app installation's repos
-// or permissions change), and the cache has no other way to learn that a token
-// it's still serving is dead. rejectedToken is only evicted if it's still what's
-// cached, so that many callers holding the same dead token don't each mint a
-// replacement and evict each other's: the first one repopulates the cache and
-// the rest see a different token and reuse it.
-//
-// The cache is per-process, so this is best-effort: a caller routed to a
-// different app server than the one that issued rejectedToken sees that
-// process's own token instead, which is a different string and so evicts
-// nothing - and is equally dead if GitHub invalidated the whole installation.
-func (g *GithubAppAuth) RecreateCachedInstallationToken(ctx context.Context, owner, repo string, lifetime time.Duration, opts *github.InstallationTokenOptions, rejectedToken string) (string, error) {
-	return g.createCachedInstallationToken(ctx, owner, repo, lifetime, opts, rejectedToken)
-}
-
-func (g *GithubAppAuth) createCachedInstallationToken(ctx context.Context, owner, repo string, lifetime time.Duration, opts *github.InstallationTokenOptions, rejectedToken string) (string, error) {
+// operations reusing the same token to fail. Set refresh to skip the cache and
+// replace the cached token with a newly minted one, for callers whose token
+// GitHub already rejected.
+func (g *GithubAppAuth) CreateCachedInstallationToken(ctx context.Context, owner, repo string, lifetime time.Duration, opts *github.InstallationTokenOptions, refresh bool) (string, error) {
 	if lifetime >= MaxInstallationTokenLifetime {
 		lifetime = MaxInstallationTokenLifetime
 	}
@@ -140,15 +121,10 @@ func (g *GithubAppAuth) createCachedInstallationToken(ctx context.Context, owner
 	if err != nil {
 		return "", errors.Wrap(err, "creating cache ID")
 	}
-	cachedToken, found := ghInstallationTokenCache.Get(ctx, id, lifetime)
-	if found && rejectedToken != "" && cachedToken == rejectedToken {
-		// Nothing serializes the re-mint, so callers that race between the delete
-		// and the put each mint their own token.
-		ghInstallationTokenCache.Delete(ctx, id)
-		found = false
-	}
-	if found {
-		return cachedToken, nil
+	if !refresh {
+		if cachedToken, found := ghInstallationTokenCache.Get(ctx, id, lifetime); found {
+			return cachedToken, nil
+		}
 	}
 
 	installToken, err := g.createInstallationTokenForID(ctx, installationID, opts)
@@ -164,7 +140,7 @@ func (g *GithubAppAuth) createCachedInstallationToken(ctx context.Context, owner
 // CreateCachedInstallationTokenForGitHubSender is a helper that creates a
 // cached installation token for the given owner/repo for the GitHub sender.
 func (g *GithubAppAuth) CreateGitHubSenderInstallationToken(ctx context.Context, owner, repo string) (string, error) {
-	return g.CreateCachedInstallationToken(ctx, owner, repo, MaxInstallationTokenLifetime, nil)
+	return g.CreateCachedInstallationToken(ctx, owner, repo, MaxInstallationTokenLifetime, nil, false)
 }
 
 // CreateInstallationToken creates an installation token for the given

--- a/model/githubapp/github_app_test.go
+++ b/model/githubapp/github_app_test.go
@@ -40,6 +40,15 @@ func (s *installationSuite) TearDownTest() {
 	s.cancel()
 }
 
+// evictCachedTokenAtCleanup drops a cache ID once the test ends.
+// ghInstallationTokenCache is process-global, so entries otherwise leak into
+// whichever test runs next.
+func (s *installationSuite) evictCachedTokenAtCleanup(id string) {
+	s.T().Cleanup(func() {
+		ghInstallationTokenCache.Delete(s.ctx, id)
+	})
+}
+
 func (s *installationSuite) TestUpsert() {
 	installation := GitHubAppInstallation{
 		Owner:          "evergreen-ci",
@@ -123,6 +132,7 @@ func (s *installationSuite) TestCreateCachedInstallationToken() {
 	id, err := createCacheID(installation.InstallationID, nil, nil)
 	s.NoError(err)
 	s.Equal("5678", id)
+	s.evictCachedTokenAtCleanup(id)
 	ghInstallationTokenCache.Put(s.ctx, id, unrestrictedToken, time.Now().Add(lifetime*2))
 
 	authFields := GithubAppAuth{
@@ -165,10 +175,11 @@ func (s *installationSuite) TestRecreateCachedInstallationToken() {
 		lifetime    = time.Minute
 	)
 
-	id, err := createCacheID(installation.InstallationID, nil)
+	id, err := createCacheID(installation.InstallationID, nil, nil)
 	s.Require().NoError(err)
 	authFields := GithubAppAuth{AppID: installation.AppID}
 
+	s.evictCachedTokenAtCleanup(id)
 	ghInstallationTokenCache.Put(s.ctx, id, cachedToken, time.Now().Add(lifetime*2))
 
 	token, err := authFields.RecreateCachedInstallationToken(s.ctx, installation.Owner, installation.Repo, lifetime, nil, "a_token_someone_else_already_replaced")

--- a/model/githubapp/github_app_test.go
+++ b/model/githubapp/github_app_test.go
@@ -138,7 +138,7 @@ func (s *installationSuite) TestCreateCachedInstallationToken() {
 	authFields := GithubAppAuth{
 		AppID: installation.AppID,
 	}
-	token, err := authFields.CreateCachedInstallationToken(s.ctx, installation.Owner, installation.Repo, lifetime, nil)
+	token, err := authFields.CreateCachedInstallationToken(s.ctx, installation.Owner, installation.Repo, lifetime, nil, false)
 	s.Require().NoError(err)
 	s.Equal(unrestrictedToken, token, "should return cached token since it is still valid for at least %s", lifetime)
 
@@ -156,12 +156,12 @@ func (s *installationSuite) TestCreateCachedInstallationToken() {
 	s.Equal("5678_contents:read_issues:write", id)
 	ghInstallationTokenCache.Put(s.ctx, id, restrictedToken, time.Now().Add(lifetime*2))
 
-	token, err = authFields.CreateCachedInstallationToken(s.ctx, installation.Owner, installation.Repo, lifetime, opts)
+	token, err = authFields.CreateCachedInstallationToken(s.ctx, installation.Owner, installation.Repo, lifetime, opts, false)
 	s.Require().NoError(err)
 	s.Equal(restrictedToken, token, "should return cached token since it is still valid for at least %s", lifetime)
 }
 
-func (s *installationSuite) TestRecreateCachedInstallationToken() {
+func (s *installationSuite) TestRefreshCachedInstallationToken() {
 	installation := GitHubAppInstallation{
 		Owner:          "evergreen-ci",
 		Repo:           "evergreen",
@@ -177,21 +177,18 @@ func (s *installationSuite) TestRecreateCachedInstallationToken() {
 
 	id, err := createCacheID(installation.InstallationID, nil, nil)
 	s.Require().NoError(err)
-	authFields := GithubAppAuth{AppID: installation.AppID}
-
 	s.evictCachedTokenAtCleanup(id)
 	ghInstallationTokenCache.Put(s.ctx, id, cachedToken, time.Now().Add(lifetime*2))
 
-	token, err := authFields.RecreateCachedInstallationToken(s.ctx, installation.Owner, installation.Repo, lifetime, nil, "a_token_someone_else_already_replaced")
-	s.Require().NoError(err)
-	s.Equal(cachedToken, token, "rejecting a token that is not the cached one should leave the cache alone")
+	// Refreshing skips the cache and mints a new token, which fails here because
+	// the app has no private key configured.
+	authFields := GithubAppAuth{AppID: installation.AppID}
+	_, err = authFields.CreateCachedInstallationToken(s.ctx, installation.Owner, installation.Repo, lifetime, nil, true)
+	s.Error(err, "refreshing should not return the still-valid cached token")
 
-	// Rejecting the cached token evicts it, so a replacement has to be minted,
-	// which fails here because the app has no private key configured.
-	_, err = authFields.RecreateCachedInstallationToken(s.ctx, installation.Owner, installation.Repo, lifetime, nil, cachedToken)
-	s.Error(err)
-	_, found := ghInstallationTokenCache.Get(s.ctx, id, lifetime)
-	s.False(found, "the rejected token should no longer be cached")
+	cached, found := ghInstallationTokenCache.Get(s.ctx, id, lifetime)
+	s.True(found, "a failed refresh should leave the cached token alone")
+	s.Equal(cachedToken, cached)
 }
 
 func TestCreateGitHubAppAuth(t *testing.T) {

--- a/model/githubapp/github_app_test.go
+++ b/model/githubapp/github_app_test.go
@@ -150,6 +150,39 @@ func (s *installationSuite) TestCreateCachedInstallationToken() {
 	s.Require().NoError(err)
 	s.Equal(restrictedToken, token, "should return cached token since it is still valid for at least %s", lifetime)
 }
+
+func (s *installationSuite) TestRecreateCachedInstallationToken() {
+	installation := GitHubAppInstallation{
+		Owner:          "evergreen-ci",
+		Repo:           "evergreen",
+		AppID:          1234,
+		InstallationID: 5678,
+	}
+	s.NoError(installation.Upsert(s.ctx))
+
+	const (
+		cachedToken = "cached_token"
+		lifetime    = time.Minute
+	)
+
+	id, err := createCacheID(installation.InstallationID, nil)
+	s.Require().NoError(err)
+	authFields := GithubAppAuth{AppID: installation.AppID}
+
+	ghInstallationTokenCache.Put(s.ctx, id, cachedToken, time.Now().Add(lifetime*2))
+
+	token, err := authFields.RecreateCachedInstallationToken(s.ctx, installation.Owner, installation.Repo, lifetime, nil, "a_token_someone_else_already_replaced")
+	s.Require().NoError(err)
+	s.Equal(cachedToken, token, "rejecting a token that is not the cached one should leave the cache alone")
+
+	// Rejecting the cached token evicts it, so a replacement has to be minted,
+	// which fails here because the app has no private key configured.
+	_, err = authFields.RecreateCachedInstallationToken(s.ctx, installation.Owner, installation.Repo, lifetime, nil, cachedToken)
+	s.Error(err)
+	_, found := ghInstallationTokenCache.Get(s.ctx, id, lifetime)
+	s.False(found, "the rejected token should no longer be cached")
+}
+
 func TestCreateGitHubAppAuth(t *testing.T) {
 	ctx := t.Context()
 

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1708,9 +1708,9 @@ type createInstallationTokenForClone struct {
 	taskID string
 	owner  string
 	repo   string
-	// rejectedToken is a previously-issued token that GitHub rejected. When set,
-	// it's evicted from the cache before a replacement is issued.
-	rejectedToken string
+	// refresh mints a new token and replaces the cached one, for callers whose
+	// token GitHub rejected.
+	refresh bool
 
 	env evergreen.Environment
 }
@@ -1740,7 +1740,7 @@ func (g *createInstallationTokenForClone) Parse(ctx context.Context, r *http.Req
 		return errors.New("missing repo")
 	}
 
-	g.rejectedToken = r.Header.Get(evergreen.RejectedGitHubTokenHeader)
+	g.refresh = r.Header.Get(evergreen.RefreshGitHubTokenHeader) == "true"
 
 	return nil
 }
@@ -1787,7 +1787,7 @@ func (g *createInstallationTokenForClone) Run(ctx context.Context) gimlet.Respon
 			Contents: utility.ToStringPtr(thirdparty.GithubPermissionRead),
 		},
 	}
-	token, err := githubapp.CreateGitHubAppAuth(g.env.Settings()).RecreateCachedInstallationToken(ctx, g.owner, g.repo, lifetime, opts, g.rejectedToken)
+	token, err := githubapp.CreateGitHubAppAuth(g.env.Settings()).CreateCachedInstallationToken(ctx, g.owner, g.repo, lifetime, opts, g.refresh)
 	if err != nil {
 		if errors.Is(err, githubapp.ErrGitHubAppNotInstalled) {
 			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1708,6 +1708,9 @@ type createInstallationTokenForClone struct {
 	taskID string
 	owner  string
 	repo   string
+	// rejectedToken is a previously-issued token that GitHub rejected. When set,
+	// it's evicted from the cache before a replacement is issued.
+	rejectedToken string
 
 	env evergreen.Environment
 }
@@ -1736,6 +1739,8 @@ func (g *createInstallationTokenForClone) Parse(ctx context.Context, r *http.Req
 	if g.repo = gimlet.GetVars(r)["repo"]; g.repo == "" {
 		return errors.New("missing repo")
 	}
+
+	g.rejectedToken = r.Header.Get(evergreen.RejectedGitHubTokenHeader)
 
 	return nil
 }
@@ -1782,7 +1787,7 @@ func (g *createInstallationTokenForClone) Run(ctx context.Context) gimlet.Respon
 			Contents: utility.ToStringPtr(thirdparty.GithubPermissionRead),
 		},
 	}
-	token, err := githubapp.CreateGitHubAppAuth(g.env.Settings()).CreateCachedInstallationToken(ctx, g.owner, g.repo, lifetime, opts)
+	token, err := githubapp.CreateGitHubAppAuth(g.env.Settings()).RecreateCachedInstallationToken(ctx, g.owner, g.repo, lifetime, opts, g.rejectedToken)
 	if err != nil {
 		if errors.Is(err, githubapp.ErrGitHubAppNotInstalled) {
 			return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -846,13 +846,11 @@ func TestCreateInstallationToken(t *testing.T) {
 			assert.Empty(t, handler.rejectedToken)
 		},
 		"ParseReadsRejectedToken": func(ctx context.Context, t *testing.T, handler *createInstallationTokenForClone) {
-			url := fmt.Sprintf("/task/{task_id}/installation_token/%s/%s", validOwner, validRepo)
-			request, err := http.NewRequest(http.MethodGet, url, bytes.NewReader(nil))
+			request, err := http.NewRequest(http.MethodGet, "/task/t1/installation_token/owner/repo", bytes.NewReader(nil))
 			assert.NoError(t, err)
 			request.Header.Set(evergreen.RejectedGitHubTokenHeader, "dead_token")
 
-			options := map[string]string{"owner": validOwner, "repo": validRepo}
-			request = gimlet.SetURLVars(request, options)
+			request = gimlet.SetURLVars(request, map[string]string{"task_id": "t1", "owner": validOwner, "repo": validRepo})
 
 			assert.NoError(t, handler.Parse(ctx, request))
 			assert.Equal(t, "dead_token", handler.rejectedToken)

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -843,6 +843,19 @@ func TestCreateInstallationToken(t *testing.T) {
 			request = gimlet.SetURLVars(request, map[string]string{"task_id": "t1", "owner": validOwner, "repo": validRepo})
 
 			assert.NoError(t, handler.Parse(ctx, request))
+			assert.Empty(t, handler.rejectedToken)
+		},
+		"ParseReadsRejectedToken": func(ctx context.Context, t *testing.T, handler *createInstallationTokenForClone) {
+			url := fmt.Sprintf("/task/{task_id}/installation_token/%s/%s", validOwner, validRepo)
+			request, err := http.NewRequest(http.MethodGet, url, bytes.NewReader(nil))
+			assert.NoError(t, err)
+			request.Header.Set(evergreen.RejectedGitHubTokenHeader, "dead_token")
+
+			options := map[string]string{"owner": validOwner, "repo": validRepo}
+			request = gimlet.SetURLVars(request, options)
+
+			assert.NoError(t, handler.Parse(ctx, request))
+			assert.Equal(t, "dead_token", handler.rejectedToken)
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -843,17 +843,17 @@ func TestCreateInstallationToken(t *testing.T) {
 			request = gimlet.SetURLVars(request, map[string]string{"task_id": "t1", "owner": validOwner, "repo": validRepo})
 
 			assert.NoError(t, handler.Parse(ctx, request))
-			assert.Empty(t, handler.rejectedToken)
+			assert.False(t, handler.refresh)
 		},
-		"ParseReadsRejectedToken": func(ctx context.Context, t *testing.T, handler *createInstallationTokenForClone) {
+		"ParseReadsRefreshHeader": func(ctx context.Context, t *testing.T, handler *createInstallationTokenForClone) {
 			request, err := http.NewRequest(http.MethodGet, "/task/t1/installation_token/owner/repo", bytes.NewReader(nil))
 			assert.NoError(t, err)
-			request.Header.Set(evergreen.RejectedGitHubTokenHeader, "dead_token")
+			request.Header.Set(evergreen.RefreshGitHubTokenHeader, "true")
 
 			request = gimlet.SetURLVars(request, map[string]string{"task_id": "t1", "owner": validOwner, "repo": validRepo})
 
 			assert.NoError(t, handler.Parse(ctx, request))
-			assert.Equal(t, "dead_token", handler.rejectedToken)
+			assert.True(t, handler.refresh)
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -460,7 +460,7 @@ func getInstallationToken(ctx context.Context, owner, repo string, opts *github.
 		return "", errors.Wrap(err, "getting config")
 	}
 
-	return githubapp.CreateGitHubAppAuth(settings).CreateCachedInstallationToken(ctx, owner, repo, defaultGitHubAPIRequestLifetime, opts)
+	return githubapp.CreateGitHubAppAuth(settings).CreateCachedInstallationToken(ctx, owner, repo, defaultGitHubAPIRequestLifetime, opts, false)
 }
 
 // RevokeInstallationToken revokes an installation token. Take care to make sure
@@ -705,7 +705,7 @@ func runGitHubOp(ctx context.Context, owner, repo, caller string, ghAppAuth *git
 // a 401 indicates the app lacks the necessary credentials and retrying would
 // be futile.
 func runGitHubOpWithExternalGitHubApp(ctx context.Context, owner, repo, caller string, ghAppAuth *githubapp.GithubAppAuth, op func(ctx context.Context, ghClient *githubapp.GitHubClient) error) error {
-	token, err := ghAppAuth.CreateCachedInstallationToken(ctx, owner, repo, defaultGitHubAPIRequestLifetime, nil)
+	token, err := ghAppAuth.CreateCachedInstallationToken(ctx, owner, repo, defaultGitHubAPIRequestLifetime, nil, false)
 	if err != nil {
 		return errors.Wrapf(err, "getting installation token with external GitHub app '%d'", ghAppAuth.AppID)
 	}
@@ -1302,7 +1302,7 @@ func CheckGithubAPILimit(ctx context.Context, owner, repo string, ghAppAuth *git
 			attribute.String(githubOwnerAttribute, owner),
 			attribute.String(githubRepoAttribute, repo),
 		)
-		token, err = ghAppAuth.CreateCachedInstallationToken(ctx, owner, repo, defaultGitHubAPIRequestLifetime, nil)
+		token, err = ghAppAuth.CreateCachedInstallationToken(ctx, owner, repo, defaultGitHubAPIRequestLifetime, nil, false)
 		if err != nil {
 			return nil, errors.Wrapf(err, "getting installation token with external GitHub app ID %d for owner/repo '%s/%s'", ghAppAuth.AppID, owner, repo)
 		}


### PR DESCRIPTION
DEVPROD-28343

### Description

we may get back a faulty token from GitHub when their services are down and retrying with the same token won't get us anywhere. when we retry for git.get_project, we now refresh the token before retrying.

### Testing

unit tests