### PR TITLE
PLATFORMS-2442: Activate container isolation for enabled distros

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -297,7 +297,7 @@ func (a *Agent) loop(ctx context.Context) error {
 			// Single task distros should exit after running a single task.
 			// However, if the task group needs tearing down, we should continue
 			// the loop so the teardown group can run in the next iteration.
-			if !needTeardownGroup && a.opts.SingleTaskDistro {
+			if a.opts.SingleTaskDistro && (ntr.taskErrored || !needTeardownGroup) {
 				return a.comm.DisableHost(ctx, a.opts.HostID, apimodels.DisableInfo{Reason: "Single task distro ran a task"})
 			}
 			if ntr.shouldExit {
@@ -330,6 +330,7 @@ type processNextResponse struct {
 	shouldExit        bool
 	noTaskToRun       bool
 	needTeardownGroup bool
+	taskErrored       bool
 	tc                *taskContext
 }
 
@@ -426,6 +427,7 @@ func (a *Agent) processNextTask(ctx context.Context, nt *apimodels.NextTaskRespo
 			tc: tc,
 			// Teardown is safe even when setup failed before a container was created.
 			needTeardownGroup: true,
+			taskErrored:       true,
 		}, nil
 	}
 	if shouldExit {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -235,6 +235,7 @@ func (a *Agent) Start(ctx context.Context) error {
 	}
 	if a.opts.Cleanup {
 		a.tryCleanupDirectory(ctx, a.opts.WorkingDirectory)
+		a.tryReapOrphanContainers(ctx)
 	}
 
 	return errors.Wrap(a.loop(ctx), "executing main agent loop")
@@ -259,6 +260,19 @@ func (a *Agent) loop(ctx context.Context) error {
 			// shutting down, close the logger to flush the remaining logs.
 			grip.Error(ctx, errors.Wrap(tc.logger.Close(), "closing logger"))
 		}
+	}()
+	// Destroy any active isolation container when the loop exits (ctx
+	// cancellation, agent shutdown, or unrecoverable error), so we don't
+	// leak containers that would otherwise only be cleaned up by teardown
+	// group commands which may never run on an abnormal exit path.
+	// Use a detached background context with a bounded timeout: the loop
+	// ctx is already cancelled on the shutdown path, which would cause
+	// ContainerRemove to fail immediately and leave the container running
+	// until the next --cleanup reaper.
+	defer func() {
+		destroyCtx, destroyCancel := context.WithTimeout(context.Background(), reaperTimeout)
+		defer destroyCancel()
+		a.destroyContainer(destroyCtx, tc.taskConfig)
 	}()
 
 	for {
@@ -405,13 +419,26 @@ func (a *Agent) processNextTask(ctx context.Context, nt *apimodels.NextTaskRespo
 	tc, shouldExit, err := a.runTask(ctx, nil, nt, shouldSetupGroup, taskDirectory)
 	if err != nil {
 		span.SetStatus(codes.Error, "error running task")
-		span.RecordError(err, trace.WithAttributes(attribute.String("task.id", tc.task.ID)), trace.WithStackTrace(true))
+		taskID := ""
+		if tc != nil {
+			taskID = tc.task.ID
+		}
+		span.RecordError(err, trace.WithAttributes(attribute.String("task.id", taskID)), trace.WithStackTrace(true))
 		grip.Critical(ctx, message.WrapError(err, message.Fields{
 			"message": "error running task",
-			"task":    tc.task.ID,
+			"task":    taskID,
 		}))
 		return processNextResponse{
 			tc: tc,
+			// Trigger teardown on the next iteration so the task-group isolation
+			// container is destroyed rather than leaked. Note: this causes
+			// runTeardownGroupCommands to execute real teardown-group scripts in
+			// addition to destroying the container. On a broken host that is
+			// acceptable: teardown scripts failing is logged and non-fatal, and
+			// the container cleanup is the primary goal. The loop-exit defer also
+			// calls destroyContainer as a fallback if the agent exits before the
+			// next iteration runs.
+			needTeardownGroup: true,
 		}, nil
 	}
 	if shouldExit {
@@ -726,6 +753,15 @@ func (a *Agent) runTask(ctx context.Context, tcInput *taskContext, nt *apimodels
 			}
 		}
 	}()
+
+	if err := a.maybeStartContainer(tskCtx, tc.taskConfig, tc.logger.Execution()); err != nil {
+		// maybeStartContainer returns a non-nil error only on the fail-closed path
+		// (require_isolation=true). The fail-open path handles its own degradation
+		// internally and returns nil. Route through handleSetupError so the task
+		// is finalized as TaskSystemFailed on the server — returning a bare error
+		// here would leave the task unfinalized (stuck in "started" state).
+		return a.handleSetupError(tskCtx, tc, errors.Wrap(err, "starting required isolation container"))
+	}
 
 	grip.Info(ctx, message.Fields{
 		"message": "running task",
@@ -1100,6 +1136,10 @@ func (a *Agent) runTeardownGroupCommands(ctx context.Context, tc *taskContext) {
 	if tc.taskConfig == nil {
 		return
 	}
+	// Destroy the task-group isolation container after teardown commands
+	// complete but before the task directory is removed, so that the bind
+	// mount is released before we attempt to delete its source path.
+	defer a.destroyContainer(ctx, tc.taskConfig)
 	// Only killProcs if tc.taskConfig is not nil. This avoids passing an
 	// empty working directory to killProcs, and is okay because this
 	// killProcs is only for the processes run in runTeardownGroupCommands.
@@ -1183,6 +1223,20 @@ func (a *Agent) handleTimeoutAndOOM(ctx context.Context, tc *taskContext, detail
 		} else {
 			tc.logger.Execution().Debugf(ctx, "Found no OOM kill (in %.3f seconds).", time.Since(startTime).Seconds())
 		}
+	}
+	// Supplement the dmesg-based OOM report with the container-native signal,
+	// emit the failure snapshot, and schedule retention on task failure.
+	if detail.Status == evergreen.TaskFailed || detail.TimedOut {
+		a.augmentOOMTrackerWithContainerSignal(ctx, tc, detail)
+		a.emitContainerFailureSnapshot(ctx, tc, detail)
+		if a.currentContainer != nil {
+			a.scheduleContainerRetention(ctx, a.currentContainer.GetName())
+		}
+	} else {
+		// Task succeeded — clear any retention window set by a prior failed
+		// task in this group so the container is cleanly destroyed at teardown
+		// rather than leaked until the orphan reaper.
+		a.retainContainerUntil = time.Time{}
 	}
 
 	if rcInfo := tc.resourceMonitor.report(); rcInfo != nil {
@@ -1566,17 +1620,59 @@ func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupC
 
 	catcher := grip.NewBasicCatcher()
 	if tc.task.ID != "" && tc.taskConfig != nil && tc.taskConfig.Distro != nil {
-		logger.Infof(ctx, "Cleaning up processes for task: '%s'.", tc.task.ID)
-		if err := agentutil.KillSpawnedProcs(ctx, tc.task.ID, tc.taskConfig.WorkDir, tc.taskConfig.Distro.ExecUser, logger); err != nil {
-			catcher.Wrap(err, "cleaning up spawned processes")
-			// If the host is in a state where ps is timing out we need human intervention.
-			if psErr := errors.Cause(err); psErr == agentutil.ErrPSTimeout {
-				disableErr := a.comm.DisableHost(ctx, a.opts.HostID, apimodels.DisableInfo{Reason: psErr.Error()})
-				logger.CriticalWhen(ctx, disableErr != nil, errors.Wrap(err, "disabling host due to ps timeout"))
+		if tc.taskConfig.ContainerID != "" {
+			// Kill user-owned processes inside the container's PID namespace.
+			// Host-side pkill cannot reach container-namespaced processes, so
+			// we use docker exec. PID 1 (sleep infinity, running as root) is
+			// preserved by the -U scoping.
+			if tc.taskConfig.Distro.ExecUser == "" {
+				// ExecUser is required for container isolation (enforced at distro
+				// validation), but degrade gracefully for pre-validation distros.
+				logger.Warningf(ctx, "Skipping in-container process cleanup for task '%s': distro has container isolation enabled but ExecUser is not set.", tc.task.ID)
+			} else {
+				logger.Infof(ctx, "Killing in-container processes for task '%s' (container '%s').", tc.task.ID, tc.taskConfig.ContainerID)
+				if err := agentutil.KillSpawnedProcsInContainer(ctx, tc.taskConfig.ContainerID, tc.taskConfig.Distro.ExecUser); err != nil {
+					if errors.Is(err, agentutil.ErrContainerExecUnavailable) {
+						// Container is unreachable (not running, paused, etc.) —
+						// warn but do not fail; no processes can be leaking.
+						logger.Warningf(ctx, "Could not reach container '%s' for process cleanup for task '%s': %s", tc.taskConfig.ContainerID, tc.task.ID, err)
+					} else {
+						catcher.Wrap(err, "killing in-container spawned processes")
+						logger.Critical(ctx, errors.Wrap(err, "killing in-container spawned processes"))
+					}
+				} else {
+					logger.Infof(ctx, "Completed in-container process cleanup for task '%s'.", tc.task.ID)
+				}
 			}
-			logger.Critical(ctx, errors.Wrap(err, "cleaning up spawned processes"))
+		} else {
+			logger.Infof(ctx, "Cleaning up processes for task: '%s'.", tc.task.ID)
+			if err := agentutil.KillSpawnedProcs(ctx, tc.task.ID, tc.taskConfig.WorkDir, tc.taskConfig.Distro.ExecUser, logger); err != nil {
+				catcher.Wrap(err, "cleaning up spawned processes")
+				// If the host is in a state where ps is timing out we need human intervention.
+				if psErr := errors.Cause(err); psErr == agentutil.ErrPSTimeout {
+					disableErr := a.comm.DisableHost(ctx, a.opts.HostID, apimodels.DisableInfo{Reason: psErr.Error()})
+					logger.CriticalWhen(ctx, disableErr != nil, errors.Wrap(err, "disabling host due to ps timeout"))
+				}
+				logger.Critical(ctx, errors.Wrap(err, "cleaning up spawned processes"))
+			}
+			logger.Infof(ctx, "Cleaned up processes for task: '%s'.", tc.task.ID)
 		}
-		logger.Infof(ctx, "Cleaned up processes for task: '%s'.", tc.task.ID)
+	}
+
+	// On container-enabled distros, skip the Docker artifact sweep regardless
+	// of whether this specific task's container started successfully. The
+	// pre-pulled evergreen-task-image is a host-level resource that must
+	// persist across all tasks; sweeping it forces a full re-pull on every
+	// subsequent task. Container.Destroy handles the task's own container.
+	// Docker-using workloads are tier-split onto non-isolation distros, so
+	// no Docker artifacts accumulate from tasks on isolation hosts.
+	//
+	// Note: tc.taskConfig.Distro.ContainerIsolation is non-nil only when
+	// the server has container isolation enabled for this distro; the
+	// agent-facing ContainerIsolationSettings struct has no Enabled field.
+	if tc.taskConfig != nil && tc.taskConfig.Distro != nil && tc.taskConfig.Distro.ContainerIsolation != nil {
+		logger.Info(ctx, "Skipping Docker artifact cleanup: distro has container isolation enabled; pre-pulled task image is preserved for subsequent tasks.")
+		return catcher.Resolve()
 	}
 
 	logger.Info(ctx, "Cleaning up Docker artifacts.")

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -424,7 +424,7 @@ func (a *Agent) processNextTask(ctx context.Context, nt *apimodels.NextTaskRespo
 		}))
 		return processNextResponse{
 			tc: tc,
-			// Trigger teardown so the isolation container is destroyed.
+			// Teardown is safe even when setup failed before a container was created.
 			needTeardownGroup: true,
 		}, nil
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -754,8 +754,8 @@ func (a *Agent) runTask(ctx context.Context, tcInput *taskContext, nt *apimodels
 		}
 	}()
 
-	if err := a.maybeStartContainer(tskCtx, tc.taskConfig, tc.logger.Execution()); err != nil {
-		// maybeStartContainer returns a non-nil error only on the fail-closed path
+	if err := a.ensureContainer(tskCtx, tc.taskConfig, tc.logger.Execution()); err != nil {
+		// ensureContainer returns a non-nil error only on the fail-closed path
 		// (require_isolation=true). The fail-open path handles its own degradation
 		// internally and returns nil. Route through handleSetupError so the task
 		// is finalized as TaskSystemFailed on the server — returning a bare error
@@ -1230,7 +1230,7 @@ func (a *Agent) handleTimeoutAndOOM(ctx context.Context, tc *taskContext, detail
 		a.augmentOOMTrackerWithContainerSignal(ctx, tc, detail)
 		a.emitContainerFailureSnapshot(ctx, tc, detail)
 		if a.currentContainer != nil {
-			a.scheduleContainerRetention(ctx, a.currentContainer.GetName())
+			a.scheduleContainerRetention(ctx, a.currentContainer.GetName(), tc.logger.Execution())
 		}
 	} else {
 		// Task succeeded — clear any retention window set by a prior failed
@@ -1667,11 +1667,8 @@ func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupC
 	// Docker-using workloads are tier-split onto non-isolation distros, so
 	// no Docker artifacts accumulate from tasks on isolation hosts.
 	//
-	// Note: tc.taskConfig.Distro.ContainerIsolation is non-nil only when
-	// the server has container isolation enabled for this distro; the
-	// agent-facing ContainerIsolationSettings struct has no Enabled field.
-	if tc.taskConfig != nil && tc.taskConfig.Distro != nil && tc.taskConfig.Distro.ContainerIsolation != nil {
-		logger.Info(ctx, "Skipping Docker artifact cleanup: distro has container isolation enabled; pre-pulled task image is preserved for subsequent tasks.")
+	if tc.taskConfig != nil && tc.taskConfig.ContainerID != "" {
+		logger.Info(ctx, "Skipping Docker artifact cleanup: task is running in an isolation container; pre-pulled task image is preserved for subsequent tasks.")
 		return catcher.Resolve()
 	}
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -261,14 +261,8 @@ func (a *Agent) loop(ctx context.Context) error {
 			grip.Error(ctx, errors.Wrap(tc.logger.Close(), "closing logger"))
 		}
 	}()
-	// Destroy any active isolation container when the loop exits (ctx
-	// cancellation, agent shutdown, or unrecoverable error), so we don't
-	// leak containers that would otherwise only be cleaned up by teardown
-	// group commands which may never run on an abnormal exit path.
-	// Use a detached background context with a bounded timeout: the loop
-	// ctx is already cancelled on the shutdown path, which would cause
-	// ContainerRemove to fail immediately and leave the container running
-	// until the next --cleanup reaper.
+	// Destroy any active isolation container on loop exit. A detached context
+	// is needed because the loop ctx is already cancelled on shutdown.
 	defer func() {
 		destroyCtx, destroyCancel := context.WithTimeout(context.Background(), reaperTimeout)
 		defer destroyCancel()
@@ -430,14 +424,7 @@ func (a *Agent) processNextTask(ctx context.Context, nt *apimodels.NextTaskRespo
 		}))
 		return processNextResponse{
 			tc: tc,
-			// Trigger teardown on the next iteration so the task-group isolation
-			// container is destroyed rather than leaked. Note: this causes
-			// runTeardownGroupCommands to execute real teardown-group scripts in
-			// addition to destroying the container. On a broken host that is
-			// acceptable: teardown scripts failing is logged and non-fatal, and
-			// the container cleanup is the primary goal. The loop-exit defer also
-			// calls destroyContainer as a fallback if the agent exits before the
-			// next iteration runs.
+			// Trigger teardown so the isolation container is destroyed.
 			needTeardownGroup: true,
 		}, nil
 	}
@@ -755,11 +742,6 @@ func (a *Agent) runTask(ctx context.Context, tcInput *taskContext, nt *apimodels
 	}()
 
 	if err := a.ensureContainer(tskCtx, tc.taskConfig, tc.logger.Execution()); err != nil {
-		// ensureContainer returns a non-nil error only on the fail-closed path
-		// (require_isolation=true). The fail-open path handles its own degradation
-		// internally and returns nil. Route through handleSetupError so the task
-		// is finalized as TaskSystemFailed on the server — returning a bare error
-		// here would leave the task unfinalized (stuck in "started" state).
 		return a.handleSetupError(tskCtx, tc, errors.Wrap(err, "starting required isolation container"))
 	}
 
@@ -1136,9 +1118,7 @@ func (a *Agent) runTeardownGroupCommands(ctx context.Context, tc *taskContext) {
 	if tc.taskConfig == nil {
 		return
 	}
-	// Destroy the task-group isolation container after teardown commands
-	// complete but before the task directory is removed, so that the bind
-	// mount is released before we attempt to delete its source path.
+	// Destroy the isolation container after teardown, before the task directory is removed.
 	defer a.destroyContainer(ctx, tc.taskConfig)
 	// Only killProcs if tc.taskConfig is not nil. This avoids passing an
 	// empty working directory to killProcs, and is okay because this
@@ -1224,8 +1204,7 @@ func (a *Agent) handleTimeoutAndOOM(ctx context.Context, tc *taskContext, detail
 			tc.logger.Execution().Debugf(ctx, "Found no OOM kill (in %.3f seconds).", time.Since(startTime).Seconds())
 		}
 	}
-	// Supplement the dmesg-based OOM report with the container-native signal,
-	// emit the failure snapshot, and schedule retention on task failure.
+	// Container-specific failure handling: OOM signal, failure snapshot, retention.
 	if detail.Status == evergreen.TaskFailed || detail.TimedOut {
 		a.augmentOOMTrackerWithContainerSignal(ctx, tc, detail)
 		a.emitContainerFailureSnapshot(ctx, tc, detail)
@@ -1233,9 +1212,7 @@ func (a *Agent) handleTimeoutAndOOM(ctx context.Context, tc *taskContext, detail
 			a.scheduleContainerRetention(ctx, a.currentContainer.GetName(), tc.logger.Execution())
 		}
 	} else {
-		// Task succeeded — clear any retention window set by a prior failed
-		// task in this group so the container is cleanly destroyed at teardown
-		// rather than leaked until the orphan reaper.
+		// Clear any retention window from a prior failed task in this group.
 		a.retainContainerUntil = time.Time{}
 	}
 
@@ -1621,10 +1598,7 @@ func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupC
 	catcher := grip.NewBasicCatcher()
 	if tc.task.ID != "" && tc.taskConfig != nil && tc.taskConfig.Distro != nil {
 		if tc.taskConfig.ContainerID != "" {
-			// Kill user-owned processes inside the container's PID namespace.
-			// Host-side pkill cannot reach container-namespaced processes, so
-			// we use docker exec. PID 1 (sleep infinity, running as root) is
-			// preserved by the -U scoping.
+			// Host-side pkill cannot reach container-namespaced processes.
 			if tc.taskConfig.Distro.ExecUser == "" {
 				// ExecUser is required for container isolation (enforced at distro
 				// validation), but degrade gracefully for pre-validation distros.
@@ -1659,14 +1633,8 @@ func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupC
 		}
 	}
 
-	// On container-enabled distros, skip the Docker artifact sweep regardless
-	// of whether this specific task's container started successfully. The
-	// pre-pulled evergreen-task-image is a host-level resource that must
-	// persist across all tasks; sweeping it forces a full re-pull on every
-	// subsequent task. Container.Destroy handles the task's own container.
-	// Docker-using workloads are tier-split onto non-isolation distros, so
-	// no Docker artifacts accumulate from tasks on isolation hosts.
-	//
+	// Skip Docker artifact cleanup for container-enabled tasks: the pre-pulled
+	// task image is a host-level resource that must persist across tasks.
 	if tc.taskConfig != nil && tc.taskConfig.ContainerID != "" {
 		logger.Info(ctx, "Skipping Docker artifact cleanup: task is running in an isolation container; pre-pulled task image is preserved for subsequent tasks.")
 		return catcher.Resolve()

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -341,6 +341,21 @@ func (s *AgentSuite) TestAgentExitsSingleTaskDistros() {
 	s.NoError(s.a.loop(ctx))
 }
 
+func (s *AgentSuite) TestProcessNextTaskErrorOnSingleTaskDistroShouldExitAfterTeardown() {
+	s.setupRunTask(defaultProjYml)
+	s.a.opts.SingleTaskDistro = true
+	s.mockCommunicator.EndTaskShouldFail = true
+
+	ntr, err := s.a.processNextTask(s.ctx, &apimodels.NextTaskResponse{
+		TaskId:     s.tc.task.ID,
+		TaskSecret: s.tc.task.Secret,
+	}, s.tc, false)
+
+	s.NoError(err)
+	s.True(ntr.needTeardownGroup)
+	s.True(ntr.taskErrored)
+}
+
 func (s *AgentSuite) TestFinishTaskWithNormalCompletedTask() {
 	s.mockCommunicator.EndTaskResponse = &apimodels.EndTaskResponse{}
 

--- a/agent/command/container_exec.go
+++ b/agent/command/container_exec.go
@@ -1,0 +1,46 @@
+package command
+
+import (
+	"context"
+
+	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/evergreen/agent/internal/client"
+	agentutil "github.com/evergreen-ci/evergreen/agent/util"
+	"github.com/mongodb/jasper"
+	"github.com/mongodb/jasper/options"
+	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func runJasperProcessWithContainer(ctx context.Context, opts *options.Create, commandName, workDir string, conf *internal.TaskConfig, manager jasper.Manager, background bool, logger client.LoggerProducer, taskID string, backgroundFailures chan<- error, continueOnError bool, backgroundCommandFailureEnabled bool) (jasper.Process, error) {
+	processCtx := ctx
+	var span trace.Span
+	if conf.Distro != nil && conf.ContainerID != "" {
+		processCtx, span = otel.Tracer("github.com/evergreen-ci/evergreen/agent").Start(ctx, "container.exec_wrap")
+		span.SetAttributes(
+			attribute.String("container.id", conf.ContainerID),
+			attribute.String("container.workdir", workDir),
+			attribute.String("container.command_name", commandName),
+		)
+	}
+	if conf.ContainerID != "" {
+		if err := agentutil.WrapWithContainer(processCtx, opts, conf.ContainerID, workDir, conf.EnvFileHostDir); err != nil {
+			if span != nil {
+				span.SetStatus(codes.Error, err.Error())
+				span.End()
+			}
+			return nil, errors.Wrap(err, "wrapping command for container execution")
+		}
+	}
+	proc, err := runJasperProcess(processCtx, manager, background, opts, taskID, logger, backgroundFailures, continueOnError, backgroundCommandFailureEnabled)
+	if span != nil {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}
+	return proc, err
+}

--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -235,9 +235,7 @@ func (c *subprocessExec) getProc(ctx context.Context, execPath string, conf *int
 		AppendTags(c.FullDisplayName()).
 		SuppressStandardError(c.IgnoreStandardError).SuppressStandardOutput(c.IgnoreStandardOutput).RedirectErrorToOutput(c.RedirectStandardErrorToOutput).
 		ProcConstructor(func(lctx context.Context, opts *options.Create) (jasper.Process, error) {
-			// Start a container.exec_wrap span only when actually running
-			// inside a container. The span wraps the shared WrapWithContainer
-			// + runJasperProcess path so there is one code path, not two.
+			// Start a container.exec_wrap span when running inside a container.
 			var span trace.Span
 			if conf.Distro != nil && conf.ContainerID != "" {
 				lctx, span = otel.Tracer("github.com/evergreen-ci/evergreen/agent").Start(lctx, "container.exec_wrap")

--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -23,6 +23,10 @@ import (
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/options"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // teardownSignalExitCodes are exit codes that typically indicate the agent terminated the process during cleanup
@@ -231,7 +235,35 @@ func (c *subprocessExec) getProc(ctx context.Context, execPath string, conf *int
 		AppendTags(c.FullDisplayName()).
 		SuppressStandardError(c.IgnoreStandardError).SuppressStandardOutput(c.IgnoreStandardOutput).RedirectErrorToOutput(c.RedirectStandardErrorToOutput).
 		ProcConstructor(func(lctx context.Context, opts *options.Create) (jasper.Process, error) {
-			return runJasperProcess(lctx, c.JasperManager(), c.Background, opts, conf.Task.Id, logger, conf.BackgroundFailures, c.ContinueOnError, conf.BackgroundCommandFailureEnabled)
+			// Start a container.exec_wrap span only when actually running
+			// inside a container. The span wraps the shared WrapWithContainer
+			// + runJasperProcess path so there is one code path, not two.
+			var span trace.Span
+			if conf.Distro != nil && conf.ContainerID != "" {
+				lctx, span = otel.Tracer("github.com/evergreen-ci/evergreen/agent").Start(lctx, "container.exec_wrap")
+				span.SetAttributes(
+					attribute.String("container.id", conf.ContainerID),
+					attribute.String("container.workdir", c.WorkingDir),
+					attribute.String("container.command_name", c.FullDisplayName()),
+				)
+			}
+			if conf.Distro != nil {
+				if err := agentutil.WrapWithContainer(lctx, opts, conf.ContainerID, c.WorkingDir, conf.EnvFileHostDir); err != nil {
+					if span != nil {
+						span.SetStatus(codes.Error, err.Error())
+						span.End()
+					}
+					return nil, errors.Wrap(err, "wrapping command for container execution")
+				}
+			}
+			proc, err := runJasperProcess(lctx, c.JasperManager(), c.Background, opts, conf.Task.Id, logger, conf.BackgroundFailures, c.ContinueOnError, conf.BackgroundCommandFailureEnabled)
+			if span != nil {
+				if err != nil {
+					span.SetStatus(codes.Error, err.Error())
+				}
+				span.End()
+			}
+			return proc, err
 		})
 
 	if !c.IgnoreStandardOutput {

--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -23,10 +23,6 @@ import (
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/options"
 	"github.com/pkg/errors"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // teardownSignalExitCodes are exit codes that typically indicate the agent terminated the process during cleanup
@@ -235,33 +231,7 @@ func (c *subprocessExec) getProc(ctx context.Context, execPath string, conf *int
 		AppendTags(c.FullDisplayName()).
 		SuppressStandardError(c.IgnoreStandardError).SuppressStandardOutput(c.IgnoreStandardOutput).RedirectErrorToOutput(c.RedirectStandardErrorToOutput).
 		ProcConstructor(func(lctx context.Context, opts *options.Create) (jasper.Process, error) {
-			// Start a container.exec_wrap span when running inside a container.
-			var span trace.Span
-			if conf.Distro != nil && conf.ContainerID != "" {
-				lctx, span = otel.Tracer("github.com/evergreen-ci/evergreen/agent").Start(lctx, "container.exec_wrap")
-				span.SetAttributes(
-					attribute.String("container.id", conf.ContainerID),
-					attribute.String("container.workdir", c.WorkingDir),
-					attribute.String("container.command_name", c.FullDisplayName()),
-				)
-			}
-			if conf.ContainerID != "" {
-				if err := agentutil.WrapWithContainer(lctx, opts, conf.ContainerID, c.WorkingDir, conf.EnvFileHostDir); err != nil {
-					if span != nil {
-						span.SetStatus(codes.Error, err.Error())
-						span.End()
-					}
-					return nil, errors.Wrap(err, "wrapping command for container execution")
-				}
-			}
-			proc, err := runJasperProcess(lctx, c.JasperManager(), c.Background, opts, conf.Task.Id, logger, conf.BackgroundFailures, c.ContinueOnError, conf.BackgroundCommandFailureEnabled)
-			if span != nil {
-				if err != nil {
-					span.SetStatus(codes.Error, err.Error())
-				}
-				span.End()
-			}
-			return proc, err
+			return runJasperProcessWithContainer(lctx, opts, c.FullDisplayName(), c.WorkingDir, conf, c.JasperManager(), c.Background, logger, conf.Task.Id, conf.BackgroundFailures, c.ContinueOnError, conf.BackgroundCommandFailureEnabled)
 		})
 
 	if !c.IgnoreStandardOutput {

--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -247,7 +247,7 @@ func (c *subprocessExec) getProc(ctx context.Context, execPath string, conf *int
 					attribute.String("container.command_name", c.FullDisplayName()),
 				)
 			}
-			if conf.Distro != nil {
+			if conf.ContainerID != "" {
 				if err := agentutil.WrapWithContainer(lctx, opts, conf.ContainerID, c.WorkingDir, conf.EnvFileHostDir); err != nil {
 					if span != nil {
 						span.SetStatus(codes.Error, err.Error())

--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -9,6 +9,7 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
+	agentutil "github.com/evergreen-ci/evergreen/agent/util"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip"
@@ -17,6 +18,10 @@ import (
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/options"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // shellExec is responsible for running the shell code.
@@ -173,7 +178,35 @@ func (c *shellExec) Execute(ctx context.Context, _ client.Communicator, logger c
 				opts.StandardInput = strings.NewReader(c.Script)
 			}
 
-			return runJasperProcess(lctx, c.JasperManager(), c.Background, opts, conf.Task.Id, logger, conf.BackgroundFailures, c.ContinueOnError, conf.BackgroundCommandFailureEnabled)
+			// Start a container.exec_wrap span only when actually running
+			// inside a container. The span wraps the shared WrapWithContainer
+			// + runJasperProcess path so there is one code path, not two.
+			var span trace.Span
+			if conf.Distro != nil && conf.ContainerID != "" {
+				lctx, span = otel.Tracer("github.com/evergreen-ci/evergreen/agent").Start(lctx, "container.exec_wrap")
+				span.SetAttributes(
+					attribute.String("container.id", conf.ContainerID),
+					attribute.String("container.workdir", c.WorkingDir),
+					attribute.String("container.command_name", c.FullDisplayName()),
+				)
+			}
+			if conf.Distro != nil {
+				if err := agentutil.WrapWithContainer(lctx, opts, conf.ContainerID, c.WorkingDir, conf.EnvFileHostDir); err != nil {
+					if span != nil {
+						span.SetStatus(codes.Error, err.Error())
+						span.End()
+					}
+					return nil, errors.Wrap(err, "wrapping command for container execution")
+				}
+			}
+			proc, err := runJasperProcess(lctx, c.JasperManager(), c.Background, opts, conf.Task.Id, logger, conf.BackgroundFailures, c.ContinueOnError, conf.BackgroundCommandFailureEnabled)
+			if span != nil {
+				if err != nil {
+					span.SetStatus(codes.Error, err.Error())
+				}
+				span.End()
+			}
+			return proc, err
 		})
 
 	if !c.IgnoreStandardOutput {

--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -178,9 +178,7 @@ func (c *shellExec) Execute(ctx context.Context, _ client.Communicator, logger c
 				opts.StandardInput = strings.NewReader(c.Script)
 			}
 
-			// Start a container.exec_wrap span only when actually running
-			// inside a container. The span wraps the shared WrapWithContainer
-			// + runJasperProcess path so there is one code path, not two.
+			// Start a container.exec_wrap span when running inside a container.
 			var span trace.Span
 			if conf.Distro != nil && conf.ContainerID != "" {
 				lctx, span = otel.Tracer("github.com/evergreen-ci/evergreen/agent").Start(lctx, "container.exec_wrap")

--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -190,7 +190,7 @@ func (c *shellExec) Execute(ctx context.Context, _ client.Communicator, logger c
 					attribute.String("container.command_name", c.FullDisplayName()),
 				)
 			}
-			if conf.Distro != nil {
+			if conf.ContainerID != "" {
 				if err := agentutil.WrapWithContainer(lctx, opts, conf.ContainerID, c.WorkingDir, conf.EnvFileHostDir); err != nil {
 					if span != nil {
 						span.SetStatus(codes.Error, err.Error())

--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -9,7 +9,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
-	agentutil "github.com/evergreen-ci/evergreen/agent/util"
 	"github.com/evergreen-ci/evergreen/util"
 	"github.com/mitchellh/mapstructure"
 	"github.com/mongodb/grip"
@@ -18,10 +17,6 @@ import (
 	"github.com/mongodb/jasper"
 	"github.com/mongodb/jasper/options"
 	"github.com/pkg/errors"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // shellExec is responsible for running the shell code.
@@ -178,33 +173,7 @@ func (c *shellExec) Execute(ctx context.Context, _ client.Communicator, logger c
 				opts.StandardInput = strings.NewReader(c.Script)
 			}
 
-			// Start a container.exec_wrap span when running inside a container.
-			var span trace.Span
-			if conf.Distro != nil && conf.ContainerID != "" {
-				lctx, span = otel.Tracer("github.com/evergreen-ci/evergreen/agent").Start(lctx, "container.exec_wrap")
-				span.SetAttributes(
-					attribute.String("container.id", conf.ContainerID),
-					attribute.String("container.workdir", c.WorkingDir),
-					attribute.String("container.command_name", c.FullDisplayName()),
-				)
-			}
-			if conf.ContainerID != "" {
-				if err := agentutil.WrapWithContainer(lctx, opts, conf.ContainerID, c.WorkingDir, conf.EnvFileHostDir); err != nil {
-					if span != nil {
-						span.SetStatus(codes.Error, err.Error())
-						span.End()
-					}
-					return nil, errors.Wrap(err, "wrapping command for container execution")
-				}
-			}
-			proc, err := runJasperProcess(lctx, c.JasperManager(), c.Background, opts, conf.Task.Id, logger, conf.BackgroundFailures, c.ContinueOnError, conf.BackgroundCommandFailureEnabled)
-			if span != nil {
-				if err != nil {
-					span.SetStatus(codes.Error, err.Error())
-				}
-				span.End()
-			}
-			return proc, err
+			return runJasperProcessWithContainer(lctx, opts, c.FullDisplayName(), c.WorkingDir, conf, c.JasperManager(), c.Background, logger, conf.Task.Id, conf.BackgroundFailures, c.ContinueOnError, conf.BackgroundCommandFailureEnabled)
 		})
 
 	if !c.IgnoreStandardOutput {

--- a/agent/container.go
+++ b/agent/container.go
@@ -68,7 +68,7 @@ const (
 // The reaper runs on a background-derived context so that a shutdown signal
 // arriving during the --cleanup phase does not cancel every Docker call and
 // silently skip the reap, leaving orphans on the host.
-func (a *Agent) tryReapOrphanContainers(ctx context.Context) { //nolint:unused
+func (a *Agent) tryReapOrphanContainers(ctx context.Context) {
 	defer recovery.LogStackTraceAndContinue("reap orphan containers")
 
 	reaperCtx, cancel := context.WithTimeout(context.Background(), reaperTimeout)
@@ -474,10 +474,10 @@ func destroyRetainedContainer(ctx context.Context, tracer trace.Tracer, containe
 }
 
 // inspectContainerTimeout bounds a single docker inspect call.
-const inspectContainerTimeout = 10 * time.Second //nolint:unused
+const inspectContainerTimeout = 10 * time.Second
 
 // inspectContainer returns the Docker inspect document for a container.
-func inspectContainer(ctx context.Context, containerID string) (dockercontainer.InspectResponse, error) { //nolint:unused
+func inspectContainer(ctx context.Context, containerID string) (dockercontainer.InspectResponse, error) {
 	inspectCtx, cancel := context.WithTimeout(ctx, inspectContainerTimeout)
 	defer cancel()
 
@@ -494,7 +494,7 @@ func inspectContainer(ctx context.Context, containerID string) (dockercontainer.
 // checkContainerOOM reads the container-native OOMKilled flag from docker
 // inspect. Returns (true, nil) when the container was OOM-killed, (false, nil)
 // when it was not, and (false, err) when inspect fails.
-func checkContainerOOM(ctx context.Context, containerID string) (bool, error) { //nolint:unused
+func checkContainerOOM(ctx context.Context, containerID string) (bool, error) {
 	info, err := inspectContainer(ctx, containerID)
 	if err != nil {
 		return false, err
@@ -514,7 +514,7 @@ func checkContainerOOM(ctx context.Context, containerID string) (bool, error) { 
 // actually fires (which is at group teardown, potentially seconds to minutes
 // later). The retention goroutine destroys the container at the deadline; if
 // the agent exits before the deadline, the reaper cleans it up at next startup.
-func (a *Agent) scheduleContainerRetention(ctx context.Context, containerName string, log grip.Journaler) { //nolint:unused
+func (a *Agent) scheduleContainerRetention(ctx context.Context, containerName string, log grip.Journaler) {
 	if a.opts.ContainerRetainOnFailureSecs <= 0 || a.currentContainer == nil {
 		return
 	}
@@ -530,7 +530,7 @@ func (a *Agent) scheduleContainerRetention(ctx context.Context, containerName st
 // isolation container and emits them as a container.failure_snapshot OTel span.
 // Only allowlisted fields are exported; every exported string passes through
 // redactForSnapshot. Raw env-file values are never exported.
-func (a *Agent) emitContainerFailureSnapshot(ctx context.Context, tc *taskContext, detail *apimodels.TaskEndDetail) { //nolint:unused
+func (a *Agent) emitContainerFailureSnapshot(ctx context.Context, tc *taskContext, detail *apimodels.TaskEndDetail) {
 	if a.currentContainer == nil || tc == nil || detail == nil {
 		return
 	}
@@ -572,7 +572,7 @@ func (a *Agent) emitContainerFailureSnapshot(ctx context.Context, tc *taskContex
 // containerInspectSummary is the allowlisted subset of docker inspect output
 // that may be exported to telemetry. The full document is deliberately
 // excluded because it embeds the container's environment and image config.
-type containerInspectSummary struct { //nolint:unused
+type containerInspectSummary struct {
 	Status       string `json:"status"`
 	ExitCode     int    `json:"exit_code"`
 	OOMKilled    bool   `json:"oom_killed"`
@@ -583,7 +583,7 @@ type containerInspectSummary struct { //nolint:unused
 }
 
 // containerInspectSummaryJSON returns the allowlisted inspect fields as JSON.
-func containerInspectSummaryJSON(ctx context.Context, containerID string) (string, error) { //nolint:unused
+func containerInspectSummaryJSON(ctx context.Context, containerID string) (string, error) {
 	info, err := inspectContainer(ctx, containerID)
 	if err != nil {
 		return "", err
@@ -655,18 +655,6 @@ func readLatestContainerEnvFile(dir string) ([]byte, error) {
 	return data, errors.Wrap(err, "reading latest container env file")
 }
 
-// containerExec runs a command inside a container and returns its combined
-// output. This forensic path uses the docker CLI rather than the SDK to keep
-// its footprint small; the main lifecycle (CreateAndStart, Destroy) uses the
-// SDK.
-func containerExec(ctx context.Context, containerID string, args ...string) (string, error) { //nolint:unused
-	execCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
-	defer cancel()
-	cmdArgs := append([]string{"exec", containerID}, args...)
-	out, err := exec.CommandContext(execCtx, "docker", cmdArgs...).CombinedOutput()
-	return strings.TrimSpace(string(out)), err
-}
-
 // redactionUnavailable replaces snapshot content when the task config needed
 // to redact secrets is missing. Exporting the raw value instead would risk
 // leaking credentials into telemetry, so redaction fails closed.
@@ -718,7 +706,7 @@ func redactForSnapshot(s string, tc *taskContext) string {
 // augmentOOMTrackerWithContainerSignal supplements the dmesg-based OOM report
 // with the container-native OOMKilled signal from docker inspect, which is
 // more reliable under containers where dmesg PIDs are host-side.
-func (a *Agent) augmentOOMTrackerWithContainerSignal(ctx context.Context, tc *taskContext, detail *apimodels.TaskEndDetail) { //nolint:unused
+func (a *Agent) augmentOOMTrackerWithContainerSignal(ctx context.Context, tc *taskContext, detail *apimodels.TaskEndDetail) {
 	if a.currentContainer == nil || tc == nil || detail == nil {
 		return
 	}

--- a/agent/container_test.go
+++ b/agent/container_test.go
@@ -13,6 +13,7 @@ import (
 
 	agentcontainer "github.com/evergreen-ci/evergreen/agent/container"
 	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	agentutil "github.com/evergreen-ci/evergreen/agent/util"
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model/task"

--- a/agent/container_test.go
+++ b/agent/container_test.go
@@ -7,6 +7,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -16,11 +17,109 @@ import (
 	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/util"
+	"github.com/mongodb/grip/send"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
 )
+
+// agentForKillTest returns a minimal Agent that passes the shouldKill guard.
+// shouldKill short-circuits to false when a.opts.Cleanup is false (added in
+// the upstream sync), so tests that want to reach the kill/cleanup logic must
+// set Cleanup: true.
+func agentForKillTest() *Agent {
+	return &Agent{opts: Options{Cleanup: true}}
+}
+
+func TestKillProcsContainerIsolationSkipsDockerCleanup(t *testing.T) {
+	ctx := t.Context()
+	a := agentForKillTest()
+
+	tc := &taskContext{
+		task: client.TaskData{ID: "test-task-1"},
+		taskConfig: &internal.TaskConfig{
+			ContainerID: "some-container-id",
+			WorkDir:     t.TempDir(),
+			Distro: &apimodels.DistroView{
+				ContainerIsolation: &apimodels.ContainerIsolationSettings{
+					Image: "ubuntu:22.04",
+				},
+			},
+		},
+	}
+
+	err := a.killProcs(ctx, tc, true, "test")
+	assert.NoError(t, err, "killProcs must preserve Docker artifacts for an active isolation container")
+}
+
+func TestKillProcsFailOpenIsolationRunsDockerCleanup(t *testing.T) {
+	ctx := t.Context()
+	a := agentForKillTest()
+	sender := send.MakeInternalLogger()
+
+	tc := &taskContext{
+		task:   client.TaskData{ID: "test-task-1"},
+		logger: client.NewSingleChannelLogHarness("test", sender),
+		taskConfig: &internal.TaskConfig{
+			WorkDir: t.TempDir(),
+			Distro: &apimodels.DistroView{
+				ContainerIsolation: &apimodels.ContainerIsolationSettings{Image: "ubuntu:22.04"},
+			},
+		},
+	}
+
+	require.NoError(t, a.killProcs(ctx, tc, true, "test"))
+	var messages []string
+	for {
+		msg, ok := sender.GetMessageSafe()
+		if !ok {
+			break
+		}
+		messages = append(messages, msg.Message.String())
+	}
+	assert.Contains(t, strings.Join(messages, "\n"), "Cleaned up Docker artifacts")
+}
+
+// TestKillProcsContainerRouting verifies that killProcs routes to the
+// in-container kill path when ContainerID is set, and the host-side
+// KillSpawnedProcs path when it is not.
+func TestKillProcsContainerRouting(t *testing.T) {
+	ctx := t.Context()
+	a := agentForKillTest()
+
+	t.Run("EmptyContainerIDTakesHostPath", func(t *testing.T) {
+		tc := &taskContext{
+			task: client.TaskData{ID: "test-task-1"},
+			taskConfig: &internal.TaskConfig{
+				WorkDir: t.TempDir(),
+				Distro:  &apimodels.DistroView{
+					// Empty ExecUser: takes the ps-based host path, which is
+					// safe without real sudo in a test environment.
+				},
+			},
+		}
+		err := a.killProcs(ctx, tc, true, "test")
+		assert.NoError(t, err)
+	})
+
+	t.Run("NonEmptyContainerIDEmptyExecUserLogsWarningNoError", func(t *testing.T) {
+		tc := &taskContext{
+			task: client.TaskData{ID: "test-task-1"},
+			taskConfig: &internal.TaskConfig{
+				ContainerID: "some-container-id",
+				WorkDir:     t.TempDir(),
+				Distro: &apimodels.DistroView{
+					ContainerIsolation: &apimodels.ContainerIsolationSettings{
+						Image: "ubuntu:22.04",
+					},
+				},
+			},
+		}
+		err := a.killProcs(ctx, tc, true, "test")
+		require.NoError(t, err)
+	})
+}
 
 func makeSnapshotTC(expansions map[string]string, redacted []string, secrets map[string]string) *taskContext {
 	exp := util.Expansions{}

--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-08-03"
+	ClientVersion = "2026-08-11"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-08-05"
+	AgentVersion = "2026-08-10"
 )
 
 const (

--- a/operations/agent.go
+++ b/operations/agent.go
@@ -25,11 +25,12 @@ import (
 const defaultAgentStatusPort = 2285
 
 const (
-	agentAPIServerURLFlagName  = "api_server"
-	agentCloudProviderFlagName = "provider"
-	agentHostIDFlagName        = "host_id"
-	agentHostSecretFlagName    = "host_secret"
-	singleTaskDistroFlagName   = "single_task_distro"
+	agentAPIServerURLFlagName            = "api_server"
+	agentCloudProviderFlagName           = "provider"
+	agentHostIDFlagName                  = "host_id"
+	agentHostSecretFlagName              = "host_secret"
+	singleTaskDistroFlagName             = "single_task_distro"
+	containerRetainOnFailureSecsFlagName = "container_retain_on_failure_secs"
 )
 
 func Agent() cli.Command {
@@ -109,6 +110,11 @@ func Agent() cli.Command {
 				Name:  singleTaskDistroFlagName,
 				Usage: "marks the agent as running in single task distro",
 			},
+			cli.IntFlag{
+				Name:  containerRetainOnFailureSecsFlagName,
+				Usage: "seconds to retain the isolation container after a task failure for on-call inspection (0 = destroy immediately, 300 = Phase 0/1 default)",
+				Value: 300,
+			},
 		},
 		Before: mergeBeforeFuncs(
 			func(c *cli.Context) error {
@@ -141,17 +147,18 @@ func Agent() cli.Command {
 			}
 
 			opts := agent.Options{
-				HostID:                     c.String(agentHostIDFlagName),
-				HostSecret:                 c.String(agentHostSecretFlagName),
-				Mode:                       globals.Mode(c.String(modeFlagName)),
-				StatusPort:                 c.Int(statusPortFlagName),
-				LogPrefix:                  c.String(logPrefixFlagName),
-				LogOutput:                  globals.LogOutputType(c.String(logOutputFlagName)),
-				WorkingDirectory:           c.String(workingDirectoryFlagName),
-				Cleanup:                    c.Bool(cleanupFlagName),
-				CloudProvider:              c.String(agentCloudProviderFlagName),
-				SendTaskLogsToGlobalSender: c.Bool(sendTaskLogsToGlobalSenderFlagName),
-				SingleTaskDistro:           c.Bool(singleTaskDistroFlagName),
+				HostID:                       c.String(agentHostIDFlagName),
+				HostSecret:                   c.String(agentHostSecretFlagName),
+				Mode:                         globals.Mode(c.String(modeFlagName)),
+				StatusPort:                   c.Int(statusPortFlagName),
+				LogPrefix:                    c.String(logPrefixFlagName),
+				LogOutput:                    globals.LogOutputType(c.String(logOutputFlagName)),
+				WorkingDirectory:             c.String(workingDirectoryFlagName),
+				Cleanup:                      c.Bool(cleanupFlagName),
+				CloudProvider:                c.String(agentCloudProviderFlagName),
+				SendTaskLogsToGlobalSender:   c.Bool(sendTaskLogsToGlobalSenderFlagName),
+				SingleTaskDistro:             c.Bool(singleTaskDistroFlagName),
+				ContainerRetainOnFailureSecs: c.Int(containerRetainOnFailureSecsFlagName),
 			}
 
 			// Once the agent has retrieved the host ID and secret, unset those

--- a/operations/agent.go
+++ b/operations/agent.go
@@ -112,7 +112,7 @@ func Agent() cli.Command {
 			},
 			cli.IntFlag{
 				Name:  containerRetainOnFailureSecsFlagName,
-				Usage: "seconds to retain the isolation container after a task failure for on-call inspection (0 = destroy immediately, 300 = Phase 0/1 default)",
+				Usage: "seconds to retain the isolation container after a task failure for on-call inspection (0 = destroy immediately, default = 300)",
 				Value: 300,
 			},
 		},


### PR DESCRIPTION
PLATFORMS-2442: Activate container isolation for enabled distros

PLATFORMS-2442

**Stack: PR 6 of 9 — depends on `pr05-orchestration` (`https://github.com/evergreen-ci/evergreen/pull/10633`).**

This PR is safe to merge alone because activation is gated by effective distro settings and other distros retain the host path.

### Description

Connects the previously inert layers to task execution. Only effectively enabled distros use containers, with configured fail-open behavior.

### Documentation

No user-facing documentation changes are required in this slice. Stack ordering and cross-PR links are maintained separately.
