### PR TITLE
DEVPROD-32852: create distro settings for subnet discovery

### DIFF
--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -135,8 +135,7 @@ func (s *EC2ProviderSettings) Validate() error {
 }
 
 // subnetTagFilter returns the tag name and value that identify the subnets
-// available to the distro. Distro subnet tags take precedence over those
-// defined in the admin settings.
+// available to the host.
 func (s *EC2ProviderSettings) subnetTagFilter(settings *evergreen.Settings) (tagName string, tagValue string) {
 	if s.SubnetTagName != "" && s.SubnetTagValue != "" {
 		return s.SubnetTagName, s.SubnetTagValue

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -134,6 +134,16 @@ func (s *EC2ProviderSettings) Validate() error {
 	return catcher.Resolve()
 }
 
+// subnetTagFilter returns the tag name and value that identify the subnets
+// available to the distro. Distro subnet tags take precedence over those
+// defined in the admin settings.
+func (s *EC2ProviderSettings) subnetTagFilter(settings *evergreen.Settings) (tagName string, tagValue string) {
+	if s.SubnetTagName != "" && s.SubnetTagValue != "" {
+		return s.SubnetTagName, s.SubnetTagValue
+	}
+	return settings.Providers.AWS.SubnetTagName, settings.Providers.AWS.SubnetTagValue
+}
+
 // region is only provided if we want to filter by region
 func (s *EC2ProviderSettings) FromDistroSettings(d distro.Distro, region string) error {
 	if len(d.ProviderSettingsList) != 0 {

--- a/cloud/ec2.go
+++ b/cloud/ec2.go
@@ -73,6 +73,14 @@ type EC2ProviderSettings struct {
 	// IsVpc is set to true if the security group is part of a VPC.
 	IsVpc bool `mapstructure:"is_vpc" json:"is_vpc,omitempty" bson:"is_vpc,omitempty"`
 
+	// SubnetTagName is the name of the tag that can be used to look up the
+	// subnets available to this distro.
+	SubnetTagName string `mapstructure:"subnet_tag_name" json:"subnet_tag_name,omitempty" bson:"subnet_tag_name,omitempty"`
+
+	// SubnetTagValue is the value of the tag that can be used to look up the
+	// subnets available to this distro.
+	SubnetTagValue string `mapstructure:"subnet_tag_value" json:"subnet_tag_value,omitempty" bson:"subnet_tag_value,omitempty"`
+
 	// UserData specifies configuration that runs after the instance starts.
 	UserData string `mapstructure:"user_data" json:"user_data,omitempty" bson:"user_data,omitempty"`
 
@@ -107,6 +115,9 @@ func (s *EC2ProviderSettings) Validate() error {
 	if s.IsVpc && s.SubnetId == "" {
 		catcher.New("must set a default subnet for a VPC")
 	}
+
+	catcher.NewWhen(s.SubnetTagName == "" && s.SubnetTagValue != "", "must specify a subnet tag name if a subnet tag value is set")
+	catcher.NewWhen(s.SubnetTagName != "" && s.SubnetTagValue == "", "must specify a subnet tag value if a subnet tag name is set")
 
 	if s.Tenancy != "" {
 		catcher.ErrorfWhen(!evergreen.IsValidEC2Tenancy(s.Tenancy), "invalid tenancy '%s', allowed values are: %s", s.Tenancy, evergreen.ValidEC2Tenancies)

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -33,10 +33,9 @@ type instanceTypeCacheKey struct {
 	account      string
 	region       string
 	instanceType string
-	// subnetTagName and subnetTagValue are part of the key because they
-	// determine which subnets are discovered. Keying on them rather than on the
-	// distro means that changing a distro's tag takes effect without having to
-	// restart the app servers, and that distros sharing a tag share an entry.
+	// subnetTagName and subnetTagValue are part of the key because different
+	// distros could use the same account/region/instance type but use different
+	// sets of subnets.
 	subnetTagName  string
 	subnetTagValue string
 }

--- a/cloud/ec2_fleet.go
+++ b/cloud/ec2_fleet.go
@@ -33,6 +33,12 @@ type instanceTypeCacheKey struct {
 	account      string
 	region       string
 	instanceType string
+	// subnetTagName and subnetTagValue are part of the key because they
+	// determine which subnets are discovered. Keying on them rather than on the
+	// distro means that changing a distro's tag takes effect without having to
+	// restart the app servers, and that distros sharing a tag share an entry.
+	subnetTagName  string
+	subnetTagValue string
 }
 
 // cachedSubnets is the result of looking up the subnets for a single
@@ -65,7 +71,7 @@ func (c *instanceTypeSubnetCache) subnetsWithInstanceType(ctx context.Context, s
 
 	var candidateSubnets []evergreen.Subnet
 	if cacheKey.account != "" {
-		discovered, err := c.discoverSubnets(ctx, settings, client)
+		discovered, err := c.discoverSubnets(ctx, client, cacheKey)
 		if err != nil {
 			c.set(cacheKey, cachedSubnets{err: err})
 			return nil, errors.Wrapf(err, "discovering subnets for account '%s'", cacheKey.account)
@@ -122,9 +128,9 @@ func (c *instanceTypeSubnetCache) set(key instanceTypeCacheKey, result cachedSub
 
 // discoverSubnets returns the subnets in the client's AWS account and region
 // that are tagged as usable by Evergreen.
-func (c *instanceTypeSubnetCache) discoverSubnets(ctx context.Context, settings *evergreen.Settings, client AWSClient) ([]evergreen.Subnet, error) {
-	tagName := settings.Providers.AWS.SubnetTagName
-	tagValue := settings.Providers.AWS.SubnetTagValue
+func (c *instanceTypeSubnetCache) discoverSubnets(ctx context.Context, client AWSClient, cacheKey instanceTypeCacheKey) ([]evergreen.Subnet, error) {
+	tagName := cacheKey.subnetTagName
+	tagValue := cacheKey.subnetTagValue
 	if tagName == "" || tagValue == "" {
 		return nil, errors.New("subnet tag name and value must both be set to discover subnets")
 	}
@@ -848,10 +854,13 @@ func (m *ec2FleetManager) makeSubnetOverrides(ctx context.Context, h *host.Host,
 		return nil, nil
 	}
 
+	subnetTagName, subnetTagValue := ec2Settings.subnetTagFilter(m.settings)
 	supportingSubnets, err := typeCache.subnetsWithInstanceType(ctx, m.settings, m.client, instanceTypeCacheKey{
-		instanceType: ec2Settings.InstanceType,
-		region:       ec2Settings.getRegion(),
-		account:      m.account,
+		instanceType:   ec2Settings.InstanceType,
+		region:         ec2Settings.getRegion(),
+		account:        m.account,
+		subnetTagName:  subnetTagName,
+		subnetTagValue: subnetTagValue,
 	})
 	if err != nil {
 		// Not being able to determine the subnets shouldn't stop the host from

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -691,6 +691,53 @@ func TestMakeSubnetOverrides(t *testing.T) {
 			}
 			assert.Equal(t, 1, client.DescribeSubnetsCount, "already-discovered subnets are cached")
 		},
+		"DistroSubnetTagTakesPrecedenceOverAdminSettings": func(ctx context.Context, t *testing.T) {
+			m, client := makeManager(account)
+			ec2Settings := &EC2ProviderSettings{
+				InstanceType:   "instanceType0",
+				SubnetId:       "subnet-discovered1",
+				SubnetTagName:  "distro-subnet-group",
+				SubnetTagValue: "distro-subnet",
+			}
+
+			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+			require.NoError(t, err)
+			require.Len(t, overrides, 2)
+
+			require.NotZero(t, client.DescribeSubnetsInput)
+			require.Len(t, client.DescribeSubnetsInput.Filters, 1)
+			assert.Equal(t, "tag:distro-subnet-group", utility.FromStringPtr(client.DescribeSubnetsInput.Filters[0].Name))
+			assert.Equal(t, []string{"distro-subnet"}, client.DescribeSubnetsInput.Filters[0].Values)
+		},
+		"AdminSettingsSubnetTagIsUsedWhenTheDistroHasNone": func(ctx context.Context, t *testing.T) {
+			m, client := makeManager(account)
+			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
+
+			_, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+			require.NoError(t, err)
+
+			require.NotZero(t, client.DescribeSubnetsInput)
+			require.Len(t, client.DescribeSubnetsInput.Filters, 1)
+			assert.Equal(t, "tag:"+tagName, utility.FromStringPtr(client.DescribeSubnetsInput.Filters[0].Name))
+			assert.Equal(t, []string{tagValue}, client.DescribeSubnetsInput.Filters[0].Values)
+		},
+		"CachedSubnetsAreNotSharedBetweenDifferentSubnetTags": func(ctx context.Context, t *testing.T) {
+			m, client := makeManager(account)
+			adminTagSettings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
+			distroTagSettings := &EC2ProviderSettings{
+				InstanceType:   "instanceType0",
+				SubnetId:       "subnet-discovered1",
+				SubnetTagName:  "distro-subnet-group",
+				SubnetTagValue: "distro-subnet",
+			}
+
+			_, err := m.makeSubnetOverrides(ctx, h, adminTagSettings)
+			require.NoError(t, err)
+			_, err = m.makeSubnetOverrides(ctx, h, distroTagSettings)
+			require.NoError(t, err)
+
+			assert.Equal(t, 2, client.DescribeSubnetsCount, "distros with different subnet tags should not share cached subnets")
+		},
 		"DefaultAccountUsesAdminSettingsSubnets": func(ctx context.Context, t *testing.T) {
 			m, client := makeManager("")
 			ec2Settings := &EC2ProviderSettings{

--- a/cloud/ec2_fleet_test.go
+++ b/cloud/ec2_fleet_test.go
@@ -2,6 +2,7 @@ package cloud
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -610,6 +611,14 @@ func TestMakeSubnetOverrides(t *testing.T) {
 		tagValue = "evergreen-subnet"
 	)
 	az := evergreen.DefaultEBSAvailabilityZone
+	adminSettingsSubnetIDs := []string{
+		"default-account-subnet-from-admin-settings1",
+		"default-account-subnet-from-admin-settings2",
+	}
+	discoveredSubnetIDs := []string{
+		"subnet-discovered1",
+		"subnet-discovered2",
+	}
 
 	expireCachedFailures := func() {
 		typeCache.mu.Lock()
@@ -634,8 +643,8 @@ func TestMakeSubnetOverrides(t *testing.T) {
 			},
 			DescribeSubnetsOutput: &ec2.DescribeSubnetsOutput{
 				Subnets: []types.Subnet{
-					{SubnetId: aws.String("subnet-discovered1"), AvailabilityZone: aws.String(az)},
-					{SubnetId: aws.String("subnet-discovered2"), AvailabilityZone: aws.String(az)},
+					{SubnetId: aws.String(discoveredSubnetIDs[0]), AvailabilityZone: aws.String(az)},
+					{SubnetId: aws.String(discoveredSubnetIDs[1]), AvailabilityZone: aws.String(az)},
 				},
 			},
 		}
@@ -649,8 +658,8 @@ func TestMakeSubnetOverrides(t *testing.T) {
 				Providers: evergreen.CloudProviders{
 					AWS: evergreen.AWSConfig{
 						Subnets: []evergreen.Subnet{
-							{AZ: az, SubnetID: "subnet-from-admin-settings1"},
-							{AZ: az, SubnetID: "subnet-from-admin-settings2"},
+							{AZ: az, SubnetID: adminSettingsSubnetIDs[0]},
+							{AZ: az, SubnetID: adminSettingsSubnetIDs[1]},
 						},
 						SubnetTagName:  tagName,
 						SubnetTagValue: tagValue,
@@ -658,6 +667,15 @@ func TestMakeSubnetOverrides(t *testing.T) {
 				},
 			},
 		}, client
+	}
+
+	subnetsMatch := func(t *testing.T, expected []string, actual []types.FleetLaunchTemplateOverridesRequest) {
+		require.Len(t, actual, len(expected))
+		var actualSubnetIDs []string
+		for _, s := range actual {
+			actualSubnetIDs = append(actualSubnetIDs, utility.FromStringPtr(s.SubnetId))
+		}
+		assert.ElementsMatch(t, expected, actualSubnetIDs)
 	}
 
 	h := &host.Host{
@@ -676,8 +694,7 @@ func TestMakeSubnetOverrides(t *testing.T) {
 			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
 			require.NoError(t, err)
 			require.Len(t, overrides, 2)
-			assert.Equal(t, "subnet-discovered1", utility.FromStringPtr(overrides[0].SubnetId))
-			assert.Equal(t, "subnet-discovered2", utility.FromStringPtr(overrides[1].SubnetId))
+			subnetsMatch(t, discoveredSubnetIDs, overrides)
 
 			require.NotZero(t, client.DescribeSubnetsInput)
 			require.Len(t, client.DescribeSubnetsInput.Filters, 1)
@@ -700,18 +717,20 @@ func TestMakeSubnetOverrides(t *testing.T) {
 				SubnetTagValue: "distro-subnet",
 			}
 
-			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
+			_, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
 			require.NoError(t, err)
-			require.Len(t, overrides, 2)
 
 			require.NotZero(t, client.DescribeSubnetsInput)
 			require.Len(t, client.DescribeSubnetsInput.Filters, 1)
-			assert.Equal(t, "tag:distro-subnet-group", utility.FromStringPtr(client.DescribeSubnetsInput.Filters[0].Name))
-			assert.Equal(t, []string{"distro-subnet"}, client.DescribeSubnetsInput.Filters[0].Values)
+			assert.Equal(t, fmt.Sprintf("tag:%s", ec2Settings.SubnetTagName), utility.FromStringPtr(client.DescribeSubnetsInput.Filters[0].Name))
+			assert.Equal(t, []string{ec2Settings.SubnetTagValue}, client.DescribeSubnetsInput.Filters[0].Values)
 		},
 		"AdminSettingsSubnetTagIsUsedWhenTheDistroHasNone": func(ctx context.Context, t *testing.T) {
 			m, client := makeManager(account)
-			ec2Settings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
+			ec2Settings := &EC2ProviderSettings{
+				InstanceType: "instanceType0",
+				SubnetId:     "subnet-discovered1",
+			}
 
 			_, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
 			require.NoError(t, err)
@@ -749,8 +768,7 @@ func TestMakeSubnetOverrides(t *testing.T) {
 			overrides, err := m.makeSubnetOverrides(ctx, h, ec2Settings)
 			require.NoError(t, err)
 			require.Len(t, overrides, 2)
-			assert.Equal(t, "subnet-from-admin-settings1", utility.FromStringPtr(overrides[0].SubnetId))
-			assert.Equal(t, "subnet-from-admin-settings2", utility.FromStringPtr(overrides[1].SubnetId))
+			subnetsMatch(t, adminSettingsSubnetIDs, overrides)
 			assert.Zero(t, client.DescribeSubnetsCount, "default account should not discover subnets")
 		},
 		"DiscoveryErrorReturnsNoOverridesAndCachesFailure": func(ctx context.Context, t *testing.T) {
@@ -851,16 +869,14 @@ func TestMakeSubnetOverrides(t *testing.T) {
 			overrides, err := defaultManager.makeSubnetOverrides(ctx, h, defaultSettings)
 			require.NoError(t, err)
 			require.Len(t, overrides, 2)
-			assert.Equal(t, "subnet-from-admin-settings1", utility.FromStringPtr(overrides[0].SubnetId))
-			assert.Equal(t, "subnet-from-admin-settings2", utility.FromStringPtr(overrides[1].SubnetId))
+			subnetsMatch(t, adminSettingsSubnetIDs, overrides)
 
 			otherManager, _ := makeManager(account)
 			otherSettings := &EC2ProviderSettings{InstanceType: "instanceType0", SubnetId: "subnet-discovered1"}
 			overrides, err = otherManager.makeSubnetOverrides(ctx, h, otherSettings)
 			require.NoError(t, err)
 			require.Len(t, overrides, 2, "the other account should not use the default account's subnets")
-			assert.Equal(t, "subnet-discovered1", utility.FromStringPtr(overrides[0].SubnetId))
-			assert.Equal(t, "subnet-discovered2", utility.FromStringPtr(overrides[1].SubnetId))
+			subnetsMatch(t, discoveredSubnetIDs, overrides)
 			assert.Zero(t, defaultClient.DescribeSubnetsCount)
 		},
 	} {

--- a/cloud/ec2_test.go
+++ b/cloud/ec2_test.go
@@ -49,12 +49,18 @@ func TestEC2Suite(t *testing.T) {
 }
 
 func TestEC2ProviderSettingsToDocument(t *testing.T) {
+	const (
+		subnetGroupName  = "subnet_group"
+		subnetGroupValue = "evergreen"
+	)
 	settings := &EC2ProviderSettings{
 		Region:                     evergreen.DefaultEC2Region,
 		AMI:                        "ami",
 		InstanceType:               "instance",
 		SecurityGroupIDs:           []string{"sg-123456"},
 		EnableNestedVirtualization: true,
+		SubnetTagName:              subnetGroupName,
+		SubnetTagValue:             subnetGroupValue,
 	}
 
 	doc, err := settings.ToDocument()
@@ -62,10 +68,18 @@ func TestEC2ProviderSettingsToDocument(t *testing.T) {
 	enabled, ok := doc.ExportMap()["enable_nested_virtualization"].(bool)
 	require.True(t, ok)
 	assert.True(t, enabled)
+	tagName, ok := doc.ExportMap()["subnet_tag_name"].(string)
+	require.True(t, ok)
+	assert.Equal(t, subnetGroupName, tagName)
+	tagValue, ok := doc.ExportMap()["subnet_tag_value"].(string)
+	require.True(t, ok)
+	assert.Equal(t, subnetGroupValue, tagValue)
 
 	var roundTrippedSettings EC2ProviderSettings
 	require.NoError(t, roundTrippedSettings.FromDocument(doc))
 	assert.True(t, roundTrippedSettings.EnableNestedVirtualization)
+	assert.Equal(t, subnetGroupName, roundTrippedSettings.SubnetTagName)
+	assert.Equal(t, subnetGroupValue, roundTrippedSettings.SubnetTagValue)
 }
 
 func (s *EC2Suite) TearDownTest() {
@@ -178,6 +192,15 @@ func (s *EC2Suite) TestValidateProviderSettings() {
 	p.IsVpc = true
 	s.Error(p.Validate())
 	p.SubnetId = "subnet-123456"
+	s.NoError(p.Validate())
+
+	p.SubnetTagName = "subnet_group"
+	s.Error(p.Validate(), "subnet tag name without a tag value should be invalid")
+	p.SubnetTagValue = "evergreen"
+	s.NoError(p.Validate())
+	p.SubnetTagName = ""
+	s.Error(p.Validate(), "subnet tag value without a tag name should be invalid")
+	p.SubnetTagValue = ""
 	s.NoError(p.Validate())
 }
 


### PR DESCRIPTION
DEVPROD-32852

### Description

Follow-up to #10646 to allow subnet tags to be settable at the distro level. This came out of discussions with infra because they will likely use different groups of subnets while migrating to non-default AWS accounts.

[UI PR](https://github.com/evergreen-ci/ui/pull/1850)

### Testing

* Tested in staging to verify that a host in a non-default account could discover and use subnets using distro subnet tags.
* Added unit tests.