### PR TITLE
DEVPROD-41255 Remove secondary artifact reads

### DIFF
--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -221,7 +221,7 @@ func PresignFile(ctx context.Context, file File, resolver CredentialResolver) (s
 }
 
 func GetAllArtifacts(ctx context.Context, tasks []TaskIDAndExecution) ([]File, error) {
-	artifacts, err := FindAllSecondary(ctx, ByTaskIdsAndExecutions(tasks))
+	artifacts, err := FindAll(ctx, ByTaskIdsAndExecutions(tasks))
 	if err != nil {
 		return nil, errors.Wrap(err, "finding artifact files for task")
 	}
@@ -230,7 +230,7 @@ func GetAllArtifacts(ctx context.Context, tasks []TaskIDAndExecution) ([]File, e
 		for _, t := range tasks {
 			taskIds = append(taskIds, t.TaskID)
 		}
-		artifacts, err = FindAllSecondary(ctx, ByTaskIds(taskIds))
+		artifacts, err = FindAll(ctx, ByTaskIds(taskIds))
 		if err != nil {
 			return nil, errors.Wrap(err, "finding artifact files for task without execution number")
 		}

--- a/model/artifact/db.go
+++ b/model/artifact/db.go
@@ -111,15 +111,6 @@ func FindAll(ctx context.Context, query db.Q) ([]Entry, error) {
 	return entries, err
 }
 
-// FindAllSecondary gets every Entry for the given query, reading from a secondary
-// node. Results may be replication-lagged, so use it only for display reads of
-// already-persisted artifacts, never in a read-after-write path.
-func FindAllSecondary(ctx context.Context, query db.Q) ([]Entry, error) {
-	entries := []Entry{}
-	err := db.FindAllQSecondary(ctx, Collection, query, &entries)
-	return entries, err
-}
-
 // UpdateFileLink updates the link for a single artifact file matching task ID, execution,
 // file name, and current link. Returns db.ErrNotFound if no file matched.
 func UpdateFileLink(ctx context.Context, taskID string, execution int, fileName, currentLink, newLink string) error {

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -671,10 +671,10 @@ func (at *APITask) getArtifacts(ctx context.Context, baseURL string) error {
 			ets = append(ets, artifact.TaskIDAndExecution{TaskID: *t, Execution: at.Execution})
 		}
 		if len(ets) > 0 {
-			entries, err = artifact.FindAllSecondary(ctx, artifact.ByTaskIdsAndExecutions(ets))
+			entries, err = artifact.FindAll(ctx, artifact.ByTaskIdsAndExecutions(ets))
 		}
 	} else {
-		entries, err = artifact.FindAllSecondary(ctx, artifact.ByTaskIdAndExecution(utility.FromStringPtr(at.Id), at.Execution))
+		entries, err = artifact.FindAll(ctx, artifact.ByTaskIdAndExecution(utility.FromStringPtr(at.Id), at.Execution))
 	}
 	if err != nil {
 		return errors.Wrap(err, "retrieving artifacts")

--- a/service/rest_task.go
+++ b/service/rest_task.go
@@ -159,7 +159,7 @@ func (restapi restAPI) getTaskInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Copy over artifacts and binaries.
-	entries, err := artifact.FindAllSecondary(r.Context(), artifact.ByTaskId(srcTask.Id))
+	entries, err := artifact.FindAll(r.Context(), artifact.ByTaskId(srcTask.Id))
 	if err != nil {
 		msg := fmt.Sprintf("Error finding task '%s'", srcTask.Id)
 		grip.Errorf(r.Context(), "%v: %+v", msg, err)


### PR DESCRIPTION
DEVPROD-41255

undo read from secondary for artifact since it was causing errors sometimes 


This is a partial revert because reading from secondary always has a risk of getting stale data
Examples attached in ticket.
Server is also implementing retries

