### PR TITLE
DEVRPOD-XXXX: Skip precommit hook on graphql updates

### DIFF
--- a/.github/workflows/sync-graphql-schema.yml
+++ b/.github/workflows/sync-graphql-schema.yml
@@ -75,7 +75,7 @@ jobs:
           git add apps/spruce/src/gql/generated/types.ts
           git add apps/parsley/src/gql/generated/types.ts
           git add packages/lib/src/gql/generated/types.ts
-          git commit --allow-empty -m "Update generated GraphQL types from evergreen@${SHORT_SHA}"
+          git commit --no-verify --allow-empty -m "Update generated GraphQL types from evergreen@${SHORT_SHA}"
           git push --force-with-lease origin "$BRANCH"
 
       - name: Create pull request


### PR DESCRIPTION
DEVPROD-XXXX

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->
For the GitHub action that opens GraphQL update PRs, don't run pre-commit hooks, including lint & typecheck. Errors in these operations were causing the operation to [fail](https://github.com/evergreen-ci/evergreen/actions/runs/31022723725/job/92363288283#step:23:2), meaning a PR would never be opened. We should always have the PR open and capture the failures via CI in the UI repo.

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
