### PR TITLE
DEVPROD-27441: use last heartbeat as finish time for system failures

### DIFF
--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1381,8 +1381,19 @@ func (t *Task) MarkFailed(ctx context.Context) error {
 	)
 }
 
+// EstimatedFinishTime returns the best available estimate of when a task that is no longer
+// reporting stopped running, given the current time. The cleanup jobs that end these tasks can run
+// several minutes after a task goes silent, so recording the time they ran makes the task look like
+// it was still running long after it stopped, overlapping the next task to run on the same host.
+func (t *Task) EstimatedFinishTime(now time.Time) time.Time {
+	if utility.IsZeroTime(t.LastHeartbeat) || t.LastHeartbeat.After(now) {
+		return now
+	}
+	return t.LastHeartbeat
+}
+
 func (t *Task) MarkSystemFailed(ctx context.Context, description string) error {
-	t.FinishTime = time.Now()
+	t.FinishTime = t.EstimatedFinishTime(time.Now())
 	t.Details = GetSystemFailureDetails(description)
 
 	switch t.ExecutionPlatform {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1381,8 +1381,11 @@ func (t *Task) MarkFailed(ctx context.Context) error {
 	)
 }
 
-// EstimatedFinishTime returns the best available estimate of when a task that
-// is no longer reporting stopped running, given the current time.
+// EstimatedFinishTime returns the best available estimate of when a
+// task stopped running for an unhealthy/unresponsive task. Typically should
+// only be used for system failures where the task itself is not finishing
+// normally. For example, when a task monitoring job determines the task is
+// stuck well after the task already stopped running.
 func (t *Task) EstimatedFinishTime(now time.Time) time.Time {
 	if utility.IsZeroTime(t.LastHeartbeat) || t.LastHeartbeat.After(now) {
 		return now

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1381,14 +1381,18 @@ func (t *Task) MarkFailed(ctx context.Context) error {
 	)
 }
 
-// EstimatedFinishTime returns the best available estimate of when a task that is no longer
-// reporting stopped running, given the current time. The cleanup jobs that end these tasks can run
-// several minutes after a task goes silent, so recording the time they ran makes the task look like
-// it was still running long after it stopped, overlapping the next task to run on the same host.
+// EstimatedFinishTime returns the best available estimate of when a task that
+// is no longer reporting stopped running, given the current time.
 func (t *Task) EstimatedFinishTime(now time.Time) time.Time {
 	if utility.IsZeroTime(t.LastHeartbeat) || t.LastHeartbeat.After(now) {
 		return now
 	}
+
+	// If the task is finishing due to certain system failures (e.g.
+	// stranded/stale task that's been unassigned from a host but wasn't marked
+	// finished), there's no definitive time when the task finished. The best
+	// guess for when the task stopped running is the last time it had a
+	// heartbeat.
 	return t.LastHeartbeat
 }
 

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1115,7 +1115,7 @@ func TestEstimatedFinishTime(t *testing.T) {
 		"IsNowWithoutAHeartbeat": {
 			expectedFinishTime: now,
 		},
-		"IsNowWhenHeartbeatIsAheadOfNow": {
+		"IsNowWhenHeartbeatMoreRecent": {
 			lastHeartbeat:      now.Add(time.Minute),
 			expectedFinishTime: now,
 		},

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1102,6 +1102,31 @@ func TestEndingTask(t *testing.T) {
 	})
 }
 
+func TestEstimatedFinishTime(t *testing.T) {
+	now := time.Now()
+	for tName, tCase := range map[string]struct {
+		lastHeartbeat      time.Time
+		expectedFinishTime time.Time
+	}{
+		"IsLastHeartbeatWhenTaskStoppedReporting": {
+			lastHeartbeat:      now.Add(-10 * time.Minute),
+			expectedFinishTime: now.Add(-10 * time.Minute),
+		},
+		"IsNowWithoutAHeartbeat": {
+			expectedFinishTime: now,
+		},
+		"IsNowWhenHeartbeatIsAheadOfNow": {
+			lastHeartbeat:      now.Add(time.Minute),
+			expectedFinishTime: now,
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			tsk := Task{LastHeartbeat: tCase.lastHeartbeat}
+			assert.Equal(t, tCase.expectedFinishTime, tsk.EstimatedFinishTime(now))
+		})
+	}
+}
+
 func TestMarkEnd(t *testing.T) {
 	ctx := t.Context()
 	t.Cleanup(func() {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -350,10 +350,13 @@ func TryResetTask(ctx context.Context, settings *evergreen.Settings, taskId, use
 	}
 
 	if detail != nil {
-		// Only the cleanup paths and automatic restarts pass end details here; a user-triggered
-		// restart passes none. In both cases the task has already stopped running, so its finish
-		// time is estimated rather than taken from the current time.
-		if err = t.MarkEnd(ctx, t.EstimatedFinishTime(time.Now()), detail); err != nil {
+		finishTime := t.FinishTime
+		if utility.IsZeroTime(finishTime) {
+			// The task could already be finished, so only use a new finish time
+			// estimate if it's not already finished.
+			finishTime = t.EstimatedFinishTime(time.Now())
+		}
+		if err = t.MarkEnd(ctx, finishTime, detail); err != nil {
 			return errors.Wrap(err, "marking task as ended")
 		}
 	}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -350,7 +350,10 @@ func TryResetTask(ctx context.Context, settings *evergreen.Settings, taskId, use
 	}
 
 	if detail != nil {
-		if err = t.MarkEnd(ctx, time.Now(), detail); err != nil {
+		// Only the cleanup paths and automatic restarts pass end details here; a user-triggered
+		// restart passes none. In both cases the task has already stopped running, so its finish
+		// time is estimated rather than taken from the current time.
+		if err = t.MarkEnd(ctx, t.EstimatedFinishTime(time.Now()), detail); err != nil {
 			return errors.Wrap(err, "marking task as ended")
 		}
 	}
@@ -2561,7 +2564,7 @@ func finishStaleAbortedTask(ctx context.Context, settings *evergreen.Settings, t
 		Type:        evergreen.CommandTypeSystem,
 		Description: evergreen.TaskDescriptionAborted,
 	}
-	if err := MarkEnd(ctx, settings, t, evergreen.APIServerTaskActivator, time.Now(), failureDetails); err != nil {
+	if err := MarkEnd(ctx, settings, t, evergreen.APIServerTaskActivator, t.EstimatedFinishTime(time.Now()), failureDetails); err != nil {
 		return errors.Wrapf(err, "calling mark finish on task '%s'", t.Id)
 	}
 	return nil
@@ -2592,13 +2595,13 @@ func endAndResetSystemFailedTask(ctx context.Context, settings *evergreen.Settin
 			}
 			for _, execTask := range execTasks {
 				if !evergreen.IsFinishedTaskStatus(execTask.Status) {
-					if err = MarkEnd(ctx, settings, &execTask, evergreen.MonitorPackage, time.Now(), &failureDetails); err != nil {
+					if err = MarkEnd(ctx, settings, &execTask, evergreen.MonitorPackage, execTask.EstimatedFinishTime(time.Now()), &failureDetails); err != nil {
 						return errors.Wrap(err, "marking execution task as ended")
 					}
 				}
 			}
 		}
-		return errors.WithStack(MarkEnd(ctx, settings, t, evergreen.MonitorPackage, time.Now(), &failureDetails))
+		return errors.WithStack(MarkEnd(ctx, settings, t, evergreen.MonitorPackage, t.EstimatedFinishTime(time.Now()), &failureDetails))
 	}
 
 	if err := t.MarkSystemFailed(ctx, description); err != nil {

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2204,6 +2204,8 @@ func TestMarkEndIsAutomaticRestart(t *testing.T) {
 		Version:            "abc",
 		BuildVariant:       "a_variant",
 		HostId:             "h1",
+		StartTime:          time.Now().Add(-time.Hour),
+		LastHeartbeat:      time.Now().Add(-30 * time.Second),
 	}
 	displayTask := &task.Task{
 		ResetWhenFinished:  true,
@@ -2292,12 +2294,19 @@ func TestMarkEndIsAutomaticRestart(t *testing.T) {
 	}
 	for name, test := range map[string]func(*testing.T){
 		"ResetsSingleTask": func(t *testing.T) {
-			assert.NoError(t, MarkEnd(ctx, &evergreen.Settings{}, runningTask, "test", time.Now(), detail))
+			finishTime := time.Now()
+			assert.NoError(t, MarkEnd(ctx, &evergreen.Settings{}, runningTask, "test", finishTime, detail))
 			runningTaskDB, err := task.FindOneId(ctx, runningTask.Id)
 			assert.NoError(t, err)
 			assert.NotNil(t, runningTaskDB)
 			assert.Equal(t, 1, runningTaskDB.Execution)
 			assert.Equal(t, evergreen.TaskUndispatched, runningTaskDB.Status)
+
+			archivedTask, err := task.FindOneIdAndExecution(ctx, runningTask.Id, 0)
+			require.NoError(t, err)
+			require.NotZero(t, archivedTask)
+			assert.WithinDuration(t, finishTime, archivedTask.FinishTime, time.Millisecond,
+				"restarting a task that reported its own end should keep the reported finish time")
 
 			// Check that trying to automatically reset again does not reset the task again.
 			runningTaskDB.HostId = "h1"

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -4163,6 +4163,8 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 
 	settings := testutil.TestConfig()
 
+	strandedTaskLastHeartbeat := time.Now().Add(-time.Hour)
+
 	tasks := []task.Task{
 		{
 			Id:            "t",
@@ -4172,6 +4174,8 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 			BuildId:       "b",
 			Version:       "version",
 			HostId:        "h1",
+			StartTime:     time.Now().Add(-90 * time.Minute),
+			LastHeartbeat: strandedTaskLastHeartbeat,
 		},
 		{
 			Id:            "t2",
@@ -4267,6 +4271,11 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 	runningTask, err := task.FindOne(ctx, db.Query(task.ById("t")))
 	require.NoError(t, err)
 	assert.Equal(evergreen.TaskUndispatched, runningTask.Status)
+
+	archivedTask, err := task.FindOneIdAndExecution(ctx, "t", 0)
+	require.NoError(t, err)
+	require.NotZero(t, archivedTask)
+	assert.WithinDuration(strandedTaskLastHeartbeat, archivedTask.FinishTime, time.Millisecond)
 
 	foundBuild, err := build.FindOneId(t.Context(), "b")
 	require.NoError(t, err)

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -2294,7 +2294,7 @@ func TestMarkEndIsAutomaticRestart(t *testing.T) {
 	}
 	for name, test := range map[string]func(*testing.T){
 		"ResetsSingleTask": func(t *testing.T) {
-			finishTime := time.Now()
+			finishTime := utility.BSONTime(time.Now())
 			assert.NoError(t, MarkEnd(ctx, &evergreen.Settings{}, runningTask, "test", finishTime, detail))
 			runningTaskDB, err := task.FindOneId(ctx, runningTask.Id)
 			assert.NoError(t, err)
@@ -2305,8 +2305,7 @@ func TestMarkEndIsAutomaticRestart(t *testing.T) {
 			archivedTask, err := task.FindOneIdAndExecution(ctx, runningTask.Id, 0)
 			require.NoError(t, err)
 			require.NotZero(t, archivedTask)
-			assert.WithinDuration(t, finishTime, archivedTask.FinishTime, time.Millisecond,
-				"restarting a task that reported its own end should keep the reported finish time")
+			assert.WithinDuration(t, finishTime, archivedTask.FinishTime, 0, "archived execution should keep its self-reported finish time")
 
 			// Check that trying to automatically reset again does not reset the task again.
 			runningTaskDB.HostId = "h1"
@@ -4172,7 +4171,7 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 
 	settings := testutil.TestConfig()
 
-	strandedTaskLastHeartbeat := time.Now().Add(-time.Hour)
+	strandedTaskLastHeartbeat := utility.BSONTime(time.Now().Add(-time.Hour))
 
 	tasks := []task.Task{
 		{
@@ -4284,7 +4283,7 @@ func TestClearAndResetStrandedHostTask(t *testing.T) {
 	archivedTask, err := task.FindOneIdAndExecution(ctx, "t", 0)
 	require.NoError(t, err)
 	require.NotZero(t, archivedTask)
-	assert.WithinDuration(strandedTaskLastHeartbeat, archivedTask.FinishTime, time.Millisecond)
+	assert.WithinDuration(strandedTaskLastHeartbeat, archivedTask.FinishTime, 0)
 
 	foundBuild, err := build.FindOneId(t.Context(), "b")
 	require.NoError(t, err)

--- a/units/task_monitor_execution_timeout_test.go
+++ b/units/task_monitor_execution_timeout_test.go
@@ -42,6 +42,8 @@ func TestTaskExecutionTimeoutJob(t *testing.T) {
 		assert.True(t, archivedTask.Archived)
 		assert.Equal(t, evergreen.TaskFailed, archivedTask.Status)
 		assert.Equal(t, description, archivedTask.Details.Description)
+		assert.WithinDuration(t, archivedTask.LastHeartbeat, archivedTask.FinishTime, time.Millisecond,
+			"task should finish when it stopped reporting, not when this job cleaned it up")
 
 		restartedTask, err := task.FindOneIdAndExecution(ctx, taskID, oldExecution+1)
 		require.NoError(t, err)
@@ -269,6 +271,7 @@ func TestTaskExecutionTimeoutJob(t *testing.T) {
 				ActivatedTime:     time.Now().Add(-10 * time.Minute),
 				Status:            evergreen.TaskStarted,
 				HostId:            h.Id,
+				StartTime:         time.Now().Add(-90 * time.Minute),
 				LastHeartbeat:     time.Now().Add(-time.Hour),
 			}
 

--- a/units/task_monitor_execution_timeout_test.go
+++ b/units/task_monitor_execution_timeout_test.go
@@ -42,8 +42,7 @@ func TestTaskExecutionTimeoutJob(t *testing.T) {
 		assert.True(t, archivedTask.Archived)
 		assert.Equal(t, evergreen.TaskFailed, archivedTask.Status)
 		assert.Equal(t, description, archivedTask.Details.Description)
-		assert.WithinDuration(t, archivedTask.LastHeartbeat, archivedTask.FinishTime, time.Millisecond,
-			"task should finish when it stopped reporting, not when this job cleaned it up")
+		assert.WithinDuration(t, archivedTask.LastHeartbeat, archivedTask.FinishTime, 0, "task finish time should be when it stopped heartbeating")
 
 		restartedTask, err := task.FindOneIdAndExecution(ctx, taskID, oldExecution+1)
 		require.NoError(t, err)


### PR DESCRIPTION
DEVPROD-27441

### Description

Follow-up to #10659. This fixes a bug where the task's finish time could be set to a deceptive time in case of system failures. In particular, I observed that the end task route sometimes fails [in between unsetting the host's running task and actually marking the task finished](https://github.com/evergreen-ci/evergreen/blob/fbb7ad5daa0b33b19740bd0e7be4876e43fc0593/rest/route/host_agent.go#L1380-L1420) with a 500. If it errors between those two steps, the retry attempt hits [this case](https://github.com/evergreen-ci/evergreen/blob/fbb7ad5daa0b33b19740bd0e7be4876e43fc0593/rest/route/host_agent.go#L1324-L1355), which causes the agent to restart and the host moves on to a new task, leaving the now-stranded task is stuck in an unfinished state. The [stale task monitor job](https://github.com/evergreen-ci/evergreen/blob/fbb7ad5daa0b33b19740bd0e7be4876e43fc0593/units/task_monitor_execution_timeout.go) eventually cleans it up and marks it system failed, but it sets the finish time to the time the job detected the staleness (keep in mind that the host has moved on to a new task, so now it looks like the system-failed task and the host's new task overlap).

Since the stale task monitor can't know the exact moment when the task actually finished, I changed it to use the last heartbeat as the task finish time. The last heartbeat seems like a reasonable enough guess as to when the task stopped running since that's the last known communication from the task.

### Testing

* Added unit tests.