### PR TITLE
DEVPROD-23865: Add task config field to graphql

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -899,6 +899,8 @@ models:
     model: github.com/evergreen-ci/evergreen/model.TaskExecutionStep
   TaskAnnotationSettingsInput:
     model: github.com/evergreen-ci/evergreen/rest/model.APITaskAnnotationSettings
+  TaskConfig:
+    model: github.com/evergreen-ci/evergreen/model.BuildVariantTaskUnit
   TaskContainerCreationOpts:
     model: github.com/evergreen-ci/evergreen/rest/model.APIPodTaskContainerCreationOptions
   Cost:
@@ -962,6 +964,8 @@ models:
     model: github.com/evergreen-ci/evergreen/rest/model.APITaskOwnershipSettings
   TaskOwnershipSettingsInput:
     model: github.com/evergreen-ci/evergreen/rest/model.APITaskOwnershipSettings
+  TaskUnitDependency:
+    model: github.com/evergreen-ci/evergreen/model.TaskUnitDependency
   TestSelectionSettings:
     model: github.com/evergreen-ci/evergreen/rest/model.APITestSelectionSettings
   TestSelectionSettingsInput:
@@ -993,6 +997,23 @@ models:
     fields:
       displayName:
         fieldName: "DispName"
+  UserRequester:
+    model: github.com/evergreen-ci/evergreen.UserRequester
+    enum_values:
+      AD_HOC:
+        value: github.com/evergreen-ci/evergreen.AdHocUserRequester
+      GIT_TAG:
+        value: github.com/evergreen-ci/evergreen.GitTagUserRequester
+      GITHUB_PR:
+        value: github.com/evergreen-ci/evergreen.GithubPRUserRequester
+      GITHUB_MERGE:
+        value: github.com/evergreen-ci/evergreen.GithubMergeUserRequester
+      PATCH_VERSION:
+        value: github.com/evergreen-ci/evergreen.PatchVersionUserRequester
+      REPOTRACKER_VERSION:
+        value: github.com/evergreen-ci/evergreen.RepotrackerVersionUserRequester
+      TRIGGER:
+        value: github.com/evergreen-ci/evergreen.TriggerUserRequester
   UserServiceFlags:
     model: github.com/evergreen-ci/evergreen/rest/model.APIServiceFlags
   UserSettings:

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -997,23 +997,6 @@ models:
     fields:
       displayName:
         fieldName: "DispName"
-  UserRequester:
-    model: github.com/evergreen-ci/evergreen.UserRequester
-    enum_values:
-      AD_HOC:
-        value: github.com/evergreen-ci/evergreen.AdHocUserRequester
-      GIT_TAG:
-        value: github.com/evergreen-ci/evergreen.GitTagUserRequester
-      GITHUB_PR:
-        value: github.com/evergreen-ci/evergreen.GithubPRUserRequester
-      GITHUB_MERGE:
-        value: github.com/evergreen-ci/evergreen.GithubMergeUserRequester
-      PATCH_VERSION:
-        value: github.com/evergreen-ci/evergreen.PatchVersionUserRequester
-      REPOTRACKER_VERSION:
-        value: github.com/evergreen-ci/evergreen.RepotrackerVersionUserRequester
-      TRIGGER:
-        value: github.com/evergreen-ci/evergreen.TriggerUserRequester
   UserServiceFlags:
     model: github.com/evergreen-ci/evergreen/rest/model.APIServiceFlags
   UserSettings:

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -77,6 +77,7 @@ type ResolverRoot interface {
 	SpruceConfig() SpruceConfigResolver
 	SubscriberWrapper() SubscriberWrapperResolver
 	Task() TaskResolver
+	TaskConfig() TaskConfigResolver
 	TaskLogs() TaskLogsResolver
 	TicketFields() TicketFieldsResolver
 	UIConfig() UIConfigResolver
@@ -2830,6 +2831,9 @@ type TaskResolver interface {
 	TotalTestCount(ctx context.Context, obj *model.APITask) (int, error)
 	Version(ctx context.Context, obj *model.APITask) (*model1.Version, error)
 	VersionMetadata(ctx context.Context, obj *model.APITask) (*model.APIVersion, error)
+}
+type TaskConfigResolver interface {
+	AllowedRequesters(ctx context.Context, obj *model1.BuildVariantTaskUnit) ([]string, error)
 }
 type TaskLogsResolver interface {
 	AgentLogs(ctx context.Context, obj *TaskLogs) ([]*apimodels.LogMessage, error)
@@ -67416,10 +67420,10 @@ func (ec *executionContext) _TaskConfig_allowedRequesters(ctx context.Context, f
 		field,
 		ec.fieldContext_TaskConfig_allowedRequesters,
 		func(ctx context.Context) (any, error) {
-			return obj.AllowedRequesters, nil
+			return ec.resolvers.TaskConfig().AllowedRequesters(ctx, obj)
 		},
 		nil,
-		ec.marshalOUserRequester2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequesterᚄ,
+		ec.marshalOString2ᚕstringᚄ,
 		true,
 		false,
 	)
@@ -67429,10 +67433,10 @@ func (ec *executionContext) fieldContext_TaskConfig_allowedRequesters(_ context.
 	fc = &graphql.FieldContext{
 		Object:     "TaskConfig",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type UserRequester does not have child fields")
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -109237,7 +109241,38 @@ func (ec *executionContext) _TaskConfig(ctx context.Context, sel ast.SelectionSe
 		case "allowedBranches":
 			out.Values[i] = ec._TaskConfig_allowedBranches(ctx, field, obj)
 		case "allowedRequesters":
-			out.Values[i] = ec._TaskConfig_allowedRequesters(ctx, field, obj)
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._TaskConfig_allowedRequesters(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "allowForGitTag":
 			out.Values[i] = ec._TaskConfig_allowForGitTag(ctx, field, obj)
 		case "batchTime":
@@ -109263,7 +109298,7 @@ func (ec *executionContext) _TaskConfig(ctx context.Context, sel ast.SelectionSe
 		case "name":
 			out.Values[i] = ec._TaskConfig_name(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "patchable":
 			out.Values[i] = ec._TaskConfig_patchable(ctx, field, obj)
@@ -120037,44 +120072,6 @@ func (ec *executionContext) marshalNUser2ᚖgithubᚗcomᚋevergreenᚑciᚋever
 	return ec._User(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNUserRequester2githubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequester(ctx context.Context, v any) (evergreen.UserRequester, error) {
-	tmp, err := graphql.UnmarshalString(v)
-	res := unmarshalNUserRequester2githubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequester[tmp]
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalNUserRequester2githubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequester(ctx context.Context, sel ast.SelectionSet, v evergreen.UserRequester) graphql.Marshaler {
-	_ = sel
-	res := graphql.MarshalString(marshalNUserRequester2githubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequester[v])
-	if res == graphql.Null {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
-		}
-	}
-	return res
-}
-
-var (
-	unmarshalNUserRequester2githubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequester = map[string]evergreen.UserRequester{
-		"AD_HOC":              evergreen.AdHocUserRequester,
-		"GIT_TAG":             evergreen.GitTagUserRequester,
-		"GITHUB_MERGE":        evergreen.GithubMergeUserRequester,
-		"GITHUB_PR":           evergreen.GithubPRUserRequester,
-		"PATCH_VERSION":       evergreen.PatchVersionUserRequester,
-		"REPOTRACKER_VERSION": evergreen.RepotrackerVersionUserRequester,
-		"TRIGGER":             evergreen.TriggerUserRequester,
-	}
-	marshalNUserRequester2githubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequester = map[evergreen.UserRequester]string{
-		evergreen.AdHocUserRequester:              "AD_HOC",
-		evergreen.GitTagUserRequester:             "GIT_TAG",
-		evergreen.GithubMergeUserRequester:        "GITHUB_MERGE",
-		evergreen.GithubPRUserRequester:           "GITHUB_PR",
-		evergreen.PatchVersionUserRequester:       "PATCH_VERSION",
-		evergreen.RepotrackerVersionUserRequester: "REPOTRACKER_VERSION",
-		evergreen.TriggerUserRequester:            "TRIGGER",
-	}
-)
-
 func (ec *executionContext) marshalNUserServiceFlags2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIServiceFlags(ctx context.Context, sel ast.SelectionSet, v *model.APIServiceFlags) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -124697,71 +124694,6 @@ func (ec *executionContext) marshalOUserConfig2ᚖgithubᚗcomᚋevergreenᚑci�
 		return graphql.Null
 	}
 	return ec._UserConfig(ctx, sel, v)
-}
-
-func (ec *executionContext) unmarshalOUserRequester2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequesterᚄ(ctx context.Context, v any) ([]evergreen.UserRequester, error) {
-	if v == nil {
-		return nil, nil
-	}
-	var vSlice []any
-	vSlice = graphql.CoerceList(v)
-	var err error
-	res := make([]evergreen.UserRequester, len(vSlice))
-	for i := range vSlice {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
-		res[i], err = ec.unmarshalNUserRequester2githubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequester(ctx, vSlice[i])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return res, nil
-}
-
-func (ec *executionContext) marshalOUserRequester2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequesterᚄ(ctx context.Context, sel ast.SelectionSet, v []evergreen.UserRequester) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNUserRequester2githubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequester(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
 }
 
 func (ec *executionContext) marshalOUserSettings2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIUserSettings(ctx context.Context, sel ast.SelectionSet, v *model.APIUserSettings) graphql.Marshaler {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1894,6 +1894,7 @@ type ComplexityRoot struct {
 		CanSchedule                  func(childComplexity int) int
 		CanSetPriority               func(childComplexity int) int
 		CanUnschedule                func(childComplexity int) int
+		Config                       func(childComplexity int) int
 		CreateTime                   func(childComplexity int) int
 		DependsOn                    func(childComplexity int) int
 		Details                      func(childComplexity int) int
@@ -1967,6 +1968,30 @@ type ComplexityRoot struct {
 
 	TaskAnnotationSettings struct {
 		FileTicketWebhook func(childComplexity int) int
+	}
+
+	TaskConfig struct {
+		Activate          func(childComplexity int) int
+		AllowForGitTag    func(childComplexity int) int
+		AllowedBranches   func(childComplexity int) int
+		AllowedRequesters func(childComplexity int) int
+		BatchTime         func(childComplexity int) int
+		CronBatchTime     func(childComplexity int) int
+		DependsOn         func(childComplexity int) int
+		Disable           func(childComplexity int) int
+		ExecTimeoutSecs   func(childComplexity int) int
+		GitTagOnly        func(childComplexity int) int
+		GroupName         func(childComplexity int) int
+		IgnoredBranches   func(childComplexity int) int
+		IsGroup           func(childComplexity int) int
+		IsPartOfGroup     func(childComplexity int) int
+		Name              func(childComplexity int) int
+		PS                func(childComplexity int) int
+		PatchOnly         func(childComplexity int) int
+		Patchable         func(childComplexity int) int
+		Priority          func(childComplexity int) int
+		RunOn             func(childComplexity int) int
+		Stepback          func(childComplexity int) int
 	}
 
 	TaskEndDetail struct {
@@ -2142,6 +2167,14 @@ type ComplexityRoot struct {
 		MatchingFailedTestNames func(childComplexity int) int
 		TaskID                  func(childComplexity int) int
 		TotalTestCount          func(childComplexity int) int
+	}
+
+	TaskUnitDependency struct {
+		Name               func(childComplexity int) int
+		OmitGeneratedTasks func(childComplexity int) int
+		PatchOptional      func(childComplexity int) int
+		Status             func(childComplexity int) int
+		Variant            func(childComplexity int) int
 	}
 
 	TestLog struct {
@@ -2745,6 +2778,7 @@ type TaskResolver interface {
 	CanSchedule(ctx context.Context, obj *model.APITask) (bool, error)
 	CanSetPriority(ctx context.Context, obj *model.APITask) (bool, error)
 	CanUnschedule(ctx context.Context, obj *model.APITask) (bool, error)
+	Config(ctx context.Context, obj *model.APITask) (*model1.BuildVariantTaskUnit, error)
 
 	DependsOn(ctx context.Context, obj *model.APITask) ([]*Dependency, error)
 
@@ -10709,6 +10743,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Task.CanUnschedule(childComplexity), true
+	case "Task.config":
+		if e.complexity.Task.Config == nil {
+			break
+		}
+
+		return e.complexity.Task.Config(childComplexity), true
 	case "Task.createTime":
 		if e.complexity.Task.CreateTime == nil {
 			break
@@ -11145,6 +11185,133 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.TaskAnnotationSettings.FileTicketWebhook(childComplexity), true
+
+	case "TaskConfig.activate":
+		if e.complexity.TaskConfig.Activate == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.Activate(childComplexity), true
+	case "TaskConfig.allowForGitTag":
+		if e.complexity.TaskConfig.AllowForGitTag == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.AllowForGitTag(childComplexity), true
+	case "TaskConfig.allowedBranches":
+		if e.complexity.TaskConfig.AllowedBranches == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.AllowedBranches(childComplexity), true
+	case "TaskConfig.allowedRequesters":
+		if e.complexity.TaskConfig.AllowedRequesters == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.AllowedRequesters(childComplexity), true
+	case "TaskConfig.batchTime":
+		if e.complexity.TaskConfig.BatchTime == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.BatchTime(childComplexity), true
+	case "TaskConfig.cronBatchTime":
+		if e.complexity.TaskConfig.CronBatchTime == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.CronBatchTime(childComplexity), true
+	case "TaskConfig.dependsOn":
+		if e.complexity.TaskConfig.DependsOn == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.DependsOn(childComplexity), true
+	case "TaskConfig.disable":
+		if e.complexity.TaskConfig.Disable == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.Disable(childComplexity), true
+	case "TaskConfig.execTimeoutSecs":
+		if e.complexity.TaskConfig.ExecTimeoutSecs == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.ExecTimeoutSecs(childComplexity), true
+	case "TaskConfig.gitTagOnly":
+		if e.complexity.TaskConfig.GitTagOnly == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.GitTagOnly(childComplexity), true
+	case "TaskConfig.groupName":
+		if e.complexity.TaskConfig.GroupName == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.GroupName(childComplexity), true
+	case "TaskConfig.ignoredBranches":
+		if e.complexity.TaskConfig.IgnoredBranches == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.IgnoredBranches(childComplexity), true
+	case "TaskConfig.isGroup":
+		if e.complexity.TaskConfig.IsGroup == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.IsGroup(childComplexity), true
+	case "TaskConfig.isPartOfGroup":
+		if e.complexity.TaskConfig.IsPartOfGroup == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.IsPartOfGroup(childComplexity), true
+	case "TaskConfig.name":
+		if e.complexity.TaskConfig.Name == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.Name(childComplexity), true
+	case "TaskConfig.ps":
+		if e.complexity.TaskConfig.PS == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.PS(childComplexity), true
+	case "TaskConfig.patchOnly":
+		if e.complexity.TaskConfig.PatchOnly == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.PatchOnly(childComplexity), true
+	case "TaskConfig.patchable":
+		if e.complexity.TaskConfig.Patchable == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.Patchable(childComplexity), true
+	case "TaskConfig.priority":
+		if e.complexity.TaskConfig.Priority == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.Priority(childComplexity), true
+	case "TaskConfig.runOn":
+		if e.complexity.TaskConfig.RunOn == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.RunOn(childComplexity), true
+	case "TaskConfig.stepback":
+		if e.complexity.TaskConfig.Stepback == nil {
+			break
+		}
+
+		return e.complexity.TaskConfig.Stepback(childComplexity), true
 
 	case "TaskEndDetail.description":
 		if e.complexity.TaskEndDetail.Description == nil {
@@ -11821,6 +11988,37 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.TaskTestResultSample.TotalTestCount(childComplexity), true
+
+	case "TaskUnitDependency.name":
+		if e.complexity.TaskUnitDependency.Name == nil {
+			break
+		}
+
+		return e.complexity.TaskUnitDependency.Name(childComplexity), true
+	case "TaskUnitDependency.omitGeneratedTasks":
+		if e.complexity.TaskUnitDependency.OmitGeneratedTasks == nil {
+			break
+		}
+
+		return e.complexity.TaskUnitDependency.OmitGeneratedTasks(childComplexity), true
+	case "TaskUnitDependency.patchOptional":
+		if e.complexity.TaskUnitDependency.PatchOptional == nil {
+			break
+		}
+
+		return e.complexity.TaskUnitDependency.PatchOptional(childComplexity), true
+	case "TaskUnitDependency.status":
+		if e.complexity.TaskUnitDependency.Status == nil {
+			break
+		}
+
+		return e.complexity.TaskUnitDependency.Status(childComplexity), true
+	case "TaskUnitDependency.variant":
+		if e.complexity.TaskUnitDependency.Variant == nil {
+			break
+		}
+
+		return e.complexity.TaskUnitDependency.Variant(childComplexity), true
 
 	case "TestLog.lineNum":
 		if e.complexity.TestLog.LineNum == nil {
@@ -20546,6 +20744,8 @@ func (ec *executionContext) fieldContext_AdminTasksToRestartPayload_tasksToResta
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -29307,6 +29507,8 @@ func (ec *executionContext) fieldContext_GroupedBuildVariant_tasks(_ context.Con
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -32874,6 +33076,8 @@ func (ec *executionContext) fieldContext_Image_latestTask(_ context.Context, fie
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -39000,6 +39204,8 @@ func (ec *executionContext) fieldContext_Mutation_abortTask(ctx context.Context,
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -39227,6 +39433,8 @@ func (ec *executionContext) fieldContext_Mutation_overrideTaskDependencies(ctx c
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -39454,6 +39662,8 @@ func (ec *executionContext) fieldContext_Mutation_restartTask(ctx context.Contex
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -39681,6 +39891,8 @@ func (ec *executionContext) fieldContext_Mutation_scheduleTasks(ctx context.Cont
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -39908,6 +40120,8 @@ func (ec *executionContext) fieldContext_Mutation_setTaskPriority(ctx context.Co
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -40135,6 +40349,8 @@ func (ec *executionContext) fieldContext_Mutation_setTaskPriorities(ctx context.
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -40362,6 +40578,8 @@ func (ec *executionContext) fieldContext_Mutation_unscheduleTask(ctx context.Con
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -40727,6 +40945,8 @@ func (ec *executionContext) fieldContext_Mutation_quarantineTask(ctx context.Con
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -40954,6 +41174,8 @@ func (ec *executionContext) fieldContext_Mutation_unquarantineTask(ctx context.C
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -42089,6 +42311,8 @@ func (ec *executionContext) fieldContext_Mutation_scheduleUndispatchedBaseTasks(
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -53649,6 +53873,8 @@ func (ec *executionContext) fieldContext_Query_task(ctx context.Context, field g
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -53876,6 +54102,8 @@ func (ec *executionContext) fieldContext_Query_taskAllExecutions(ctx context.Con
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -61856,6 +62084,8 @@ func (ec *executionContext) fieldContext_Task_baseTask(_ context.Context, field 
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -62465,6 +62695,79 @@ func (ec *executionContext) fieldContext_Task_canUnschedule(_ context.Context, f
 	return fc, nil
 }
 
+func (ec *executionContext) _Task_config(ctx context.Context, field graphql.CollectedField, obj *model.APITask) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_Task_config,
+		func(ctx context.Context) (any, error) {
+			return ec.resolvers.Task().Config(ctx, obj)
+		},
+		nil,
+		ec.marshalOTaskConfig2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐBuildVariantTaskUnit,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_Task_config(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Task",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "activate":
+				return ec.fieldContext_TaskConfig_activate(ctx, field)
+			case "allowedBranches":
+				return ec.fieldContext_TaskConfig_allowedBranches(ctx, field)
+			case "allowedRequesters":
+				return ec.fieldContext_TaskConfig_allowedRequesters(ctx, field)
+			case "allowForGitTag":
+				return ec.fieldContext_TaskConfig_allowForGitTag(ctx, field)
+			case "batchTime":
+				return ec.fieldContext_TaskConfig_batchTime(ctx, field)
+			case "cronBatchTime":
+				return ec.fieldContext_TaskConfig_cronBatchTime(ctx, field)
+			case "dependsOn":
+				return ec.fieldContext_TaskConfig_dependsOn(ctx, field)
+			case "disable":
+				return ec.fieldContext_TaskConfig_disable(ctx, field)
+			case "execTimeoutSecs":
+				return ec.fieldContext_TaskConfig_execTimeoutSecs(ctx, field)
+			case "gitTagOnly":
+				return ec.fieldContext_TaskConfig_gitTagOnly(ctx, field)
+			case "groupName":
+				return ec.fieldContext_TaskConfig_groupName(ctx, field)
+			case "ignoredBranches":
+				return ec.fieldContext_TaskConfig_ignoredBranches(ctx, field)
+			case "isGroup":
+				return ec.fieldContext_TaskConfig_isGroup(ctx, field)
+			case "isPartOfGroup":
+				return ec.fieldContext_TaskConfig_isPartOfGroup(ctx, field)
+			case "name":
+				return ec.fieldContext_TaskConfig_name(ctx, field)
+			case "patchable":
+				return ec.fieldContext_TaskConfig_patchable(ctx, field)
+			case "patchOnly":
+				return ec.fieldContext_TaskConfig_patchOnly(ctx, field)
+			case "priority":
+				return ec.fieldContext_TaskConfig_priority(ctx, field)
+			case "ps":
+				return ec.fieldContext_TaskConfig_ps(ctx, field)
+			case "runOn":
+				return ec.fieldContext_TaskConfig_runOn(ctx, field)
+			case "stepback":
+				return ec.fieldContext_TaskConfig_stepback(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TaskConfig", field.Name)
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Task_createTime(ctx context.Context, field graphql.CollectedField, obj *model.APITask) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -62776,6 +63079,8 @@ func (ec *executionContext) fieldContext_Task_displayTask(_ context.Context, fie
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -63180,6 +63485,8 @@ func (ec *executionContext) fieldContext_Task_executionTasksFull(ctx context.Con
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -63615,6 +63922,8 @@ func (ec *executionContext) fieldContext_Task_generator(_ context.Context, field
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -64101,6 +64410,8 @@ func (ec *executionContext) fieldContext_Task_nextTask(_ context.Context, field 
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -64316,6 +64627,8 @@ func (ec *executionContext) fieldContext_Task_nextTaskCompleted(_ context.Contex
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -64531,6 +64844,8 @@ func (ec *executionContext) fieldContext_Task_nextTaskFailing(_ context.Context,
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -64746,6 +65061,8 @@ func (ec *executionContext) fieldContext_Task_nextTaskPassing(_ context.Context,
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -65153,6 +65470,8 @@ func (ec *executionContext) fieldContext_Task_prevTask(_ context.Context, field 
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -65369,6 +65688,8 @@ func (ec *executionContext) fieldContext_Task_prevTaskCompleted(ctx context.Cont
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -65595,6 +65916,8 @@ func (ec *executionContext) fieldContext_Task_prevTaskFailing(_ context.Context,
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -65810,6 +66133,8 @@ func (ec *executionContext) fieldContext_Task_prevTaskPassing(_ context.Context,
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -67026,6 +67351,627 @@ func (ec *executionContext) fieldContext_TaskAnnotationSettings_fileTicketWebhoo
 	return fc, nil
 }
 
+func (ec *executionContext) _TaskConfig_activate(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_activate,
+		func(ctx context.Context) (any, error) {
+			return obj.Activate, nil
+		},
+		nil,
+		ec.marshalOBoolean2ᚖbool,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_activate(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_allowedBranches(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_allowedBranches,
+		func(ctx context.Context) (any, error) {
+			return obj.AllowedBranches, nil
+		},
+		nil,
+		ec.marshalOString2ᚕstringᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_allowedBranches(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_allowedRequesters(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_allowedRequesters,
+		func(ctx context.Context) (any, error) {
+			return obj.AllowedRequesters, nil
+		},
+		nil,
+		ec.marshalOUserRequester2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequesterᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_allowedRequesters(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type UserRequester does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_allowForGitTag(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_allowForGitTag,
+		func(ctx context.Context) (any, error) {
+			return obj.AllowForGitTag, nil
+		},
+		nil,
+		ec.marshalOBoolean2ᚖbool,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_allowForGitTag(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_batchTime(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_batchTime,
+		func(ctx context.Context) (any, error) {
+			return obj.BatchTime, nil
+		},
+		nil,
+		ec.marshalOInt2ᚖint,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_batchTime(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_cronBatchTime(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_cronBatchTime,
+		func(ctx context.Context) (any, error) {
+			return obj.CronBatchTime, nil
+		},
+		nil,
+		ec.marshalOString2string,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_cronBatchTime(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_dependsOn(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_dependsOn,
+		func(ctx context.Context) (any, error) {
+			return obj.DependsOn, nil
+		},
+		nil,
+		ec.marshalOTaskUnitDependency2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐTaskUnitDependencyᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_dependsOn(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "name":
+				return ec.fieldContext_TaskUnitDependency_name(ctx, field)
+			case "omitGeneratedTasks":
+				return ec.fieldContext_TaskUnitDependency_omitGeneratedTasks(ctx, field)
+			case "patchOptional":
+				return ec.fieldContext_TaskUnitDependency_patchOptional(ctx, field)
+			case "status":
+				return ec.fieldContext_TaskUnitDependency_status(ctx, field)
+			case "variant":
+				return ec.fieldContext_TaskUnitDependency_variant(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type TaskUnitDependency", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_disable(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_disable,
+		func(ctx context.Context) (any, error) {
+			return obj.Disable, nil
+		},
+		nil,
+		ec.marshalOBoolean2ᚖbool,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_disable(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_execTimeoutSecs(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_execTimeoutSecs,
+		func(ctx context.Context) (any, error) {
+			return obj.ExecTimeoutSecs, nil
+		},
+		nil,
+		ec.marshalOInt2int,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_execTimeoutSecs(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_gitTagOnly(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_gitTagOnly,
+		func(ctx context.Context) (any, error) {
+			return obj.GitTagOnly, nil
+		},
+		nil,
+		ec.marshalOBoolean2ᚖbool,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_gitTagOnly(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_groupName(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_groupName,
+		func(ctx context.Context) (any, error) {
+			return obj.GroupName, nil
+		},
+		nil,
+		ec.marshalOString2string,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_groupName(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_ignoredBranches(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_ignoredBranches,
+		func(ctx context.Context) (any, error) {
+			return obj.IgnoredBranches, nil
+		},
+		nil,
+		ec.marshalOString2ᚕstringᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_ignoredBranches(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_isGroup(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_isGroup,
+		func(ctx context.Context) (any, error) {
+			return obj.IsGroup, nil
+		},
+		nil,
+		ec.marshalOBoolean2bool,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_isGroup(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_isPartOfGroup(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_isPartOfGroup,
+		func(ctx context.Context) (any, error) {
+			return obj.IsPartOfGroup, nil
+		},
+		nil,
+		ec.marshalOBoolean2bool,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_isPartOfGroup(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_name(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_name,
+		func(ctx context.Context) (any, error) {
+			return obj.Name, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_patchable(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_patchable,
+		func(ctx context.Context) (any, error) {
+			return obj.Patchable, nil
+		},
+		nil,
+		ec.marshalOBoolean2ᚖbool,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_patchable(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_patchOnly(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_patchOnly,
+		func(ctx context.Context) (any, error) {
+			return obj.PatchOnly, nil
+		},
+		nil,
+		ec.marshalOBoolean2ᚖbool,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_patchOnly(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_priority(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_priority,
+		func(ctx context.Context) (any, error) {
+			return obj.Priority, nil
+		},
+		nil,
+		ec.marshalOInt2int64,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_priority(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_ps(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_ps,
+		func(ctx context.Context) (any, error) {
+			return obj.PS, nil
+		},
+		nil,
+		ec.marshalOString2ᚖstring,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_ps(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_runOn(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_runOn,
+		func(ctx context.Context) (any, error) {
+			return obj.RunOn, nil
+		},
+		nil,
+		ec.marshalOString2ᚕstringᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_runOn(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskConfig_stepback(ctx context.Context, field graphql.CollectedField, obj *model1.BuildVariantTaskUnit) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskConfig_stepback,
+		func(ctx context.Context) (any, error) {
+			return obj.Stepback, nil
+		},
+		nil,
+		ec.marshalOBoolean2ᚖbool,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskConfig_stepback(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TaskEndDetail_description(ctx context.Context, field graphql.CollectedField, obj *model.ApiTaskEndDetail) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -68124,6 +69070,8 @@ func (ec *executionContext) fieldContext_TaskHistory_tasks(_ context.Context, fi
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -70535,6 +71483,151 @@ func (ec *executionContext) fieldContext_TaskTestResultSample_totalTestCount(_ c
 	return fc, nil
 }
 
+func (ec *executionContext) _TaskUnitDependency_name(ctx context.Context, field graphql.CollectedField, obj *model1.TaskUnitDependency) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskUnitDependency_name,
+		func(ctx context.Context) (any, error) {
+			return obj.Name, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskUnitDependency_name(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskUnitDependency",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskUnitDependency_omitGeneratedTasks(ctx context.Context, field graphql.CollectedField, obj *model1.TaskUnitDependency) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskUnitDependency_omitGeneratedTasks,
+		func(ctx context.Context) (any, error) {
+			return obj.OmitGeneratedTasks, nil
+		},
+		nil,
+		ec.marshalNBoolean2bool,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskUnitDependency_omitGeneratedTasks(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskUnitDependency",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskUnitDependency_patchOptional(ctx context.Context, field graphql.CollectedField, obj *model1.TaskUnitDependency) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskUnitDependency_patchOptional,
+		func(ctx context.Context) (any, error) {
+			return obj.PatchOptional, nil
+		},
+		nil,
+		ec.marshalNBoolean2bool,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskUnitDependency_patchOptional(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskUnitDependency",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskUnitDependency_status(ctx context.Context, field graphql.CollectedField, obj *model1.TaskUnitDependency) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskUnitDependency_status,
+		func(ctx context.Context) (any, error) {
+			return obj.Status, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskUnitDependency_status(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskUnitDependency",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TaskUnitDependency_variant(ctx context.Context, field graphql.CollectedField, obj *model1.TaskUnitDependency) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_TaskUnitDependency_variant,
+		func(ctx context.Context) (any, error) {
+			return obj.Variant, nil
+		},
+		nil,
+		ec.marshalNString2string,
+		true,
+		true,
+	)
+}
+
+func (ec *executionContext) fieldContext_TaskUnitDependency_variant(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "TaskUnitDependency",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _TestLog_lineNum(ctx context.Context, field graphql.CollectedField, obj *model.TestLogs) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -72795,6 +73888,8 @@ func (ec *executionContext) fieldContext_UpstreamProject_task(_ context.Context,
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -77197,6 +78292,8 @@ func (ec *executionContext) fieldContext_VersionTasks_data(_ context.Context, fi
 				return ec.fieldContext_Task_canSetPriority(ctx, field)
 			case "canUnschedule":
 				return ec.fieldContext_Task_canUnschedule(ctx, field)
+			case "config":
+				return ec.fieldContext_Task_config(ctx, field)
 			case "createTime":
 				return ec.fieldContext_Task_createTime(ctx, field)
 			case "dependsOn":
@@ -106764,6 +107861,39 @@ func (ec *executionContext) _Task(ctx context.Context, sel ast.SelectionSet, obj
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "config":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Task_config(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "createTime":
 			out.Values[i] = ec._Task_createTime(ctx, field, obj)
 		case "dependsOn":
@@ -108091,6 +109221,85 @@ func (ec *executionContext) _TaskAnnotationSettings(ctx context.Context, sel ast
 	return out
 }
 
+var taskConfigImplementors = []string{"TaskConfig"}
+
+func (ec *executionContext) _TaskConfig(ctx context.Context, sel ast.SelectionSet, obj *model1.BuildVariantTaskUnit) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, taskConfigImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TaskConfig")
+		case "activate":
+			out.Values[i] = ec._TaskConfig_activate(ctx, field, obj)
+		case "allowedBranches":
+			out.Values[i] = ec._TaskConfig_allowedBranches(ctx, field, obj)
+		case "allowedRequesters":
+			out.Values[i] = ec._TaskConfig_allowedRequesters(ctx, field, obj)
+		case "allowForGitTag":
+			out.Values[i] = ec._TaskConfig_allowForGitTag(ctx, field, obj)
+		case "batchTime":
+			out.Values[i] = ec._TaskConfig_batchTime(ctx, field, obj)
+		case "cronBatchTime":
+			out.Values[i] = ec._TaskConfig_cronBatchTime(ctx, field, obj)
+		case "dependsOn":
+			out.Values[i] = ec._TaskConfig_dependsOn(ctx, field, obj)
+		case "disable":
+			out.Values[i] = ec._TaskConfig_disable(ctx, field, obj)
+		case "execTimeoutSecs":
+			out.Values[i] = ec._TaskConfig_execTimeoutSecs(ctx, field, obj)
+		case "gitTagOnly":
+			out.Values[i] = ec._TaskConfig_gitTagOnly(ctx, field, obj)
+		case "groupName":
+			out.Values[i] = ec._TaskConfig_groupName(ctx, field, obj)
+		case "ignoredBranches":
+			out.Values[i] = ec._TaskConfig_ignoredBranches(ctx, field, obj)
+		case "isGroup":
+			out.Values[i] = ec._TaskConfig_isGroup(ctx, field, obj)
+		case "isPartOfGroup":
+			out.Values[i] = ec._TaskConfig_isPartOfGroup(ctx, field, obj)
+		case "name":
+			out.Values[i] = ec._TaskConfig_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "patchable":
+			out.Values[i] = ec._TaskConfig_patchable(ctx, field, obj)
+		case "patchOnly":
+			out.Values[i] = ec._TaskConfig_patchOnly(ctx, field, obj)
+		case "priority":
+			out.Values[i] = ec._TaskConfig_priority(ctx, field, obj)
+		case "ps":
+			out.Values[i] = ec._TaskConfig_ps(ctx, field, obj)
+		case "runOn":
+			out.Values[i] = ec._TaskConfig_runOn(ctx, field, obj)
+		case "stepback":
+			out.Values[i] = ec._TaskConfig_stepback(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
 var taskEndDetailImplementors = []string{"TaskEndDetail"}
 
 func (ec *executionContext) _TaskEndDetail(ctx context.Context, sel ast.SelectionSet, obj *model.ApiTaskEndDetail) graphql.Marshaler {
@@ -109390,6 +110599,65 @@ func (ec *executionContext) _TaskTestResultSample(ctx context.Context, sel ast.S
 			}
 		case "totalTestCount":
 			out.Values[i] = ec._TaskTestResultSample_totalTestCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var taskUnitDependencyImplementors = []string{"TaskUnitDependency"}
+
+func (ec *executionContext) _TaskUnitDependency(ctx context.Context, sel ast.SelectionSet, obj *model1.TaskUnitDependency) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, taskUnitDependencyImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TaskUnitDependency")
+		case "name":
+			out.Values[i] = ec._TaskUnitDependency_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "omitGeneratedTasks":
+			out.Values[i] = ec._TaskUnitDependency_omitGeneratedTasks(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "patchOptional":
+			out.Values[i] = ec._TaskUnitDependency_patchOptional(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "status":
+			out.Values[i] = ec._TaskUnitDependency_status(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "variant":
+			out.Values[i] = ec._TaskUnitDependency_variant(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -118418,6 +119686,10 @@ func (ec *executionContext) marshalNTaskTestResultSample2ᚖgithubᚗcomᚋeverg
 	return ec._TaskTestResultSample(ctx, sel, v)
 }
 
+func (ec *executionContext) marshalNTaskUnitDependency2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐTaskUnitDependency(ctx context.Context, sel ast.SelectionSet, v model1.TaskUnitDependency) graphql.Marshaler {
+	return ec._TaskUnitDependency(ctx, sel, &v)
+}
+
 func (ec *executionContext) unmarshalNTestFilter2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTestFilterᚄ(ctx context.Context, v any) ([]*TestFilter, error) {
 	var vSlice []any
 	vSlice = graphql.CoerceList(v)
@@ -118776,6 +120048,44 @@ func (ec *executionContext) marshalNUser2ᚖgithubᚗcomᚋevergreenᚑciᚋever
 	}
 	return ec._User(ctx, sel, v)
 }
+
+func (ec *executionContext) unmarshalNUserRequester2githubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequester(ctx context.Context, v any) (evergreen.UserRequester, error) {
+	tmp, err := graphql.UnmarshalString(v)
+	res := unmarshalNUserRequester2githubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequester[tmp]
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNUserRequester2githubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequester(ctx context.Context, sel ast.SelectionSet, v evergreen.UserRequester) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalString(marshalNUserRequester2githubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequester[v])
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
+var (
+	unmarshalNUserRequester2githubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequester = map[string]evergreen.UserRequester{
+		"AD_HOC":              evergreen.AdHocUserRequester,
+		"GIT_TAG":             evergreen.GitTagUserRequester,
+		"GITHUB_MERGE":        evergreen.GithubMergeUserRequester,
+		"GITHUB_PR":           evergreen.GithubPRUserRequester,
+		"PATCH_VERSION":       evergreen.PatchVersionUserRequester,
+		"REPOTRACKER_VERSION": evergreen.RepotrackerVersionUserRequester,
+		"TRIGGER":             evergreen.TriggerUserRequester,
+	}
+	marshalNUserRequester2githubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequester = map[evergreen.UserRequester]string{
+		evergreen.AdHocUserRequester:              "AD_HOC",
+		evergreen.GitTagUserRequester:             "GIT_TAG",
+		evergreen.GithubMergeUserRequester:        "GITHUB_MERGE",
+		evergreen.GithubPRUserRequester:           "GITHUB_PR",
+		evergreen.PatchVersionUserRequester:       "PATCH_VERSION",
+		evergreen.RepotrackerVersionUserRequester: "REPOTRACKER_VERSION",
+		evergreen.TriggerUserRequester:            "TRIGGER",
+	}
+)
 
 func (ec *executionContext) marshalNUserServiceFlags2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIServiceFlags(ctx context.Context, sel ast.SelectionSet, v *model.APIServiceFlags) graphql.Marshaler {
 	if v == nil {
@@ -122864,6 +124174,13 @@ func (ec *executionContext) unmarshalOTaskAnnotationSettingsInput2githubᚗcom�
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
+func (ec *executionContext) marshalOTaskConfig2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐBuildVariantTaskUnit(ctx context.Context, sel ast.SelectionSet, v *model1.BuildVariantTaskUnit) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._TaskConfig(ctx, sel, v)
+}
+
 func (ec *executionContext) unmarshalOTaskCountOptions2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTaskCountOptions(ctx context.Context, v any) (*TaskCountOptions, error) {
 	if v == nil {
 		return nil, nil
@@ -123121,6 +124438,53 @@ func (ec *executionContext) marshalOTaskTestResultSample2ᚕᚖgithubᚗcomᚋev
 	return ret
 }
 
+func (ec *executionContext) marshalOTaskUnitDependency2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐTaskUnitDependencyᚄ(ctx context.Context, sel ast.SelectionSet, v []model1.TaskUnitDependency) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTaskUnitDependency2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐTaskUnitDependency(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) unmarshalOTestFilterOptions2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐTestFilterOptions(ctx context.Context, v any) (*TestFilterOptions, error) {
 	if v == nil {
 		return nil, nil
@@ -123345,6 +124709,71 @@ func (ec *executionContext) marshalOUserConfig2ᚖgithubᚗcomᚋevergreenᚑci�
 		return graphql.Null
 	}
 	return ec._UserConfig(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalOUserRequester2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequesterᚄ(ctx context.Context, v any) ([]evergreen.UserRequester, error) {
+	if v == nil {
+		return nil, nil
+	}
+	var vSlice []any
+	vSlice = graphql.CoerceList(v)
+	var err error
+	res := make([]evergreen.UserRequester, len(vSlice))
+	for i := range vSlice {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithIndex(i))
+		res[i], err = ec.unmarshalNUserRequester2githubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequester(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) marshalOUserRequester2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequesterᚄ(ctx context.Context, sel ast.SelectionSet, v []evergreen.UserRequester) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNUserRequester2githubᚗcomᚋevergreenᚑciᚋevergreenᚐUserRequester(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalOUserSettings2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIUserSettings(ctx context.Context, sel ast.SelectionSet, v *model.APIUserSettings) graphql.Marshaler {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -71522,9 +71522,9 @@ func (ec *executionContext) _TaskUnitDependency_omitGeneratedTasks(ctx context.C
 			return obj.OmitGeneratedTasks, nil
 		},
 		nil,
-		ec.marshalNBoolean2bool,
+		ec.marshalOBoolean2bool,
 		true,
-		true,
+		false,
 	)
 }
 
@@ -71551,9 +71551,9 @@ func (ec *executionContext) _TaskUnitDependency_patchOptional(ctx context.Contex
 			return obj.PatchOptional, nil
 		},
 		nil,
-		ec.marshalNBoolean2bool,
+		ec.marshalOBoolean2bool,
 		true,
-		true,
+		false,
 	)
 }
 
@@ -71580,9 +71580,9 @@ func (ec *executionContext) _TaskUnitDependency_status(ctx context.Context, fiel
 			return obj.Status, nil
 		},
 		nil,
-		ec.marshalNString2string,
+		ec.marshalOString2string,
 		true,
-		true,
+		false,
 	)
 }
 
@@ -71609,9 +71609,9 @@ func (ec *executionContext) _TaskUnitDependency_variant(ctx context.Context, fie
 			return obj.Variant, nil
 		},
 		nil,
-		ec.marshalNString2string,
+		ec.marshalOString2string,
 		true,
-		true,
+		false,
 	)
 }
 
@@ -110643,24 +110643,12 @@ func (ec *executionContext) _TaskUnitDependency(ctx context.Context, sel ast.Sel
 			}
 		case "omitGeneratedTasks":
 			out.Values[i] = ec._TaskUnitDependency_omitGeneratedTasks(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		case "patchOptional":
 			out.Values[i] = ec._TaskUnitDependency_patchOptional(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		case "status":
 			out.Values[i] = ec._TaskUnitDependency_status(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		case "variant":
 			out.Values[i] = ec._TaskUnitDependency_variant(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/graphql/schema/types/task.graphql
+++ b/graphql/schema/types/task.graphql
@@ -88,6 +88,7 @@ type Task {
   canSchedule: Boolean!
   canSetPriority: Boolean!
   canUnschedule: Boolean!
+  config: TaskConfig
   createTime: Time
   dependsOn: [Dependency!]
   details: TaskEndDetail
@@ -393,4 +394,46 @@ input QuarantineTestInput {
 input UnquarantineTestInput {
   taskId: String! @requireProjectAccess(permission: TASKS, access: EDIT)
   testName: String!
+}
+
+enum UserRequester {
+  AD_HOC
+  GIT_TAG
+  GITHUB_MERGE
+  GITHUB_PR
+  PATCH_VERSION
+  REPOTRACKER_VERSION
+  TRIGGER
+}
+
+type TaskUnitDependency {
+  name: String!
+  omitGeneratedTasks: Boolean!
+  patchOptional: Boolean!
+  status: String!
+  variant: String!
+}
+
+type TaskConfig {
+  activate: Boolean
+  allowedBranches: [String!]
+  allowedRequesters: [UserRequester!]
+  allowForGitTag: Boolean
+  batchTime: Int
+  cronBatchTime: String
+  dependsOn: [TaskUnitDependency!]
+  disable: Boolean
+  execTimeoutSecs: Int
+  gitTagOnly: Boolean
+  groupName: String
+  ignoredBranches: [String!]
+  isGroup: Boolean
+  isPartOfGroup: Boolean
+  name: String!
+  patchable: Boolean
+  patchOnly: Boolean
+  priority: Int
+  ps: String
+  runOn: [String!]
+  stepback: Boolean
 }

--- a/graphql/schema/types/task.graphql
+++ b/graphql/schema/types/task.graphql
@@ -408,10 +408,10 @@ enum UserRequester {
 
 type TaskUnitDependency {
   name: String!
-  omitGeneratedTasks: Boolean!
-  patchOptional: Boolean!
-  status: String!
-  variant: String!
+  omitGeneratedTasks: Boolean
+  patchOptional: Boolean
+  status: String
+  variant: String
 }
 
 type TaskConfig {

--- a/graphql/schema/types/task.graphql
+++ b/graphql/schema/types/task.graphql
@@ -396,16 +396,6 @@ input UnquarantineTestInput {
   testName: String!
 }
 
-enum UserRequester {
-  AD_HOC
-  GIT_TAG
-  GITHUB_MERGE
-  GITHUB_PR
-  PATCH_VERSION
-  REPOTRACKER_VERSION
-  TRIGGER
-}
-
 type TaskUnitDependency {
   name: String!
   omitGeneratedTasks: Boolean
@@ -417,7 +407,7 @@ type TaskUnitDependency {
 type TaskConfig {
   activate: Boolean
   allowedBranches: [String!]
-  allowedRequesters: [UserRequester!]
+  allowedRequesters: [String!]
   allowForGitTag: Boolean
   batchTime: Int
   cronBatchTime: String

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -283,6 +283,15 @@ func (r *taskResolver) CanUnschedule(ctx context.Context, obj *restModel.APITask
 	return (obj.Activated && *obj.Status == evergreen.TaskUndispatched && obj.ParentTaskId == ""), nil
 }
 
+// Config is the resolver for the config field.
+func (r *taskResolver) Config(ctx context.Context, obj *restModel.APITask) (*model.BuildVariantTaskUnit, error) {
+	project, err := model.FindProjectFromVersionID(ctx, utility.FromStringPtr(obj.Version))
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, err.Error())
+	}
+	return project.FindTaskForVariant(utility.FromStringPtr(obj.DisplayName), utility.FromStringPtr(obj.BuildVariant)), nil
+}
+
 // DependsOn is the resolver for the dependsOn field.
 func (r *taskResolver) DependsOn(ctx context.Context, obj *restModel.APITask) ([]*Dependency, error) {
 	dependencies := []*Dependency{}

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -967,11 +967,24 @@ func (r *taskResolver) VersionMetadata(ctx context.Context, obj *restModel.APITa
 	return apiVersion, nil
 }
 
+// AllowedRequesters is the resolver for the allowedRequesters field.
+func (r *taskConfigResolver) AllowedRequesters(ctx context.Context, obj *model.BuildVariantTaskUnit) ([]string, error) {
+	requesters := make([]string, len(obj.AllowedRequesters))
+	for i, requester := range obj.AllowedRequesters {
+		requesters[i] = string(requester)
+	}
+	return requesters, nil
+}
+
 // Cost returns CostResolver implementation.
 func (r *Resolver) Cost() CostResolver { return &costResolver{r} }
 
 // Task returns TaskResolver implementation.
 func (r *Resolver) Task() TaskResolver { return &taskResolver{r} }
 
+// TaskConfig returns TaskConfigResolver implementation.
+func (r *Resolver) TaskConfig() TaskConfigResolver { return &taskConfigResolver{r} }
+
 type costResolver struct{ *Resolver }
 type taskResolver struct{ *Resolver }
+type taskConfigResolver struct{ *Resolver }

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -289,7 +289,7 @@ func (r *taskResolver) Config(ctx context.Context, obj *restModel.APITask) (*mod
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, err.Error())
 	}
-	return project.FindTaskForVariant(utility.FromStringPtr(obj.DisplayName), utility.FromStringPtr(obj.BuildVariant)), nil
+	return project.FindExpandedTaskForVariant(utility.FromStringPtr(obj.DisplayName), utility.FromStringPtr(obj.BuildVariant)), nil
 }
 
 // DependsOn is the resolver for the dependsOn field.

--- a/graphql/tests/task/config/data.json
+++ b/graphql/tests/task/config/data.json
@@ -20,17 +20,6 @@
       "display_task_id": ""
     },
     {
-      "_id": "task_without_config",
-      "version": "config_version",
-      "branch": "config_project",
-      "build_variant": "linux",
-      "display_name": "not_in_project",
-      "r": "gitter_request",
-      "status": "success",
-      "execution": 0,
-      "display_task_id": ""
-    },
-    {
       "_id": "task_group_member",
       "version": "config_version",
       "branch": "config_project",

--- a/graphql/tests/task/config/data.json
+++ b/graphql/tests/task/config/data.json
@@ -64,6 +64,9 @@
           "ps": "task-ps"
         },
         {
+          "name": "group_setup"
+        },
+        {
           "name": "test",
           "priority": 4,
           "depends_on": [
@@ -79,7 +82,8 @@
       "task_groups": [
         {
           "name": "test_group",
-          "tasks": ["test"]
+          "max_hosts": 1,
+          "tasks": ["group_setup", "test"]
         }
       ],
       "buildvariants": [

--- a/graphql/tests/task/config/data.json
+++ b/graphql/tests/task/config/data.json
@@ -1,8 +1,14 @@
 {
+  "project_ref": [
+    {
+      "_id": "spruce",
+      "identifier": "spruce"
+    }
+  ],
   "versions": [
     {
       "_id": "config_version",
-      "identifier": "config_project",
+      "identifier": "spruce",
       "storage_method": "db",
       "r": "gitter_request"
     }
@@ -11,7 +17,7 @@
     {
       "_id": "configured_task",
       "version": "config_version",
-      "branch": "config_project",
+      "branch": "spruce",
       "build_variant": "linux",
       "display_name": "compile",
       "r": "gitter_request",
@@ -22,7 +28,7 @@
     {
       "_id": "task_group_member",
       "version": "config_version",
-      "branch": "config_project",
+      "branch": "spruce",
       "build_variant": "linux",
       "display_name": "test",
       "r": "gitter_request",
@@ -34,7 +40,7 @@
   "parser_projects": [
     {
       "_id": "config_version",
-      "identifier": "config_project",
+      "identifier": "spruce",
       "tasks": [
         {
           "name": "setup"

--- a/graphql/tests/task/config/data.json
+++ b/graphql/tests/task/config/data.json
@@ -1,0 +1,122 @@
+{
+  "versions": [
+    {
+      "_id": "config_version",
+      "identifier": "config_project",
+      "storage_method": "db",
+      "r": "gitter_request"
+    }
+  ],
+  "tasks": [
+    {
+      "_id": "configured_task",
+      "version": "config_version",
+      "branch": "config_project",
+      "build_variant": "linux",
+      "display_name": "compile",
+      "r": "gitter_request",
+      "status": "success",
+      "execution": 0,
+      "display_task_id": ""
+    },
+    {
+      "_id": "task_without_config",
+      "version": "config_version",
+      "branch": "config_project",
+      "build_variant": "linux",
+      "display_name": "not_in_project",
+      "r": "gitter_request",
+      "status": "success",
+      "execution": 0,
+      "display_task_id": ""
+    },
+    {
+      "_id": "task_group_member",
+      "version": "config_version",
+      "branch": "config_project",
+      "build_variant": "linux",
+      "display_name": "test",
+      "r": "gitter_request",
+      "status": "success",
+      "execution": 0,
+      "display_task_id": ""
+    }
+  ],
+  "parser_projects": [
+    {
+      "_id": "config_version",
+      "identifier": "config_project",
+      "tasks": [
+        {
+          "name": "setup"
+        },
+        {
+          "name": "compile",
+          "priority": 5,
+          "exec_timeout_secs": 300,
+          "run_on": ["task-distro"],
+          "patchable": false,
+          "patch_only": true,
+          "allowed_requesters": ["patch", "github_pr"],
+          "allowed_branches": ["^main$"],
+          "ignored_branches": ["^legacy$"],
+          "stepback": true,
+          "ps": "task-ps"
+        },
+        {
+          "name": "test",
+          "priority": 4,
+          "depends_on": [
+            {
+              "taskselector": {
+                "name": "setup"
+              },
+              "status": "success"
+            }
+          ]
+        }
+      ],
+      "task_groups": [
+        {
+          "name": "test_group",
+          "tasks": ["test"]
+        }
+      ],
+      "buildvariants": [
+        {
+          "name": "linux",
+          "run_on": ["variant-distro"],
+          "disable": true,
+          "allow_for_git_tag": false,
+          "git_tag_only": true,
+          "exec_timeout_secs": 600,
+          "tasks": [
+            {
+              "name": "setup"
+            },
+            {
+              "name": "compile",
+              "priority": 9,
+              "batchtime": 15,
+              "activate": false,
+              "stepback": false,
+              "depends_on": [
+                {
+                  "taskselector": {
+                    "name": "setup"
+                  },
+                  "status": "success",
+                  "patch_optional": true,
+                  "omit_generated_tasks": true
+                }
+              ]
+            },
+            {
+              "name": "test_group"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/graphql/tests/task/config/data.json
+++ b/graphql/tests/task/config/data.json
@@ -116,7 +116,12 @@
               ]
             },
             {
-              "name": "test_group"
+              "name": "test_group",
+              "allowed_branches": ["^group$"],
+              "ignored_branches": ["^ignored$"],
+              "exec_timeout_secs": 45,
+              "batchtime": 20,
+              "ps": "group-ps"
             }
           ]
         }

--- a/graphql/tests/task/config/queries/config.graphql
+++ b/graphql/tests/task/config/queries/config.graphql
@@ -1,0 +1,34 @@
+{
+  task(taskId: "configured_task") {
+    id
+    config {
+      activate
+      allowedBranches
+      allowedRequesters
+      allowForGitTag
+      batchTime
+      cronBatchTime
+      dependsOn {
+        name
+        omitGeneratedTasks
+        patchOptional
+        status
+        variant
+      }
+      disable
+      execTimeoutSecs
+      gitTagOnly
+      groupName
+      ignoredBranches
+      isGroup
+      isPartOfGroup
+      name
+      patchable
+      patchOnly
+      priority
+      ps
+      runOn
+      stepback
+    }
+  }
+}

--- a/graphql/tests/task/config/queries/no_config.graphql
+++ b/graphql/tests/task/config/queries/no_config.graphql
@@ -1,0 +1,8 @@
+{
+  task(taskId: "task_without_config") {
+    id
+    config {
+      name
+    }
+  }
+}

--- a/graphql/tests/task/config/queries/no_config.graphql
+++ b/graphql/tests/task/config/queries/no_config.graphql
@@ -1,8 +1,0 @@
-{
-  task(taskId: "task_without_config") {
-    id
-    config {
-      name
-    }
-  }
-}

--- a/graphql/tests/task/config/queries/task_group_config.graphql
+++ b/graphql/tests/task/config/queries/task_group_config.graphql
@@ -1,0 +1,17 @@
+{
+  task(taskId: "task_group_member") {
+    id
+    config {
+      dependsOn {
+        name
+        status
+        variant
+      }
+      groupName
+      isGroup
+      isPartOfGroup
+      name
+      priority
+    }
+  }
+}

--- a/graphql/tests/task/config/queries/task_group_config.graphql
+++ b/graphql/tests/task/config/queries/task_group_config.graphql
@@ -2,16 +2,21 @@
   task(taskId: "task_group_member") {
     id
     config {
+      allowedBranches
+      batchTime
       dependsOn {
         name
         status
         variant
       }
+      execTimeoutSecs
       groupName
+      ignoredBranches
       isGroup
       isPartOfGroup
       name
       priority
+      ps
     }
   }
 }

--- a/graphql/tests/task/config/results.json
+++ b/graphql/tests/task/config/results.json
@@ -53,6 +53,11 @@
                   "name": "setup",
                   "status": "success",
                   "variant": ""
+                },
+                {
+                  "name": "group_setup",
+                  "status": "success",
+                  "variant": "linux"
                 }
               ],
               "groupName": "test_group",

--- a/graphql/tests/task/config/results.json
+++ b/graphql/tests/task/config/results.json
@@ -9,7 +9,7 @@
             "config": {
               "activate": false,
               "allowedBranches": ["^main$"],
-              "allowedRequesters": ["PATCH_VERSION", "GITHUB_PR"],
+              "allowedRequesters": ["patch", "github_pr"],
               "allowForGitTag": false,
               "batchTime": 15,
               "cronBatchTime": "",
@@ -71,17 +71,6 @@
               "priority": 4,
               "ps": "group-ps"
             }
-          }
-        }
-      }
-    },
-    {
-      "query_file": "no_config.graphql",
-      "result": {
-        "data": {
-          "task": {
-            "id": "task_without_config",
-            "config": null
           }
         }
       }

--- a/graphql/tests/task/config/results.json
+++ b/graphql/tests/task/config/results.json
@@ -1,0 +1,80 @@
+{
+  "tests": [
+    {
+      "query_file": "config.graphql",
+      "result": {
+        "data": {
+          "task": {
+            "id": "configured_task",
+            "config": {
+              "activate": false,
+              "allowedBranches": ["^main$"],
+              "allowedRequesters": ["PATCH_VERSION", "GITHUB_PR"],
+              "allowForGitTag": false,
+              "batchTime": 15,
+              "cronBatchTime": "",
+              "dependsOn": [
+                {
+                  "name": "setup",
+                  "omitGeneratedTasks": true,
+                  "patchOptional": true,
+                  "status": "success",
+                  "variant": ""
+                }
+              ],
+              "disable": true,
+              "execTimeoutSecs": 300,
+              "gitTagOnly": true,
+              "groupName": "",
+              "ignoredBranches": ["^legacy$"],
+              "isGroup": false,
+              "isPartOfGroup": false,
+              "name": "compile",
+              "patchable": false,
+              "patchOnly": true,
+              "priority": 9,
+              "ps": "task-ps",
+              "runOn": ["task-distro"],
+              "stepback": false
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "task_group_config.graphql",
+      "result": {
+        "data": {
+          "task": {
+            "id": "task_group_member",
+            "config": {
+              "dependsOn": [
+                {
+                  "name": "setup",
+                  "status": "success",
+                  "variant": ""
+                }
+              ],
+              "groupName": "test_group",
+              "isGroup": false,
+              "isPartOfGroup": true,
+              "name": "test",
+              "priority": 4
+            }
+          }
+        }
+      }
+    },
+    {
+      "query_file": "no_config.graphql",
+      "result": {
+        "data": {
+          "task": {
+            "id": "task_without_config",
+            "config": null
+          }
+        }
+      }
+    }
+  ]
+}

--- a/graphql/tests/task/config/results.json
+++ b/graphql/tests/task/config/results.json
@@ -48,6 +48,8 @@
           "task": {
             "id": "task_group_member",
             "config": {
+              "allowedBranches": ["^group$"],
+              "batchTime": 20,
               "dependsOn": [
                 {
                   "name": "setup",
@@ -60,11 +62,14 @@
                   "variant": "linux"
                 }
               ],
+              "execTimeoutSecs": 45,
               "groupName": "test_group",
+              "ignoredBranches": ["^ignored$"],
               "isGroup": false,
               "isPartOfGroup": true,
               "name": "test",
-              "priority": 4
+              "priority": 4,
+              "ps": "group-ps"
             }
           }
         }

--- a/model/project.go
+++ b/model/project.go
@@ -1498,8 +1498,9 @@ func (p *Project) FindTaskForVariant(task, variant string) *BuildVariantTaskUnit
 }
 
 // FindExpandedTaskForVariant returns the fully populated build variant task
-// unit for a task. Unlike FindTaskForVariant, tasks within task groups are
-// returned as individual task units rather than as their containing group.
+// unit for a task, including implicit task group dependencies. Unlike
+// FindTaskForVariant, tasks within task groups are returned as individual task
+// units rather than as their containing group.
 func (p *Project) FindExpandedTaskForVariant(task, variant string) *BuildVariantTaskUnit {
 	bv := p.FindBuildVariant(variant)
 	if bv == nil {
@@ -1510,6 +1511,7 @@ func (p *Project) FindExpandedTaskForVariant(task, variant string) *BuildVariant
 		if bvt.IsGroup {
 			for _, expandedTask := range p.tasksFromGroup(bvt) {
 				if expandedTask.Name == task {
+					p.addImplicitTaskGroupDependency(&expandedTask)
 					return &expandedTask
 				}
 			}
@@ -1523,6 +1525,26 @@ func (p *Project) FindExpandedTaskForVariant(task, variant string) *BuildVariant
 		}
 	}
 	return nil
+}
+
+func (p *Project) addImplicitTaskGroupDependency(bvt *BuildVariantTaskUnit) {
+	if bvt.GroupName == "" {
+		return
+	}
+	tg := p.FindTaskGroup(bvt.GroupName)
+	if tg == nil || tg.MaxHosts > 1 {
+		return
+	}
+	for i, taskName := range tg.Tasks {
+		if taskName == bvt.Name && i > 0 {
+			bvt.DependsOn = append(bvt.DependsOn, TaskUnitDependency{
+				Name:    tg.Tasks[i-1],
+				Variant: bvt.Variant,
+				Status:  evergreen.TaskSucceeded,
+			})
+			return
+		}
+	}
 }
 
 func (p *Project) FindBuildVariant(build string) *BuildVariant {
@@ -2284,20 +2306,7 @@ func (p *Project) DependencyGraph() task.DependencyGraph {
 func dependenciesForTaskUnit(taskUnits []BuildVariantTaskUnit, p *Project) []task.DependencyEdge {
 	var dependencies []task.DependencyEdge
 	for _, dependentTask := range taskUnits {
-		if dependentTask.GroupName != "" {
-			tg := p.FindTaskGroup(dependentTask.GroupName)
-			if tg != nil && tg.MaxHosts <= 1 {
-				// Single host task groups are a special case of dependencies because they implicitly form a linear
-				// dependency chain on the prior task group tasks.
-				for i, v := range slices.Backward(tg.Tasks) {
-					// Check the task display names since no display name will appear twice
-					// within the same task group.
-					if dependentTask.Name == v && i > 0 {
-						dependentTask.DependsOn = append(dependentTask.DependsOn, TaskUnitDependency{Name: tg.Tasks[i-1], Variant: dependentTask.Variant})
-					}
-				}
-			}
-		}
+		p.addImplicitTaskGroupDependency(&dependentTask)
 		for _, dep := range dependentTask.DependsOn {
 			// Use the current variant if none is specified.
 			if dep.Variant == "" {

--- a/model/project.go
+++ b/model/project.go
@@ -1514,9 +1514,20 @@ func (p *Project) FindExpandedTaskForVariant(task, variant string) *BuildVariant
 	if bv == nil {
 		return nil
 	}
-	for _, bvt := range p.expandBuildVariantTasks(*bv) {
+	for _, bvt := range bv.Tasks {
+		if bvt.IsGroup {
+			for _, groupTask := range p.tasksFromGroup(bvt) {
+				if groupTask.Name == task {
+					p.addImplicitTaskGroupDependency(&groupTask)
+					return &groupTask
+				}
+			}
+			continue
+		}
 		if bvt.Name == task {
-			p.addImplicitTaskGroupDependency(&bvt)
+			if projectTask := p.FindProjectTask(task); projectTask != nil {
+				bvt.Populate(*projectTask, *bv)
+			}
 			return &bvt
 		}
 	}
@@ -1753,26 +1764,22 @@ func (p *Project) FindAllVariants() []string {
 // considered build variant task units, are not preserved. Instead, each task in
 // the task group is expanded into its own individual tasks units.
 func (p *Project) FindAllBuildVariantTasks() []BuildVariantTaskUnit {
+	tasksByName := map[string]ProjectTask{}
+	for _, t := range p.Tasks {
+		tasksByName[t.Name] = t
+	}
 	allBVTs := []BuildVariantTaskUnit{}
 	for _, b := range p.BuildVariants {
-		allBVTs = append(allBVTs, p.expandBuildVariantTasks(b)...)
+		for _, t := range b.Tasks {
+			if t.IsGroup {
+				allBVTs = append(allBVTs, p.tasksFromGroup(t)...)
+			} else {
+				t.Populate(tasksByName[t.Name], b)
+				allBVTs = append(allBVTs, t)
+			}
+		}
 	}
 	return allBVTs
-}
-
-func (p *Project) expandBuildVariantTasks(bv BuildVariant) []BuildVariantTaskUnit {
-	tasks := []BuildVariantTaskUnit{}
-	for _, bvt := range bv.Tasks {
-		if bvt.IsGroup {
-			tasks = append(tasks, p.tasksFromGroup(bvt)...)
-			continue
-		}
-		if projectTask := p.FindProjectTask(bvt.Name); projectTask != nil {
-			bvt.Populate(*projectTask, bv)
-		}
-		tasks = append(tasks, bvt)
-	}
-	return tasks
 }
 
 // tasksFromGroup returns a slice of the task group's tasks.

--- a/model/project.go
+++ b/model/project.go
@@ -1497,6 +1497,34 @@ func (p *Project) FindTaskForVariant(task, variant string) *BuildVariantTaskUnit
 	return nil
 }
 
+// FindExpandedTaskForVariant returns the fully populated build variant task
+// unit for a task. Unlike FindTaskForVariant, tasks within task groups are
+// returned as individual task units rather than as their containing group.
+func (p *Project) FindExpandedTaskForVariant(task, variant string) *BuildVariantTaskUnit {
+	bv := p.FindBuildVariant(variant)
+	if bv == nil {
+		return nil
+	}
+
+	for _, bvt := range bv.Tasks {
+		if bvt.IsGroup {
+			for _, expandedTask := range p.tasksFromGroup(bvt) {
+				if expandedTask.Name == task {
+					return &expandedTask
+				}
+			}
+			continue
+		}
+		if bvt.Name == task {
+			if projectTask := p.FindProjectTask(task); projectTask != nil {
+				bvt.Populate(*projectTask, *bv)
+			}
+			return &bvt
+		}
+	}
+	return nil
+}
+
 func (p *Project) FindBuildVariant(build string) *BuildVariant {
 	for _, b := range p.BuildVariants {
 		if b.Name == build {

--- a/model/project.go
+++ b/model/project.go
@@ -191,6 +191,14 @@ type BuildVariantTaskUnit struct {
 	CreateCheckRun *CheckRun `yaml:"create_check_run,omitempty" bson:"create_check_run,omitempty"`
 }
 
+func (bvt BuildVariantTaskUnit) asTaskGroupMember(task string) BuildVariantTaskUnit {
+	bvt.GroupName = bvt.Name
+	bvt.Name = task
+	bvt.IsGroup = false
+	bvt.IsPartOfGroup = true
+	return bvt
+}
+
 func (b BuildVariant) Get(name string) (BuildVariantTaskUnit, error) {
 	for idx := range b.Tasks {
 		if b.Tasks[idx].Name == name {
@@ -1506,21 +1514,9 @@ func (p *Project) FindExpandedTaskForVariant(task, variant string) *BuildVariant
 	if bv == nil {
 		return nil
 	}
-
-	for _, bvt := range bv.Tasks {
-		if bvt.IsGroup {
-			for _, expandedTask := range p.tasksFromGroup(bvt) {
-				if expandedTask.Name == task {
-					p.addImplicitTaskGroupDependency(&expandedTask)
-					return &expandedTask
-				}
-			}
-			continue
-		}
+	for _, bvt := range p.expandBuildVariantTasks(*bv) {
 		if bvt.Name == task {
-			if projectTask := p.FindProjectTask(task); projectTask != nil {
-				bvt.Populate(*projectTask, *bv)
-			}
+			p.addImplicitTaskGroupDependency(&bvt)
 			return &bvt
 		}
 	}
@@ -1537,7 +1533,7 @@ func (p *Project) addImplicitTaskGroupDependency(bvt *BuildVariantTaskUnit) {
 	}
 	for i, taskName := range tg.Tasks {
 		if taskName == bvt.Name && i > 0 {
-			bvt.DependsOn = append(bvt.DependsOn, TaskUnitDependency{
+			bvt.DependsOn = append(slices.Clone(bvt.DependsOn), TaskUnitDependency{
 				Name:    tg.Tasks[i-1],
 				Variant: bvt.Variant,
 				Status:  evergreen.TaskSucceeded,
@@ -1757,22 +1753,26 @@ func (p *Project) FindAllVariants() []string {
 // considered build variant task units, are not preserved. Instead, each task in
 // the task group is expanded into its own individual tasks units.
 func (p *Project) FindAllBuildVariantTasks() []BuildVariantTaskUnit {
-	tasksByName := map[string]ProjectTask{}
-	for _, t := range p.Tasks {
-		tasksByName[t.Name] = t
-	}
 	allBVTs := []BuildVariantTaskUnit{}
 	for _, b := range p.BuildVariants {
-		for _, t := range b.Tasks {
-			if t.IsGroup {
-				allBVTs = append(allBVTs, p.tasksFromGroup(t)...)
-			} else {
-				t.Populate(tasksByName[t.Name], b)
-				allBVTs = append(allBVTs, t)
-			}
-		}
+		allBVTs = append(allBVTs, p.expandBuildVariantTasks(b)...)
 	}
 	return allBVTs
+}
+
+func (p *Project) expandBuildVariantTasks(bv BuildVariant) []BuildVariantTaskUnit {
+	tasks := []BuildVariantTaskUnit{}
+	for _, bvt := range bv.Tasks {
+		if bvt.IsGroup {
+			tasks = append(tasks, p.tasksFromGroup(bvt)...)
+			continue
+		}
+		if projectTask := p.FindProjectTask(bvt.Name); projectTask != nil {
+			bvt.Populate(*projectTask, bv)
+		}
+		tasks = append(tasks, bvt)
+	}
+	return tasks
 }
 
 // tasksFromGroup returns a slice of the task group's tasks.
@@ -1797,34 +1797,12 @@ func (p *Project) tasksFromGroup(bvTaskGroup BuildVariantTaskUnit) []BuildVarian
 	}
 
 	tasks := []BuildVariantTaskUnit{}
-	taskMap := map[string]ProjectTask{}
-	for _, projTask := range p.Tasks {
-		taskMap[projTask.Name] = projTask
-	}
-
 	for _, t := range tg.Tasks {
-		bvt := BuildVariantTaskUnit{
-			Name: t,
-			// IsPartOfGroup and GroupName are used to indicate that the task
-			// unit is a task within the task group, not the task group itself.
-			// These are not persisted.
-			IsPartOfGroup:     true,
-			GroupName:         bvTaskGroup.Name,
-			Variant:           bvTaskGroup.Variant,
-			Patchable:         bvTaskGroup.Patchable,
-			PatchOnly:         bvTaskGroup.PatchOnly,
-			Disable:           bvTaskGroup.Disable,
-			AllowForGitTag:    bvTaskGroup.AllowForGitTag,
-			GitTagOnly:        bvTaskGroup.GitTagOnly,
-			AllowedRequesters: bvTaskGroup.AllowedRequesters,
-			Priority:          bvTaskGroup.Priority,
-			DependsOn:         bvTaskGroup.DependsOn,
-			RunOn:             bvTaskGroup.RunOn,
-			Stepback:          bvTaskGroup.Stepback,
-			Activate:          bvTaskGroup.Activate,
-		}
+		bvt := bvTaskGroup.asTaskGroupMember(t)
 		// Default to project task settings when unspecified
-		bvt.Populate(taskMap[t], *bv)
+		if projectTask := p.FindProjectTask(t); projectTask != nil {
+			bvt.Populate(*projectTask, *bv)
+		}
 		tasks = append(tasks, bvt)
 	}
 	return tasks

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -2689,6 +2689,8 @@ func TestFindExpandedTaskForVariant(t *testing.T) {
 		bvName = "bv"
 		tgName = "task_group"
 	)
+	batchTime := 15
+	ps := "group-ps"
 	p := Project{
 		Tasks: []ProjectTask{
 			{Name: "standalone", Priority: 1},
@@ -2699,7 +2701,18 @@ func TestFindExpandedTaskForVariant(t *testing.T) {
 			Name: bvName,
 			Tasks: []BuildVariantTaskUnit{
 				{Name: "standalone", Variant: bvName},
-				{Name: tgName, IsGroup: true, Variant: bvName},
+				{
+					Name:              tgName,
+					IsGroup:           true,
+					Variant:           bvName,
+					AllowedBranches:   []string{"^group$"},
+					IgnoredBranches:   []string{"^ignored$"},
+					ExecTimeoutSecs:   30,
+					BatchTime:         &batchTime,
+					PS:                &ps,
+					CreateCheckRun:    &CheckRun{},
+					AllowedRequesters: []evergreen.UserRequester{evergreen.AdHocUserRequester},
+				},
 			},
 		}},
 		TaskGroups: []TaskGroup{{Name: tgName, MaxHosts: 1, Tasks: []string{"in_group_0", "in_group"}}},
@@ -2723,6 +2736,13 @@ func TestFindExpandedTaskForVariant(t *testing.T) {
 		assert.False(t, bvt.IsGroup)
 		assert.True(t, bvt.IsPartOfGroup)
 		assert.Equal(t, tgName, bvt.GroupName)
+		assert.Equal(t, []string{"^group$"}, bvt.AllowedBranches)
+		assert.Equal(t, []string{"^ignored$"}, bvt.IgnoredBranches)
+		assert.Equal(t, 30, bvt.ExecTimeoutSecs)
+		assert.Equal(t, &batchTime, bvt.BatchTime)
+		assert.Equal(t, &ps, bvt.PS)
+		assert.NotNil(t, bvt.CreateCheckRun)
+		assert.Equal(t, []evergreen.UserRequester{evergreen.AdHocUserRequester}, bvt.AllowedRequesters)
 		require.Len(t, bvt.DependsOn, 1)
 		assert.Equal(t, TaskUnitDependency{
 			Name:    "in_group_0",
@@ -2733,6 +2753,10 @@ func TestFindExpandedTaskForVariant(t *testing.T) {
 
 	t.Run("MissingTask", func(t *testing.T) {
 		assert.Nil(t, p.FindExpandedTaskForVariant("missing", bvName))
+	})
+
+	t.Run("TaskGroupParent", func(t *testing.T) {
+		assert.Nil(t, p.FindExpandedTaskForVariant(tgName, bvName))
 	})
 
 	t.Run("MissingVariant", func(t *testing.T) {

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -2692,6 +2692,7 @@ func TestFindExpandedTaskForVariant(t *testing.T) {
 	p := Project{
 		Tasks: []ProjectTask{
 			{Name: "standalone", Priority: 1},
+			{Name: "in_group_0"},
 			{Name: "in_group", Priority: 2},
 		},
 		BuildVariants: []BuildVariant{{
@@ -2701,7 +2702,7 @@ func TestFindExpandedTaskForVariant(t *testing.T) {
 				{Name: tgName, IsGroup: true, Variant: bvName},
 			},
 		}},
-		TaskGroups: []TaskGroup{{Name: tgName, Tasks: []string{"in_group"}}},
+		TaskGroups: []TaskGroup{{Name: tgName, MaxHosts: 1, Tasks: []string{"in_group_0", "in_group"}}},
 	}
 
 	t.Run("StandaloneTask", func(t *testing.T) {
@@ -2722,6 +2723,12 @@ func TestFindExpandedTaskForVariant(t *testing.T) {
 		assert.False(t, bvt.IsGroup)
 		assert.True(t, bvt.IsPartOfGroup)
 		assert.Equal(t, tgName, bvt.GroupName)
+		require.Len(t, bvt.DependsOn, 1)
+		assert.Equal(t, TaskUnitDependency{
+			Name:    "in_group_0",
+			Variant: bvName,
+			Status:  evergreen.TaskSucceeded,
+		}, bvt.DependsOn[0])
 	})
 
 	t.Run("MissingTask", func(t *testing.T) {
@@ -2913,8 +2920,8 @@ func TestDependenciesForTaskUnit(t *testing.T) {
 				},
 			},
 			expectedDependencies: []task.DependencyEdge{
-				{From: task.TaskNode{Name: "task2", Variant: "ubuntu"}, To: task.TaskNode{Name: "task1", Variant: "ubuntu"}},
-				{From: task.TaskNode{Name: "task3", Variant: "ubuntu"}, To: task.TaskNode{Name: "task2", Variant: "ubuntu"}},
+				{Status: evergreen.TaskSucceeded, From: task.TaskNode{Name: "task2", Variant: "ubuntu"}, To: task.TaskNode{Name: "task1", Variant: "ubuntu"}},
+				{Status: evergreen.TaskSucceeded, From: task.TaskNode{Name: "task3", Variant: "ubuntu"}, To: task.TaskNode{Name: "task2", Variant: "ubuntu"}},
 			},
 		},
 		"WithMultiHostTaskGroup": {
@@ -2994,7 +3001,7 @@ func TestDependenciesForTaskUnit(t *testing.T) {
 				},
 			},
 			expectedDependencies: []task.DependencyEdge{
-				{From: task.TaskNode{Name: "task2", Variant: "ubuntu"}, To: task.TaskNode{Name: "task1", Variant: "ubuntu"}},
+				{Status: evergreen.TaskSucceeded, From: task.TaskNode{Name: "task2", Variant: "ubuntu"}, To: task.TaskNode{Name: "task1", Variant: "ubuntu"}},
 				{From: task.TaskNode{Name: "task2", Variant: "ubuntu"}, To: task.TaskNode{Name: "external_task", Variant: "ubuntu"}},
 			},
 		},

--- a/model/project_test.go
+++ b/model/project_test.go
@@ -2684,6 +2684,55 @@ func TestFindAllBuildVariantTasks(t *testing.T) {
 	})
 }
 
+func TestFindExpandedTaskForVariant(t *testing.T) {
+	const (
+		bvName = "bv"
+		tgName = "task_group"
+	)
+	p := Project{
+		Tasks: []ProjectTask{
+			{Name: "standalone", Priority: 1},
+			{Name: "in_group", Priority: 2},
+		},
+		BuildVariants: []BuildVariant{{
+			Name: bvName,
+			Tasks: []BuildVariantTaskUnit{
+				{Name: "standalone", Variant: bvName},
+				{Name: tgName, IsGroup: true, Variant: bvName},
+			},
+		}},
+		TaskGroups: []TaskGroup{{Name: tgName, Tasks: []string{"in_group"}}},
+	}
+
+	t.Run("StandaloneTask", func(t *testing.T) {
+		bvt := p.FindExpandedTaskForVariant("standalone", bvName)
+		require.NotNil(t, bvt)
+		assert.Equal(t, "standalone", bvt.Name)
+		assert.Equal(t, int64(1), bvt.Priority)
+		assert.False(t, bvt.IsGroup)
+		assert.False(t, bvt.IsPartOfGroup)
+		assert.Empty(t, bvt.GroupName)
+	})
+
+	t.Run("TaskGroupMember", func(t *testing.T) {
+		bvt := p.FindExpandedTaskForVariant("in_group", bvName)
+		require.NotNil(t, bvt)
+		assert.Equal(t, "in_group", bvt.Name)
+		assert.Equal(t, int64(2), bvt.Priority)
+		assert.False(t, bvt.IsGroup)
+		assert.True(t, bvt.IsPartOfGroup)
+		assert.Equal(t, tgName, bvt.GroupName)
+	})
+
+	t.Run("MissingTask", func(t *testing.T) {
+		assert.Nil(t, p.FindExpandedTaskForVariant("missing", bvName))
+	})
+
+	t.Run("MissingVariant", func(t *testing.T) {
+		assert.Nil(t, p.FindExpandedTaskForVariant("standalone", "missing"))
+	})
+}
+
 func TestDependenciesForTaskUnit(t *testing.T) {
 	for testName, testCase := range map[string]struct {
 		expectedDependencies []task.DependencyEdge


### PR DESCRIPTION
DEVPROD-23865

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->
A user specifically requested a way to see the batchtime applied to the current task, but I think exposing the various configuration options in use may help people answer their own questions!

- Add a `Config` field to the `Task` type exposing the config used at runtime. This will be called only on-demand by a user if they navigate to a certain tab.
- The main edge case was around handling task groups. `FindTaskForVariant` pulled down the entire task group for any given task within it, since this is the unit used for scheduling. I added `FindExpandedTaskForVariant` which returns details for the individual task, not the group.
  - This allows us to populate the "depends_on" field with task group dependencies

### Testing
- Add graphql tests for task and task group
- Add task for new model method
<!--add a description of how you tested it-->

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
