### PR TITLE
DEVPROD-24671: Conclude unscheduled GitHub statuses and retry while pending

### DIFF
--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -1460,7 +1460,7 @@ func (r *mutationResolver) RefreshGitHubStatuses(ctx context.Context, opts Refre
 		return nil, InputValidationError.Send(ctx, fmt.Sprintf("version '%s' is not associated with a GitHub pull request or merge queue patch", versionID))
 	}
 
-	j := units.NewGithubStatusRefreshJob(p)
+	j := units.NewGithubStatusReconcileJob(p, 0)
 	if err := amboy.EnqueueUniqueJob(ctx, evergreen.GetEnvironment().RemoteQueue(), j); err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("creating GitHub status refresh job: %s", err.Error()))
 	}

--- a/model/patch/patch.go
+++ b/model/patch/patch.go
@@ -666,6 +666,25 @@ func (p *Patch) IsMergeQueuePatch() bool {
 	return p.Alias == evergreen.CommitQueueAlias || p.GithubMergeData.HeadSHA != ""
 }
 
+// GitHubStatusTarget returns the owner, repo, and commit SHA Evergreen should
+// post GitHub commit statuses to for this patch. Merge-queue patches must use
+// the merge group head SHA; PR patches use the PR head.
+func (p *Patch) GitHubStatusTarget() (owner, repo, ref string) {
+	if p.GithubMergeData.HeadSHA != "" {
+		return p.GithubMergeData.Org, p.GithubMergeData.Repo, p.GithubMergeData.HeadSHA
+	}
+	return p.GithubPatchData.BaseOwner, p.GithubPatchData.BaseRepo, p.GithubPatchData.HeadHash
+}
+
+// GitHubStatusBranch returns the base branch used to look up GitHub required
+// status checks for this patch.
+func (p *Patch) GitHubStatusBranch() string {
+	if p.GithubMergeData.HeadSHA != "" {
+		return p.GithubMergeData.BaseBranch
+	}
+	return p.GithubPatchData.BaseBranch
+}
+
 func (p *Patch) IsChild() bool {
 	return p.Triggers.ParentPatch != ""
 }

--- a/model/patch/patch_test.go
+++ b/model/patch/patch_test.go
@@ -15,6 +15,42 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+func TestGitHubStatusTarget(t *testing.T) {
+	prPatch := Patch{
+		GithubPatchData: thirdparty.GithubPatch{
+			BaseOwner:  "evergreen-ci",
+			BaseRepo:   "evergreen",
+			HeadHash:   "pr-head",
+			BaseBranch: "main",
+		},
+	}
+	owner, repo, ref := prPatch.GitHubStatusTarget()
+	assert.Equal(t, "evergreen-ci", owner)
+	assert.Equal(t, "evergreen", repo)
+	assert.Equal(t, "pr-head", ref)
+	assert.Equal(t, "main", prPatch.GitHubStatusBranch())
+
+	mqPatch := Patch{
+		GithubPatchData: thirdparty.GithubPatch{
+			BaseOwner:  "should-not-use",
+			BaseRepo:   "should-not-use",
+			HeadHash:   "pr-head",
+			BaseBranch: "pr-base",
+		},
+		GithubMergeData: thirdparty.GithubMergeGroup{
+			Org:        "10gen",
+			Repo:       "mms",
+			HeadSHA:    "merge-group-sha",
+			BaseBranch: "master",
+		},
+	}
+	owner, repo, ref = mqPatch.GitHubStatusTarget()
+	assert.Equal(t, "10gen", owner)
+	assert.Equal(t, "mms", repo)
+	assert.Equal(t, "merge-group-sha", ref)
+	assert.Equal(t, "master", mqPatch.GitHubStatusBranch())
+}
+
 func TestAliasesToResolve(t *testing.T) {
 	for name, tc := range map[string]struct {
 		patch    Patch

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -45,6 +45,7 @@ const (
 	GithubInvestigation        = "Github API Limit Investigation"
 	PRDiffTooLargeErrorMessage = "the diff exceeded the maximum"
 	GithubStatusDefaultContext = "evergreen"
+	githubCommitStatusPending  = "pending"
 )
 
 const (
@@ -1747,6 +1748,89 @@ func getRulesWithEvergreenPrefix(rules []string) []string {
 		}
 	}
 	return rulesWithEvergreenPrefix
+}
+
+// GetEvergreenRequiredStatusContexts returns GitHub required status contexts
+// that Evergreen is responsible for: the default "evergreen" context plus any
+// branch protection or ruleset checks prefixed with "evergreen". Errors fetching
+// rules are logged and omitted so callers can still send the default context.
+func GetEvergreenRequiredStatusContexts(ctx context.Context, owner, repo, branch string) []string {
+	branchProtectionRules, err := GetEvergreenBranchProtectionRules(ctx, owner, repo, branch)
+	grip.Error(ctx, message.WrapError(err, message.Fields{
+		"message": "failed to get branch protection rules",
+		"org":     owner,
+		"repo":    repo,
+		"branch":  branch,
+	}))
+
+	rulesetRules, err := GetEvergreenRulesetRules(ctx, owner, repo, branch)
+	grip.Error(ctx, message.WrapError(err, message.Fields{
+		"message": "failed to get ruleset rules",
+		"org":     owner,
+		"repo":    repo,
+		"branch":  branch,
+	}))
+
+	allRules := append([]string{GithubStatusDefaultContext}, branchProtectionRules...)
+	allRules = append(allRules, rulesetRules...)
+	return utility.UniqueStrings(allRules)
+}
+
+// GetPendingEvergreenCommitStatusContexts returns Evergreen commit status
+// contexts that GitHub still reports as pending for the given ref.
+func GetPendingEvergreenCommitStatusContexts(ctx context.Context, owner, repo, ref string) ([]string, error) {
+	caller := "GetPendingEvergreenCommitStatusContexts"
+	ctx, span := tracer.Start(ctx, caller, trace.WithAttributes(
+		attribute.String(githubEndpointAttribute, caller),
+		attribute.String(githubOwnerAttribute, owner),
+		attribute.String(githubRepoAttribute, repo),
+		attribute.String(githubRefAttribute, ref),
+	))
+	defer span.End()
+
+	token, err := getInstallationToken(ctx, owner, repo, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting installation token")
+	}
+
+	githubClient := getGithubClient(token, caller, retryConfig{})
+	defer githubClient.Close()
+
+	opts := &github.ListOptions{PerPage: 100}
+	var statuses []*github.RepoStatus
+	for {
+		combined, resp, err := githubClient.Repositories.GetCombinedStatus(ctx, owner, repo, ref, opts)
+		if resp != nil {
+			defer resp.Body.Close()
+			span.SetAttributes(attribute.Bool(githubCachedAttribute, respFromCache(resp.Response)))
+		}
+		if err != nil {
+			return nil, errors.Wrap(err, "getting combined commit status")
+		}
+		if combined != nil {
+			statuses = append(statuses, combined.Statuses...)
+		}
+		if resp == nil || resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
+	}
+
+	return evergreenPendingStatusContexts(statuses), nil
+}
+
+func evergreenPendingStatusContexts(statuses []*github.RepoStatus) []string {
+	pending := []string{}
+	for _, st := range statuses {
+		if st == nil {
+			continue
+		}
+		context := st.GetContext()
+		if st.GetState() == githubCommitStatusPending && strings.HasPrefix(context, GithubStatusDefaultContext) {
+			pending = append(pending, context)
+		}
+	}
+	return pending
 }
 
 // GetBranchProtectionRules gets all branch protection checks as a list of strings.

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -693,3 +693,16 @@ func TestBuildGithubHeadPRURL(t *testing.T) {
 		})
 	}
 }
+
+func TestEvergreenPendingStatusContexts(t *testing.T) {
+	pending := "pending"
+	success := "success"
+	statuses := []*github.RepoStatus{
+		{Context: github.Ptr("evergreen"), State: github.Ptr(pending)},
+		{Context: github.Ptr("evergreen/int"), State: github.Ptr(pending)},
+		{Context: github.Ptr("evergreen/js"), State: github.Ptr(success)},
+		{Context: github.Ptr("mms-global-pr"), State: github.Ptr(pending)},
+		nil,
+	}
+	assert.Equal(t, []string{"evergreen", "evergreen/int"}, evergreenPendingStatusContexts(statuses))
+}

--- a/units/event_notifier.go
+++ b/units/event_notifier.go
@@ -9,6 +9,7 @@ import (
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model/event"
 	"github.com/evergreen-ci/evergreen/model/notification"
+	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/trigger"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
@@ -123,6 +124,7 @@ func (j *eventNotifierJob) processEvent(ctx context.Context, e *event.EventLogEn
 	// Continue on error even if some jobs couldn't be marked disabled.
 	catcher.Add(errors.Wrap(err, "getting notification jobs"))
 	catcher.Add(errors.Wrap(j.q.PutMany(ctx, jobs), "enqueueing notification jobs"))
+	catcher.Add(j.enqueueGitHubStatusReconcile(ctx, e))
 
 	endTime := time.Now()
 	totalDuration := endTime.Sub(startTime)
@@ -222,6 +224,27 @@ func (j *eventNotifierJob) processEventTriggers(ctx context.Context, e *event.Ev
 	})
 
 	return n, err
+}
+
+func (j *eventNotifierJob) enqueueGitHubStatusReconcile(ctx context.Context, e *event.EventLogEntry) error {
+	if e.ResourceType != event.ResourceTypePatch || e.EventType != event.PatchStateChange {
+		return nil
+	}
+	data, ok := e.Data.(*event.PatchEventData)
+	if !ok || data == nil || !evergreen.IsFinishedVersionStatus(data.Status) {
+		return nil
+	}
+	if !patch.IsValidId(e.ResourceId) {
+		return nil
+	}
+	p, err := patch.FindOneId(ctx, e.ResourceId)
+	if err != nil {
+		return errors.Wrapf(err, "finding patch '%s' to reconcile GitHub statuses", e.ResourceId)
+	}
+	if p == nil || (!p.IsGithubPRPatch() && !p.IsMergeQueuePatch()) {
+		return nil
+	}
+	return errors.Wrap(amboy.EnqueueUniqueJob(ctx, j.q, NewGithubStatusReconcileJob(p, githubStatusReconcileDelay)), "enqueueing GitHub status reconcile job")
 }
 
 func notificationJobs(ctx context.Context, notifications []notification.Notification, flags *evergreen.ServiceFlags, ts time.Time) ([]amboy.Job, error) {

--- a/units/github_status_api.go
+++ b/units/github_status_api.go
@@ -37,6 +37,7 @@ const (
 	mergeQueueDisabled                = "merge queue disabled for project"
 	ignoredFiles                      = "all patched files are ignored"
 	ignoredFilesForVariant            = "variant ignored due to path filtering"
+	unscheduledGitHubVariant          = "variant was not scheduled"
 	insufficientChildPatchPermissions = "insufficient permissions to submit patches on child project"
 	checkRunLimitExceeded             = "patch exceeds check run limit"
 	invalidRegexPattern               = "invalid regex in variant or task selector"

--- a/units/github_status_refresh.go
+++ b/units/github_status_refresh.go
@@ -3,6 +3,7 @@ package units
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
@@ -13,6 +14,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/patch"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/thirdparty"
+	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/amboy"
 	"github.com/mongodb/amboy/job"
 	"github.com/mongodb/amboy/registry"
@@ -26,19 +28,58 @@ import (
 
 const (
 	githubStatusRefreshJobName = "github-status-refresh"
+
+	githubStatusReconcileMaxAttempts = 6
+	githubStatusReconcileRetryWait   = 20 * time.Second
+	githubStatusReconcileDelay       = 15 * time.Second
 )
 
 func init() {
 	registry.AddJobType(githubStatusRefreshJobName, func() amboy.Job { return makeGithubStatusRefreshJob() })
 }
 
-// NewGithubStatusRefreshJob is a job that re-sends github statuses to the PR associated with the given patch.
+type githubStatusRefreshConfig struct {
+	reconcile bool
+	delay     time.Duration
+}
+
+// NewGithubStatusRefreshJob re-sends GitHub statuses for the given patch.
 func NewGithubStatusRefreshJob(p *patch.Patch) amboy.Job {
+	return newGithubStatusRefreshJob(p, githubStatusRefreshConfig{})
+}
+
+// NewGithubStatusReconcileJob re-sends GitHub statuses for a finished patch,
+// posts a terminal success for required evergreen contexts that have no
+// matching build, and retries while any evergreen context is still pending on
+// GitHub. delay defers the first attempt so in-flight status notifications can
+// land first; a non-zero delay also uses a stable job ID so only one reconcile
+// is queued per version.
+func NewGithubStatusReconcileJob(p *patch.Patch, delay time.Duration) amboy.Job {
+	return newGithubStatusRefreshJob(p, githubStatusRefreshConfig{reconcile: true, delay: delay})
+}
+
+func newGithubStatusRefreshJob(p *patch.Patch, cfg githubStatusRefreshConfig) amboy.Job {
 	job := makeGithubStatusRefreshJob()
 	job.FetchID = p.Version
 	job.patch = p
+	job.ReconcileGitHub = cfg.reconcile
 
-	job.SetID(fmt.Sprintf("%s:%s-%s", githubStatusRefreshJobName, p.Version, time.Now().String()))
+	if cfg.reconcile && cfg.delay > 0 {
+		job.SetID(fmt.Sprintf("%s:reconcile:%s", githubStatusRefreshJobName, p.Version))
+		job.SetScopes([]string{fmt.Sprintf("%s.%s", githubStatusRefreshJobName, p.Version)})
+		job.SetEnqueueAllScopes(true)
+		job.SetTimeInfo(amboy.JobTimeInfo{WaitUntil: time.Now().Add(cfg.delay)})
+	} else {
+		job.SetID(fmt.Sprintf("%s:%s-%s", githubStatusRefreshJobName, p.Version, time.Now().String()))
+	}
+
+	if cfg.reconcile {
+		job.UpdateRetryInfo(amboy.JobRetryOptions{
+			Retryable:   utility.TruePtr(),
+			MaxAttempts: utility.ToIntPtr(githubStatusReconcileMaxAttempts),
+			WaitUntil:   utility.ToTimeDurationPtr(githubStatusReconcileRetryWait),
+		})
+	}
 	return job
 }
 
@@ -52,7 +93,12 @@ type githubStatusRefreshJob struct {
 	builds       []build.Build
 	childPatches []patch.Patch
 
-	FetchID string `bson:"fetch_id" json:"fetch_id" yaml:"fetch_id"`
+	// Optional overrides for tests. Nil means use the production GitHub helpers.
+	requiredEvergreenContexts    func(ctx context.Context, owner, repo, branch string) []string
+	listPendingEvergreenStatuses func(ctx context.Context, owner, repo, ref string) ([]string, error)
+
+	FetchID         string `bson:"fetch_id" json:"fetch_id" yaml:"fetch_id"`
+	ReconcileGitHub bool   `bson:"reconcile_github" json:"reconcile_github" yaml:"reconcile_github"`
 }
 
 func makeGithubStatusRefreshJob() *githubStatusRefreshJob {
@@ -107,7 +153,8 @@ func (j *githubStatusRefreshJob) fetch(ctx context.Context) error {
 		}
 	}
 
-	j.sender, err = j.env.GetGitHubSender(j.patch.GithubPatchData.BaseOwner, j.patch.GithubPatchData.BaseRepo, githubapp.CreateGitHubAppAuth(j.env.Settings()).CreateGitHubSenderInstallationToken)
+	owner, repo, _ := j.patch.GitHubStatusTarget()
+	j.sender, err = j.env.GetGitHubSender(owner, repo, githubapp.CreateGitHubAppAuth(j.env.Settings()).CreateGitHubSenderInstallationToken)
 	if err != nil {
 		return err
 	}
@@ -124,6 +171,15 @@ func (j *githubStatusRefreshJob) fetch(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func (j *githubStatusRefreshJob) baseStatus() *message.GithubStatus {
+	owner, repo, ref := j.patch.GitHubStatusTarget()
+	return &message.GithubStatus{
+		Owner: owner,
+		Repo:  repo,
+		Ref:   ref,
+	}
 }
 
 func (j *githubStatusRefreshJob) sendStatus(ctx context.Context, status *message.GithubStatus) {
@@ -151,11 +207,7 @@ func (j *githubStatusRefreshJob) sendChildPatchStatuses(ctx context.Context) err
 		return nil
 	}
 
-	status := &message.GithubStatus{
-		Owner: j.patch.GithubPatchData.BaseOwner,
-		Repo:  j.patch.GithubPatchData.BaseRepo,
-		Ref:   j.patch.GithubPatchData.HeadHash,
-	}
+	status := j.baseStatus()
 
 	for _, childPatch := range j.childPatches {
 		projectIdentifier, err := model.GetIdentifierForProject(ctx, childPatch.Project)
@@ -192,11 +244,7 @@ func getGithubStateAndDescriptionForPatch(p *patch.Patch) (message.GithubState, 
 }
 
 func (j *githubStatusRefreshJob) sendBuildStatuses(ctx context.Context) {
-	status := &message.GithubStatus{
-		Owner: j.patch.GithubPatchData.BaseOwner,
-		Repo:  j.patch.GithubPatchData.BaseRepo,
-		Ref:   j.patch.GithubPatchData.HeadHash,
-	}
+	status := j.baseStatus()
 	for _, b := range j.builds {
 		status.Context = fmt.Sprintf("%s/%s", thirdparty.GithubStatusDefaultContext, b.BuildVariant)
 		status.URL = b.GetURL(j.urlBase)
@@ -222,6 +270,100 @@ func (j *githubStatusRefreshJob) sendBuildStatuses(ctx context.Context) {
 	}
 }
 
+func (j *githubStatusRefreshJob) scheduledGitHubContexts(ctx context.Context) map[string]struct{} {
+	scheduled := map[string]struct{}{
+		thirdparty.GithubStatusDefaultContext: {},
+	}
+	for _, b := range j.builds {
+		scheduled[fmt.Sprintf("%s/%s", thirdparty.GithubStatusDefaultContext, b.BuildVariant)] = struct{}{}
+	}
+	for i := range j.childPatches {
+		projectIdentifier, err := model.GetIdentifierForProject(ctx, j.childPatches[i].Project)
+		if err != nil {
+			j.AddError(errors.Wrap(err, "finding project identifier for child patch"))
+			continue
+		}
+		context, err := patch.GetGithubContextForChildPatch(projectIdentifier, j.patch, &j.childPatches[i])
+		if err != nil {
+			j.AddError(errors.Wrapf(err, "getting github context for child patch '%s'", j.childPatches[i].Id.Hex()))
+			continue
+		}
+		scheduled[context] = struct{}{}
+	}
+	return scheduled
+}
+
+func (j *githubStatusRefreshJob) sendUnscheduledRequiredStatuses(ctx context.Context, contexts []string, scheduled map[string]struct{}) {
+	status := j.baseStatus()
+	status.URL = j.patch.GetURL(j.urlBase)
+	status.State = message.GithubStateSuccess
+	status.Description = unscheduledGitHubVariant
+
+	for _, context := range contexts {
+		if context == "" {
+			continue
+		}
+		if _, ok := scheduled[context]; ok {
+			continue
+		}
+		status.Context = context
+		j.sendStatus(ctx, status)
+		scheduled[context] = struct{}{}
+	}
+}
+
+func (j *githubStatusRefreshJob) requiredContexts(ctx context.Context, owner, repo, branch string) []string {
+	if j.requiredEvergreenContexts != nil {
+		return j.requiredEvergreenContexts(ctx, owner, repo, branch)
+	}
+	return thirdparty.GetEvergreenRequiredStatusContexts(ctx, owner, repo, branch)
+}
+
+func (j *githubStatusRefreshJob) pendingContexts(ctx context.Context, owner, repo, ref string) ([]string, error) {
+	if j.listPendingEvergreenStatuses != nil {
+		return j.listPendingEvergreenStatuses(ctx, owner, repo, ref)
+	}
+	return thirdparty.GetPendingEvergreenCommitStatusContexts(ctx, owner, repo, ref)
+}
+
+func (j *githubStatusRefreshJob) reconcileGitHubStatuses(ctx context.Context) {
+	if !j.ReconcileGitHub || j.patch == nil || !evergreen.IsFinishedVersionStatus(j.patch.Status) {
+		return
+	}
+
+	owner, repo, ref := j.patch.GitHubStatusTarget()
+	scheduled := j.scheduledGitHubContexts(ctx)
+
+	required := j.requiredContexts(ctx, owner, repo, j.patch.GitHubStatusBranch())
+	j.sendUnscheduledRequiredStatuses(ctx, required, scheduled)
+
+	pending, err := j.pendingContexts(ctx, owner, repo, ref)
+	if err != nil {
+		grip.Error(ctx, message.WrapError(err, message.Fields{
+			"job":      j.ID(),
+			"job_type": j.Type().Name,
+			"message":  "failed to list pending GitHub commit statuses",
+			"owner":    owner,
+			"repo":     repo,
+			"ref":      ref,
+			"patch_id": j.FetchID,
+		}))
+		j.AddRetryableError(errors.Wrap(err, "listing pending GitHub commit statuses"))
+		return
+	}
+
+	j.sendUnscheduledRequiredStatuses(ctx, pending, scheduled)
+
+	if len(pending) == 0 {
+		return
+	}
+
+	// Anything still pending after we posted terminal statuses for unscheduled
+	// contexts is either a missed send for a real build or GitHub lag. Retry
+	// so a later attempt can confirm the statuses landed.
+	j.AddRetryableError(errors.Errorf("GitHub still pending for evergreen contexts: %s", strings.Join(pending, ", ")))
+}
+
 func (j *githubStatusRefreshJob) Run(ctx context.Context) {
 	shouldUpdate, err := j.shouldUpdate(ctx)
 	if err != nil {
@@ -236,13 +378,9 @@ func (j *githubStatusRefreshJob) Run(ctx context.Context) {
 		return
 	}
 
-	status := &message.GithubStatus{
-		URL:     j.patch.GetURL(j.urlBase),
-		Context: thirdparty.GithubStatusDefaultContext,
-		Owner:   j.patch.GithubPatchData.BaseOwner,
-		Repo:    j.patch.GithubPatchData.BaseRepo,
-		Ref:     j.patch.GithubPatchData.HeadHash,
-	}
+	status := j.baseStatus()
+	status.URL = j.patch.GetURL(j.urlBase)
+	status.Context = thirdparty.GithubStatusDefaultContext
 	status.State, status.Description = getGithubStateAndDescriptionForPatch(j.patch)
 
 	// Send patch status
@@ -256,4 +394,6 @@ func (j *githubStatusRefreshJob) Run(ctx context.Context) {
 
 	// For each build, send build status.
 	j.sendBuildStatuses(ctx)
+
+	j.reconcileGitHubStatuses(ctx)
 }

--- a/units/github_status_refresh_test.go
+++ b/units/github_status_refresh_test.go
@@ -472,8 +472,143 @@ func (s *githubStatusRefreshSuite) getAndValidateStatus(sender *send.InternalSen
 	status, ok := raw.Raw().(*message.GithubStatus)
 	s.Require().True(ok)
 
-	s.Equal("evergreen-ci", status.Owner)
-	s.Equal("evergreen", status.Repo)
-	s.Equal("776f608b5b12cd27b8d931c8ee4ca0c13f857299", status.Ref)
+	owner, repo, ref := s.patchDoc.GitHubStatusTarget()
+	s.Equal(owner, status.Owner)
+	s.Equal(repo, status.Repo)
+	s.Equal(ref, status.Ref)
 	return status
+}
+
+func (s *githubStatusRefreshSuite) TestMergeQueueUsesHeadSHA() {
+	s.patchDoc.GithubMergeData = thirdparty.GithubMergeGroup{
+		Org:        "10gen",
+		Repo:       "mms",
+		HeadSHA:    "merge-group-sha",
+		BaseBranch: "master",
+	}
+	s.patchDoc.Status = evergreen.VersionSucceeded
+
+	b := build.Build{
+		Id:           "b1",
+		BuildVariant: "js",
+		Version:      s.patchDoc.Version,
+		Status:       evergreen.BuildSucceeded,
+		StartTime:    time.Now(),
+		FinishTime:   time.Now().Add(time.Minute),
+	}
+	s.NoError(b.Insert(s.ctx))
+	s.NoError(task.Task{
+		Id:      "t1",
+		Version: s.patchDoc.Version,
+		BuildId: b.Id,
+		Status:  evergreen.TaskSucceeded,
+	}.Insert(s.ctx))
+
+	job, ok := NewGithubStatusRefreshJob(s.patchDoc).(*githubStatusRefreshJob)
+	s.Require().True(ok)
+	job.env = s.env
+	job.Run(s.ctx)
+	s.False(job.HasErrors())
+
+	status := s.getAndValidateStatus(s.env.InternalSender)
+	s.Equal("evergreen", status.Context)
+	s.Equal(message.GithubStateSuccess, status.State)
+
+	status = s.getAndValidateStatus(s.env.InternalSender)
+	s.Equal("evergreen/js", status.Context)
+	s.Equal(message.GithubStateSuccess, status.State)
+}
+
+func (s *githubStatusRefreshSuite) TestReconcileConcludesUnscheduledRequiredContext() {
+	s.patchDoc.Status = evergreen.VersionSucceeded
+	s.patchDoc.GithubPatchData.BaseBranch = "main"
+
+	b := build.Build{
+		Id:           "b1",
+		BuildVariant: "js",
+		Version:      s.patchDoc.Version,
+		Status:       evergreen.BuildSucceeded,
+		StartTime:    time.Now(),
+		FinishTime:   time.Now().Add(time.Minute),
+	}
+	s.NoError(b.Insert(s.ctx))
+	s.NoError(task.Task{
+		Id:      "t1",
+		Version: s.patchDoc.Version,
+		BuildId: b.Id,
+		Status:  evergreen.TaskSucceeded,
+	}.Insert(s.ctx))
+
+	job, ok := NewGithubStatusReconcileJob(s.patchDoc, 0).(*githubStatusRefreshJob)
+	s.Require().True(ok)
+	job.env = s.env
+	job.requiredEvergreenContexts = func(context.Context, string, string, string) []string {
+		return []string{thirdparty.GithubStatusDefaultContext, "evergreen/int"}
+	}
+	job.listPendingEvergreenStatuses = func(context.Context, string, string, string) ([]string, error) {
+		return nil, nil
+	}
+	job.Run(s.ctx)
+	s.False(job.HasErrors())
+	s.False(job.RetryInfo().NeedsRetry)
+
+	status := s.getAndValidateStatus(s.env.InternalSender)
+	s.Equal("evergreen", status.Context)
+	s.Equal(message.GithubStateSuccess, status.State)
+
+	status = s.getAndValidateStatus(s.env.InternalSender)
+	s.Equal("evergreen/js", status.Context)
+	s.Equal(message.GithubStateSuccess, status.State)
+
+	status = s.getAndValidateStatus(s.env.InternalSender)
+	s.Equal("evergreen/int", status.Context)
+	s.Equal(message.GithubStateSuccess, status.State)
+	s.Equal(unscheduledGitHubVariant, status.Description)
+}
+
+func (s *githubStatusRefreshSuite) TestReconcileRetriesWhenGitHubStillPending() {
+	s.patchDoc.Status = evergreen.VersionSucceeded
+
+	b := build.Build{
+		Id:           "b1",
+		BuildVariant: "js",
+		Version:      s.patchDoc.Version,
+		Status:       evergreen.BuildSucceeded,
+		StartTime:    time.Now(),
+		FinishTime:   time.Now().Add(time.Minute),
+	}
+	s.NoError(b.Insert(s.ctx))
+	s.NoError(task.Task{
+		Id:      "t1",
+		Version: s.patchDoc.Version,
+		BuildId: b.Id,
+		Status:  evergreen.TaskSucceeded,
+	}.Insert(s.ctx))
+
+	job, ok := NewGithubStatusReconcileJob(s.patchDoc, githubStatusReconcileDelay).(*githubStatusRefreshJob)
+	s.Require().True(ok)
+	s.NotZero(job.RetryInfo().GetMaxAttempts())
+	s.Contains(job.ID(), "reconcile")
+
+	job.env = s.env
+	job.requiredEvergreenContexts = func(context.Context, string, string, string) []string {
+		return []string{thirdparty.GithubStatusDefaultContext}
+	}
+	job.listPendingEvergreenStatuses = func(context.Context, string, string, string) ([]string, error) {
+		return []string{"evergreen/int"}, nil
+	}
+	job.Run(s.ctx)
+	s.True(job.HasErrors())
+	s.True(job.RetryInfo().NeedsRetry)
+
+	status := s.getAndValidateStatus(s.env.InternalSender)
+	s.Equal("evergreen", status.Context)
+
+	status = s.getAndValidateStatus(s.env.InternalSender)
+	s.Equal("evergreen/js", status.Context)
+
+	status = s.getAndValidateStatus(s.env.InternalSender)
+	s.Equal("evergreen/int", status.Context)
+	s.Equal(message.GithubStateSuccess, status.State)
+	s.Equal(unscheduledGitHubVariant, status.Description)
 }

--- a/units/patch_intent.go
+++ b/units/patch_intent.go
@@ -1625,32 +1625,7 @@ func (j *patchIntentProcessor) gitHubStatusRuleTarget(patchDoc *patch.Patch, pro
 // If we don't find rules, we'll send the status default context. We log the error but don't
 // return it, because we might have permission to send statuses but not to get the rules.
 func (j *patchIntentProcessor) getEvergreenRulesForStatuses(ctx context.Context, owner, repo, branch string) []string {
-	branchProtectionRules, err := thirdparty.GetEvergreenBranchProtectionRules(ctx, owner, repo, branch)
-	grip.Error(ctx, message.WrapError(err, message.Fields{
-		"job":      j.ID(),
-		"job_type": j.Type,
-		"message":  "failed to get branch protection rules",
-		"org":      owner,
-		"repo":     repo,
-		"branch":   branch,
-		"patch":    j.PatchID.Hex(),
-	}))
-
-	rulesetRules, err := thirdparty.GetEvergreenRulesetRules(ctx, owner, repo, branch)
-	grip.Error(ctx, message.WrapError(err, message.Fields{
-		"job":      j.ID(),
-		"job_type": j.Type,
-		"message":  "failed to get ruleset rules",
-		"org":      owner,
-		"repo":     repo,
-		"branch":   branch,
-		"patch":    j.PatchID.Hex(),
-	}))
-
-	allRules := append([]string{thirdparty.GithubStatusDefaultContext}, branchProtectionRules...)
-	allRules = append(allRules, rulesetRules...)
-
-	return utility.UniqueStrings(allRules)
+	return thirdparty.GetEvergreenRequiredStatusContexts(ctx, owner, repo, branch)
 }
 
 // filterOutIgnoredVariants checks which variants should be ignored based on


### PR DESCRIPTION
## Summary
- GitHub merge queue / PR required checks can stay `pending` after Evergreen has finished: the refresh job posted to `GithubPatchData` (empty for merge-queue patches), and it only concluded variants that actually had builds. A required context like `evergreen/int` that was never scheduled (or whose terminal send was dropped) blocked GitHub until the merge-queue timeout.
- When a GitHub PR or merge-queue patch finishes, enqueue a reconcile job that (1) posts to the correct owner/repo/SHA (merge-group `HeadSHA` for MQ), (2) posts terminal success for required `evergreen/<variant>` contexts with no matching build, and (3) lists GitHub commit statuses and retries while any `evergreen*` context is still pending.
- Spruce "Refresh GitHub statuses" now uses the same reconcile path. Follow-up to DEVPROD-24671.

## Test plan
- [ ] Unit tests: `go test ./units -run TestGithubStatusRefresh` (merge-queue SHA, unscheduled required context, retry while pending)
- [ ] Unit tests: `go test ./model/patch -run TestGitHubStatusTarget` and `go test ./thirdparty -run TestEvergreenPendingStatusContexts`
- [ ] On a merge-queue patch whose GitHub ruleset requires a variant that was not scheduled, confirm GitHub gets a terminal `evergreen/<variant>` success after the version finishes (instead of remaining `pending` until timeout)
- [ ] On a PR/MQ patch where a status send is dropped, confirm the reconcile job retries and GitHub eventually shows success/failure
- [ ] Spruce "Refresh GitHub statuses" on a finished merge-queue version posts to the merge-group SHA


Made with [Cursor](https://cursor.com)