### PR TITLE
DEVPROD-41987 New virtual execution platform type

### DIFF
--- a/model/task/db.go
+++ b/model/task/db.go
@@ -661,12 +661,8 @@ func ByExecutionPlatform(platform ExecutionPlatform) bson.M {
 				{ExecutionPlatformKey: platform},
 			},
 		}
-	case ExecutionPlatformContainer:
-		return bson.M{
-			ExecutionPlatformKey: platform,
-		}
 	default:
-		return bson.M{}
+		return bson.M{ExecutionPlatformKey: platform}
 	}
 }
 

--- a/model/task/db_test.go
+++ b/model/task/db_test.go
@@ -2237,6 +2237,35 @@ func TestActivateTasksUpdate(t *testing.T) {
 		assert.False(t, dbTask.UnattainableDependency)
 		assert.EqualValues(t, 0, dbTask.Priority)
 	})
+	t.Run("VirtualTaskExcludedFromHostSchedulable", func(t *testing.T) {
+		ctx := t.Context()
+		require.NoError(t, db.ClearCollections(Collection, distro.Collection))
+
+		d := distro.Distro{Id: "d"}
+		hostTask := Task{
+			Id:                "host_task",
+			Status:            evergreen.TaskUndispatched,
+			Activated:         true,
+			ExecutionPlatform: ExecutionPlatformHost,
+			DistroId:          "d",
+		}
+		virtualTask := Task{
+			Id:                "virtual_task",
+			Status:            evergreen.TaskUndispatched,
+			Activated:         true,
+			ExecutionPlatform: ExecutionPlatformVirtual,
+			DistroId:          "d",
+		}
+
+		require.NoError(t, d.Insert(ctx))
+		require.NoError(t, hostTask.Insert(ctx))
+		require.NoError(t, virtualTask.Insert(ctx))
+
+		tasks, err := FindHostSchedulable(ctx, "d")
+		require.NoError(t, err)
+		require.Len(t, tasks, 1)
+		assert.Equal(t, "host_task", tasks[0].Id)
+	})
 }
 
 func TestFindGeneratedTasksFromID(t *testing.T) {

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -426,8 +426,9 @@ type ExecutionPlatform string
 const (
 	// ExecutionPlatformHost indicates that the task runs in a host.
 	ExecutionPlatformHost ExecutionPlatform = "host"
-	// ExecutionPlatformContainer indicates that the task runs in a container.
-	ExecutionPlatformContainer ExecutionPlatform = "container"
+	// ExecutionPlatformVirtual indicates that the task's results are pushed
+	// externally and it never enters a task queue or runs on a host.
+	ExecutionPlatformVirtual ExecutionPlatform = "virtual"
 )
 
 func (t *Task) MarshalBSON() ([]byte, error)  { return mgobson.Marshal(t) }

--- a/model/task/task_test.go
+++ b/model/task/task_test.go
@@ -1081,13 +1081,13 @@ func TestEndingTask(t *testing.T) {
 				So(task.FinishTime.Unix(), ShouldEqual, now.Unix())
 			})
 		})
-		Convey("a task that is allocated a container should be deallocated", func() {
+		Convey("a non-host task should still be markable as ended", func() {
 			now := time.Now()
 			task := &Task{
 				Id:                "taskId",
 				Status:            evergreen.TaskStarted,
 				StartTime:         now.Add(-5 * time.Minute),
-				ExecutionPlatform: ExecutionPlatformContainer,
+				ExecutionPlatform: ExecutionPlatformVirtual,
 			}
 			So(task.Insert(t.Context()), ShouldBeNil)
 			details := &apimodels.TaskEndDetail{
@@ -2684,8 +2684,8 @@ func TestIsHostDispatchable(t *testing.T) {
 			tsk.ExecutionPlatform = ""
 			assert.True(t, tsk.IsHostDispatchable())
 		},
-		"ReturnsFalseForContainerTask": func(t *testing.T, tsk Task) {
-			tsk.ExecutionPlatform = ExecutionPlatformContainer
+		"ReturnsFalseForVirtualTask": func(t *testing.T, tsk Task) {
+			tsk.ExecutionPlatform = ExecutionPlatformVirtual
 			assert.False(t, tsk.IsHostDispatchable())
 		},
 		"ReturnsFalseForTaskWithoutUndispatchedStatus": func(t *testing.T, tsk Task) {
@@ -3616,9 +3616,9 @@ func TestArchive(t *testing.T) {
 
 			checkEventLogHostTaskExecutions(t, hostID, archivedExecTaskID, archivedExecution)
 		},
-		"ArchivesContainerTask": func(t *testing.T, tsk Task) {
+		"ArchivesVirtualTask": func(t *testing.T, tsk Task) {
 			archivedTaskID := MakeOldID(tsk.Id, tsk.Execution)
-			tsk.ExecutionPlatform = ExecutionPlatformContainer
+			tsk.ExecutionPlatform = ExecutionPlatformVirtual
 			require.NoError(t, tsk.Insert(ctx))
 
 			require.NoError(t, tsk.Archive(ctx))
@@ -4684,7 +4684,7 @@ func TestWillRun(t *testing.T) {
 		tsk := Task{
 			Status:            evergreen.TaskUndispatched,
 			Activated:         true,
-			ExecutionPlatform: ExecutionPlatformContainer,
+			ExecutionPlatform: ExecutionPlatformHost,
 			DependsOn:         []Dependency{{Unattainable: false}},
 		}
 		assert.True(t, tsk.WillRun())
@@ -4693,7 +4693,7 @@ func TestWillRun(t *testing.T) {
 		tsk := Task{
 			Status:            evergreen.TaskUndispatched,
 			Activated:         true,
-			ExecutionPlatform: ExecutionPlatformContainer,
+			ExecutionPlatform: ExecutionPlatformHost,
 			DependsOn:         []Dependency{{Unattainable: true}},
 		}
 		assert.False(t, tsk.WillRun())


### PR DESCRIPTION
DEVPROD-41987

### Description
Adding a new "virtual" task execution platform to support the upcoming virtual tasks. Did a drive by change to remove the unused container execution platform. "Execution" platform is a little ironic because virtual tasks by definition do not execute but I think it's best/easiest to add a case for that field since there is a lot of existing logic in the scheduler etc that will make them very easy to filter out.
### Testing
Added some unit tests.
