### PR TITLE
DEVPROD-33377 Add max time and retries for host termination job

### DIFF
--- a/units/host_termination.go
+++ b/units/host_termination.go
@@ -24,6 +24,8 @@ import (
 const (
 	HostTerminationJobName         = "host-termination-job"
 	hostTerminationAttributePrefix = "evergreen.host_termination"
+	hostTerminationMaxAttempts     = 3
+	hostTerminationMaxTime         = 5 * time.Minute
 )
 
 func init() {
@@ -77,6 +79,13 @@ func NewHostTerminationJob(env evergreen.Environment, h *host.Host, opts HostTer
 	j.SetID(fmt.Sprintf("%s.%s.%s", HostTerminationJobName, h.Id, ts))
 	j.SetScopes([]string{fmt.Sprintf("%s.%s", HostTerminationJobName, h.Id)})
 	j.SetEnqueueAllScopes(true)
+	j.UpdateRetryInfo(amboy.JobRetryOptions{
+		Retryable:   utility.TruePtr(),
+		MaxAttempts: utility.ToIntPtr(hostTerminationMaxAttempts),
+	})
+	j.UpdateTimeInfo(amboy.JobTimeInfo{
+		MaxTime: hostTerminationMaxTime,
+	})
 
 	return j
 }


### PR DESCRIPTION
DEVPROD-33377

### Description

add retries and max time for host termination job 

decided with 5 minutes because it was the max length of the job on honeycomb (average is much lower) 
https://ui.honeycomb.io/mongodb-4b/environments/production/datasets/evergreen/result/GscWwr1t6HY