### PR TITLE
DEVPROD-41320 Redirect all generated task json inserts to S3

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -1274,6 +1274,9 @@ func FindOneId(ctx context.Context, id string) (*Task, error) {
 
 // FindOneIdWithGeneratedJSON returns a single task with the given ID,
 // including the GeneratedJSONAsString field.
+//
+// TODO (DEVPROD-41456): delete this function. Once no task stores its generated
+// JSON in the DB, FindOneId is equivalent.
 func FindOneIdWithGeneratedJSON(ctx context.Context, id string) (*Task, error) {
 	task, err := FindOne(ctx, db.Query(bson.M{IdKey: id}))
 	return task, errors.Wrap(err, "finding task by ID with generated JSON")

--- a/model/task/generated_json_db.go
+++ b/model/task/generated_json_db.go
@@ -6,6 +6,9 @@ import (
 
 // generatedJSONDBStorage implements the generatedJSONDBStorage interface to
 // access generated JSON files stored in a task document in the DB.
+//
+// TODO (DEVPROD-41456): delete this type. All new generated JSON is written to
+// S3; this only remains to read tasks written before that switch.
 type generatedJSONDBStorage struct {
 }
 
@@ -13,10 +16,4 @@ type generatedJSONDBStorage struct {
 // the context parameter.
 func (s generatedJSONDBStorage) Find(_ context.Context, t *Task) (GeneratedJSONFiles, error) {
 	return t.GeneratedJSONAsString, nil
-}
-
-// Insert inserts all the generated JSON files for the given task. If the files
-// are already persisted, this will no-op.
-func (s generatedJSONDBStorage) Insert(ctx context.Context, t *Task, files GeneratedJSONFiles) error {
-	return t.SetGeneratedJSON(ctx, files)
 }

--- a/model/task/generated_json_storage.go
+++ b/model/task/generated_json_storage.go
@@ -4,9 +4,6 @@ import (
 	"context"
 
 	"github.com/evergreen-ci/evergreen"
-	"github.com/evergreen-ci/evergreen/db"
-	"github.com/mongodb/grip"
-	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 )
 
@@ -15,9 +12,6 @@ import (
 type GeneratedJSONFileStorage interface {
 	// FindByTaskID finds all generated JSON files for a given task.
 	Find(ctx context.Context, t *Task) (GeneratedJSONFiles, error)
-	// Insert inserts all the generated JSON files for the given task. If any
-	// of the files already exist, they are replaced.
-	Insert(ctx context.Context, t *Task, files GeneratedJSONFiles) error
 }
 
 // GetGeneratedJSONFileStorage returns the generated JSON file storage mechanism
@@ -45,42 +39,11 @@ func GeneratedJSONFind(ctx context.Context, settings *evergreen.Settings, t *Tas
 }
 
 // GeneratedJSONInsert is a convenience wrapper to insert all generated JSON
-// files for the given task to persistent storage.
-func GeneratedJSONInsert(ctx context.Context, settings *evergreen.Settings, t *Task, files GeneratedJSONFiles, method evergreen.ParserProjectStorageMethod) error {
-	fileStorage, err := GetGeneratedJSONFileStorage(ctx, settings, method)
+// files for the given task into S3.
+func GeneratedJSONInsert(ctx context.Context, settings *evergreen.Settings, t *Task, files GeneratedJSONFiles) error {
+	fileStorage, err := newGeneratedJSONS3Storage(ctx, settings.Providers.AWS.ParserProject)
 	if err != nil {
 		return errors.Wrap(err, "getting generated JSON file storage")
 	}
 	return fileStorage.Insert(ctx, t, files)
-}
-
-// GeneratedJSONInsertWithS3Fallback attempts to insert the generated JSON files
-// into persistent storage using the given storage method. If it fails due to DB
-// document size limitations, it will attempt to fall back to using S3 to store
-// it. If it succeeds, this returns the actual storage method used to persist
-// the generated JSON files; otherwise, it returns the originally-requested
-// storage method.
-func GeneratedJSONInsertWithS3Fallback(ctx context.Context, settings *evergreen.Settings, t *Task, files GeneratedJSONFiles, method evergreen.ParserProjectStorageMethod) (evergreen.ParserProjectStorageMethod, error) {
-	err := GeneratedJSONInsert(ctx, settings, t, files, method)
-	if method == evergreen.ProjectStorageMethodS3 {
-		return method, errors.Wrap(err, "inserting generated JSON files into S3")
-	}
-
-	if !db.IsDocumentLimit(err) {
-		return method, errors.Wrap(err, "inserting generated JSON files into the DB")
-	}
-
-	newMethod := evergreen.ProjectStorageMethodS3
-	if err := GeneratedJSONInsert(ctx, settings, t, files, newMethod); err != nil {
-		return method, errors.Wrap(err, "falling back to generated JSON files into S3")
-	}
-
-	grip.Info(ctx, message.Fields{
-		"message":            "successfully inserted generated JSON files into S3 as fallback due to document size limitation",
-		"task_id":            t.Id,
-		"old_storage_method": method,
-		"new_storage_method": newMethod,
-	})
-
-	return newMethod, nil
 }

--- a/model/task/generated_json_storage_test.go
+++ b/model/task/generated_json_storage_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGeneratedJSONStorage(t *testing.T) {
+func TestGeneratedJSONS3Storage(t *testing.T) {
 	ctx := t.Context()
 
 	env := &mock.Environment{}
@@ -41,65 +41,116 @@ func TestGeneratedJSONStorage(t *testing.T) {
 		assert.NoError(t, db.ClearCollections(Collection))
 	}()
 
-	for methodName, storageMethod := range map[string]evergreen.ParserProjectStorageMethod{
-		"DB": evergreen.ProjectStorageMethodDB,
-		"S3": evergreen.ProjectStorageMethodS3,
+	for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, tsk *Task){
+		"FindReturnsNilErrorAndResultForTaskWithNoGeneratedJSON": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk *Task) {
+			fileStorage, err := newGeneratedJSONS3Storage(ctx, env.Settings().Providers.AWS.ParserProject)
+			require.NoError(t, err)
+
+			files, err := fileStorage.Find(ctx, tsk)
+			assert.NoError(t, err)
+			assert.Empty(t, files)
+		},
+		"InsertStoresGeneratedJSONFiles": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk *Task) {
+			fileStorage, err := newGeneratedJSONS3Storage(ctx, env.Settings().Providers.AWS.ParserProject)
+			require.NoError(t, err)
+
+			files := GeneratedJSONFiles{`{"key0": "value0"}`, `{"key1": "value1"}`}
+			assert.NoError(t, fileStorage.Insert(ctx, tsk, files))
+
+			storedFiles, err := fileStorage.Find(ctx, tsk)
+			assert.NoError(t, err)
+			require.NotNil(t, storedFiles)
+			assert.Equal(t, files, storedFiles)
+		},
+		"InsertNoopsForExistingGeneratedJSONFiles": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk *Task) {
+			fileStorage, err := newGeneratedJSONS3Storage(ctx, env.Settings().Providers.AWS.ParserProject)
+			require.NoError(t, err)
+
+			files := GeneratedJSONFiles{`{"key": "value"}`}
+			assert.NoError(t, fileStorage.Insert(ctx, tsk, files))
+
+			storedFiles, err := fileStorage.Find(ctx, tsk)
+			assert.NoError(t, err)
+			require.NotNil(t, files)
+			assert.Equal(t, files, storedFiles)
+
+			newFiles := GeneratedJSONFiles{`{"new_key": "new_value"}`}
+			assert.NoError(t, fileStorage.Insert(ctx, tsk, newFiles))
+
+			storedFiles, err = fileStorage.Find(ctx, tsk)
+			assert.NoError(t, err)
+			require.NotNil(t, storedFiles)
+			assert.Equal(t, files, storedFiles, "inserting new files should not overwrite existing files")
+		},
 	} {
-		t.Run("StorageMethod"+methodName, func(t *testing.T) {
-			for testName, testCase := range map[string]func(ctx context.Context, t *testing.T, env *mock.Environment, tsk *Task){
-				"FindReturnsNilErrorAndResultForTaskWithNoGeneratedJSON": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk *Task) {
-					filesStorage, err := GetGeneratedJSONFileStorage(ctx, env.Settings(), storageMethod)
-					require.NoError(t, err)
+		t.Run(testName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(Collection))
+			require.NoError(t, bucket.RemovePrefix(ctx, ppConf.Prefix))
 
-					files, err := filesStorage.Find(ctx, tsk)
-					assert.NoError(t, err)
-					assert.Empty(t, files)
-				},
-				"InsertStoresGeneratedJSONFiles": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk *Task) {
-					fileStorage, err := GetGeneratedJSONFileStorage(ctx, env.Settings(), storageMethod)
-					require.NoError(t, err)
-
-					files := GeneratedJSONFiles{`{"key0": "value0"}`, `{"key1": "value1"}`}
-					assert.NoError(t, fileStorage.Insert(ctx, tsk, files))
-
-					storedFiles, err := fileStorage.Find(ctx, tsk)
-					assert.NoError(t, err)
-					require.NotNil(t, storedFiles)
-					assert.Equal(t, files, storedFiles)
-				},
-				"InsertNoopsForExistingGeneratedJSONFiles": func(ctx context.Context, t *testing.T, env *mock.Environment, tsk *Task) {
-					fileStorage, err := GetGeneratedJSONFileStorage(ctx, env.Settings(), storageMethod)
-					require.NoError(t, err)
-
-					files := GeneratedJSONFiles{`{"key": "value"}`}
-					assert.NoError(t, fileStorage.Insert(ctx, tsk, files))
-
-					storedFiles, err := fileStorage.Find(ctx, tsk)
-					assert.NoError(t, err)
-					require.NotNil(t, files)
-					assert.Equal(t, files, storedFiles)
-
-					newFiles := GeneratedJSONFiles{`{"new_key": "new_value"}`}
-					assert.NoError(t, fileStorage.Insert(ctx, tsk, newFiles))
-
-					storedFiles, err = fileStorage.Find(ctx, tsk)
-					assert.NoError(t, err)
-					require.NotNil(t, storedFiles)
-					assert.Equal(t, files, storedFiles, "inserting new files should not overwrite existing files")
-				},
-			} {
-				t.Run(testName, func(t *testing.T) {
-					require.NoError(t, db.ClearCollections(Collection))
-					require.NoError(t, bucket.RemovePrefix(ctx, ppConf.Prefix))
-
-					tsk := &Task{
-						Id: fmt.Sprintf("%s-%s", path.Base(t.Name()), utility.RandomString()),
-					}
-					require.NoError(t, tsk.Insert(t.Context()))
-
-					testCase(ctx, t, env, tsk)
-				})
+			tsk := &Task{
+				Id: fmt.Sprintf("%s-%s", path.Base(t.Name()), utility.RandomString()),
 			}
+			require.NoError(t, tsk.Insert(t.Context()))
+
+			testCase(ctx, t, env, tsk)
+		})
+	}
+}
+
+// TestGeneratedJSONFind covers retrieval for every storage method. generate.tasks
+// only writes to S3 now, but tasks that ran before that switch still store their
+// generated JSON in the task document.
+func TestGeneratedJSONFind(t *testing.T) {
+	ctx := t.Context()
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
+	testutil.ConfigureIntegrationTest(t, env.Settings())
+
+	c := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(c)
+
+	ppConf := env.Settings().Providers.AWS.ParserProject
+	bucket, err := pail.NewS3BucketWithHTTPClient(ctx, c, pail.S3Options{
+		Name:   ppConf.Bucket,
+		Region: evergreen.DefaultEC2Region,
+	})
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, bucket.RemovePrefix(ctx, ppConf.GeneratedJSONPrefix))
+	}()
+
+	files := GeneratedJSONFiles{`{"key0": "value0"}`, `{"key1": "value1"}`}
+
+	for testName, storeFiles := range map[string]func(t *testing.T, tsk *Task){
+		"UnsetStorageMethodReadsFromTheTaskDocument": func(t *testing.T, tsk *Task) {
+			tsk.GeneratedJSONAsString = files
+		},
+		"DBStorageMethodReadsFromTheTaskDocument": func(t *testing.T, tsk *Task) {
+			tsk.GeneratedJSONAsString = files
+			tsk.GeneratedJSONStorageMethod = evergreen.ProjectStorageMethodDB
+		},
+		"S3StorageMethodReadsFromS3": func(t *testing.T, tsk *Task) {
+			require.NoError(t, GeneratedJSONInsert(ctx, env.Settings(), tsk, files))
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			require.NoError(t, db.ClearCollections(Collection))
+			t.Cleanup(func() {
+				assert.NoError(t, db.ClearCollections(Collection))
+			})
+
+			tsk := &Task{
+				Id: fmt.Sprintf("%s-%s", path.Base(t.Name()), utility.RandomString()),
+			}
+			require.NoError(t, tsk.Insert(ctx))
+
+			storeFiles(t, tsk)
+
+			storedFiles, err := GeneratedJSONFind(ctx, env.Settings(), tsk)
+			require.NoError(t, err)
+			assert.Equal(t, files, storedFiles)
 		})
 	}
 }

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -318,6 +318,9 @@ type Task struct {
 	// project YAML for generate.tasks. This is only used to store the
 	// configuration if GeneratedJSONStorageMethod is unset or is explicitly set
 	// to "db".
+	//
+	// TODO (DEVPROD-41456): delete this field. Only tasks written before the
+	// switch to S3 still store their generated JSON here.
 	GeneratedJSONAsString GeneratedJSONFiles `bson:"generated_json,omitempty" json:"generated_json,omitempty"`
 	// GeneratedJSONStorageMethod describes how the generated JSON for
 	// generate.tasks is stored for this task before it's merged with the
@@ -1091,41 +1094,11 @@ func MarkGeneratedTasksErr(ctx context.Context, taskID string, errorToSet error)
 func GenerateNotRun(ctx context.Context) ([]Task, error) {
 	const maxGenerateTimeAgo = 24 * time.Hour
 	return FindAll(ctx, db.Query(bson.M{
-		StatusKey:                evergreen.TaskStarted,                              // task is running
-		StartTimeKey:             bson.M{"$gt": time.Now().Add(-maxGenerateTimeAgo)}, // ignore older tasks, just in case
-		GeneratedTasksKey:        bson.M{"$ne": true},                                // generate.tasks has not yet run
-		GeneratedJSONAsStringKey: bson.M{"$exists": true},                            // config has been posted by generate.tasks command
+		StatusKey:                     evergreen.TaskStarted,                              // task is running
+		StartTimeKey:                  bson.M{"$gt": time.Now().Add(-maxGenerateTimeAgo)}, // ignore older tasks, just in case
+		GeneratedTasksKey:             bson.M{"$ne": true},                                // generate.tasks has not yet run
+		GeneratedJSONStorageMethodKey: bson.M{"$exists": true},                            // config has been posted by generate.tasks command
 	}))
-}
-
-// SetGeneratedJSON sets JSON data to generate tasks from. If the generated JSON
-// files have already been stored, this is a no-op.
-func (t *Task) SetGeneratedJSON(ctx context.Context, files GeneratedJSONFiles) error {
-	if len(t.GeneratedJSONAsString) > 0 || t.GeneratedJSONStorageMethod != "" {
-		return nil
-	}
-
-	if err := UpdateOne(
-		ctx,
-		bson.M{
-			IdKey:                         t.Id,
-			GeneratedJSONAsStringKey:      bson.M{"$exists": false},
-			GeneratedJSONStorageMethodKey: nil,
-		},
-		bson.M{
-			"$set": bson.M{
-				GeneratedJSONAsStringKey:      files,
-				GeneratedJSONStorageMethodKey: evergreen.ProjectStorageMethodDB,
-			},
-		},
-	); err != nil {
-		return err
-	}
-
-	t.GeneratedJSONAsString = files
-	t.GeneratedJSONStorageMethod = evergreen.ProjectStorageMethodDB
-
-	return nil
 }
 
 // SetGeneratedJSONStorageMethod sets the task's generated JSON file storage

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -4864,7 +4864,7 @@ func TestGenerateNotRun(t *testing.T) {
 			assert.Empty(t, tasks)
 		},
 		"IgnoresTasksThatHaveNothingToGenerate": func(t *testing.T, tsk *Task) {
-			tsk.GeneratedJSONAsString = nil
+			tsk.GeneratedJSONStorageMethod = ""
 			require.NoError(t, tsk.Insert(t.Context()))
 
 			tasks, err := GenerateNotRun(ctx)
@@ -4884,87 +4884,11 @@ func TestGenerateNotRun(t *testing.T) {
 			require.NoError(t, db.ClearCollections(Collection))
 
 			tCase(t, &Task{
-				Id:                    "task_id",
-				Status:                evergreen.TaskStarted,
-				StartTime:             time.Now(),
-				GeneratedTasks:        false,
-				GeneratedJSONAsString: []string{"some_generated_json"},
-			})
-		})
-	}
-}
-
-func TestSetGeneratedJSON(t *testing.T) {
-	ctx := t.Context()
-
-	defer func() {
-		assert.NoError(t, db.ClearCollections(Collection))
-	}()
-
-	for tName, tCase := range map[string]func(t *testing.T, tsk *Task){
-		"Succeeds": func(t *testing.T, tsk *Task) {
-			files := GeneratedJSONFiles{"generated_json"}
-			require.NoError(t, tsk.Insert(t.Context()))
-
-			require.NoError(t, tsk.SetGeneratedJSON(ctx, files))
-
-			dbTask, err := FindOneIdWithGeneratedJSON(ctx, tsk.Id)
-			require.NoError(t, err)
-			require.NotZero(t, dbTask)
-			assert.Equal(t, files, dbTask.GeneratedJSONAsString)
-		},
-		"NoopsForAlreadySetGeneratedJSON": func(t *testing.T, tsk *Task) {
-			originalFiles := GeneratedJSONFiles{"generated_files"}
-			tsk.GeneratedJSONAsString = originalFiles
-			require.NoError(t, tsk.Insert(t.Context()))
-
-			require.NoError(t, tsk.SetGeneratedJSON(ctx, []string{"new_generated_json"}))
-
-			dbTask, err := FindOneIdWithGeneratedJSON(ctx, tsk.Id)
-			require.NoError(t, err)
-			require.NotZero(t, dbTask)
-			assert.EqualValues(t, originalFiles, dbTask.GeneratedJSONAsString)
-			assert.Empty(t, dbTask.GeneratedJSONStorageMethod)
-		},
-		"NoopsForAlreadySetGeneratedJSONDBStorage": func(t *testing.T, tsk *Task) {
-			originalFiles := GeneratedJSONFiles{"generated_json"}
-			tsk.GeneratedJSONAsString = originalFiles
-			tsk.GeneratedJSONStorageMethod = evergreen.ProjectStorageMethodDB
-			require.NoError(t, tsk.Insert(t.Context()))
-
-			require.NoError(t, tsk.SetGeneratedJSON(ctx, GeneratedJSONFiles{"new_generated_json"}))
-
-			dbTask, err := FindOneIdWithGeneratedJSON(ctx, tsk.Id)
-			require.NoError(t, err)
-			require.NotZero(t, dbTask)
-			assert.Equal(t, originalFiles, dbTask.GeneratedJSONAsString)
-			assert.Equal(t, evergreen.ProjectStorageMethodDB, dbTask.GeneratedJSONStorageMethod)
-		},
-		"NoopsForAlreadySetGeneratedJSONS3Storage": func(t *testing.T, tsk *Task) {
-			tsk.GeneratedJSONStorageMethod = evergreen.ProjectStorageMethodS3
-			require.NoError(t, tsk.Insert(t.Context()))
-
-			require.NoError(t, tsk.SetGeneratedJSON(ctx, GeneratedJSONFiles{"new_generated_json"}))
-
-			dbTask, err := FindOneId(ctx, tsk.Id)
-			require.NoError(t, err)
-			require.NotZero(t, dbTask)
-			assert.Equal(t, evergreen.ProjectStorageMethodS3, dbTask.GeneratedJSONStorageMethod)
-			assert.Empty(t, dbTask.GeneratedJSONAsString)
-		},
-		"FailsForNonexistentTask": func(t *testing.T, tsk *Task) {
-			assert.Error(t, tsk.SetGeneratedJSON(ctx, GeneratedJSONFiles{"generated_json"}))
-			assert.Empty(t, tsk.GeneratedJSONAsString)
-			assert.Empty(t, tsk.GeneratedJSONStorageMethod)
-		},
-	} {
-		t.Run(tName, func(t *testing.T) {
-			require.NoError(t, db.ClearCollections(Collection))
-
-			tCase(t, &Task{
-				Id:        "task_id",
-				Status:    evergreen.TaskStarted,
-				StartTime: time.Now(),
+				Id:                         "task_id",
+				Status:                     evergreen.TaskStarted,
+				StartTime:                  time.Now(),
+				GeneratedTasks:             false,
+				GeneratedJSONStorageMethod: evergreen.ProjectStorageMethodS3,
 			})
 		})
 	}

--- a/rest/data/generate.go
+++ b/rest/data/generate.go
@@ -34,7 +34,7 @@ func GenerateTasks(ctx context.Context, settings *evergreen.Settings, taskID str
 	for _, f := range jsonFiles {
 		files = append(files, string(f))
 	}
-	if _, err := task.GeneratedJSONInsertWithS3Fallback(ctx, settings, t, files, evergreen.ProjectStorageMethodDB); err != nil {
+	if err := task.GeneratedJSONInsert(ctx, settings, t, files); err != nil {
 		return errors.Wrapf(err, "inserting generated JSON files for task '%s'", t.Id)
 	}
 

--- a/rest/route/task_generate_test.go
+++ b/rest/route/task_generate_test.go
@@ -56,18 +56,37 @@ func TestValidate(t *testing.T) {
 	assert.NoError(validateFileSize(files, 1))
 }
 
-func TestGenerateExecuteWithSmallFileInDB(t *testing.T) {
+func TestGenerateExecuteWithSmallFileInS3(t *testing.T) {
 	ctx := t.Context()
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
+	testutil.ConfigureIntegrationTest(t, env.Settings())
+
+	c := utility.GetHTTPClient()
+	defer utility.PutHTTPClient(c)
+
+	ppConf := env.Settings().Providers.AWS.ParserProject
+	bucket, err := pail.NewS3BucketWithHTTPClient(ctx, c, pail.S3Options{
+		Name:   ppConf.Bucket,
+		Region: evergreen.DefaultEC2Region,
+	})
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, bucket.RemovePrefix(ctx, ppConf.GeneratedJSONPrefix))
+	}()
+
 	require.NoError(t, db.ClearCollections(task.Collection))
+	defer func() {
+		assert.NoError(t, db.ClearCollections(task.Collection))
+	}()
 
 	tsk := task.Task{
 		Id:      "task_id",
 		Version: "version_id",
 	}
 	require.NoError(t, tsk.Insert(t.Context()))
-
-	env := &mock.Environment{}
-	require.NoError(t, env.Configure(ctx))
 
 	genJSON := `{"key": "value"}`
 	h := &generateHandler{
@@ -80,15 +99,15 @@ func TestGenerateExecuteWithSmallFileInDB(t *testing.T) {
 	assert.Equal(t, struct{}{}, r.Data())
 	assert.Equal(t, http.StatusOK, r.Status())
 
-	dbTask, err := task.FindOneIdWithGeneratedJSON(ctx, tsk.Id)
+	dbTask, err := task.FindOneId(ctx, tsk.Id)
 	require.NoError(t, err)
 	require.NotZero(t, dbTask)
-	assert.Equal(t, evergreen.ProjectStorageMethodDB, dbTask.GeneratedJSONStorageMethod)
+	assert.Equal(t, evergreen.ProjectStorageMethodS3, dbTask.GeneratedJSONStorageMethod, "files under the DB document limit should still be stored in S3")
 
-	genJSONInDB, err := task.GeneratedJSONFind(ctx, env.Settings(), dbTask)
+	genJSONInS3, err := task.GeneratedJSONFind(ctx, env.Settings(), dbTask)
 	require.NoError(t, err)
-	require.Len(t, genJSONInDB, len(h.files), "generated JSON in DB should be non-empty")
-	assert.JSONEq(t, genJSON, genJSONInDB[0])
+	require.Len(t, genJSONInS3, len(h.files), "generated JSON in S3 should be non-empty")
+	assert.JSONEq(t, genJSON, genJSONInS3[0])
 
 	queue, err := env.RemoteQueueGroup().Get(ctx, fmt.Sprintf("service.generate.tasks.version.%s", tsk.Version))
 	require.NoError(t, err)

--- a/smoke/internal/agentmonitor/smoke_test.go
+++ b/smoke/internal/agentmonitor/smoke_test.go
@@ -72,6 +72,7 @@ func startAgentMonitor(ctx context.Context, t *testing.T, params smokeTestParams
 	agentCmd, err := internal.SmokeRunBinary(ctx,
 		"smoke-agent-monitor",
 		params.EVGHome,
+		nil,
 		params.CLIPath,
 		"service",
 		"deploy",

--- a/smoke/internal/host/util.go
+++ b/smoke/internal/host/util.go
@@ -201,7 +201,7 @@ func waitForRepotracker(ctx context.Context, t *testing.T, params SmokeTestParam
 func submitSmokeTestPatch(ctx context.Context, t *testing.T, params SmokeTestParams) {
 	grip.Info(ctx, "Submitting patch to smoke test app server.")
 
-	cmd, err := internal.SmokeRunBinary(ctx, "smoke-patch-submission", params.EVGHome, params.CLIPath, "-c", params.CLIConfigPath, "patch", "-p", params.ProjectID, "-v", params.BVName, "-t", "all", "-f", "-y", "-d", "Smoke test patch")
+	cmd, err := internal.SmokeRunBinary(ctx, "smoke-patch-submission", params.EVGHome, nil, params.CLIPath, "-c", params.CLIConfigPath, "patch", "-p", params.ProjectID, "-v", params.BVName, "-t", "all", "-f", "-y", "-d", "Smoke test patch")
 	require.NoError(t, err, "should have submitted patch")
 	exitCode, err := cmd.Wait(ctx)
 	require.NoError(t, err, "expected to finish successful CLI patch")

--- a/smoke/internal/testdata/admin_settings.yml
+++ b/smoke/internal/testdata/admin_settings.yml
@@ -66,6 +66,9 @@ providers:
   aws:
     aws_id: "foo"
     aws_secret: "bar"
+    parser_project:
+      bucket: "mciuploads"
+      generated_json_prefix: "evergreen/smoke/generated-json"
 
 keys:
   test: "/dev/null"

--- a/smoke/internal/util.go
+++ b/smoke/internal/util.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -311,16 +312,20 @@ func MakeSmokeRequest(ctx context.Context, params APIParams, method string, clie
 
 // SmokeRunBinary runs a smoke test Evergreen binary in the background. The name
 // indicates the process name so that it can be tracked in output logs. The
-// given wd is used as the working directory for the command.
-func SmokeRunBinary(ctx context.Context, name, wd, bin string, cmdParts ...string) (jasper.Process, error) {
+// given wd is used as the working directory for the command, and env holds any
+// environment variables to set in addition to EVGHOME.
+func SmokeRunBinary(ctx context.Context, name, wd string, env map[string]string, bin string, cmdParts ...string) (jasper.Process, error) {
 	grip.Infof(ctx, "Running command: %s", append([]string{bin}, cmdParts...))
 
 	cmdSender := send.NewWriterSender(send.MakeNative())
 	cmdSender.SetName(name)
 
+	procEnv := map[string]string{"EVGHOME": wd}
+	maps.Copy(procEnv, env)
+
 	proc, err := jasper.NewProcess(ctx, &options.Create{
 		Args:             append([]string{bin}, cmdParts...),
-		Environment:      map[string]string{"EVGHOME": wd},
+		Environment:      procEnv,
 		WorkingDirectory: wd,
 		Output: options.Output{
 			Output: cmdSender,
@@ -338,9 +343,19 @@ func SmokeRunBinary(ctx context.Context, name, wd, bin string, cmdParts ...strin
 func StartAppServer(ctx context.Context, t *testing.T, params APIParams) jasper.Process {
 	grip.Info(ctx, "Starting smoke test app server.")
 
+	// The app server stores generated task JSON in S3, and pail resolves those
+	// credentials from the environment rather than the admin settings.
+	awsEnv := map[string]string{}
+	for _, envVar := range []string{"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"} {
+		if val := os.Getenv(envVar); val != "" {
+			awsEnv[envVar] = val
+		}
+	}
+
 	appServerCmd, err := SmokeRunBinary(ctx,
 		"smoke-app-server",
 		params.EVGHome,
+		awsEnv,
 		params.CLIPath,
 		"service",
 		"deploy",
@@ -363,6 +378,7 @@ func StartAgent(ctx context.Context, t *testing.T, params APIParams, hostID, hos
 	agentCmd, err := SmokeRunBinary(ctx,
 		"smoke-agent",
 		params.EVGHome,
+		nil,
 		params.CLIPath,
 		"service",
 		"deploy",

--- a/units/generate_tasks_test.go
+++ b/units/generate_tasks_test.go
@@ -544,9 +544,15 @@ func TestGenerateTasksWithDifferentGeneratedJSONStorageMethods(t *testing.T) {
 				DisplayName: "sample_task",
 				Status:      evergreen.TaskStarted,
 			}
+			if storageMethod == evergreen.ProjectStorageMethodDB {
+				sampleTask.GeneratedJSONAsString = sampleGeneratedProject
+				sampleTask.GeneratedJSONStorageMethod = storageMethod
+			}
 			require.NoError(sampleTask.Insert(t.Context()))
 
-			require.NoError(task.GeneratedJSONInsert(ctx, env.Settings(), &sampleTask, sampleGeneratedProject, storageMethod))
+			if storageMethod == evergreen.ProjectStorageMethodS3 {
+				require.NoError(task.GeneratedJSONInsert(ctx, env.Settings(), &sampleTask, sampleGeneratedProject))
+			}
 
 			sampleDistros := []distro.Distro{
 				{


### PR DESCRIPTION
DEVPROD-41320

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

move all generate task json to s3 so the large field doesnt mess with the DB cache 
(and have potential other benefits) 


### Testing

unit tests
