### PR TITLE
DEVPROD-37414: Valdiate urls for artifact files and test logs

### DIFF
--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/pail"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -93,6 +94,26 @@ type File struct {
 	AssociatedLinks []AssociatedLink `json:"associated_links,omitempty" bson:"associated_links,omitempty"`
 	// DoNotEncodeLink indicates that the file link should not be escaped.
 	DoNotEncodeLink bool `json:"do_not_encode_link,omitempty" bson:"do_not_encode_link,omitempty"`
+}
+
+// ValidateFiles verifies that artifact links are safe to render as anchor hrefs.
+func ValidateFiles(files []File) error {
+	for _, file := range files {
+		if file.Link != "" {
+			if err := util.CheckURL(file.Link); err != nil {
+				return errors.Wrapf(err, "validating URL for artifact file '%s'", file.Name)
+			}
+		}
+		for _, link := range file.AssociatedLinks {
+			if link.Link != "" {
+				if err := util.CheckURL(link.Link); err != nil {
+					return errors.Wrapf(err, "validating URL for associated artifact link '%s'", link.Name)
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func (f *File) validate() error {

--- a/model/artifact/validation_test.go
+++ b/model/artifact/validation_test.go
@@ -1,0 +1,56 @@
+package artifact
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateFiles(t *testing.T) {
+	for testName, testCase := range map[string]struct {
+		files []File
+		want  bool
+	}{
+		"AllowsHTTPAndHTTPSLinks": {
+			files: []File{
+				{
+					Link: "http://example.com/artifact.txt",
+					AssociatedLinks: []AssociatedLink{
+						{Link: "https://example.com/report.html"},
+					},
+				},
+			},
+			want: true,
+		},
+		"AllowsEmptyLinks": {
+			files: []File{{}},
+			want:  true,
+		},
+		"RejectsUnsafeArtifactLinkSchemes": {
+			files: []File{
+				{Link: "javascript:alert(document.domain)"},
+				{Link: "data:text/html,<script>alert(1)</script>"},
+				{Link: "vbscript:msgbox(1)"},
+			},
+		},
+		"RejectsUnsafeAssociatedArtifactLinkScheme": {
+			files: []File{
+				{
+					Link: "https://example.com/artifact.txt",
+					AssociatedLinks: []AssociatedLink{
+						{Link: "javascript:alert(document.domain)"},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			err := ValidateFiles(testCase.files)
+			if testCase.want {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}

--- a/model/testresult/testresult.go
+++ b/model/testresult/testresult.go
@@ -176,18 +176,19 @@ func (tr TestResult) GetLogURL(root, parsleyURL string, viewer evergreen.LogView
 	case evergreen.LogViewerHTML:
 		// Return an empty string for logkeeper URLS.
 		if tr.LogURL != "" {
-			for _, url := range deprecatedLogkeeperURLs {
-				if strings.Contains(tr.LogURL, url) {
-					return ""
+			if err := util.CheckURL(tr.LogURL); err == nil {
+				for _, url := range deprecatedLogkeeperURLs {
+					if strings.Contains(tr.LogURL, url) {
+						return ""
+					}
 				}
-			}
-			// Some test results may have internal URLs that are
-			// missing the root.
-			if err := util.CheckURL(tr.LogURL); err != nil {
-				return root + tr.LogURL
+
+				return tr.LogURL
 			}
 
-			return tr.LogURL
+			// Some test results may have internal URLs that are
+			// missing the root.
+			return root + tr.LogURL
 		}
 
 		return fmt.Sprintf("%s/test_log/%s/%d?test_name=%s#L%d",
@@ -202,10 +203,12 @@ func (tr TestResult) GetLogURL(root, parsleyURL string, viewer evergreen.LogView
 			return ""
 		}
 
-		for _, url := range deprecatedLogkeeperURLs {
-			if strings.Contains(tr.LogURL, url) {
-				updatedResmokeParsleyURL := strings.Replace(tr.LogURL, fmt.Sprintf("%s/build", url), parsleyURL+"/resmoke", 1)
-				return fmt.Sprintf("%s?shareLine=%d", updatedResmokeParsleyURL, tr.getLineNum())
+		if err := util.CheckURL(tr.LogURL); err == nil {
+			for _, url := range deprecatedLogkeeperURLs {
+				if strings.Contains(tr.LogURL, url) {
+					updatedResmokeParsleyURL := strings.Replace(tr.LogURL, fmt.Sprintf("%s/build", url), parsleyURL+"/resmoke", 1)
+					return fmt.Sprintf("%s?shareLine=%d", updatedResmokeParsleyURL, tr.getLineNum())
+				}
 			}
 		}
 

--- a/model/testresult/testresult_test.go
+++ b/model/testresult/testresult_test.go
@@ -68,3 +68,29 @@ func TestGetLogURL(t *testing.T) {
 	url = test3.GetLogURL(evergreenBaseURL, parsleyURL, evergreen.LogViewerParsley)
 	assert.Equal(t, "https://parsley.mongodb.org/test/task1/0/test3?shareLine=0", url)
 }
+
+func TestGetLogURLDoesNotReturnUnsafeSchemes(t *testing.T) {
+	const (
+		evergreenBaseURL = "https://request.evergreen.example.com"
+		parsleyURL       = "https://parsley.mongodb.org"
+	)
+	result := TestResult{
+		TaskID:    "task1",
+		TestName:  "test1",
+		LogURL:    "javascript:https://logkeeper.mongodb.org/build/task1",
+		RawLogURL: "data:text/html,<script>alert(1)</script>",
+	}
+
+	assert.Equal(t,
+		evergreenBaseURL+"javascript:https://logkeeper.mongodb.org/build/task1",
+		result.GetLogURL(evergreenBaseURL, parsleyURL, evergreen.LogViewerHTML),
+	)
+	assert.Equal(t,
+		parsleyURL+"/test/task1/0/test1?shareLine=0",
+		result.GetLogURL(evergreenBaseURL, parsleyURL, evergreen.LogViewerParsley),
+	)
+	assert.Equal(t,
+		evergreenBaseURL+"data:text/html,<script>alert(1)</script>",
+		result.GetLogURL(evergreenBaseURL, parsleyURL, evergreen.LogViewerRaw),
+	)
+}

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -737,6 +737,9 @@ func (h *attachFilesHandler) Parse(ctx context.Context, r *http.Request) error {
 		grip.Error(ctx, message)
 		return errors.Wrap(err, message)
 	}
+	if err := artifact.ValidateFiles(h.files); err != nil {
+		return errors.Wrap(err, "validating artifact file links")
+	}
 	return nil
 }
 

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -18,6 +18,7 @@ import (
 	mgobson "github.com/evergreen-ci/evergreen/db/mgo/bson"
 	"github.com/evergreen-ci/evergreen/mock"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/artifact"
 	"github.com/evergreen-ci/evergreen/model/distro"
 	"github.com/evergreen-ci/evergreen/model/githubapp"
 	"github.com/evergreen-ci/evergreen/model/host"
@@ -41,6 +42,43 @@ import (
 var (
 	taskSecret = "tasksecret"
 )
+
+func TestAttachFilesHandlerParse(t *testing.T) {
+	for testName, testCase := range map[string]struct {
+		files []artifact.File
+		want  bool
+	}{
+		"AllowsHTTPSArtifactLinks": {
+			files: []artifact.File{{Link: "https://example.com/artifact.txt"}},
+			want:  true,
+		},
+		"RejectsJavaScriptArtifactLinks": {
+			files: []artifact.File{{Link: "javascript:alert(document.domain)"}},
+		},
+		"RejectsDataAssociatedArtifactLinks": {
+			files: []artifact.File{{
+				Link:            "https://example.com/artifact.txt",
+				AssociatedLinks: []artifact.AssociatedLink{{Link: "data:text/html,<script>alert(1)</script>"}},
+			}},
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			body, err := json.Marshal(testCase.files)
+			require.NoError(t, err)
+
+			req, err := http.NewRequest(http.MethodPost, "https://example.com/rest/v2/task/task1/files", bytes.NewReader(body))
+			require.NoError(t, err)
+			req = gimlet.SetURLVars(req, map[string]string{"task_id": "task1"})
+
+			err = (&attachFilesHandler{}).Parse(t.Context(), req)
+			if testCase.want {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
 
 func TestAgentGetExpansionsAndVars(t *testing.T) {
 	for tName, tCase := range map[string]func(ctx context.Context, t *testing.T, rh *getExpansionsAndVarsHandler){


### PR DESCRIPTION
DEVPROD-37414

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Rejecting unsafe url formats when tasks register new artifacts file links and test log urls. This prevents people throwing in `javascript:` in the paths as that's technically a valid url.

### Testing
* Unit tests