### PR TITLE
DEVPROD-27441: estimate missing task start time from dispatch time

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2137,6 +2137,10 @@ func (t *Task) MarkEnd(ctx context.Context, finishTime time.Time, detail *apimod
 		} else if timedOutStart.Before(t.IngestTime) {
 			t.StartTime = t.IngestTime
 		} else {
+			// If the task was never dispatched and the ingest time is a long
+			// time ago (e.g. restarting a really old task), set the start time
+			// to 2 hours ago. This is an arbitrary guess, but that's preferable
+			// to having a really long task duration.
 			t.StartTime = timedOutStart
 		}
 	}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -2127,16 +2127,17 @@ func DeactivateDependencies(ctx context.Context, tasks []string, caller string) 
 	return errors.Wrap(deactivateDependencies(ctx, tasksToUpdate, taskIDsToUpdate, caller), "marking dependencies deactivated")
 }
 
-// MarkEnd handles the Task updates associated with ending a task. If the task's start time is zero
-// at this time, it will set it to the finish time minus the timeout time.
+// MarkEnd handles the Task updates associated with ending a task. If the task
+// never reported that it started, its start time is estimated.
 func (t *Task) MarkEnd(ctx context.Context, finishTime time.Time, detail *apimodels.TaskEndDetail) error {
-	// if there is no start time set, either set it to the create time
-	// or set 2 hours previous to the finish time.
 	if utility.IsZeroTime(t.StartTime) {
 		timedOutStart := finishTime.Add(-2 * time.Hour)
-		t.StartTime = timedOutStart
-		if timedOutStart.Before(t.IngestTime) {
+		if !utility.IsZeroTime(t.DispatchTime) {
+			t.StartTime = t.DispatchTime
+		} else if timedOutStart.Before(t.IngestTime) {
 			t.StartTime = t.IngestTime
+		} else {
+			t.StartTime = timedOutStart
 		}
 	}
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1166,6 +1166,73 @@ func TestMarkEnd(t *testing.T) {
 		require.NotNil(t, dbTask)
 		assert.True(t, dbTask.TaskCost.IsZero())
 	})
+
+	t.Run("EstimatedStartTimeForTaskThatNeverStarted", func(t *testing.T) {
+		finishTime := time.Now()
+		for tName, tCase := range map[string]struct {
+			dispatchTime      time.Time
+			ingestTime        time.Time
+			expectedStartTime time.Time
+		}{
+			"IsDispatchTimeIfSet": {
+				dispatchTime:      finishTime.Add(-time.Minute),
+				ingestTime:        finishTime.Add(-3 * time.Hour),
+				expectedStartTime: finishTime.Add(-time.Minute),
+			},
+			"IsIngestTimeIfDispatchTimeIsUnset": {
+				ingestTime:        finishTime.Add(-time.Minute),
+				expectedStartTime: finishTime.Add(-time.Minute),
+			},
+			"IsDispatchTimeEvenWhenItIsOlderThanTheOtherEstimates": {
+				dispatchTime:      finishTime.Add(-10 * time.Hour),
+				ingestTime:        finishTime.Add(-3 * time.Hour),
+				expectedStartTime: finishTime.Add(-10 * time.Hour),
+			},
+		} {
+			t.Run(tName, func(t *testing.T) {
+				require.NoError(t, db.Clear(Collection))
+				tsk := Task{
+					Id:           "task_that_never_started",
+					HostId:       "host",
+					DistroId:     "test_distro",
+					DispatchTime: tCase.dispatchTime,
+					IngestTime:   tCase.ingestTime,
+				}
+				require.NoError(t, tsk.Insert(ctx))
+
+				require.NoError(t, tsk.MarkEnd(ctx, finishTime, &apimodels.TaskEndDetail{Status: evergreen.TaskFailed}))
+
+				dbTask, err := FindOneId(ctx, tsk.Id)
+				require.NoError(t, err)
+				require.NotNil(t, dbTask)
+				assert.WithinDuration(t, tCase.expectedStartTime, dbTask.StartTime, time.Millisecond)
+				assert.Equal(t, finishTime.Sub(tCase.expectedStartTime), dbTask.TimeTaken)
+			})
+		}
+	})
+
+	t.Run("StartTimeIsKeptIfTaskStarted", func(t *testing.T) {
+		require.NoError(t, db.Clear(Collection))
+		finishTime := time.Now()
+		startTime := finishTime.Add(-10 * time.Minute)
+		tsk := Task{
+			Id:           "started_task",
+			HostId:       "host",
+			DistroId:     "test_distro",
+			DispatchTime: finishTime.Add(-11 * time.Minute),
+			IngestTime:   finishTime.Add(-30 * time.Minute),
+			StartTime:    startTime,
+		}
+		require.NoError(t, tsk.Insert(ctx))
+
+		require.NoError(t, tsk.MarkEnd(ctx, finishTime, &apimodels.TaskEndDetail{Status: evergreen.TaskSucceeded}))
+
+		dbTask, err := FindOneId(ctx, tsk.Id)
+		require.NoError(t, err)
+		require.NotNil(t, dbTask)
+		assert.WithinDuration(t, startTime, dbTask.StartTime, time.Millisecond)
+		assert.Equal(t, 10*time.Minute, dbTask.TimeTaken)
+	})
 }
 
 func TestTaskResultOutcome(t *testing.T) {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1123,7 +1123,7 @@ func TestMarkEnd(t *testing.T) {
 
 	t.Run("HostTaskHasRuntimeCost", func(t *testing.T) {
 		require.NoError(t, db.Clear(Collection))
-		now := time.Now()
+		now := utility.BSONTime(time.Now())
 		tsk := Task{
 			Id:        "host_task",
 			HostId:    "host",
@@ -1168,7 +1168,7 @@ func TestMarkEnd(t *testing.T) {
 	})
 
 	t.Run("EstimatedStartTimeForTaskThatNeverStarted", func(t *testing.T) {
-		finishTime := time.Now()
+		finishTime := utility.BSONTime(time.Now())
 		for tName, tCase := range map[string]struct {
 			dispatchTime      time.Time
 			ingestTime        time.Time
@@ -1205,7 +1205,7 @@ func TestMarkEnd(t *testing.T) {
 				dbTask, err := FindOneId(ctx, tsk.Id)
 				require.NoError(t, err)
 				require.NotNil(t, dbTask)
-				assert.WithinDuration(t, tCase.expectedStartTime, dbTask.StartTime, time.Millisecond)
+				assert.WithinDuration(t, tCase.expectedStartTime, dbTask.StartTime, 0)
 				assert.Equal(t, finishTime.Sub(tCase.expectedStartTime), dbTask.TimeTaken)
 			})
 		}
@@ -1213,7 +1213,7 @@ func TestMarkEnd(t *testing.T) {
 
 	t.Run("StartTimeIsKeptIfTaskStarted", func(t *testing.T) {
 		require.NoError(t, db.Clear(Collection))
-		finishTime := time.Now()
+		finishTime := utility.BSONTime(time.Now())
 		startTime := finishTime.Add(-10 * time.Minute)
 		tsk := Task{
 			Id:           "started_task",
@@ -1230,7 +1230,7 @@ func TestMarkEnd(t *testing.T) {
 		dbTask, err := FindOneId(ctx, tsk.Id)
 		require.NoError(t, err)
 		require.NotNil(t, dbTask)
-		assert.WithinDuration(t, startTime, dbTask.StartTime, time.Millisecond)
+		assert.WithinDuration(t, startTime, dbTask.StartTime, 0)
 		assert.Equal(t, 10*time.Minute, dbTask.TimeTaken)
 	})
 }


### PR DESCRIPTION
DEVPROD-27441

### Description

Some tasks have overlapping start/end times in the Trino data. From my investigation, I didn't find any evidence that tasks _actually_ run simultaneously on the same host. However, there are two bugs I found which cause the task start and finish time to be guesstimated so it _looks_ like they're running concurrently with another task. Will post a fix for the 2nd bug in a follow-up PR.

This one fixes an issue with task start time because the task dispatched but never started. For example:

* [Some tasks can't find the parser project during task setup](https://spruce.corp.mongodb.com/task/mongodb_mongo_v4.4_enterprise_rhel_8_64_bit_compile_patch_af23f9edcd07d80f8483cac1291c3196dc2fa1a3_6882659a3fa03b0007b7011d_25_07_24_16_56_40/logs?execution=15) (filed DEVPROD-41432 to investigate)
* Some were aborted in the moment between dispatching and starting the host.
* [Some static hosts are already unhealthy when trying to start the task](https://spruce.corp.mongodb.com/task/mongodb_mongo_master_nightly_macos_unit_test_group4_5d0d15677d9b2f19dcc646bb54d4086dc55051a7_26_07_31_23_44_09/logs?execution=0&logtype=task).

If something happens in between task dispatch and start that causes it to system-fail, the start time is guessed to be either the ingest time or 2 hours ago. Changed this to prefer using the dispatch time instead. This fixes the overlapping task issue since tasks can only dispatch when the host has no assigned task.

### Testing

* Added unit tests.