### PR TITLE
DEVPROD-41283: Stop logging expected S3 lifecycle lookup misses for accounts without lifecycle rules

### DIFF
--- a/config_cost.go
+++ b/config_cost.go
@@ -173,22 +173,28 @@ func IsDevprodOwnedArtifactIAMRole(awsRoleARN string, devprodOwnedAWSAccountIDs 
 	return ok && IsInDevProdOwnedAccountList(acctID, devprodOwnedAWSAccountIDs)
 }
 
+// ResolveUploadAccountID returns the AWS account ID that owns an upload. When awsRoleARN is non-empty
+// the account is derived from the ARN, and an unparseable ARN resolves to no account. When awsRoleARN is
+// empty, awsAccountID is used directly (key+secret auth, where no ARN is available).
+func ResolveUploadAccountID(awsRoleARN, awsAccountID string) string {
+	if awsRoleARN == "" {
+		return awsAccountID
+	}
+	acctID, ok := util.AWSAccountIDFromIAMARN(awsRoleARN)
+	if !ok {
+		return ""
+	}
+	return acctID
+}
+
 // IsDevprodOwnedUpload reports whether an upload belongs to a devprod-owned account.
-// When awsRoleARN is non-empty, the account ID is derived from the ARN. When awsRoleARN
-// is empty, awsAccountID is used directly (for key+secret auth where no ARN is available).
 // Returns true when the owned account list is empty, meaning all uploads are tracked.
 func IsDevprodOwnedUpload(awsRoleARN, awsAccountID string, devprodOwnedAWSAccountIDs []string) bool {
 	if len(devprodOwnedAWSAccountIDs) == 0 {
 		return true
 	}
-	if awsRoleARN != "" {
-		acctID, ok := util.AWSAccountIDFromIAMARN(awsRoleARN)
-		return ok && IsInDevProdOwnedAccountList(acctID, devprodOwnedAWSAccountIDs)
-	}
-	if awsAccountID != "" {
-		return IsInDevProdOwnedAccountList(awsAccountID, devprodOwnedAWSAccountIDs)
-	}
-	return false
+	acctID := ResolveUploadAccountID(awsRoleARN, awsAccountID)
+	return acctID != "" && IsInDevProdOwnedAccountList(acctID, devprodOwnedAWSAccountIDs)
 }
 
 // ShouldHideCost reports whether the given project's cost fields should be hidden.

--- a/config_cost_test.go
+++ b/config_cost_test.go
@@ -389,3 +389,21 @@ func TestCostConfigSetAndGet(t *testing.T) {
 		assert.Equal(t, []string{"210987654321"}, retrieved.S3Cost.Storage.ArtifactAWSAccountsWithoutLifecycleRules)
 	})
 }
+
+func TestResolveUploadAccountID(t *testing.T) {
+	t.Run("RoleARNResolvesToItsAccount", func(t *testing.T) {
+		assert.Equal(t, "123456789012", ResolveUploadAccountID("arn:aws:iam::123456789012:role/r", ""))
+	})
+	t.Run("RoleARNTakesPrecedenceOverAccountID", func(t *testing.T) {
+		assert.Equal(t, "123456789012", ResolveUploadAccountID("arn:aws:iam::123456789012:role/r", "999999999999"))
+	})
+	t.Run("UnparseableRoleARNResolvesToNoAccount", func(t *testing.T) {
+		assert.Empty(t, ResolveUploadAccountID("not-an-arn", "999999999999"))
+	})
+	t.Run("EmptyRoleARNFallsBackToAccountID", func(t *testing.T) {
+		assert.Equal(t, "999999999999", ResolveUploadAccountID("", "999999999999"))
+	})
+	t.Run("BothEmptyResolvesToNoAccount", func(t *testing.T) {
+		assert.Empty(t, ResolveUploadAccountID("", ""))
+	})
+}

--- a/model/s3usage/s3usage.go
+++ b/model/s3usage/s3usage.go
@@ -74,8 +74,10 @@ type S3UploadMetrics struct {
 type BucketFileMetrics struct {
 	Bucket string `bson:"bucket" json:"bucket"`
 	// AWSRoleARN is the IAM role ARN used for artifact uploads (when assume-role is configured).
-	AWSRoleARN string      `bson:"aws_role_arn,omitempty" json:"aws_role_arn,omitempty"`
-	Files      []FileBytes `bson:"files" json:"files"`
+	AWSRoleARN string `bson:"aws_role_arn,omitempty" json:"aws_role_arn,omitempty"`
+	// AWSAccountID is the owning account, resolved by the agent when AWSRoleARN is empty.
+	AWSAccountID string      `bson:"aws_account_id,omitempty" json:"aws_account_id,omitempty"`
+	Files        []FileBytes `bson:"files" json:"files"`
 }
 
 // FileBytes tracks bytes uploaded for a single S3 file key.
@@ -292,8 +294,9 @@ func (s *S3Usage) IncrementArtifacts(opts ArtifactIncrementOptions) {
 	}
 	if bucketEntry == nil {
 		s.Artifacts.BytesByBucketAndKey = append(s.Artifacts.BytesByBucketAndKey, BucketFileMetrics{
-			Bucket:     opts.Bucket,
-			AWSRoleARN: opts.AWSRoleARN,
+			Bucket:       opts.Bucket,
+			AWSRoleARN:   opts.AWSRoleARN,
+			AWSAccountID: opts.AWSAccountID,
 		})
 		bucketEntry = &s.Artifacts.BytesByBucketAndKey[len(s.Artifacts.BytesByBucketAndKey)-1]
 	}

--- a/model/s3usage/s3usage_test.go
+++ b/model/s3usage/s3usage_test.go
@@ -204,6 +204,23 @@ func TestS3Usage(t *testing.T) {
 		assert.True(t, s3Usage.IsZero())
 	})
 
+	t.Run("IncrementArtifactsRecordsResolvedAccountIDOnBucketEntry", func(t *testing.T) {
+		s3Usage := S3Usage{}
+		opts := ArtifactIncrementOptions{
+			PutRequests:  1,
+			UploadBytes:  50,
+			FileCount:    1,
+			MaxPuts:      1,
+			MinPuts:      1,
+			Bucket:       "b",
+			AWSAccountID: "999999999999",
+			Files:        []FileMetrics{{RemotePath: "z", FileSizeBytes: 50}},
+		}
+		s3Usage.IncrementArtifacts(opts)
+		require.Len(t, s3Usage.Artifacts.BytesByBucketAndKey, 1)
+		assert.Equal(t, "999999999999", s3Usage.Artifacts.BytesByBucketAndKey[0].AWSAccountID, "key+secret uploads must persist the resolved account ID for cost-time lifecycle checks")
+	})
+
 	t.Run("IncrementLogs", func(t *testing.T) {
 		s3Usage := S3Usage{}
 		assert.Equal(t, 0, s3Usage.Logs.PutRequests)

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -4457,9 +4457,13 @@ func (t *Task) setS3ArtifactStorageCosts(ctx context.Context, lookup bucketExpir
 	t.TaskCost.OnDemandS3ArtifactStorageCost = 0
 	t.TaskCost.AdjustedS3ArtifactStorageCost = 0
 	for _, bucketEntry := range t.S3Usage.Artifacts.BytesByBucketAndKey {
+		// A lookup miss is expected for these accounts, so don't log one. The lookup still runs because
+		// rules cached before the account was listed are still valid.
+		accountID := evergreen.ResolveUploadAccountID(bucketEntry.AWSRoleARN, bucketEntry.AWSAccountID)
+		expectedMiss := evergreen.IsAccountWithoutLifecycleRules(accountID, costConfig.S3Cost.Storage.ArtifactAWSAccountsWithoutLifecycleRules)
 		for _, fileEntry := range bucketEntry.Files {
 			days, usedLookup := lookupExpirationDays(ctx, bucketEntry.Bucket, fileEntry.FileKey, lookup, costConfig)
-			if !usedLookup {
+			if !usedLookup && !expectedMiss {
 				grip.Info(ctx, message.Fields{
 					"message": "no S3 lifecycle rule found for artifact bucket, using default expiration days",
 					"bucket":  bucketEntry.Bucket,

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -21,6 +21,10 @@ import (
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/level"
+	"github.com/mongodb/grip/message"
+	"github.com/mongodb/grip/send"
 	"github.com/pkg/errors"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
@@ -5918,5 +5922,82 @@ func TestIncNumQuarantinedTestsSkipped(t *testing.T) {
 		require.NoError(t, staleTask.IncNumQuarantinedTestsSkipped(ctx, 7))
 		assert.Zero(t, staleTask.NumQuarantinedTestsSkipped)
 		assert.Equal(t, 5, findTask(t).NumQuarantinedTestsSkipped, "an increment for a previous execution should not apply to the current one")
+	})
+}
+
+func TestSetS3ArtifactStorageCostsLifecycleMissLogging(t *testing.T) {
+	ctx := t.Context()
+
+	// Capture grip output to assert on the log the cost path emits on a lifecycle lookup miss.
+	sender, err := send.NewInternalLogger("test", send.LevelInfo{Threshold: level.Debug, Default: level.Debug})
+	require.NoError(t, err)
+	original := grip.GetSender()
+	require.NoError(t, grip.SetSender(sender))
+	t.Cleanup(func() {
+		require.NoError(t, grip.SetSender(original))
+	})
+
+	const skippedAccount = "999999999999"
+	costConfig := &evergreen.CostConfig{
+		S3Cost: evergreen.S3CostConfig{
+			Storage: evergreen.S3StorageCostConfig{
+				DefaultMaxArtifactExpirationDays:         365,
+				ArtifactAWSAccountsWithoutLifecycleRules: []string{skippedAccount},
+			},
+		},
+	}
+	// Always miss, so the only thing under test is whether the miss is logged.
+	missingLookup := func(context.Context, string, string) (int, bool) { return 0, false }
+
+	loggedBuckets := func() []string {
+		var buckets []string
+		for sender.HasMessage() {
+			fields, ok := sender.GetMessage().Message.Raw().(message.Fields)
+			if !ok {
+				continue
+			}
+			if fields["message"] == "no S3 lifecycle rule found for artifact bucket, using default expiration days" {
+				buckets = append(buckets, fields["bucket"].(string))
+			}
+		}
+		return buckets
+	}
+
+	usage := func(bucket, roleARN, accountID string) s3usage.S3Usage {
+		return s3usage.S3Usage{
+			Artifacts: s3usage.ArtifactMetrics{
+				BytesByBucketAndKey: []s3usage.BucketFileMetrics{{
+					Bucket:       bucket,
+					AWSRoleARN:   roleARN,
+					AWSAccountID: accountID,
+					Files:        []s3usage.FileBytes{{FileKey: "f", Bytes: 5 * 1024 * 1024}},
+				}},
+			},
+		}
+	}
+
+	t.Run("SuppressesMissForKeySecretUploadInAccountWithoutLifecycleRules", func(t *testing.T) {
+		tk := Task{Id: "t1", S3Usage: usage("cdn-origin-compass-dev", "", skippedAccount)}
+		tk.setS3ArtifactStorageCosts(ctx, missingLookup, costConfig)
+		assert.Empty(t, loggedBuckets())
+		assert.True(t, tk.TaskCost.OnDemandS3ArtifactStorageCost > 0, "cost must still be computed from the default expiration days")
+	})
+
+	t.Run("SuppressesMissForRoleARNUploadInAccountWithoutLifecycleRules", func(t *testing.T) {
+		tk := Task{Id: "t2", S3Usage: usage("b", "arn:aws:iam::"+skippedAccount+":role/r", "")}
+		tk.setS3ArtifactStorageCosts(ctx, missingLookup, costConfig)
+		assert.Empty(t, loggedBuckets())
+	})
+
+	t.Run("LogsMissForAccountThatShouldHaveLifecycleRules", func(t *testing.T) {
+		tk := Task{Id: "t3", S3Usage: usage("mciuploads", "arn:aws:iam::123456789012:role/r", "")}
+		tk.setS3ArtifactStorageCosts(ctx, missingLookup, costConfig)
+		assert.Equal(t, []string{"mciuploads"}, loggedBuckets())
+	})
+
+	t.Run("LogsMissWhenBucketAccountIsUnknown", func(t *testing.T) {
+		tk := Task{Id: "t4", S3Usage: usage("mciuploads", "", "")}
+		tk.setS3ArtifactStorageCosts(ctx, missingLookup, costConfig)
+		assert.Equal(t, []string{"mciuploads"}, loggedBuckets())
 	})
 }


### PR DESCRIPTION
DEVPROD-41283

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
These were noisy and made it harder to set up alerting for legitimate misses. This persists the account ID the agent already
resolves for key+secret uploads so the cost path can recognize the miss as expected.

### Testing
Added tests 



<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
