### PR TITLE
DEVPROD-41216 Authorize GitHub PR patches against the PR author

### DIFF
--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -256,7 +256,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 				break
 			}
 
-			if err := gh.AddIntentForPR(ctx, event.PullRequest, event.Sender.GetLogin(), patch.AutomatedCaller, "", false); err != nil {
+			if err := gh.AddIntentForPR(ctx, event.PullRequest, event.PullRequest.GetUser().GetLogin(), patch.AutomatedCaller, "", false); err != nil {
 				grip.Error(ctx, message.WrapError(err, message.Fields{
 					"source":    "GitHub hook",
 					"msg_id":    gh.msgID,

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -135,6 +135,11 @@ func (s *GithubWebhookRouteSuite) TestAddIntentAndFailsWithDuplicate() {
 	s.NoError(err)
 	s.Equal(1, count)
 
+	// The intent must be authorized against the PR author, not the webhook sender.
+	var intent bson.M
+	s.NoError(db.FindOneQ(s.T().Context(), patch.IntentCollection, db.Query(bson.M{}), &intent))
+	s.Equal("ZackarySantana", intent["user"])
+
 	resp = s.h.Run(s.T().Context())
 	s.NotEqual(http.StatusOK, resp.Status())
 	count, err = db.CountQ(s.T().Context(), patch.IntentCollection, db.Query(bson.M{}))

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -135,11 +135,6 @@ func (s *GithubWebhookRouteSuite) TestAddIntentAndFailsWithDuplicate() {
 	s.NoError(err)
 	s.Equal(1, count)
 
-	// The intent must be authorized against the PR author, not the webhook sender.
-	var intent bson.M
-	s.NoError(db.FindOneQ(s.T().Context(), patch.IntentCollection, db.Query(bson.M{}), &intent))
-	s.Equal("ZackarySantana", intent["user"])
-
 	resp = s.h.Run(s.T().Context())
 	s.NotEqual(http.StatusOK, resp.Status())
 	count, err = db.CountQ(s.T().Context(), patch.IntentCollection, db.Query(bson.M{}))

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -135,6 +135,12 @@ func (s *GithubWebhookRouteSuite) TestAddIntentAndFailsWithDuplicate() {
 	s.NoError(err)
 	s.Equal(1, count)
 
+	intent, err := patch.FindIntent(s.T().Context(), "1", patch.GithubIntentType)
+	s.NoError(err)
+	s.Require().NotNil(intent)
+	patchDoc := intent.NewPatch()
+	s.Equal("ZackarySantana", patchDoc.GithubPatchData.Author)
+
 	resp = s.h.Run(s.T().Context())
 	s.NotEqual(http.StatusOK, resp.Status())
 	count, err = db.CountQ(s.T().Context(), patch.IntentCollection, db.Query(bson.M{}))

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1453,11 +1453,14 @@ func (j *patchIntentProcessor) isUserAuthorized(ctx context.Context, patchDoc *p
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	// GitHub Dependabot patches should be automatically authorized.
-	if githubUser == githubDependabotUser || githubUser == githubActionsUser {
+	// Dependabot and GitHub Actions patches are automatically authorized, but
+	// only for same-repo PRs to ensure we never auto-authorize code originating from an external fork.
+	isSameRepoPR := patchDoc.GithubPatchData.HeadOwner == patchDoc.GithubPatchData.BaseOwner &&
+		patchDoc.GithubPatchData.HeadRepo == patchDoc.GithubPatchData.BaseRepo
+	if isSameRepoPR && (githubUser == githubDependabotUser || githubUser == githubActionsUser) {
 		grip.Info(ctx, message.Fields{
 			"job":       j.ID(),
-			"message":   fmt.Sprintf("authorizing patch from special user '%s'", githubDependabotUser),
+			"message":   fmt.Sprintf("authorizing patch from special user '%s'", githubUser),
 			"source":    "patch intents",
 			"base_repo": fmt.Sprintf("%s/%s", patchDoc.GithubPatchData.BaseOwner, patchDoc.GithubPatchData.BaseRepo),
 			"head_repo": fmt.Sprintf("%s/%s", patchDoc.GithubPatchData.HeadOwner, patchDoc.GithubPatchData.HeadRepo),

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1455,8 +1455,8 @@ func (j *patchIntentProcessor) isUserAuthorized(ctx context.Context, patchDoc *p
 
 	// Dependabot and GitHub Actions patches are automatically authorized, but
 	// only for same-repo PRs to ensure we never auto-authorize code originating from an external fork.
-	isSameRepoPR := patchDoc.GithubPatchData.HeadOwner == patchDoc.GithubPatchData.BaseOwner &&
-		patchDoc.GithubPatchData.HeadRepo == patchDoc.GithubPatchData.BaseRepo
+	isSameRepoPR := strings.EqualFold(patchDoc.GithubPatchData.HeadOwner, patchDoc.GithubPatchData.BaseOwner) &&
+		strings.EqualFold(patchDoc.GithubPatchData.HeadRepo, patchDoc.GithubPatchData.BaseRepo)
 	if isSameRepoPR && (githubUser == githubDependabotUser || githubUser == githubActionsUser) {
 		grip.Info(ctx, message.Fields{
 			"job":       j.ID(),

--- a/units/patch_intent_test.go
+++ b/units/patch_intent_test.go
@@ -2887,4 +2887,129 @@ func TestIsUserAuthorized(t *testing.T) {
 		assert.Equal(t, "base-owner", checkedOwner)
 		assert.Equal(t, "base-repo", checkedRepo)
 	})
+
+	t.Run("ExternalForkAuthorWithoutAccessIsUnauthorized", func(t *testing.T) {
+		originalGitHubUserInOrganization := githubUserInOrganization
+		originalAppAuthorizedForOrg := appAuthorizedForOrg
+		originalGitHubUserHasWritePermission := githubUserHasWritePermission
+		t.Cleanup(func() {
+			githubUserInOrganization = originalGitHubUserInOrganization
+			appAuthorizedForOrg = originalAppAuthorizedForOrg
+			githubUserHasWritePermission = originalGitHubUserHasWritePermission
+		})
+
+		githubUserInOrganization = func(ctx context.Context, org, username string) (bool, error) {
+			return false, nil
+		}
+		appAuthorizedForOrg = func(ctx context.Context, org, username string) (bool, error) {
+			return false, nil
+		}
+		var checkedOwner, checkedRepo string
+		githubUserHasWritePermission = func(ctx context.Context, owner, repo, username string) (bool, error) {
+			checkedOwner = owner
+			checkedRepo = repo
+			return false, nil
+		}
+
+		j := &patchIntentProcessor{}
+		patchDoc := &patch.Patch{
+			GithubPatchData: thirdparty.GithubPatch{
+				BaseOwner: "base-owner",
+				BaseRepo:  "base-repo",
+				HeadOwner: "fork-owner",
+				HeadRepo:  "fork-repo",
+				PRNumber:  123,
+				Author:    "external-user",
+			},
+		}
+
+		authorized, err := j.isUserAuthorized(t.Context(), patchDoc, "required-org", "external-user")
+
+		assert.NoError(t, err)
+		assert.False(t, authorized)
+		assert.Equal(t, "base-owner", checkedOwner)
+		assert.Equal(t, "base-repo", checkedRepo)
+	})
+
+	t.Run("AutoAuthorizesDependabot", func(t *testing.T) {
+		originalGitHubUserInOrganization := githubUserInOrganization
+		originalAppAuthorizedForOrg := appAuthorizedForOrg
+		originalGitHubUserHasWritePermission := githubUserHasWritePermission
+		t.Cleanup(func() {
+			githubUserInOrganization = originalGitHubUserInOrganization
+			appAuthorizedForOrg = originalAppAuthorizedForOrg
+			githubUserHasWritePermission = originalGitHubUserHasWritePermission
+		})
+		var consultedFallback bool
+		githubUserInOrganization = func(ctx context.Context, org, username string) (bool, error) {
+			consultedFallback = true
+			return false, nil
+		}
+		appAuthorizedForOrg = func(ctx context.Context, org, username string) (bool, error) {
+			consultedFallback = true
+			return false, nil
+		}
+		githubUserHasWritePermission = func(ctx context.Context, owner, repo, username string) (bool, error) {
+			consultedFallback = true
+			return false, nil
+		}
+
+		j := &patchIntentProcessor{}
+		patchDoc := &patch.Patch{
+			GithubPatchData: thirdparty.GithubPatch{
+				BaseOwner: "base-owner",
+				BaseRepo:  "base-repo",
+				HeadOwner: "base-owner",
+				HeadRepo:  "base-repo",
+				PRNumber:  123,
+				Author:    githubDependabotUser,
+			},
+		}
+
+		authorized, err := j.isUserAuthorized(t.Context(), patchDoc, "required-org", githubDependabotUser)
+
+		assert.NoError(t, err)
+		assert.True(t, authorized)
+		assert.False(t, consultedFallback)
+	})
+
+	t.Run("DoesNotAutoAuthorizeForkDependabot", func(t *testing.T) {
+		originalGitHubUserInOrganization := githubUserInOrganization
+		originalAppAuthorizedForOrg := appAuthorizedForOrg
+		originalGitHubUserHasWritePermission := githubUserHasWritePermission
+		t.Cleanup(func() {
+			githubUserInOrganization = originalGitHubUserInOrganization
+			appAuthorizedForOrg = originalAppAuthorizedForOrg
+			githubUserHasWritePermission = originalGitHubUserHasWritePermission
+		})
+		githubUserInOrganization = func(ctx context.Context, org, username string) (bool, error) {
+			return false, nil
+		}
+		appAuthorizedForOrg = func(ctx context.Context, org, username string) (bool, error) {
+			return false, nil
+		}
+		var consultedWritePermission bool
+		githubUserHasWritePermission = func(ctx context.Context, owner, repo, username string) (bool, error) {
+			consultedWritePermission = true
+			return false, nil
+		}
+
+		j := &patchIntentProcessor{}
+		patchDoc := &patch.Patch{
+			GithubPatchData: thirdparty.GithubPatch{
+				BaseOwner: "base-owner",
+				BaseRepo:  "base-repo",
+				HeadOwner: "fork-owner",
+				HeadRepo:  "fork-repo",
+				PRNumber:  123,
+				Author:    githubDependabotUser,
+			},
+		}
+
+		authorized, err := j.isUserAuthorized(t.Context(), patchDoc, "required-org", githubDependabotUser)
+
+		assert.NoError(t, err)
+		assert.False(t, authorized)
+		assert.True(t, consultedWritePermission)
+	})
 }


### PR DESCRIPTION
DEVPROD-41216
### Description

PRs currently look at whatever triggered the event rather than who wrote the code when determining if it should be allowed to run. Those two things can deviate in a fork PR, for example if a trusted bot like dependabot pushed to it, even if the original human code writer was not trusted.

### Fix
Authorize against the PR author rather than the event sender. The author is fixed by Github and can't be changed. I also added a defensive check to make sure auto approval for actions/dependabot only applies for PR that are not external forks.

The generated ticket recommends the following but should not be necessary because the PR author is already immutable itself.
> Defense in depth: bind the authorization decision to the immutable tuple (PR author ID, head owner/repo, head SHA, base owner/repo, PR number) and carry a prior denial across base changes unless that exact tuple is manually approved.
### Testing

Added unit tests.