### PR TITLE
DEVPROD-19220 productionize cross-file YAML anchors 

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-08-12"
+	ClientVersion = "2026-08-19"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/config_db.go
+++ b/config_db.go
@@ -61,6 +61,7 @@ var (
 	taskDispatchKey                       = bsonutil.MustHaveTag(ServiceFlags{}, "TaskDispatchDisabled")
 	hostInitKey                           = bsonutil.MustHaveTag(ServiceFlags{}, "HostInitDisabled")
 	largeParserProjectsDisabledKey        = bsonutil.MustHaveTag(ServiceFlags{}, "LargeParserProjectsDisabled")
+	crossFileYAMLAnchorsEnabledKey        = bsonutil.MustHaveTag(ServiceFlags{}, "CrossFileYAMLAnchorsEnabled")
 	monitorKey                            = bsonutil.MustHaveTag(ServiceFlags{}, "MonitorDisabled")
 	mergeQueueRecoveryEnabledKey          = bsonutil.MustHaveTag(ServiceFlags{}, "MergeQueueRecoveryEnabled")
 	alertsKey                             = bsonutil.MustHaveTag(ServiceFlags{}, "AlertsDisabled")

--- a/config_serviceflags.go
+++ b/config_serviceflags.go
@@ -14,6 +14,7 @@ type ServiceFlags struct {
 	TaskDispatchDisabled               bool `bson:"task_dispatch_disabled" json:"task_dispatch_disabled"`
 	HostInitDisabled                   bool `bson:"host_init_disabled" json:"host_init_disabled"`
 	LargeParserProjectsDisabled        bool `bson:"large_parser_projects_disabled" json:"large_parser_projects_disabled"`
+	CrossFileYAMLAnchorsEnabled        bool `bson:"cross_file_yaml_anchors_enabled" json:"cross_file_yaml_anchors_enabled"`
 	MonitorDisabled                    bool `bson:"monitor_disabled" json:"monitor_disabled"`
 	MergeQueueRecoveryEnabled          bool `bson:"merge_queue_recovery_enabled" json:"merge_queue_recovery_enabled"`
 	AlertsDisabled                     bool `bson:"alerts_disabled" json:"alerts_disabled"`
@@ -84,6 +85,7 @@ func (c *ServiceFlags) Set(ctx context.Context) error {
 			taskDispatchKey:                       c.TaskDispatchDisabled,
 			hostInitKey:                           c.HostInitDisabled,
 			largeParserProjectsDisabledKey:        c.LargeParserProjectsDisabled,
+			crossFileYAMLAnchorsEnabledKey:        c.CrossFileYAMLAnchorsEnabled,
 			monitorKey:                            c.MonitorDisabled,
 			mergeQueueRecoveryEnabledKey:          c.MergeQueueRecoveryEnabled,
 			alertsKey:                             c.AlertsDisabled,

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -357,9 +357,9 @@ include:
     module: module_name
 ```
 
-#### YAML Anchors (Beta)
+#### YAML Anchors
 
-YAML anchors (`&name`) and aliases (`*name`) are supported within a single file and across include files. Cross-file anchor support is in beta and requires passing `--yaml-anchors` to `evergreen validate` or `evergreen evaluate`.
+YAML anchors (`&name`) and aliases (`*name`) are supported within a single file and across include files.
 
 An anchor defined in the main config file or in an earlier include file can be referenced as an alias in any later include file. Files are processed in the order they are listed in `include`, so an alias can only refer to an anchor that was defined in a file that appears earlier in the list (or in the main config file).
 

--- a/graphql/tests/mutation/saveAdminSettings/data.json
+++ b/graphql/tests/mutation/saveAdminSettings/data.json
@@ -113,6 +113,7 @@
       "task_dispatch_disabled": false,
       "s3_binary_downloads_disabled": false,
       "large_parser_projects_disabled": false,
+      "cross_file_yaml_anchors_enabled": false,
       "monitor_disabled": false,
       "notifications_disabled": false,
       "taskrunner_disabled": false,

--- a/graphql/tests/mutation/setServiceFlags/results.json
+++ b/graphql/tests/mutation/setServiceFlags/results.json
@@ -25,6 +25,7 @@
             { "name": "task_dispatch_disabled", "enabled": true },
             { "name": "host_init_disabled", "enabled": false },
             { "name": "large_parser_projects_disabled", "enabled": false },
+            { "name": "cross_file_yaml_anchors_enabled", "enabled": false },
             { "name": "monitor_disabled", "enabled": false },
             { "name": "merge_queue_recovery_enabled", "enabled": false },
             { "name": "alerts_disabled", "enabled": false },

--- a/graphql/tests/query/adminSettings/results.json
+++ b/graphql/tests/query/adminSettings/results.json
@@ -577,6 +577,7 @@
               { "name": "task_dispatch_disabled", "enabled": false },
               { "name": "host_init_disabled", "enabled": false },
               { "name": "large_parser_projects_disabled", "enabled": false },
+              { "name": "cross_file_yaml_anchors_enabled", "enabled": false },
               { "name": "monitor_disabled", "enabled": false },
               { "name": "merge_queue_recovery_enabled", "enabled": false },
               { "name": "alerts_disabled", "enabled": false },

--- a/model/patch_lifecycle.go
+++ b/model/patch_lifecycle.go
@@ -420,6 +420,11 @@ func GetPatchedProject(ctx context.Context, settings *evergreen.Settings, p *pat
 		return nil, nil, errors.Wrap(err, "fetching project options for patch")
 	}
 	opts.cacheEnabled = projectTranslationCacheEnabled(settings)
+	svcFlags, err := evergreen.GetServiceFlags(ctx)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "getting service flags")
+	}
+	opts.CrossFileYAMLAnchorsEnabled = svcFlags.CrossFileYAMLAnchorsEnabled
 
 	projectFileBytes, err := getPatchedProjectYAML(ctx, projectRef, opts, p)
 	if err != nil {
@@ -496,10 +501,11 @@ func GetPatchedProjectConfig(ctx context.Context, p *patch.Patch) (string, error
 
 	// Parse the config directly instead of going through LoadProjectInto to
 	// avoid paying for project translation, which isn't needed for the config.
-	intermediateProject, err := createIntermediateProject(projectFileBytes, opts.UnmarshalStrict, nil)
+	intermediateProject, decodeErr, err := createIntermediateProject(projectFileBytes, opts.UnmarshalStrict, nil)
 	if err != nil {
 		return "", errors.Wrapf(err, LoadProjectError)
 	}
+	logDecodeErrorWithOpts(ctx, projectRef.Id, "", "GetPatchedProjectConfig", decodeErr, opts)
 	if len(intermediateProject.Include) > 0 {
 		if err := mergeIncludes(ctx, p.Project, intermediateProject, nil, opts); err != nil {
 			return "", errors.Wrap(err, "merging included files")

--- a/model/patch_lifecycle_test.go
+++ b/model/patch_lifecycle_test.go
@@ -746,7 +746,7 @@ func TestMakePatchedConfigRenamed(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, projectData)
 
-	intermediateProject, err := createIntermediateProject(projectData, false, nil)
+	intermediateProject, _, err := createIntermediateProject(projectData, false, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, intermediateProject)
 	require.Len(t, intermediateProject.BuildVariants, 1)

--- a/model/project_matrix_test.go
+++ b/model/project_matrix_test.go
@@ -41,7 +41,7 @@ buildvariants:
       set:
         tags: "gotcha_boy"
 `
-			p, err := createIntermediateProject([]byte(axes), true, nil)
+			p, _, err := createIntermediateProject([]byte(axes), true, nil)
 			So(err, ShouldBeNil)
 			axis := p.Axes[0]
 			So(axis.Id, ShouldEqual, "os")
@@ -77,7 +77,7 @@ buildvariants:
     - blue
     - green
 `
-			p, err := createIntermediateProject([]byte(simple), false, nil)
+			p, _, err := createIntermediateProject([]byte(simple), false, nil)
 			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
 			m1 := *p.BuildVariants[0].Matrix
@@ -108,7 +108,7 @@ buildvariants:
 - name: "single_variant"
   tasks: "*"
 `
-			p, err := createIntermediateProject([]byte(simple), false, nil)
+			p, _, err := createIntermediateProject([]byte(simple), false, nil)
 			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
 			m1 := *p.BuildVariants[0].Matrix

--- a/model/project_parser.go
+++ b/model/project_parser.go
@@ -27,7 +27,6 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	yaml2 "gopkg.in/yaml.v2"
 	"gopkg.in/yaml.v3"
 )
 
@@ -940,24 +939,25 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, pro
 	defer span.End()
 
 	unmarshalStrict := false
-	var anchorRegistry *anchorEntries
+	var registry *anchorRegistry
 	if opts != nil {
 		unmarshalStrict = opts.UnmarshalStrict
-		if opts.EnableYAMLAnchors {
-			anchorRegistry = &anchorEntries{}
+		if opts.CrossFileYAMLAnchorsEnabled {
+			registry = &anchorRegistry{}
 		}
 	}
-	intermediateProject, err := createIntermediateProject(data, unmarshalStrict, anchorRegistry)
+	intermediateProject, decodeErr, err := createIntermediateProject(data, unmarshalStrict, registry)
 	if err != nil {
 		return nil, errors.Wrapf(err, LoadProjectError)
 	}
+	logDecodeErrorWithOpts(ctx, projectID, "", "LoadProjectInto", decodeErr, opts)
 
 	if !slices.Contains(priorityBypassProjects, projectID) {
 		capParserPriorities(intermediateProject)
 	}
 
 	if len(intermediateProject.Include) > 0 {
-		if err := mergeIncludes(ctx, projectID, intermediateProject, anchorRegistry, opts); err != nil {
+		if err := mergeIncludes(ctx, projectID, intermediateProject, registry, opts); err != nil {
 			return nil, errors.Wrap(err, "merging included files")
 		}
 	}
@@ -982,6 +982,30 @@ func LoadProjectInto(ctx context.Context, data []byte, opts *GetProjectOpts, pro
 	return intermediateProject, errors.Wrapf(err, LoadProjectError)
 }
 
+func logDecodeErrorWithOpts(ctx context.Context, projectID, filename, caller string, decodeErr error, opts *GetProjectOpts) {
+	if decodeErr == nil {
+		return
+	}
+	logFields := message.Fields{
+		"message":        "anchor preamble parsing failed",
+		"ticket":         "DEVPROD-19220",
+		"project_id":     projectID,
+		"read_file_from": ReadFromGithub, // this is the default if unspecified
+	}
+	if opts != nil {
+		if opts.ReadFileFrom != "" {
+			logFields["read_file_from"] = opts.ReadFileFrom
+		}
+		if opts.PatchOpts != nil && opts.PatchOpts.patch != nil {
+			logFields["patch_id"] = opts.PatchOpts.patch.Id.Hex()
+		}
+	}
+	if filename != "" {
+		logFields["filename"] = filename
+	}
+	grip.Debug(ctx, message.WrapError(decodeErr, logFields))
+}
+
 // loadTranslateProject translates the post-merge intermediate project, optionally serving the
 // result from the content-hash translation cache keyed on its content and projectID.
 func loadTranslateProject(ctx context.Context, span trace.Span, intermediateProject *ParserProject, projectID, revision string, cacheEnabled bool) (*Project, error) {
@@ -989,7 +1013,7 @@ func loadTranslateProject(ctx context.Context, span trace.Span, intermediateProj
 }
 
 // mergeIncludes merges all included files into intermediateProject.
-func mergeIncludes(ctx context.Context, projectID string, intermediateProject *ParserProject, anchorRegistry *anchorEntries, opts *GetProjectOpts) error {
+func mergeIncludes(ctx context.Context, projectID string, intermediateProject *ParserProject, anchorRegistry *anchorRegistry, opts *GetProjectOpts) error {
 	ctx, span := tracer.Start(ctx, "mergeIncludes")
 	defer span.End()
 
@@ -1084,11 +1108,12 @@ func mergeIncludes(ctx context.Context, projectID string, intermediateProject *P
 			return errors.WithStack(errors.Errorf("yaml was nil in map for %s, but it never should be", path.FileName))
 		}
 
-		add, err := createIntermediateProject(yamlMap[path.FileName], opts.UnmarshalStrict, anchorRegistry)
+		add, decodeErr, err := createIntermediateProject(yamlMap[path.FileName], opts.UnmarshalStrict, anchorRegistry)
 		if err != nil {
 			// Return intermediateProject even if we run into issues to show merge progress.
 			return errors.Wrapf(err, "%s: loading file '%s'", LoadProjectError, path.FileName)
 		}
+		logDecodeErrorWithOpts(ctx, projectID, path.FileName, "mergeIncludes", decodeErr, opts)
 
 		if err = intermediateProject.mergeMultipleParserProjects(add); err != nil {
 			// Return intermediateProject even if we run into issues to show merge progress.
@@ -1366,8 +1391,9 @@ type GetProjectOpts struct {
 	// LocalIncludeDir is the base directory for resolving relative include
 	// file paths when ReadFileFrom is ReadFromLocal.
 	LocalIncludeDir string
-	// EnableYAMLAnchors opts into cross-file YAML anchor and alias support.
-	EnableYAMLAnchors bool
+	// CrossFileYAMLAnchorsEnabled enables cross-file YAML anchor and alias support.
+	// Must be set from the CrossFileYAMLAnchorsEnabled service flag; do not default to true.
+	CrossFileYAMLAnchorsEnabled bool
 	// cacheEnabled routes the translate step through the content-hash translation cache. It is only
 	// set internally by GetProjectFromFile from the ServiceFlag, so external callers stay uncached.
 	cacheEnabled bool
@@ -1600,6 +1626,11 @@ func GetProjectFromFile(ctx context.Context, opts GetProjectOpts, settings *ever
 	defer cancel()
 
 	opts.cacheEnabled = projectTranslationCacheEnabled(settings)
+	svcFlags, err := evergreen.GetServiceFlags(ctx)
+	if err != nil {
+		return ProjectInfo{}, errors.Wrap(err, "getting service flags")
+	}
+	opts.CrossFileYAMLAnchorsEnabled = svcFlags.CrossFileYAMLAnchorsEnabled
 
 	fileContents, err := retrieveFile(ctx, opts)
 	if err != nil {
@@ -1625,58 +1656,62 @@ func GetProjectFromFile(ctx context.Context, opts GetProjectOpts, settings *ever
 // createIntermediateProject marshals the supplied YAML into our intermediate project representation
 // (i.e. before selectors or matrix logic has been evaluated).
 // If unmarshalStrict is true, use the strict version of unmarshalling.
-// When anchorRegistry is non-nil, cross-file anchor support is enabled: existing anchors are prepended so the
-// parser can resolve cross-file aliases, and any new anchor definitions are appended to the registry for future files.
-func createIntermediateProject(parseBytes []byte, unmarshalStrict bool, anchorRegistry *anchorEntries) (*ParserProject, error) {
+// When anchorRegistry is non-nil, always uses decodeWithAnchors to collect anchors from each file
+// into the registry. If the registry already has entries, a preamble is prepended so aliases from
+// prior files resolve. Falls back to standard unmarshalling if decoding with anchors fails.
+func createIntermediateProject(parseBytes []byte, unmarshalStrict bool, anchorRegistry *anchorRegistry) (pp *ParserProject, decodeErr error, err error) {
+	if anchorRegistry != nil {
+		var combined []byte
+		if anchorRegistry.Length() > 0 {
+			var preamble []byte
+			preamble, decodeErr = buildAnchorPreamble(anchorRegistry)
+			if decodeErr == nil {
+				combined = append(preamble, parseBytes...)
+			}
+		}
+		if decodeErr == nil {
+			if combined == nil {
+				combined = parseBytes
+			}
+			pp, decodeErr = decodeWithAnchors(combined, unmarshalStrict, anchorRegistry)
+			if decodeErr == nil {
+				return pp, nil, nil
+			}
+		}
+	}
+	pp, err = standardUnmarshal(parseBytes, unmarshalStrict)
+	return pp, decodeErr, err
+}
+
+func standardUnmarshal(parseBytes []byte, unmarshalStrict bool) (*ParserProject, error) {
 	p := ParserProject{}
-
-	if anchorRegistry == nil {
-		if unmarshalStrict {
-			strictProjectWithVariables := struct {
-				ParserProject       `yaml:"pp,inline"`
-				ProjectConfigFields `yaml:"pc,inline"`
-				// Variables is only used to suppress yaml unmarshalling errors related
-				// to a non-existent variables field.
-				Variables any `yaml:"variables,omitempty" bson:"-"`
-			}{}
-			if err := util.UnmarshalYAMLStrictWithFallback(parseBytes, &strictProjectWithVariables); err != nil {
-				return nil, errors.Wrap(err, "unmarshalling parser project from YAML")
-			}
-			p = strictProjectWithVariables.ParserProject
-			if !strictProjectWithVariables.ProjectConfigFields.isEmpty() {
-				p.projectConfigFields = &strictProjectWithVariables.ProjectConfigFields
-			}
-		} else {
-			if err := util.UnmarshalYAMLWithFallback(parseBytes, &p); err != nil {
-				return nil, errors.Wrap(err, "unmarshalling parser project from YAML")
-			}
-			if err := p.setProjectConfigFields(parseBytes); err != nil {
-				return nil, err
-			}
+	if unmarshalStrict {
+		strictProjectWithVariables := struct {
+			ParserProject       `yaml:"pp,inline"`
+			ProjectConfigFields `yaml:"pc,inline"`
+			// Variables is only used to suppress yaml unmarshalling errors related
+			// to a non-existent variables field.
+			Variables any `yaml:"variables,omitempty" bson:"-"`
+		}{}
+		if err := util.UnmarshalYAMLStrictWithFallback(parseBytes, &strictProjectWithVariables); err != nil {
+			return nil, errors.Wrap(err, "unmarshalling parser project from YAML")
 		}
-		if p.Functions == nil {
-			p.Functions = map[string]*YAMLCommandSet{}
+		p = strictProjectWithVariables.ParserProject
+		if !strictProjectWithVariables.ProjectConfigFields.isEmpty() {
+			p.projectConfigFields = &strictProjectWithVariables.ProjectConfigFields
 		}
-		return &p, nil
-	}
-
-	// Prepend accumulated anchors as a preamble so the parser can resolve cross-file aliases.
-	if len(*anchorRegistry) > 0 {
-		preamble, err := buildAnchorPreamble(anchorRegistry)
-		if err != nil {
-			return nil, errors.Wrap(err, "building anchor preamble")
+	} else {
+		if err := util.UnmarshalYAMLWithFallback(parseBytes, &p); err != nil {
+			return nil, errors.Wrap(err, "unmarshalling parser project from YAML")
 		}
-		parseBytes = append(preamble, parseBytes...)
+		if err := p.setProjectConfigFields(parseBytes); err != nil {
+			return nil, err
+		}
 	}
-
-	result, err := decodeWithAnchors(parseBytes, unmarshalStrict, anchorRegistry)
-	if err != nil {
-		return nil, errors.Wrap(err, "decoding project with anchors")
+	if p.Functions == nil {
+		p.Functions = map[string]*YAMLCommandSet{}
 	}
-	if result.Functions == nil {
-		result.Functions = map[string]*YAMLCommandSet{}
-	}
-	return result, nil
+	return &p, nil
 }
 
 func (pp *ParserProject) setProjectConfigFields(parseBytes []byte) error {
@@ -1711,7 +1746,7 @@ func (pp *ParserProject) MergedProjectConfig(identifier string) *ProjectConfig {
 // decodeWithAnchors decodes parseBytes into a ParserProject using a yaml.Node as an intermediate
 // representation, and merges any new anchor definitions found into anchorRegistry. Returns an
 // empty ParserProject for empty input.
-func decodeWithAnchors(parseBytes []byte, unmarshalStrict bool, anchorRegistry *anchorEntries) (*ParserProject, error) {
+func decodeWithAnchors(parseBytes []byte, unmarshalStrict bool, anchorRegistry *anchorRegistry) (*ParserProject, error) {
 	var node yaml.Node
 	if err := yaml.NewDecoder(bytes.NewReader(parseBytes)).Decode(&node); err != nil && !errors.Is(err, io.EOF) {
 		yamlErr := thirdparty.YAMLFormatError{Message: err.Error()}
@@ -1742,30 +1777,16 @@ func decodeWithAnchors(parseBytes []byte, unmarshalStrict bool, anchorRegistry *
 		p = strictProjectWithVariables.ParserProject
 	} else {
 		if err := node.Decode(&p); err != nil {
-			// yaml.v3 node decode failed; fall back to yaml.v2, which is more lenient.
-			// The node is still used for anchor collection below.
-			p = ParserProject{}
-			if err2 := yaml2.Unmarshal(parseBytes, &p); err2 != nil {
-				yamlErr := thirdparty.YAMLFormatError{Message: err2.Error()}
-				return nil, errors.Wrap(yamlErr, "unmarshalling parser project from YAML")
-			}
+			yamlErr := thirdparty.YAMLFormatError{Message: err.Error()}
+			return nil, errors.Wrap(yamlErr, "unmarshalling parser project from YAML")
 		}
 	}
 
-	for _, anchor := range collectAnchors(&node) {
-		replaced := false
-		for i, existing := range *anchorRegistry {
-			if existing.name == anchor.name {
-				(*anchorRegistry)[i] = anchor
-				replaced = true
-				break
-			}
-		}
-		if !replaced {
-			*anchorRegistry = append(*anchorRegistry, anchor)
-		}
-	}
+	anchorRegistry.mergeAnchorsFrom(&node)
 
+	if p.Functions == nil {
+		p.Functions = map[string]*YAMLCommandSet{}
+	}
 	return &p, nil
 }
 

--- a/model/project_parser_anchors.go
+++ b/model/project_parser_anchors.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
 )
 
@@ -16,17 +17,46 @@ type anchorEntry struct {
 	node *yaml.Node
 }
 
-// anchorEntries accumulates YAML anchor definitions across include files for cross-file alias resolution.
-type anchorEntries []anchorEntry
+// anchorRegistry accumulates YAML anchor definitions across include files for cross-file alias resolution.
+type anchorRegistry struct {
+	entries []anchorEntry
+}
+
+// Length returns the number of entries, or 0 if the receiver is nil.
+func (a *anchorRegistry) Length() int {
+	if a == nil {
+		return 0
+	}
+	return len(a.entries)
+}
+
+// mergeAnchorsFrom collects all anchor definitions from node and merges them
+// into the registry by name. Move re-defined anchors to later in the list to
+// ensure they're defined after dependencies (i.e. any other new anchors that
+// they themselves reference).
+func (a *anchorRegistry) mergeAnchorsFrom(node *yaml.Node) {
+	if a == nil {
+		return
+	}
+	for _, anchor := range collectAnchors(node) {
+		for i, existing := range a.entries {
+			if existing.name == anchor.name {
+				a.entries = append(a.entries[:i], a.entries[i+1:]...)
+				break
+			}
+		}
+		a.entries = append(a.entries, anchor)
+	}
+}
 
 // collectAnchors walks node in pre-order and returns all anchored nodes in
 // encounter order. AliasNodes are not followed, so only anchor definitions
 // (&name) are collected, never alias uses (*name).
-func collectAnchors(node *yaml.Node) anchorEntries {
+func collectAnchors(node *yaml.Node) []anchorEntry {
 	if node == nil {
 		return nil
 	}
-	var entries anchorEntries
+	var entries []anchorEntry
 	var walk func(*yaml.Node)
 	walk = func(n *yaml.Node) {
 		if n == nil || n.Kind == yaml.AliasNode {
@@ -51,12 +81,12 @@ func collectAnchors(node *yaml.Node) anchorEntries {
 // Entries must be in encounter order so that any alias references within anchor
 // values (e.g. an anchor whose value itself uses an alias to an earlier anchor)
 // are valid when the preamble is parsed.
-func buildAnchorPreamble(entries *anchorEntries) ([]byte, error) {
-	if entries == nil || len(*entries) == 0 {
+func buildAnchorPreamble(registry *anchorRegistry) ([]byte, error) {
+	if registry.Length() == 0 {
 		return nil, nil
 	}
-	seqContent := make([]*yaml.Node, 0, len(*entries))
-	for _, e := range *entries {
+	seqContent := make([]*yaml.Node, 0, len(registry.entries))
+	for _, e := range registry.entries {
 		seqContent = append(seqContent, e.node)
 	}
 	preambleDoc := &yaml.Node{
@@ -71,7 +101,8 @@ func buildAnchorPreamble(entries *anchorEntries) ([]byte, error) {
 			},
 		},
 	}
-	return yaml.Marshal(preambleDoc)
+	out, err := yaml.Marshal(preambleDoc)
+	return out, errors.Wrap(err, "building anchor preamble")
 }
 
 // stripEvgAnchorsKey removes the _evg_anchors key and its value from the

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -67,7 +67,7 @@ tasks:
     status: "failed"
     patch_optional: true
 `
-			p, err := createIntermediateProject([]byte(simple), false, nil)
+			p, _, err := createIntermediateProject([]byte(simple), false, nil)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(p.Tasks[2].DependsOn[0].TaskSelector.Name, ShouldEqual, "compile")
@@ -84,7 +84,7 @@ tasks:
 - name: task1
   depends_on: task0
 `
-			p, err := createIntermediateProject([]byte(single), false, nil)
+			p, _, err := createIntermediateProject([]byte(single), false, nil)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(p.Tasks[2].DependsOn[0].TaskSelector.Name, ShouldEqual, "task0")
@@ -96,7 +96,7 @@ tasks:
 - name: "compile"
   depends_on: ""
 `
-				p, err := createIntermediateProject([]byte(nameless), false, nil)
+				p, _, err := createIntermediateProject([]byte(nameless), false, nil)
 				So(p, ShouldBeNil)
 				So(err, ShouldNotBeNil)
 			})
@@ -108,7 +108,7 @@ tasks:
   - name: "task1"
   - status: "failed" #this has no task attached
 `
-				p, err := createIntermediateProject([]byte(nameless), false, nil)
+				p, _, err := createIntermediateProject([]byte(nameless), false, nil)
 				So(p, ShouldBeNil)
 				So(err, ShouldNotBeNil)
 			})
@@ -117,7 +117,7 @@ tasks:
 tasks:
 - name: "compile"
 `
-				p, err := createIntermediateProject([]byte(nameless), false, nil)
+				p, _, err := createIntermediateProject([]byte(nameless), false, nil)
 				So(p, ShouldNotBeNil)
 				So(err, ShouldBeNil)
 			})
@@ -146,7 +146,7 @@ buildvariants:
     stepback: false
     priority: 77
 `
-			p, err := createIntermediateProject([]byte(simple), false, nil)
+			p, _, err := createIntermediateProject([]byte(simple), false, nil)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			bv := p.BuildVariants[0]
@@ -170,7 +170,7 @@ buildvariants:
   - name: "t2"
     depends_on: "t3"
 `
-			p, err := createIntermediateProject([]byte(simple), false, nil)
+			p, _, err := createIntermediateProject([]byte(simple), false, nil)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			bv := p.BuildVariants[0]
@@ -188,7 +188,7 @@ buildvariants:
   tasks:
     name: "t1"
 `
-			p, err := createIntermediateProject([]byte(simple), false, nil)
+			p, _, err := createIntermediateProject([]byte(simple), false, nil)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(len(p.BuildVariants), ShouldEqual, 2)
@@ -212,7 +212,7 @@ buildvariants:
   run_on: "distro1"
   tasks: "*"
 `
-			p, err := createIntermediateProject([]byte(single), false, nil)
+			p, _, err := createIntermediateProject([]byte(single), false, nil)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(len(p.Ignore), ShouldEqual, 1)
@@ -233,7 +233,7 @@ buildvariants:
   - name: "t1"
     run_on: "test"
 `
-			p, err := createIntermediateProject([]byte(single), false, nil)
+			p, _, err := createIntermediateProject([]byte(single), false, nil)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			So(p.BuildVariants[0].Tasks[0].RunOn[0], ShouldEqual, "test")
@@ -248,7 +248,7 @@ buildvariants:
     run_on: "test"
     distros: "asdasdasd"
 `
-			p, err := createIntermediateProject([]byte(single), false, nil)
+			p, _, err := createIntermediateProject([]byte(single), false, nil)
 			So(p, ShouldBeNil)
 			So(err, ShouldNotBeNil)
 		})
@@ -260,7 +260,7 @@ buildvariants:
   - name: "t1"
     commit_queue_merge: true
 `
-			p, err := createIntermediateProject([]byte(single), false, nil)
+			p, _, err := createIntermediateProject([]byte(single), false, nil)
 			So(p, ShouldNotBeNil)
 			So(err, ShouldBeNil)
 			bv := p.BuildVariants[0]
@@ -283,7 +283,7 @@ buildvariants:
   - name: "t1"
     activate: true
 `
-	p, err := createIntermediateProject([]byte(yml), false, nil)
+	p, _, err := createIntermediateProject([]byte(yml), false, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, p)
 	bv := p.BuildVariants[0]
@@ -1018,7 +1018,7 @@ tasks:
 - name: execTask3
 - name: execTask4
 `
-	p, err := createIntermediateProject([]byte(yml), false, nil)
+	p, _, err := createIntermediateProject([]byte(yml), false, nil)
 
 	// check that display tasks in bv1 parsed correctly
 	assert.NoError(err)
@@ -1047,7 +1047,7 @@ parameters:
 - key: buggy
   value: driver
 `
-	p, err := createIntermediateProject([]byte(yml), false, nil)
+	p, _, err := createIntermediateProject([]byte(yml), false, nil)
 	assert.NoError(t, err)
 	require.Len(t, p.Parameters, 2)
 	assert.Equal(t, "iter_count", p.Parameters[0].Key)
@@ -1356,7 +1356,7 @@ tasks:
 - name: execTask4
   tags: [ "even" ]
 `
-	pp, err := createIntermediateProject([]byte(tagYml), false, nil)
+	pp, _, err := createIntermediateProject([]byte(tagYml), false, nil)
 	assert.NotNil(pp)
 	assert.NoError(err)
 	require.Len(pp.BuildVariants[0].DisplayTasks, 2)
@@ -2176,7 +2176,7 @@ buildvariants:
 }
 
 func checkProjectPersists(ctx context.Context, t *testing.T, env evergreen.Environment, yml []byte, ppStorageMethod evergreen.ParserProjectStorageMethod) {
-	pp, err := createIntermediateProject(yml, false, nil)
+	pp, _, err := createIntermediateProject(yml, false, nil)
 	assert.NoError(t, err)
 	pp.Id = "my-project"
 	pp.Identifier = utility.ToStringPtr("old-project-identifier")
@@ -2199,7 +2199,7 @@ func checkProjectPersists(ctx context.Context, t *testing.T, env evergreen.Envir
 	assert.True(t, bytes.Equal(newYaml, yamlToCompare))
 
 	// ensure that updating with the re-parsed project doesn't error
-	pp, err = createIntermediateProject(newYaml, false, nil)
+	pp, _, err = createIntermediateProject(newYaml, false, nil)
 	assert.NoError(t, err)
 	pp.Id = "my-project"
 	pp.Identifier = utility.ToStringPtr("new-project-identifier")
@@ -2226,7 +2226,7 @@ func TestParserProjectRoundtrip(t *testing.T) {
 	yml, err := os.ReadFile(filepath)
 	assert.NoError(t, err)
 
-	original, err := createIntermediateProject(yml, false, nil)
+	original, _, err := createIntermediateProject(yml, false, nil)
 	assert.NoError(t, err)
 
 	// to and from yaml
@@ -2850,10 +2850,10 @@ ignore:
   - ".github/*"
 `
 
-	p1, err := createIntermediateProject([]byte(mainYaml), false, nil)
+	p1, _, err := createIntermediateProject([]byte(mainYaml), false, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, p1)
-	p2, err := createIntermediateProject([]byte(smallYaml), false, nil)
+	p2, _, err := createIntermediateProject([]byte(smallYaml), false, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, p2)
 	err = p1.mergeMultipleParserProjects(p2)
@@ -2899,13 +2899,13 @@ buildvariants:
       - name: task3
 `
 
-	p1, err := createIntermediateProject([]byte(mainYaml), false, nil)
+	p1, _, err := createIntermediateProject([]byte(mainYaml), false, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, p1)
-	p2, err := createIntermediateProject([]byte(succeed), false, nil)
+	p2, _, err := createIntermediateProject([]byte(succeed), false, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, p2)
-	p3, err := createIntermediateProject([]byte(fail), false, nil)
+	p3, _, err := createIntermediateProject([]byte(fail), false, nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, p3)
 	err = p1.mergeMultipleParserProjects(p2)
@@ -2943,9 +2943,9 @@ commit_queue_aliases:
   - variant: ".*"
     task: ".*"
 `
-		p1, err := createIntermediateProject([]byte(mainYaml), false, nil)
+		p1, _, err := createIntermediateProject([]byte(mainYaml), false, nil)
 		require.NoError(t, err)
-		p2, err := createIntermediateProject([]byte(includedYaml), false, nil)
+		p2, _, err := createIntermediateProject([]byte(includedYaml), false, nil)
 		require.NoError(t, err)
 
 		p1.mergeProjectConfigFields(p2)
@@ -2973,9 +2973,9 @@ task_annotation_settings:
   file_ticket_webhook:
     endpoint: "https://example.com"
 `
-		p1, err := createIntermediateProject([]byte(mainYaml), false, nil)
+		p1, _, err := createIntermediateProject([]byte(mainYaml), false, nil)
 		require.NoError(t, err)
-		p2, err := createIntermediateProject([]byte(includedYaml), false, nil)
+		p2, _, err := createIntermediateProject([]byte(includedYaml), false, nil)
 		require.NoError(t, err)
 
 		p1.mergeProjectConfigFields(p2)
@@ -3005,7 +3005,7 @@ workstation_config:
 `
 		for name, unmarshalStrict := range map[string]bool{"Strict": true, "NonStrict": false} {
 			t.Run(name, func(t *testing.T) {
-				pp, err := createIntermediateProject([]byte(singleFileYaml), unmarshalStrict, nil)
+				pp, _, err := createIntermediateProject([]byte(singleFileYaml), unmarshalStrict, nil)
 				require.NoError(t, err)
 				merged := pp.MergedProjectConfig("my-project")
 				require.NotNil(t, merged)
@@ -3022,7 +3022,7 @@ workstation_config:
 	})
 
 	t.Run("ConfigFieldsAreNotMarshalled", func(t *testing.T) {
-		pp, err := createIntermediateProject([]byte(`
+		pp, _, err := createIntermediateProject([]byte(`
 stepback: true
 patch_aliases:
   - alias: "my-alias"
@@ -3591,7 +3591,7 @@ tasks:
 - name: task2
   commands: *common-commands
 `
-	p, err := createIntermediateProject([]byte(yml), false, nil)
+	p, _, err := createIntermediateProject([]byte(yml), false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, p)
 	require.Len(t, p.Tasks, 2)
@@ -3619,7 +3619,7 @@ tasks:
       os: linux
       arch: amd64
 `
-	p, err := createIntermediateProject([]byte(yml), false, nil)
+	p, _, err := createIntermediateProject([]byte(yml), false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, p)
 	require.Len(t, p.Tasks, 1)
@@ -3635,17 +3635,13 @@ tasks:
 }
 
 // moduleIncludeOpts builds GetProjectOpts that serves include files from
-// inline bytes, bypassing GitHub and git.
-func moduleIncludeOpts(includes ...patch.LocalModuleInclude) *GetProjectOpts {
-	return &GetProjectOpts{LocalModuleIncludes: includes}
-}
-
-// anchorModuleIncludeOpts is like moduleIncludeOpts but also enables cross-file
-// YAML anchor support, which is required for cross-file alias tests.
-func anchorModuleIncludeOpts(includes ...patch.LocalModuleInclude) *GetProjectOpts {
-	opts := moduleIncludeOpts(includes...)
-	opts.EnableYAMLAnchors = true
-	return opts
+// inline bytes, bypassing GitHub and git, with cross-file YAML anchors enabled.
+func moduleIncludeOpts(t testing.TB, includes ...patch.LocalModuleInclude) *GetProjectOpts {
+	t.Helper()
+	return &GetProjectOpts{
+		LocalModuleIncludes:         includes,
+		CrossFileYAMLAnchorsEnabled: true,
+	}
 }
 
 // mainYAMLWithModuleIncludes builds a minimal main YAML that declares one
@@ -3707,7 +3703,8 @@ steps:
 	anchors := collectAnchors(&node)
 	require.Len(t, anchors, 2)
 
-	preamble, err := buildAnchorPreamble(&anchors)
+	registry := &anchorRegistry{entries: anchors}
+	preamble, err := buildAnchorPreamble(registry)
 	require.NoError(t, err)
 	require.NotEmpty(t, preamble)
 
@@ -3749,7 +3746,7 @@ tasks:
 `
 	proj := &Project{}
 	_, err := LoadProjectInto(t.Context(), []byte(mainYAML),
-		anchorModuleIncludeOpts(moduleInclude("include.yml", includeYAML)), "proj", proj)
+		moduleIncludeOpts(t, moduleInclude("include.yml", includeYAML)), "proj", proj)
 	require.NoError(t, err)
 
 	tasksByName := map[string]ProjectTask{}
@@ -3785,7 +3782,7 @@ tasks:
 `
 	proj := &Project{}
 	_, err := LoadProjectInto(t.Context(), []byte(mainYAML),
-		anchorModuleIncludeOpts(
+		moduleIncludeOpts(t,
 			moduleInclude("first.yml", firstYAML),
 			moduleInclude("second.yml", secondYAML),
 		), "proj", proj)
@@ -3824,7 +3821,7 @@ tasks:
 `
 	proj := &Project{}
 	_, err := LoadProjectInto(t.Context(), []byte(mainYAML),
-		anchorModuleIncludeOpts(
+		moduleIncludeOpts(t,
 			moduleInclude("first.yml", firstYAML),
 			moduleInclude("second.yml", secondYAML),
 		), "proj", proj)
@@ -3866,7 +3863,7 @@ tasks:
 `
 	proj := &Project{}
 	_, err := LoadProjectInto(t.Context(), []byte(mainYAML),
-		anchorModuleIncludeOpts(
+		moduleIncludeOpts(t,
 			moduleInclude("first.yml", firstYAML),
 			moduleInclude("second.yml", secondYAML),
 			moduleInclude("third.yml", thirdYAML),
@@ -3894,6 +3891,118 @@ tasks:
 	require.Contains(t, tasksByName, "third-task")
 	require.Len(t, tasksByName["third-task"].Commands, 1)
 	assert.Equal(t, "git.get_project", tasksByName["third-task"].Commands[0].Command)
+}
+
+// TestAnchorRedefinedWithAliasDependencyDoesNotError is a regression test for a
+// production bug where a project failed to load with "unknown anchor" errors.
+//
+// The failure pattern requires three files:
+//  1. first.yml defines &template-expansions with a plain string value (no aliases).
+//  2. second.yml defines &compile-dependency (a mapping) that contains a nested
+//     scalar anchor &compile-variant. It also redefines &template-expansions,
+//     replacing the plain string with an alias: compile_variant: *compile-variant.
+//  3. third.yml need not reference these anchors at all; the bug fires when
+//     building the preamble injected before third.yml is parsed.
+//
+// Before the fix, upsert updated the registry entry for &template-expansions
+// in-place, so it stayed at its original index K. The new entries
+// &compile-dependency and &compile-variant were appended after K. When the
+// preamble was marshaled, &template-expansions appeared before &compile-variant,
+// causing the re-parse to fail with "unknown anchor 'compile-variant' referenced".
+//
+// After the fix, when an anchor is redefined, the old entry is removed and the
+// new one is appended at the end, so all dependencies always precede their users.
+func TestAnchorRedefinedWithAliasDependencyDoesNotError(t *testing.T) {
+	mainYAML := mainYAMLWithModuleIncludes("", "first.yml", "second.yml", "third.yml")
+
+	// first.yml: &task-template has no alias dependencies.
+	firstYAML := `
+tasks:
+- name: first-task
+  commands:
+  - &task-template
+    command: shell.exec
+    params:
+      script: ./first.sh
+`
+	// second.yml: &compile-setup is a mapping anchor with a nested scalar anchor
+	// &compile-script (on the params.script value). It also redefines
+	// &task-template so that its params.script uses *compile-script.
+	secondYAML := `
+tasks:
+- name: second-task
+  commands:
+  - &compile-setup
+    command: shell.exec
+    params:
+      script: &compile-script ./compile.sh
+  - command: shell.exec
+    params:
+      script: *compile-script
+  - &task-template
+    command: shell.exec
+    params:
+      script: *compile-script
+`
+	// third.yml: nothing that references these anchors; the preamble parse still
+	// fails before any content is processed if the ordering is wrong.
+	thirdYAML := `
+tasks:
+- name: third-task
+  commands:
+  - command: shell.exec
+    params:
+      script: ./third.sh
+`
+	proj := &Project{}
+	_, err := LoadProjectInto(t.Context(), []byte(mainYAML),
+		moduleIncludeOpts(t,
+			moduleInclude("first.yml", firstYAML),
+			moduleInclude("second.yml", secondYAML),
+			moduleInclude("third.yml", thirdYAML),
+		), "proj", proj)
+	require.NoError(t, err, "preamble ordering bug: anchor redefined with alias dependency should not produce unknown-anchor error")
+}
+
+// TestAnchorPreambleFailureFallsBack verifies that if the anchor preamble itself is
+// invalid (alias-before-definition ordering), createIntermediateProject falls back to
+// parsing without the preamble rather than propagating the error. This guards against
+// any future preamble-construction bugs breaking projects that don't use cross-file anchors.
+func TestAnchorPreambleFailureFallsBack(t *testing.T) {
+	// Build a registry with broken ordering: entry 0 is a mapping that contains
+	// *my-anchor (an AliasNode), but entry 1 is the node that defines &my-anchor.
+	// Marshaling this produces alias-before-definition in the preamble YAML.
+	scalarNode := &yaml.Node{Kind: yaml.ScalarNode, Value: "hello", Anchor: "my-anchor"}
+	aliasNode := &yaml.Node{Kind: yaml.AliasNode, Value: "my-anchor", Alias: scalarNode}
+	mappingNode := &yaml.Node{
+		Kind:   yaml.MappingNode,
+		Anchor: "my-template",
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "key"},
+			aliasNode,
+		},
+	}
+	registry := &anchorRegistry{
+		entries: []anchorEntry{
+			{name: "my-template", node: mappingNode},
+			{name: "my-anchor", node: scalarNode},
+		},
+	}
+
+	// Confirm the preamble is invalid on re-parse (alias appears before its definition).
+	preamble, err := buildAnchorPreamble(registry)
+	require.NoError(t, err)
+	var preambleNode yaml.Node
+	require.Error(t, yaml.NewDecoder(bytes.NewReader(preamble)).Decode(&preambleNode),
+		"preamble should fail to parse due to alias-before-definition")
+
+	// createIntermediateProject should fall back to parsing without the preamble.
+	simpleYAML := []byte("tasks:\n- name: my-task\n  commands:\n  - command: shell.exec\n")
+	result, preambleErr, err := createIntermediateProject(simpleYAML, false, registry)
+	require.NoError(t, err, "should succeed via fallback when preamble is invalid")
+	require.Error(t, preambleErr, "preamble error should be set when fallback occurs")
+	require.Len(t, result.Tasks, 1)
+	assert.Equal(t, "my-task", result.Tasks[0].Name)
 }
 
 // TestAnchorWithNestedAlias verifies that a file can use an alias from an
@@ -3932,7 +4041,7 @@ tasks:
 `
 	proj := &Project{}
 	_, err := LoadProjectInto(t.Context(), []byte(mainYAML),
-		anchorModuleIncludeOpts(
+		moduleIncludeOpts(t,
 			moduleInclude("first.yml", firstYAML),
 			moduleInclude("second.yml", secondYAML),
 			moduleInclude("third.yml", thirdYAML),
@@ -3968,7 +4077,7 @@ tasks:
 `
 	proj := &Project{}
 	pp, err := LoadProjectInto(t.Context(), []byte(mainYAML),
-		anchorModuleIncludeOpts(moduleInclude("include.yml", includeYAML)), "proj", proj)
+		moduleIncludeOpts(t, moduleInclude("include.yml", includeYAML)), "proj", proj)
 	require.NoError(t, err)
 
 	// Marshal the parser project back to YAML and confirm _evg_anchors is absent.
@@ -3998,7 +4107,7 @@ tasks:
   - *step
 `
 	proj := &Project{}
-	opts := anchorModuleIncludeOpts(moduleInclude("include.yml", includeYAML))
+	opts := moduleIncludeOpts(t, moduleInclude("include.yml", includeYAML))
 	opts.UnmarshalStrict = true
 	_, err := LoadProjectInto(t.Context(), []byte(mainYAML), opts, "proj", proj)
 	require.NoError(t, err)
@@ -4010,6 +4119,92 @@ tasks:
 	require.Contains(t, tasksByName, "include-task")
 	require.Len(t, tasksByName["include-task"].Commands, 1)
 	assert.Equal(t, "shell.exec", tasksByName["include-task"].Commands[0].Command)
+}
+
+// TestMergeKeyListSyntaxInIncludeFile verifies that the standard YAML list merge
+// key syntax (<<: [*a, *b]) works correctly when the referenced anchors are
+// defined in an earlier include file. Earlier entries in the list take priority
+// over later ones for conflicting keys.
+func TestMergeKeyListSyntaxInIncludeFile(t *testing.T) {
+	mainYAML := mainYAMLWithModuleIncludes(`
+tasks:
+- name: main-task
+  commands:
+  - &base-cmd
+    command: shell.exec
+    params:
+      script: ./base.sh
+      working_dir: src
+  - &override-cmd
+    command: shell.exec
+    params:
+      script: ./override.sh
+`, "include.yml")
+
+	// include.yml uses <<: [*base-cmd, *override-cmd]; earlier entry (*base-cmd) wins on conflicts.
+	includeYAML := `
+tasks:
+- name: include-task
+  commands:
+  - <<: [*base-cmd, *override-cmd]
+`
+	proj := &Project{}
+	_, err := LoadProjectInto(t.Context(), []byte(mainYAML),
+		moduleIncludeOpts(t, moduleInclude("include.yml", includeYAML)), "proj", proj)
+	require.NoError(t, err)
+
+	tasksByName := map[string]ProjectTask{}
+	for _, task := range proj.Tasks {
+		tasksByName[task.Name] = task
+	}
+	require.Contains(t, tasksByName, "include-task")
+	require.Len(t, tasksByName["include-task"].Commands, 1)
+	// *base-cmd is listed first in the merge list, so it wins on key conflicts.
+	// Both command: shell.exec entries agree, so the command field is shell.exec.
+	assert.Equal(t, "shell.exec", tasksByName["include-task"].Commands[0].Command)
+}
+
+// TestIncludeFileWithLocalAnchorOnlyParsesCorrectly verifies that a project whose
+// include file uses anchors only within that file (no cross-file aliases) parses
+// correctly regardless of whether cross-file anchors are enabled. This is the primary
+// backwards-compatibility check for the preamble injection change.
+func TestIncludeFileWithLocalAnchorOnlyParsesCorrectly(t *testing.T) {
+	mainYAML := mainYAMLWithModuleIncludes(`
+tasks:
+- name: main-task
+  commands:
+  - &shared-cmd
+    command: shell.exec
+    params:
+      script: ./run.sh
+`, "include.yml")
+
+	// include.yml defines its own anchor and does NOT reference any anchor from main.
+	includeYAML := `
+tasks:
+- name: include-task
+  commands:
+  - &local-cmd
+    command: shell.exec
+    params:
+      script: ./include.sh
+  - *local-cmd
+buildvariants:
+- name: linux
+  display_name: Linux
+  run_on:
+  - rhel80-small
+  tasks:
+  - name: include-task
+`
+	proj := &Project{}
+	opts := moduleIncludeOpts(t, moduleInclude("include.yml", includeYAML))
+	_, err := LoadProjectInto(t.Context(), []byte(mainYAML), opts, "proj", proj)
+	require.NoError(t, err)
+	require.Len(t, proj.Tasks, 2)
+	require.Len(t, proj.BuildVariants, 1)
+	assert.Equal(t, "include-task", proj.Tasks[1].Name)
+	assert.Len(t, proj.Tasks[1].Commands, 2)
 }
 
 // TestNoAnchorsInIncludeFiles verifies that projects without anchors produce
@@ -4030,7 +4225,7 @@ tasks:
 `
 	proj := &Project{}
 	_, err := LoadProjectInto(t.Context(), []byte(mainYAML),
-		anchorModuleIncludeOpts(moduleInclude("include.yml", includeYAML)), "proj", proj)
+		moduleIncludeOpts(t, moduleInclude("include.yml", includeYAML)), "proj", proj)
 	require.NoError(t, err)
 
 	tasksByName := map[string]ProjectTask{}
@@ -4066,7 +4261,7 @@ buildvariants:
 `
 	proj := &Project{}
 	_, err := LoadProjectInto(t.Context(), []byte(mainYAML),
-		anchorModuleIncludeOpts(moduleInclude("include.yml", includeYAML)), "proj", proj)
+		moduleIncludeOpts(t, moduleInclude("include.yml", includeYAML)), "proj", proj)
 	require.NoError(t, err)
 
 	require.Len(t, proj.BuildVariants, 1)
@@ -4098,7 +4293,7 @@ tasks:
 `
 	proj := &Project{}
 	_, err := LoadProjectInto(t.Context(), []byte(mainYAML),
-		anchorModuleIncludeOpts(moduleInclude("include.yml", includeYAML)), "proj", proj)
+		moduleIncludeOpts(t, moduleInclude("include.yml", includeYAML)), "proj", proj)
 	require.NoError(t, err)
 
 	tasksByName := map[string]ProjectTask{}
@@ -4340,4 +4535,119 @@ func mustLoadIntermediate(t *testing.T, yml string) *ParserProject {
 	pp, err := LoadProjectInto(t.Context(), []byte(yml), nil, "id", proj)
 	require.NoError(t, err)
 	return pp
+}
+
+// TestAnchorInFunctionsDefinition verifies that anchors defined inside a
+// functions block in the main file can be aliased in an include file.
+func TestAnchorInFunctionsDefinition(t *testing.T) {
+	mainYAML := mainYAMLWithModuleIncludes(`
+functions:
+  setup: &setup-cmds
+    command: shell.exec
+    params:
+      script: ./setup.sh
+`, "include.yml")
+
+	includeYAML := `
+tasks:
+- name: use-setup
+  commands:
+  - *setup-cmds
+`
+	proj := &Project{}
+	_, err := LoadProjectInto(t.Context(), []byte(mainYAML),
+		moduleIncludeOpts(t, moduleInclude("include.yml", includeYAML)), "proj", proj)
+	require.NoError(t, err)
+	require.Len(t, proj.Tasks, 1)
+	assert.Equal(t, "use-setup", proj.Tasks[0].Name)
+	require.Len(t, proj.Tasks[0].Commands, 1)
+	assert.Equal(t, "shell.exec", proj.Tasks[0].Commands[0].Command)
+}
+
+// TestAliasInMainReferencingIncludeAnchorShouldError documents that anchors
+// defined in an include file cannot be aliased in the main file, because the
+// main file is parsed before any includes are processed.
+func TestAliasInMainReferencingIncludeAnchorShouldError(t *testing.T) {
+	mainYAML := mainYAMLWithModuleIncludes(`
+tasks:
+- name: main-task
+  commands:
+  - *from-include
+`, "include.yml")
+
+	includeYAML := `
+tasks:
+- name: include-task
+  commands:
+  - &from-include
+    command: shell.exec
+`
+	proj := &Project{}
+	_, err := LoadProjectInto(t.Context(), []byte(mainYAML),
+		moduleIncludeOpts(t, moduleInclude("include.yml", includeYAML)), "proj", proj)
+	require.Error(t, err)
+}
+
+// TestWithinSingleFileNoIncludes confirms that single-file projects with
+// anchors continue to work exactly as before (no regressions from always-on).
+func TestWithinSingleFileNoIncludes(t *testing.T) {
+	yml := `
+tasks:
+- name: base
+  commands:
+  - &cmd
+    command: shell.exec
+    params:
+      script: ./run.sh
+- name: derived
+  commands:
+  - *cmd
+`
+	proj := &Project{}
+	_, err := LoadProjectInto(t.Context(), []byte(yml), nil, "proj", proj)
+	require.NoError(t, err)
+
+	byName := map[string]ProjectTask{}
+	for _, task := range proj.Tasks {
+		byName[task.Name] = task
+	}
+	require.Contains(t, byName, "derived")
+	require.Len(t, byName["derived"].Commands, 1)
+	assert.Equal(t, "shell.exec", byName["derived"].Commands[0].Command)
+}
+
+// BenchmarkLoadProjectWithCrossFileAnchors measures end-to-end project loading
+// with cross-file anchors across several include files.
+func BenchmarkLoadProjectWithCrossFileAnchors(b *testing.B) {
+	const numIncludes = 10
+	includes := make([]patch.LocalModuleInclude, 0, numIncludes)
+	filenames := make([]string, 0, numIncludes)
+	for i := range numIncludes {
+		fn := fmt.Sprintf("inc%d.yml", i)
+		filenames = append(filenames, fn)
+		content := fmt.Sprintf(`
+tasks:
+- name: task-%d
+  commands:
+  - *common-setup
+`, i)
+		includes = append(includes, moduleInclude(fn, content))
+	}
+	mainYAML := mainYAMLWithModuleIncludes(`
+tasks:
+- name: setup
+  commands:
+  - &common-setup
+    command: shell.exec
+    params:
+      script: ./setup.sh
+`, filenames...)
+	opts := moduleIncludeOpts(b, includes...)
+
+	b.ResetTimer()
+	for range b.N {
+		proj := &Project{}
+		_, err := LoadProjectInto(b.Context(), []byte(mainYAML), opts, "proj", proj)
+		require.NoError(b, err)
+	}
 }

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -1601,7 +1601,7 @@ tasks:
   depends_on:
     - name: dist-test
 `
-	intermediate, err := createIntermediateProject([]byte(projYml), false, nil)
+	intermediate, _, err := createIntermediateProject([]byte(projYml), false, nil)
 	s.NoError(err)
 	marshaled, err := yaml.Marshal(intermediate)
 	s.NoError(err)

--- a/operations/evaluate.go
+++ b/operations/evaluate.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 	"gopkg.in/yaml.v3"
@@ -14,10 +15,9 @@ import (
 
 func Evaluate() cli.Command {
 	const (
-		taskFlagName        = "tasks"
-		variantsFlagName    = "variants"
-		diffableFlagName    = "diffable"
-		yamlAnchorsFlagName = "yaml-anchors"
+		taskFlagName     = "tasks"
+		variantsFlagName = "variants"
+		diffableFlagName = "diffable"
 	)
 
 	return cli.Command{
@@ -39,10 +39,6 @@ func Evaluate() cli.Command {
 			cli.StringSliceFlag{
 				Name:  joinFlagNames(localModulesFlagName, "lm"),
 				Usage: "specify local modules for included files as MODULE_NAME=PATH pairs",
-			},
-			cli.BoolFlag{
-				Name:  yamlAnchorsFlagName,
-				Usage: "(BETA) enable cross-file YAML anchors in included files",
 			},
 		),
 		Before: mergeBeforeFuncs(requirePathFlag),
@@ -67,13 +63,23 @@ func Evaluate() cli.Command {
 				return errors.Wrap(err, "getting current working directory")
 			}
 
+			confPath := c.Parent().String(ConfFlagName)
+			conf, err := NewClientSettings(confPath)
+			if err != nil {
+				return errors.Wrap(err, "loading configuration")
+			}
+
 			p := &model.Project{}
 			ctx := context.Background()
+			anchorsEnabled, err := getCrossFileYAMLAnchorsEnabled(conf)
+			if err != nil {
+				grip.Warning(ctx, errors.Wrap(err, "could not get cross-file YAML anchors setting; anchors will be disabled"))
+			}
 			opts := &model.GetProjectOpts{
-				LocalModules:      localModuleMap,
-				ReadFileFrom:      model.ReadFromLocal,
-				LocalIncludeDir:   cwd,
-				EnableYAMLAnchors: c.Bool(yamlAnchorsFlagName),
+				LocalModules:                localModuleMap,
+				ReadFileFrom:                model.ReadFromLocal,
+				LocalIncludeDir:             cwd,
+				CrossFileYAMLAnchorsEnabled: anchorsEnabled,
 			}
 			_, err = model.LoadProjectInto(ctx, configBytes, opts, "", p)
 			if err != nil {

--- a/operations/validate.go
+++ b/operations/validate.go
@@ -7,9 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/evergreen-ci/evergreen/util"
-
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/evergreen/validator"
 	"github.com/mongodb/grip"
 	"github.com/pkg/errors"
@@ -93,14 +92,14 @@ func getCrossFileYAMLAnchorsEnabled(conf *ClientSettings) (bool, error) {
 		return false, errors.Wrap(err, "setting up REST communicator")
 	}
 	defer client.Close()
-	settings, err := client.GetSettings(ctx)
+	flags, err := client.GetServiceFlags(ctx)
 	if err != nil {
-		return false, errors.Wrap(err, "getting admin settings")
+		return false, errors.Wrap(err, "getting service flags")
 	}
-	if settings == nil {
+	if flags == nil {
 		return false, nil
 	}
-	return settings.ServiceFlags.CrossFileYAMLAnchorsEnabled, nil
+	return flags.CrossFileYAMLAnchorsEnabled, nil
 }
 
 func getLocalModulesFromInput(localModulePaths []string) (map[string]string, error) {

--- a/operations/validate.go
+++ b/operations/validate.go
@@ -18,8 +18,6 @@ import (
 )
 
 func Validate() cli.Command {
-	const yamlAnchorsFlagName = "yaml-anchors"
-
 	return cli.Command{
 		Name:  "validate",
 		Usage: "verify that an evergreen project config is valid",
@@ -35,9 +33,6 @@ func Validate() cli.Command {
 		}, cli.StringFlag{
 			Name:  joinFlagNames(projectFlagName, "p"),
 			Usage: "specify project identifier in order to run validation requiring project settings",
-		}, cli.BoolFlag{
-			Name:  yamlAnchorsFlagName,
-			Usage: "(BETA) enable cross-file YAML anchors in included files",
 		}),
 		Before: mergeBeforeFuncs(autoUpdateCLI, setPlainLogger, requirePathFlag),
 		Action: func(c *cli.Context) error {
@@ -49,7 +44,6 @@ func Validate() cli.Command {
 			quiet := c.Bool(quietFlagName)
 			errorOnWarnings := c.Bool(errorOnWarningsFlagName)
 			projectID := c.String(projectFlagName)
-			enableAnchors := c.Bool(yamlAnchorsFlagName)
 			localModulePaths := c.StringSlice(localModulesFlagName)
 			localModuleMap, err := getLocalModulesFromInput(localModulePaths)
 			if err != nil {
@@ -60,7 +54,6 @@ func Validate() cli.Command {
 			if err != nil {
 				return errors.Wrap(err, "loading configuration")
 			}
-
 			if projectID == "" {
 				cwd, err := os.Getwd()
 				grip.Error(ctx, errors.Wrap(err, "getting current working directory"))
@@ -81,15 +74,35 @@ func Validate() cli.Command {
 				}
 				catcher := grip.NewSimpleCatcher()
 				for _, file := range files {
-					catcher.Add(validateFile(conf, filepath.Join(path, file.Name()), quiet, errorOnWarnings, enableAnchors, localModuleMap, projectID))
+					catcher.Add(validateFile(conf, filepath.Join(path, file.Name()), quiet, errorOnWarnings, localModuleMap, projectID))
 				}
 				return catcher.Resolve()
 			}
 
-			return validateFile(conf, path, quiet, errorOnWarnings, enableAnchors, localModuleMap, projectID)
+			return validateFile(conf, path, quiet, errorOnWarnings, localModuleMap, projectID)
 		},
 	}
 }
+
+// getCrossFileYAMLAnchorsEnabled fetches the CrossFileYAMLAnchorsEnabled service flag from the
+// server via REST.
+func getCrossFileYAMLAnchorsEnabled(conf *ClientSettings) (bool, error) {
+	ctx := context.Background()
+	client, err := conf.setupRestCommunicator(ctx, false)
+	if err != nil {
+		return false, errors.Wrap(err, "setting up REST communicator")
+	}
+	defer client.Close()
+	settings, err := client.GetSettings(ctx)
+	if err != nil {
+		return false, errors.Wrap(err, "getting admin settings")
+	}
+	if settings == nil {
+		return false, nil
+	}
+	return settings.ServiceFlags.CrossFileYAMLAnchorsEnabled, nil
+}
+
 func getLocalModulesFromInput(localModulePaths []string) (map[string]string, error) {
 	moduleMap := make(map[string]string)
 	catcher := grip.NewBasicCatcher()
@@ -104,8 +117,8 @@ func getLocalModulesFromInput(localModulePaths []string) (map[string]string, err
 	return moduleMap, catcher.Resolve()
 }
 
-func validateFile(conf *ClientSettings, path string, quiet, errorOnWarnings, enableAnchors bool, localModuleMap map[string]string, projectID string) error {
-	projectYaml, err := loadProjectYAML(path, quiet, errorOnWarnings, enableAnchors, localModuleMap, projectID)
+func validateFile(conf *ClientSettings, path string, quiet, errorOnWarnings bool, localModuleMap map[string]string, projectID string) error {
+	projectYaml, err := loadProjectYAML(conf, path, quiet, errorOnWarnings, localModuleMap, projectID)
 	if err != nil {
 		return err
 	}
@@ -114,7 +127,7 @@ func validateFile(conf *ClientSettings, path string, quiet, errorOnWarnings, ena
 
 // loadProjectYAML reads and parses the project config file, performs local validation,
 // and returns the marshalled YAML bytes for remote validation.
-func loadProjectYAML(path string, quiet, errorOnWarnings, enableAnchors bool, localModuleMap map[string]string, projectID string) ([]byte, error) {
+func loadProjectYAML(conf *ClientSettings, path string, quiet, errorOnWarnings bool, localModuleMap map[string]string, projectID string) ([]byte, error) {
 	confFile, err := os.ReadFile(path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "reading file '%s'", path)
@@ -125,11 +138,15 @@ func loadProjectYAML(path string, quiet, errorOnWarnings, enableAnchors bool, lo
 	}
 	project := &model.Project{}
 	ctx := context.Background()
+	anchorsEnabled, err := getCrossFileYAMLAnchorsEnabled(conf)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting cross-file YAML anchors setting")
+	}
 	opts := &model.GetProjectOpts{
-		LocalModules:      localModuleMap,
-		ReadFileFrom:      model.ReadFromLocal,
-		LocalIncludeDir:   cwd,
-		EnableYAMLAnchors: enableAnchors,
+		LocalModules:                localModuleMap,
+		ReadFileFrom:                model.ReadFromLocal,
+		LocalIncludeDir:             cwd,
+		CrossFileYAMLAnchorsEnabled: anchorsEnabled,
 	}
 	if !quiet {
 		opts.UnmarshalStrict = true

--- a/operations/validate_test.go
+++ b/operations/validate_test.go
@@ -186,10 +186,10 @@ func TestLoadProjectYAML(t *testing.T) {
 	require.NoError(t, err)
 
 	for testName, testCase := range map[string]struct {
-		useNonexistentPath  bool
-		fileContent         []byte
-		serviceFlagErr      error
-		expectErr           string
+		useNonexistentPath bool
+		fileContent        []byte
+		serviceFlagErr     error
+		expectErr          string
 	}{
 		"SucceedsWithValidFile": {},
 		"FailsWithNonexistentFile": {

--- a/operations/validate_test.go
+++ b/operations/validate_test.go
@@ -169,7 +169,7 @@ func TestValidateFile(t *testing.T) {
 				path = filepath.Join(t.TempDir(), "project.yml")
 				require.NoError(t, os.WriteFile(path, sampleYAML, 0644))
 			}
-			err := validateFile(&ClientSettings{}, path, testCase.quiet, testCase.errorOnWarnings, false, nil, "")
+			err := validateFile(&ClientSettings{}, path, testCase.quiet, testCase.errorOnWarnings, nil, "")
 
 			if testCase.expectErr != "" {
 				assert.ErrorContains(t, err, testCase.expectErr)
@@ -201,6 +201,7 @@ func TestLoadProjectYAML(t *testing.T) {
 		},
 	} {
 		t.Run(testName, func(t *testing.T) {
+			mockClient = &client.Mock{}
 			var path string
 			if testCase.useNonexistentPath {
 				path = filepath.Join("nonexistent", "file.yml")
@@ -212,7 +213,7 @@ func TestLoadProjectYAML(t *testing.T) {
 				path = filepath.Join(t.TempDir(), "project.yml")
 				require.NoError(t, os.WriteFile(path, content, 0644))
 			}
-			projectYaml, err := loadProjectYAML(path, false, false, false, nil, "")
+			projectYaml, err := loadProjectYAML(&ClientSettings{}, path, false, false, nil, "")
 
 			if testCase.expectErr != "" {
 				assert.ErrorContains(t, err, testCase.expectErr)

--- a/operations/validate_test.go
+++ b/operations/validate_test.go
@@ -186,9 +186,10 @@ func TestLoadProjectYAML(t *testing.T) {
 	require.NoError(t, err)
 
 	for testName, testCase := range map[string]struct {
-		useNonexistentPath bool
-		fileContent        []byte
-		expectErr          string
+		useNonexistentPath  bool
+		fileContent         []byte
+		serviceFlagErr      error
+		expectErr           string
 	}{
 		"SucceedsWithValidFile": {},
 		"FailsWithNonexistentFile": {
@@ -199,9 +200,13 @@ func TestLoadProjectYAML(t *testing.T) {
 			fileContent: []byte("invalid: [yaml: bad"),
 			expectErr:   "invalid configuration",
 		},
+		"ReturnsErrorWhenGetServiceFlagsFails": {
+			serviceFlagErr: errors.New("not authorized"),
+			expectErr:      "getting service flags",
+		},
 	} {
 		t.Run(testName, func(t *testing.T) {
-			mockClient = &client.Mock{}
+			mockClient = &client.Mock{MockServiceFlagErr: testCase.serviceFlagErr}
 			var path string
 			if testCase.useNonexistentPath {
 				path = filepath.Join("nonexistent", "file.yml")

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -41,6 +41,8 @@ type Communicator interface {
 	GetBannerMessage(context.Context) (string, error)
 	GetUiV2URL(context.Context) (string, error)
 	SetServiceFlags(context.Context, *restmodel.APIServiceFlags) error
+	// GetServiceFlags returns the service flags for the Evergreen service; this purposefully doesn't require admin permissions,
+	// since it's needed to make hard changes to CLI behavior in response to service flag changes.
 	GetServiceFlags(context.Context) (*restmodel.APIServiceFlags, error)
 	IsServiceUser(context.Context, string) (bool, error)
 	RestartRecentTasks(context.Context, time.Time, time.Time) error

--- a/rest/client/interface.go
+++ b/rest/client/interface.go
@@ -41,8 +41,6 @@ type Communicator interface {
 	GetBannerMessage(context.Context) (string, error)
 	GetUiV2URL(context.Context) (string, error)
 	SetServiceFlags(context.Context, *restmodel.APIServiceFlags) error
-	// GetServiceFlags returns the service flags for the Evergreen service; this purposefully doesn't require admin permissions,
-	// since it's needed to make hard changes to CLI behavior in response to service flag changes.
 	GetServiceFlags(context.Context) (*restmodel.APIServiceFlags, error)
 	IsServiceUser(context.Context, string) (bool, error)
 	RestartRecentTasks(context.Context, time.Time, time.Time) error

--- a/rest/client/methods.go
+++ b/rest/client/methods.go
@@ -693,6 +693,8 @@ func (c *communicatorImpl) SetServiceFlags(ctx context.Context, f *model.APIServ
 	return nil
 }
 
+// GetServiceFlags returns the service flags for the Evergreen service; this purposefully doesn't require admin permissions,
+// since it's needed to make hard changes to CLI behavior in response to service flag changes.
 func (c *communicatorImpl) GetServiceFlags(ctx context.Context) (*model.APIServiceFlags, error) {
 	info := requestInfo{
 		method: http.MethodGet,

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -2117,6 +2117,7 @@ type APIServiceFlags struct {
 	TaskDispatchDisabled               bool `json:"task_dispatch_disabled"`
 	HostInitDisabled                   bool `json:"host_init_disabled"`
 	LargeParserProjectsDisabled        bool `json:"large_parser_projects_disabled"`
+	CrossFileYAMLAnchorsEnabled        bool `json:"cross_file_yaml_anchors_enabled"`
 	MonitorDisabled                    bool `json:"monitor_disabled"`
 	MergeQueueRecoveryEnabled          bool `json:"merge_queue_recovery_enabled"`
 	AlertsDisabled                     bool `json:"alerts_disabled"`
@@ -2576,6 +2577,7 @@ func (as *APIServiceFlags) BuildFromService(h any) error {
 		as.TaskDispatchDisabled = v.TaskDispatchDisabled
 		as.HostInitDisabled = v.HostInitDisabled
 		as.LargeParserProjectsDisabled = v.LargeParserProjectsDisabled
+		as.CrossFileYAMLAnchorsEnabled = v.CrossFileYAMLAnchorsEnabled
 		as.MonitorDisabled = v.MonitorDisabled
 		as.MergeQueueRecoveryEnabled = v.MergeQueueRecoveryEnabled
 		as.AlertsDisabled = v.AlertsDisabled
@@ -2631,6 +2633,7 @@ func (as *APIServiceFlags) ToService() (any, error) {
 		TaskDispatchDisabled:               as.TaskDispatchDisabled,
 		HostInitDisabled:                   as.HostInitDisabled,
 		LargeParserProjectsDisabled:        as.LargeParserProjectsDisabled,
+		CrossFileYAMLAnchorsEnabled:        as.CrossFileYAMLAnchorsEnabled,
 		MonitorDisabled:                    as.MonitorDisabled,
 		MergeQueueRecoveryEnabled:          as.MergeQueueRecoveryEnabled,
 		AlertsDisabled:                     as.AlertsDisabled,

--- a/rest/route/admin_flags_test.go
+++ b/rest/route/admin_flags_test.go
@@ -72,7 +72,12 @@ func TestFetchServiceFlagsAllFieldsReturned(t *testing.T) {
 			f.SetBool(true)
 		}
 	}
+	original, err := evergreen.GetServiceFlags(ctx)
+	require.NoError(t, err)
 	require.NoError(t, allTrue.Set(ctx))
+	t.Cleanup(func() {
+		require.NoError(t, original.Set(context.Background()))
+	})
 
 	getHandler := makeFetchServiceFlags()
 	resp := getHandler.Run(ctx)

--- a/rest/route/admin_flags_test.go
+++ b/rest/route/admin_flags_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"reflect"
 	"testing"
 
 	"github.com/evergreen-ci/evergreen"
@@ -12,6 +13,7 @@ import (
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAdminFlagsRouteSuite(t *testing.T) {
@@ -52,4 +54,41 @@ func TestAdminFlagsRouteSuite(t *testing.T) {
 	assert.Equal(body.Flags.HostInitDisabled, settings.ServiceFlags.HostInitDisabled)
 	assert.Equal(body.Flags.AgentStartDisabled, settings.ServiceFlags.AgentStartDisabled)
 	assert.Equal(body.Flags.RepotrackerDisabled, settings.ServiceFlags.RepotrackerDisabled)
+}
+
+// TestFetchServiceFlagsAllFieldsReturned verifies that GET /admin/service_flags
+// returns every field defined in ServiceFlags. If a new flag is added to
+// ServiceFlags but not wired through BuildFromService, this test will fail.
+func TestFetchServiceFlagsAllFieldsReturned(t *testing.T) {
+	ctx := context.Background()
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "user"})
+
+	// Build a ServiceFlags with every bool field set to true.
+	var allTrue evergreen.ServiceFlags
+	rv := reflect.ValueOf(&allTrue).Elem()
+	for i := range rv.NumField() {
+		f := rv.Field(i)
+		if f.Kind() == reflect.Bool {
+			f.SetBool(true)
+		}
+	}
+	require.NoError(t, allTrue.Set(ctx))
+
+	getHandler := makeFetchServiceFlags()
+	resp := getHandler.Run(ctx)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.Status())
+
+	flags, ok := resp.Data().(*model.APIServiceFlags)
+	require.True(t, ok, "response data should be *model.APIServiceFlags")
+
+	// Every bool field in the response must be true — any field that is false
+	// was not wired through BuildFromService.
+	rv = reflect.ValueOf(flags).Elem()
+	for i := range rv.NumField() {
+		f := rv.Field(i)
+		if f.Kind() == reflect.Bool {
+			assert.True(t, f.Bool(), "field %s should be true but was false — check BuildFromService", rv.Type().Field(i).Name)
+		}
+	}
 }

--- a/rest/route/project_validate.go
+++ b/rest/route/project_validate.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/validator"
 	"github.com/evergreen-ci/gimlet"
@@ -67,8 +68,13 @@ func (v *validateProjectHandler) Run(ctx context.Context) gimlet.Responder {
 	var projectConfig *model.ProjectConfig
 	var err error
 
+	flags, err := evergreen.GetServiceFlags(ctx)
+	if err != nil {
+		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "getting service flags"))
+	}
 	opts := &model.GetProjectOpts{
-		ReadFileFrom: model.ReadFromLocal,
+		ReadFileFrom:                model.ReadFromLocal,
+		CrossFileYAMLAnchorsEnabled: flags.CrossFileYAMLAnchorsEnabled,
 	}
 	validationErr := validator.ValidationError{}
 	pp, err := model.LoadProjectInto(ctx, v.input.ProjectYaml, opts, v.input.ProjectID, project)

--- a/rest/route/service_flags.go
+++ b/rest/route/service_flags.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/pkg/errors"
 )
 
 type serviceFlagsGetHandler struct{}
@@ -22,13 +25,13 @@ func (h *serviceFlagsGetHandler) Parse(ctx context.Context, r *http.Request) err
 }
 
 func (h *serviceFlagsGetHandler) Run(ctx context.Context) gimlet.Responder {
-	// TODO (DEVPROD-36538): Remove this route once unsupported CLIs no longer
-	// need the legacy service flags payload.
-	flags := struct {
-		StaticAPIKeysDisabled bool `json:"static_api_keys_disabled"`
-	}{
-		StaticAPIKeysDisabled: true,
+	flags, err := evergreen.GetServiceFlags(ctx)
+	if err != nil {
+		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "getting service flags"))
 	}
-
-	return gimlet.NewJSONResponse(flags)
+	apiFlags := &model.APIServiceFlags{}
+	if err := apiFlags.BuildFromService(*flags); err != nil {
+		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "building service flags response"))
+	}
+	return gimlet.NewJSONResponse(apiFlags)
 }

--- a/rest/route/service_flags_test.go
+++ b/rest/route/service_flags_test.go
@@ -2,9 +2,10 @@ package route
 
 import (
 	"context"
-	"encoding/json"
+	"net/http"
 	"testing"
 
+	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -22,9 +23,6 @@ func (s *ServiceFlagsSuite) TestServiceFlagsGet() {
 
 	resp := route.Run(ctx)
 	s.NotNil(resp)
-	s.Equal(200, resp.Status())
-
-	data, err := json.Marshal(resp.Data())
-	s.NoError(err)
-	s.JSONEq(`{"static_api_keys_disabled":true}`, string(data))
+	s.Equal(http.StatusOK, resp.Status())
+	s.IsType(&model.APIServiceFlags{}, resp.Data())
 }

--- a/rest/route/service_flags_test.go
+++ b/rest/route/service_flags_test.go
@@ -24,5 +24,8 @@ func (s *ServiceFlagsSuite) TestServiceFlagsGet() {
 	resp := route.Run(ctx)
 	s.NotNil(resp)
 	s.Equal(http.StatusOK, resp.Status())
-	s.IsType(&model.APIServiceFlags{}, resp.Data())
+
+	flags, ok := resp.Data().(*model.APIServiceFlags)
+	s.True(ok)
+	s.NotNil(flags)
 }

--- a/service/api.go
+++ b/service/api.go
@@ -232,8 +232,14 @@ func (as *APIServer) validateProjectConfig(w http.ResponseWriter, r *http.Reques
 	project := &model.Project{}
 	var projectConfig *model.ProjectConfig
 	ctx := context.Background()
+	svcFlags, err := evergreen.GetServiceFlags(ctx)
+	if err != nil {
+		gimlet.WriteJSONError(r.Context(), w, errors.Wrap(err, "getting service flags"))
+		return
+	}
 	opts := &model.GetProjectOpts{
-		ReadFileFrom: model.ReadFromLocal,
+		ReadFileFrom:                model.ReadFromLocal,
+		CrossFileYAMLAnchorsEnabled: svcFlags.CrossFileYAMLAnchorsEnabled,
 	}
 	validationErr := validator.ValidationError{}
 	pp, err := model.LoadProjectInto(ctx, input.ProjectYaml, opts, input.ProjectID, project)

--- a/units/periodic_builds.go
+++ b/units/periodic_builds.go
@@ -171,6 +171,11 @@ func (j *periodicBuildJob) addVersion(ctx context.Context, metadata model.Versio
 		Revision:     metadata.Revision.Revision,
 		ReadFileFrom: model.ReadFromGithub,
 	}
+	svcFlags, err := evergreen.GetServiceFlags(ctx)
+	if err != nil {
+		return errors.Wrap(err, "getting service flags")
+	}
+	opts.CrossFileYAMLAnchorsEnabled = svcFlags.CrossFileYAMLAnchorsEnabled
 	intermediateProject, err := model.LoadProjectInto(ctx, configBytes, opts, j.project.Id, proj)
 	if err != nil {
 		return errors.Wrap(err, "parsing config file")

--- a/util/yaml.go
+++ b/util/yaml.go
@@ -2,7 +2,10 @@ package util
 
 import (
 	"bytes"
+	"context"
 
+	"github.com/mongodb/grip"
+	"github.com/mongodb/grip/message"
 	"github.com/pkg/errors"
 	yaml2 "gopkg.in/yaml.v2"
 	"gopkg.in/yaml.v3"
@@ -20,6 +23,12 @@ func UnmarshalYAMLWithFallback(in []byte, out any) error {
 		if err2 := yaml2.Unmarshal(in, out); err2 != nil {
 			return err
 		}
+		grip.Debug(context.Background(), message.Fields{
+			"message":   "yaml v3 unmarshal failed, fell back to v2",
+			"operation": "yaml parsing",
+			"ticket":    "DEVPROD-19220",
+			"error":     err.Error(),
+		})
 	}
 	return nil
 }
@@ -34,6 +43,12 @@ func UnmarshalYAMLStrictWithFallback(in []byte, out any) error {
 		if err2 := yaml2.UnmarshalStrict(in, out); err2 != nil {
 			return errors.Wrap(err, UnmarshalStrictError)
 		}
+		grip.Debug(context.Background(), message.Fields{
+			"message":   "yaml v3 strict unmarshal failed, fell back to v2",
+			"operation": "yaml parsing",
+			"ticket":    "DEVPROD-19220",
+			"error":     err.Error(),
+		})
 	}
 	return nil
 }


### PR DESCRIPTION
DEVPROD-19220 
Best intentions aside, getting evergreen settings requires admin permission (which I didn't catch in testing because I have this permission). Switch to using GetServiceFlags (and shore it up to actually return service flags). I'm going to recommend we close DEVPROD-36538; I think it's helpful to have service flags on the CLI to allow us to influence the behavior when needed.

Added a test for this behavior, and added a test to verify that GetServiceFlags always contains all flags (i.e. that BuildFromService never misses a flag).

**May want to just review the latest commit, since the previous commit is a revert.**