### PR TITLE
DEVPROD-31861: avoid double MarkEnd on execution tasks when resetting display task

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -300,6 +300,18 @@ func TryResetTask(ctx context.Context, settings *evergreen.Settings, taskId, use
 		if !t.IsFinished() {
 			if detail != nil {
 				if t.DisplayOnly {
+					// TODO (DEVPROD-31861): remove this log once confirmed that
+					// the display task does not race to reset anymore.
+					grip.Info(ctx, message.Fields{
+						"message":                     "reached max executions for display task, marking the display task and all unfinished execution tasks as finished",
+						"display_task_id":             t.Id,
+						"display_task_execution":      t.Execution,
+						"display_task_status":         t.Status,
+						"display_task_max_executions": maxExecution,
+						"num_execution_tasks":         len(t.ExecutionTasks),
+						"origin":                      origin,
+						"ticket":                      "DEVPROD-31861",
+					})
 					for _, etId := range t.ExecutionTasks {
 						execTask, err = task.FindOneId(ctx, etId)
 						if err != nil {
@@ -309,6 +321,20 @@ func TryResetTask(ctx context.Context, settings *evergreen.Settings, taskId, use
 						// some individual execution tasks may already be
 						// finished. Only MarkEnd on unfinished execution tasks.
 						if !evergreen.IsFinishedTaskStatus(execTask.Status) {
+							// TODO (DEVPROD-31861): remove this log once
+							// confirmed that the display task does not race to
+							// reset anymore.
+							grip.Info(ctx, message.Fields{
+								"message":                     "reached max executions for display task, marking unfinished execution task as finished",
+								"display_task_id":             t.Id,
+								"display_task_execution":      t.Execution,
+								"display_task_max_executions": maxExecution,
+								"execution_task_id":           execTask.Id,
+								"execution_task_execution":    execTask.Execution,
+								"execution_task_status":       execTask.Status,
+								"origin":                      origin,
+								"ticket":                      "DEVPROD-31861",
+							})
 							if err = MarkEnd(ctx, settings, execTask, origin, time.Now(), detail); err != nil {
 								return errors.Wrap(err, "marking execution task as ended")
 							}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -309,13 +309,13 @@ func TryResetTask(ctx context.Context, settings *evergreen.Settings, taskId, use
 						// some individual execution tasks may already be
 						// finished. Only MarkEnd on unfinished execution tasks.
 						if !evergreen.IsFinishedTaskStatus(execTask.Status) {
-							if err = MarkEnd(ctx, settings, execTask, origin, execTask.EstimatedFinishTime(time.Now()), detail); err != nil {
+							if err = MarkEnd(ctx, settings, execTask, origin, time.Now(), detail); err != nil {
 								return errors.Wrap(err, "marking execution task as ended")
 							}
 						}
 					}
 				}
-				return errors.WithStack(MarkEnd(ctx, settings, t, origin, t.EstimatedFinishTime(time.Now()), detail))
+				return errors.WithStack(MarkEnd(ctx, settings, t, origin, time.Now(), detail))
 			} else {
 				grip.Critical(ctx, message.Fields{
 					"message":     "TryResetTask called with nil TaskEndDetail",

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -309,12 +309,17 @@ func TryResetTask(ctx context.Context, settings *evergreen.Settings, taskId, use
 						if err != nil {
 							return errors.Wrap(err, "finding execution task")
 						}
-						if err = MarkEnd(ctx, settings, execTask, origin, time.Now(), detail); err != nil {
-							return errors.Wrap(err, "marking execution task as ended")
+						// Even though the overall display task is unfinished,
+						// some individual execution tasks may already be
+						// finished. Only MarkEnd on unfinished execution tasks.
+						if !evergreen.IsFinishedTaskStatus(execTask.Status) {
+							if err = MarkEnd(ctx, settings, execTask, origin, execTask.EstimatedFinishTime(time.Now()), detail); err != nil {
+								return errors.Wrap(err, "marking execution task as ended")
+							}
 						}
 					}
 				}
-				return errors.WithStack(MarkEnd(ctx, settings, t, origin, time.Now(), detail))
+				return errors.WithStack(MarkEnd(ctx, settings, t, origin, t.EstimatedFinishTime(time.Now()), detail))
 			} else {
 				grip.Critical(ctx, message.Fields{
 					"message":     "TryResetTask called with nil TaskEndDetail",

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -291,10 +291,6 @@ func TryResetTask(ctx context.Context, settings *evergreen.Settings, taskId, use
 	// For system failures, we restart once for tasks on their first execution, if configured.
 	if !settings.ServiceFlags.SystemFailedTaskRestartDisabled &&
 		!detail.IsEmpty() && detail.Type == evergreen.CommandTypeSystem {
-		// kim: NOTE: if it's a display task and one of the execution tasks
-		// system failed, then it goes into this case to try re-running
-		// once. This is why many tasks have the same pattern of execution 0
-		// and 1 being weird.
 		maxExecution = 1
 	}
 

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -291,6 +291,10 @@ func TryResetTask(ctx context.Context, settings *evergreen.Settings, taskId, use
 	// For system failures, we restart once for tasks on their first execution, if configured.
 	if !settings.ServiceFlags.SystemFailedTaskRestartDisabled &&
 		!detail.IsEmpty() && detail.Type == evergreen.CommandTypeSystem {
+		// kim: NOTE: if it's a display task and one of the execution tasks
+		// system failed, then it goes into this case to try re-running
+		// once. This is why many tasks have the same pattern of execution 0
+		// and 1 being weird.
 		maxExecution = 1
 	}
 

--- a/model/task_lifecycle_test.go
+++ b/model/task_lifecycle_test.go
@@ -6833,3 +6833,118 @@ func TestBuildTaskCompletedSpanAttributesCostFields(t *testing.T) {
 		assert.False(t, hasEBSStorage)
 	})
 }
+
+func TestTryResetDisplayTaskAtMaxExecution(t *testing.T) {
+	settings := testutil.TestConfig()
+
+	realStartTime := time.Date(2026, time.August, 20, 2, 30, 25, 0, time.UTC)
+	realFinishTime := time.Date(2026, time.August, 20, 2, 31, 39, 0, time.UTC)
+
+	systemFailure := &apimodels.TaskEndDetail{
+		Status:      evergreen.TaskFailed,
+		Type:        evergreen.CommandTypeSystem,
+		Description: evergreen.TaskDescriptionHeartbeat,
+		TimedOut:    true,
+	}
+
+	for tName, tCase := range map[string]struct {
+		execTaskStatus string
+		test           func(t *testing.T, execTask *task.Task)
+	}{
+		"SucceededExecutionTaskKeepsItsResults": {
+			execTaskStatus: evergreen.TaskSucceeded,
+			test: func(t *testing.T, execTask *task.Task) {
+				assert.Equal(t, evergreen.TaskSucceeded, execTask.Status)
+				assert.True(t, realFinishTime.Equal(execTask.FinishTime), "finish time should not move to the time the display task hit its execution cap")
+				assert.Empty(t, execTask.Details.Description)
+			},
+		},
+		"FailedExecutionTaskKeepsItsResults": {
+			execTaskStatus: evergreen.TaskFailed,
+			test: func(t *testing.T, execTask *task.Task) {
+				assert.Equal(t, evergreen.TaskFailed, execTask.Status)
+				assert.True(t, realFinishTime.Equal(execTask.FinishTime), "finish time should not move to the time the display task hit its execution cap")
+				assert.Empty(t, execTask.Details.Description)
+			},
+		},
+		"UnfinishedExecutionTaskIsMarkedEnded": {
+			execTaskStatus: evergreen.TaskStarted,
+			test: func(t *testing.T, execTask *task.Task) {
+				assert.Equal(t, evergreen.TaskFailed, execTask.Status)
+				assert.Equal(t, evergreen.TaskDescriptionHeartbeat, execTask.Details.Description)
+			},
+		},
+	} {
+		t.Run(tName, func(t *testing.T) {
+			ctx := t.Context()
+			require.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection, VersionCollection, event.EventCollection, host.Collection))
+			t.Cleanup(func() {
+				assert.NoError(t, db.ClearCollections(task.Collection, task.OldCollection, build.Collection, VersionCollection, event.EventCollection, host.Collection))
+			})
+
+			h := &host.Host{
+				Id:          "host",
+				RunningTask: "exec_task",
+			}
+			require.NoError(t, h.Insert(ctx))
+			v := &Version{
+				Id:     "version",
+				Status: evergreen.VersionStarted,
+			}
+			require.NoError(t, v.Insert(t.Context()))
+			b := &build.Build{
+				Id:      "build",
+				Version: v.Id,
+				Status:  evergreen.BuildStarted,
+			}
+			require.NoError(t, b.Insert(t.Context()))
+
+			execTask := &task.Task{
+				Id:            "exec_task",
+				DisplayName:   "exec_task",
+				BuildId:       b.Id,
+				Version:       v.Id,
+				Project:       "project",
+				Activated:     true,
+				HostId:        "host",
+				Status:        tCase.execTaskStatus,
+				StartTime:     realStartTime,
+				FinishTime:    realFinishTime,
+				LastHeartbeat: realFinishTime,
+			}
+			if !evergreen.IsFinishedTaskStatus(tCase.execTaskStatus) {
+				execTask.FinishTime = time.Time{}
+			}
+			require.NoError(t, execTask.Insert(t.Context()))
+
+			// System failures only allow one restart, so a display task
+			// already on execution 1 is past its cap and resetting it falls
+			// into the branch that marks it and its execution tasks as ended.
+			dt := &task.Task{
+				Id:             "display_task",
+				DisplayName:    "display_task",
+				BuildId:        b.Id,
+				Version:        v.Id,
+				Project:        "project",
+				DisplayOnly:    true,
+				Activated:      true,
+				Execution:      1,
+				Status:         evergreen.TaskStarted,
+				ExecutionTasks: []string{execTask.Id},
+			}
+			require.NoError(t, dt.Insert(t.Context()))
+
+			require.NoError(t, TryResetTask(ctx, settings, dt.Id, evergreen.User, evergreen.MonitorPackage, systemFailure))
+
+			dbExecTask, err := task.FindOneId(ctx, execTask.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbExecTask)
+			tCase.test(t, dbExecTask)
+
+			dbDisplayTask, err := task.FindOneId(ctx, dt.Id)
+			require.NoError(t, err)
+			require.NotZero(t, dbDisplayTask)
+			assert.True(t, dbDisplayTask.IsFinished(), "display task should be marked finished once it is past its execution cap")
+		})
+	}
+}


### PR DESCRIPTION
DEVPROD-31861

### Description

Looks like the odd symptoms reported in the ticket is a combination of the following:

* Some display tasks have _a lot_ of execution tasks (hundreds).
* At least one of those execution tasks system fails (e.g. due to consuming all host resources), so the display task gets marked to restart after all the tasks have finished.
* The last two unfinished execution tasks under the display task are in end task concurrently trying to mark themselves finished _and_ auto-restart the display task (because of the system failure). They can race to restart the display task:
    * The fast execution task [is allowed one auto-restart](https://github.com/evergreen-ci/evergreen/blob/953ae910a5f919eb9afbaa516a0a9d9f1bafd23f/model/task_lifecycle.go#L316), so it successfully [auto-restarts the display task](https://github.com/evergreen-ci/evergreen/blob/953ae910a5f919eb9afbaa516a0a9d9f1bafd23f/model/task_lifecycle.go#L401).
    * The slow execution task [detects that the display task already was auto-restarted once already](https://github.com/evergreen-ci/evergreen/blob/953ae910a5f919eb9afbaa516a0a9d9f1bafd23f/model/task_lifecycle.go#L316) (by the fast execution task) and it hit the system-failure auto-restart limit, so it tries [marking all execution tasks and display task as system-failed](https://github.com/evergreen-ci/evergreen/blob/953ae910a5f919eb9afbaa516a0a9d9f1bafd23f/model/task_lifecycle.go#L322-L335).

This race is causing some execution tasks that are already finished to get overwritten (by the slow execution task thread), so they change from initial success/failure to system-failed. This also messes up the task timing because the task finish time is updated by calling `MarkEnd` on it again.

This PR resolves the issue where already-finished execution tasks get their data overwritten by the slow execution task trying to set them all to system-failed. I'm going to make a follow-up PR to reduce the likelihood of the display task reset race happening more generally.

#### Note on Skipped Executions

The double `MarkEnd` behavior I described is a bug. But despite what the ticket says, it's valid behavior in Evergreen for individual execution tasks to have missing their execution numbers because display tasks can restart subsets of tasks. For example:

* Execution 1 finishes for all tasks.
* Auto-restarting system failures causes failures to restart (so failures are on execution 2, successes are on execution 1).
* A user manually restarts all tasks under the display task. Now failures are on execution 3, successes are also on execution 3 (but they lack an execution 2).

### Testing

Added unit tests.
