### PR TITLE
DEVPROD-41227 Authorize PR comment triggers

### DIFF
--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -146,8 +146,12 @@ func ByUserAndCommitQueue(user string, filterCommitQueue bool) db.Q {
 	return db.Query(q)
 }
 
-func ByGithash(githash string) db.Q {
-	return db.Query(bson.M{bsonutil.GetDottedKeyName(githubPatchDataKey, headHashKey): githash})
+func ByGithash(githash, owner, repo string) db.Q {
+	return db.Query(bson.M{
+		bsonutil.GetDottedKeyName(githubPatchDataKey, headHashKey):                        githash,
+		bsonutil.GetDottedKeyName(githubPatchDataKey, thirdparty.GithubPatchBaseOwnerKey): owner,
+		bsonutil.GetDottedKeyName(githubPatchDataKey, thirdparty.GithubPatchBaseRepoKey):  repo,
+	})
 }
 
 type ProjectOrUserPatchesOptions struct {

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -73,19 +73,6 @@ var (
 // the PR title or description.
 var skipCILabels = []string{"[skip ci]", "[skip-ci]"}
 
-// isCommenterAuthorized checks whether a GitHub comment author is authorized
-// to trigger versions.
-var isCommenterAuthorized = func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
-	isMember, err := thirdparty.GithubUserInOrganization(ctx, requiredOrg, commenter)
-	if err != nil {
-		return false, err
-	}
-	if isMember {
-		return true, nil
-	}
-	return thirdparty.GitHubUserHasWritePermission(ctx, owner, repo, commenter)
-}
-
 type githubHookApi struct {
 	queue  amboy.Queue
 	secret []byte
@@ -96,25 +83,42 @@ type githubHookApi struct {
 	sc        data.Connector
 	settings  *evergreen.Settings
 	comments  githubComments
+
+	// isCommenterAuthorized checks whether a GitHub comment author is
+	// authorized to trigger CI. It can be overridden in tests.
+	isCommenterAuthorized func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error)
+}
+
+func defaultIsCommenterAuthorized(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
+	isMember, err := thirdparty.GithubUserInOrganization(ctx, requiredOrg, commenter)
+	if err != nil {
+		return false, err
+	}
+	if isMember {
+		return true, nil
+	}
+	return thirdparty.GitHubUserHasWritePermission(ctx, owner, repo, commenter)
 }
 
 func makeGithubHooksRoute(sc data.Connector, queue amboy.Queue, secret []byte, settings *evergreen.Settings) gimlet.RouteHandler {
 	return &githubHookApi{
-		sc:       sc,
-		settings: settings,
-		queue:    queue,
-		secret:   secret,
-		comments: newGithubComments(settings.Ui.UIv2Url),
+		sc:                    sc,
+		settings:              settings,
+		queue:                 queue,
+		secret:                secret,
+		comments:              newGithubComments(settings.Ui.UIv2Url),
+		isCommenterAuthorized: defaultIsCommenterAuthorized,
 	}
 }
 
 func (gh *githubHookApi) Factory() gimlet.RouteHandler {
 	return &githubHookApi{
-		queue:    gh.queue,
-		secret:   gh.secret,
-		sc:       gh.sc,
-		settings: gh.settings,
-		comments: newGithubComments(gh.settings.Ui.UIv2Url),
+		queue:                 gh.queue,
+		secret:                gh.secret,
+		sc:                    gh.sc,
+		settings:              gh.settings,
+		comments:              newGithubComments(gh.settings.Ui.UIv2Url),
+		isCommenterAuthorized: defaultIsCommenterAuthorized,
 	}
 }
 
@@ -1078,7 +1082,7 @@ func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequ
 
 	if commenter != "" {
 		requiredOrg := gh.settings.GithubPRCreatorOrg
-		authorized, err := isCommenterAuthorized(ctx, requiredOrg, baseOwnerRepo[0], baseOwnerRepo[1], commenter)
+		authorized, err := gh.isCommenterAuthorized(ctx, requiredOrg, baseOwnerRepo[0], baseOwnerRepo[1], commenter)
 		if err != nil {
 			grip.Error(ctx, message.WrapError(err, message.Fields{
 				"message":   "checking commenter authorization",

--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -73,6 +73,19 @@ var (
 // the PR title or description.
 var skipCILabels = []string{"[skip ci]", "[skip-ci]"}
 
+// isCommenterAuthorized checks whether a GitHub comment author is authorized
+// to trigger versions.
+var isCommenterAuthorized = func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
+	isMember, err := thirdparty.GithubUserInOrganization(ctx, requiredOrg, commenter)
+	if err != nil {
+		return false, err
+	}
+	if isMember {
+		return true, nil
+	}
+	return thirdparty.GitHubUserHasWritePermission(ctx, owner, repo, commenter)
+}
+
 type githubHookApi struct {
 	queue  amboy.Queue
 	secret []byte
@@ -256,7 +269,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 				break
 			}
 
-			if err := gh.AddIntentForPR(ctx, event.PullRequest, event.PullRequest.GetUser().GetLogin(), patch.AutomatedCaller, "", false); err != nil {
+			if err := gh.AddIntentForPR(ctx, event.PullRequest, event.PullRequest.GetUser().GetLogin(), patch.AutomatedCaller, "", "", false); err != nil {
 				grip.Error(ctx, message.WrapError(err, message.Fields{
 					"source":    "GitHub hook",
 					"msg_id":    gh.msgID,
@@ -715,7 +728,7 @@ func (gh *githubHookApi) handleComment(ctx context.Context, event *github.IssueC
 		}
 		grip.Info(ctx, gh.getCommentLogWithMessage(event, fmt.Sprintf("'%s' triggered", commentBody)))
 
-		err := gh.createPRPatch(ctx, event.Repo.Owner.GetLogin(), event.Repo.GetName(), callerType, alias, event.Issue.GetNumber())
+		err := gh.createPRPatch(ctx, event.Repo.Owner.GetLogin(), event.Repo.GetName(), callerType, alias, event.GetSender().GetLogin(), event.Issue.GetNumber())
 		grip.Error(ctx, message.WrapError(err, gh.getCommentLogWithMessage(event,
 			fmt.Sprintf("can't create PR for '%s'", commentBody))))
 		return errors.Wrap(err, "creating patch")
@@ -965,7 +978,7 @@ func shouldSkipCIForGraphite(ctx context.Context, owner, repo string, prNumber i
 	return responseBody.Skip, nil
 }
 
-func (gh *githubHookApi) createPRPatch(ctx context.Context, owner, repo, calledBy, alias string, prNumber int) error {
+func (gh *githubHookApi) createPRPatch(ctx context.Context, owner, repo, calledBy, alias, commenter string, prNumber int) error {
 	pr, err := thirdparty.GetGithubPullRequest(ctx, owner, repo, prNumber)
 	if err != nil {
 		return errors.Wrapf(err, "getting PR for repo '%s:%s', PR #%d", owner, repo, prNumber)
@@ -987,7 +1000,7 @@ func (gh *githubHookApi) createPRPatch(ctx context.Context, owner, repo, calledB
 		return gh.sc.AddCommentToPR(ctx, owner, repo, prNumber, graphiteRebaseComment)
 	}
 
-	return gh.AddIntentForPR(ctx, pr, pr.User.GetLogin(), calledBy, alias, true)
+	return gh.AddIntentForPR(ctx, pr, pr.User.GetLogin(), calledBy, alias, commenter, true)
 }
 
 // keepPRPatchDefinition looks for the most recent patch created for the pr number and updates the
@@ -1039,7 +1052,7 @@ func (gh *githubHookApi) refreshPatchStatus(ctx context.Context, owner, repo str
 // before creating a new one. For example, if multiple patches with the same head sha exist, the PR(s) will get
 // both updates from patches and be in a race condition for which one GitHub checks shows last- so we want
 // to avoid this state when possible.
-func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequest, owner, calledBy, alias string, overrideExisting bool) error {
+func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequest, owner, calledBy, alias, commenter string, overrideExisting bool) error {
 	// Verify that the owner/repo uses PR testing before inserting the intent.
 	baseRepoName := pr.Base.Repo.GetFullName()
 	baseOwnerRepo := strings.Split(baseRepoName, "/")
@@ -1061,6 +1074,31 @@ func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequ
 			"pr_num":  pr.GetNumber(),
 		})
 		return nil
+	}
+
+	if commenter != "" {
+		requiredOrg := gh.settings.GithubPRCreatorOrg
+		authorized, err := isCommenterAuthorized(ctx, requiredOrg, baseOwnerRepo[0], baseOwnerRepo[1], commenter)
+		if err != nil {
+			grip.Error(ctx, message.WrapError(err, message.Fields{
+				"message":   "checking commenter authorization",
+				"commenter": commenter,
+				"owner":     baseOwnerRepo[0],
+				"repo":      baseOwnerRepo[1],
+				"pr_num":    pr.GetNumber(),
+			}))
+		}
+		if !authorized {
+			grip.Warning(ctx, message.Fields{
+				"message":   "commenter is not authorized to trigger CI",
+				"commenter": commenter,
+				"owner":     baseOwnerRepo[0],
+				"repo":      baseOwnerRepo[1],
+				"pr_num":    pr.GetNumber(),
+			})
+			unauthorizedComment := fmt.Sprintf("GitHub user %s is not authorized to trigger Evergreen CI.", commenter)
+			return gh.sc.AddCommentToPR(ctx, baseOwnerRepo[0], baseOwnerRepo[1], pr.GetNumber(), unauthorizedComment)
+		}
 	}
 
 	if isGraphiteBaseBranch(baseBranch) {
@@ -1133,7 +1171,7 @@ func (gh *githubHookApi) AddIntentForPR(ctx context.Context, pr *github.PullRequ
 		}
 	}
 
-	conflictingPatches, err := getOtherPatchesWithHash(ctx, pr.Head.GetSHA(), pr.GetNumber())
+	conflictingPatches, err := getOtherPatchesWithHash(ctx, pr.Head.GetSHA(), baseOwnerRepo[0], baseOwnerRepo[1], pr.GetNumber())
 	if err != nil {
 		grip.Error(ctx, message.WrapError(err, message.Fields{
 			"message":           "error getting same hash patches",
@@ -1531,8 +1569,8 @@ func (gh *githubHookApi) createVersionForTag(ctx context.Context, pRef model.Pro
 	return gh.sc.CreateVersionFromConfig(ctx, &projectInfo, metadata)
 }
 
-func getOtherPatchesWithHash(ctx context.Context, githash string, prNum int) ([]patch.Patch, error) {
-	patches, err := patch.Find(ctx, patch.ByGithash(githash))
+func getOtherPatchesWithHash(ctx context.Context, githash, owner, repo string, prNum int) ([]patch.Patch, error) {
+	patches, err := patch.Find(ctx, patch.ByGithash(githash, owner, repo))
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting same hash patches")
 	}

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -599,3 +599,199 @@ func TestShouldSkipWebhookPersonalStaging(t *testing.T) {
 		})
 	}
 }
+
+func TestGetOtherPatchesWithHash(t *testing.T) {
+	ctx := t.Context()
+	require.NoError(t, db.Clear(patch.Collection))
+
+	sha := "abc123def456"
+	owner := "evergreen-ci"
+	repo := "evergreen"
+
+	sameRepoPatch := patch.Patch{
+		Id: mgobson.NewObjectId(),
+		GithubPatchData: thirdparty.GithubPatch{
+			BaseOwner: owner,
+			BaseRepo:  repo,
+			HeadHash:  sha,
+			PRNumber:  10,
+		},
+	}
+	differentRepoPatch := patch.Patch{
+		Id: mgobson.NewObjectId(),
+		GithubPatchData: thirdparty.GithubPatch{
+			BaseOwner: "other-org",
+			BaseRepo:  "other-repo",
+			HeadHash:  sha,
+			PRNumber:  20,
+		},
+	}
+	differentOwnerPatch := patch.Patch{
+		Id: mgobson.NewObjectId(),
+		GithubPatchData: thirdparty.GithubPatch{
+			BaseOwner: "other-org",
+			BaseRepo:  repo,
+			HeadHash:  sha,
+			PRNumber:  30,
+		},
+	}
+	samePRPatch := patch.Patch{
+		Id: mgobson.NewObjectId(),
+		GithubPatchData: thirdparty.GithubPatch{
+			BaseOwner: owner,
+			BaseRepo:  repo,
+			HeadHash:  sha,
+			PRNumber:  5,
+		},
+	}
+	require.NoError(t, db.InsertMany(ctx, patch.Collection, sameRepoPatch, differentRepoPatch, differentOwnerPatch, samePRPatch))
+
+	for testName, testCase := range map[string]func(*testing.T){
+		"SameRepoReturnsOnlyMatchingOwnerAndRepo": func(t *testing.T) {
+			patches, err := getOtherPatchesWithHash(ctx, sha, owner, repo, 999)
+			require.NoError(t, err)
+			assert.Len(t, patches, 2)
+			prNumbers := []int{}
+			for _, p := range patches {
+				prNumbers = append(prNumbers, p.GithubPatchData.PRNumber)
+			}
+			assert.Contains(t, prNumbers, 10)
+			assert.Contains(t, prNumbers, 5)
+		},
+		"DifferentRepoNotReturned": func(t *testing.T) {
+			patches, err := getOtherPatchesWithHash(ctx, sha, "other-org", "other-repo", 999)
+			require.NoError(t, err)
+			assert.Len(t, patches, 1)
+			assert.Equal(t, 20, patches[0].GithubPatchData.PRNumber)
+		},
+		"SamePRNumberFilteredOut": func(t *testing.T) {
+			patches, err := getOtherPatchesWithHash(ctx, sha, owner, repo, 10)
+			require.NoError(t, err)
+			assert.Len(t, patches, 1)
+			assert.Equal(t, 5, patches[0].GithubPatchData.PRNumber)
+		},
+		"NoMatchingHashReturnsEmpty": func(t *testing.T) {
+			patches, err := getOtherPatchesWithHash(ctx, "nonexistent-sha", owner, repo, 999)
+			require.NoError(t, err)
+			assert.Empty(t, patches)
+		},
+	} {
+		t.Run(testName, testCase)
+	}
+}
+
+func TestAddIntentForPRCommenterAuthorization(t *testing.T) {
+	originalIsCommenterAuthorized := isCommenterAuthorized
+	t.Cleanup(func() {
+		isCommenterAuthorized = originalIsCommenterAuthorized
+	})
+
+	repoOwner := "evergreen-ci"
+	repoName := "evergreen"
+	fullName := repoOwner + "/" + repoName
+	branchName := "main"
+	prNum := 42
+	headSHA := "abc123"
+	prUser := "pr-author"
+	makePR := func() *github.PullRequest {
+		return &github.PullRequest{
+			Number: &prNum,
+			User:   &github.User{Login: &prUser},
+			Base: &github.PullRequestBranch{
+				Ref:  &branchName,
+				Repo: &github.Repository{FullName: &fullName, Name: &repoName},
+				User: &github.User{Login: &repoOwner},
+			},
+			Head: &github.PullRequestBranch{
+				SHA: &headSHA,
+				Ref: &branchName,
+			},
+		}
+	}
+
+	for testName, testCase := range map[string]func(*testing.T){
+		"UnauthorizedCommenterIsRejected": func(t *testing.T) {
+			authCheckCalled := false
+			isCommenterAuthorized = func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
+				authCheckCalled = true
+				assert.Equal(t, "mongodb", requiredOrg)
+				assert.Equal(t, repoOwner, owner)
+				assert.Equal(t, repoName, repo)
+				assert.Equal(t, "attacker", commenter)
+				return false, nil
+			}
+			gh := &githubHookApi{
+				sc: &data.MockGitHubConnector{
+					MockGitHubConnectorImpl: data.MockGitHubConnectorImpl{},
+				},
+				settings: &evergreen.Settings{
+					GithubPRCreatorOrg: "mongodb",
+				},
+			}
+
+			// Insert a project ref so we reach the authorization check.
+			trueBool := true
+			pRef := model.ProjectRef{
+				Id:               "test-project",
+				Owner:            repoOwner,
+				Repo:             repoName,
+				Branch:           branchName,
+				Enabled:          true,
+				PRTestingEnabled: &trueBool,
+			}
+			require.NoError(t, pRef.Insert(t.Context()))
+
+			err := gh.AddIntentForPR(t.Context(), makePR(), prUser, patch.AllCallers, "", "attacker", true)
+			assert.NoError(t, err)
+			assert.True(t, authCheckCalled, "authorization check should have been called")
+		},
+		"AuthorizedCommenterProceeds": func(t *testing.T) {
+			authCheckCalled := false
+			isCommenterAuthorized = func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
+				authCheckCalled = true
+				return true, nil
+			}
+			gh := &githubHookApi{
+				settings: &evergreen.Settings{
+					GithubPRCreatorOrg: "mongodb",
+				},
+			}
+
+			// Insert a project ref so we reach the authorization check.
+			trueBool := true
+			pRef := model.ProjectRef{
+				Id:               "test-project",
+				Owner:            repoOwner,
+				Repo:             repoName,
+				Branch:           branchName,
+				Enabled:          true,
+				PRTestingEnabled: &trueBool,
+			}
+			require.NoError(t, pRef.Insert(t.Context()))
+
+			// Authorized commenter proceeds past auth and fails later
+			// (e.g., getting merge base), proving auth was not the blocker.
+			err := gh.AddIntentForPR(t.Context(), makePR(), prUser, patch.AllCallers, "", "authorized-user", true)
+			assert.Error(t, err)
+			assert.True(t, authCheckCalled, "authorization check should have been called")
+		},
+		"EmptyCommenterSkipsAuthorizationCheck": func(t *testing.T) {
+			isCommenterAuthorized = func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
+				t.Error("isCommenterAuthorized should not be called for empty commenter")
+				return false, nil
+			}
+			gh := &githubHookApi{
+				settings: &evergreen.Settings{
+					GithubPRCreatorOrg: "mongodb",
+				},
+			}
+
+			// No project ref → returns nil early, never reaching the auth check.
+			err := gh.AddIntentForPR(t.Context(), makePR(), prUser, patch.AutomatedCaller, "", "", false)
+			assert.NoError(t, err)
+		},
+	} {
+		require.NoError(t, db.ClearCollections(model.ProjectRefCollection))
+		t.Run(testName, testCase)
+	}
+}

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -679,6 +679,7 @@ func TestAddIntentForPRCommenterAuthorization(t *testing.T) {
 		assert.Error(t, err)
 	})
 	t.Run("EmptyCommenterSkipsCheck", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(model.ProjectRefCollection))
 		isCommenterAuthorized = func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
 			t.Error("should not be called for empty commenter")
 			return false, nil

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -605,91 +605,39 @@ func TestGetOtherPatchesWithHash(t *testing.T) {
 	require.NoError(t, db.Clear(patch.Collection))
 
 	sha := "abc123def456"
-	owner := "evergreen-ci"
-	repo := "evergreen"
+	makePatch := func(owner, repo string, prNum int) patch.Patch {
+		return patch.Patch{
+			Id:              mgobson.NewObjectId(),
+			GithubPatchData: thirdparty.GithubPatch{BaseOwner: owner, BaseRepo: repo, HeadHash: sha, PRNumber: prNum},
+		}
+	}
+	require.NoError(t, db.InsertMany(ctx, patch.Collection,
+		makePatch("evergreen-ci", "evergreen", 10),
+		makePatch("evergreen-ci", "evergreen", 5),
+		makePatch("other-org", "other-repo", 20),
+	))
 
-	sameRepoPatch := patch.Patch{
-		Id: mgobson.NewObjectId(),
-		GithubPatchData: thirdparty.GithubPatch{
-			BaseOwner: owner,
-			BaseRepo:  repo,
-			HeadHash:  sha,
-			PRNumber:  10,
-		},
-	}
-	differentRepoPatch := patch.Patch{
-		Id: mgobson.NewObjectId(),
-		GithubPatchData: thirdparty.GithubPatch{
-			BaseOwner: "other-org",
-			BaseRepo:  "other-repo",
-			HeadHash:  sha,
-			PRNumber:  20,
-		},
-	}
-	differentOwnerPatch := patch.Patch{
-		Id: mgobson.NewObjectId(),
-		GithubPatchData: thirdparty.GithubPatch{
-			BaseOwner: "other-org",
-			BaseRepo:  repo,
-			HeadHash:  sha,
-			PRNumber:  30,
-		},
-	}
-	samePRPatch := patch.Patch{
-		Id: mgobson.NewObjectId(),
-		GithubPatchData: thirdparty.GithubPatch{
-			BaseOwner: owner,
-			BaseRepo:  repo,
-			HeadHash:  sha,
-			PRNumber:  5,
-		},
-	}
-	require.NoError(t, db.InsertMany(ctx, patch.Collection, sameRepoPatch, differentRepoPatch, differentOwnerPatch, samePRPatch))
-
-	for testName, testCase := range map[string]func(*testing.T){
-		"SameRepoReturnsOnlyMatchingOwnerAndRepo": func(t *testing.T) {
-			patches, err := getOtherPatchesWithHash(ctx, sha, owner, repo, 999)
-			require.NoError(t, err)
-			assert.Len(t, patches, 2)
-			prNumbers := []int{}
-			for _, p := range patches {
-				prNumbers = append(prNumbers, p.GithubPatchData.PRNumber)
-			}
-			assert.Contains(t, prNumbers, 10)
-			assert.Contains(t, prNumbers, 5)
-		},
-		"DifferentRepoNotReturned": func(t *testing.T) {
-			patches, err := getOtherPatchesWithHash(ctx, sha, "other-org", "other-repo", 999)
-			require.NoError(t, err)
-			assert.Len(t, patches, 1)
-			assert.Equal(t, 20, patches[0].GithubPatchData.PRNumber)
-		},
-		"SamePRNumberFilteredOut": func(t *testing.T) {
-			patches, err := getOtherPatchesWithHash(ctx, sha, owner, repo, 10)
-			require.NoError(t, err)
-			assert.Len(t, patches, 1)
-			assert.Equal(t, 5, patches[0].GithubPatchData.PRNumber)
-		},
-		"NoMatchingHashReturnsEmpty": func(t *testing.T) {
-			patches, err := getOtherPatchesWithHash(ctx, "nonexistent-sha", owner, repo, 999)
-			require.NoError(t, err)
-			assert.Empty(t, patches)
-		},
-	} {
-		t.Run(testName, testCase)
-	}
+	t.Run("CrossRepoExcluded", func(t *testing.T) {
+		patches, err := getOtherPatchesWithHash(ctx, sha, "evergreen-ci", "evergreen", 999)
+		require.NoError(t, err)
+		assert.Len(t, patches, 2)
+	})
+	t.Run("SamePRFilteredOut", func(t *testing.T) {
+		patches, err := getOtherPatchesWithHash(ctx, sha, "evergreen-ci", "evergreen", 10)
+		require.NoError(t, err)
+		assert.Len(t, patches, 1)
+		assert.Equal(t, 5, patches[0].GithubPatchData.PRNumber)
+	})
 }
 
 func TestAddIntentForPRCommenterAuthorization(t *testing.T) {
 	originalIsCommenterAuthorized := isCommenterAuthorized
-	t.Cleanup(func() {
-		isCommenterAuthorized = originalIsCommenterAuthorized
-	})
+	t.Cleanup(func() { isCommenterAuthorized = originalIsCommenterAuthorized })
 
-	repoOwner := "evergreen-ci"
+	owner := "evergreen-ci"
 	repoName := "evergreen"
-	fullName := repoOwner + "/" + repoName
-	branchName := "main"
+	fullName := owner + "/" + repoName
+	branch := "main"
 	prNum := 42
 	headSHA := "abc123"
 	prUser := "pr-author"
@@ -697,101 +645,46 @@ func TestAddIntentForPRCommenterAuthorization(t *testing.T) {
 		return &github.PullRequest{
 			Number: &prNum,
 			User:   &github.User{Login: &prUser},
-			Base: &github.PullRequestBranch{
-				Ref:  &branchName,
-				Repo: &github.Repository{FullName: &fullName, Name: &repoName},
-				User: &github.User{Login: &repoOwner},
-			},
-			Head: &github.PullRequestBranch{
-				SHA: &headSHA,
-				Ref: &branchName,
-			},
+			Base:   &github.PullRequestBranch{Ref: &branch, Repo: &github.Repository{FullName: &fullName, Name: &repoName}, User: &github.User{Login: &owner}},
+			Head:   &github.PullRequestBranch{SHA: &headSHA, Ref: &branch},
 		}
 	}
-
-	for testName, testCase := range map[string]func(*testing.T){
-		"UnauthorizedCommenterIsRejected": func(t *testing.T) {
-			authCheckCalled := false
-			isCommenterAuthorized = func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
-				authCheckCalled = true
-				assert.Equal(t, "mongodb", requiredOrg)
-				assert.Equal(t, repoOwner, owner)
-				assert.Equal(t, repoName, repo)
-				assert.Equal(t, "attacker", commenter)
-				return false, nil
-			}
-			gh := &githubHookApi{
-				sc: &data.MockGitHubConnector{
-					MockGitHubConnectorImpl: data.MockGitHubConnectorImpl{},
-				},
-				settings: &evergreen.Settings{
-					GithubPRCreatorOrg: "mongodb",
-				},
-			}
-
-			// Insert a project ref so we reach the authorization check.
-			trueBool := true
-			pRef := model.ProjectRef{
-				Id:               "test-project",
-				Owner:            repoOwner,
-				Repo:             repoName,
-				Branch:           branchName,
-				Enabled:          true,
-				PRTestingEnabled: &trueBool,
-			}
-			require.NoError(t, pRef.Insert(t.Context()))
-
-			err := gh.AddIntentForPR(t.Context(), makePR(), prUser, patch.AllCallers, "", "attacker", true)
-			assert.NoError(t, err)
-			assert.True(t, authCheckCalled, "authorization check should have been called")
-		},
-		"AuthorizedCommenterProceeds": func(t *testing.T) {
-			authCheckCalled := false
-			isCommenterAuthorized = func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
-				authCheckCalled = true
-				return true, nil
-			}
-			gh := &githubHookApi{
-				settings: &evergreen.Settings{
-					GithubPRCreatorOrg: "mongodb",
-				},
-			}
-
-			// Insert a project ref so we reach the authorization check.
-			trueBool := true
-			pRef := model.ProjectRef{
-				Id:               "test-project",
-				Owner:            repoOwner,
-				Repo:             repoName,
-				Branch:           branchName,
-				Enabled:          true,
-				PRTestingEnabled: &trueBool,
-			}
-			require.NoError(t, pRef.Insert(t.Context()))
-
-			// Authorized commenter proceeds past auth and fails later
-			// (e.g., getting merge base), proving auth was not the blocker.
-			err := gh.AddIntentForPR(t.Context(), makePR(), prUser, patch.AllCallers, "", "authorized-user", true)
-			assert.Error(t, err)
-			assert.True(t, authCheckCalled, "authorization check should have been called")
-		},
-		"EmptyCommenterSkipsAuthorizationCheck": func(t *testing.T) {
-			isCommenterAuthorized = func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
-				t.Error("isCommenterAuthorized should not be called for empty commenter")
-				return false, nil
-			}
-			gh := &githubHookApi{
-				settings: &evergreen.Settings{
-					GithubPRCreatorOrg: "mongodb",
-				},
-			}
-
-			// No project ref → returns nil early, never reaching the auth check.
-			err := gh.AddIntentForPR(t.Context(), makePR(), prUser, patch.AutomatedCaller, "", "", false)
-			assert.NoError(t, err)
-		},
-	} {
-		require.NoError(t, db.ClearCollections(model.ProjectRefCollection))
-		t.Run(testName, testCase)
+	insertProjectRef := func(t *testing.T) {
+		require.NoError(t, (&model.ProjectRef{
+			Id: "test-project", Owner: owner, Repo: repoName, Branch: branch, Enabled: true, PRTestingEnabled: utility.TruePtr(),
+		}).Insert(t.Context()))
 	}
+
+	t.Run("UnauthorizedCommenterIsRejected", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(model.ProjectRefCollection))
+		isCommenterAuthorized = func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
+			return false, nil
+		}
+		insertProjectRef(t)
+		gh := &githubHookApi{
+			sc:       &data.MockGitHubConnector{MockGitHubConnectorImpl: data.MockGitHubConnectorImpl{}},
+			settings: &evergreen.Settings{GithubPRCreatorOrg: "mongodb"},
+		}
+		err := gh.AddIntentForPR(t.Context(), makePR(), prUser, patch.AllCallers, "", "attacker", true)
+		assert.NoError(t, err)
+	})
+	t.Run("AuthorizedCommenterProceeds", func(t *testing.T) {
+		require.NoError(t, db.ClearCollections(model.ProjectRefCollection))
+		isCommenterAuthorized = func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
+			return true, nil
+		}
+		insertProjectRef(t)
+		gh := &githubHookApi{settings: &evergreen.Settings{GithubPRCreatorOrg: "mongodb"}}
+		err := gh.AddIntentForPR(t.Context(), makePR(), prUser, patch.AllCallers, "", "member", true)
+		assert.Error(t, err)
+	})
+	t.Run("EmptyCommenterSkipsCheck", func(t *testing.T) {
+		isCommenterAuthorized = func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
+			t.Error("should not be called for empty commenter")
+			return false, nil
+		}
+		gh := &githubHookApi{settings: &evergreen.Settings{GithubPRCreatorOrg: "mongodb"}}
+		err := gh.AddIntentForPR(t.Context(), makePR(), prUser, patch.AutomatedCaller, "", "", false)
+		assert.NoError(t, err)
+	})
 }

--- a/rest/route/github_test.go
+++ b/rest/route/github_test.go
@@ -631,9 +631,6 @@ func TestGetOtherPatchesWithHash(t *testing.T) {
 }
 
 func TestAddIntentForPRCommenterAuthorization(t *testing.T) {
-	originalIsCommenterAuthorized := isCommenterAuthorized
-	t.Cleanup(func() { isCommenterAuthorized = originalIsCommenterAuthorized })
-
 	owner := "evergreen-ci"
 	repoName := "evergreen"
 	fullName := owner + "/" + repoName
@@ -657,34 +654,38 @@ func TestAddIntentForPRCommenterAuthorization(t *testing.T) {
 
 	t.Run("UnauthorizedCommenterIsRejected", func(t *testing.T) {
 		require.NoError(t, db.ClearCollections(model.ProjectRefCollection))
-		isCommenterAuthorized = func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
-			return false, nil
-		}
 		insertProjectRef(t)
 		gh := &githubHookApi{
 			sc:       &data.MockGitHubConnector{MockGitHubConnectorImpl: data.MockGitHubConnectorImpl{}},
 			settings: &evergreen.Settings{GithubPRCreatorOrg: "mongodb"},
+			isCommenterAuthorized: func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
+				return false, nil
+			},
 		}
 		err := gh.AddIntentForPR(t.Context(), makePR(), prUser, patch.AllCallers, "", "attacker", true)
 		assert.NoError(t, err)
 	})
 	t.Run("AuthorizedCommenterProceeds", func(t *testing.T) {
 		require.NoError(t, db.ClearCollections(model.ProjectRefCollection))
-		isCommenterAuthorized = func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
-			return true, nil
-		}
 		insertProjectRef(t)
-		gh := &githubHookApi{settings: &evergreen.Settings{GithubPRCreatorOrg: "mongodb"}}
+		gh := &githubHookApi{
+			settings: &evergreen.Settings{GithubPRCreatorOrg: "mongodb"},
+			isCommenterAuthorized: func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
+				return true, nil
+			},
+		}
 		err := gh.AddIntentForPR(t.Context(), makePR(), prUser, patch.AllCallers, "", "member", true)
 		assert.Error(t, err)
 	})
 	t.Run("EmptyCommenterSkipsCheck", func(t *testing.T) {
 		require.NoError(t, db.ClearCollections(model.ProjectRefCollection))
-		isCommenterAuthorized = func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
-			t.Error("should not be called for empty commenter")
-			return false, nil
+		gh := &githubHookApi{
+			settings: &evergreen.Settings{GithubPRCreatorOrg: "mongodb"},
+			isCommenterAuthorized: func(ctx context.Context, requiredOrg, owner, repo, commenter string) (bool, error) {
+				t.Error("should not be called for empty commenter")
+				return false, nil
+			},
 		}
-		gh := &githubHookApi{settings: &evergreen.Settings{GithubPRCreatorOrg: "mongodb"}}
 		err := gh.AddIntentForPR(t.Context(), makePR(), prUser, patch.AutomatedCaller, "", "", false)
 		assert.NoError(t, err)
 	})


### PR DESCRIPTION
DEVPROD-41227

### Description
An attacker can fetch a public PR's head commit, push it to their own fork, open a PR, and comment `evergreen retry`, causing Evergreen to cancel the victim's patches because the lookup for "conflicting patches" is based commit SHA alone.

Fix is to scope the query to the same owner/repo and require the commenter to be authorized.
### Testing

Unit tests.

