### PR TITLE
DEVPROD-41872  Skip S3 lifecycle rule lookups for excluded accounts

### DIFF
--- a/config_cost.go
+++ b/config_cost.go
@@ -150,17 +150,11 @@ func validateAWSAccountID(id, fieldLabel string) error {
 	return nil
 }
 
-// isInAccountList reports whether an account ID is in the given list, ignoring surrounding whitespace.
-func isInAccountList(accountID string, list []string) bool {
-	return slices.ContainsFunc(list, func(id string) bool {
-		return strings.TrimSpace(id) == accountID
+// containsTrimmed reports whether value is in the list, ignoring whitespace on the list entries.
+func containsTrimmed(value string, list []string) bool {
+	return slices.ContainsFunc(list, func(entry string) bool {
+		return strings.TrimSpace(entry) == value
 	})
-}
-
-// IsAccountWithoutLifecycleRules reports whether the account ID is in the list of accounts
-// for which we do not have access to fetch S3 lifecycle rules.
-func IsAccountWithoutLifecycleRules(accountID string, accountsWithoutLifecycleRules []string) bool {
-	return isInAccountList(accountID, accountsWithoutLifecycleRules)
 }
 
 // IsDevprodOwnedArtifactIAMRole reports whether an IAM role ARN belongs to an account in the list
@@ -170,7 +164,7 @@ func IsDevprodOwnedArtifactIAMRole(awsRoleARN string, devprodOwnedAWSAccountIDs 
 		return true
 	}
 	acctID, ok := util.AWSAccountIDFromIAMARN(awsRoleARN)
-	return ok && isInAccountList(acctID, devprodOwnedAWSAccountIDs)
+	return ok && containsTrimmed(acctID, devprodOwnedAWSAccountIDs)
 }
 
 // ResolveUploadAccountID returns the AWS account ID that owns an upload. When awsRoleARN is non-empty
@@ -187,6 +181,25 @@ func ResolveUploadAccountID(awsRoleARN, awsAccountID string) string {
 	return acctID
 }
 
+// ShouldSkipLifecycleRules reports whether Evergreen should neither ask AWS for an upload's bucket
+// lifecycle rules nor expect to find any. It mirrors IsDevprodOwnedUpload, which gates whether the
+// upload is recorded at all, so an upload with no resolvable account is skipped here too.
+func (c *S3StorageCostConfig) ShouldSkipLifecycleRules(awsRoleARN, awsAccountID string) bool {
+	if !IsDevprodOwnedUpload(awsRoleARN, awsAccountID, c.DevprodOwnedAWSAccountIDs) {
+		return true
+	}
+	return containsTrimmed(ResolveUploadAccountID(awsRoleARN, awsAccountID), c.ArtifactAWSAccountsWithoutLifecycleRules)
+}
+
+// ShouldSkipLifecycleRuleSync is ShouldSkipLifecycleRules for the sync job, where an unrecorded account
+// must keep syncing because nothing would ever populate it.
+func (c *S3StorageCostConfig) ShouldSkipLifecycleRuleSync(awsAccountID string) bool {
+	if awsAccountID == "" {
+		return false
+	}
+	return c.ShouldSkipLifecycleRules("", awsAccountID)
+}
+
 // IsDevprodOwnedUpload reports whether an upload belongs to a devprod-owned account.
 // Returns true when the owned account list is empty, meaning all uploads are tracked.
 func IsDevprodOwnedUpload(awsRoleARN, awsAccountID string, devprodOwnedAWSAccountIDs []string) bool {
@@ -194,7 +207,7 @@ func IsDevprodOwnedUpload(awsRoleARN, awsAccountID string, devprodOwnedAWSAccoun
 		return true
 	}
 	acctID := ResolveUploadAccountID(awsRoleARN, awsAccountID)
-	return acctID != "" && isInAccountList(acctID, devprodOwnedAWSAccountIDs)
+	return acctID != "" && containsTrimmed(acctID, devprodOwnedAWSAccountIDs)
 }
 
 // ShouldHideCost reports whether the given project's cost fields should be hidden.

--- a/config_cost.go
+++ b/config_cost.go
@@ -191,15 +191,6 @@ func (c *S3StorageCostConfig) ShouldSkipLifecycleRules(awsRoleARN, awsAccountID 
 	return containsTrimmed(ResolveUploadAccountID(awsRoleARN, awsAccountID), c.ArtifactAWSAccountsWithoutLifecycleRules)
 }
 
-// ShouldSkipLifecycleRuleSync is ShouldSkipLifecycleRules for the sync job, where an unrecorded account
-// must keep syncing because nothing would ever populate it.
-func (c *S3StorageCostConfig) ShouldSkipLifecycleRuleSync(awsAccountID string) bool {
-	if awsAccountID == "" {
-		return false
-	}
-	return c.ShouldSkipLifecycleRules("", awsAccountID)
-}
-
 // IsDevprodOwnedUpload reports whether an upload belongs to a devprod-owned account.
 // Returns true when the owned account list is empty, meaning all uploads are tracked.
 func IsDevprodOwnedUpload(awsRoleARN, awsAccountID string, devprodOwnedAWSAccountIDs []string) bool {

--- a/config_cost_test.go
+++ b/config_cost_test.go
@@ -159,11 +159,11 @@ func TestCostConfigValidateAndDefault(t *testing.T) {
 	})
 }
 
-func TestAWSAccountIDMatchesConfiguredList(t *testing.T) {
-	assert.True(t, isInAccountList("123456789012", []string{"123456789012"}))
-	assert.True(t, isInAccountList("123456789012", []string{" 123456789012 "}))
-	assert.False(t, isInAccountList("123456789012", []string{"999999999999"}))
-	assert.False(t, isInAccountList("123456789012", nil))
+func TestContainsTrimmed(t *testing.T) {
+	assert.True(t, containsTrimmed("123456789012", []string{"123456789012"}))
+	assert.True(t, containsTrimmed("123456789012", []string{" 123456789012 "}))
+	assert.False(t, containsTrimmed("123456789012", []string{"999999999999"}))
+	assert.False(t, containsTrimmed("123456789012", nil))
 }
 
 func TestIsDevprodOwnedArtifactIAMRole(t *testing.T) {
@@ -406,4 +406,65 @@ func TestResolveUploadAccountID(t *testing.T) {
 	t.Run("BothEmptyResolvesToNoAccount", func(t *testing.T) {
 		assert.Empty(t, ResolveUploadAccountID("", ""))
 	})
+}
+
+func TestShouldSkipLifecycleRules(t *testing.T) {
+	cfg := S3StorageCostConfig{
+		DevprodOwnedAWSAccountIDs:                []string{"123456789012"},
+		ArtifactAWSAccountsWithoutLifecycleRules: []string{"999999999999", "123456789012"},
+	}
+
+	for _, tc := range []struct {
+		name      string
+		cfg       S3StorageCostConfig
+		roleARN   string
+		accountID string
+		want      bool
+	}{
+		{
+			name:      "ListedAccountIsSkipped",
+			cfg:       cfg,
+			accountID: "123456789012",
+			want:      true,
+		},
+		{
+			name:      "AccountOutsideDevprodOwnedListIsSkipped",
+			cfg:       cfg,
+			accountID: "210987654321",
+			want:      true,
+		},
+		{
+			name: "UnresolvableAccountIsSkipped",
+			cfg:  cfg,
+			want: true,
+		},
+		{
+			name:      "UnparseableRoleARNIsSkipped",
+			cfg:       cfg,
+			roleARN:   "not-an-arn",
+			accountID: "123456789012",
+			want:      true,
+		},
+		{
+			name:    "DevprodOwnedUnlistedAccountIsNotSkipped",
+			cfg:     S3StorageCostConfig{DevprodOwnedAWSAccountIDs: []string{"123456789012"}},
+			roleARN: "arn:aws:iam::123456789012:role/r",
+		},
+		{
+			name:      "NoDevprodOwnedListTracksEverything",
+			accountID: "210987654321",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.cfg.ShouldSkipLifecycleRules(tc.roleARN, tc.accountID))
+		})
+	}
+}
+
+func TestShouldSkipLifecycleRuleSync(t *testing.T) {
+	cfg := S3StorageCostConfig{DevprodOwnedAWSAccountIDs: []string{"123456789012"}}
+
+	assert.False(t, cfg.ShouldSkipLifecycleRuleSync(""), "rules cached before the account ID was stored must keep being refreshed")
+	assert.True(t, cfg.ShouldSkipLifecycleRuleSync("210987654321"))
+	assert.False(t, cfg.ShouldSkipLifecycleRuleSync("123456789012"))
 }

--- a/config_cost_test.go
+++ b/config_cost_test.go
@@ -460,11 +460,3 @@ func TestShouldSkipLifecycleRules(t *testing.T) {
 		})
 	}
 }
-
-func TestShouldSkipLifecycleRuleSync(t *testing.T) {
-	cfg := S3StorageCostConfig{DevprodOwnedAWSAccountIDs: []string{"123456789012"}}
-
-	assert.False(t, cfg.ShouldSkipLifecycleRuleSync(""), "rules cached before the account ID was stored must keep being refreshed")
-	assert.True(t, cfg.ShouldSkipLifecycleRuleSync("210987654321"))
-	assert.False(t, cfg.ShouldSkipLifecycleRuleSync("123456789012"))
-}

--- a/model/s3lifecycle/s3_lifecycle.go
+++ b/model/s3lifecycle/s3_lifecycle.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/db"
-	"github.com/evergreen-ci/evergreen/util"
 	"github.com/evergreen-ci/pail"
 	"github.com/evergreen-ci/utility"
 	"github.com/mongodb/anser/bsonutil"
@@ -109,28 +108,12 @@ type S3LifecycleClient interface {
 
 // DiscoverAndCacheProjectBucket checks if we have lifecycle rules cached for a bucket and fetches them if not.
 // It returns true if rules were successfully cached (discovery succeeded), false if already cached, if the
-// bucket's account is in accountsWithoutLifecycleRules, or if discovery failed.
+// bucket's artifacts are never priced or its rules are unreadable, or if discovery failed.
 // fallbackAccountID is used when the account cannot be derived from roleARN, which is the case for key+secret
-// uploads. Without it those buckets bypass the skip list entirely.
+// s3.put uploads. An upload with no account at all is skipped, since it is never priced.
 // This is best-effort - errors are logged but not returned to avoid failing file uploads.
-func DiscoverAndCacheProjectBucket(ctx context.Context, bucketName, region string, roleARN *string, externalID *string, fallbackAccountID, projectID string, accountsWithoutLifecycleRules []string, client S3LifecycleClient) bool {
-	// Derive the AWS account ID from the role ARN so we can check it against the skip list.
-	awsAccountID := fallbackAccountID
-	if roleARN != nil {
-		if id, ok := util.AWSAccountIDFromIAMARN(*roleARN); ok {
-			awsAccountID = id
-		}
-	}
-
-	if awsAccountID != "" && evergreen.IsAccountWithoutLifecycleRules(awsAccountID, accountsWithoutLifecycleRules) {
-		grip.Info(ctx, message.Fields{
-			"message":    "skipping lifecycle rule discovery for bucket in account without lifecycle rules access",
-			"bucket":     bucketName,
-			"account_id": awsAccountID,
-			"project":    projectID,
-		})
-		return false
-	}
+func DiscoverAndCacheProjectBucket(ctx context.Context, bucketName, region string, roleARN *string, externalID *string, fallbackAccountID, projectID string, storageCostConfig *evergreen.S3StorageCostConfig, client S3LifecycleClient) bool {
+	awsAccountID := evergreen.ResolveUploadAccountID(utility.FromStringPtr(roleARN), fallbackAccountID)
 
 	existingRules, err := FindAllRulesForBucket(ctx, bucketName)
 	if err != nil {
@@ -142,6 +125,18 @@ func DiscoverAndCacheProjectBucket(ctx context.Context, bucketName, region strin
 	}
 
 	if len(existingRules) > 0 {
+		return false
+	}
+
+	// Never ask AWS for a bucket whose artifacts are not priced or whose rules we cannot read. Nothing
+	// is cached, so discovery runs again on the next upload once the configuration changes.
+	if storageCostConfig.ShouldSkipLifecycleRules("", awsAccountID) {
+		grip.Debug(ctx, message.Fields{
+			"message":    "skipping lifecycle rule discovery for bucket configured without lifecycle rules",
+			"bucket":     bucketName,
+			"account_id": awsAccountID,
+			"project":    projectID,
+		})
 		return false
 	}
 

--- a/model/s3lifecycle/s3_lifecycle_test.go
+++ b/model/s3lifecycle/s3_lifecycle_test.go
@@ -310,7 +310,7 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 			},
 		}
 
-		discovered := DiscoverAndCacheProjectBucket(t.Context(), "test-bucket", "us-east-1", &roleARN, nil, "", "test-project", nil, mockClient)
+		discovered := DiscoverAndCacheProjectBucket(t.Context(), "test-bucket", "us-east-1", &roleARN, nil, "", "test-project", &evergreen.S3StorageCostConfig{}, mockClient)
 		assert.True(t, discovered, "should trigger discovery for new bucket")
 
 		rules, err := FindAllRulesForBucket(t.Context(), "test-bucket")
@@ -352,7 +352,7 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 			rules: []pail.LifecycleRule{{ID: "should-not-be-called"}},
 		}
 
-		discovered := DiscoverAndCacheProjectBucket(t.Context(), "cached-bucket", "us-east-1", nil, nil, "", "test-project", nil, mockClient)
+		discovered := DiscoverAndCacheProjectBucket(t.Context(), "cached-bucket", "us-east-1", nil, nil, "", "test-project", &evergreen.S3StorageCostConfig{}, mockClient)
 		assert.False(t, discovered, "should skip discovery for cached bucket")
 
 		rules, err := FindAllRulesForBucket(t.Context(), "cached-bucket")
@@ -368,12 +368,15 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 			err: errors.New("AWS API error"),
 		}
 
-		discovered := DiscoverAndCacheProjectBucket(t.Context(), "error-bucket", "us-east-1", nil, nil, "", "test-project", nil, mockClient)
+		discovered := DiscoverAndCacheProjectBucket(t.Context(), "error-bucket", "us-east-1", nil, nil, "", "test-project", &evergreen.S3StorageCostConfig{}, mockClient)
 		assert.False(t, discovered, "should return false when AWS call fails")
 
 		rules, err := FindAllRulesForBucket(t.Context(), "error-bucket")
 		require.NoError(t, err)
-		assert.Len(t, rules, 0)
+		assert.Empty(t, rules, "a failed discovery should cache nothing")
+
+		assert.False(t, DiscoverAndCacheProjectBucket(t.Context(), "error-bucket", "us-east-1", nil, nil, "", "test-project", &evergreen.S3StorageCostConfig{}, mockClient))
+		assert.Equal(t, 2, mockClient.callCount, "nothing is cached, so the next upload asks AWS again")
 	})
 
 	t.Run("NoLifecycleRules", func(t *testing.T) {
@@ -383,7 +386,7 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 			rules: []pail.LifecycleRule{},
 		}
 
-		discovered := DiscoverAndCacheProjectBucket(t.Context(), "empty-bucket", "us-east-1", nil, nil, "", "test-project", nil, mockClient)
+		discovered := DiscoverAndCacheProjectBucket(t.Context(), "empty-bucket", "us-east-1", nil, nil, "", "test-project", &evergreen.S3StorageCostConfig{}, mockClient)
 		assert.True(t, discovered, "should trigger discovery even if no rules returned")
 
 		rules, err := FindAllRulesForBucket(t.Context(), "empty-bucket")
@@ -400,27 +403,29 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 			rules: []pail.LifecycleRule{{ID: "should-not-be-called"}},
 		}
 
-		discovered := DiscoverAndCacheProjectBucket(t.Context(), "restricted-bucket", "us-east-1", &roleARN, nil, "", "test-project", accountsWithoutLifecycleRules, mockClient)
+		discovered := DiscoverAndCacheProjectBucket(t.Context(), "restricted-bucket", "us-east-1", &roleARN, nil, "", "test-project", &evergreen.S3StorageCostConfig{ArtifactAWSAccountsWithoutLifecycleRules: accountsWithoutLifecycleRules}, mockClient)
 		assert.False(t, discovered, "should skip discovery for buckets in accounts without lifecycle rules access")
 
 		rules, err := FindAllRulesForBucket(t.Context(), "restricted-bucket")
 		require.NoError(t, err)
-		assert.Empty(t, rules, "no rules should be cached for restricted account")
+		assert.Empty(t, rules, "a skipped bucket should cache nothing")
 		assert.Zero(t, mockClient.callCount, "should not have called AWS")
 	})
 
 	roleARN := "arn:aws:iam::111111111111:role/my-role"
+	unownedRoleARN := "arn:aws:iam::999999999999:role/my-role"
 	for _, tc := range []struct {
 		name              string
 		bucket            string
 		roleARN           *string
 		fallbackAccountID string
 		withoutRules      []string
+		devprodOwned      []string
 		wantDiscovered    bool
 		wantAccountID     string
 	}{
 		{
-			name:           "UnknownAccountCannotBeCheckedAgainstList",
+			name:           "UnknownAccountWithNoDevprodOwnedListIsCached",
 			bucket:         "key-secret-bucket",
 			withoutRules:   []string{"999999999999"},
 			wantDiscovered: true,
@@ -440,6 +445,17 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 			wantAccountID:     "222222222222",
 		},
 		{
+			name:         "UnknownAccountSkipsDiscoveryWhenDevprodOwnedListIsSet",
+			bucket:       "unknown-account-bucket",
+			devprodOwned: []string{"111111111111"},
+		},
+		{
+			name:         "AccountOutsideDevprodOwnedListSkipsDiscovery",
+			bucket:       "unowned-bucket",
+			roleARN:      &unownedRoleARN,
+			devprodOwned: []string{"111111111111"},
+		},
+		{
 			name:              "RoleARNTakesPrecedenceOverFallback",
 			bucket:            "mixed-bucket",
 			roleARN:           &roleARN,
@@ -453,14 +469,18 @@ func TestDiscoverAndCacheProjectBucket(t *testing.T) {
 				rules: []pail.LifecycleRule{{ID: "rule1", Status: "Enabled", ExpirationDays: ptr(int32(30))}},
 			}
 
-			discovered := DiscoverAndCacheProjectBucket(t.Context(), tc.bucket, "us-east-1", tc.roleARN, nil, tc.fallbackAccountID, "test-project", tc.withoutRules, mockClient)
+			cfg := &evergreen.S3StorageCostConfig{
+				ArtifactAWSAccountsWithoutLifecycleRules: tc.withoutRules,
+				DevprodOwnedAWSAccountIDs:                tc.devprodOwned,
+			}
+			discovered := DiscoverAndCacheProjectBucket(t.Context(), tc.bucket, "us-east-1", tc.roleARN, nil, tc.fallbackAccountID, "test-project", cfg, mockClient)
 			assert.Equal(t, tc.wantDiscovered, discovered)
 
 			rules, err := FindAllRulesForBucket(t.Context(), tc.bucket)
 			require.NoError(t, err)
 			if !tc.wantDiscovered {
-				assert.Empty(t, rules)
 				assert.Zero(t, mockClient.callCount, "should not have called AWS")
+				assert.Empty(t, rules, "a skipped bucket should cache nothing")
 				return
 			}
 			require.Len(t, rules, 1)

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -4484,10 +4484,9 @@ func (t *Task) setS3ArtifactStorageCosts(ctx context.Context, lookup bucketExpir
 	t.TaskCost.OnDemandS3ArtifactStorageCost = 0
 	t.TaskCost.AdjustedS3ArtifactStorageCost = 0
 	for _, bucketEntry := range t.S3Usage.Artifacts.BytesByBucketAndKey {
-		// A lookup miss is expected for these accounts, so don't log one. The lookup still runs because
+		// A lookup miss is expected for these buckets, so don't log one. The lookup still runs because
 		// rules cached before the account was listed are still valid.
-		accountID := evergreen.ResolveUploadAccountID(bucketEntry.AWSRoleARN, bucketEntry.AWSAccountID)
-		expectedMiss := evergreen.IsAccountWithoutLifecycleRules(accountID, costConfig.S3Cost.Storage.ArtifactAWSAccountsWithoutLifecycleRules)
+		expectedMiss := costConfig.S3Cost.Storage.ShouldSkipLifecycleRules(bucketEntry.AWSRoleARN, bucketEntry.AWSAccountID)
 		for _, fileEntry := range bucketEntry.Files {
 			days, usedLookup := lookupExpirationDays(ctx, bucketEntry.Bucket, fileEntry.FileKey, lookup, costConfig)
 			if !usedLookup && !expectedMiss {

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -6016,4 +6016,25 @@ func TestSetS3ArtifactStorageCostsLifecycleMissLogging(t *testing.T) {
 		tk.setS3ArtifactStorageCosts(ctx, missingLookup, costConfig)
 		assert.Equal(t, []string{"mciuploads"}, loggedBuckets())
 	})
+
+	// Uploads that are not devprod owned are never priced, so a lookup miss is expected for them.
+	t.Run("SuppressesMissForUploadsOutsideDevprodOwnedList", func(t *testing.T) {
+		ownedConfig := &evergreen.CostConfig{
+			S3Cost: evergreen.S3CostConfig{
+				Storage: evergreen.S3StorageCostConfig{
+					DefaultMaxArtifactExpirationDays: 365,
+					DevprodOwnedAWSAccountIDs:        []string{"123456789012"},
+				},
+			},
+		}
+
+		tk := Task{Id: "t5", S3Usage: usage("unowned-bucket", "arn:aws:iam::210987654321:role/r", "")}
+		tk.setS3ArtifactStorageCosts(ctx, missingLookup, ownedConfig)
+		assert.Empty(t, loggedBuckets())
+
+		tk = Task{Id: "t6", S3Usage: usage("unresolved-bucket", "", "")}
+		tk.setS3ArtifactStorageCosts(ctx, missingLookup, ownedConfig)
+		assert.Empty(t, loggedBuckets(), "an upload with no resolvable account is not devprod owned")
+		assert.Positive(t, tk.TaskCost.OnDemandS3ArtifactStorageCost, "cost must still be computed from the default expiration days")
+	})
 }

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -801,7 +801,7 @@ func discoverAndCacheBucketLifecycleRules(ctx context.Context, t *task.Task, fil
 			externalID = &file.ExternalID
 		}
 
-		wasCached := s3lifecycle.DiscoverAndCacheProjectBucket(ctx, bucketName, region, roleARN, externalID, file.AWSAccountID, t.Project, costConfig.S3Cost.Storage.ArtifactAWSAccountsWithoutLifecycleRules, cloud.NewS3LifecycleClient())
+		wasCached := s3lifecycle.DiscoverAndCacheProjectBucket(ctx, bucketName, region, roleARN, externalID, file.AWSAccountID, t.Project, &costConfig.S3Cost.Storage, cloud.NewS3LifecycleClient())
 		if wasCached {
 			cachedBuckets = append(cachedBuckets, bucketName)
 		}

--- a/units/s3_lifecycle_sync_project_buckets.go
+++ b/units/s3_lifecycle_sync_project_buckets.go
@@ -140,7 +140,9 @@ func (j *s3LifecycleSyncProjectBucketsJob) syncBucket(ctx context.Context, clien
 	// The configuration is the only gate on asking AWS, so removing an account from either list takes
 	// effect on this run.
 	awsAccountID := existingRules[0].AWSAccountID
-	if storageCostConfig.ShouldSkipLifecycleRuleSync(awsAccountID) {
+	// An unrecorded account must keep syncing because nothing would ever populate it.
+	shouldSkip := awsAccountID != "" && storageCostConfig.ShouldSkipLifecycleRules("", awsAccountID)
+	if shouldSkip {
 		grip.Info(ctx, message.Fields{
 			"message":    "skipping lifecycle rule sync for bucket configured without lifecycle rules",
 			"bucket":     bucketName,

--- a/units/s3_lifecycle_sync_project_buckets.go
+++ b/units/s3_lifecycle_sync_project_buckets.go
@@ -96,7 +96,7 @@ func (j *s3LifecycleSyncProjectBucketsJob) Run(ctx context.Context) {
 	var failedBuckets []string
 
 	for _, bucketName := range bucketNames {
-		if err := j.syncBucket(ctx, client, bucketName, costConfig.S3Cost.Storage.ArtifactAWSAccountsWithoutLifecycleRules); err != nil {
+		if err := j.syncBucket(ctx, client, bucketName, &costConfig.S3Cost.Storage); err != nil {
 			grip.Error(ctx, message.WrapError(err, message.Fields{
 				"message": "failed to sync bucket",
 				"bucket":  bucketName,
@@ -105,7 +105,6 @@ func (j *s3LifecycleSyncProjectBucketsJob) Run(ctx context.Context) {
 			j.AddError(err)
 			failureCount++
 			failedBuckets = append(failedBuckets, bucketName)
-			continue
 		}
 	}
 
@@ -122,7 +121,7 @@ func (j *s3LifecycleSyncProjectBucketsJob) Run(ctx context.Context) {
 	grip.Info(ctx, msg)
 }
 
-func (j *s3LifecycleSyncProjectBucketsJob) syncBucket(ctx context.Context, client cloud.S3LifecycleClient, bucketName string, accountsWithoutLifecycleRules []string) error {
+func (j *s3LifecycleSyncProjectBucketsJob) syncBucket(ctx context.Context, client cloud.S3LifecycleClient, bucketName string, storageCostConfig *evergreen.S3StorageCostConfig) error {
 	// Get existing rules to extract region and account ID (all rules for same bucket share these).
 	existingRules, err := s3lifecycle.FindAllRulesForBucket(ctx, bucketName)
 	if err != nil {
@@ -138,13 +137,12 @@ func (j *s3LifecycleSyncProjectBucketsJob) syncBucket(ctx context.Context, clien
 		return nil
 	}
 
-	// Skip sync for buckets belonging to accounts where we don't have lifecycle rule access.
-	// AWSAccountID is populated during discovery for role-based auth buckets. Buckets using
-	// key+secret auth or those discovered before this field was added will have an empty
-	// AWSAccountID and are always synced.
-	if awsAccountID := existingRules[0].AWSAccountID; awsAccountID != "" && evergreen.IsAccountWithoutLifecycleRules(awsAccountID, accountsWithoutLifecycleRules) {
+	// The configuration is the only gate on asking AWS, so removing an account from either list takes
+	// effect on this run.
+	awsAccountID := existingRules[0].AWSAccountID
+	if storageCostConfig.ShouldSkipLifecycleRuleSync(awsAccountID) {
 		grip.Info(ctx, message.Fields{
-			"message":    "skipping lifecycle rule sync for bucket in account without lifecycle rules access",
+			"message":    "skipping lifecycle rule sync for bucket configured without lifecycle rules",
 			"bucket":     bucketName,
 			"account_id": awsAccountID,
 			"job_id":     j.ID(),

--- a/units/s3_lifecycle_sync_project_buckets_test.go
+++ b/units/s3_lifecycle_sync_project_buckets_test.go
@@ -272,7 +272,7 @@ func TestSyncBucket(t *testing.T) {
 	}
 
 	job := makeS3LifecycleSyncProjectBucketsJob()
-	err := job.syncBucket(ctx, mockClient, "test-bucket", nil)
+	err := job.syncBucket(ctx, mockClient, "test-bucket", &evergreen.S3StorageCostConfig{})
 	require.NoError(t, err)
 
 	// Verify sandbox/ rule was updated.
@@ -316,7 +316,7 @@ func TestSyncBucketWithNoExistingRules(t *testing.T) {
 	}
 
 	job := makeS3LifecycleSyncProjectBucketsJob()
-	err := job.syncBucket(ctx, mockClient, "test-bucket", nil)
+	err := job.syncBucket(ctx, mockClient, "test-bucket", &evergreen.S3StorageCostConfig{})
 	require.NoError(t, err)
 
 	// No error, but also no sync should happen since there are no existing rules.
@@ -364,7 +364,7 @@ func TestSyncBucketAWSAccountIDPreserved(t *testing.T) {
 
 	job := makeS3LifecycleSyncProjectBucketsJob()
 	// Account is not in the restricted list, so the sync should proceed.
-	err := job.syncBucket(t.Context(), mockClient, "my-bucket", nil)
+	err := job.syncBucket(t.Context(), mockClient, "my-bucket", &evergreen.S3StorageCostConfig{})
 	require.NoError(t, err)
 
 	// The rule should be updated with the new AWS data AND the AWSAccountID must be preserved.
@@ -406,7 +406,7 @@ func TestSyncBucketSkipsAccountWithoutLifecycleRulesAccess(t *testing.T) {
 
 	accountsWithoutLifecycleRules := []string{"999999999999"}
 	job := makeS3LifecycleSyncProjectBucketsJob()
-	err := job.syncBucket(t.Context(), mockClient, "restricted-bucket", accountsWithoutLifecycleRules)
+	err := job.syncBucket(t.Context(), mockClient, "restricted-bucket", &evergreen.S3StorageCostConfig{ArtifactAWSAccountsWithoutLifecycleRules: accountsWithoutLifecycleRules})
 	require.NoError(t, err)
 
 	// The existing rule should be unchanged, confirming no AWS call was made.
@@ -414,4 +414,72 @@ func TestSyncBucketSkipsAccountWithoutLifecycleRulesAccess(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, rule)
 	assert.Equal(t, "old-rule", rule.RuleID, "rule should be unchanged when sync is skipped")
+}
+
+// TestSyncBucketConfigGate covers which buckets the sync job asks AWS about. A rule with no stored
+// account ID must keep being refreshed: discovery never revisits a bucket that already has rules, so
+// nothing would ever populate its account ID, and skipping it would freeze its expiration days forever.
+func TestSyncBucketConfigGate(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		accountID    string
+		devprodOwned []string
+		wantSynced   bool
+	}{
+		{
+			name:         "NoStoredAccountIDIsSynced",
+			devprodOwned: []string{"123456789012"},
+			wantSynced:   true,
+		},
+		{
+			name:       "UnlistedAccountIsSynced",
+			accountID:  "999999999999",
+			wantSynced: true,
+		},
+		{
+			name:         "NonDevprodOwnedAccountIsSkipped",
+			accountID:    "999999999999",
+			devprodOwned: []string{"123456789012"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, db.Clear(s3lifecycle.Collection))
+			t.Cleanup(func() {
+				require.NoError(t, db.Clear(s3lifecycle.Collection))
+			})
+
+			existingRule := &s3lifecycle.S3LifecycleRuleDoc{
+				BucketName:     "b",
+				BucketType:     s3lifecycle.BucketTypeUserSpecified,
+				Region:         "us-east-1",
+				AWSAccountID:   tc.accountID,
+				RuleID:         "stale-rule",
+				RuleStatus:     "Enabled",
+				ExpirationDays: utility.ToIntPtr(30),
+				LastSyncedAt:   time.Now().Add(-24 * time.Hour),
+			}
+			require.NoError(t, existingRule.Upsert(t.Context()))
+
+			mockClient := &mockS3LifecycleClient{
+				rules: map[string][]pail.LifecycleRule{
+					"b": {{ID: "fresh-rule", Status: "Enabled", ExpirationDays: utility.ToInt32Ptr(90)}},
+				},
+			}
+			job := makeS3LifecycleSyncProjectBucketsJob()
+			require.NoError(t, job.syncBucket(t.Context(), mockClient, "b", &evergreen.S3StorageCostConfig{
+				DevprodOwnedAWSAccountIDs: tc.devprodOwned,
+			}))
+
+			rule, err := s3lifecycle.FindByBucketAndPrefix(t.Context(), "b", "")
+			require.NoError(t, err)
+			require.NotNil(t, rule)
+			if !tc.wantSynced {
+				assert.Equal(t, "stale-rule", rule.RuleID, "a skipped bucket must not be refreshed")
+				return
+			}
+			assert.Equal(t, "fresh-rule", rule.RuleID)
+			require.NotNil(t, rule.ExpirationDays)
+			assert.Equal(t, 90, *rule.ExpirationDays)
+		})
+	}
 }


### PR DESCRIPTION
DEVPROD-41872

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

These changes ensure that we only ask AWS for a bucket's S3 lifecycle rules (and only expects to find them) when the upload's AWS account resolves, is devprod-owned, and isn't listed as having no lifecycle rules. 

This stops the unnecessary AWS calls and "no S3 lifecycle rule found" logs for buckets that we don't expect to get rules for. 

### Testing
Added tests 
