### PR TITLE
DEVPROD-32852: discover subnets for hosts in non-default account

### DIFF
--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -50,6 +50,9 @@ type AWSClient interface {
 	// DescribeInstanceTypeOfferings is a wrapper for ec2.DescribeInstanceTypeOfferings.
 	DescribeInstanceTypeOfferings(context.Context, *ec2.DescribeInstanceTypeOfferingsInput) (*ec2.DescribeInstanceTypeOfferingsOutput, error)
 
+	// DescribeSubnets is a wrapper for ec2.DescribeSubnets.
+	DescribeSubnets(context.Context, *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
+
 	// CreateTags is a wrapper for ec2.CreateTags.
 	CreateTags(context.Context, *ec2.CreateTagsInput) (*ec2.CreateTagsOutput, error)
 
@@ -286,6 +289,31 @@ func (c *awsClientImpl) DescribeInstanceTypeOfferings(ctx context.Context, input
 		func() (bool, error) {
 			msg := makeAWSLogMessage("DescribeInstanceTypeOfferings", fmt.Sprintf("%T", c), input)
 			output, err = c.ec2Client.DescribeInstanceTypeOfferings(ctx, input)
+			if err != nil {
+				var apiErr smithy.APIError
+				if errors.As(err, &apiErr) {
+					grip.Debug(ctx, message.WrapError(apiErr, msg))
+				}
+				return true, err
+			}
+			grip.Info(ctx, msg)
+			return false, nil
+		}, awsClientDefaultRetryOptions())
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+// DescribeSubnets is a wrapper for ec2.DescribeSubnets.
+func (c *awsClientImpl) DescribeSubnets(ctx context.Context, input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+	var output *ec2.DescribeSubnetsOutput
+	var err error
+	err = utility.Retry(
+		ctx,
+		func() (bool, error) {
+			msg := makeAWSLogMessage("DescribeSubnets", fmt.Sprintf("%T", c), input)
+			output, err = c.ec2Client.DescribeSubnets(ctx, input)
 			if err != nil {
 				var apiErr smithy.APIError
 				if errors.As(err, &apiErr) {
@@ -1146,6 +1174,11 @@ type awsClientMock struct { //nolint
 	DescribeInstancesError      error
 	*ec2.DescribeInstanceTypeOfferingsOutput
 
+	*ec2.DescribeSubnetsInput
+	*ec2.DescribeSubnetsOutput
+	DescribeSubnetsError error
+	DescribeSubnetsCount int
+
 	launchTemplates []types.LaunchTemplate
 
 	*route53.ChangeResourceRecordSetsInput
@@ -1242,6 +1275,15 @@ func (c *awsClientMock) ModifyInstanceAttribute(ctx context.Context, input *ec2.
 func (c *awsClientMock) DescribeInstanceTypeOfferings(ctx context.Context, input *ec2.DescribeInstanceTypeOfferingsInput) (*ec2.DescribeInstanceTypeOfferingsOutput, error) {
 	c.DescribeInstanceTypeOfferingsInput = input
 	return c.DescribeInstanceTypeOfferingsOutput, nil
+}
+
+func (c *awsClientMock) DescribeSubnets(ctx context.Context, input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error) {
+	c.DescribeSubnetsInput = input
+	c.DescribeSubnetsCount++
+	if c.DescribeSubnetsError != nil {
+		return nil, c.DescribeSubnetsError
+	}
+	return c.DescribeSubnetsOutput, nil
 }
 
 // TerminateInstances is a mock for ec2.TerminateInstances.

--- a/cloud/ec2_client.go
+++ b/cloud/ec2_client.go
@@ -1173,6 +1173,8 @@ type awsClientMock struct { //nolint
 	RequestGetInstanceInfoError error
 	DescribeInstancesError      error
 	*ec2.DescribeInstanceTypeOfferingsOutput
+	DescribeInstanceTypeOfferingsError error
+	DescribeInstanceTypeOfferingsCount int
 
 	*ec2.DescribeSubnetsInput
 	*ec2.DescribeSubnetsOutput
@@ -1274,6 +1276,10 @@ func (c *awsClientMock) ModifyInstanceAttribute(ctx context.Context, input *ec2.
 
 func (c *awsClientMock) DescribeInstanceTypeOfferings(ctx context.Context, input *ec2.DescribeInstanceTypeOfferingsInput) (*ec2.DescribeInstanceTypeOfferingsOutput, error) {
 	c.DescribeInstanceTypeOfferingsInput = input
+	c.DescribeInstanceTypeOfferingsCount++
+	if c.DescribeInstanceTypeOfferingsError != nil {
+		return nil, c.DescribeInstanceTypeOfferingsError
+	}
 	return c.DescribeInstanceTypeOfferingsOutput, nil
 }
 

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -20,41 +21,135 @@ import (
 
 const launchTemplateExpiration = 24 * time.Hour
 
-type instanceTypeSubnetCache map[instanceRegionPair][]evergreen.Subnet
-
-type instanceRegionPair struct {
-	instanceType string
-	region       string
+// instanceTypeSubnetCache caches the subnets that can run a particular instance
+// type.
+type instanceTypeSubnetCache struct {
+	mu    sync.Mutex
+	cache map[instanceTypeCacheKey]cachedSubnets
 }
 
-var typeCache instanceTypeSubnetCache
+type instanceTypeCacheKey struct {
+	account      string
+	region       string
+	instanceType string
+}
+
+// cachedSubnets is the result of looking up the subnets for a single
+// instanceRegionPair.
+type cachedSubnets struct {
+	subnets []evergreen.Subnet
+	// err is cached if subnets cannot be looked up for the instance type (to
+	// avoid repeating failing lookups).
+	err error
+}
+
+var typeCache *instanceTypeSubnetCache
 
 func init() {
-	typeCache = make(map[instanceRegionPair][]evergreen.Subnet)
+	typeCache = &instanceTypeSubnetCache{cache: map[instanceTypeCacheKey]cachedSubnets{}}
 }
 
-func (c instanceTypeSubnetCache) subnetsWithInstanceType(ctx context.Context, settings *evergreen.Settings, client AWSClient, instanceRegion instanceRegionPair) ([]evergreen.Subnet, error) {
-	if subnets, ok := c[instanceRegion]; ok {
-		return subnets, nil
+// subnetsWithInstanceType returns the subnets that Evergreen can use for the
+// given instance type, region, and AWS account. Subnets for the default account
+// come from the admin settings, while subnets for any other account are
+// discovered from AWS by their tag.
+func (c *instanceTypeSubnetCache) subnetsWithInstanceType(ctx context.Context, settings *evergreen.Settings, client AWSClient, cacheKey instanceTypeCacheKey) ([]evergreen.Subnet, error) {
+	if cached, ok := c.get(cacheKey); ok {
+		return cached.subnets, cached.err
 	}
 
-	supportingAZs, err := c.getAZs(ctx, client, instanceRegion)
+	var candidateSubnets []evergreen.Subnet
+	if cacheKey.account != "" {
+		discovered, err := c.discoverSubnets(ctx, settings, client)
+		if err != nil {
+			c.set(cacheKey, cachedSubnets{err: err})
+			return nil, errors.Wrapf(err, "discovering subnets for account '%s'", cacheKey.account)
+		}
+		candidateSubnets = discovered
+	} else {
+		candidateSubnets = settings.Providers.AWS.Subnets
+	}
+
+	supportingAZs, err := c.getAZs(ctx, client, cacheKey)
 	if err != nil {
+		c.set(cacheKey, cachedSubnets{err: err})
 		return nil, errors.Wrap(err, "getting supported AZs")
 	}
 
-	subnets := make([]evergreen.Subnet, 0, len(supportingAZs))
-	for _, subnet := range settings.Providers.AWS.Subnets {
+	// Filter subnets to those that are in AZs that support the instance type.
+	subnets := make([]evergreen.Subnet, 0, len(candidateSubnets))
+	for _, subnet := range candidateSubnets {
 		if utility.StringSliceContains(supportingAZs, subnet.AZ) {
 			subnets = append(subnets, subnet)
 		}
 	}
-	c[instanceRegion] = subnets
+	c.set(cacheKey, cachedSubnets{subnets: subnets})
 
 	return subnets, nil
 }
 
-func (c instanceTypeSubnetCache) getAZs(ctx context.Context, client AWSClient, instanceRegion instanceRegionPair) ([]string, error) {
+func (c *instanceTypeSubnetCache) get(instanceRegion instanceTypeCacheKey) (cachedSubnets, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	cached, ok := c.cache[instanceRegion]
+	return cached, ok
+}
+
+// set stores the result of a subnet lookup. A failed lookup never replaces a
+// successful one because entries never expire, so a failure that raced with a
+// success would otherwise persist until the app servers restart.
+func (c *instanceTypeSubnetCache) set(instanceRegion instanceTypeCacheKey, result cachedSubnets) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, alreadyCached := c.cache[instanceRegion]; alreadyCached && result.err != nil {
+		return
+	}
+	c.cache[instanceRegion] = result
+}
+
+// discoverSubnets returns the subnets in the client's AWS account and region
+// that are tagged as usable by Evergreen.
+func (c *instanceTypeSubnetCache) discoverSubnets(ctx context.Context, settings *evergreen.Settings, client AWSClient) ([]evergreen.Subnet, error) {
+	tagName := settings.Providers.AWS.SubnetTagName
+	tagValue := settings.Providers.AWS.SubnetTagValue
+	if tagName == "" || tagValue == "" {
+		return nil, errors.New("subnet tag name and value must both be set to discover subnets")
+	}
+
+	output, err := client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
+		Filters: []types.Filter{
+			{
+				Name:   aws.String(fmt.Sprintf("tag:%s", tagName)),
+				Values: []string{tagValue},
+			},
+		},
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "describing subnets")
+	}
+	if output == nil {
+		return nil, errors.New("DescribeSubnets returned nil output")
+	}
+
+	subnets := make([]evergreen.Subnet, 0, len(output.Subnets))
+	for _, subnet := range output.Subnets {
+		az := utility.FromStringPtr(subnet.AvailabilityZone)
+		subnetID := utility.FromStringPtr(subnet.SubnetId)
+		if az == "" || subnetID == "" {
+			continue
+		}
+		subnets = append(subnets, evergreen.Subnet{AZ: az, SubnetID: subnetID})
+	}
+	if len(subnets) == 0 {
+		return nil, errors.Errorf("no subnets are tagged with '%s: %s'", tagName, tagValue)
+	}
+
+	return subnets, nil
+}
+
+func (c *instanceTypeSubnetCache) getAZs(ctx context.Context, client AWSClient, instanceRegion instanceTypeCacheKey) ([]string, error) {
 	// DescribeInstanceTypeOfferings only returns AZs in the client's region
 	output, err := client.DescribeInstanceTypeOfferings(ctx, &ec2.DescribeInstanceTypeOfferingsInput{
 		LocationType: types.LocationTypeAvailabilityZone,
@@ -693,13 +788,9 @@ func (m *ec2FleetManager) uploadLaunchTemplate(ctx context.Context, h *host.Host
 }
 
 func (m *ec2FleetManager) requestFleet(ctx context.Context, h *host.Host, ec2Settings *EC2ProviderSettings) (string, error) {
-	var overrides []types.FleetLaunchTemplateOverridesRequest
-	var err error
-	if ec2Settings.VpcName != "" {
-		overrides, err = m.makeOverrides(ctx, ec2Settings)
-		if err != nil {
-			return "", errors.Wrapf(err, "making overrides for VPC '%s'", ec2Settings.VpcName)
-		}
+	overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+	if err != nil {
+		return "", errors.Wrap(err, "making launch template overrides")
 	}
 
 	// Create a fleet with a single instance from the launch template
@@ -727,20 +818,53 @@ func (m *ec2FleetManager) requestFleet(ctx context.Context, h *host.Host, ec2Set
 	return createFleetResponse.Instances[0].InstanceIds[0], nil
 }
 
-func (m *ec2FleetManager) makeOverrides(ctx context.Context, ec2Settings *EC2ProviderSettings) ([]types.FleetLaunchTemplateOverridesRequest, error) {
-	subnets := m.settings.Providers.AWS.Subnets
-	if len(subnets) == 0 {
-		return nil, errors.New("no AWS subnets were configured")
-	}
-
-	supportingSubnets, err := typeCache.subnetsWithInstanceType(ctx, m.settings, m.client, instanceRegionPair{instanceType: ec2Settings.InstanceType, region: ec2Settings.getRegion()})
-	if err != nil {
-		return nil, errors.Wrapf(err, "getting AZs supporting instance type '%s'", ec2Settings.InstanceType)
-	}
-	if len(supportingSubnets) == 0 || (len(supportingSubnets) == 1 && supportingSubnets[0].SubnetID == ec2Settings.SubnetId) {
+// makeSubnetOverrides returns the subnets that the fleet request can choose
+// between to launch the host. Returning no subnet overrides means the fleet
+// request is limited to the distro's default subnet.
+// Allowing multiple subnets allows an instance to spawn in different
+// availability zones. Multiple subnets have a better chance of successfully
+// spawning the host in case one AZ is out of capacity for the instance type.
+func (m *ec2FleetManager) makeSubnetOverrides(ctx context.Context, h *host.Host, ec2Settings *EC2ProviderSettings) ([]types.FleetLaunchTemplateOverridesRequest, error) {
+	if m.account == "" && ec2Settings.VpcName == "" {
+		// An EC2 fleet request can only use different subnets if:
+		// 1. Hosts are being started in a non-default account (i.e. account is
+		//    non-empty) or
+		// 2. In the legacy case, hosts in the default AWS account use VPC name
+		//    as a feature flag to indicate they have multiple subnets
+		//    available.
 		return nil, nil
 	}
-	overrides := make([]types.FleetLaunchTemplateOverridesRequest, 0, len(subnets))
+
+	supportingSubnets, err := typeCache.subnetsWithInstanceType(ctx, m.settings, m.client, instanceTypeCacheKey{
+		instanceType: ec2Settings.InstanceType,
+		region:       ec2Settings.getRegion(),
+		account:      m.account,
+	})
+	if err != nil {
+		// Not being able to determine the subnets shouldn't stop the host from
+		// spawning, but it does mean that this distro can't fall back to other
+		// AZs, which reduces resilience during times of low instance capacity.
+		// Ideally this should not consistently error since it likely indicates
+		// a configuration problem (e.g. AWS permissions issues).
+		grip.Warning(ctx, message.WrapError(err, message.Fields{
+			"message":          "could not determine which subnets are available to the host, so it can only use the default distro subnet (and AZ)",
+			"host_id":          h.Id,
+			"host_provider":    h.Distro.Provider,
+			"distro":           h.Distro.Id,
+			"provider_account": m.account,
+			"instance_type":    ec2Settings.InstanceType,
+			"region":           ec2Settings.getRegion(),
+		}))
+		return nil, nil
+	}
+
+	if len(supportingSubnets) == 0 || (len(supportingSubnets) == 1 && supportingSubnets[0].SubnetID == ec2Settings.SubnetId) {
+		// No other subnets are available, so don't bother with making explicit
+		// overrides.
+		return nil, nil
+	}
+
+	overrides := make([]types.FleetLaunchTemplateOverridesRequest, 0, len(supportingSubnets))
 	for _, subnet := range supportingSubnets {
 		overrides = append(overrides, types.FleetLaunchTemplateOverridesRequest{SubnetId: aws.String(subnet.SubnetID)})
 	}

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -22,7 +22,8 @@ import (
 const launchTemplateExpiration = 24 * time.Hour
 
 // instanceTypeSubnetCache caches the subnets that can run a particular instance
-// type.
+// type. Successful lookups are cached until the app servers restart, while
+// failed ones are cached and retried on a TTL.
 type instanceTypeSubnetCache struct {
 	mu    sync.Mutex
 	cache map[instanceTypeCacheKey]cachedSubnets
@@ -41,6 +42,8 @@ type cachedSubnets struct {
 	// err is cached if subnets cannot be looked up for the instance type (to
 	// avoid repeating failing lookups).
 	err error
+	// errExpiresAt marks when a cached err can be retried.
+	errExpiresAt time.Time
 }
 
 // typeCache caches the subnets that can run a particular instance type within a
@@ -96,13 +99,24 @@ func (c *instanceTypeSubnetCache) get(key instanceTypeCacheKey) (cachedSubnets, 
 	defer c.mu.Unlock()
 
 	cached, ok := c.cache[key]
-	return cached, ok
+	if !ok {
+		return cachedSubnets{}, false
+	}
+	if cached.err != nil && time.Now().After(cached.errExpiresAt) {
+		return cachedSubnets{}, false
+	}
+
+	return cached, true
 }
 
 func (c *instanceTypeSubnetCache) set(key instanceTypeCacheKey, result cachedSubnets) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	if result.err != nil {
+		const cacheErrTTL = 15 * time.Minute
+		result.errExpiresAt = time.Now().Add(cacheErrTTL)
+	}
 	c.cache[key] = result
 }
 

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -112,12 +112,6 @@ func (c *instanceTypeSubnetCache) discoverSubnets(ctx context.Context, settings 
 		return nil, errors.New("subnet tag name and value must both be set to discover subnets")
 	}
 
-	grip.Info(ctx, message.Fields{
-		"message":   "kim: calling DescribeSubnets to discover subnets",
-		"tag_name":  tagName,
-		"tag_value": tagValue,
-	})
-
 	output, err := client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
 		Filters: []types.Filter{
 			{
@@ -142,13 +136,6 @@ func (c *instanceTypeSubnetCache) discoverSubnets(ctx context.Context, settings 
 		}
 		subnets = append(subnets, evergreen.Subnet{AZ: az, SubnetID: subnetID})
 	}
-	grip.Info(ctx, message.Fields{
-		"message":   "kim: successfully called DescribeSubnets to discover subnets",
-		"tag_name":  tagName,
-		"tag_value": tagValue,
-		"subnets":   subnets,
-	})
-
 	if len(subnets) == 0 {
 		return nil, errors.Errorf("no subnets are tagged with '%s: %s'", tagName, tagValue)
 	}
@@ -832,17 +819,6 @@ func (m *ec2FleetManager) requestFleet(ctx context.Context, h *host.Host, ec2Set
 // availability zones. Multiple subnets have a better chance of successfully
 // spawning the host in case one AZ is out of capacity for the instance type.
 func (m *ec2FleetManager) makeSubnetOverrides(ctx context.Context, h *host.Host, ec2Settings *EC2ProviderSettings) ([]types.FleetLaunchTemplateOverridesRequest, error) {
-	grip.Info(ctx, message.Fields{
-		"message":       "kim: making subnet overrides",
-		"aws_account":   m.account,
-		"aws_role":      m.role,
-		"aws_region":    ec2Settings.getRegion(),
-		"instance_type": ec2Settings.InstanceType,
-		"host_id":       h.Id,
-		"distro_id":     h.Distro.Id,
-		"vpc_name":      ec2Settings.VpcName,
-	})
-
 	if m.account == "" && ec2Settings.VpcName == "" {
 		// An EC2 fleet request can only use different subnets if:
 		// 1. Hosts are being started in a non-default account (i.e. account is
@@ -865,8 +841,9 @@ func (m *ec2FleetManager) makeSubnetOverrides(ctx context.Context, h *host.Host,
 		// Ideally this should not consistently error since it likely indicates
 		// a configuration problem (e.g. AWS permissions issues).
 		grip.Warning(ctx, message.WrapError(err, message.Fields{
-			"message":          "kim: could not determine which subnets are available to the host, so it can only use the default distro subnet (and AZ)",
+			"message":          "could not determine which subnets are available to the host, so it can only use the default distro subnet (and AZ)",
 			"host_id":          h.Id,
+			"host_provider":    h.Distro.Provider,
 			"distro":           h.Distro.Id,
 			"provider_account": m.account,
 			"instance_type":    ec2Settings.InstanceType,

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -35,7 +35,7 @@ type instanceTypeCacheKey struct {
 }
 
 // cachedSubnets is the result of looking up the subnets for a single
-// instanceRegionPair.
+// instance type in a particular account.
 type cachedSubnets struct {
 	subnets []evergreen.Subnet
 	// err is cached if subnets cannot be looked up for the instance type (to
@@ -43,6 +43,8 @@ type cachedSubnets struct {
 	err error
 }
 
+// typeCache caches the subnets that can run a particular instance type within a
+// particular region and AWS account.
 var typeCache *instanceTypeSubnetCache
 
 func init() {
@@ -83,24 +85,25 @@ func (c *instanceTypeSubnetCache) subnetsWithInstanceType(ctx context.Context, s
 			subnets = append(subnets, subnet)
 		}
 	}
+
 	c.set(cacheKey, cachedSubnets{subnets: subnets})
 
 	return subnets, nil
 }
 
-func (c *instanceTypeSubnetCache) get(instanceRegion instanceTypeCacheKey) (cachedSubnets, bool) {
+func (c *instanceTypeSubnetCache) get(key instanceTypeCacheKey) (cachedSubnets, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	cached, ok := c.cache[instanceRegion]
+	cached, ok := c.cache[key]
 	return cached, ok
 }
 
-func (c *instanceTypeSubnetCache) set(instanceRegion instanceTypeCacheKey, result cachedSubnets) {
+func (c *instanceTypeSubnetCache) set(key instanceTypeCacheKey, result cachedSubnets) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	c.cache[instanceRegion] = result
+	c.cache[key] = result
 }
 
 // discoverSubnets returns the subnets in the client's AWS account and region
@@ -143,19 +146,21 @@ func (c *instanceTypeSubnetCache) discoverSubnets(ctx context.Context, settings 
 	return subnets, nil
 }
 
-func (c *instanceTypeSubnetCache) getAZs(ctx context.Context, client AWSClient, instanceRegion instanceTypeCacheKey) ([]string, error) {
+// getAZsf returns the availability zones that support a particular instance
+// type.
+func (c *instanceTypeSubnetCache) getAZs(ctx context.Context, client AWSClient, cacheKey instanceTypeCacheKey) ([]string, error) {
 	// DescribeInstanceTypeOfferings only returns AZs in the client's region
 	output, err := client.DescribeInstanceTypeOfferings(ctx, &ec2.DescribeInstanceTypeOfferingsInput{
 		LocationType: types.LocationTypeAvailabilityZone,
 		Filters: []types.Filter{
-			{Name: aws.String("instance-type"), Values: []string{instanceRegion.instanceType}},
+			{Name: aws.String("instance-type"), Values: []string{cacheKey.instanceType}},
 		},
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "getting instance types for filter '%s' in region '%s'", instanceRegion.instanceType, instanceRegion.region)
+		return nil, errors.Wrapf(err, "getting instance types for filter '%s' in region '%s'", cacheKey.instanceType, cacheKey.region)
 	}
 	if output == nil {
-		return nil, errors.Errorf("DescribeInstanceTypeOfferings returned nil output for instance type filter '%s' in '%s'", instanceRegion.instanceType, instanceRegion.region)
+		return nil, errors.Errorf("DescribeInstanceTypeOfferings returned nil output for instance type filter '%s' in '%s'", cacheKey.instanceType, cacheKey.region)
 	}
 	supportingAZs := make([]string, 0, len(output.InstanceTypeOfferings))
 	for _, offering := range output.InstanceTypeOfferings {
@@ -819,13 +824,13 @@ func (m *ec2FleetManager) requestFleet(ctx context.Context, h *host.Host, ec2Set
 // availability zones. Multiple subnets have a better chance of successfully
 // spawning the host in case one AZ is out of capacity for the instance type.
 func (m *ec2FleetManager) makeSubnetOverrides(ctx context.Context, h *host.Host, ec2Settings *EC2ProviderSettings) ([]types.FleetLaunchTemplateOverridesRequest, error) {
+	// An EC2 fleet request can only use different subnets if:
+	// 1. Hosts are being started in a non-default account (i.e. account is
+	//    non-empty) or
+	// 2. In the legacy case, hosts in the default AWS account use VPC name
+	//    as a feature flag to indicate they have multiple subnets
+	//    available.
 	if m.account == "" && ec2Settings.VpcName == "" {
-		// An EC2 fleet request can only use different subnets if:
-		// 1. Hosts are being started in a non-default account (i.e. account is
-		//    non-empty) or
-		// 2. In the legacy case, hosts in the default AWS account use VPC name
-		//    as a feature flag to indicate they have multiple subnets
-		//    available.
 		return nil, nil
 	}
 

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -96,16 +96,10 @@ func (c *instanceTypeSubnetCache) get(instanceRegion instanceTypeCacheKey) (cach
 	return cached, ok
 }
 
-// set stores the result of a subnet lookup. A failed lookup never replaces a
-// successful one because entries never expire, so a failure that raced with a
-// success would otherwise persist until the app servers restart.
 func (c *instanceTypeSubnetCache) set(instanceRegion instanceTypeCacheKey, result cachedSubnets) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if _, alreadyCached := c.cache[instanceRegion]; alreadyCached && result.err != nil {
-		return
-	}
 	c.cache[instanceRegion] = result
 }
 

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -112,6 +112,12 @@ func (c *instanceTypeSubnetCache) discoverSubnets(ctx context.Context, settings 
 		return nil, errors.New("subnet tag name and value must both be set to discover subnets")
 	}
 
+	grip.Info(ctx, message.Fields{
+		"message":   "kim: calling DescribeSubnets to discover subnets",
+		"tag_name":  tagName,
+		"tag_value": tagValue,
+	})
+
 	output, err := client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
 		Filters: []types.Filter{
 			{
@@ -136,6 +142,13 @@ func (c *instanceTypeSubnetCache) discoverSubnets(ctx context.Context, settings 
 		}
 		subnets = append(subnets, evergreen.Subnet{AZ: az, SubnetID: subnetID})
 	}
+	grip.Info(ctx, message.Fields{
+		"message":   "kim: successfully called DescribeSubnets to discover subnets",
+		"tag_name":  tagName,
+		"tag_value": tagValue,
+		"subnets":   subnets,
+	})
+
 	if len(subnets) == 0 {
 		return nil, errors.Errorf("no subnets are tagged with '%s: %s'", tagName, tagValue)
 	}
@@ -819,6 +832,17 @@ func (m *ec2FleetManager) requestFleet(ctx context.Context, h *host.Host, ec2Set
 // availability zones. Multiple subnets have a better chance of successfully
 // spawning the host in case one AZ is out of capacity for the instance type.
 func (m *ec2FleetManager) makeSubnetOverrides(ctx context.Context, h *host.Host, ec2Settings *EC2ProviderSettings) ([]types.FleetLaunchTemplateOverridesRequest, error) {
+	grip.Info(ctx, message.Fields{
+		"message":       "kim: making subnet overrides",
+		"aws_account":   m.account,
+		"aws_role":      m.role,
+		"aws_region":    ec2Settings.getRegion(),
+		"instance_type": ec2Settings.InstanceType,
+		"host_id":       h.Id,
+		"distro_id":     h.Distro.Id,
+		"vpc_name":      ec2Settings.VpcName,
+	})
+
 	if m.account == "" && ec2Settings.VpcName == "" {
 		// An EC2 fleet request can only use different subnets if:
 		// 1. Hosts are being started in a non-default account (i.e. account is
@@ -841,9 +865,8 @@ func (m *ec2FleetManager) makeSubnetOverrides(ctx context.Context, h *host.Host,
 		// Ideally this should not consistently error since it likely indicates
 		// a configuration problem (e.g. AWS permissions issues).
 		grip.Warning(ctx, message.WrapError(err, message.Fields{
-			"message":          "could not determine which subnets are available to the host, so it can only use the default distro subnet (and AZ)",
+			"message":          "kim: could not determine which subnets are available to the host, so it can only use the default distro subnet (and AZ)",
 			"host_id":          h.Id,
-			"host_provider":    h.Distro.Provider,
 			"distro":           h.Distro.Id,
 			"provider_account": m.account,
 			"instance_type":    ec2Settings.InstanceType,

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -378,65 +378,6 @@ func TestFleet(t *testing.T) {
 			assert.Len(t, client.CreateFleetInput.LaunchTemplateConfigs, 1)
 			assert.Equal(t, "ht_1", *client.CreateFleetInput.LaunchTemplateConfigs[0].LaunchTemplateSpecification.LaunchTemplateName)
 		},
-		"MakeOverridesWithoutVpcNameInDefaultAccountReturnsNoOverrides": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
-			ec2Settings := &EC2ProviderSettings{
-				InstanceType: "instanceType0",
-				SubnetId:     "subnet-654321",
-			}
-
-			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
-			assert.NoError(t, err)
-			assert.Nil(t, overrides)
-		},
-		"MakeOverridesWithUnsupportedInstanceTypeReturnsNoOverrides": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
-			ec2Settings := &EC2ProviderSettings{
-				VpcName:      "my_vpc",
-				InstanceType: "not_supported",
-				SubnetId:     "subnet-654321",
-			}
-
-			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
-			assert.NoError(t, err)
-			assert.Nil(t, overrides)
-		},
-		"MakeOverridesWithOnlyTheHostsOwnSubnetReturnsNoOverrides": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
-			ec2Settings := &EC2ProviderSettings{
-				VpcName:      "my_vpc",
-				InstanceType: "instanceType0",
-				SubnetId:     "subnet-654321",
-			}
-
-			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
-			assert.NoError(t, err)
-			assert.Nil(t, overrides, "overriding with the launch template's own subnet would have no effect")
-		},
-		"MakeOverridesWithSubnetNotAvailableToHostReturnsNoOverrides": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
-			ec2Settings := &EC2ProviderSettings{
-				VpcName:      "my_vpc",
-				InstanceType: "instanceType0",
-				SubnetId:     "subnet-not-in-admin-settings",
-			}
-
-			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
-			assert.NoError(t, err)
-			assert.Nil(t, overrides)
-		},
-		"MakeOverridesReturnsEverySupportingSubnet": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
-			typeCache.cache[instanceTypeCacheKey{instanceType: "instanceType0", region: evergreen.DefaultEC2Region}] = cachedSubnets{
-				subnets: []evergreen.Subnet{{SubnetID: "subnet-654321"}, {SubnetID: "subnet-123456"}},
-			}
-			ec2Settings := &EC2ProviderSettings{
-				VpcName:      "my_vpc",
-				InstanceType: "instanceType0",
-				SubnetId:     "subnet-654321",
-			}
-
-			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
-			assert.NoError(t, err)
-			require.Len(t, overrides, 2)
-			assert.Equal(t, "subnet-654321", utility.FromStringPtr(overrides[0].SubnetId))
-			assert.Equal(t, "subnet-123456", utility.FromStringPtr(overrides[1].SubnetId))
-		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			tctx, tcancel := context.WithCancel(ctx)
@@ -460,7 +401,6 @@ func TestFleet(t *testing.T) {
 			require.NoError(t, db.Clear(host.Collection))
 			require.NoError(t, h.Insert(ctx))
 
-			resetTypeCache(t)
 			typeCache.cache[instanceTypeCacheKey{instanceType: "instanceType0", region: evergreen.DefaultEC2Region}] = cachedSubnets{
 				subnets: []evergreen.Subnet{{SubnetID: "subnet-654321"}},
 			}
@@ -663,28 +603,11 @@ func TestGetManagerForEc2Fleet(t *testing.T) {
 	assert.True(t, ok, "ec2-fleet provider should return an ec2FleetManager")
 }
 
-func subnetIDsFromOverrides(overrides []types.FleetLaunchTemplateOverridesRequest) []string {
-	ids := make([]string, 0, len(overrides))
-	for _, override := range overrides {
-		ids = append(ids, utility.FromStringPtr(override.SubnetId))
-	}
-	return ids
-}
-
-// resetTypeCache clears the package-level subnet cache so that tests don't
-// affect each other.
-func resetTypeCache(t *testing.T) {
-	typeCache = &instanceTypeSubnetCache{cache: map[instanceTypeCacheKey]cachedSubnets{}}
-	t.Cleanup(func() {
-		typeCache = &instanceTypeSubnetCache{cache: map[instanceTypeCacheKey]cachedSubnets{}}
-	})
-}
-
-func TestSubnetDiscovery(t *testing.T) {
+func TestMakeSubnetOverrides(t *testing.T) {
 	const (
 		account  = "some-account"
-		tagName  = "SubnetGroupName"
-		tagValue = "workloads"
+		tagName  = "subnet-group"
+		tagValue = "evergreen-subnet"
 	)
 	az := evergreen.DefaultEBSAvailabilityZone
 
@@ -732,7 +655,7 @@ func TestSubnetDiscovery(t *testing.T) {
 	}
 
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T){
-		"NonDefaultAccountDiscoversSubnets": func(ctx context.Context, t *testing.T) {
+		"NonDefaultAccountDiscoversSubnetsAndCachesThem": func(ctx context.Context, t *testing.T) {
 			m, client := makeManager(account)
 			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
 
@@ -742,18 +665,17 @@ func TestSubnetDiscovery(t *testing.T) {
 			assert.Equal(t, "subnet-discovered1", utility.FromStringPtr(overrides[0].SubnetId))
 			assert.Equal(t, "subnet-discovered2", utility.FromStringPtr(overrides[1].SubnetId))
 
-			require.NotNil(t, client.DescribeSubnetsInput)
+			require.NotZero(t, client.DescribeSubnetsInput)
 			require.Len(t, client.DescribeSubnetsInput.Filters, 1)
 			assert.Equal(t, "tag:"+tagName, utility.FromStringPtr(client.DescribeSubnetsInput.Filters[0].Name))
 			assert.Equal(t, []string{tagValue}, client.DescribeSubnetsInput.Filters[0].Values)
-		},
-		"NonDefaultAccountDoesNotNeedVpcName": func(ctx context.Context, t *testing.T) {
-			m, _ := makeManager(account)
-			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
 
-			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
-			require.NoError(t, err)
-			assert.Len(t, overrides, 2, "a non-default account should opt in without a VPC name")
+			for range 3 {
+				overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+				require.NoError(t, err)
+				assert.Len(t, overrides, 2)
+			}
+			assert.Equal(t, 1, client.DescribeSubnetsCount, "already-discovered subnets are cached")
 		},
 		"DefaultAccountUsesAdminSettingsSubnets": func(ctx context.Context, t *testing.T) {
 			m, client := makeManager("")
@@ -770,37 +692,21 @@ func TestSubnetDiscovery(t *testing.T) {
 			assert.Equal(t, "subnet-from-admin-settings2", utility.FromStringPtr(overrides[1].SubnetId))
 			assert.Zero(t, client.DescribeSubnetsCount, "default account should not discover subnets")
 		},
-		"DiscoveryErrorReturnsNoOverrides": func(ctx context.Context, t *testing.T) {
+		"DiscoveryErrorReturnsNoOverridesAndCachesFailure": func(ctx context.Context, t *testing.T) {
 			m, client := makeManager(account)
 			client.DescribeSubnetsError = errors.New("not authorized to describe subnets")
 			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
 
 			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
-			assert.NoError(t, err, "discovery failure should not prevent the host from spawning")
-			assert.Nil(t, overrides)
-		},
-		"DiscoveryErrorIsCached": func(ctx context.Context, t *testing.T) {
-			m, client := makeManager(account)
-			client.DescribeSubnetsError = errors.New("not authorized to describe subnets")
-			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
+			assert.NoError(t, err)
+			assert.Zero(t, overrides)
 
-			for range 3 {
+			for range 10 {
 				overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
-				require.NoError(t, err)
-				assert.Nil(t, overrides)
+				assert.NoError(t, err)
+				assert.Zero(t, overrides)
 			}
-			assert.Equal(t, 1, client.DescribeSubnetsCount, "a failed discovery should not be retried")
-		},
-		"DiscoveryResultIsCached": func(ctx context.Context, t *testing.T) {
-			m, client := makeManager(account)
-			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
-
-			for range 3 {
-				overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
-				require.NoError(t, err)
-				assert.Len(t, overrides, 2)
-			}
-			assert.Equal(t, 1, client.DescribeSubnetsCount)
+			assert.Equal(t, 1, client.DescribeSubnetsCount, "failed subnet discovery API calls should not be retried")
 		},
 		"UntaggedSubnetsAreTreatedAsFailure": func(ctx context.Context, t *testing.T) {
 			m, client := makeManager(account)
@@ -809,11 +715,11 @@ func TestSubnetDiscovery(t *testing.T) {
 
 			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
 			require.NoError(t, err)
-			assert.Nil(t, overrides)
+			assert.Zero(t, overrides)
 
 			_, err = m.makeSubnetOverrides(ctx, h, ec2Settings)
 			require.NoError(t, err)
-			assert.Equal(t, 1, client.DescribeSubnetsCount, "finding no tagged subnets should be cached")
+			assert.Equal(t, 1, client.DescribeSubnetsCount, "discovering no tagged subnets should be cached")
 		},
 		"MissingTagSettingsSkipsDiscovery": func(ctx context.Context, t *testing.T) {
 			m, client := makeManager(account)
@@ -823,18 +729,19 @@ func TestSubnetDiscovery(t *testing.T) {
 
 			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
 			require.NoError(t, err)
-			assert.Nil(t, overrides)
+			assert.Zero(t, overrides)
 			assert.Zero(t, client.DescribeSubnetsCount)
 		},
-		"HostSubnetNotDiscoveredReturnsNoOverrides": func(ctx context.Context, t *testing.T) {
-			m, _ := makeManager(account)
-			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-untagged"}
+		"UnsupportedInstanceTypeReturnsNoOverridesAndCachesFailure": func(ctx context.Context, t *testing.T) {
+			m, client := makeManager(account)
+			client.DescribeInstanceTypeOfferingsOutput = &ec2.DescribeInstanceTypeOfferingsOutput{}
+			ec2Settings := &EC2ProviderSettings{InstanceType: "not_supported", SubnetId: "subnet-discovered1"}
 
 			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
 			require.NoError(t, err)
-			assert.Nil(t, overrides, "the host's subnet must be one of the options to override it")
+			assert.Zero(t, overrides)
 		},
-		"CacheIsNotSharedBetweenAccounts": func(ctx context.Context, t *testing.T) {
+		"CachedSubnetsAreNotSharedBetweenAccounts": func(ctx context.Context, t *testing.T) {
 			defaultManager, defaultClient := makeManager("")
 			defaultSettings := &EC2ProviderSettings{
 				VpcName:      "my_vpc",
@@ -844,49 +751,27 @@ func TestSubnetDiscovery(t *testing.T) {
 			overrides, err := defaultManager.makeSubnetOverrides(ctx, h, defaultSettings)
 			require.NoError(t, err)
 			require.Len(t, overrides, 2)
-			assert.Equal(t, []string{"subnet-from-admin-settings1", "subnet-from-admin-settings2"}, subnetIDsFromOverrides(overrides))
+			assert.Equal(t, "subnet-from-admin-settings1", utility.FromStringPtr(overrides[0].SubnetId))
+			assert.Equal(t, "subnet-from-admin-settings2", utility.FromStringPtr(overrides[1].SubnetId))
 
 			otherManager, _ := makeManager(account)
 			otherSettings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
 			overrides, err = otherManager.makeSubnetOverrides(ctx, h, otherSettings)
 			require.NoError(t, err)
-			require.Len(t, overrides, 2, "the other account should not reuse the default account's subnets")
+			require.Len(t, overrides, 2, "the other account should not use the default account's subnets")
+			assert.Equal(t, "subnet-discovered1", utility.FromStringPtr(overrides[0].SubnetId))
+			assert.Equal(t, "subnet-discovered2", utility.FromStringPtr(overrides[1].SubnetId))
 			assert.Zero(t, defaultClient.DescribeSubnetsCount)
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			resetTypeCache(t)
+			typeCache = &instanceTypeSubnetCache{cache: map[instanceTypeCacheKey]cachedSubnets{}}
+			t.Cleanup(func() {
+				typeCache = &instanceTypeSubnetCache{cache: map[instanceTypeCacheKey]cachedSubnets{}}
+			})
 			tCase(t.Context(), t)
 		})
 	}
-}
-
-func TestInstanceTypeSubnetCacheSet(t *testing.T) {
-	instanceRegion := instanceTypeCacheKey{instanceType: "instanceType0", region: evergreen.DefaultEC2Region}
-	success := cachedSubnets{subnets: []evergreen.Subnet{{SubnetID: "sn0"}}}
-	failure := cachedSubnets{err: errors.New("could not discover subnets")}
-
-	t.Run("FailureDoesNotReplaceSuccess", func(t *testing.T) {
-		cache := &instanceTypeSubnetCache{cache: map[instanceTypeCacheKey]cachedSubnets{}}
-		cache.set(instanceRegion, success)
-		cache.set(instanceRegion, failure)
-
-		cached, ok := cache.get(instanceRegion)
-		require.True(t, ok)
-		assert.NoError(t, cached.err, "a failure racing with a success should not be cached")
-		require.Len(t, cached.subnets, 1)
-		assert.Equal(t, "sn0", cached.subnets[0].SubnetID)
-	})
-	t.Run("SuccessReplacesFailure", func(t *testing.T) {
-		cache := &instanceTypeSubnetCache{cache: map[instanceTypeCacheKey]cachedSubnets{}}
-		cache.set(instanceRegion, failure)
-		cache.set(instanceRegion, success)
-
-		cached, ok := cache.get(instanceRegion)
-		require.True(t, ok)
-		assert.NoError(t, cached.err)
-		assert.Len(t, cached.subnets, 1)
-	})
 }
 
 func TestInstanceTypeAZCache(t *testing.T) {

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/host"
+	"github.com/evergreen-ci/utility"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -377,31 +378,64 @@ func TestFleet(t *testing.T) {
 			assert.Len(t, client.CreateFleetInput.LaunchTemplateConfigs, 1)
 			assert.Equal(t, "ht_1", *client.CreateFleetInput.LaunchTemplateConfigs[0].LaunchTemplateSpecification.LaunchTemplateName)
 		},
-		"MakeOverrides": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
+		"MakeOverridesWithoutVpcNameInDefaultAccountReturnsNoOverrides": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
 			ec2Settings := &EC2ProviderSettings{
-				InstanceType:          "instanceType0",
-				IAMInstanceProfileARN: "my-profile",
+				InstanceType: "instanceType0",
+				SubnetId:     "subnet-654321",
 			}
-			overrides, err := m.makeOverrides(ctx, ec2Settings)
-			assert.NoError(t, err)
-			require.Len(t, overrides, 1)
-			assert.Equal(t, "subnet-654321", *overrides[0].SubnetId)
 
-			ec2Settings = &EC2ProviderSettings{
+			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+			assert.NoError(t, err)
+			assert.Nil(t, overrides)
+		},
+		"MakeOverridesWithUnsupportedInstanceTypeReturnsNoOverrides": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
+			ec2Settings := &EC2ProviderSettings{
+				VpcName:      "my_vpc",
 				InstanceType: "not_supported",
+				SubnetId:     "subnet-654321",
 			}
-			overrides, err = m.makeOverrides(ctx, ec2Settings)
-			assert.NoError(t, err)
-			assert.Nil(t, overrides)
 
-			ec2Settings = &EC2ProviderSettings{
-				InstanceType:          "instanceType0",
-				IAMInstanceProfileARN: "my-profile",
-				SubnetId:              "subnet-654321",
-			}
-			overrides, err = m.makeOverrides(ctx, ec2Settings)
+			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
 			assert.NoError(t, err)
 			assert.Nil(t, overrides)
+		},
+		"MakeOverridesWithOnlyTheHostsOwnSubnetReturnsNoOverrides": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
+			ec2Settings := &EC2ProviderSettings{
+				VpcName:      "my_vpc",
+				InstanceType: "instanceType0",
+				SubnetId:     "subnet-654321",
+			}
+
+			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+			assert.NoError(t, err)
+			assert.Nil(t, overrides, "overriding with the launch template's own subnet would have no effect")
+		},
+		"MakeOverridesWithSubnetNotAvailableToHostReturnsNoOverrides": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
+			ec2Settings := &EC2ProviderSettings{
+				VpcName:      "my_vpc",
+				InstanceType: "instanceType0",
+				SubnetId:     "subnet-not-in-admin-settings",
+			}
+
+			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+			assert.NoError(t, err)
+			assert.Nil(t, overrides)
+		},
+		"MakeOverridesReturnsEverySupportingSubnet": func(ctx context.Context, t *testing.T, m *ec2FleetManager, client *awsClientMock, h *host.Host) {
+			typeCache.cache[instanceTypeCacheKey{instanceType: "instanceType0", region: evergreen.DefaultEC2Region}] = cachedSubnets{
+				subnets: []evergreen.Subnet{{SubnetID: "subnet-654321"}, {SubnetID: "subnet-123456"}},
+			}
+			ec2Settings := &EC2ProviderSettings{
+				VpcName:      "my_vpc",
+				InstanceType: "instanceType0",
+				SubnetId:     "subnet-654321",
+			}
+
+			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+			assert.NoError(t, err)
+			require.Len(t, overrides, 2)
+			assert.Equal(t, "subnet-654321", utility.FromStringPtr(overrides[0].SubnetId))
+			assert.Equal(t, "subnet-123456", utility.FromStringPtr(overrides[1].SubnetId))
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -426,8 +460,11 @@ func TestFleet(t *testing.T) {
 			require.NoError(t, db.Clear(host.Collection))
 			require.NoError(t, h.Insert(ctx))
 
-			typeCache[instanceRegionPair{instanceType: "instanceType0", region: evergreen.DefaultEC2Region}] = []evergreen.Subnet{{SubnetID: "subnet-654321"}}
-			typeCache[instanceRegionPair{instanceType: "not_supported", region: evergreen.DefaultEC2Region}] = []evergreen.Subnet{}
+			resetTypeCache(t)
+			typeCache.cache[instanceTypeCacheKey{instanceType: "instanceType0", region: evergreen.DefaultEC2Region}] = cachedSubnets{
+				subnets: []evergreen.Subnet{{SubnetID: "subnet-654321"}},
+			}
+			typeCache.cache[instanceTypeCacheKey{instanceType: "not_supported", region: evergreen.DefaultEC2Region}] = cachedSubnets{}
 
 			env := &mock.Environment{}
 			require.NoError(t, env.Configure(ctx))
@@ -626,8 +663,234 @@ func TestGetManagerForEc2Fleet(t *testing.T) {
 	assert.True(t, ok, "ec2-fleet provider should return an ec2FleetManager")
 }
 
+func subnetIDsFromOverrides(overrides []types.FleetLaunchTemplateOverridesRequest) []string {
+	ids := make([]string, 0, len(overrides))
+	for _, override := range overrides {
+		ids = append(ids, utility.FromStringPtr(override.SubnetId))
+	}
+	return ids
+}
+
+// resetTypeCache clears the package-level subnet cache so that tests don't
+// affect each other.
+func resetTypeCache(t *testing.T) {
+	typeCache = &instanceTypeSubnetCache{cache: map[instanceTypeCacheKey]cachedSubnets{}}
+	t.Cleanup(func() {
+		typeCache = &instanceTypeSubnetCache{cache: map[instanceTypeCacheKey]cachedSubnets{}}
+	})
+}
+
+func TestSubnetDiscovery(t *testing.T) {
+	const (
+		account  = "some-account"
+		tagName  = "SubnetGroupName"
+		tagValue = "workloads"
+	)
+	az := evergreen.DefaultEBSAvailabilityZone
+
+	makeManager := func(account string) (*ec2FleetManager, *awsClientMock) {
+		client := &awsClientMock{
+			DescribeInstanceTypeOfferingsOutput: &ec2.DescribeInstanceTypeOfferingsOutput{
+				InstanceTypeOfferings: []types.InstanceTypeOffering{
+					{InstanceType: "instanceType0", Location: aws.String(az)},
+				},
+			},
+			DescribeSubnetsOutput: &ec2.DescribeSubnetsOutput{
+				Subnets: []types.Subnet{
+					{SubnetId: aws.String("subnet-discovered1"), AvailabilityZone: aws.String(az)},
+					{SubnetId: aws.String("subnet-discovered2"), AvailabilityZone: aws.String(az)},
+				},
+			},
+		}
+		return &ec2FleetManager{
+			EC2FleetManagerOptions: &EC2FleetManagerOptions{
+				client:  client,
+				region:  evergreen.DefaultEC2Region,
+				account: account,
+			},
+			settings: &evergreen.Settings{
+				Providers: evergreen.CloudProviders{
+					AWS: evergreen.AWSConfig{
+						Subnets: []evergreen.Subnet{
+							{AZ: az, SubnetID: "subnet-from-admin-settings1"},
+							{AZ: az, SubnetID: "subnet-from-admin-settings2"},
+						},
+						SubnetTagName:  tagName,
+						SubnetTagValue: tagValue,
+					},
+				},
+			},
+		}, client
+	}
+
+	h := &host.Host{
+		Id: "h1",
+		Distro: distro.Distro{
+			Id:       "d1",
+			Provider: evergreen.ProviderNameEc2Fleet,
+		},
+	}
+
+	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T){
+		"NonDefaultAccountDiscoversSubnets": func(ctx context.Context, t *testing.T) {
+			m, client := makeManager(account)
+			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
+
+			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+			require.NoError(t, err)
+			require.Len(t, overrides, 2)
+			assert.Equal(t, "subnet-discovered1", utility.FromStringPtr(overrides[0].SubnetId))
+			assert.Equal(t, "subnet-discovered2", utility.FromStringPtr(overrides[1].SubnetId))
+
+			require.NotNil(t, client.DescribeSubnetsInput)
+			require.Len(t, client.DescribeSubnetsInput.Filters, 1)
+			assert.Equal(t, "tag:"+tagName, utility.FromStringPtr(client.DescribeSubnetsInput.Filters[0].Name))
+			assert.Equal(t, []string{tagValue}, client.DescribeSubnetsInput.Filters[0].Values)
+		},
+		"NonDefaultAccountDoesNotNeedVpcName": func(ctx context.Context, t *testing.T) {
+			m, _ := makeManager(account)
+			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
+
+			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+			require.NoError(t, err)
+			assert.Len(t, overrides, 2, "a non-default account should opt in without a VPC name")
+		},
+		"DefaultAccountUsesAdminSettingsSubnets": func(ctx context.Context, t *testing.T) {
+			m, client := makeManager("")
+			ec2Settings := &EC2ProviderSettings{
+				VpcName:      "my_vpc",
+				InstanceType: "instanceType0",
+				SubnetId:     "subnet-from-admin-settings1",
+			}
+
+			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+			require.NoError(t, err)
+			require.Len(t, overrides, 2)
+			assert.Equal(t, "subnet-from-admin-settings1", utility.FromStringPtr(overrides[0].SubnetId))
+			assert.Equal(t, "subnet-from-admin-settings2", utility.FromStringPtr(overrides[1].SubnetId))
+			assert.Zero(t, client.DescribeSubnetsCount, "default account should not discover subnets")
+		},
+		"DiscoveryErrorReturnsNoOverrides": func(ctx context.Context, t *testing.T) {
+			m, client := makeManager(account)
+			client.DescribeSubnetsError = errors.New("not authorized to describe subnets")
+			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
+
+			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+			assert.NoError(t, err, "discovery failure should not prevent the host from spawning")
+			assert.Nil(t, overrides)
+		},
+		"DiscoveryErrorIsCached": func(ctx context.Context, t *testing.T) {
+			m, client := makeManager(account)
+			client.DescribeSubnetsError = errors.New("not authorized to describe subnets")
+			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
+
+			for range 3 {
+				overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+				require.NoError(t, err)
+				assert.Nil(t, overrides)
+			}
+			assert.Equal(t, 1, client.DescribeSubnetsCount, "a failed discovery should not be retried")
+		},
+		"DiscoveryResultIsCached": func(ctx context.Context, t *testing.T) {
+			m, client := makeManager(account)
+			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
+
+			for range 3 {
+				overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+				require.NoError(t, err)
+				assert.Len(t, overrides, 2)
+			}
+			assert.Equal(t, 1, client.DescribeSubnetsCount)
+		},
+		"UntaggedSubnetsAreTreatedAsFailure": func(ctx context.Context, t *testing.T) {
+			m, client := makeManager(account)
+			client.DescribeSubnetsOutput = &ec2.DescribeSubnetsOutput{}
+			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
+
+			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+			require.NoError(t, err)
+			assert.Nil(t, overrides)
+
+			_, err = m.makeSubnetOverrides(ctx, h, ec2Settings)
+			require.NoError(t, err)
+			assert.Equal(t, 1, client.DescribeSubnetsCount, "finding no tagged subnets should be cached")
+		},
+		"MissingTagSettingsSkipsDiscovery": func(ctx context.Context, t *testing.T) {
+			m, client := makeManager(account)
+			m.settings.Providers.AWS.SubnetTagName = ""
+			m.settings.Providers.AWS.SubnetTagValue = ""
+			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
+
+			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+			require.NoError(t, err)
+			assert.Nil(t, overrides)
+			assert.Zero(t, client.DescribeSubnetsCount)
+		},
+		"HostSubnetNotDiscoveredReturnsNoOverrides": func(ctx context.Context, t *testing.T) {
+			m, _ := makeManager(account)
+			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-untagged"}
+
+			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+			require.NoError(t, err)
+			assert.Nil(t, overrides, "the host's subnet must be one of the options to override it")
+		},
+		"CacheIsNotSharedBetweenAccounts": func(ctx context.Context, t *testing.T) {
+			defaultManager, defaultClient := makeManager("")
+			defaultSettings := &EC2ProviderSettings{
+				VpcName:      "my_vpc",
+				InstanceType: "instanceType0",
+				SubnetId:     "subnet-from-admin-settings1",
+			}
+			overrides, err := defaultManager.makeSubnetOverrides(ctx, h, defaultSettings)
+			require.NoError(t, err)
+			require.Len(t, overrides, 2)
+			assert.Equal(t, []string{"subnet-from-admin-settings1", "subnet-from-admin-settings2"}, subnetIDsFromOverrides(overrides))
+
+			otherManager, _ := makeManager(account)
+			otherSettings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
+			overrides, err = otherManager.makeSubnetOverrides(ctx, h, otherSettings)
+			require.NoError(t, err)
+			require.Len(t, overrides, 2, "the other account should not reuse the default account's subnets")
+			assert.Zero(t, defaultClient.DescribeSubnetsCount)
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			resetTypeCache(t)
+			tCase(t.Context(), t)
+		})
+	}
+}
+
+func TestInstanceTypeSubnetCacheSet(t *testing.T) {
+	instanceRegion := instanceTypeCacheKey{instanceType: "instanceType0", region: evergreen.DefaultEC2Region}
+	success := cachedSubnets{subnets: []evergreen.Subnet{{SubnetID: "sn0"}}}
+	failure := cachedSubnets{err: errors.New("could not discover subnets")}
+
+	t.Run("FailureDoesNotReplaceSuccess", func(t *testing.T) {
+		cache := &instanceTypeSubnetCache{cache: map[instanceTypeCacheKey]cachedSubnets{}}
+		cache.set(instanceRegion, success)
+		cache.set(instanceRegion, failure)
+
+		cached, ok := cache.get(instanceRegion)
+		require.True(t, ok)
+		assert.NoError(t, cached.err, "a failure racing with a success should not be cached")
+		require.Len(t, cached.subnets, 1)
+		assert.Equal(t, "sn0", cached.subnets[0].SubnetID)
+	})
+	t.Run("SuccessReplacesFailure", func(t *testing.T) {
+		cache := &instanceTypeSubnetCache{cache: map[instanceTypeCacheKey]cachedSubnets{}}
+		cache.set(instanceRegion, failure)
+		cache.set(instanceRegion, success)
+
+		cached, ok := cache.get(instanceRegion)
+		require.True(t, ok)
+		assert.NoError(t, cached.err)
+		assert.Len(t, cached.subnets, 1)
+	})
+}
+
 func TestInstanceTypeAZCache(t *testing.T) {
-	cache := instanceTypeSubnetCache{}
+	cache := &instanceTypeSubnetCache{cache: map[instanceTypeCacheKey]cachedSubnets{}}
 	defaultRegionClient := &awsClientMock{
 		DescribeInstanceTypeOfferingsOutput: &ec2.DescribeInstanceTypeOfferingsOutput{
 			InstanceTypeOfferings: []types.InstanceTypeOffering{
@@ -641,19 +904,19 @@ func TestInstanceTypeAZCache(t *testing.T) {
 	settings := &evergreen.Settings{}
 	settings.Providers.AWS.Subnets = []evergreen.Subnet{{SubnetID: "sn0", AZ: evergreen.DefaultEBSAvailabilityZone}}
 
-	azsWithInstanceType, err := cache.subnetsWithInstanceType(t.Context(), settings, defaultRegionClient, instanceRegionPair{instanceType: "instanceType0", region: evergreen.DefaultEC2Region})
+	azsWithInstanceType, err := cache.subnetsWithInstanceType(t.Context(), settings, defaultRegionClient, instanceTypeCacheKey{instanceType: "instanceType0", region: evergreen.DefaultEC2Region})
 	assert.NoError(t, err)
 	assert.Len(t, azsWithInstanceType, 1)
 	assert.Equal(t, "sn0", azsWithInstanceType[0].SubnetID)
 
 	// cache is populated
-	subnets, ok := cache[instanceRegionPair{instanceType: "instanceType0", region: evergreen.DefaultEC2Region}]
+	cached, ok := cache.cache[instanceTypeCacheKey{instanceType: "instanceType0", region: evergreen.DefaultEC2Region}]
 	assert.True(t, ok)
-	assert.Len(t, subnets, 1)
+	assert.Len(t, cached.subnets, 1)
 
 	// unsupported instance type
 	defaultRegionClient.DescribeInstanceTypeOfferingsOutput = &ec2.DescribeInstanceTypeOfferingsOutput{}
-	azsWithInstanceType, err = cache.subnetsWithInstanceType(t.Context(), settings, defaultRegionClient, instanceRegionPair{instanceType: "not_supported", region: evergreen.DefaultEC2Region})
+	azsWithInstanceType, err = cache.subnetsWithInstanceType(t.Context(), settings, defaultRegionClient, instanceTypeCacheKey{instanceType: "not_supported", region: evergreen.DefaultEC2Region})
 	assert.NoError(t, err)
 	assert.Empty(t, azsWithInstanceType)
 }

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -611,6 +611,20 @@ func TestMakeSubnetOverrides(t *testing.T) {
 	)
 	az := evergreen.DefaultEBSAvailabilityZone
 
+	expireCachedFailures := func() {
+		typeCache.mu.Lock()
+		defer typeCache.mu.Unlock()
+
+		for key, cached := range typeCache.cache {
+			if cached.err == nil {
+				continue
+			}
+			// Update the error TTL so the cache considers the error stale.
+			cached.errExpiresAt = time.Now().Add(-time.Minute)
+			typeCache.cache[key] = cached
+		}
+	}
+
 	makeManager := func(account string) (*ec2FleetManager, *awsClientMock) {
 		client := &awsClientMock{
 			DescribeInstanceTypeOfferingsOutput: &ec2.DescribeInstanceTypeOfferingsOutput{
@@ -708,6 +722,24 @@ func TestMakeSubnetOverrides(t *testing.T) {
 			}
 			assert.Equal(t, 1, client.DescribeSubnetsCount, "failed subnet discovery API calls should not be retried")
 		},
+		"DiscoveryIsRetriedOnceTheCachedFailureExpires": func(ctx context.Context, t *testing.T) {
+			m, client := makeManager(account)
+			client.DescribeSubnetsError = errors.New("not authorized to describe subnets")
+			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
+
+			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+			require.NoError(t, err)
+			assert.Zero(t, overrides)
+			require.Equal(t, 1, client.DescribeSubnetsCount)
+
+			expireCachedFailures()
+			client.DescribeSubnetsError = nil
+
+			overrides, err = m.makeSubnetOverrides(ctx, h, ec2Settings)
+			require.NoError(t, err)
+			assert.Len(t, overrides, 2, "discovery should recover once the cached failure expires")
+			assert.Equal(t, 2, client.DescribeSubnetsCount)
+		},
 		"UntaggedSubnetsAreTreatedAsFailure": func(ctx context.Context, t *testing.T) {
 			m, client := makeManager(account)
 			client.DescribeSubnetsOutput = &ec2.DescribeSubnetsOutput{}
@@ -740,6 +772,27 @@ func TestMakeSubnetOverrides(t *testing.T) {
 			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
 			require.NoError(t, err)
 			assert.Zero(t, overrides)
+		},
+		"AvailabilityZoneLookupIsRetriedOnceTheCachedFailureExpires": func(ctx context.Context, t *testing.T) {
+			m, client := makeManager(account)
+			client.DescribeInstanceTypeOfferingsError = errors.New("rate exceeded")
+			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
+
+			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+			require.NoError(t, err)
+			assert.Zero(t, overrides)
+
+			_, err = m.makeSubnetOverrides(ctx, h, ec2Settings)
+			require.NoError(t, err)
+			require.Equal(t, 1, client.DescribeInstanceTypeOfferingsCount, "failed AZ lookups should not be retried until the cached failure expires")
+
+			expireCachedFailures()
+			client.DescribeInstanceTypeOfferingsError = nil
+
+			overrides, err = m.makeSubnetOverrides(ctx, h, ec2Settings)
+			require.NoError(t, err)
+			assert.Len(t, overrides, 2, "the AZ lookup should recover once the cached failure expires")
+			assert.Equal(t, 2, client.DescribeInstanceTypeOfferingsCount)
 		},
 		"CachedSubnetsAreNotSharedBetweenAccounts": func(ctx context.Context, t *testing.T) {
 			defaultManager, defaultClient := makeManager("")

--- a/cloud/ec2_util.go
+++ b/cloud/ec2_util.go
@@ -672,12 +672,16 @@ func ValidVolumeOptions(v *host.Volume, s *evergreen.Settings) error {
 		catcher.Errorf("invalid volume type '%s', valid EBS volume types are: %s", v.Type, ValidVolumeTypes)
 	}
 
-	_, err := getSubnetForZone(s.Providers.AWS.Subnets, v.AvailabilityZone)
+	// Spawn hosts/volumes are only supported in the default AWS account
+	// currently, so only look for subnets in the default account.
+	_, err := getSubnetForZoneInDefaultAccount(s.Providers.AWS.Subnets, v.AvailabilityZone)
 	catcher.Add(err)
 	return catcher.Resolve()
 }
 
-func getSubnetForZone(subnets []evergreen.Subnet, zone string) (string, error) {
+// getSubnetForZoneInDefaultAccount gets a subnet that is in the given
+// availability zone. This only supports subnets in the default AWS account.
+func getSubnetForZoneInDefaultAccount(subnets []evergreen.Subnet, zone string) (string, error) {
 	zones := []string{}
 	for _, subnet := range subnets {
 		if subnet.AZ == zone {

--- a/cloud/spawn.go
+++ b/cloud/spawn.go
@@ -515,7 +515,9 @@ func modifySpawnHostProviderSettings(ctx context.Context, d distro.Distro, setti
 			return nil, errors.Wrapf(err, "getting volume '%s'", volumeID)
 		}
 
-		ec2Settings.SubnetId, err = getSubnetForZone(settings.Providers.AWS.Subnets, volume.AvailabilityZone)
+		// Spawn hosts/volumes are only supported in the default AWS account
+		// currently, so only look for subnets in the default account.
+		ec2Settings.SubnetId, err = getSubnetForZoneInDefaultAccount(settings.Providers.AWS.Subnets, volume.AvailabilityZone)
 		if err != nil {
 			return nil, errors.Wrapf(err, "getting subnet for AZ '%s'", volume.AvailabilityZone)
 		}


### PR DESCRIPTION
DEVPROD-32852

### Description

Follow-up to #10632.

* Discover available subnets that a host can use based on the account it's spawning in.
    * For hosts starting in the default AWS account (i.e. kernel-build), use the list of subnets in the admin settings to figure out which ones the host can use (this is how it already was, and we're just leaving it like this since the default AWS account has a bespoke/legacy setup).
    * For hosts starting in a non-default AWS account, dynamically discover which subnets the host can use using the AWS API (this is the new behavior).
* Rename `getSubnetForZone` to make it explicit that volumes can only spawn in the default AWS account currently.
    * Note: this isn't a logical change, but thought it would be worth calling out explicitly that the spawn hosts and volumes are _not_ currently supported in other AWS accounts (there are other changes beyond the scope of this ticket that would need to happen for them to work).

### Testing

* Tested in staging by creating a [staging distro](https://spruce-staging.corp.mongodb.com/distro/DEVPROD-32852-non-default-test-127372371477/settings/host) with 1 min host and confirmed that the host came up. Also confirmed that the request to create the fleet specified multiple different subnets that it discovered dynamically.
* Added unit tests.