### PR TITLE
DEVPROD-30481: only set positive time_in_queue_ms

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -1932,7 +1932,9 @@ func EmitMergeQueueCompletionMetrics(ctx context.Context, p *patch.Patch, v *Ver
 
 	if !endTime.IsZero() && !queueEntryTime.IsZero() {
 		timeInQueue := endTime.Sub(queueEntryTime).Milliseconds()
-		span.SetAttributes(attribute.Int64(patch.MergeQueueAttrTimeInQueueMs, timeInQueue))
+		if timeInQueue > 0 {
+			span.SetAttributes(attribute.Int64(patch.MergeQueueAttrTimeInQueueMs, timeInQueue))
+		}
 	}
 
 	// Collect all version IDs for the patch family (parent + all children).


### PR DESCRIPTION
DEVPROD-30481

### Description

Don't set the field if it's zero, otherwise Honeycomb queries might underestimate time in queue unless they explicitly filter for `> 0`.