### PR TITLE
DEVPROD-41576 Reduce number of calls to DB

### DIFF
--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3603,20 +3603,6 @@ func GetPaginatedRunningHosts(ctx context.Context, opts HostsFilterOptions) ([]H
 		{
 			"$match": bson.M{StatusKey: bson.M{"$ne": evergreen.HostTerminated}},
 		},
-		{
-			"$lookup": bson.M{
-				"from":         task.Collection,
-				"localField":   RunningTaskKey,
-				"foreignField": task.IdKey,
-				"as":           RunningTaskFullKey,
-			},
-		},
-		{
-			"$unwind": bson.M{
-				"path":                       "$" + RunningTaskFullKey,
-				"preserveNullAndEmptyArrays": true,
-			},
-		},
 	}
 
 	countPipeline := []bson.M{}
@@ -3724,6 +3710,26 @@ func GetPaginatedRunningHosts(ctx context.Context, opts HostsFilterOptions) ([]H
 	if opts.SortBy != IdKey {
 		sorters = append(sorters, bson.E{Key: IdKey, Value: 1})
 	}
+	// The running-task join is applied after filtering and before sorting, so the
+	// counts above never pay for it and it runs over the filtered set rather than
+	// every non-terminated host.
+	runningHostsPipeline = append(runningHostsPipeline,
+		bson.M{
+			"$lookup": bson.M{
+				"from":         task.Collection,
+				"localField":   RunningTaskKey,
+				"foreignField": task.IdKey,
+				"as":           RunningTaskFullKey,
+			},
+		},
+		bson.M{
+			"$unwind": bson.M{
+				"path":                       "$" + RunningTaskFullKey,
+				"preserveNullAndEmptyArrays": true,
+			},
+		},
+	)
+
 	runningHostsPipeline = append(runningHostsPipeline, bson.M{
 		"$sort": sorters,
 	})

--- a/model/host/host.go
+++ b/model/host/host.go
@@ -3710,9 +3710,7 @@ func GetPaginatedRunningHosts(ctx context.Context, opts HostsFilterOptions) ([]H
 	if opts.SortBy != IdKey {
 		sorters = append(sorters, bson.E{Key: IdKey, Value: 1})
 	}
-	// The running-task join is applied after filtering and before sorting, so the
-	// counts above never pay for it and it runs over the filtered set rather than
-	// every non-terminated host.
+	// Only add the lookup stage after counting since it's not needed for the count pipelines.
 	runningHostsPipeline = append(runningHostsPipeline,
 		bson.M{
 			"$lookup": bson.M{

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -7300,17 +7300,20 @@ func TestValidateDisplayName(t *testing.T) {
 	}
 }
 
-// TestGetPaginatedRunningHostsCountsAndTaskJoin pins the behavior that the
-// running-task $lookup is applied after filtering: the counts must not depend on
-// it, and hosts with no running task must still be returned.
+// TestGetPaginatedRunningHostsCountsAndTaskJoin tests that the
+// running-task $lookup is applied after filtering.
 func TestGetPaginatedRunningHostsCountsAndTaskJoin(t *testing.T) {
 	ctx := t.Context()
 	require.NoError(t, db.ClearCollections(Collection, task.Collection))
 	t.Cleanup(func() {
 		assert.NoError(t, db.ClearCollections(Collection, task.Collection))
 	})
+	someTask := task.Task{
+		Id:          "t1",
+		DisplayName: "some_task",
+	}
 
-	require.NoError(t, (&task.Task{Id: "t1", DisplayName: "some_task"}).Insert(ctx))
+	require.NoError(t, someTask.Insert(ctx))
 	for _, h := range []Host{
 		{Id: "h1", Status: evergreen.HostRunning, StartedBy: "me", RunningTask: "t1"},
 		{Id: "h2", Status: evergreen.HostRunning, StartedBy: "me"},

--- a/model/host/host_test.go
+++ b/model/host/host_test.go
@@ -7299,3 +7299,52 @@ func TestValidateDisplayName(t *testing.T) {
 		})
 	}
 }
+
+// TestGetPaginatedRunningHostsCountsAndTaskJoin pins the behavior that the
+// running-task $lookup is applied after filtering: the counts must not depend on
+// it, and hosts with no running task must still be returned.
+func TestGetPaginatedRunningHostsCountsAndTaskJoin(t *testing.T) {
+	ctx := t.Context()
+	require.NoError(t, db.ClearCollections(Collection, task.Collection))
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(Collection, task.Collection))
+	})
+
+	require.NoError(t, (&task.Task{Id: "t1", DisplayName: "some_task"}).Insert(ctx))
+	for _, h := range []Host{
+		{Id: "h1", Status: evergreen.HostRunning, StartedBy: "me", RunningTask: "t1"},
+		{Id: "h2", Status: evergreen.HostRunning, StartedBy: "me"},
+		{Id: "h3", Status: evergreen.HostProvisioning, StartedBy: "someone_else"},
+		{Id: "h4", Status: evergreen.HostTerminated, StartedBy: "me"},
+	} {
+		require.NoError(t, h.Insert(ctx))
+	}
+
+	t.Run("NoFiltersCountsEveryNonTerminatedHostAndLeavesFilteredCountNil", func(t *testing.T) {
+		hosts, filteredCount, totalCount, err := GetPaginatedRunningHosts(ctx, HostsFilterOptions{SortDir: 1})
+		require.NoError(t, err)
+		assert.Equal(t, 3, totalCount)
+		assert.Nil(t, filteredCount)
+		require.Len(t, hosts, 3)
+	})
+
+	t.Run("FilteredCountReflectsTheFilterAndTotalStaysWhole", func(t *testing.T) {
+		hosts, filteredCount, totalCount, err := GetPaginatedRunningHosts(ctx, HostsFilterOptions{StartedBy: "me", SortDir: 1})
+		require.NoError(t, err)
+		assert.Equal(t, 3, totalCount)
+		require.NotNil(t, filteredCount)
+		assert.Equal(t, 2, *filteredCount)
+		require.Len(t, hosts, 2)
+	})
+
+	t.Run("HostsWithoutARunningTaskAreStillReturnedAndTheTaskIsJoined", func(t *testing.T) {
+		hosts, _, _, err := GetPaginatedRunningHosts(ctx, HostsFilterOptions{SortBy: IdKey, SortDir: 1})
+		require.NoError(t, err)
+		require.Len(t, hosts, 3)
+		require.Equal(t, "h1", hosts[0].Id)
+		require.NotNil(t, hosts[0].RunningTaskFull)
+		assert.Equal(t, "some_task", hosts[0].RunningTaskFull.DisplayName)
+		assert.Equal(t, "h2", hosts[1].Id)
+		assert.Nil(t, hosts[1].RunningTaskFull)
+	})
+}

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -480,13 +480,7 @@ type APITaskArgs struct {
 	IncludeArtifacts         bool
 	LogURL                   string
 	ParsleyLogURL            string
-	// ArtifactsByTask, when non-nil, supplies the artifact entries keyed by the
-	// task ID and execution they were stored under, instead of querying for them.
-	// Callers converting a page of tasks should prefetch with
-	// artifact.ByTaskIdsAndExecutions rather than paying one query per task. The
-	// execution is part of the key because a page can contain both a display task
-	// and its execution tasks at differing executions.
-	ArtifactsByTask map[artifact.TaskIDAndExecution][]artifact.Entry
+	ArtifactsCache           map[artifact.TaskIDAndExecution][]artifact.Entry
 }
 
 // BuildFromService converts from a service level task by loading the data
@@ -528,7 +522,7 @@ func (at *APITask) BuildFromService(ctx context.Context, t *task.Task, args *API
 		}
 	}
 	if args.IncludeArtifacts {
-		if err := at.getArtifacts(ctx, args.LogURL, args.ArtifactsByTask); err != nil {
+		if err := at.getArtifacts(ctx, args.LogURL, args.ArtifactsCache); err != nil {
 			return errors.Wrap(err, "getting artifacts")
 		}
 	}

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -480,6 +480,13 @@ type APITaskArgs struct {
 	IncludeArtifacts         bool
 	LogURL                   string
 	ParsleyLogURL            string
+	// ArtifactsByTask, when non-nil, supplies the artifact entries keyed by the
+	// task ID and execution they were stored under, instead of querying for them.
+	// Callers converting a page of tasks should prefetch with
+	// artifact.ByTaskIdsAndExecutions rather than paying one query per task. The
+	// execution is part of the key because a page can contain both a display task
+	// and its execution tasks at differing executions.
+	ArtifactsByTask map[artifact.TaskIDAndExecution][]artifact.Entry
 }
 
 // BuildFromService converts from a service level task by loading the data
@@ -521,7 +528,7 @@ func (at *APITask) BuildFromService(ctx context.Context, t *task.Task, args *API
 		}
 	}
 	if args.IncludeArtifacts {
-		if err := at.getArtifacts(ctx, args.LogURL); err != nil {
+		if err := at.getArtifacts(ctx, args.LogURL, args.ArtifactsByTask); err != nil {
 			return errors.Wrap(err, "getting artifacts")
 		}
 	}
@@ -662,10 +669,17 @@ func (at *APITask) ToService() (*task.Task, error) {
 	return st, nil
 }
 
-func (at *APITask) getArtifacts(ctx context.Context, baseURL string) error {
+func (at *APITask) getArtifacts(ctx context.Context, baseURL string, prefetched map[artifact.TaskIDAndExecution][]artifact.Entry) error {
 	var err error
 	var entries []artifact.Entry
-	if at.DisplayOnly {
+	switch {
+	case prefetched != nil && at.DisplayOnly:
+		for _, t := range at.ExecutionTasks {
+			entries = append(entries, prefetched[artifact.TaskIDAndExecution{TaskID: utility.FromStringPtr(t), Execution: at.Execution}]...)
+		}
+	case prefetched != nil:
+		entries = prefetched[artifact.TaskIDAndExecution{TaskID: utility.FromStringPtr(at.Id), Execution: at.Execution}]
+	case at.DisplayOnly:
 		ets := []artifact.TaskIDAndExecution{}
 		for _, t := range at.ExecutionTasks {
 			ets = append(ets, artifact.TaskIDAndExecution{TaskID: *t, Execution: at.Execution})
@@ -673,7 +687,7 @@ func (at *APITask) getArtifacts(ctx context.Context, baseURL string) error {
 		if len(ets) > 0 {
 			entries, err = artifact.FindAll(ctx, artifact.ByTaskIdsAndExecutions(ets))
 		}
-	} else {
+	default:
 		entries, err = artifact.FindAll(ctx, artifact.ByTaskIdAndExecution(utility.FromStringPtr(at.Id), at.Execution))
 	}
 	if err != nil {

--- a/rest/model/task.go
+++ b/rest/model/task.go
@@ -663,6 +663,8 @@ func (at *APITask) ToService() (*task.Task, error) {
 	return st, nil
 }
 
+// getArtifacts batch fetches artifacts for all tasks. If the prefetched artifacts are passed in, we can guarantee
+// that all needed artifacts are in the cache.
 func (at *APITask) getArtifacts(ctx context.Context, baseURL string, prefetched map[artifact.TaskIDAndExecution][]artifact.Entry) error {
 	var err error
 	var entries []artifact.Entry

--- a/rest/route/build_task.go
+++ b/rest/route/build_task.go
@@ -105,10 +105,7 @@ func (tbh *tasksByBuildHandler) Run(ctx context.Context) gimlet.Responder {
 
 	tasks = tasks[:lastIndex]
 
-	// Artifacts, the project identifier, and host AMIs are all resolved up front
-	// for the whole page. Letting BuildFromService fetch them per task turns a
-	// single request into hundreds of queries.
-	artifactsByTask, err := getArtifactsForTasks(ctx, tasks)
+	artifactsCache, err := getArtifactsForTasks(ctx, tasks)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding artifacts for tasks in build '%s'", tbh.buildId))
 	}
@@ -116,9 +113,6 @@ func (tbh *tasksByBuildHandler) Run(ctx context.Context) gimlet.Responder {
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding hosts for tasks in build '%s'", tbh.buildId))
 	}
-	// Every task in a build belongs to the same project. A lookup failure is not
-	// fatal here, and a successful lookup of an empty identifier still sets the
-	// field, both matching APITask.GetProjectIdentifier.
 	projectIdentifier, foundProjectIdentifier := getProjectIdentifierForTasks(ctx, tasks)
 
 	for i := range tasks {
@@ -126,7 +120,7 @@ func (tbh *tasksByBuildHandler) Run(ctx context.Context) gimlet.Responder {
 
 		if err = taskModel.BuildFromService(ctx, &tasks[i], &model.APITaskArgs{
 			IncludeArtifacts: true,
-			ArtifactsByTask:  artifactsByTask,
+			ArtifactsCache:   artifactsCache,
 			LogURL:           GetURL(ctx),
 			ParsleyLogURL:    tbh.parsleyURL,
 		}); err != nil {
@@ -167,9 +161,7 @@ func (tbh *tasksByBuildHandler) Run(ctx context.Context) gimlet.Responder {
 }
 
 // getArtifactsForTasks fetches the artifact entries for a page of tasks in one
-// query, keyed by the task ID and execution they were stored under. Display
-// tasks store their artifacts under their execution tasks, so those IDs are keys
-// as well, at the display task's execution.
+// query. Display tasks store their artifacts under their execution tasks.
 func getArtifactsForTasks(ctx context.Context, tasks []task.Task) (map[artifact.TaskIDAndExecution][]artifact.Entry, error) {
 	var pairs []artifact.TaskIDAndExecution
 	for _, t := range tasks {
@@ -197,8 +189,7 @@ func getArtifactsForTasks(ctx context.Context, tasks []task.Task) (map[artifact.
 	return artifactsByTask, nil
 }
 
-// getAMIsForTasks fetches the AMI of every host running a task in the page in
-// one query, keyed by host ID.
+// getAMIsForTasks fetches the AMI of every host running a task in the page.
 func getAMIsForTasks(ctx context.Context, tasks []task.Task) (map[string]string, error) {
 	var hostIDs []string
 	seen := map[string]bool{}
@@ -227,9 +218,7 @@ func getAMIsForTasks(ctx context.Context, tasks []task.Task) (map[string]string,
 }
 
 // getProjectIdentifierForTasks resolves the project identifier shared by a page
-// of tasks. The boolean reports whether the lookup succeeded, so that a project
-// ref with an empty identifier still sets the field rather than leaving it null,
-// matching APITask.GetProjectIdentifier.
+// of tasks. Project ref with an empty identifier still sets the field rather than leaving it null
 func getProjectIdentifierForTasks(ctx context.Context, tasks []task.Task) (string, bool) {
 	if len(tasks) == 0 || tasks[0].Project == "" {
 		return "", false

--- a/rest/route/build_task.go
+++ b/rest/route/build_task.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"net/http"
 
+	dbModel "github.com/evergreen-ci/evergreen/model"
+	"github.com/evergreen-ci/evergreen/model/artifact"
+	"github.com/evergreen-ci/evergreen/model/host"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
@@ -101,17 +104,39 @@ func (tbh *tasksByBuildHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	tasks = tasks[:lastIndex]
+
+	// Artifacts, the project identifier, and host AMIs are all resolved up front
+	// for the whole page. Letting BuildFromService fetch them per task turns a
+	// single request into hundreds of queries.
+	artifactsByTask, err := getArtifactsForTasks(ctx, tasks)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding artifacts for tasks in build '%s'", tbh.buildId))
+	}
+	amisByHostID, err := getAMIsForTasks(ctx, tasks)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding hosts for tasks in build '%s'", tbh.buildId))
+	}
+	// Every task in a build belongs to the same project. A lookup failure is not
+	// fatal here, and a successful lookup of an empty identifier still sets the
+	// field, both matching APITask.GetProjectIdentifier.
+	projectIdentifier, foundProjectIdentifier := getProjectIdentifierForTasks(ctx, tasks)
+
 	for i := range tasks {
 		taskModel := &model.APITask{}
 
 		if err = taskModel.BuildFromService(ctx, &tasks[i], &model.APITaskArgs{
-			IncludeAMI:               true,
-			IncludeArtifacts:         true,
-			IncludeProjectIdentifier: true,
-			LogURL:                   GetURL(ctx),
-			ParsleyLogURL:            tbh.parsleyURL,
+			IncludeArtifacts: true,
+			ArtifactsByTask:  artifactsByTask,
+			LogURL:           GetURL(ctx),
+			ParsleyLogURL:    tbh.parsleyURL,
 		}); err != nil {
 			return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "converting task '%s' to API model", tasks[i].Id))
+		}
+		if foundProjectIdentifier {
+			taskModel.ProjectIdentifier = utility.ToStringPtr(projectIdentifier)
+		}
+		if ami := amisByHostID[tasks[i].HostId]; ami != "" {
+			taskModel.AMI = utility.ToStringPtr(ami)
 		}
 
 		if tbh.fetchAllExecutions {
@@ -139,4 +164,76 @@ func (tbh *tasksByBuildHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 
 	return resp
+}
+
+// getArtifactsForTasks fetches the artifact entries for a page of tasks in one
+// query, keyed by the task ID and execution they were stored under. Display
+// tasks store their artifacts under their execution tasks, so those IDs are keys
+// as well, at the display task's execution.
+func getArtifactsForTasks(ctx context.Context, tasks []task.Task) (map[artifact.TaskIDAndExecution][]artifact.Entry, error) {
+	var pairs []artifact.TaskIDAndExecution
+	for _, t := range tasks {
+		if t.DisplayOnly {
+			for _, execTaskID := range t.ExecutionTasks {
+				pairs = append(pairs, artifact.TaskIDAndExecution{TaskID: execTaskID, Execution: t.Execution})
+			}
+			continue
+		}
+		pairs = append(pairs, artifact.TaskIDAndExecution{TaskID: t.Id, Execution: t.Execution})
+	}
+
+	artifactsByTask := map[artifact.TaskIDAndExecution][]artifact.Entry{}
+	if len(pairs) == 0 {
+		return artifactsByTask, nil
+	}
+	entries, err := artifact.FindAll(ctx, artifact.ByTaskIdsAndExecutions(pairs))
+	if err != nil {
+		return nil, errors.Wrap(err, "finding artifacts")
+	}
+	for _, entry := range entries {
+		key := artifact.TaskIDAndExecution{TaskID: entry.TaskId, Execution: entry.Execution}
+		artifactsByTask[key] = append(artifactsByTask[key], entry)
+	}
+	return artifactsByTask, nil
+}
+
+// getAMIsForTasks fetches the AMI of every host running a task in the page in
+// one query, keyed by host ID.
+func getAMIsForTasks(ctx context.Context, tasks []task.Task) (map[string]string, error) {
+	var hostIDs []string
+	seen := map[string]bool{}
+	for _, t := range tasks {
+		if t.HostId == "" || seen[t.HostId] {
+			continue
+		}
+		seen[t.HostId] = true
+		hostIDs = append(hostIDs, t.HostId)
+	}
+
+	amisByHostID := map[string]string{}
+	if len(hostIDs) == 0 {
+		return amisByHostID, nil
+	}
+	hosts, err := host.Find(ctx, host.ByIds(hostIDs))
+	if err != nil {
+		return nil, errors.Wrap(err, "finding hosts")
+	}
+	for _, h := range hosts {
+		if ami := h.GetAMI(); ami != "" {
+			amisByHostID[h.Id] = ami
+		}
+	}
+	return amisByHostID, nil
+}
+
+// getProjectIdentifierForTasks resolves the project identifier shared by a page
+// of tasks. The boolean reports whether the lookup succeeded, so that a project
+// ref with an empty identifier still sets the field rather than leaving it null,
+// matching APITask.GetProjectIdentifier.
+func getProjectIdentifierForTasks(ctx context.Context, tasks []task.Task) (string, bool) {
+	if len(tasks) == 0 || tasks[0].Project == "" {
+		return "", false
+	}
+	identifier, err := dbModel.GetIdentifierForProjectSecondary(ctx, tasks[0].Project)
+	return identifier, err == nil
 }

--- a/rest/route/task_project.go
+++ b/rest/route/task_project.go
@@ -135,10 +135,7 @@ func (tph *tasksByProjectHandler) Run(ctx context.Context) gimlet.Responder {
 
 	tasks = tasks[:lastIndex]
 
-	// Artifacts, the project identifier, and host AMIs are all resolved up front
-	// for the whole page. Letting BuildFromService fetch them per task turns a
-	// single request into hundreds of queries.
-	artifactsByTask, err := getArtifactsForTasks(ctx, tasks)
+	artifactsCache, err := getArtifactsForTasks(ctx, tasks)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "finding artifacts for tasks"))
 	}
@@ -146,16 +143,13 @@ func (tph *tasksByProjectHandler) Run(ctx context.Context) gimlet.Responder {
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "finding hosts for tasks"))
 	}
-	// The tasks are queried by project, so they all share one identifier. A lookup
-	// failure is not fatal here, and a successful lookup of an empty identifier
-	// still sets the field, both matching APITask.GetProjectIdentifier.
 	projectIdentifier, foundProjectIdentifier := getProjectIdentifierForTasks(ctx, tasks)
 
 	for _, t := range tasks {
 		taskModel := &model.APITask{}
 		err = taskModel.BuildFromService(ctx, &t, &model.APITaskArgs{
 			IncludeArtifacts: true,
-			ArtifactsByTask:  artifactsByTask,
+			ArtifactsCache:   artifactsCache,
 			LogURL:           GetURL(ctx),
 			ParsleyLogURL:    tph.parsleyURL,
 		})

--- a/rest/route/task_project.go
+++ b/rest/route/task_project.go
@@ -8,6 +8,7 @@ import (
 	"github.com/evergreen-ci/evergreen/rest/data"
 	"github.com/evergreen-ci/evergreen/rest/model"
 	"github.com/evergreen-ci/gimlet"
+	"github.com/evergreen-ci/utility"
 	"github.com/pkg/errors"
 )
 
@@ -134,17 +135,38 @@ func (tph *tasksByProjectHandler) Run(ctx context.Context) gimlet.Responder {
 
 	tasks = tasks[:lastIndex]
 
+	// Artifacts, the project identifier, and host AMIs are all resolved up front
+	// for the whole page. Letting BuildFromService fetch them per task turns a
+	// single request into hundreds of queries.
+	artifactsByTask, err := getArtifactsForTasks(ctx, tasks)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "finding artifacts for tasks"))
+	}
+	amisByHostID, err := getAMIsForTasks(ctx, tasks)
+	if err != nil {
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrap(err, "finding hosts for tasks"))
+	}
+	// The tasks are queried by project, so they all share one identifier. A lookup
+	// failure is not fatal here, and a successful lookup of an empty identifier
+	// still sets the field, both matching APITask.GetProjectIdentifier.
+	projectIdentifier, foundProjectIdentifier := getProjectIdentifierForTasks(ctx, tasks)
+
 	for _, t := range tasks {
 		taskModel := &model.APITask{}
 		err = taskModel.BuildFromService(ctx, &t, &model.APITaskArgs{
-			IncludeAMI:               true,
-			IncludeProjectIdentifier: true,
-			IncludeArtifacts:         true,
-			LogURL:                   GetURL(ctx),
-			ParsleyLogURL:            tph.parsleyURL,
+			IncludeArtifacts: true,
+			ArtifactsByTask:  artifactsByTask,
+			LogURL:           GetURL(ctx),
+			ParsleyLogURL:    tph.parsleyURL,
 		})
 		if err != nil {
 			return gimlet.MakeJSONErrorResponder(err)
+		}
+		if foundProjectIdentifier {
+			taskModel.ProjectIdentifier = utility.ToStringPtr(projectIdentifier)
+		}
+		if ami := amisByHostID[t.HostId]; ami != "" {
+			taskModel.AMI = utility.ToStringPtr(ami)
 		}
 
 		err = resp.AddData(taskModel)

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -2311,32 +2311,27 @@ func checkBuildVariants(project *model.Project) ValidationErrors {
 func GetAllowedSingleTaskDistroTasksForProject(ctx context.Context, identifier string, settings *evergreen.Settings) (evergreen.ProjectTasksPair, error) {
 	allowList := evergreen.ProjectTasksPair{}
 
-	if len(settings.SingleTaskDistro.ProjectTasksPairs) == 0 {
-		return allowList, nil
-	}
-
-	// The refs depend only on the identifier, so they are resolved once rather
-	// than once per configured pair.
 	projectsToLookFor := []string{}
-	pRef, err := model.FindBranchProjectRef(ctx, identifier)
-	if err != nil {
-		return allowList, errors.Wrapf(err, "finding project ref '%s'", identifier)
-	}
-	if pRef != nil {
-		projectsToLookFor = append(projectsToLookFor, pRef.Id, pRef.Identifier, pRef.RepoRefId)
-	} else {
-		// If project ref is nil, it means the project is a repo project.
-		repoRef, err := model.FindOneRepoRef(ctx, identifier)
-		if err != nil {
-			return allowList, errors.Wrapf(err, "finding repo ref '%s'", identifier)
-		}
-		if repoRef == nil {
-			return allowList, errors.Errorf("project or repo ref '%s' not found", identifier)
-		}
-		projectsToLookFor = append(projectsToLookFor, repoRef.Id)
-	}
-
 	for _, pairs := range settings.SingleTaskDistro.ProjectTasksPairs {
+		pRef, err := model.FindBranchProjectRef(ctx, identifier)
+		if err != nil {
+			return allowList, errors.Wrapf(err, "finding project ref '%s'", identifier)
+		}
+
+		// Look for allowed tasks for the project and its repo project.
+		if pRef != nil {
+			projectsToLookFor = append(projectsToLookFor, pRef.Id, pRef.Identifier, pRef.RepoRefId)
+		} else {
+			// If project ref is nil, it means the project is a repo project.
+			repoRef, err := model.FindOneRepoRef(ctx, identifier)
+			if err != nil {
+				return allowList, errors.Wrapf(err, "finding repo ref '%s'", identifier)
+			}
+			if repoRef == nil {
+				return allowList, errors.Errorf("project or repo ref '%s' not found", identifier)
+			}
+			projectsToLookFor = append(projectsToLookFor, repoRef.Id)
+		}
 		if utility.StringSliceContains(projectsToLookFor, pairs.ProjectID) {
 			allowList.AllowedTasks = append(allowList.AllowedTasks, pairs.AllowedTasks...)
 			allowList.AllowedBVs = append(allowList.AllowedBVs, pairs.AllowedBVs...)

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -2311,27 +2311,32 @@ func checkBuildVariants(project *model.Project) ValidationErrors {
 func GetAllowedSingleTaskDistroTasksForProject(ctx context.Context, identifier string, settings *evergreen.Settings) (evergreen.ProjectTasksPair, error) {
 	allowList := evergreen.ProjectTasksPair{}
 
-	projectsToLookFor := []string{}
-	for _, pairs := range settings.SingleTaskDistro.ProjectTasksPairs {
-		pRef, err := model.FindBranchProjectRef(ctx, identifier)
-		if err != nil {
-			return allowList, errors.Wrapf(err, "finding project ref '%s'", identifier)
-		}
+	if len(settings.SingleTaskDistro.ProjectTasksPairs) == 0 {
+		return allowList, nil
+	}
 
-		// Look for allowed tasks for the project and its repo project.
-		if pRef != nil {
-			projectsToLookFor = append(projectsToLookFor, pRef.Id, pRef.Identifier, pRef.RepoRefId)
-		} else {
-			// If project ref is nil, it means the project is a repo project.
-			repoRef, err := model.FindOneRepoRef(ctx, identifier)
-			if err != nil {
-				return allowList, errors.Wrapf(err, "finding repo ref '%s'", identifier)
-			}
-			if repoRef == nil {
-				return allowList, errors.Errorf("project or repo ref '%s' not found", identifier)
-			}
-			projectsToLookFor = append(projectsToLookFor, repoRef.Id)
+	// The refs depend only on the identifier, so they are resolved once rather
+	// than once per configured pair.
+	projectsToLookFor := []string{}
+	pRef, err := model.FindBranchProjectRef(ctx, identifier)
+	if err != nil {
+		return allowList, errors.Wrapf(err, "finding project ref '%s'", identifier)
+	}
+	if pRef != nil {
+		projectsToLookFor = append(projectsToLookFor, pRef.Id, pRef.Identifier, pRef.RepoRefId)
+	} else {
+		// If project ref is nil, it means the project is a repo project.
+		repoRef, err := model.FindOneRepoRef(ctx, identifier)
+		if err != nil {
+			return allowList, errors.Wrapf(err, "finding repo ref '%s'", identifier)
 		}
+		if repoRef == nil {
+			return allowList, errors.Errorf("project or repo ref '%s' not found", identifier)
+		}
+		projectsToLookFor = append(projectsToLookFor, repoRef.Id)
+	}
+
+	for _, pairs := range settings.SingleTaskDistro.ProjectTasksPairs {
 		if utility.StringSliceContains(projectsToLookFor, pairs.ProjectID) {
 			allowList.AllowedTasks = append(allowList.AllowedTasks, pairs.AllowedTasks...)
 			allowList.AllowedBVs = append(allowList.AllowedBVs, pairs.AllowedBVs...)


### PR DESCRIPTION
DEVPROD-41576


### Description

remove individual calls to the db and consolidate them when possible. 

2 main fixes (also explained in the comments) 

1. running hosts pipeline was doing unnecessary look ups 
2. pass in artifacts and amis once instead of looking for it every time

### Testing

no existing tests should fail since all functionalities should remain the same
some new tests

put in fake data in staging and verified it correctly fetches 
and only 1 db query for 30 artifacts in [honeycomb](https://ui.honeycomb.io/mongodb-4b/environments/staging/result/2xxiFFM1UvA/trace/qgMGLL6nTVx?fields%5B%5D=s_name&fields%5B%5D=s_serviceName&span=25821c008baba878) 
<img width="872" height="669" alt="image" src="https://github.com/user-attachments/assets/06c15cde-7bf0-42d6-812f-fc523894d507" />

