### PR TITLE
DEVPROD-36661: Prevent restarts for any merge queue patches included in `versionsToRestart`

### DIFF
--- a/model/version_db.go
+++ b/model/version_db.go
@@ -479,6 +479,17 @@ func GetVersionAuthorID(ctx context.Context, versionID string) (string, error) {
 	return v.AuthorID, nil
 }
 
+func GetVersionRequester(ctx context.Context, versionID string) (string, error) {
+	v, err := VersionFindOne(ctx, VersionById(versionID).WithFields(VersionRequesterKey))
+	if err != nil {
+		return "", errors.Wrapf(err, "getting version '%s'", versionID)
+	}
+	if v == nil {
+		return "", errors.Errorf("no version found for ID '%s'", versionID)
+	}
+	return v.Requester, nil
+}
+
 func FindLastPeriodicBuild(ctx context.Context, projectID, definitionID string) (*Version, error) {
 	versions, err := VersionFind(ctx, db.Query(bson.M{
 		VersionPeriodicBuildIDKey: definitionID,

--- a/model/version_modification.go
+++ b/model/version_modification.go
@@ -8,6 +8,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/model/user"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/utility"
 	"github.com/pkg/errors"
 )
 
@@ -22,8 +23,14 @@ type VersionModification struct {
 func ModifyVersion(ctx context.Context, version Version, user user.DBUser, modifications VersionModification) (int, error) {
 	switch modifications.Action {
 	case evergreen.RestartAction:
-		if version.Requester == evergreen.GithubMergeRequester {
-			return http.StatusBadRequest, errors.New("merge queue patches cannot be manually restarted")
+		for _, vtr := range modifications.VersionsToRestart {
+			r, err := GetVersionRequester(ctx, utility.FromStringPtr(vtr.VersionId))
+			if err != nil {
+				return http.StatusInternalServerError, errors.Wrap(err, "getting version requester")
+			}
+			if r == evergreen.GithubMergeRequester {
+				return http.StatusBadRequest, errors.Errorf("merge queue patch '%s' cannot be manually restarted", utility.FromStringPtr(vtr.VersionId))
+			}
 		}
 		if err := RestartVersions(ctx, modifications.VersionsToRestart, modifications.Abort, user.Id); err != nil {
 			return http.StatusInternalServerError, errors.Wrap(err, "restarting patch")

--- a/model/version_modification_test.go
+++ b/model/version_modification_test.go
@@ -44,7 +44,7 @@ func TestModifyVersionRestart(t *testing.T) {
 		})
 		assert.Error(t, err)
 		assert.Equal(t, http.StatusBadRequest, statusCode)
-		assert.Contains(t, err.Error(), "merge queue patches cannot be manually restarted")
+		assert.Contains(t, err.Error(), "merge queue patch 'merge-queue-version' cannot be manually restarted")
 	})
 
 	t.Run("RestartRejectsMergeQueueVersionInList", func(t *testing.T) {
@@ -57,7 +57,7 @@ func TestModifyVersionRestart(t *testing.T) {
 		})
 		assert.Error(t, err)
 		assert.Equal(t, http.StatusBadRequest, statusCode)
-		assert.Contains(t, err.Error(), "merge queue patches cannot be manually restarted")
+		assert.Contains(t, err.Error(), "merge queue patch 'merge-queue-version' cannot be manually restarted")
 	})
 
 	t.Run("RestartAllowsNonMergeQueueVersions", func(t *testing.T) {

--- a/model/version_modification_test.go
+++ b/model/version_modification_test.go
@@ -1,0 +1,162 @@
+package model
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/db"
+	"github.com/evergreen-ci/evergreen/model/build"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/evergreen-ci/evergreen/model/user"
+	"github.com/evergreen-ci/utility"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModifyVersionRestart(t *testing.T) {
+	ctx := t.Context()
+	require.NoError(t, db.ClearCollections(VersionCollection, task.Collection, build.Collection, task.OldCollection))
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(VersionCollection, task.Collection, build.Collection, task.OldCollection))
+	})
+
+	mergeQueueVersion := &Version{
+		Id:        "merge-queue-version",
+		Requester: evergreen.GithubMergeRequester,
+	}
+	require.NoError(t, mergeQueueVersion.Insert(ctx))
+
+	patchVersion := &Version{
+		Id:        "patch-version",
+		Requester: evergreen.PatchVersionRequester,
+	}
+	require.NoError(t, patchVersion.Insert(ctx))
+
+	u := user.DBUser{Id: "user"}
+
+	t.Run("RestartRejectsTopLevelMergeQueueVersion", func(t *testing.T) {
+		statusCode, err := ModifyVersion(ctx, *mergeQueueVersion, u, VersionModification{
+			Action: evergreen.RestartAction,
+			VersionsToRestart: []*VersionToRestart{
+				{VersionId: utility.ToStringPtr(mergeQueueVersion.Id)},
+			},
+		})
+		assert.Error(t, err)
+		assert.Equal(t, http.StatusBadRequest, statusCode)
+		assert.Contains(t, err.Error(), "merge queue patches cannot be manually restarted")
+	})
+
+	t.Run("RestartRejectsMergeQueueVersionInList", func(t *testing.T) {
+		statusCode, err := ModifyVersion(ctx, *patchVersion, u, VersionModification{
+			Action: evergreen.RestartAction,
+			VersionsToRestart: []*VersionToRestart{
+				{VersionId: utility.ToStringPtr(patchVersion.Id)},
+				{VersionId: utility.ToStringPtr(mergeQueueVersion.Id)},
+			},
+		})
+		assert.Error(t, err)
+		assert.Equal(t, http.StatusBadRequest, statusCode)
+		assert.Contains(t, err.Error(), "merge queue patches cannot be manually restarted")
+	})
+
+	t.Run("RestartAllowsNonMergeQueueVersions", func(t *testing.T) {
+		statusCode, err := ModifyVersion(ctx, *patchVersion, u, VersionModification{
+			Action: evergreen.RestartAction,
+			VersionsToRestart: []*VersionToRestart{
+				{VersionId: utility.ToStringPtr(patchVersion.Id)},
+			},
+		})
+		assert.NoError(t, err)
+		assert.Zero(t, statusCode)
+	})
+}
+
+func TestModifyVersionSetActive(t *testing.T) {
+	ctx := t.Context()
+	require.NoError(t, db.ClearCollections(VersionCollection, task.Collection, build.Collection))
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(VersionCollection, task.Collection, build.Collection))
+	})
+
+	u := user.DBUser{Id: "user"}
+
+	t.Run("SetActiveRejectsMergeQueueVersion", func(t *testing.T) {
+		v := &Version{
+			Id:        "merge-queue-version",
+			Requester: evergreen.GithubMergeRequester,
+		}
+		require.NoError(t, v.Insert(ctx))
+		statusCode, err := ModifyVersion(ctx, *v, u, VersionModification{
+			Action: evergreen.SetActiveAction,
+			Active: true,
+		})
+		assert.Error(t, err)
+		assert.Equal(t, http.StatusBadRequest, statusCode)
+		assert.Contains(t, err.Error(), "merge queue patches cannot be manually scheduled")
+	})
+
+	t.Run("SetActiveAllowsNonMergeQueueVersion", func(t *testing.T) {
+		v := &Version{
+			Id:        "patch-version",
+			Requester: evergreen.PatchVersionRequester,
+		}
+		require.NoError(t, v.Insert(ctx))
+		statusCode, err := ModifyVersion(ctx, *v, u, VersionModification{
+			Action: evergreen.SetActiveAction,
+			Active: true,
+		})
+		assert.NoError(t, err)
+		assert.Zero(t, statusCode)
+	})
+}
+
+func TestModifyVersionSetPriority(t *testing.T) {
+	ctx := t.Context()
+	require.NoError(t, db.ClearCollections(VersionCollection, task.Collection))
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(VersionCollection, task.Collection))
+	})
+
+	u := user.DBUser{Id: "user"}
+
+	t.Run("SetPriorityRequiresProjectIdentifier", func(t *testing.T) {
+		v := &Version{
+			Id:        "version-no-project",
+			Requester: evergreen.PatchVersionRequester,
+		}
+		require.NoError(t, v.Insert(ctx))
+		statusCode, err := ModifyVersion(ctx, *v, u, VersionModification{
+			Action:   evergreen.SetPriorityAction,
+			Priority: 5,
+		})
+		assert.Error(t, err)
+		assert.Equal(t, http.StatusNotFound, statusCode)
+	})
+
+	t.Run("SetPrioritySucceeds", func(t *testing.T) {
+		v := &Version{
+			Id:         "version-with-project",
+			Requester:  evergreen.PatchVersionRequester,
+			Identifier: "proj",
+		}
+		require.NoError(t, v.Insert(ctx))
+		statusCode, err := ModifyVersion(ctx, *v, u, VersionModification{
+			Action:   evergreen.SetPriorityAction,
+			Priority: 5,
+		})
+		assert.NoError(t, err)
+		assert.Zero(t, statusCode)
+	})
+}
+
+func TestModifyVersionUnrecognizedAction(t *testing.T) {
+	v := Version{Id: "v1"}
+	u := user.DBUser{Id: "user"}
+	statusCode, err := ModifyVersion(t.Context(), v, u, VersionModification{
+		Action: "invalid",
+	})
+	assert.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, statusCode)
+	assert.Contains(t, err.Error(), "unrecognized action")
+}


### PR DESCRIPTION
DEVPROD-36661

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Continued from evergreen-ci/evergreen/pull/10568.

When restarting versions, we only check if the top-level version is on the merge queue, but we should check every version included in `VersionsToRestart`.

### Testing
* Test file for `ModifyVersion` function