### PR TITLE
PLATFORMS-2443: Pre-pull container images during host provisioning

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-08-11"
+	ClientVersion = "2026-08-12"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/host_provision.go
+++ b/operations/host_provision.go
@@ -19,6 +19,12 @@ import (
 	"github.com/urfave/cli"
 )
 
+// containerImagePullTimeout bounds the docker pull step in host provisioning.
+// Large evergreen-task-images can be several GB; 15 minutes accommodates
+// realistic EC2-to-ECR pull speeds while ensuring a stalled registry connection
+// does not block the host from finishing provisioning.
+const containerImagePullTimeout = 15 * time.Minute
+
 func hostProvision() cli.Command {
 	const (
 		hostIDFlagName        = "host_id"
@@ -111,6 +117,20 @@ func hostProvision() cli.Command {
 				return errors.Wrap(err, "running host provisioning script")
 			}
 
+			if opts.ContainerImage != "" {
+				// Bound the pull so a stalled registry cannot block provisioning
+				// indefinitely. Failure is non-fatal: the first task will pull.
+				pullCtx, pullCancel := context.WithTimeout(ctx, containerImagePullTimeout)
+				defer pullCancel()
+				if err := prePullContainerImage(pullCtx, opts.ContainerImage); err != nil {
+					grip.Warning(ctx, message.Fields{
+						"message": "failed to pre-pull container image during provisioning; the first task will pull it at exec time",
+						"image":   opts.ContainerImage,
+						"error":   err.Error(),
+					})
+				}
+			}
+
 			return nil
 		},
 	}
@@ -172,4 +192,25 @@ func runHostProvisioningScript(ctx context.Context, shellPath, scriptPath, worki
 		return errors.WithStack(err)
 	}
 	return nil
+}
+
+// prePullContainerImage runs `docker pull` for the given image so it is
+// resident in the local Docker image store before the first task runs.
+// This amortizes the pull cost across the host lifetime rather than paying
+// it on the first task's critical path.
+//
+// The docker CLI is used here (rather than the Docker SDK ImagePull used by
+// agent/container/lifecycle.go's ensureImage) so that the host's configured
+// credential helpers are inherited automatically. Private ECR images require
+// the amazon-ecr-credential-helper; the CLI picks this up from ~/.docker/config.json
+// while the SDK would need explicit RegistryAuth constructed separately.
+func prePullContainerImage(ctx context.Context, image string) error {
+	return errors.Wrapf(
+		jasper.NewCommand().
+			Add([]string{"docker", "pull", image}).
+			SetOutputWriter(utility.NopWriteCloser(os.Stdout)).
+			SetErrorWriter(utility.NopWriteCloser(os.Stderr)).
+			Run(ctx),
+		"pulling container image '%s'", image,
+	)
 }

--- a/operations/host_provision.go
+++ b/operations/host_provision.go
@@ -199,11 +199,9 @@ func runHostProvisioningScript(ctx context.Context, shellPath, scriptPath, worki
 // This amortizes the pull cost across the host lifetime rather than paying
 // it on the first task's critical path.
 //
-// The docker CLI is used here (rather than the Docker SDK ImagePull used by
-// agent/container/lifecycle.go's ensureImage) so that the host's configured
-// credential helpers are inherited automatically. Private ECR images require
-// the amazon-ecr-credential-helper; the CLI picks this up from ~/.docker/config.json
-// while the SDK would need explicit RegistryAuth constructed separately.
+// The docker CLI is used so the host's configured credential helpers are
+// inherited automatically. Private ECR images require the
+// amazon-ecr-credential-helper, which the CLI loads from ~/.docker/config.json.
 func prePullContainerImage(ctx context.Context, image string) error {
 	return errors.Wrapf(
 		jasper.NewCommand().

--- a/operations/host_provision.go
+++ b/operations/host_provision.go
@@ -19,10 +19,7 @@ import (
 	"github.com/urfave/cli"
 )
 
-// containerImagePullTimeout bounds the docker pull step in host provisioning.
-// Large evergreen-task-images can be several GB; 15 minutes accommodates
-// realistic EC2-to-ECR pull speeds while ensuring a stalled registry connection
-// does not block the host from finishing provisioning.
+// containerImagePullTimeout bounds image pulls during provisioning.
 const containerImagePullTimeout = 15 * time.Minute
 
 func hostProvision() cli.Command {
@@ -118,8 +115,7 @@ func hostProvision() cli.Command {
 			}
 
 			if opts.ContainerImage != "" {
-				// Bound the pull so a stalled registry cannot block provisioning
-				// indefinitely. Failure is non-fatal: the first task will pull.
+				// Pull failures are non-fatal because the first task can retry.
 				pullCtx, pullCancel := context.WithTimeout(ctx, containerImagePullTimeout)
 				defer pullCancel()
 				if err := prePullContainerImage(pullCtx, opts.ContainerImage); err != nil {
@@ -194,14 +190,7 @@ func runHostProvisioningScript(ctx context.Context, shellPath, scriptPath, worki
 	return nil
 }
 
-// prePullContainerImage runs `docker pull` for the given image so it is
-// resident in the local Docker image store before the first task runs.
-// This amortizes the pull cost across the host lifetime rather than paying
-// it on the first task's critical path.
-//
-// The docker CLI is used so the host's configured credential helpers are
-// inherited automatically. Private ECR images require the
-// amazon-ecr-credential-helper, which the CLI loads from ~/.docker/config.json.
+// prePullContainerImage uses the host's Docker credential helpers.
 func prePullContainerImage(ctx context.Context, image string) error {
 	return errors.Wrapf(
 		jasper.NewCommand().

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -91,24 +91,26 @@ func NewIntentHost(ctx context.Context, options *restmodel.HostRequestOptions, u
 	return intentHost, nil
 }
 
-// GenerateHostProvisioningScript generates and returns the script to
-// provision the host given by host ID.
-func GenerateHostProvisioningScript(ctx context.Context, env evergreen.Environment, hostID string) (string, error) {
+// GenerateHostProvisioningScript generates and returns the provisioning script
+// for the host and, if the distro has container isolation enabled, the
+// fully-qualified container image to pre-pull. Both values are derived from the
+// same host lookup so callers receive them without a second DB round-trip.
+func GenerateHostProvisioningScript(ctx context.Context, env evergreen.Environment, hostID string) (script, containerImage string, err error) {
 	if hostID == "" {
-		return "", gimlet.ErrorResponse{
+		return "", "", gimlet.ErrorResponse{
 			StatusCode: http.StatusBadRequest,
 			Message:    "cannot generate host provisioning script without a host ID",
 		}
 	}
 	h, err := host.FindOneByIdOrTag(ctx, hostID)
 	if err != nil {
-		return "", gimlet.ErrorResponse{
+		return "", "", gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    errors.Wrapf(err, "finding host '%s'", hostID).Error(),
 		}
 	}
 	if h == nil {
-		return "", gimlet.ErrorResponse{
+		return "", "", gimlet.ErrorResponse{
 			StatusCode: http.StatusNotFound,
 			Message:    fmt.Sprintf("host with id '%s' not found", hostID),
 		}
@@ -116,7 +118,7 @@ func GenerateHostProvisioningScript(ctx context.Context, env evergreen.Environme
 
 	creds, err := h.GenerateJasperCredentials(ctx, env)
 	if err != nil {
-		return "", gimlet.ErrorResponse{
+		return "", "", gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    errors.Wrap(err, "generating Jasper credentials").Error(),
 		}
@@ -132,20 +134,29 @@ func GenerateHostProvisioningScript(ctx context.Context, env evergreen.Environme
 			"task":    h.ProvisionOptions.TaskId,
 		}))
 	}
-	script, err := h.GenerateUserDataProvisioningScript(ctx, env.Settings(), creds, githubAppToken, moduleTokens)
+	script, err = h.GenerateUserDataProvisioningScript(ctx, env.Settings(), creds, githubAppToken, moduleTokens)
 	if err != nil {
-		return "", gimlet.ErrorResponse{
+		return "", "", gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    errors.Wrap(err, "generating host provisioning script").Error(),
 		}
 	}
 	if err := h.SaveJasperCredentials(ctx, env, creds); err != nil {
-		return "", gimlet.ErrorResponse{
+		return "", "", gimlet.ErrorResponse{
 			StatusCode: http.StatusInternalServerError,
 			Message:    errors.Wrap(err, "saving Jasper credentials").Error(),
 		}
 	}
-	return script, nil
+	if ci := h.Distro.BootstrapSettings.ContainerIsolation; ci.Enabled {
+		if ci.Image == "" {
+			grip.Warning(ctx, message.Fields{
+				"message": "container isolation is enabled for this distro but no image is configured; pre-pull will be skipped",
+				"host_id": hostID,
+			})
+		}
+		containerImage = ci.Image
+	}
+	return script, containerImage, nil
 }
 
 // FindHostByIdWithOwner finds a host with given host ID that was

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -149,9 +149,9 @@ func GenerateHostProvisioningScript(ctx context.Context, env evergreen.Environme
 		}
 	}
 	ci := h.Distro.BootstrapSettings.ContainerIsolation
-	containerIsolationDisabled := env.Settings().ServiceFlags.ContainerIsolationDisabled
-	containerImage = getContainerImageForPrePull(ci, containerIsolationDisabled)
-	if ci.Enabled && !containerIsolationDisabled {
+	containerIsolationEnabled := env.Settings().ServiceFlags.ContainerIsolationEnabled
+	containerImage = getContainerImageForPrePull(ci, containerIsolationEnabled)
+	if ci.Enabled && containerIsolationEnabled {
 		if ci.Image == "" {
 			grip.Warning(ctx, message.Fields{
 				"message": "container isolation is enabled for this distro but no image is configured; pre-pull will be skipped",
@@ -162,8 +162,8 @@ func GenerateHostProvisioningScript(ctx context.Context, env evergreen.Environme
 	return script, containerImage, nil
 }
 
-func getContainerImageForPrePull(settings distro.ContainerIsolationSettings, containerIsolationDisabled bool) string {
-	if !settings.Enabled || containerIsolationDisabled {
+func getContainerImageForPrePull(settings distro.ContainerIsolationSettings, containerIsolationEnabled bool) string {
+	if !settings.Enabled || !containerIsolationEnabled {
 		return ""
 	}
 	return settings.Image

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -92,10 +92,8 @@ func NewIntentHost(ctx context.Context, options *restmodel.HostRequestOptions, u
 	return intentHost, nil
 }
 
-// GenerateHostProvisioningScript generates and returns the provisioning script
-// for the host and, if the distro has container isolation enabled, the
-// fully-qualified container image to pre-pull. Both values are derived from the
-// same host lookup so callers receive them without a second DB round-trip.
+// GenerateHostProvisioningScript returns the provisioning script and optional
+// container image for a host.
 func GenerateHostProvisioningScript(ctx context.Context, env evergreen.Environment, hostID string) (script, containerImage string, err error) {
 	if hostID == "" {
 		return "", "", gimlet.ErrorResponse{

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -148,23 +148,21 @@ func GenerateHostProvisioningScript(ctx context.Context, env evergreen.Environme
 	}
 	ci := h.Distro.BootstrapSettings.ContainerIsolation
 	containerIsolationEnabled := env.Settings().ServiceFlags.ContainerIsolationEnabled
-	containerImage = getContainerImageForPrePull(ci, containerIsolationEnabled)
-	if ci.Enabled && containerIsolationEnabled {
-		if ci.Image == "" {
-			grip.Warning(ctx, message.Fields{
-				"message": "container isolation is enabled for this distro but no image is configured; pre-pull will be skipped",
-				"host_id": hostID,
-			})
-		}
+	containerImage, effectiveIsolationEnabled := getContainerImageForPrePull(ci, containerIsolationEnabled)
+	if effectiveIsolationEnabled && containerImage == "" {
+		grip.Warning(ctx, message.Fields{
+			"message": "container isolation is enabled for this distro but no image is configured; pre-pull will be skipped",
+			"host_id": hostID,
+		})
 	}
 	return script, containerImage, nil
 }
 
-func getContainerImageForPrePull(settings distro.ContainerIsolationSettings, containerIsolationEnabled bool) string {
+func getContainerImageForPrePull(settings distro.ContainerIsolationSettings, containerIsolationEnabled bool) (string, bool) {
 	if !settings.Enabled || !containerIsolationEnabled {
-		return ""
+		return "", false
 	}
-	return settings.Image
+	return settings.Image, true
 }
 
 // FindHostByIdWithOwner finds a host with given host ID that was

--- a/rest/data/host.go
+++ b/rest/data/host.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/cloud"
+	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
@@ -147,16 +148,25 @@ func GenerateHostProvisioningScript(ctx context.Context, env evergreen.Environme
 			Message:    errors.Wrap(err, "saving Jasper credentials").Error(),
 		}
 	}
-	if ci := h.Distro.BootstrapSettings.ContainerIsolation; ci.Enabled {
+	ci := h.Distro.BootstrapSettings.ContainerIsolation
+	containerIsolationDisabled := env.Settings().ServiceFlags.ContainerIsolationDisabled
+	containerImage = getContainerImageForPrePull(ci, containerIsolationDisabled)
+	if ci.Enabled && !containerIsolationDisabled {
 		if ci.Image == "" {
 			grip.Warning(ctx, message.Fields{
 				"message": "container isolation is enabled for this distro but no image is configured; pre-pull will be skipped",
 				"host_id": hostID,
 			})
 		}
-		containerImage = ci.Image
 	}
 	return script, containerImage, nil
+}
+
+func getContainerImageForPrePull(settings distro.ContainerIsolationSettings, containerIsolationDisabled bool) string {
+	if !settings.Enabled || containerIsolationDisabled {
+		return ""
+	}
+	return settings.Image
 }
 
 // FindHostByIdWithOwner finds a host with given host ID that was

--- a/rest/data/host_test.go
+++ b/rest/data/host_test.go
@@ -328,6 +328,7 @@ func TestGetContainerImageForPrePull(t *testing.T) {
 		settings                  distro.ContainerIsolationSettings
 		containerIsolationEnabled bool
 		expected                  string
+		effective                 bool
 	}{
 		"EnabledReturnsImage": {
 			settings: distro.ContainerIsolationSettings{
@@ -336,6 +337,7 @@ func TestGetContainerImageForPrePull(t *testing.T) {
 			},
 			containerIsolationEnabled: true,
 			expected:                  "example.com/evergreen/task:latest",
+			effective:                 true,
 		},
 		"KillSwitchReturnsEmpty": {
 			settings: distro.ContainerIsolationSettings{
@@ -349,9 +351,18 @@ func TestGetContainerImageForPrePull(t *testing.T) {
 				Image: "example.com/evergreen/task:latest",
 			},
 		},
+		"EnabledDistroWithEmptyImageReturnsEmpty": {
+			settings: distro.ContainerIsolationSettings{
+				Enabled: true,
+			},
+			containerIsolationEnabled: true,
+			effective:                 true,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, test.expected, getContainerImageForPrePull(test.settings, test.containerIsolationEnabled))
+			image, effective := getContainerImageForPrePull(test.settings, test.containerIsolationEnabled)
+			require.Equal(t, test.expected, image)
+			require.Equal(t, test.effective, effective)
 		})
 	}
 }

--- a/rest/data/host_test.go
+++ b/rest/data/host_test.go
@@ -309,7 +309,7 @@ func (s *HostConnectorSuite) TestFindHostByIdWithSuperUser() {
 func (s *HostConnectorSuite) TestGenerateHostProvisioningScriptSucceeds() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	script, err := GenerateHostProvisioningScript(ctx, s.env, "host1")
+	script, _, err := GenerateHostProvisioningScript(ctx, s.env, "host1")
 	s.Require().NoError(err)
 	s.NotZero(script)
 
@@ -318,7 +318,7 @@ func (s *HostConnectorSuite) TestGenerateHostProvisioningScriptSucceeds() {
 func (s *HostConnectorSuite) TestGenerateHostProvisioningScriptFailsWithInvalidHostID() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	script, err := GenerateHostProvisioningScript(ctx, s.env, "foo")
+	script, _, err := GenerateHostProvisioningScript(ctx, s.env, "foo")
 	s.Error(err)
 	s.Zero(script)
 }

--- a/rest/data/host_test.go
+++ b/rest/data/host_test.go
@@ -325,23 +325,24 @@ func (s *HostConnectorSuite) TestGenerateHostProvisioningScriptFailsWithInvalidH
 
 func TestGetContainerImageForPrePull(t *testing.T) {
 	for name, test := range map[string]struct {
-		settings                   distro.ContainerIsolationSettings
-		containerIsolationDisabled bool
-		expected                   string
+		settings                  distro.ContainerIsolationSettings
+		containerIsolationEnabled bool
+		expected                  string
 	}{
 		"EnabledReturnsImage": {
 			settings: distro.ContainerIsolationSettings{
 				Enabled: true,
 				Image:   "example.com/evergreen/task:latest",
 			},
-			expected: "example.com/evergreen/task:latest",
+			containerIsolationEnabled: true,
+			expected:                  "example.com/evergreen/task:latest",
 		},
 		"KillSwitchReturnsEmpty": {
 			settings: distro.ContainerIsolationSettings{
 				Enabled: true,
 				Image:   "example.com/evergreen/task:latest",
 			},
-			containerIsolationDisabled: true,
+			containerIsolationEnabled: false,
 		},
 		"DisabledDistroReturnsEmpty": {
 			settings: distro.ContainerIsolationSettings{
@@ -350,7 +351,7 @@ func TestGetContainerImageForPrePull(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, test.expected, getContainerImageForPrePull(test.settings, test.containerIsolationDisabled))
+			require.Equal(t, test.expected, getContainerImageForPrePull(test.settings, test.containerIsolationEnabled))
 		})
 	}
 }

--- a/rest/data/host_test.go
+++ b/rest/data/host_test.go
@@ -322,3 +322,35 @@ func (s *HostConnectorSuite) TestGenerateHostProvisioningScriptFailsWithInvalidH
 	s.Error(err)
 	s.Zero(script)
 }
+
+func TestGetContainerImageForPrePull(t *testing.T) {
+	for name, test := range map[string]struct {
+		settings                   distro.ContainerIsolationSettings
+		containerIsolationDisabled bool
+		expected                   string
+	}{
+		"EnabledReturnsImage": {
+			settings: distro.ContainerIsolationSettings{
+				Enabled: true,
+				Image:   "example.com/evergreen/task:latest",
+			},
+			expected: "example.com/evergreen/task:latest",
+		},
+		"KillSwitchReturnsEmpty": {
+			settings: distro.ContainerIsolationSettings{
+				Enabled: true,
+				Image:   "example.com/evergreen/task:latest",
+			},
+			containerIsolationDisabled: true,
+		},
+		"DisabledDistroReturnsEmpty": {
+			settings: distro.ContainerIsolationSettings{
+				Image: "example.com/evergreen/task:latest",
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, test.expected, getContainerImageForPrePull(test.settings, test.containerIsolationDisabled))
+		})
+	}
+}

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -297,4 +297,8 @@ type APIOffboardUserResults struct {
 // APIHostProvisioningOptions represents the script to provision a host.
 type APIHostProvisioningOptions struct {
 	Content string `json:"content"`
+	// ContainerImage is the fully-qualified image reference to pre-pull after
+	// provisioning, populated when the distro has container isolation enabled.
+	// Empty string means no pre-pull is required.
+	ContainerImage string `json:"container_image,omitempty"`
 }

--- a/rest/model/host.go
+++ b/rest/model/host.go
@@ -297,8 +297,6 @@ type APIOffboardUserResults struct {
 // APIHostProvisioningOptions represents the script to provision a host.
 type APIHostProvisioningOptions struct {
 	Content string `json:"content"`
-	// ContainerImage is the fully-qualified image reference to pre-pull after
-	// provisioning, populated when the distro has container isolation enabled.
-	// Empty string means no pre-pull is required.
+	// ContainerImage is the image to pre-pull after provisioning, if configured.
 	ContainerImage string `json:"container_image,omitempty"`
 }

--- a/rest/route/host.go
+++ b/rest/route/host.go
@@ -433,14 +433,14 @@ func (rh *hostProvisioningOptionsGetHandler) Parse(ctx context.Context, r *http.
 }
 
 func (rh *hostProvisioningOptionsGetHandler) Run(ctx context.Context) gimlet.Responder {
-	script, err := data.GenerateHostProvisioningScript(ctx, rh.env, rh.hostID)
+	script, containerImage, err := data.GenerateHostProvisioningScript(ctx, rh.env, rh.hostID)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "generating host provisioning script"))
 	}
-	apiOpts := model.APIHostProvisioningOptions{
-		Content: script,
-	}
-	return gimlet.NewJSONResponse(apiOpts)
+	return gimlet.NewJSONResponse(model.APIHostProvisioningOptions{
+		Content:        script,
+		ContainerImage: containerImage,
+	})
 }
 
 // POST /hosts/{host_id}/is_up


### PR DESCRIPTION
PLATFORMS-2443: Pre-pull container images during host provisioning

PLATFORMS-2443

**Stack: PR 7 of 9 — depends on `pr06-activation` (`https://github.com/evergreen-ci/evergreen/pull/10648`).**

This PR is safe to merge alone because it is additive provisioning behavior and selects an image only for effective isolation. It functionally depends only on PR1/PR2; the position after pr06 is for stack linearity only, not a real functional dependency.

### Description

Returns the effective image in provisioning responses and pre-pulls it before agent start, surfacing image and credential-helper failures earlier.

### Documentation

No user-facing documentation changes are required in this slice. Stack ordering and cross-PR links are maintained separately.
