### PR TITLE
DEVPROD-35961 Skip generate task estimation queries when limit is disabled

### DIFF
--- a/model/lifecycle.go
+++ b/model/lifecycle.go
@@ -775,20 +775,24 @@ func createTasksForBuild(ctx context.Context, creationInfo TaskCreationInfo) (ta
 	}
 
 	// Fetch generate tasks estimations for all generator tasks.
-	var generatorDisplayNames []string
-	for _, t := range tasksToCreate {
-		if creationInfo.Project.IsGenerateTask(t.Name) {
-			generatorDisplayNames = append(generatorDisplayNames, t.Name)
+	// Skip the query when the limit is disabled.
+	var generateTaskEstimations map[string]task.GenerateTasksEstimation
+	if evergreen.GetEnvironment().Settings().TaskLimits.MaxPendingGeneratedTasks > 0 {
+		var generatorDisplayNames []string
+		for _, t := range tasksToCreate {
+			if creationInfo.Project.IsGenerateTask(t.Name) {
+				generatorDisplayNames = append(generatorDisplayNames, t.Name)
+			}
 		}
-	}
-	generateTaskEstimations, err := task.GetBatchedGenerateTasksEstimations(ctx, creationInfo.Project.Identifier, creationInfo.BuildVariant.Name, generatorDisplayNames)
-	if err != nil {
-		grip.Warning(ctx, message.WrapError(err, message.Fields{
-			"message": "getting batched generate tasks estimations",
-			"project": creationInfo.Project.Identifier,
-			"variant": creationInfo.BuildVariant.Name,
-		}))
-		generateTaskEstimations = map[string]task.GenerateTasksEstimation{}
+		var err error
+		generateTaskEstimations, err = task.GetBatchedGenerateTasksEstimations(ctx, creationInfo.Project.Identifier, creationInfo.BuildVariant.Name, generatorDisplayNames)
+		if err != nil {
+			grip.Warning(ctx, message.WrapError(err, message.Fields{
+				"message": "getting batched generate tasks estimations",
+				"project": creationInfo.Project.Identifier,
+				"variant": creationInfo.BuildVariant.Name,
+			}))
+		}
 	}
 
 	// create all the actual tasks


### PR DESCRIPTION
DEVPROD-35961

### Description

The generate tasks throttle limit is currently set to 0 (disabled), but the estimation queries still run on each build creation. These are not super lightweight queries so we should skip them when the limit is off, they will resume automatically if the limit is ever set.
### Testing
Existing tests.
