### PR TITLE
DEVPROD-41891 Fix task debugger module cloning

### DIFF
--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -304,18 +304,27 @@ func NewTaskConfig(opts TaskConfigOptions) (*TaskConfig, error) {
 	}
 
 	if opts.ExpansionsAndVars != nil && opts.ExpansionsAndVars.Expansions != nil {
-		expandedModules := make([]string, 0, len(taskConfig.BuildVariant.Modules))
-		for _, moduleName := range taskConfig.BuildVariant.Modules {
-			expanded, err := opts.ExpansionsAndVars.Expansions.ExpandString(moduleName)
-			if err != nil {
-				return nil, errors.Wrapf(err, "expanding module '%s'", moduleName)
-			}
-			expandedModules = append(expandedModules, expanded)
+		var err error
+		taskConfig.BuildVariant.Modules, err = ExpandModuleNames(taskConfig.BuildVariant.Modules, opts.ExpansionsAndVars.Expansions)
+		if err != nil {
+			return nil, err
 		}
-		taskConfig.BuildVariant.Modules = expandedModules
 	}
 
 	return taskConfig, nil
+}
+
+// ExpandModuleNames expands any expansion variables in module names.
+func ExpandModuleNames(modules []string, expansions util.Expansions) ([]string, error) {
+	expanded := make([]string, 0, len(modules))
+	for _, moduleName := range modules {
+		name, err := expansions.ExpandString(moduleName)
+		if err != nil {
+			return nil, errors.Wrapf(err, "expanding module '%s'", moduleName)
+		}
+		expanded = append(expanded, name)
+	}
+	return expanded, nil
 }
 
 // ApplyFunctionVarsToExpansions expands the given function vars and puts them into

--- a/agent/taskexec/local_executor.go
+++ b/agent/taskexec/local_executor.go
@@ -707,13 +707,9 @@ func (e *LocalExecutor) PrepareTask(ctx context.Context, taskName, variantName s
 		e.taskConfig.Expansions.Put("build_variant", variantName)
 		e.taskConfig.Expansions.Update(bv.Expansions)
 
-		expandedModules := make([]string, 0, len(e.taskConfig.BuildVariant.Modules))
-		for _, moduleName := range e.taskConfig.BuildVariant.Modules {
-			expanded, err := e.taskConfig.Expansions.ExpandString(moduleName)
-			if err != nil {
-				return errors.Wrapf(err, "expanding module '%s'", moduleName)
-			}
-			expandedModules = append(expandedModules, expanded)
+		expandedModules, err := internal.ExpandModuleNames(e.taskConfig.BuildVariant.Modules, e.taskConfig.Expansions)
+		if err != nil {
+			return err
 		}
 		e.taskConfig.BuildVariant.Modules = expandedModules
 

--- a/agent/taskexec/local_executor.go
+++ b/agent/taskexec/local_executor.go
@@ -703,8 +703,20 @@ func (e *LocalExecutor) PrepareTask(ctx context.Context, taskName, variantName s
 			}
 		}
 		e.debugState.SelectedVariant = variantName
+		e.taskConfig.BuildVariant = *bv
 		e.taskConfig.Expansions.Put("build_variant", variantName)
 		e.taskConfig.Expansions.Update(bv.Expansions)
+
+		expandedModules := make([]string, 0, len(e.taskConfig.BuildVariant.Modules))
+		for _, moduleName := range e.taskConfig.BuildVariant.Modules {
+			expanded, err := e.taskConfig.Expansions.ExpandString(moduleName)
+			if err != nil {
+				return errors.Wrapf(err, "expanding module '%s'", moduleName)
+			}
+			expandedModules = append(expandedModules, expanded)
+		}
+		e.taskConfig.BuildVariant.Modules = expandedModules
+
 		e.logger.Infof(ctx, "Applied expansions from build variant: %s", variantName)
 	}
 

--- a/agent/taskexec/local_executor_test.go
+++ b/agent/taskexec/local_executor_test.go
@@ -345,6 +345,44 @@ buildvariants:
 		assert.Equal(t, "enterprise", executor.taskConfig.Expansions.Get("edition"))
 	})
 
+	t.Run("PopulatesBuildVariantModules", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		yamlFile := filepath.Join(tmpDir, "test.yml")
+		yamlContent := `
+tasks:
+  - name: test-task
+    commands:
+      - command: shell.exec
+        params:
+          script: echo "test"
+modules:
+  - name: my-module
+    repo: git@github.com:test/my-module.git
+    branch: main
+    prefix: src/modules
+buildvariants:
+  - name: ubuntu2204
+    display_name: Ubuntu 22.04
+    modules:
+      - my-module
+    tasks:
+      - name: test-task
+`
+		err := os.WriteFile(yamlFile, []byte(yamlContent), 0644)
+		require.NoError(t, err)
+
+		executor, err := NewLocalExecutor(t.Context(), LocalExecutorOptions{})
+		require.NoError(t, err)
+
+		_, err = executor.LoadProject(yamlFile)
+		require.NoError(t, err)
+
+		err = executor.PrepareTask(t.Context(), "test-task", "ubuntu2204")
+		require.NoError(t, err)
+		require.Len(t, executor.taskConfig.BuildVariant.Modules, 1)
+		assert.Equal(t, "my-module", executor.taskConfig.BuildVariant.Modules[0])
+	})
+
 	t.Run("ReturnsErrorForNonexistentVariant", func(t *testing.T) {
 		tmpDir := t.TempDir()
 		yamlFile := filepath.Join(tmpDir, "test.yml")

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-08-18"
+	AgentVersion = "2026-08-20"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-41891

### Description

When using the task debugger, `git.get_project` needs to include and expand the BV's module list in the task config so that it clones module repos properly, matching what the normal agent path does.
### Testing

Repro'd in staging and verified the issue went away + quick unit test.