### PR TITLE
DEVPROD-41560 Reject GitHub subscriber types in subscription API

### DIFF
--- a/model/event/subscribers.go
+++ b/model/event/subscribers.go
@@ -44,6 +44,17 @@ var SubscriberTypes = []string{
 	RunChildPatchSubscriberType,
 }
 
+// IsGitHubSubscriberType returns whether the given subscriber type is one of
+// the GitHub subscriber types that post statuses via our global GitHub app.
+func IsGitHubSubscriberType(t string) bool {
+	switch t {
+	case GithubPullRequestSubscriberType, GithubCheckSubscriberType, GithubMergeSubscriberType:
+		return true
+	default:
+		return false
+	}
+}
+
 type Subscriber struct {
 	Type string `bson:"type"`
 	// sad violin
@@ -121,6 +132,18 @@ func (s *Subscriber) Validate() error {
 	case WebhookSubscriber:
 		catcher.Add(v.validate())
 	case *WebhookSubscriber:
+		catcher.Add(v.validate())
+	case GithubPullRequestSubscriber:
+		catcher.Add(v.validate())
+	case *GithubPullRequestSubscriber:
+		catcher.Add(v.validate())
+	case GithubCheckSubscriber:
+		catcher.Add(v.validate())
+	case *GithubCheckSubscriber:
+		catcher.Add(v.validate())
+	case GithubMergeSubscriber:
+		catcher.Add(v.validate())
+	case *GithubMergeSubscriber:
 		catcher.Add(v.validate())
 	}
 
@@ -232,6 +255,14 @@ func (s *GithubPullRequestSubscriber) String() string {
 	return fmt.Sprintf("%s-%s-%d-%s-%s", s.Owner, s.Repo, s.PRNumber, s.Ref, s.ChildId)
 }
 
+func (s *GithubPullRequestSubscriber) validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(s.Owner == "", "owner is required for GitHub pull request subscriber")
+	catcher.NewWhen(s.Repo == "", "repo is required for GitHub pull request subscriber")
+	catcher.NewWhen(s.Ref == "", "ref is required for GitHub pull request subscriber")
+	return catcher.Resolve()
+}
+
 type GithubCheckSubscriber struct {
 	Owner string `bson:"owner"`
 	Repo  string `bson:"repo"`
@@ -240,6 +271,14 @@ type GithubCheckSubscriber struct {
 
 func (s *GithubCheckSubscriber) String() string {
 	return fmt.Sprintf("%s-%s-%s", s.Owner, s.Repo, s.Ref)
+}
+
+func (s *GithubCheckSubscriber) validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(s.Owner == "", "owner is required for GitHub check subscriber")
+	catcher.NewWhen(s.Repo == "", "repo is required for GitHub check subscriber")
+	catcher.NewWhen(s.Ref == "", "ref is required for GitHub check subscriber")
+	return catcher.Resolve()
 }
 
 type GithubMergeSubscriber struct {
@@ -251,6 +290,14 @@ type GithubMergeSubscriber struct {
 
 func (s *GithubMergeSubscriber) String() string {
 	return fmt.Sprintf("%s-%s-%s-%s", s.Owner, s.Repo, s.Ref, s.ChildId)
+}
+
+func (s *GithubMergeSubscriber) validate() error {
+	catcher := grip.NewBasicCatcher()
+	catcher.NewWhen(s.Owner == "", "owner is required for GitHub merge subscriber")
+	catcher.NewWhen(s.Repo == "", "repo is required for GitHub merge subscriber")
+	catcher.NewWhen(s.Ref == "", "ref is required for GitHub merge subscriber")
+	return catcher.Resolve()
 }
 
 type ChildPatchSubscriber struct {

--- a/model/event/subscribers_test.go
+++ b/model/event/subscribers_test.go
@@ -225,6 +225,48 @@ func TestValidate(t *testing.T) {
 			},
 			errorExpected: false,
 		},
+		"GithubPullRequestMissingOwnerShouldError": {
+			s: Subscriber{
+				Type:   GithubPullRequestSubscriberType,
+				Target: &GithubPullRequestSubscriber{Repo: "evergreen", Ref: "abc123"},
+			},
+			errorExpected: true,
+		},
+		"GithubPullRequestMissingRepoShouldError": {
+			s: Subscriber{
+				Type:   GithubPullRequestSubscriberType,
+				Target: &GithubPullRequestSubscriber{Owner: "mongodb", Ref: "abc123"},
+			},
+			errorExpected: true,
+		},
+		"GithubPullRequestMissingRefShouldError": {
+			s: Subscriber{
+				Type:   GithubPullRequestSubscriberType,
+				Target: &GithubPullRequestSubscriber{Owner: "mongodb", Repo: "evergreen"},
+			},
+			errorExpected: true,
+		},
+		"ValidGithubPullRequest": {
+			s: Subscriber{
+				Type:   GithubPullRequestSubscriberType,
+				Target: &GithubPullRequestSubscriber{Owner: "mongodb", Repo: "evergreen", Ref: "abc123"},
+			},
+			errorExpected: false,
+		},
+		"GithubMergeMissingRepoShouldError": {
+			s: Subscriber{
+				Type:   GithubMergeSubscriberType,
+				Target: &GithubMergeSubscriber{Owner: "mongodb", Ref: "abc123"},
+			},
+			errorExpected: true,
+		},
+		"ValidGithubMerge": {
+			s: Subscriber{
+				Type:   GithubMergeSubscriberType,
+				Target: &GithubMergeSubscriber{Owner: "mongodb", Repo: "evergreen", Ref: "abc123"},
+			},
+			errorExpected: false,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			if testCase.errorExpected {

--- a/rest/data/subscription.go
+++ b/rest/data/subscription.go
@@ -62,6 +62,13 @@ func SaveSubscriptions(ctx context.Context, owner string, subscriptions []restMo
 				Message:    errors.Wrap(err, "converting subscription to service model").Error(),
 			}
 		}
+		if event.IsGitHubSubscriberType(dbSubscription.Subscriber.Type) {
+			return gimlet.ErrorResponse{
+				StatusCode: http.StatusBadRequest,
+				Message:    "GitHub subscriber types cannot be created through the API",
+			}
+		}
+
 		if isProjectOwner {
 			dbSubscription.OwnerType = event.OwnerTypeProject
 			dbSubscription.Owner = owner


### PR DESCRIPTION
DEVPROD-41560

### Description

Blocks users from creating GitHub notification subscriptions through our APIs. This is currently allowed which it shouldn't be because it could direct Evergreen's GitHub App to post commit statuses to unrelated repos. Legitimate GitHub subscriptions are created internally from webhooks so they should be unaffected by this change.
### Testing

Added some unit tests.
