### PR TITLE
DEVPROD-41457 Account for deps met time being before scheduled time in metrics dashboards

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2085,10 +2085,7 @@ func buildTaskCompletedSpanAttributes(t *task.Task) []attribute.KeyValue {
 			t.ScheduledTime.Sub(t.ActivatedTime).Milliseconds()))
 	}
 	if len(t.DependsOn) > 0 && !utility.IsZeroTime(t.DependenciesMetTime) && !utility.IsZeroTime(t.ScheduledTime) {
-		depWait := t.DependenciesMetTime.Sub(t.ScheduledTime)
-		if depWait < 0 {
-			depWait = 0
-		}
+		depWait := max(t.DependenciesMetTime.Sub(t.ScheduledTime), 0)
 		attrs = append(attrs, attribute.Int64(evergreen.TaskTimeWaitingForDepsMsOtelAttribute,
 			depWait.Milliseconds()))
 	}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2085,15 +2085,17 @@ func buildTaskCompletedSpanAttributes(t *task.Task) []attribute.KeyValue {
 			t.ScheduledTime.Sub(t.ActivatedTime).Milliseconds()))
 	}
 	if len(t.DependsOn) > 0 && !utility.IsZeroTime(t.DependenciesMetTime) && !utility.IsZeroTime(t.ScheduledTime) {
+		depWait := t.DependenciesMetTime.Sub(t.ScheduledTime)
+		if depWait < 0 {
+			depWait = 0
+		}
 		attrs = append(attrs, attribute.Int64(evergreen.TaskTimeWaitingForDepsMsOtelAttribute,
-			t.DependenciesMetTime.Sub(t.ScheduledTime).Milliseconds()))
+			depWait.Milliseconds()))
 	}
 	if !utility.IsZeroTime(t.StartTime) {
-		var readyToRunTime time.Time
-		if len(t.DependsOn) > 0 {
+		readyToRunTime := t.ScheduledTime
+		if t.DependenciesMetTime.After(readyToRunTime) {
 			readyToRunTime = t.DependenciesMetTime
-		} else {
-			readyToRunTime = t.ScheduledTime
 		}
 		if !utility.IsZeroTime(readyToRunTime) {
 			attrs = append(attrs, attribute.Int64(evergreen.TaskTimeWaitingInQueueMsOtelAttribute,

--- a/units/stats_task.go
+++ b/units/stats_task.go
@@ -141,9 +141,9 @@ func getWaitTimeMessages(tasks []task.Task) []message.Fields {
 			continue
 		}
 
-		submitTime := t.DependenciesMetTime
-		if utility.IsZeroTime(submitTime) {
-			submitTime = t.ScheduledTime
+		submitTime := t.ScheduledTime
+		if t.DependenciesMetTime.After(submitTime) {
+			submitTime = t.DependenciesMetTime
 		}
 		if utility.IsZeroTime(submitTime) {
 			continue


### PR DESCRIPTION
DEVPROD-41457

### Description
`DependenciesMetTime` can end up before `ScheduledTime` when a task's dependencies finish before it gets scheduled. This apparently happens often-ish with git tag and trigger versions due to frequent manual scheduling and unscheduling, which skews the wait time metrics for them in our [dashboards](https://mongodb.splunkcloud.com/en-US/app/search/evergreen_product__operational_metrics?tab=layout_1&form.global_time.earliest=-24h%40h&form.global_time.latest=now). 

This patches that assumption in both our splunk and HC dashboards.
### Testing
Existing tests.