### PR TITLE
DEVPROD-41056 Retry tasks failed on git.get_project

### DIFF
--- a/agent/command/registry.go
+++ b/agent/command/registry.go
@@ -197,7 +197,11 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 		cmd.SetIdleTimeout(time.Duration(c.TimeoutSecs) * time.Second)
 
 		// Special case on git.get_project due to increasing GitHub instability.
-		cmd.SetRetryOnFailure(utility.FromBoolPtr(c.RetryOnFailure) || c.Command == evergreen.GitGetProjectCommandName)
+		retryOnFailure := c.Command == evergreen.GitGetProjectCommandName
+		if c.RetryOnFailure != nil {
+			retryOnFailure = utility.FromBoolPtr(c.RetryOnFailure)
+		}
+		cmd.SetRetryOnFailure(retryOnFailure)
 		cmd.SetFailureMetadataTags(c.FailureMetadataTags)
 
 		out = append(out, cmd)

--- a/agent/command/registry.go
+++ b/agent/command/registry.go
@@ -195,7 +195,13 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 		cmd.SetType(c.GetType(project))
 		cmd.SetFullDisplayName(c.DisplayName)
 		cmd.SetIdleTimeout(time.Duration(c.TimeoutSecs) * time.Second)
-		cmd.SetRetryOnFailure(c.RetryOnFailure)
+
+		// Special case on git.get_project due to increasing GitHub instability.
+		retryOnFailure := c.Command == evergreen.GitGetProjectCommandName
+		if c.RetryOnFailure != nil {
+			retryOnFailure = *c.RetryOnFailure
+		}
+		cmd.SetRetryOnFailure(retryOnFailure)
 		cmd.SetFailureMetadataTags(c.FailureMetadataTags)
 
 		out = append(out, cmd)

--- a/agent/command/registry.go
+++ b/agent/command/registry.go
@@ -197,11 +197,7 @@ func (r *commandRegistry) renderCommands(commandInfo model.PluginCommandConf,
 		cmd.SetIdleTimeout(time.Duration(c.TimeoutSecs) * time.Second)
 
 		// Special case on git.get_project due to increasing GitHub instability.
-		retryOnFailure := c.Command == evergreen.GitGetProjectCommandName
-		if c.RetryOnFailure != nil {
-			retryOnFailure = *c.RetryOnFailure
-		}
-		cmd.SetRetryOnFailure(retryOnFailure)
+		cmd.SetRetryOnFailure(utility.FromBoolPtr(c.RetryOnFailure) || c.Command == evergreen.GitGetProjectCommandName)
 		cmd.SetFailureMetadataTags(c.FailureMetadataTags)
 
 		out = append(out, cmd)

--- a/agent/command/registry_test.go
+++ b/agent/command/registry_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/utility"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -248,4 +249,47 @@ func TestGetFullDisplayName(t *testing.T) {
 			TotalSubCmds: 10,
 		}))
 	})
+}
+
+func TestRenderCommandsRetryOnFailure(t *testing.T) {
+	registry := newCommandRegistry()
+	registry.cmds = map[string]CommandFactory{
+		evergreen.GitGetProjectCommandName: gitFetchProjectFactory,
+		"command.mock":                     MockCommandFactory,
+	}
+	gitParams := map[string]any{"directory": "src"}
+
+	for _, tCase := range []struct {
+		name     string
+		info     model.PluginCommandConf
+		expected bool
+	}{
+		{
+			name:     "GitGetProjectUnsetShouldRetry",
+			info:     model.PluginCommandConf{Command: evergreen.GitGetProjectCommandName, Params: gitParams},
+			expected: true,
+		},
+		{
+			name:     "GitGetProjectExplicitFalseShouldNotRetry",
+			info:     model.PluginCommandConf{Command: evergreen.GitGetProjectCommandName, Params: gitParams, RetryOnFailure: utility.FalsePtr()},
+			expected: false,
+		},
+		{
+			name:     "OtherCommandUnsetShouldNotRetry",
+			info:     model.PluginCommandConf{Command: "command.mock"},
+			expected: false,
+		},
+		{
+			name:     "OtherCommandExplicitTrueShouldRetry",
+			info:     model.PluginCommandConf{Command: "command.mock", RetryOnFailure: utility.TruePtr()},
+			expected: true,
+		},
+	} {
+		t.Run(tCase.name, func(t *testing.T) {
+			cmds, err := registry.renderCommands(tCase.info, &model.Project{}, BlockInfo{})
+			require.NoError(t, err)
+			require.Len(t, cmds, 1)
+			assert.Equal(t, tCase.expected, cmds[0].RetryOnFailure())
+		})
+	}
 }

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-08-21"
+	AgentVersion = "2026-08-24"
 )
 
 const (

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -916,8 +916,9 @@ directory, and checks out the revision associated with the task. Also
 applies patches to the source after cloning it, if the task was created
 by a patch submission.
 
-Due to increased GitHub instability, git.get_project will have the retry_on_failure parameter set to true by default. 
-This means that if the task fails at this command, the task will restart automatically, unless set otherwise.
+Due to increased GitHub instability, `git.get_project` sets `retry_on_failure` to
+true by default. If the task fails at this command, it restarts once
+automatically, unless `retry_on_failure` is explicitly set to false.
 
 ```yaml
 - command: git.get_project

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -916,8 +916,12 @@ directory, and checks out the revision associated with the task. Also
 applies patches to the source after cloning it, if the task was created
 by a patch submission.
 
+Due to increased GitHub instability, git.get_project will have the retry_on_failure parameter set to true by default. 
+This means that if the task fails at this command, the task will restart automatically, unless set otherwise.
+
 ```yaml
 - command: git.get_project
+  retry_on_failure: false ## optional, defaults to true for this command only.
   params:
     directory: src
     revisions:

--- a/globals.go
+++ b/globals.go
@@ -919,6 +919,7 @@ const (
 	AttachXUnitResultsCommandName = "attach.xunit_results"
 	CacheRestoreCommandName       = "cache.restore"
 	CacheSaveCommandName          = "cache.save"
+	GitGetProjectCommandName      = "git.get_project"
 )
 
 var AttachCommands = []string{

--- a/model/project.go
+++ b/model/project.go
@@ -643,7 +643,8 @@ type PluginCommandConf struct {
 	Vars map[string]string `yaml:"vars,omitempty" bson:"vars,omitempty"`
 
 	// RetryOnFailure indicates whether the task should be retried if this command fails.
-	RetryOnFailure bool `yaml:"retry_on_failure,omitempty" bson:"retry_on_failure,omitempty"`
+	// Defaults to false except git.get_project commands.
+	RetryOnFailure *bool `yaml:"retry_on_failure,omitempty" bson:"retry_on_failure,omitempty"`
 
 	// FailureMetadataTags are user-defined tags which are not used directly by
 	// Evergreen but can be used to allow users to set additional metadata about
@@ -678,7 +679,7 @@ func (c *PluginCommandConf) UnmarshalYAML(unmarshal func(any) error) error {
 		Params              map[string]any    `yaml:"params,omitempty" bson:"params,omitempty"`
 		ParamsYAML          string            `yaml:"params_yaml,omitempty" bson:"params_yaml,omitempty"`
 		Vars                map[string]string `yaml:"vars,omitempty" bson:"vars,omitempty"`
-		RetryOnFailure      bool              `yaml:"retry_on_failure,omitempty" bson:"retry_on_failure,omitempty"`
+		RetryOnFailure      *bool             `yaml:"retry_on_failure,omitempty" bson:"retry_on_failure,omitempty"`
 		FailureMetadataTags []string          `yaml:"failure_metadata_tags,omitempty" bson:"failure_metadata_tags,omitempty"`
 	}{}
 

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1476,7 +1476,7 @@ func validateCommands(section, taskName, tgName string, project *model.Project, 
 				Message: fmt.Sprintf("cannot specify both command '%s' and function '%s'%s", cmd.Command, cmd.Function, formattedTaskMsg),
 			})
 		}
-		if cmd.Function != "" && cmd.RetryOnFailure {
+		if cmd.Function != "" && utility.FromBoolPtr(cmd.RetryOnFailure) {
 			errs = append(errs, ValidationError{
 				Level:   Warning,
 				Message: fmt.Sprintf("cannot specify retry_on_failure with function '%s'%s, can only specify retry_on_failure on individual commands", cmd.Function, formattedTaskMsg),


### PR DESCRIPTION
DEVPROD-41056


### Description

we will auto-restart tasks that failed on git.get_project by default
caused by increased github instability as clone times increase 10 fold during outages (even if unrelated) 
there is an ongoing investigation but this will help with the issue 


### Testing
unit test to make sure it is set correctly

### Documentation
added docs to project command section 
