### PR TITLE
DEVPROD-41919 prevent stripping [bot] from usernames when validating

### DIFF
--- a/rest/route/github.go
+++ b/rest/route/github.go
@@ -218,6 +218,7 @@ func (gh *githubHookApi) Run(ctx context.Context) gimlet.Responder {
 				"pr_number": event.GetPullRequest().GetNumber(),
 				"hash":      event.GetPullRequest().GetHead().GetSHA(),
 				"user":      event.GetSender().GetLogin(),
+				"user_id":   event.GetSender().GetID(),
 				"message":   "PR accepted, attempting to queue",
 			})
 

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1415,6 +1415,14 @@ func AppAuthorizedForOrg(ctx context.Context, requiredOrganization, name string)
 	))
 	defer span.End()
 
+	// Do not attempt to authorize names that aren't formatted as apps, since a
+	// user can share a name with an app.
+	if !strings.HasSuffix(name, botSuffix) {
+		return false, nil
+	}
+	// Remove the bot suffix because GitHub doesn't include it in the app slug.
+	nameWithoutBotSuffix := strings.TrimSuffix(name, botSuffix)
+
 	token, err := getInstallationTokenWithDefaultOwnerRepo(ctx, nil)
 	if err != nil {
 		return false, errors.Wrap(err, "getting installation token")
@@ -1422,9 +1430,6 @@ func AppAuthorizedForOrg(ctx context.Context, requiredOrganization, name string)
 
 	githubClient := getGithubClient(token, caller, retryConfig{retry: true})
 	defer githubClient.Close()
-
-	// GitHub often appends [bot] to GitHub App usage, but this doesn't match the App slug, so we should check without this.
-	nameWithoutBotSuffix := strings.TrimSuffix(name, botSuffix)
 	opts := &github.ListOptions{PerPage: 100}
 	for {
 		installations, resp, err := githubClient.Organizations.ListInstallations(ctx, requiredOrganization, opts)
@@ -1437,7 +1442,12 @@ func AppAuthorizedForOrg(ctx context.Context, requiredOrganization, name string)
 
 		for _, installation := range installations.Installations {
 			appSlug := installation.GetAppSlug()
-			if appSlug == name || appSlug == nameWithoutBotSuffix {
+			grip.Debug(ctx, message.Fields{
+				"message":  "DEVPROD-41919",
+				"app_slug": appSlug,
+				"app_id":   installation.GetAppID(),
+			})
+			if appSlug == nameWithoutBotSuffix {
 				prPermission := installation.GetPermissions().GetPullRequests()
 				if utility.StringSliceContains(githubWritePermissions, prPermission) {
 					return true, nil

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -1418,6 +1418,11 @@ func AppAuthorizedForOrg(ctx context.Context, requiredOrganization, name string)
 	// Do not attempt to authorize names that aren't formatted as apps, since a
 	// user can share a name with an app.
 	if !strings.HasSuffix(name, botSuffix) {
+		grip.Debug(ctx, message.Fields{
+			"message": "name does not have bot suffix, skipping app authorization",
+			"name":    name,
+			"ticket":  "DEVPROD-41932",
+		})
 		return false, nil
 	}
 	// Remove the bot suffix because GitHub doesn't include it in the app slug.
@@ -1443,7 +1448,7 @@ func AppAuthorizedForOrg(ctx context.Context, requiredOrganization, name string)
 		for _, installation := range installations.Installations {
 			appSlug := installation.GetAppSlug()
 			grip.Debug(ctx, message.Fields{
-				"message":  "DEVPROD-41919",
+				"message":  "DEVPROD-41932",
 				"app_slug": appSlug,
 				"app_id":   installation.GetAppID(),
 			})

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -693,3 +693,30 @@ func TestBuildGithubHeadPRURL(t *testing.T) {
 		})
 	}
 }
+
+func TestAppAuthorizedForOrgNonAppNames(t *testing.T) {
+	// A GitHub user can share a name with an app, so anything that isn't
+	// suffixed like an app must not be authorized. These cases short-circuit
+	// before any GitHub call, so they need no integration setup.
+	for _, name := range []string{"annie", "annie[bot", "annie[bot]extra", "[bot]annie", "", "bot"} {
+		t.Run("Name"+name, func(t *testing.T) {
+			authorized, err := AppAuthorizedForOrg(t.Context(), "evergreen-ci", name)
+			assert.NoError(t, err)
+			assert.False(t, authorized)
+		})
+	}
+}
+
+func (s *githubSuite) TestAppAuthorizedForOrgWithUninstalledApp() {
+	authorized, err := AppAuthorizedForOrg(s.ctx, "evergreen-ci", "not-a-real-evergreen-app[bot]")
+	s.NoError(err)
+	s.False(authorized)
+}
+
+func (s *githubSuite) TestAppAuthorizedForOrgWithUserSharingAppName() {
+	// A user whose name matches an installed app slug must not be authorized
+	// without the bot suffix.
+	authorized, err := AppAuthorizedForOrg(s.ctx, "evergreen-ci", "evergreen-ci")
+	s.NoError(err)
+	s.False(authorized)
+}


### PR DESCRIPTION
DEVPROD-41919 
<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

More information in the ticket.

I added some logging for user ID because I wonder if we can just be using that instead of any of the stuff we're doing, but I think we should lock this down first anyway. 

### Testing

Tests updated.

### Documentation
