### PR TITLE
DEVPROD-41100: add admin settings for per-project hourly patch task limits

### DIFF
--- a/config_task_limits.go
+++ b/config_task_limits.go
@@ -79,12 +79,11 @@ type HourlyPatchTaskOverride struct {
 
 // HourlyPatchTaskLimitForProject returns the hourly per-user patch task limit
 // for the given project, along with the ID of the project or repo whose
-// override supplied it. An empty ID means the default limit applies and
-// usage is tracked against the user's general counter. A limit of 0 means no
-// limit is enforced. A branch project-level override takes precedence over a
-// repo-level one.
+// override supplied it.
 func (c *TaskLimitsConfig) HourlyPatchTaskLimitForProject(projectID, repoRefID string) (hourlyLimit int, projectOrRepoID string) {
 	if projectID != "" {
+		// A limit specific to one branch project takes precedence over a
+		// repo-wide limit, so check that first.
 		for _, o := range c.HourlyPatchTaskOverrides {
 			if o.ProjectOrRepoID == projectID {
 				return o.MaxHourlyPatchTasks, o.ProjectOrRepoID

--- a/config_task_limits.go
+++ b/config_task_limits.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/mongodb/anser/bsonutil"
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 )
@@ -21,7 +22,8 @@ type TaskLimitsConfig struct {
 	MaxIncludesPerVersion int `bson:"max_includes_per_version" json:"max_includes_per_version" yaml:"max_includes_per_version"`
 
 	// MaxHourlyPatchTasks is the maximum number of patch tasks a single user can
-	// schedule per hour.
+	// schedule per hour. This can be overridden for individual projects or
+	// repos (see HourlyPatchTaskOverrides).
 	MaxHourlyPatchTasks int `bson:"max_hourly_patch_tasks" json:"max_hourly_patch_tasks" yaml:"max_hourly_patch_tasks"`
 
 	// MaxPendingGeneratedTasks is the maximum number of tasks that can be created
@@ -54,6 +56,50 @@ type TaskLimitsConfig struct {
 
 	// MaxScheduledTasksPerDistro is the cap for the number of max tasks materialized into a distro's queue doc per pass.
 	MaxScheduledTasksPerDistro int `bson:"max_scheduled_tasks_per_distro" json:"max_scheduled_tasks_per_distro" yaml:"max_scheduled_tasks_per_distro"`
+
+	// HourlyPatchTaskOverrides sets a separate hourly patch task
+	// scheduling limit for individual branch projects or repos. If a project or
+	// repo has an override, users scheduling patch tasks in that project or
+	// repo will have their usage count against the override's limit instead of
+	// MaxHourlyPatchTasks.
+	HourlyPatchTaskOverrides []HourlyPatchTaskOverride `bson:"hourly_patch_task_overrides" json:"hourly_patch_task_overrides" yaml:"hourly_patch_task_overrides"`
+}
+
+// HourlyPatchTaskOverride is a per-project or per-repo override to the default
+// hourly per-user patch task scheduling limit.
+type HourlyPatchTaskOverride struct {
+	// ProjectOrRepoID is the ID of the branch project or repo that the override
+	// applies to. If it's a repo, all branch projects tracking the repo that
+	// have no override of their own share the repo's limit.
+	ProjectOrRepoID string `bson:"project_or_repo_id" json:"project_or_repo_id" yaml:"project_or_repo_id"`
+	// MaxHourlyPatchTasks is the maximum number of patch tasks a single user
+	// can schedule per hour in the project or repo.
+	MaxHourlyPatchTasks int `bson:"max_hourly_patch_tasks" json:"max_hourly_patch_tasks" yaml:"max_hourly_patch_tasks"`
+}
+
+// HourlyPatchTaskLimitForProject returns the hourly per-user patch task limit
+// for the given project, along with the ID of the project or repo whose
+// override supplied it. An empty ID means the default limit applies and
+// usage is tracked against the user's general counter. A limit of 0 means no
+// limit is enforced. A branch project-level override takes precedence over a
+// repo-level one.
+func (c *TaskLimitsConfig) HourlyPatchTaskLimitForProject(projectID, repoRefID string) (hourlyLimit int, projectOrRepoID string) {
+	if projectID != "" {
+		for _, o := range c.HourlyPatchTaskOverrides {
+			if o.ProjectOrRepoID == projectID {
+				return o.MaxHourlyPatchTasks, o.ProjectOrRepoID
+			}
+		}
+	}
+
+	if repoRefID != "" {
+		for _, o := range c.HourlyPatchTaskOverrides {
+			if o.ProjectOrRepoID == repoRefID {
+				return o.MaxHourlyPatchTasks, o.ProjectOrRepoID
+			}
+		}
+	}
+	return c.MaxHourlyPatchTasks, ""
 }
 
 var (
@@ -70,6 +116,7 @@ var (
 	maxTaskExecutionKey                              = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxTaskExecution")
 	maxDailyAutomaticRestartsKey                     = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxDailyAutomaticRestarts")
 	maxScheduledTasksPerDistroKey                    = bsonutil.MustHaveTag(TaskLimitsConfig{}, "MaxScheduledTasksPerDistro")
+	hourlyPatchTaskOverridesKey                      = bsonutil.MustHaveTag(TaskLimitsConfig{}, "HourlyPatchTaskOverrides")
 )
 
 func (c *TaskLimitsConfig) SectionId() string { return "task_limits" }
@@ -94,10 +141,28 @@ func (c *TaskLimitsConfig) Set(ctx context.Context) error {
 			maxTaskExecutionKey:                              c.MaxTaskExecution,
 			maxDailyAutomaticRestartsKey:                     c.MaxDailyAutomaticRestarts,
 			maxScheduledTasksPerDistroKey:                    c.MaxScheduledTasksPerDistro,
+			hourlyPatchTaskOverridesKey:                      c.HourlyPatchTaskOverrides,
 		},
 	}), "updating config section '%s'", c.SectionId())
 }
 
 func (c *TaskLimitsConfig) ValidateAndDefault() error {
-	return nil
+	catcher := grip.NewBasicCatcher()
+	projectOrRepoIDs := make(map[string]bool, len(c.HourlyPatchTaskOverrides))
+	for idx, o := range c.HourlyPatchTaskOverrides {
+		catcher.ErrorfWhen(o.MaxHourlyPatchTasks <= 0, "hourly patch task limit override for project/repo '%s' at index %d must be positive", o.ProjectOrRepoID, idx)
+
+		if o.ProjectOrRepoID == "" {
+			catcher.Errorf("hourly patch task limit override at index %d must set a project/repo ID", idx)
+			continue
+		}
+
+		if projectOrRepoIDs[o.ProjectOrRepoID] {
+			catcher.Errorf("duplicate hourly patch task limit override for project/repo '%s'", o.ProjectOrRepoID)
+			continue
+		}
+		projectOrRepoIDs[o.ProjectOrRepoID] = true
+
+	}
+	return catcher.Resolve()
 }

--- a/config_task_limits_test.go
+++ b/config_task_limits_test.go
@@ -8,19 +8,19 @@ import (
 
 func TestHourlyPatchTaskLimitForProject(t *testing.T) {
 	for tName, tCase := range map[string]struct {
-		config          TaskLimitsConfig
-		projectID       string
-		repoRefID       string
-		expectedLimit   int
-		expectedScopeID string
+		config                  TaskLimitsConfig
+		projectID               string
+		repoRefID               string
+		expectedLimit           int
+		expectedProjectOrRepoID string
 	}{
 		"NoOverridesUsesGeneralLimit": {
 			config: TaskLimitsConfig{
 				MaxHourlyPatchTasks: 15000,
 			},
-			projectID:       "project",
-			expectedLimit:   15000,
-			expectedScopeID: "",
+			projectID:               "project",
+			expectedLimit:           15000,
+			expectedProjectOrRepoID: "",
 		},
 		"ProjectOverrideAppliesToItsOwnProject": {
 			config: TaskLimitsConfig{
@@ -36,9 +36,9 @@ func TestHourlyPatchTaskLimitForProject(t *testing.T) {
 					},
 				},
 			},
-			projectID:       "project",
-			expectedLimit:   40000,
-			expectedScopeID: "project",
+			projectID:               "project",
+			expectedLimit:           40000,
+			expectedProjectOrRepoID: "project",
 		},
 		"ProjectOverrideDoesNotApplyToOtherProjects": {
 			config: TaskLimitsConfig{
@@ -50,9 +50,9 @@ func TestHourlyPatchTaskLimitForProject(t *testing.T) {
 					},
 				},
 			},
-			projectID:       "project",
-			expectedLimit:   15000,
-			expectedScopeID: "",
+			projectID:               "project",
+			expectedLimit:           15000,
+			expectedProjectOrRepoID: "",
 		},
 		"RepoOverrideAppliesToProjectTrackingTheRepo": {
 			config: TaskLimitsConfig{
@@ -64,10 +64,10 @@ func TestHourlyPatchTaskLimitForProject(t *testing.T) {
 					},
 				},
 			},
-			projectID:       "project",
-			repoRefID:       "repo",
-			expectedLimit:   40000,
-			expectedScopeID: "repo",
+			projectID:               "project",
+			repoRefID:               "repo",
+			expectedLimit:           40000,
+			expectedProjectOrRepoID: "repo",
 		},
 		"RepoOverrideDoesNotApplyToProjectTrackingAnotherRepo": {
 			config: TaskLimitsConfig{
@@ -79,27 +79,12 @@ func TestHourlyPatchTaskLimitForProject(t *testing.T) {
 					},
 				},
 			},
-			projectID:       "project",
-			repoRefID:       "other_repo",
-			expectedLimit:   15000,
-			expectedScopeID: "",
+			projectID:               "project",
+			repoRefID:               "other_repo",
+			expectedLimit:           15000,
+			expectedProjectOrRepoID: "",
 		},
-		"RepoOverrideIsIgnoredWhenProjectTracksNoRepo": {
-			config: TaskLimitsConfig{
-				MaxHourlyPatchTasks: 15000,
-				HourlyPatchTaskOverrides: []HourlyPatchTaskOverride{
-					{
-						ProjectOrRepoID:     "repo",
-						MaxHourlyPatchTasks: 40000,
-					},
-				},
-			},
-			projectID:       "project",
-			repoRefID:       "",
-			expectedLimit:   15000,
-			expectedScopeID: "",
-		},
-		"ProjectOverrideTakesPrecedenceOverRepoOverrideWhenBothCouldApply": {
+		"BranchProjectOverrideTakesPrecedenceOverRepoOverrideWhenBothCouldApply": {
 			config: TaskLimitsConfig{
 				MaxHourlyPatchTasks: 15000,
 				HourlyPatchTaskOverrides: []HourlyPatchTaskOverride{
@@ -113,10 +98,10 @@ func TestHourlyPatchTaskLimitForProject(t *testing.T) {
 					},
 				},
 			},
-			projectID:       "project",
-			repoRefID:       "repo",
-			expectedLimit:   20000,
-			expectedScopeID: "project",
+			projectID:               "project",
+			repoRefID:               "repo",
+			expectedLimit:           20000,
+			expectedProjectOrRepoID: "project",
 		},
 		"OverrideStillAppliesWhenDefaultLimitIsDisabled": {
 			config: TaskLimitsConfig{
@@ -128,9 +113,9 @@ func TestHourlyPatchTaskLimitForProject(t *testing.T) {
 					},
 				},
 			},
-			projectID:       "project",
-			expectedLimit:   40000,
-			expectedScopeID: "project",
+			projectID:               "project",
+			expectedLimit:           40000,
+			expectedProjectOrRepoID: "project",
 		},
 		"DisabledDefaultLimitEnforcesNoLimitOnProjectWithoutAnOverride": {
 			config: TaskLimitsConfig{
@@ -142,9 +127,9 @@ func TestHourlyPatchTaskLimitForProject(t *testing.T) {
 					},
 				},
 			},
-			projectID:       "project",
-			expectedLimit:   0,
-			expectedScopeID: "",
+			projectID:               "project",
+			expectedLimit:           0,
+			expectedProjectOrRepoID: "",
 		},
 		"OverrideCanLowerTheLimitForItsProject": {
 			config: TaskLimitsConfig{
@@ -156,15 +141,15 @@ func TestHourlyPatchTaskLimitForProject(t *testing.T) {
 					},
 				},
 			},
-			projectID:       "project",
-			expectedLimit:   100,
-			expectedScopeID: "project",
+			projectID:               "project",
+			expectedLimit:           100,
+			expectedProjectOrRepoID: "project",
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			limit, scopeID := tCase.config.HourlyPatchTaskLimitForProject(tCase.projectID, tCase.repoRefID)
 			assert.Equal(t, tCase.expectedLimit, limit)
-			assert.Equal(t, tCase.expectedScopeID, scopeID)
+			assert.Equal(t, tCase.expectedProjectOrRepoID, scopeID)
 		})
 	}
 }
@@ -177,7 +162,15 @@ func TestTaskLimitsConfigValidateAndDefault(t *testing.T) {
 		"NoOverridesShouldSucceed": {
 			overrides: nil,
 		},
-		"ProjectAndRepoOverridesShouldSucceed": {
+		"OverrideWithoutAProjectOrRepoIDShouldError": {
+			overrides: []HourlyPatchTaskOverride{
+				{
+					MaxHourlyPatchTasks: 40000,
+				},
+			},
+			expectedErr: "must set a project/repo ID",
+		},
+		"MultipleUniqueOverridesShouldSucceed": {
 			overrides: []HourlyPatchTaskOverride{
 				{
 					ProjectOrRepoID:     "project",
@@ -188,14 +181,6 @@ func TestTaskLimitsConfigValidateAndDefault(t *testing.T) {
 					MaxHourlyPatchTasks: 30000,
 				},
 			},
-		},
-		"OverrideWithoutAProjectOrRepoIDShouldError": {
-			overrides: []HourlyPatchTaskOverride{
-				{
-					MaxHourlyPatchTasks: 40000,
-				},
-			},
-			expectedErr: "must set a project/repo ID",
 		},
 		"DuplicateOverridesShouldError": {
 			overrides: []HourlyPatchTaskOverride{

--- a/config_task_limits_test.go
+++ b/config_task_limits_test.go
@@ -1,0 +1,242 @@
+package evergreen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHourlyPatchTaskLimitForProject(t *testing.T) {
+	for tName, tCase := range map[string]struct {
+		config          TaskLimitsConfig
+		projectID       string
+		repoRefID       string
+		expectedLimit   int
+		expectedScopeID string
+	}{
+		"NoOverridesUsesGeneralLimit": {
+			config: TaskLimitsConfig{
+				MaxHourlyPatchTasks: 15000,
+			},
+			projectID:       "project",
+			expectedLimit:   15000,
+			expectedScopeID: "",
+		},
+		"ProjectOverrideAppliesToItsOwnProject": {
+			config: TaskLimitsConfig{
+				MaxHourlyPatchTasks: 15000,
+				HourlyPatchTaskOverrides: []HourlyPatchTaskOverride{
+					{
+						ProjectOrRepoID:     "project",
+						MaxHourlyPatchTasks: 40000,
+					},
+					{
+						ProjectOrRepoID:     "other_project",
+						MaxHourlyPatchTasks: 30000,
+					},
+				},
+			},
+			projectID:       "project",
+			expectedLimit:   40000,
+			expectedScopeID: "project",
+		},
+		"ProjectOverrideDoesNotApplyToOtherProjects": {
+			config: TaskLimitsConfig{
+				MaxHourlyPatchTasks: 15000,
+				HourlyPatchTaskOverrides: []HourlyPatchTaskOverride{
+					{
+						ProjectOrRepoID:     "other_project",
+						MaxHourlyPatchTasks: 40000,
+					},
+				},
+			},
+			projectID:       "project",
+			expectedLimit:   15000,
+			expectedScopeID: "",
+		},
+		"RepoOverrideAppliesToProjectTrackingTheRepo": {
+			config: TaskLimitsConfig{
+				MaxHourlyPatchTasks: 15000,
+				HourlyPatchTaskOverrides: []HourlyPatchTaskOverride{
+					{
+						ProjectOrRepoID:     "repo",
+						MaxHourlyPatchTasks: 40000,
+					},
+				},
+			},
+			projectID:       "project",
+			repoRefID:       "repo",
+			expectedLimit:   40000,
+			expectedScopeID: "repo",
+		},
+		"RepoOverrideDoesNotApplyToProjectTrackingAnotherRepo": {
+			config: TaskLimitsConfig{
+				MaxHourlyPatchTasks: 15000,
+				HourlyPatchTaskOverrides: []HourlyPatchTaskOverride{
+					{
+						ProjectOrRepoID:     "other_project",
+						MaxHourlyPatchTasks: 40000,
+					},
+				},
+			},
+			projectID:       "project",
+			repoRefID:       "other_repo",
+			expectedLimit:   15000,
+			expectedScopeID: "",
+		},
+		"RepoOverrideIsIgnoredWhenProjectTracksNoRepo": {
+			config: TaskLimitsConfig{
+				MaxHourlyPatchTasks: 15000,
+				HourlyPatchTaskOverrides: []HourlyPatchTaskOverride{
+					{
+						ProjectOrRepoID:     "repo",
+						MaxHourlyPatchTasks: 40000,
+					},
+				},
+			},
+			projectID:       "project",
+			repoRefID:       "",
+			expectedLimit:   15000,
+			expectedScopeID: "",
+		},
+		"ProjectOverrideTakesPrecedenceOverRepoOverrideWhenBothCouldApply": {
+			config: TaskLimitsConfig{
+				MaxHourlyPatchTasks: 15000,
+				HourlyPatchTaskOverrides: []HourlyPatchTaskOverride{
+					{
+						ProjectOrRepoID:     "repo",
+						MaxHourlyPatchTasks: 40000,
+					},
+					{
+						ProjectOrRepoID:     "project",
+						MaxHourlyPatchTasks: 20000,
+					},
+				},
+			},
+			projectID:       "project",
+			repoRefID:       "repo",
+			expectedLimit:   20000,
+			expectedScopeID: "project",
+		},
+		"OverrideStillAppliesWhenDefaultLimitIsDisabled": {
+			config: TaskLimitsConfig{
+				MaxHourlyPatchTasks: 0,
+				HourlyPatchTaskOverrides: []HourlyPatchTaskOverride{
+					{
+						ProjectOrRepoID:     "project",
+						MaxHourlyPatchTasks: 40000,
+					},
+				},
+			},
+			projectID:       "project",
+			expectedLimit:   40000,
+			expectedScopeID: "project",
+		},
+		"DisabledDefaultLimitEnforcesNoLimitOnProjectWithoutAnOverride": {
+			config: TaskLimitsConfig{
+				MaxHourlyPatchTasks: 0,
+				HourlyPatchTaskOverrides: []HourlyPatchTaskOverride{
+					{
+						ProjectOrRepoID:     "other_project",
+						MaxHourlyPatchTasks: 40000,
+					},
+				},
+			},
+			projectID:       "project",
+			expectedLimit:   0,
+			expectedScopeID: "",
+		},
+		"OverrideCanLowerTheLimitForItsProject": {
+			config: TaskLimitsConfig{
+				MaxHourlyPatchTasks: 15000,
+				HourlyPatchTaskOverrides: []HourlyPatchTaskOverride{
+					{
+						ProjectOrRepoID:     "project",
+						MaxHourlyPatchTasks: 100,
+					},
+				},
+			},
+			projectID:       "project",
+			expectedLimit:   100,
+			expectedScopeID: "project",
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			limit, scopeID := tCase.config.HourlyPatchTaskLimitForProject(tCase.projectID, tCase.repoRefID)
+			assert.Equal(t, tCase.expectedLimit, limit)
+			assert.Equal(t, tCase.expectedScopeID, scopeID)
+		})
+	}
+}
+
+func TestTaskLimitsConfigValidateAndDefault(t *testing.T) {
+	for tName, tCase := range map[string]struct {
+		overrides   []HourlyPatchTaskOverride
+		expectedErr string
+	}{
+		"NoOverridesShouldSucceed": {
+			overrides: nil,
+		},
+		"ProjectAndRepoOverridesShouldSucceed": {
+			overrides: []HourlyPatchTaskOverride{
+				{
+					ProjectOrRepoID:     "project",
+					MaxHourlyPatchTasks: 40000,
+				},
+				{
+					ProjectOrRepoID:     "repo",
+					MaxHourlyPatchTasks: 30000,
+				},
+			},
+		},
+		"OverrideWithoutAProjectOrRepoIDShouldError": {
+			overrides: []HourlyPatchTaskOverride{
+				{
+					MaxHourlyPatchTasks: 40000,
+				},
+			},
+			expectedErr: "must set a project/repo ID",
+		},
+		"DuplicateOverridesShouldError": {
+			overrides: []HourlyPatchTaskOverride{
+				{
+					ProjectOrRepoID:     "project",
+					MaxHourlyPatchTasks: 40000,
+				},
+				{
+					ProjectOrRepoID:     "project",
+					MaxHourlyPatchTasks: 30000,
+				},
+			},
+			expectedErr: "duplicate hourly patch task limit override for project/repo 'project'",
+		},
+		"NegativeOverrideLimitShouldError": {
+			overrides: []HourlyPatchTaskOverride{
+				{
+					ProjectOrRepoID:     "project",
+					MaxHourlyPatchTasks: -1,
+				},
+			},
+			expectedErr: "must be positive",
+		},
+		"ZeroOverrideLimitShouldError": {
+			overrides: []HourlyPatchTaskOverride{
+				{
+					ProjectOrRepoID:     "project",
+					MaxHourlyPatchTasks: 0,
+				},
+			},
+			expectedErr: "must be positive",
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			c := TaskLimitsConfig{HourlyPatchTaskOverrides: tCase.overrides}
+			err := c.ValidateAndDefault()
+			if tCase.expectedErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorContains(t, err, tCase.expectedErr)
+		})
+	}
+}

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -314,6 +314,10 @@ models:
     model: github.com/evergreen-ci/evergreen/rest/model.APIHomeVolumeSettings
   Host:
     model: github.com/evergreen-ci/evergreen/rest/model.APIHost
+  HourlyPatchTaskOverride:
+    model: github.com/evergreen-ci/evergreen/rest/model.APIHourlyPatchTaskOverride
+  HourlyPatchTaskOverrideInput:
+    model: github.com/evergreen-ci/evergreen/rest/model.APIHourlyPatchTaskOverride
   HostAllocatorSettings:
     model: github.com/evergreen-ci/evergreen/rest/model.APIHostAllocatorSettings
   HostAllocatorSettingsInput:

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -69014,9 +69014,9 @@ func (ec *executionContext) _TaskLimitsConfig_hourlyPatchTaskOverrides(ctx conte
 			return obj.HourlyPatchTaskOverrides, nil
 		},
 		nil,
-		ec.marshalOHourlyPatchTaskOverride2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIHourlyPatchTaskOverrideᚄ,
+		ec.marshalNHourlyPatchTaskOverride2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIHourlyPatchTaskOverrideᚄ,
 		true,
-		false,
+		true,
 	)
 }
 
@@ -108516,6 +108516,9 @@ func (ec *executionContext) _TaskLimitsConfig(ctx context.Context, sel ast.Selec
 			out.Values[i] = ec._TaskLimitsConfig_maxScheduledTasksPerDistro(ctx, field, obj)
 		case "hourlyPatchTaskOverrides":
 			out.Values[i] = ec._TaskLimitsConfig_hourlyPatchTaskOverrides(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -115014,6 +115017,50 @@ func (ec *executionContext) marshalNHourlyPatchTaskOverride2githubᚗcomᚋeverg
 	return ec._HourlyPatchTaskOverride(ctx, sel, &v)
 }
 
+func (ec *executionContext) marshalNHourlyPatchTaskOverride2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIHourlyPatchTaskOverrideᚄ(ctx context.Context, sel ast.SelectionSet, v []model.APIHourlyPatchTaskOverride) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNHourlyPatchTaskOverride2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIHourlyPatchTaskOverride(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) unmarshalNHourlyPatchTaskOverrideInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIHourlyPatchTaskOverride(ctx context.Context, v any) (model.APIHourlyPatchTaskOverride, error) {
 	res, err := ec.unmarshalInputHourlyPatchTaskOverrideInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -120783,53 +120830,6 @@ func (ec *executionContext) marshalOHostSortBy2ᚖgithubᚗcomᚋevergreenᚑci�
 		return graphql.Null
 	}
 	return v
-}
-
-func (ec *executionContext) marshalOHourlyPatchTaskOverride2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIHourlyPatchTaskOverrideᚄ(ctx context.Context, sel ast.SelectionSet, v []model.APIHourlyPatchTaskOverride) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNHourlyPatchTaskOverride2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIHourlyPatchTaskOverride(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
 }
 
 func (ec *executionContext) unmarshalOHourlyPatchTaskOverrideInput2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIHourlyPatchTaskOverrideᚄ(ctx context.Context, v any) ([]model.APIHourlyPatchTaskOverride, error) {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -816,6 +816,11 @@ type ComplexityRoot struct {
 		TotalHostsCount    func(childComplexity int) int
 	}
 
+	HourlyPatchTaskOverride struct {
+		MaxHourlyPatchTasks func(childComplexity int) int
+		ProjectOrRepoID     func(childComplexity int) int
+	}
+
 	IceCreamSettings struct {
 		ConfigPath    func(childComplexity int) int
 		SchedulerHost func(childComplexity int) int
@@ -2036,6 +2041,7 @@ type ComplexityRoot struct {
 	}
 
 	TaskLimitsConfig struct {
+		HourlyPatchTaskOverrides                         func(childComplexity int) int
 		MaxConcurrentLargeParserProjectTasks             func(childComplexity int) int
 		MaxDailyAutomaticRestarts                        func(childComplexity int) int
 		MaxDegradedModeConcurrentLargeParserProjectTasks func(childComplexity int) int
@@ -5710,6 +5716,19 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.HostsResponse.TotalHostsCount(childComplexity), true
+
+	case "HourlyPatchTaskOverride.maxHourlyPatchTasks":
+		if e.complexity.HourlyPatchTaskOverride.MaxHourlyPatchTasks == nil {
+			break
+		}
+
+		return e.complexity.HourlyPatchTaskOverride.MaxHourlyPatchTasks(childComplexity), true
+	case "HourlyPatchTaskOverride.projectOrRepoId":
+		if e.complexity.HourlyPatchTaskOverride.ProjectOrRepoID == nil {
+			break
+		}
+
+		return e.complexity.HourlyPatchTaskOverride.ProjectOrRepoID(childComplexity), true
 
 	case "IceCreamSettings.configPath":
 		if e.complexity.IceCreamSettings.ConfigPath == nil {
@@ -11404,6 +11423,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.TaskInfo.Name(childComplexity), true
 
+	case "TaskLimitsConfig.hourlyPatchTaskOverrides":
+		if e.complexity.TaskLimitsConfig.HourlyPatchTaskOverrides == nil {
+			break
+		}
+
+		return e.complexity.TaskLimitsConfig.HourlyPatchTaskOverrides(childComplexity), true
 	case "TaskLimitsConfig.maxConcurrentLargeParserProjectTasks":
 		if e.complexity.TaskLimitsConfig.MaxConcurrentLargeParserProjectTasks == nil {
 			break
@@ -13277,6 +13302,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 		ec.unmarshalInputHostEventsInput,
 		ec.unmarshalInputHostInitConfigInput,
 		ec.unmarshalInputHostJasperConfigInput,
+		ec.unmarshalInputHourlyPatchTaskOverrideInput,
 		ec.unmarshalInputIceCreamSettingsInput,
 		ec.unmarshalInputImageFileOpts,
 		ec.unmarshalInputInstanceTagInput,
@@ -20339,6 +20365,8 @@ func (ec *executionContext) fieldContext_AdminSettings_taskLimits(_ context.Cont
 				return ec.fieldContext_TaskLimitsConfig_maxDailyAutomaticRestarts(ctx, field)
 			case "maxScheduledTasksPerDistro":
 				return ec.fieldContext_TaskLimitsConfig_maxScheduledTasksPerDistro(ctx, field)
+			case "hourlyPatchTaskOverrides":
+				return ec.fieldContext_TaskLimitsConfig_hourlyPatchTaskOverrides(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type TaskLimitsConfig", field.Name)
 		},
@@ -32550,6 +32578,64 @@ func (ec *executionContext) _HostsResponse_totalHostsCount(ctx context.Context, 
 func (ec *executionContext) fieldContext_HostsResponse_totalHostsCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "HostsResponse",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HourlyPatchTaskOverride_projectOrRepoId(ctx context.Context, field graphql.CollectedField, obj *model.APIHourlyPatchTaskOverride) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_HourlyPatchTaskOverride_projectOrRepoId,
+		func(ctx context.Context) (any, error) {
+			return obj.ProjectOrRepoID, nil
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_HourlyPatchTaskOverride_projectOrRepoId(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HourlyPatchTaskOverride",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _HourlyPatchTaskOverride_maxHourlyPatchTasks(ctx context.Context, field graphql.CollectedField, obj *model.APIHourlyPatchTaskOverride) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_HourlyPatchTaskOverride_maxHourlyPatchTasks,
+		func(ctx context.Context) (any, error) {
+			return obj.MaxHourlyPatchTasks, nil
+		},
+		nil,
+		ec.marshalOInt2ᚖint,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_HourlyPatchTaskOverride_maxHourlyPatchTasks(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HourlyPatchTaskOverride",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -68918,6 +69004,41 @@ func (ec *executionContext) fieldContext_TaskLimitsConfig_maxScheduledTasksPerDi
 	return fc, nil
 }
 
+func (ec *executionContext) _TaskLimitsConfig_hourlyPatchTaskOverrides(ctx context.Context, field graphql.CollectedField, obj *model.APITaskLimitsConfig) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskLimitsConfig_hourlyPatchTaskOverrides,
+		func(ctx context.Context) (any, error) {
+			return obj.HourlyPatchTaskOverrides, nil
+		},
+		nil,
+		ec.marshalOHourlyPatchTaskOverride2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIHourlyPatchTaskOverrideᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskLimitsConfig_hourlyPatchTaskOverrides(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskLimitsConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "projectOrRepoId":
+				return ec.fieldContext_HourlyPatchTaskOverride_projectOrRepoId(ctx, field)
+			case "maxHourlyPatchTasks":
+				return ec.fieldContext_HourlyPatchTaskOverride_maxHourlyPatchTasks(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type HourlyPatchTaskOverride", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TaskLogLinks_agentLogLink(ctx context.Context, field graphql.CollectedField, obj *model.LogLinks) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -84205,6 +84326,40 @@ func (ec *executionContext) unmarshalInputHostJasperConfigInput(ctx context.Cont
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputHourlyPatchTaskOverrideInput(ctx context.Context, obj any) (model.APIHourlyPatchTaskOverride, error) {
+	var it model.APIHourlyPatchTaskOverride
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"projectOrRepoId", "maxHourlyPatchTasks"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "projectOrRepoId":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("projectOrRepoId"))
+			data, err := ec.unmarshalNString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ProjectOrRepoID = data
+		case "maxHourlyPatchTasks":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("maxHourlyPatchTasks"))
+			data, err := ec.unmarshalNInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.MaxHourlyPatchTasks = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputIceCreamSettingsInput(ctx context.Context, obj any) (model.APIIceCreamSettings, error) {
 	var it model.APIIceCreamSettings
 	asMap := map[string]any{}
@@ -89972,7 +90127,7 @@ func (ec *executionContext) unmarshalInputTaskLimitsConfigInput(ctx context.Cont
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"maxTasksPerVersion", "maxIncludesPerVersion", "maxHourlyPatchTasks", "maxPendingGeneratedTasks", "maxGenerateTaskJSONSize", "maxConcurrentLargeParserProjectTasks", "maxDegradedModeConcurrentLargeParserProjectTasks", "maxDegradedModeParserProjectSize", "maxParserProjectSize", "maxExecTimeoutSecs", "maxTaskExecution", "maxDailyAutomaticRestarts", "maxScheduledTasksPerDistro"}
+	fieldsInOrder := [...]string{"maxTasksPerVersion", "maxIncludesPerVersion", "maxHourlyPatchTasks", "maxPendingGeneratedTasks", "maxGenerateTaskJSONSize", "maxConcurrentLargeParserProjectTasks", "maxDegradedModeConcurrentLargeParserProjectTasks", "maxDegradedModeParserProjectSize", "maxParserProjectSize", "maxExecTimeoutSecs", "maxTaskExecution", "maxDailyAutomaticRestarts", "maxScheduledTasksPerDistro", "hourlyPatchTaskOverrides"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -90070,6 +90225,13 @@ func (ec *executionContext) unmarshalInputTaskLimitsConfigInput(ctx context.Cont
 				return it, err
 			}
 			it.MaxScheduledTasksPerDistro = data
+		case "hourlyPatchTaskOverrides":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("hourlyPatchTaskOverrides"))
+			data, err := ec.unmarshalOHourlyPatchTaskOverrideInput2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIHourlyPatchTaskOverrideᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.HourlyPatchTaskOverrides = data
 		}
 	}
 
@@ -96646,6 +96808,44 @@ func (ec *executionContext) _HostsResponse(ctx context.Context, sel ast.Selectio
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var hourlyPatchTaskOverrideImplementors = []string{"HourlyPatchTaskOverride"}
+
+func (ec *executionContext) _HourlyPatchTaskOverride(ctx context.Context, sel ast.SelectionSet, obj *model.APIHourlyPatchTaskOverride) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, hourlyPatchTaskOverrideImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("HourlyPatchTaskOverride")
+		case "projectOrRepoId":
+			out.Values[i] = ec._HourlyPatchTaskOverride_projectOrRepoId(ctx, field, obj)
+		case "maxHourlyPatchTasks":
+			out.Values[i] = ec._HourlyPatchTaskOverride_maxHourlyPatchTasks(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -108314,6 +108514,8 @@ func (ec *executionContext) _TaskLimitsConfig(ctx context.Context, sel ast.Selec
 			out.Values[i] = ec._TaskLimitsConfig_maxDailyAutomaticRestarts(ctx, field, obj)
 		case "maxScheduledTasksPerDistro":
 			out.Values[i] = ec._TaskLimitsConfig_maxScheduledTasksPerDistro(ctx, field, obj)
+		case "hourlyPatchTaskOverrides":
+			out.Values[i] = ec._TaskLimitsConfig_hourlyPatchTaskOverrides(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -114808,6 +115010,15 @@ func (ec *executionContext) marshalNHostsResponse2ᚖgithubᚗcomᚋevergreenᚑ
 	return ec._HostsResponse(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNHourlyPatchTaskOverride2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIHourlyPatchTaskOverride(ctx context.Context, sel ast.SelectionSet, v model.APIHourlyPatchTaskOverride) graphql.Marshaler {
+	return ec._HourlyPatchTaskOverride(ctx, sel, &v)
+}
+
+func (ec *executionContext) unmarshalNHourlyPatchTaskOverrideInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIHourlyPatchTaskOverride(ctx context.Context, v any) (model.APIHourlyPatchTaskOverride, error) {
+	res, err := ec.unmarshalInputHourlyPatchTaskOverrideInput(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
 func (ec *executionContext) unmarshalNID2string(ctx context.Context, v any) (string, error) {
 	res, err := graphql.UnmarshalID(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -120572,6 +120783,71 @@ func (ec *executionContext) marshalOHostSortBy2ᚖgithubᚗcomᚋevergreenᚑci�
 		return graphql.Null
 	}
 	return v
+}
+
+func (ec *executionContext) marshalOHourlyPatchTaskOverride2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIHourlyPatchTaskOverrideᚄ(ctx context.Context, sel ast.SelectionSet, v []model.APIHourlyPatchTaskOverride) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNHourlyPatchTaskOverride2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIHourlyPatchTaskOverride(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) unmarshalOHourlyPatchTaskOverrideInput2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIHourlyPatchTaskOverrideᚄ(ctx context.Context, v any) ([]model.APIHourlyPatchTaskOverride, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]model.APIHourlyPatchTaskOverride, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNHourlyPatchTaskOverrideInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIHourlyPatchTaskOverride(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
 }
 
 func (ec *executionContext) unmarshalOID2ᚖstring(ctx context.Context, v any) (*string, error) {

--- a/graphql/schema/types/adminSettings/runners.graphql
+++ b/graphql/schema/types/adminSettings/runners.graphql
@@ -32,6 +32,17 @@ input TaskLimitsConfigInput {
   maxTaskExecution: Int!
   maxDailyAutomaticRestarts: Int!
   maxScheduledTasksPerDistro: Int!
+  hourlyPatchTaskOverrides: [HourlyPatchTaskOverrideInput!]
+}
+
+input HourlyPatchTaskOverrideInput {
+  projectOrRepoId: String!
+  maxHourlyPatchTasks: Int!
+}
+
+type HourlyPatchTaskOverride {
+  projectOrRepoId: String
+  maxHourlyPatchTasks: Int
 }
 
 type TaskLimitsConfig {
@@ -48,6 +59,7 @@ type TaskLimitsConfig {
   maxTaskExecution: Int
   maxDailyAutomaticRestarts: Int
   maxScheduledTasksPerDistro: Int
+  hourlyPatchTaskOverrides: [HourlyPatchTaskOverride!]
 }
 
 input HostInitConfigInput {

--- a/graphql/schema/types/adminSettings/runners.graphql
+++ b/graphql/schema/types/adminSettings/runners.graphql
@@ -59,7 +59,7 @@ type TaskLimitsConfig {
   maxTaskExecution: Int
   maxDailyAutomaticRestarts: Int
   maxScheduledTasksPerDistro: Int
-  hourlyPatchTaskOverrides: [HourlyPatchTaskOverride!]
+  hourlyPatchTaskOverrides: [HourlyPatchTaskOverride!]!
 }
 
 input HostInitConfigInput {

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -3050,6 +3050,29 @@ type APITaskLimitsConfig struct {
 	MaxDailyAutomaticRestarts *int `json:"max_daily_automatic_restarts"`
 	// MaxScheduledTasksPerDistro is the cap for the number of max tasks materialized into a distro's queue doc per pass.
 	MaxScheduledTasksPerDistro *int `json:"max_scheduled_tasks_per_distro"`
+	// HourlyPatchTaskOverrides sets a separate hourly patch task scheduling limit for individual projects or repos.
+	HourlyPatchTaskOverrides []APIHourlyPatchTaskOverride `json:"hourly_patch_task_overrides"`
+}
+
+// APIHourlyPatchTaskOverride is a per-project or per-repo override to the
+// hourly per-user patch task scheduling limit.
+type APIHourlyPatchTaskOverride struct {
+	// ProjectOrRepoID is the ID of the branch project or repo the override applies to.
+	ProjectOrRepoID *string `json:"project_or_repo_id"`
+	// MaxHourlyPatchTasks is the maximum number of patch tasks a single user can schedule per hour in the target project or repo.
+	MaxHourlyPatchTasks *int `json:"max_hourly_patch_tasks"`
+}
+
+func (o *APIHourlyPatchTaskOverride) BuildFromService(h evergreen.HourlyPatchTaskOverride) {
+	o.ProjectOrRepoID = utility.ToStringPtr(h.ProjectOrRepoID)
+	o.MaxHourlyPatchTasks = utility.ToIntPtr(h.MaxHourlyPatchTasks)
+}
+
+func (o *APIHourlyPatchTaskOverride) ToService() evergreen.HourlyPatchTaskOverride {
+	return evergreen.HourlyPatchTaskOverride{
+		ProjectOrRepoID:     utility.FromStringPtr(o.ProjectOrRepoID),
+		MaxHourlyPatchTasks: utility.FromIntPtr(o.MaxHourlyPatchTasks),
+	}
 }
 
 func (c *APITaskLimitsConfig) BuildFromService(h any) error {
@@ -3068,6 +3091,10 @@ func (c *APITaskLimitsConfig) BuildFromService(h any) error {
 		c.MaxTaskExecution = utility.ToIntPtr(v.MaxTaskExecution)
 		c.MaxDailyAutomaticRestarts = utility.ToIntPtr(v.MaxDailyAutomaticRestarts)
 		c.MaxScheduledTasksPerDistro = utility.ToIntPtr(v.MaxScheduledTasksPerDistro)
+		c.HourlyPatchTaskOverrides = make([]APIHourlyPatchTaskOverride, len(v.HourlyPatchTaskOverrides))
+		for i, o := range v.HourlyPatchTaskOverrides {
+			c.HourlyPatchTaskOverrides[i].BuildFromService(o)
+		}
 		return nil
 	default:
 		return errors.Errorf("programmatic error: expected task limits config but got type %T", h)
@@ -3075,6 +3102,10 @@ func (c *APITaskLimitsConfig) BuildFromService(h any) error {
 }
 
 func (c *APITaskLimitsConfig) ToService() (any, error) {
+	overrides := make([]evergreen.HourlyPatchTaskOverride, len(c.HourlyPatchTaskOverrides))
+	for i, o := range c.HourlyPatchTaskOverrides {
+		overrides[i] = o.ToService()
+	}
 	return evergreen.TaskLimitsConfig{
 		MaxTasksPerVersion:                               utility.FromIntPtr(c.MaxTasksPerVersion),
 		MaxIncludesPerVersion:                            utility.FromIntPtr(c.MaxIncludesPerVersion),
@@ -3089,6 +3120,7 @@ func (c *APITaskLimitsConfig) ToService() (any, error) {
 		MaxTaskExecution:                                 utility.FromIntPtr(c.MaxTaskExecution),
 		MaxDailyAutomaticRestarts:                        utility.FromIntPtr(c.MaxDailyAutomaticRestarts),
 		MaxScheduledTasksPerDistro:                       utility.FromIntPtr(c.MaxScheduledTasksPerDistro),
+		HourlyPatchTaskOverrides:                         overrides,
 	}, nil
 }
 

--- a/rest/model/admin_test.go
+++ b/rest/model/admin_test.go
@@ -975,3 +975,58 @@ func TestAPIRateLimitConfig(t *testing.T) {
 		})
 	})
 }
+
+func TestAPITaskLimitsConfigHourlyPatchTaskOverrides(t *testing.T) {
+	t.Run("BuildFromServiceConvertsProjectAndRepoOverrides", func(t *testing.T) {
+		svc := evergreen.TaskLimitsConfig{
+			MaxHourlyPatchTasks: 15000,
+			HourlyPatchTaskOverrides: []evergreen.HourlyPatchTaskOverride{
+				{
+					ProjectOrRepoID:     "project",
+					MaxHourlyPatchTasks: 40000,
+				},
+				{
+					ProjectOrRepoID:     "repo",
+					MaxHourlyPatchTasks: 30000,
+				},
+			},
+		}
+		api := APITaskLimitsConfig{}
+		require.NoError(t, api.BuildFromService(svc))
+		require.Len(t, api.HourlyPatchTaskOverrides, 2)
+		assert.Equal(t, "project", utility.FromStringPtr(api.HourlyPatchTaskOverrides[0].ProjectOrRepoID))
+		assert.Equal(t, 40000, utility.FromIntPtr(api.HourlyPatchTaskOverrides[0].MaxHourlyPatchTasks))
+		assert.Equal(t, "repo", utility.FromStringPtr(api.HourlyPatchTaskOverrides[1].ProjectOrRepoID))
+		assert.Equal(t, 30000, utility.FromIntPtr(api.HourlyPatchTaskOverrides[1].MaxHourlyPatchTasks))
+	})
+
+	t.Run("RoundTripPreservesOverrides", func(t *testing.T) {
+		svc := evergreen.TaskLimitsConfig{
+			MaxHourlyPatchTasks: 15000,
+			HourlyPatchTaskOverrides: []evergreen.HourlyPatchTaskOverride{
+				{
+					ProjectOrRepoID:     "project",
+					MaxHourlyPatchTasks: 40000,
+				},
+				{
+					ProjectOrRepoID:     "repo",
+					MaxHourlyPatchTasks: 30000,
+				},
+			},
+		}
+		api := APITaskLimitsConfig{}
+		require.NoError(t, api.BuildFromService(svc))
+		roundTripped, err := api.ToService()
+		require.NoError(t, err)
+		assert.Equal(t, svc.HourlyPatchTaskOverrides, roundTripped.(evergreen.TaskLimitsConfig).HourlyPatchTaskOverrides)
+	})
+
+	t.Run("NoOverridesRoundTripsToEmpty", func(t *testing.T) {
+		api := APITaskLimitsConfig{}
+		require.NoError(t, api.BuildFromService(evergreen.TaskLimitsConfig{MaxHourlyPatchTasks: 15000}))
+		assert.Empty(t, api.HourlyPatchTaskOverrides)
+		roundTripped, err := api.ToService()
+		require.NoError(t, err)
+		assert.Empty(t, roundTripped.(evergreen.TaskLimitsConfig).HourlyPatchTaskOverrides)
+	})
+}

--- a/testutil/config.go
+++ b/testutil/config.go
@@ -283,6 +283,12 @@ func MockConfig() *evergreen.Settings {
 		},
 		TaskLimits: evergreen.TaskLimitsConfig{
 			MaxTasksPerVersion: 1000,
+			HourlyPatchTaskOverrides: []evergreen.HourlyPatchTaskOverride{
+				{
+					ProjectOrRepoID:     "project_id",
+					MaxHourlyPatchTasks: 2000,
+				},
+			},
 		},
 		LoggerConfig: evergreen.LoggerConfig{
 			Buffer: evergreen.LogBuffering{


### PR DESCRIPTION
DEVPROD-41100

### Description

Implementing per-project hourly patch scheduling limits in two parts. This is the first part to introduce a new admin setting that will let us set the per-project/repo limit.

https://github.com/evergreen-ci/ui/pull/1864

### Testing

* Tested locally to confirm that the admin UI works as intended.
* Added unit tests.

### Documentation

Will document in the ops guide how to set per-project patch scheduling limits once the feature is fully working.