### PR TITLE
DEVPROD-27669 Update single task distro message

### DIFF
--- a/units/crons.go
+++ b/units/crons.go
@@ -201,9 +201,13 @@ func hostTerminationJobs(ctx context.Context, env evergreen.Environment, _ time.
 			})
 			continue
 		}
+		terminationReason := "host is expired, decommissioned, or failed to provision"
+		if h.Distro.SingleTaskDistro && h.LastTask != "" {
+			terminationReason = "single task host finished its task"
+		}
 		jobs = append(jobs, NewHostTerminationJob(env, &h, HostTerminationOptions{
 			TerminateIfBusy:   true,
-			TerminationReason: "host is expired, decommissioned, or failed to provision (this is not an error)",
+			TerminationReason: terminationReason,
 		}))
 	}
 


### PR DESCRIPTION
[DEVPROD-27669](https://jira.mongodb.org/browse/DEVPROD-27669)

### Description
update termination message only for single task distros that ran a task 