### PR TITLE
DEVPROD-36828 Support label-based PR alias triggering

### DIFF
--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -272,6 +272,36 @@ For security reasons, commits by users outside of your organization will
 not automatically be run. A patch will still be created and must be
 manually authorized to run by a logged-in user.
 
+#### Label-Based PR Testing
+
+You can conditionally include PR alias entries based on GitHub PR labels by adding a
+`required_labels` field to your `github_pr_aliases` in the project YAML. This lets teams
+gate specific test suites behind labels like `myproject:e2e`, reducing work on PRs that don't need those tests.
+Removing labels is a no-op. Tasks that were already created are not removed.
+
+##### Configuration
+
+Add `required_labels` to any `github_pr_aliases` entry in your project YAML:
+
+```yaml
+github_pr_aliases:
+  # Always runs
+  - variant: "^lint$"
+    task: "^generate-lint$"
+
+  # Only runs when the PR has the "evergreen:e2e" or "evergreen:full" label.
+  - variant_tags: ["e2e"]
+    task: ".*"
+    required_labels:
+      - "evergreen:e2e"
+      - "evergreen:full"
+```
+
+For [build Variant Path Filtering](Project-Configuration-Files#build-variant-path-filtering), 
+label-triggered tasks still respect `paths` on their build variants. If a variant's path
+patterns don't match the PR's changed files, it will not run even if the label condition is
+satisfied.
+
 #### Limiting when PR patches will run
 
 You can optionally specify the oldest commit SHA that is allowed to be a merge base
@@ -761,7 +791,17 @@ commit_queue_aliases:
 github_pr_aliases:
   - variant: "^lint$"
     task: "^generate-lint$"
+
+  - variant_tags: ["e2e"]
+    task: ".*"
+    required_labels:
+      - "evergreen:e2e"
+      - "evergreen:full"
 ```
+
+PR aliases support an optional `required_labels` field. When set, the alias only
+includes its variants and tasks if the PR carries at least one of the
+listed labels. See [Label-Based PR Testing](#label-based-pr-testing) for full details.
 
 ### Git Tag Aliases
 

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -277,7 +277,9 @@ manually authorized to run by a logged-in user.
 You can conditionally include PR alias entries based on GitHub PR labels by adding a
 `required_labels` field to your `github_pr_aliases` in the project YAML. This lets teams
 gate specific test suites behind labels like `myproject:e2e`, reducing work on PRs that don't need those tests.
-Removing labels is a no-op. Tasks that were already created are not removed.
+
+Removing labels is a no-op. Tasks that were already created are not removed. Labels added
+before the PR patch finishes creating won't take effect until the next push or `evergreen retry`.
 
 ##### Configuration
 

--- a/docs/Project-Configuration/Project-and-Distro-Settings.md
+++ b/docs/Project-Configuration/Project-and-Distro-Settings.md
@@ -299,7 +299,7 @@ github_pr_aliases:
       - "evergreen:full"
 ```
 
-For [build Variant Path Filtering](Project-Configuration-Files#build-variant-path-filtering), 
+For [build Variant Path Filtering](Project-Configuration-Files#build-variant-path-filtering),
 label-triggered tasks still respect `paths` on their build variants. If a variant's path
 patterns don't match the PR's changed files, it will not run even if the label condition is
 satisfied.

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1355,16 +1355,17 @@ type ComplexityRoot struct {
 	}
 
 	ProjectAlias struct {
-		Alias       func(childComplexity int) int
-		Description func(childComplexity int) int
-		GitTag      func(childComplexity int) int
-		ID          func(childComplexity int) int
-		Parameters  func(childComplexity int) int
-		RemotePath  func(childComplexity int) int
-		Task        func(childComplexity int) int
-		TaskTags    func(childComplexity int) int
-		Variant     func(childComplexity int) int
-		VariantTags func(childComplexity int) int
+		Alias          func(childComplexity int) int
+		Description    func(childComplexity int) int
+		GitTag         func(childComplexity int) int
+		ID             func(childComplexity int) int
+		Parameters     func(childComplexity int) int
+		RemotePath     func(childComplexity int) int
+		RequiredLabels func(childComplexity int) int
+		Task           func(childComplexity int) int
+		TaskTags       func(childComplexity int) int
+		Variant        func(childComplexity int) int
+		VariantTags    func(childComplexity int) int
 	}
 
 	ProjectBanner struct {
@@ -8357,6 +8358,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.ProjectAlias.RemotePath(childComplexity), true
+	case "ProjectAlias.requiredLabels":
+		if e.complexity.ProjectAlias.RequiredLabels == nil {
+			break
+		}
+
+		return e.complexity.ProjectAlias.RequiredLabels(childComplexity), true
 	case "ProjectAlias.task":
 		if e.complexity.ProjectAlias.Task == nil {
 			break
@@ -49150,6 +49157,35 @@ func (ec *executionContext) fieldContext_ProjectAlias_parameters(_ context.Conte
 	return fc, nil
 }
 
+func (ec *executionContext) _ProjectAlias_requiredLabels(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectAlias) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_ProjectAlias_requiredLabels,
+		func(ctx context.Context) (any, error) {
+			return obj.RequiredLabels, nil
+		},
+		nil,
+		ec.marshalNString2ᚕᚖstringᚄ,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_ProjectAlias_requiredLabels(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ProjectAlias",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ProjectBanner_text(ctx context.Context, field graphql.CollectedField, obj *model.APIProjectBanner) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -49576,6 +49612,8 @@ func (ec *executionContext) fieldContext_ProjectEventSettings_aliases(_ context.
 				return ec.fieldContext_ProjectAlias_variantTags(ctx, field)
 			case "parameters":
 				return ec.fieldContext_ProjectAlias_parameters(ctx, field)
+			case "requiredLabels":
+				return ec.fieldContext_ProjectAlias_requiredLabels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ProjectAlias", field.Name)
 		},
@@ -51171,6 +51209,8 @@ func (ec *executionContext) fieldContext_ProjectSettings_aliases(_ context.Conte
 				return ec.fieldContext_ProjectAlias_variantTags(ctx, field)
 			case "parameters":
 				return ec.fieldContext_ProjectAlias_parameters(ctx, field)
+			case "requiredLabels":
+				return ec.fieldContext_ProjectAlias_requiredLabels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ProjectAlias", field.Name)
 		},
@@ -57050,6 +57090,8 @@ func (ec *executionContext) fieldContext_RepoSettings_aliases(_ context.Context,
 				return ec.fieldContext_ProjectAlias_variantTags(ctx, field)
 			case "parameters":
 				return ec.fieldContext_ProjectAlias_parameters(ctx, field)
+			case "requiredLabels":
+				return ec.fieldContext_ProjectAlias_requiredLabels(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ProjectAlias", field.Name)
 		},
@@ -86193,7 +86235,7 @@ func (ec *executionContext) unmarshalInputProjectAliasInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "alias", "description", "gitTag", "remotePath", "task", "taskTags", "variant", "variantTags", "parameters"}
+	fieldsInOrder := [...]string{"id", "alias", "description", "gitTag", "remotePath", "task", "taskTags", "variant", "variantTags", "parameters", "requiredLabels"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -86270,6 +86312,13 @@ func (ec *executionContext) unmarshalInputProjectAliasInput(ctx context.Context,
 				return it, err
 			}
 			it.Parameters = data
+		case "requiredLabels":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requiredLabels"))
+			data, err := ec.unmarshalOString2ᚕᚖstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.RequiredLabels = data
 		}
 	}
 
@@ -101438,6 +101487,11 @@ func (ec *executionContext) _ProjectAlias(ctx context.Context, sel ast.Selection
 			}
 		case "parameters":
 			out.Values[i] = ec._ProjectAlias_parameters(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "requiredLabels":
+			out.Values[i] = ec._ProjectAlias_requiredLabels(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/graphql/schema/types/project.graphql
+++ b/graphql/schema/types/project.graphql
@@ -69,6 +69,7 @@ input ProjectAliasInput {
   variant: String!
   variantTags: [String!]!
   parameters: [ParameterInput!]
+  requiredLabels: [String!]
 }
 
 input PeriodicBuildInput {

--- a/graphql/schema/types/project_settings.graphql
+++ b/graphql/schema/types/project_settings.graphql
@@ -185,4 +185,5 @@ type ProjectAlias {
   variant: String!
   variantTags: [String!]!
   parameters: [Parameter!]!
+  requiredLabels: [String!]!
 }

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -503,6 +503,26 @@ func FindLatestGithubPRPatch(ctx context.Context, owner, repo string, prNumber i
 	return &patches[0], nil
 }
 
+// FindFinalizedGithubPRPatchForHeadSHA returns a finalized patch for the given
+// PR and head SHA, if one exists.
+func FindFinalizedGithubPRPatchForHeadSHA(ctx context.Context, owner, repo string, prNumber int, headSHA string) (*Patch, error) {
+	patches, err := Find(ctx, db.Query(bson.M{
+		AliasKey:   bson.M{"$ne": evergreen.CommitQueueAlias},
+		VersionKey: bson.M{"$ne": ""},
+		bsonutil.GetDottedKeyName(githubPatchDataKey, thirdparty.GithubPatchBaseOwnerKey): owner,
+		bsonutil.GetDottedKeyName(githubPatchDataKey, thirdparty.GithubPatchBaseRepoKey):  repo,
+		bsonutil.GetDottedKeyName(githubPatchDataKey, thirdparty.GithubPatchPRNumberKey):  prNumber,
+		bsonutil.GetDottedKeyName(githubPatchDataKey, thirdparty.GithubPatchHeadHashKey):  headSHA,
+	}).Sort([]string{"-" + CreateTimeKey}).Limit(1))
+	if err != nil {
+		return nil, err
+	}
+	if len(patches) == 0 {
+		return nil, nil
+	}
+	return &patches[0], nil
+}
+
 func FindProjectForPatch(ctx context.Context, patchID mgobson.ObjectId) (string, error) {
 	p, err := FindOne(ctx, ById(patchID).Project(bson.M{ProjectKey: 1}))
 	if err != nil {

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -100,6 +100,9 @@ type githubIntent struct {
 
 	// Alias defines the variants and tasks to run this patch on. It will default to __github if not set.
 	Alias string `bson:"alias"`
+
+	// Labels are the GitHub PR labels at the time the intent was created.
+	Labels []string `bson:"labels,omitempty"`
 }
 
 // BSON fields for the patches
@@ -163,6 +166,13 @@ func NewGithubIntent(ctx context.Context, msgDeliveryID, patchOwner, calledBy, a
 		return nil, errors.Wrap(err, "getting patch to repeat definitions from")
 	}
 
+	labels := make([]string, 0, len(pr.Labels))
+	for _, l := range pr.Labels {
+		if l.GetName() != "" {
+			labels = append(labels, l.GetName())
+		}
+	}
+
 	return &githubIntent{
 		DocumentID:    msgDeliveryID,
 		MsgID:         msgDeliveryID,
@@ -181,6 +191,7 @@ func NewGithubIntent(ctx context.Context, msgDeliveryID, patchOwner, calledBy, a
 		CalledBy:      calledBy,
 		RepeatPatchId: repeat,
 		Alias:         alias,
+		Labels:        labels,
 	}, nil
 }
 
@@ -303,6 +314,7 @@ func (g *githubIntent) NewPatch() *Patch {
 			MergeBase:  g.MergeBase,
 			Author:     g.User,
 			AuthorUID:  g.UID,
+			Labels:     g.Labels,
 		},
 	}
 	return patchDoc

--- a/model/patch/github.go
+++ b/model/patch/github.go
@@ -166,7 +166,7 @@ func NewGithubIntent(ctx context.Context, msgDeliveryID, patchOwner, calledBy, a
 		return nil, errors.Wrap(err, "getting patch to repeat definitions from")
 	}
 
-	labels := make([]string, 0, len(pr.Labels))
+	var labels []string
 	for _, l := range pr.Labels {
 		if l.GetName() != "" {
 			labels = append(labels, l.GetName())

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -400,6 +400,20 @@ func (p *Patch) SetVariantsTasks(ctx context.Context, variantsTasks []VariantTas
 	)
 }
 
+// SetGithubLabels updates the GitHub PR labels on the patch document.
+func (p *Patch) SetGithubLabels(ctx context.Context, labels []string) error {
+	p.GithubPatchData.Labels = labels
+	return UpdateOne(
+		ctx,
+		bson.M{IdKey: p.Id},
+		bson.M{
+			"$set": bson.M{
+				bsonutil.GetDottedKeyName(githubPatchDataKey, thirdparty.GithubPatchLabelsKey): labels,
+			},
+		},
+	)
+}
+
 // UpdateRepeatPatchId updates the repeat patch Id value to be used for subsequent pr patches
 func (p *Patch) UpdateRepeatPatchId(ctx context.Context, patchId string) error {
 	repeatKey := bsonutil.GetDottedKeyName(githubPatchDataKey, thirdparty.RepeatPatchIdNextPatchKey)

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -144,6 +144,14 @@ func AddLabelTriggeredTasksForPatch(ctx context.Context, settings *evergreen.Set
 		return nil
 	}
 
+	changedFiles := p.FilesChanged()
+	if len(changedFiles) > 0 {
+		tvPairs = filterTVPairsByPaths(tvPairs, project, changedFiles)
+		if len(tvPairs.ExecTasks) == 0 && len(tvPairs.DisplayTasks) == 0 {
+			return nil
+		}
+	}
+
 	tvPairs.ExecTasks, err = IncludeDependencies(project, tvPairs.ExecTasks, p.GetRequester(), "", nil)
 	if err != nil {
 		grip.Warning(ctx, message.WrapError(err, message.Fields{
@@ -190,6 +198,27 @@ func AddLabelTriggeredTasksForPatch(ctx context.Context, settings *evergreen.Set
 		}
 	}
 	return errors.Wrap(p.SetVariantsTasks(ctx, mergedVTs), "updating patch variant tasks")
+}
+
+// filterTVPairsByPaths removes task/variant pairs whose build variant has
+// path filters that don't match the changed files.
+func filterTVPairsByPaths(pairs TaskVariantPairs, project *Project, changedFiles []string) TaskVariantPairs {
+	filtered := TaskVariantPairs{}
+	for _, pair := range pairs.ExecTasks {
+		bv := project.FindBuildVariant(pair.Variant)
+		if bv != nil && len(bv.Paths) > 0 && !bv.ChangedFilesMatchPaths(changedFiles) {
+			continue
+		}
+		filtered.ExecTasks = append(filtered.ExecTasks, pair)
+	}
+	for _, pair := range pairs.DisplayTasks {
+		bv := project.FindBuildVariant(pair.Variant)
+		if bv != nil && len(bv.Paths) > 0 && !bv.ChangedFilesMatchPaths(changedFiles) {
+			continue
+		}
+		filtered.DisplayTasks = append(filtered.DisplayTasks, pair)
+	}
+	return filtered
 }
 
 type PatchUpdate struct {

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -117,6 +117,81 @@ func addNewTasksAndBuildsForPatch(ctx context.Context, p *patch.Patch, creationI
 	return errors.Wrap(err, "activating existing inactive tasks")
 }
 
+// AddLabelTriggeredTasksForPatch resolves GitHub PR aliases that are now
+// applicable due to the given labels, and injects the resulting tasks into the
+// existing patch version. Tasks that already exist in the version are skipped.
+func AddLabelTriggeredTasksForPatch(ctx context.Context, settings *evergreen.Settings, p *patch.Patch, v *Version, projectRef *ProjectRef, currentLabels []string) error {
+	project, _, err := FindAndTranslateProjectForPatch(ctx, settings, p)
+	if err != nil {
+		return errors.Wrap(err, "translating project for patch")
+	}
+
+	aliasDefs, err := findAliasesForPatch(ctx, project.Identifier, evergreen.GithubPRAlias, p)
+	if err != nil {
+		return errors.Wrap(err, "finding GitHub PR aliases")
+	}
+
+	filteredAliases := filterAliasesByLabels(aliasDefs, currentLabels)
+	if len(filteredAliases) == 0 {
+		return nil
+	}
+
+	tvPairs, err := project.BuildProjectTVPairsWithAlias(filteredAliases, p.GetRequester(), "")
+	if err != nil {
+		return errors.Wrap(err, "building task/variant pairs from aliases")
+	}
+	if len(tvPairs.ExecTasks) == 0 && len(tvPairs.DisplayTasks) == 0 {
+		return nil
+	}
+
+	tvPairs.ExecTasks, err = IncludeDependencies(project, tvPairs.ExecTasks, p.GetRequester(), "", nil)
+	if err != nil {
+		grip.Warning(ctx, message.WrapError(err, message.Fields{
+			"message": "error including dependencies for label-triggered tasks",
+			"patch":   p.Id.Hex(),
+		}))
+	}
+
+	if err := p.SetGithubLabels(ctx, currentLabels); err != nil {
+		return errors.Wrap(err, "updating patch labels")
+	}
+
+	creationInfo := TaskCreationInfo{
+		Project:        project,
+		ProjectRef:     projectRef,
+		Version:        v,
+		Pairs:          tvPairs,
+		ActivationInfo: specificActivationInfo{},
+	}
+	if err := addNewTasksAndBuildsForPatch(ctx, p, creationInfo, patch.AutomatedCaller); err != nil {
+		return errors.Wrap(err, "adding label-triggered tasks to version")
+	}
+
+	mergedVTs := tvPairs.TVPairsToVariantTasks()
+	for _, existing := range p.VariantsTasks {
+		found := false
+		for i, vt := range mergedVTs {
+			if vt.Variant == existing.Variant {
+				taskSet := map[string]struct{}{}
+				for _, t := range mergedVTs[i].Tasks {
+					taskSet[t] = struct{}{}
+				}
+				for _, t := range existing.Tasks {
+					if _, ok := taskSet[t]; !ok {
+						mergedVTs[i].Tasks = append(mergedVTs[i].Tasks, t)
+					}
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			mergedVTs = append(mergedVTs, existing)
+		}
+	}
+	return errors.Wrap(p.SetVariantsTasks(ctx, mergedVTs), "updating patch variant tasks")
+}
+
 type PatchUpdate struct {
 	Description         string               `json:"description"`
 	Caller              string               `json:"caller"`

--- a/model/project.go
+++ b/model/project.go
@@ -1937,6 +1937,10 @@ func (p *Project) ResolvePatchVTs(ctx context.Context, patchDoc *patch.Patch, re
 		aliasDefs, err := findAliasesForPatch(ctx, p.Identifier, alias, patchDoc)
 		catcher.Wrapf(err, "retrieving alias '%s' for patched project config '%s'", alias, patchDoc.Id.Hex())
 
+		if !catcher.HasErrors() && patchDoc.IsGithubPRPatch() {
+			aliasDefs = filterAliasesByLabels(aliasDefs, patchDoc.GithubPatchData.Labels)
+		}
+
 		aliasPairs := TaskVariantPairs{}
 		if !catcher.HasErrors() {
 			aliasPairs, err = p.BuildProjectTVPairsWithAlias(aliasDefs, requester, branch)

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -68,17 +68,18 @@ const (
 // variants/tasks, assuming the tag matches the defined git_tag regex.
 // In this way, users can define different behavior for different kind of tags.
 type ProjectAlias struct {
-	ID          mgobson.ObjectId  `bson:"_id,omitempty" json:"_id" yaml:"id"`
-	ProjectID   string            `bson:"project_id" json:"project_id" yaml:"project_id"`
-	Alias       string            `bson:"alias" json:"alias" yaml:"alias"`
-	Variant     string            `bson:"variant,omitempty" json:"variant" yaml:"variant"`
-	Description string            `bson:"description" json:"description" yaml:"description"`
-	GitTag      string            `bson:"git_tag" json:"git_tag" yaml:"git_tag"`
-	RemotePath  string            `bson:"remote_path" json:"remote_path" yaml:"remote_path"`
-	VariantTags []string          `bson:"variant_tags,omitempty" json:"variant_tags" yaml:"variant_tags"`
-	Task        string            `bson:"task,omitempty" json:"task" yaml:"task"`
-	TaskTags    []string          `bson:"tags,omitempty" json:"tags" yaml:"task_tags"`
-	Parameters  []patch.Parameter `bson:"parameters,omitempty" json:"parameters" yaml:"parameters"`
+	ID             mgobson.ObjectId  `bson:"_id,omitempty" json:"_id" yaml:"id"`
+	ProjectID      string            `bson:"project_id" json:"project_id" yaml:"project_id"`
+	Alias          string            `bson:"alias" json:"alias" yaml:"alias"`
+	Variant        string            `bson:"variant,omitempty" json:"variant" yaml:"variant"`
+	Description    string            `bson:"description" json:"description" yaml:"description"`
+	GitTag         string            `bson:"git_tag" json:"git_tag" yaml:"git_tag"`
+	RemotePath     string            `bson:"remote_path" json:"remote_path" yaml:"remote_path"`
+	VariantTags    []string          `bson:"variant_tags,omitempty" json:"variant_tags" yaml:"variant_tags"`
+	Task           string            `bson:"task,omitempty" json:"task" yaml:"task"`
+	TaskTags       []string          `bson:"tags,omitempty" json:"tags" yaml:"task_tags"`
+	Parameters     []patch.Parameter `bson:"parameters,omitempty" json:"parameters" yaml:"parameters"`
+	RequiredLabels []string          `bson:"required_labels,omitempty" json:"required_labels,omitempty" yaml:"required_labels"`
 
 	// Source is not stored; indicates where the alias is stored for the project.
 	Source string `bson:"-" json:"-" yaml:"-"`
@@ -673,6 +674,31 @@ func isValidRegexOrTag(curItem string, curTags, aliasTags []string, aliasRegex *
 	return false
 }
 
+// filterAliasesByLabels returns only aliases whose required labels are
+// satisfied by the given PR labels. An alias with no required labels
+// always passes. An alias with required labels passes if the PR has
+// at least one of the required labels (OR semantics, case-sensitive).
+func filterAliasesByLabels(aliases []ProjectAlias, prLabels []string) []ProjectAlias {
+	prLabelSet := make(map[string]struct{}, len(prLabels))
+	for _, l := range prLabels {
+		prLabelSet[l] = struct{}{}
+	}
+	filtered := make([]ProjectAlias, 0, len(aliases))
+	for _, a := range aliases {
+		if len(a.RequiredLabels) == 0 {
+			filtered = append(filtered, a)
+			continue
+		}
+		for _, rl := range a.RequiredLabels {
+			if _, ok := prLabelSet[rl]; ok {
+				filtered = append(filtered, a)
+				break
+			}
+		}
+	}
+	return filtered
+}
+
 func ValidateProjectAliases(aliases []ProjectAlias, aliasType string) []string {
 	errs := []string{}
 	for i, pd := range aliases {
@@ -685,6 +711,9 @@ func ValidateProjectAliases(aliases []ProjectAlias, aliasType string) []string {
 		}
 		if strings.TrimSpace(pd.GitTag) != "" || strings.TrimSpace(pd.RemotePath) != "" {
 			errs = append(errs, fmt.Sprintf("%s: cannot define git tag or remote path on line #%d", aliasType, i+1))
+		}
+		if len(pd.RequiredLabels) > 0 && pd.Alias != evergreen.GithubPRAlias {
+			errs = append(errs, fmt.Sprintf("%s: required_labels can only be used on github_pr_aliases on line #%d", aliasType, i+1))
 		}
 		errs = append(errs, validateAliasPatchDefinition(pd, aliasType, i+1)...)
 	}

--- a/model/project_aliases.go
+++ b/model/project_aliases.go
@@ -20,17 +20,18 @@ import (
 )
 
 var (
-	idKey          = bsonutil.MustHaveTag(ProjectAlias{}, "ID")
-	projectIDKey   = bsonutil.MustHaveTag(ProjectAlias{}, "ProjectID")
-	aliasKey       = bsonutil.MustHaveTag(ProjectAlias{}, "Alias")
-	gitTagKey      = bsonutil.MustHaveTag(ProjectAlias{}, "GitTag")
-	remotePathKey  = bsonutil.MustHaveTag(ProjectAlias{}, "RemotePath")
-	variantKey     = bsonutil.MustHaveTag(ProjectAlias{}, "Variant")
-	descriptionKey = bsonutil.MustHaveTag(ProjectAlias{}, "Description")
-	taskKey        = bsonutil.MustHaveTag(ProjectAlias{}, "Task")
-	parametersKey  = bsonutil.MustHaveTag(ProjectAlias{}, "Parameters")
-	variantTagsKey = bsonutil.MustHaveTag(ProjectAlias{}, "VariantTags")
-	taskTagsKey    = bsonutil.MustHaveTag(ProjectAlias{}, "TaskTags")
+	idKey             = bsonutil.MustHaveTag(ProjectAlias{}, "ID")
+	projectIDKey      = bsonutil.MustHaveTag(ProjectAlias{}, "ProjectID")
+	aliasKey          = bsonutil.MustHaveTag(ProjectAlias{}, "Alias")
+	gitTagKey         = bsonutil.MustHaveTag(ProjectAlias{}, "GitTag")
+	remotePathKey     = bsonutil.MustHaveTag(ProjectAlias{}, "RemotePath")
+	variantKey        = bsonutil.MustHaveTag(ProjectAlias{}, "Variant")
+	descriptionKey    = bsonutil.MustHaveTag(ProjectAlias{}, "Description")
+	taskKey           = bsonutil.MustHaveTag(ProjectAlias{}, "Task")
+	parametersKey     = bsonutil.MustHaveTag(ProjectAlias{}, "Parameters")
+	variantTagsKey    = bsonutil.MustHaveTag(ProjectAlias{}, "VariantTags")
+	taskTagsKey       = bsonutil.MustHaveTag(ProjectAlias{}, "TaskTags")
+	requiredLabelsKey = bsonutil.MustHaveTag(ProjectAlias{}, "RequiredLabels")
 )
 
 const (
@@ -429,16 +430,17 @@ func (p *ProjectAlias) Upsert(ctx context.Context) error {
 		p.ID = mgobson.NewObjectId()
 	}
 	update := bson.M{
-		aliasKey:       p.Alias,
-		gitTagKey:      p.GitTag,
-		remotePathKey:  p.RemotePath,
-		projectIDKey:   p.ProjectID,
-		variantKey:     p.Variant,
-		descriptionKey: p.Description,
-		variantTagsKey: p.VariantTags,
-		taskTagsKey:    p.TaskTags,
-		taskKey:        p.Task,
-		parametersKey:  p.Parameters,
+		aliasKey:          p.Alias,
+		gitTagKey:         p.GitTag,
+		remotePathKey:     p.RemotePath,
+		projectIDKey:      p.ProjectID,
+		variantKey:        p.Variant,
+		descriptionKey:    p.Description,
+		variantTagsKey:    p.VariantTags,
+		taskTagsKey:       p.TaskTags,
+		taskKey:           p.Task,
+		parametersKey:     p.Parameters,
+		requiredLabelsKey: p.RequiredLabels,
 	}
 
 	_, err := db.Upsert(ctx, ProjectAliasCollection, bson.M{

--- a/model/project_aliases_test.go
+++ b/model/project_aliases_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
@@ -835,4 +836,66 @@ func TestValidateGitTagAlias(t *testing.T) {
 	a.RemotePath = "hello.yml"
 	errs = validateGitTagAlias(a, "gitTag", 1)
 	assert.Empty(t, errs)
+}
+
+func TestFilterAliasesByLabels(t *testing.T) {
+	noLabels := ProjectAlias{Alias: evergreen.GithubPRAlias, Variant: ".*"}
+	withLabelA := ProjectAlias{Alias: evergreen.GithubPRAlias, Variant: ".*", RequiredLabels: []string{"A"}}
+	withLabelAB := ProjectAlias{Alias: evergreen.GithubPRAlias, Variant: ".*", RequiredLabels: []string{"A", "B"}}
+
+	t.Run("NoRequiredLabelsAlwaysPasses", func(t *testing.T) {
+		result := filterAliasesByLabels([]ProjectAlias{noLabels}, nil)
+		assert.Len(t, result, 1)
+	})
+	t.Run("MatchingLabelPasses", func(t *testing.T) {
+		result := filterAliasesByLabels([]ProjectAlias{withLabelA}, []string{"A"})
+		assert.Len(t, result, 1)
+	})
+	t.Run("ORSemanticsAnyLabelSuffices", func(t *testing.T) {
+		result := filterAliasesByLabels([]ProjectAlias{withLabelAB}, []string{"B"})
+		assert.Len(t, result, 1)
+	})
+	t.Run("CaseSensitiveMismatch", func(t *testing.T) {
+		result := filterAliasesByLabels([]ProjectAlias{withLabelA}, []string{"a"})
+		assert.Len(t, result, 0)
+	})
+	t.Run("NoMatchingLabelsExcludesAlias", func(t *testing.T) {
+		result := filterAliasesByLabels([]ProjectAlias{withLabelA}, []string{"C"})
+		assert.Len(t, result, 0)
+	})
+	t.Run("MixedAliasesReturnsCorrectSubset", func(t *testing.T) {
+		result := filterAliasesByLabels([]ProjectAlias{noLabels, withLabelA, withLabelAB}, []string{"B"})
+		assert.Len(t, result, 2)
+		assert.Empty(t, result[0].RequiredLabels)
+		assert.Equal(t, []string{"A", "B"}, result[1].RequiredLabels)
+	})
+	t.Run("EmptyPRLabelsOnlyReturnsUnlabeled", func(t *testing.T) {
+		result := filterAliasesByLabels([]ProjectAlias{noLabels, withLabelA}, nil)
+		assert.Len(t, result, 1)
+		assert.Empty(t, result[0].RequiredLabels)
+	})
+}
+
+func TestValidateRequiredLabelsOnlyOnGithubPRAliases(t *testing.T) {
+	alias := ProjectAlias{
+		Alias:          evergreen.CommitQueueAlias,
+		Variant:        ".*",
+		Task:           ".*",
+		RequiredLabels: []string{"foo"},
+	}
+	errs := ValidateProjectAliases([]ProjectAlias{alias}, "commit_queue_aliases")
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e, "required_labels") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected validation error for required_labels on non-github alias")
+
+	alias.Alias = evergreen.GithubPRAlias
+	errs = ValidateProjectAliases([]ProjectAlias{alias}, "github_pr_aliases")
+	for _, e := range errs {
+		assert.NotContains(t, e, "required_labels")
+	}
 }

--- a/model/project_config_test.go
+++ b/model/project_config_test.go
@@ -45,4 +45,19 @@ github_pr_aliases:
 	assert.Equal(t, []string{"BF"}, pc.BuildBaronSettings.TicketSearchProjects)
 	assert.Equal(t, "BF", pc.BuildBaronSettings.TicketCreateProject)
 	assert.Equal(t, "Bug", pc.BuildBaronSettings.TicketCreateIssueType)
+
+	projYml = `
+github_pr_aliases:
+  - variant_tags: ["pr-default"]
+    task: ".*"
+  - variant_tags: ["pr-e2e"]
+    task: ".*"
+    required_labels: ["evergreen:e2e"]
+`
+	pc, err = CreateProjectConfig([]byte(projYml), "")
+	assert.NoError(t, err)
+	assert.NotNil(t, pc)
+	assert.Len(t, pc.GitHubPRAliases, 2)
+	assert.Empty(t, pc.GitHubPRAliases[0].RequiredLabels)
+	assert.Equal(t, []string{"evergreen:e2e"}, pc.GitHubPRAliases[1].RequiredLabels)
 }

--- a/rest/model/project_event.go
+++ b/rest/model/project_event.go
@@ -87,6 +87,8 @@ type APIProjectAlias struct {
 	ID *string `json:"_id,omitempty"`
 	// List of allowed parameters to the alias.
 	Parameters []*APIParameter `json:"parameters,omitempty"`
+	// GitHub PR labels required for this alias to contribute tasks.
+	RequiredLabels []*string `json:"required_labels,omitempty"`
 }
 
 func (e *APIProjectEvent) BuildFromService(ctx context.Context, entry model.ProjectChangeEventEntry) error {
@@ -192,14 +194,15 @@ func (p *APIProjectVars) BuildFromService(v model.ProjectVars) {
 
 func (a *APIProjectAlias) ToService() model.ProjectAlias {
 	res := model.ProjectAlias{
-		Alias:       utility.FromStringPtr(a.Alias),
-		Task:        utility.FromStringPtr(a.Task),
-		Variant:     utility.FromStringPtr(a.Variant),
-		Description: utility.FromStringPtr(a.Description),
-		GitTag:      utility.FromStringPtr(a.GitTag),
-		RemotePath:  utility.FromStringPtr(a.RemotePath),
-		TaskTags:    utility.FromStringPtrSlice(a.TaskTags),
-		VariantTags: utility.FromStringPtrSlice(a.VariantTags),
+		Alias:          utility.FromStringPtr(a.Alias),
+		Task:           utility.FromStringPtr(a.Task),
+		Variant:        utility.FromStringPtr(a.Variant),
+		Description:    utility.FromStringPtr(a.Description),
+		GitTag:         utility.FromStringPtr(a.GitTag),
+		RemotePath:     utility.FromStringPtr(a.RemotePath),
+		TaskTags:       utility.FromStringPtrSlice(a.TaskTags),
+		VariantTags:    utility.FromStringPtrSlice(a.VariantTags),
+		RequiredLabels: utility.FromStringPtrSlice(a.RequiredLabels),
 	}
 	res.Parameters = []patch.Parameter{}
 	for _, param := range a.Parameters {
@@ -225,6 +228,7 @@ func (a *APIProjectAlias) BuildFromService(in model.ProjectAlias) {
 	a.VariantTags = APIVariantTags
 	a.TaskTags = APITaskTags
 	a.ID = utility.ToStringPtr(in.ID.Hex())
+	a.RequiredLabels = utility.ToStringPtrSlice(in.RequiredLabels)
 	APIParameters := []*APIParameter{}
 	for _, param := range in.Parameters {
 		APIParam := &APIParameter{}
@@ -238,15 +242,16 @@ func dbProjectAliasesToRestModel(aliases []model.ProjectAlias) []APIProjectAlias
 	result := []APIProjectAlias{}
 	for _, alias := range aliases {
 		apiAlias := APIProjectAlias{
-			ID:          utility.ToStringPtr(alias.ID.String()),
-			Alias:       utility.ToStringPtr(alias.Alias),
-			Variant:     utility.ToStringPtr(alias.Variant),
-			Description: utility.ToStringPtr(alias.Description),
-			Task:        utility.ToStringPtr(alias.Task),
-			RemotePath:  utility.ToStringPtr(alias.RemotePath),
-			GitTag:      utility.ToStringPtr(alias.GitTag),
-			TaskTags:    utility.ToStringPtrSlice(alias.TaskTags),
-			VariantTags: utility.ToStringPtrSlice(alias.VariantTags),
+			ID:             utility.ToStringPtr(alias.ID.String()),
+			Alias:          utility.ToStringPtr(alias.Alias),
+			Variant:        utility.ToStringPtr(alias.Variant),
+			Description:    utility.ToStringPtr(alias.Description),
+			Task:           utility.ToStringPtr(alias.Task),
+			RemotePath:     utility.ToStringPtr(alias.RemotePath),
+			GitTag:         utility.ToStringPtr(alias.GitTag),
+			TaskTags:       utility.ToStringPtrSlice(alias.TaskTags),
+			VariantTags:    utility.ToStringPtrSlice(alias.VariantTags),
+			RequiredLabels: utility.ToStringPtrSlice(alias.RequiredLabels),
 		}
 		result = append(result, apiAlias)
 	}

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -36,6 +36,8 @@ const (
 	githubActionSynchronize     = "synchronize"
 	githubActionReopened        = "reopened"
 	githubActionAutoBaseChange  = "automatic_base_change_succeeded"
+	githubActionLabeled         = "labeled"
+	githubActionUnlabeled       = "unlabeled"
 	githubActionChecksRequested = "checks_requested"
 	githubActionRerequested     = "rerequested"
 	githubActionDestroyed       = "destroyed"
@@ -293,6 +295,41 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 			}
 
 			return gimlet.NewJSONResponse(struct{}{})
+		} else if action == githubActionLabeled {
+			grip.Info(ctx, message.Fields{
+				"source":    "GitHub hook",
+				"msg_id":    gh.msgID,
+				"event":     gh.eventType,
+				"action":    action,
+				"repo":      event.GetPullRequest().GetBase().GetRepo().GetFullName(),
+				"pr_number": event.GetPullRequest().GetNumber(),
+				"label":     event.GetLabel().GetName(),
+				"hash":      event.GetPullRequest().GetHead().GetSHA(),
+				"message":   "PR labeled, checking for newly applicable aliases",
+			})
+			if err := gh.handlePRLabeled(ctx, event); err != nil {
+				grip.Error(ctx, message.WrapError(err, message.Fields{
+					"source":    "GitHub hook",
+					"msg_id":    gh.msgID,
+					"event":     gh.eventType,
+					"repo":      event.GetPullRequest().GetBase().GetRepo().GetFullName(),
+					"pr_number": event.GetPullRequest().GetNumber(),
+					"label":     event.GetLabel().GetName(),
+					"message":   "handling labeled event",
+				}))
+				return gimlet.NewJSONInternalErrorResponse(errors.Wrap(err, "handling labeled PR event"))
+			}
+		} else if action == githubActionUnlabeled {
+			grip.Debug(ctx, message.Fields{
+				"source":    "GitHub hook",
+				"msg_id":    gh.msgID,
+				"event":     gh.eventType,
+				"action":    action,
+				"repo":      event.GetPullRequest().GetBase().GetRepo().GetFullName(),
+				"pr_number": event.GetPullRequest().GetNumber(),
+				"label":     event.GetLabel().GetName(),
+				"message":   "PR unlabeled, no-op",
+			})
 		}
 	case *github.PushEvent:
 		fromApp := event.GetInstallation() != nil
@@ -1173,6 +1210,65 @@ func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequ
 	}
 
 	return errors.Wrap(data.AddPRPatchIntent(ctx, ghi, gh.queue), "saving GitHub patch intent")
+}
+
+// handlePRLabeled processes a GitHub PR "labeled" event by finding the existing
+// patch version for the PR's head SHA and injecting tasks from any aliases that
+// are now applicable due to the label. If no finalized patch exists for the SHA,
+// this is a no-op.
+func (gh *githubHookApi) handlePRLabeled(ctx context.Context, event *github.PullRequestEvent) error {
+	pr := event.GetPullRequest()
+	if pr == nil || pr.Base == nil || pr.Base.Repo == nil || pr.Head == nil {
+		return errors.New("incomplete pull request event")
+	}
+
+	owner := pr.Base.Repo.Owner.GetLogin()
+	repo := pr.Base.Repo.GetName()
+	prNumber := pr.GetNumber()
+	headSHA := pr.Head.GetSHA()
+	baseBranch := pr.Base.GetRef()
+
+	projectRef, err := model.FindOneProjectRefByRepoAndBranchWithPRTesting(ctx, owner, repo, baseBranch, patch.AutomatedCaller)
+	if err != nil {
+		return errors.Wrap(err, "finding project ref")
+	}
+	if projectRef == nil {
+		return nil
+	}
+
+	existingPatch, err := patch.FindFinalizedGithubPRPatchForHeadSHA(ctx, owner, repo, prNumber, headSHA)
+	if err != nil {
+		return errors.Wrap(err, "finding existing patch for head SHA")
+	}
+	if existingPatch == nil {
+		grip.Debug(ctx, message.Fields{
+			"source":    "GitHub hook",
+			"msg_id":    gh.msgID,
+			"message":   "no finalized patch for head SHA, skipping labeled event",
+			"owner":     owner,
+			"repo":      repo,
+			"pr_number": prNumber,
+			"head_sha":  headSHA,
+		})
+		return nil
+	}
+
+	v, err := model.VersionFindOneId(ctx, existingPatch.Version)
+	if err != nil {
+		return errors.Wrapf(err, "finding version '%s'", existingPatch.Version)
+	}
+	if v == nil {
+		return errors.Errorf("version '%s' not found", existingPatch.Version)
+	}
+
+	currentLabels := make([]string, 0, len(pr.Labels))
+	for _, l := range pr.Labels {
+		if l.GetName() != "" {
+			currentLabels = append(currentLabels, l.GetName())
+		}
+	}
+
+	return model.AddLabelTriggeredTasksForPatch(ctx, gh.settings, existingPatch, v, projectRef, currentLabels)
 }
 
 // overrideOtherPRs aborts the given patches and comments on each patch's PR to inform the user that their patch

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -176,7 +176,8 @@ type GithubPatch struct {
 	CommitMessage string `bson:"commit_message"`
 	MergeBase     string `bson:"merge_base"`
 	// the patchId to copy the definitions for for the next patch the pr creates
-	RepeatPatchIdNextPatch string `bson:"repeat_patch_id_next_patch"`
+	RepeatPatchIdNextPatch string   `bson:"repeat_patch_id_next_patch"`
+	Labels                 []string `bson:"labels,omitempty"`
 }
 
 // GithubMergeGroup stores patch data for patches created from GitHub merge groups
@@ -313,6 +314,8 @@ var (
 	GithubPatchBaseOwnerKey   = bsonutil.MustHaveTag(GithubPatch{}, "BaseOwner")
 	GithubPatchBaseRepoKey    = bsonutil.MustHaveTag(GithubPatch{}, "BaseRepo")
 	RepeatPatchIdNextPatchKey = bsonutil.MustHaveTag(GithubPatch{}, "RepeatPatchIdNextPatch")
+	GithubPatchLabelsKey      = bsonutil.MustHaveTag(GithubPatch{}, "Labels")
+	GithubPatchHeadHashKey    = bsonutil.MustHaveTag(GithubPatch{}, "HeadHash")
 )
 
 type retryConfig struct {


### PR DESCRIPTION
DEVPROD-36828
### Description

Adds a required_labels field to `github_pr_aliases` so alias entries only contribute their variants/tasks when the PR has a matching label. This lets teams gate expensive test suites behind GitHub labels and skip them on PRs that don't need them.

Aliases without required_labels always run and aliases with it only run if the PR carries at least one of the listed labels. Adding a label to an existing PR injects the tasks into the version. Removing a label is a no-op.

### Testing
Tested in staging sandbox and verified that opening a PR without the label only runs the default tasks, and that adding the label injects the relevant tasks into the version, and that path filtering is respected.
### Documentation

Added user facing docs
