### PR TITLE
DEVPROD-28491: add google.golang.org/grpc to dependabot ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,7 @@ updates:
       - dependency-name: "golang.org/x/sync"
       - dependency-name: "golang.org/x/text"
       - dependency-name: "golang.org/x/tools"
+      - dependency-name: "google.golang.org/grpc"
     groups:
       otel-dependencies:
         applies-to: version-updates


### PR DESCRIPTION
DEVPROD-28491

### Description

The [latest grpc bump requires go 1.25](https://github.com/evergreen-ci/evergreen/pull/10630/changes). Unable to upgrade until Evergreen can upgrade to go 1.25.