### PR TITLE
PLATFORMS-30948: Add workdir-boundary telemetry to agent commands

### DIFF
--- a/agent/command/archive_auto_create.go
+++ b/agent/command/archive_auto_create.go
@@ -62,6 +62,8 @@ func (c *autoArchiveCreate) Execute(ctx context.Context,
 
 	c.SourceDir = GetWorkingDirectory(conf, c.SourceDir)
 	c.Target = GetWorkingDirectory(conf, c.Target)
+	SetWorkdirBoundaryAttribute(ctx, conf, c.Target)
+	SetWorkdirBoundaryAttribute(ctx, conf, c.SourceDir)
 
 	var filenames []string
 	var directoryArchive bool

--- a/agent/command/archive_auto_create.go
+++ b/agent/command/archive_auto_create.go
@@ -62,8 +62,7 @@ func (c *autoArchiveCreate) Execute(ctx context.Context,
 
 	c.SourceDir = GetWorkingDirectory(conf, c.SourceDir)
 	c.Target = GetWorkingDirectory(conf, c.Target)
-	SetWorkdirBoundaryAttribute(ctx, conf, c.Target)
-	SetWorkdirBoundaryAttribute(ctx, conf, c.SourceDir)
+	SetWorkdirBoundaryAttribute(ctx, conf, c.Target, c.SourceDir)
 
 	var filenames []string
 	var directoryArchive bool

--- a/agent/command/archive_auto_extract.go
+++ b/agent/command/archive_auto_extract.go
@@ -50,6 +50,8 @@ func (e *autoExtract) Execute(ctx context.Context,
 	if !filepath.IsAbs(e.ArchivePath) {
 		e.ArchivePath = GetWorkingDirectory(conf, e.ArchivePath)
 	}
+	SetWorkdirBoundaryAttribute(ctx, conf, e.TargetDirectory)
+	SetWorkdirBoundaryAttribute(ctx, conf, e.ArchivePath)
 
 	if _, err := os.Stat(e.ArchivePath); os.IsNotExist(err) {
 		return errors.Errorf("archive '%s' does not exist", e.ArchivePath)

--- a/agent/command/archive_auto_extract.go
+++ b/agent/command/archive_auto_extract.go
@@ -50,8 +50,7 @@ func (e *autoExtract) Execute(ctx context.Context,
 	if !filepath.IsAbs(e.ArchivePath) {
 		e.ArchivePath = GetWorkingDirectory(conf, e.ArchivePath)
 	}
-	SetWorkdirBoundaryAttribute(ctx, conf, e.TargetDirectory)
-	SetWorkdirBoundaryAttribute(ctx, conf, e.ArchivePath)
+	SetWorkdirBoundaryAttribute(ctx, conf, e.TargetDirectory, e.ArchivePath)
 
 	if _, err := os.Stat(e.ArchivePath); os.IsNotExist(err) {
 		return errors.Errorf("archive '%s' does not exist", e.ArchivePath)

--- a/agent/command/archive_tarball_create.go
+++ b/agent/command/archive_tarball_create.go
@@ -88,6 +88,8 @@ func (c *tarballCreate) Execute(ctx context.Context,
 	if !filepath.IsAbs(c.Target) {
 		c.Target = GetWorkingDirectory(conf, c.Target)
 	}
+	SetWorkdirBoundaryAttribute(ctx, conf, c.Target)
+	SetWorkdirBoundaryAttribute(ctx, conf, c.SourceDir)
 
 	errChan := make(chan error)
 	filesArchived := -1

--- a/agent/command/archive_tarball_create.go
+++ b/agent/command/archive_tarball_create.go
@@ -88,8 +88,7 @@ func (c *tarballCreate) Execute(ctx context.Context,
 	if !filepath.IsAbs(c.Target) {
 		c.Target = GetWorkingDirectory(conf, c.Target)
 	}
-	SetWorkdirBoundaryAttribute(ctx, conf, c.Target)
-	SetWorkdirBoundaryAttribute(ctx, conf, c.SourceDir)
+	SetWorkdirBoundaryAttribute(ctx, conf, c.Target, c.SourceDir)
 
 	errChan := make(chan error)
 	filesArchived := -1

--- a/agent/command/archive_tarball_create_test.go
+++ b/agent/command/archive_tarball_create_test.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
@@ -23,6 +24,8 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestTarGzPackParseParams(t *testing.T) {
@@ -266,4 +269,48 @@ func TestTarGzCommandMakeArchive(t *testing.T) {
 			})
 		})
 	})
+}
+
+func TestTarballCreateSetsWorkdirBoundaryAttributeOnViolation(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, tp.Shutdown(ctx))
+	})
+
+	ctx, span := tp.Tracer("test").Start(t.Context(), "test")
+
+	comm := client.NewMock("http://localhost.com")
+	conf := &internal.TaskConfig{
+		WorkDir:    "/data/mci/work",
+		Expansions: util.Expansions{},
+		Task:       task.Task{},
+		Project:    model.Project{},
+	}
+	logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+	require.NoError(t, err)
+
+	cmd := tarballCreateFactory().(*tarballCreate)
+	cmd.Target = "/tmp/outside-workdir.tgz"
+	cmd.SourceDir = "/etc"
+	cmd.Include = []string{"passwd"}
+
+	// Execute will fail (cannot create archive at /tmp), but the workdir
+	// boundary attribute is set before the archive operation begins.
+	_ = cmd.Execute(ctx, comm, logger, conf)
+	span.End()
+
+	ended := spanRecorder.Ended()
+	require.Len(t, ended, 1)
+
+	found := false
+	for _, attr := range ended[0].Attributes() {
+		if string(attr.Key) == workdirBoundaryViolationAttribute {
+			assert.True(t, attr.Value.AsBool(), "workdir boundary violation attribute should be true")
+			found = true
+		}
+	}
+	assert.True(t, found, "workdir boundary violation attribute was not set on the span")
 }

--- a/agent/command/archive_tarball_create_test.go
+++ b/agent/command/archive_tarball_create_test.go
@@ -283,8 +283,16 @@ func TestTarballCreateSetsWorkdirBoundaryAttributeOnViolation(t *testing.T) {
 	ctx, span := tp.Tracer("test").Start(t.Context(), "test")
 
 	comm := client.NewMock("http://localhost.com")
+	testDir := t.TempDir()
+	workDir := filepath.Join(testDir, "workdir")
+	sourceDir := filepath.Join(testDir, "source")
+	target := filepath.Join(testDir, "outside-workdir.tgz")
+	require.NoError(t, os.Mkdir(workDir, 0755))
+	require.NoError(t, os.Mkdir(sourceDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(sourceDir, "input.txt"), []byte("archive contents"), 0600))
+
 	conf := &internal.TaskConfig{
-		WorkDir:    "/data/mci/work",
+		WorkDir:    workDir,
 		Expansions: util.Expansions{},
 		Task:       task.Task{},
 		Project:    model.Project{},
@@ -293,13 +301,12 @@ func TestTarballCreateSetsWorkdirBoundaryAttributeOnViolation(t *testing.T) {
 	require.NoError(t, err)
 
 	cmd := tarballCreateFactory().(*tarballCreate)
-	cmd.Target = "/tmp/outside-workdir.tgz"
-	cmd.SourceDir = "/etc"
-	cmd.Include = []string{"passwd"}
+	cmd.Target = target
+	cmd.SourceDir = sourceDir
+	cmd.Include = []string{"input.txt"}
 
-	// Execute will fail (cannot create archive at /tmp), but the workdir
-	// boundary attribute is set before the archive operation begins.
-	_ = cmd.Execute(ctx, comm, logger, conf)
+	require.NoError(t, cmd.Execute(ctx, comm, logger, conf))
+	require.FileExists(t, target)
 	span.End()
 
 	ended := spanRecorder.Ended()

--- a/agent/command/archive_tarball_extract.go
+++ b/agent/command/archive_tarball_extract.go
@@ -49,6 +49,8 @@ func (e *tarballExtract) Execute(ctx context.Context,
 
 	destinationPath := GetWorkingDirectory(conf, e.TargetDirectory)
 	archivePath := GetWorkingDirectory(conf, e.ArchivePath)
+	SetWorkdirBoundaryAttribute(ctx, conf, e.TargetDirectory)
+	SetWorkdirBoundaryAttribute(ctx, conf, e.ArchivePath)
 
 	archive, err := os.Open(archivePath)
 	if err != nil {

--- a/agent/command/archive_tarball_extract.go
+++ b/agent/command/archive_tarball_extract.go
@@ -49,8 +49,7 @@ func (e *tarballExtract) Execute(ctx context.Context,
 
 	destinationPath := GetWorkingDirectory(conf, e.TargetDirectory)
 	archivePath := GetWorkingDirectory(conf, e.ArchivePath)
-	SetWorkdirBoundaryAttribute(ctx, conf, e.TargetDirectory)
-	SetWorkdirBoundaryAttribute(ctx, conf, e.ArchivePath)
+	SetWorkdirBoundaryAttribute(ctx, conf, e.TargetDirectory, e.ArchivePath)
 
 	archive, err := os.Open(archivePath)
 	if err != nil {

--- a/agent/command/archive_zip_create.go
+++ b/agent/command/archive_zip_create.go
@@ -73,6 +73,8 @@ func (c *zipArchiveCreate) Execute(ctx context.Context,
 	if !filepath.IsAbs(c.Target) {
 		c.Target = GetWorkingDirectory(conf, c.Target)
 	}
+	SetWorkdirBoundaryAttribute(ctx, conf, c.Target)
+	SetWorkdirBoundaryAttribute(ctx, conf, c.SourceDir)
 
 	files, _, err := findContentsToArchive(ctx, c.SourceDir, c.Include, c.ExcludeFiles)
 	if err != nil {

--- a/agent/command/archive_zip_create.go
+++ b/agent/command/archive_zip_create.go
@@ -73,8 +73,7 @@ func (c *zipArchiveCreate) Execute(ctx context.Context,
 	if !filepath.IsAbs(c.Target) {
 		c.Target = GetWorkingDirectory(conf, c.Target)
 	}
-	SetWorkdirBoundaryAttribute(ctx, conf, c.Target)
-	SetWorkdirBoundaryAttribute(ctx, conf, c.SourceDir)
+	SetWorkdirBoundaryAttribute(ctx, conf, c.Target, c.SourceDir)
 
 	files, _, err := findContentsToArchive(ctx, c.SourceDir, c.Include, c.ExcludeFiles)
 	if err != nil {

--- a/agent/command/archive_zip_extract.go
+++ b/agent/command/archive_zip_extract.go
@@ -50,6 +50,8 @@ func (e *zipExtract) Execute(ctx context.Context,
 	if !filepath.IsAbs(e.ArchivePath) {
 		e.ArchivePath = GetWorkingDirectory(conf, e.ArchivePath)
 	}
+	SetWorkdirBoundaryAttribute(ctx, conf, e.TargetDirectory)
+	SetWorkdirBoundaryAttribute(ctx, conf, e.ArchivePath)
 
 	if _, err := os.Stat(e.ArchivePath); os.IsNotExist(err) {
 		return errors.Errorf("archive '%s' does not exist", e.ArchivePath)

--- a/agent/command/archive_zip_extract.go
+++ b/agent/command/archive_zip_extract.go
@@ -50,8 +50,7 @@ func (e *zipExtract) Execute(ctx context.Context,
 	if !filepath.IsAbs(e.ArchivePath) {
 		e.ArchivePath = GetWorkingDirectory(conf, e.ArchivePath)
 	}
-	SetWorkdirBoundaryAttribute(ctx, conf, e.TargetDirectory)
-	SetWorkdirBoundaryAttribute(ctx, conf, e.ArchivePath)
+	SetWorkdirBoundaryAttribute(ctx, conf, e.TargetDirectory, e.ArchivePath)
 
 	if _, err := os.Stat(e.ArchivePath); os.IsNotExist(err) {
 		return errors.Errorf("archive '%s' does not exist", e.ArchivePath)

--- a/agent/command/attach_artifacts.go
+++ b/agent/command/attach_artifacts.go
@@ -58,6 +58,11 @@ func (c *attachArtifacts) Execute(ctx context.Context,
 		return errors.Wrap(err, "applying expansions")
 	}
 
+	SetWorkdirBoundaryAttribute(ctx, conf, c.Prefix)
+	for _, file := range c.Files {
+		SetWorkdirBoundaryAttribute(ctx, conf, file)
+	}
+
 	if !c.ExactFileNames {
 		workDir := GetWorkingDirectory(conf, c.Prefix)
 		include := utility.NewGitIgnoreFileMatcher(workDir, c.Files...)

--- a/agent/command/attach_artifacts.go
+++ b/agent/command/attach_artifacts.go
@@ -58,10 +58,9 @@ func (c *attachArtifacts) Execute(ctx context.Context,
 		return errors.Wrap(err, "applying expansions")
 	}
 
-	SetWorkdirBoundaryAttribute(ctx, conf, c.Prefix)
-	for _, file := range c.Files {
-		SetWorkdirBoundaryAttribute(ctx, conf, file)
-	}
+	paths := []string{c.Prefix}
+	paths = append(paths, c.Files...)
+	SetWorkdirBoundaryAttribute(ctx, conf, paths...)
 
 	if !c.ExactFileNames {
 		workDir := GetWorkingDirectory(conf, c.Prefix)

--- a/agent/command/attach_artifacts.go
+++ b/agent/command/attach_artifacts.go
@@ -58,9 +58,7 @@ func (c *attachArtifacts) Execute(ctx context.Context,
 		return errors.Wrap(err, "applying expansions")
 	}
 
-	paths := []string{c.Prefix}
-	paths = append(paths, c.Files...)
-	SetWorkdirBoundaryAttribute(ctx, conf, paths...)
+	SetWorkdirBoundaryAttribute(ctx, conf, append([]string{c.Prefix}, c.Files...)...)
 
 	if !c.ExactFileNames {
 		workDir := GetWorkingDirectory(conf, c.Prefix)

--- a/agent/command/exec.go
+++ b/agent/command/exec.go
@@ -410,6 +410,7 @@ func (c *subprocessExec) Execute(ctx context.Context, comm client.Communicator, 
 			"path":            c.WorkingDir,
 			"required_prefix": conf.WorkDir,
 		})
+	SetWorkdirBoundaryAttribute(ctx, conf, c.WorkingDir)
 	c.WorkingDir, err = getWorkingDirectoryLegacy(conf, c.WorkingDir)
 	if err != nil {
 		return errors.Wrap(err, "getting working directory")

--- a/agent/command/exec_test.go
+++ b/agent/command/exec_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 type execCmdSuite struct {
@@ -554,6 +556,42 @@ func (s *execCmdSuite) TestConcurrentBackgroundFailuresSendToChannel() {
 		}
 	}
 	s.Equal(numProcs, received)
+}
+
+func (s *execCmdSuite) TestWorkdirBoundaryViolationSetsSpanAttribute() {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	s.T().Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		s.Require().NoError(tp.Shutdown(ctx))
+	})
+
+	ctx, span := tp.Tracer("test").Start(s.ctx, "test_subprocess_exec_workdir_boundary")
+
+	s.conf.WorkDir = "/data/mci/work"
+	cmd := &subprocessExec{
+		WorkingDir: "/etc",
+		Command:    "bash -c 'exit 0'",
+	}
+	cmd.SetJasperManager(s.jasper)
+	s.NoError(cmd.ParseParams(map[string]any{}))
+
+	// Execute errors because getWorkingDirectoryLegacy cannot resolve the
+	// joined path, but the boundary attribute is set before that point.
+	s.Error(cmd.Execute(ctx, s.comm, s.logger, s.conf))
+	span.End()
+
+	ended := spanRecorder.Ended()
+	s.Require().Len(ended, 1)
+	found := false
+	for _, attr := range ended[0].Attributes() {
+		if string(attr.Key) == workdirBoundaryViolationAttribute {
+			s.True(attr.Value.AsBool(), "workdir boundary violation attribute should be true")
+			found = true
+		}
+	}
+	s.True(found, "workdir boundary violation attribute was not set on the span")
 }
 
 func TestAddTemp(t *testing.T) {

--- a/agent/command/exec_test.go
+++ b/agent/command/exec_test.go
@@ -569,9 +569,11 @@ func (s *execCmdSuite) TestWorkdirBoundaryViolationSetsSpanAttribute() {
 
 	ctx, span := tp.Tracer("test").Start(s.ctx, "test_subprocess_exec_workdir_boundary")
 
-	s.conf.WorkDir = "/data/mci/work"
+	root := s.T().TempDir()
+	s.conf.WorkDir = filepath.Join(root, "work")
+	s.Require().NoError(os.MkdirAll(s.conf.WorkDir, 0755))
 	cmd := &subprocessExec{
-		WorkingDir: "/etc",
+		WorkingDir: filepath.Join(root, "outside"),
 		Command:    "bash -c 'exit 0'",
 	}
 	cmd.SetJasperManager(s.jasper)

--- a/agent/command/host_list.go
+++ b/agent/command/host_list.go
@@ -69,6 +69,7 @@ func (c *listHosts) Execute(ctx context.Context, comm client.Communicator, logge
 		if !filepath.IsAbs(c.Path) {
 			c.Path = GetWorkingDirectory(conf, c.Path)
 		}
+		SetWorkdirBoundaryAttribute(ctx, conf, c.Path)
 	}
 
 	if c.TimeoutSecs > 0 {

--- a/agent/command/host_list.go
+++ b/agent/command/host_list.go
@@ -69,8 +69,8 @@ func (c *listHosts) Execute(ctx context.Context, comm client.Communicator, logge
 		if !filepath.IsAbs(c.Path) {
 			c.Path = GetWorkingDirectory(conf, c.Path)
 		}
-		SetWorkdirBoundaryAttribute(ctx, conf, c.Path)
 	}
+	SetWorkdirBoundaryAttribute(ctx, conf, c.Path)
 
 	if c.TimeoutSecs > 0 {
 		var cancel context.CancelFunc

--- a/agent/command/host_list_test.go
+++ b/agent/command/host_list_test.go
@@ -3,13 +3,18 @@ package command
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/evergreen/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 type HostListSuite struct {
@@ -104,4 +109,85 @@ func (s *HostListSuite) TestExpansions() {
 	))
 	s.NoError(s.cmd.Execute(s.ctx, s.comm, s.logger, s.conf))
 	s.Equal("3", s.cmd.NumHosts)
+}
+
+func TestHostListSetsWorkdirBoundaryAttributeOnViolation(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, tp.Shutdown(ctx))
+	})
+
+	ctx, span := tp.Tracer("test").Start(t.Context(), "test")
+
+	comm := client.NewMock("http://localhost.com")
+	conf := &internal.TaskConfig{
+		WorkDir:    "/data/mci/work",
+		Expansions: util.Expansions{},
+		Task:       task.Task{},
+		Project:    model.Project{},
+	}
+	logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+	require.NoError(t, err)
+
+	cmd := listHostFactory().(*listHosts)
+	cmd.Path = "/etc/passwd"
+	cmd.Silent = true
+
+	// Execute may return an error (e.g. cannot write to /etc/passwd), but
+	// the workdir boundary attribute is set before any file I/O.
+	_ = cmd.Execute(ctx, comm, logger, conf)
+	span.End()
+
+	ended := spanRecorder.Ended()
+	require.Len(t, ended, 1)
+
+	found := false
+	for _, attr := range ended[0].Attributes() {
+		if string(attr.Key) == workdirBoundaryViolationAttribute {
+			assert.True(t, attr.Value.AsBool(), "workdir boundary violation attribute should be true")
+			found = true
+		}
+	}
+	assert.True(t, found, "workdir boundary violation attribute was not set on the span")
+}
+
+func TestHostListDoesNotSetWorkdirBoundaryAttributeForRelativePath(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, tp.Shutdown(ctx))
+	})
+
+	ctx, span := tp.Tracer("test").Start(t.Context(), "test")
+
+	comm := client.NewMock("http://localhost.com")
+	conf := &internal.TaskConfig{
+		WorkDir:    "/data/mci/work",
+		Expansions: util.Expansions{},
+		Task:       task.Task{},
+		Project:    model.Project{},
+	}
+	logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+	require.NoError(t, err)
+
+	cmd := listHostFactory().(*listHosts)
+	cmd.Path = "hosts.json"
+	cmd.Silent = true
+
+	_ = cmd.Execute(ctx, comm, logger, conf)
+	span.End()
+
+	ended := spanRecorder.Ended()
+	require.Len(t, ended, 1)
+
+	for _, attr := range ended[0].Attributes() {
+		if string(attr.Key) == workdirBoundaryViolationAttribute {
+			t.Fatalf("workdir boundary violation attribute should not be set for a relative path, got value %v", attr.Value.AsBool())
+		}
+	}
 }

--- a/agent/command/host_list_test.go
+++ b/agent/command/host_list_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -123,8 +124,9 @@ func TestHostListSetsWorkdirBoundaryAttributeOnViolation(t *testing.T) {
 	ctx, span := tp.Tracer("test").Start(t.Context(), "test")
 
 	comm := client.NewMock("http://localhost.com")
+	root := t.TempDir()
 	conf := &internal.TaskConfig{
-		WorkDir:    "/data/mci/work",
+		WorkDir:    filepath.Join(root, "work"),
 		Expansions: util.Expansions{},
 		Task:       task.Task{},
 		Project:    model.Project{},
@@ -133,10 +135,10 @@ func TestHostListSetsWorkdirBoundaryAttributeOnViolation(t *testing.T) {
 	require.NoError(t, err)
 
 	cmd := listHostFactory().(*listHosts)
-	cmd.Path = "/etc/passwd"
+	cmd.Path = filepath.Join(root, "outside", "hosts.json")
 	cmd.Silent = true
 
-	// Execute may return an error (e.g. cannot write to /etc/passwd), but
+	// Execute may return an error because the output directory does not exist, but
 	// the workdir boundary attribute is set before any file I/O.
 	_ = cmd.Execute(ctx, comm, logger, conf)
 	span.End()

--- a/agent/command/host_list_test.go
+++ b/agent/command/host_list_test.go
@@ -194,3 +194,40 @@ func TestHostListSetsFalseWorkdirBoundaryAttributeForRelativePath(t *testing.T) 
 	}
 	assert.True(t, found, "workdir boundary violation attribute was not set on the span")
 }
+
+func TestHostListSetsFalseWorkdirBoundaryAttributeWithoutPath(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, tp.Shutdown(ctx))
+	})
+
+	ctx, span := tp.Tracer("test").Start(t.Context(), "test")
+	comm := client.NewMock("http://localhost.com")
+	conf := &internal.TaskConfig{
+		WorkDir:    "/data/mci/work",
+		Expansions: util.Expansions{},
+		Task:       task.Task{},
+		Project:    model.Project{},
+	}
+	logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+	require.NoError(t, err)
+
+	cmd := listHostFactory().(*listHosts)
+	require.NoError(t, cmd.Execute(ctx, comm, logger, conf))
+	span.End()
+
+	ended := spanRecorder.Ended()
+	require.Len(t, ended, 1)
+
+	found := false
+	for _, attr := range ended[0].Attributes() {
+		if string(attr.Key) == workdirBoundaryViolationAttribute {
+			assert.False(t, attr.Value.AsBool(), "workdir boundary violation attribute should be false")
+			found = true
+		}
+	}
+	assert.True(t, found, "workdir boundary violation attribute was not set on the span")
+}

--- a/agent/command/host_list_test.go
+++ b/agent/command/host_list_test.go
@@ -154,7 +154,7 @@ func TestHostListSetsWorkdirBoundaryAttributeOnViolation(t *testing.T) {
 	assert.True(t, found, "workdir boundary violation attribute was not set on the span")
 }
 
-func TestHostListDoesNotSetWorkdirBoundaryAttributeForRelativePath(t *testing.T) {
+func TestHostListSetsFalseWorkdirBoundaryAttributeForRelativePath(t *testing.T) {
 	spanRecorder := tracetest.NewSpanRecorder()
 	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
 	t.Cleanup(func() {
@@ -185,9 +185,12 @@ func TestHostListDoesNotSetWorkdirBoundaryAttributeForRelativePath(t *testing.T)
 	ended := spanRecorder.Ended()
 	require.Len(t, ended, 1)
 
+	found := false
 	for _, attr := range ended[0].Attributes() {
 		if string(attr.Key) == workdirBoundaryViolationAttribute {
-			t.Fatalf("workdir boundary violation attribute should not be set for a relative path, got value %v", attr.Value.AsBool())
+			assert.False(t, attr.Value.AsBool(), "workdir boundary violation attribute should be false")
+			found = true
 		}
 	}
+	assert.True(t, found, "workdir boundary violation attribute was not set on the span")
 }

--- a/agent/command/perf_send.go
+++ b/agent/command/perf_send.go
@@ -61,6 +61,7 @@ func (c *perfSend) Execute(ctx context.Context, comm client.Communicator, logger
 
 	// Read the file and add the Evergreen info.
 	filename := GetWorkingDirectory(conf, c.File)
+	SetWorkdirBoundaryAttribute(ctx, conf, c.File)
 	report, err := poplar.LoadTests(filename)
 	if err != nil {
 		return errors.Wrapf(err, "reading tests from file '%s'", filename)

--- a/agent/command/results_gotest.go
+++ b/agent/command/results_gotest.go
@@ -68,6 +68,7 @@ func (c *goTestResults) Execute(ctx context.Context,
 	// All file patterns should be relative to the task's working directory.
 	for i, file := range c.Files {
 		c.Files[i] = GetWorkingDirectory(conf, file)
+		SetWorkdirBoundaryAttribute(ctx, conf, file)
 	}
 
 	// will be all files containing test results

--- a/agent/command/results_gotest.go
+++ b/agent/command/results_gotest.go
@@ -66,9 +66,9 @@ func (c *goTestResults) Execute(ctx context.Context,
 	}
 
 	// All file patterns should be relative to the task's working directory.
+	SetWorkdirBoundaryAttribute(ctx, conf, c.Files...)
 	for i, file := range c.Files {
 		c.Files[i] = GetWorkingDirectory(conf, file)
-		SetWorkdirBoundaryAttribute(ctx, conf, file)
 	}
 
 	// will be all files containing test results

--- a/agent/command/results_native.go
+++ b/agent/command/results_native.go
@@ -104,6 +104,7 @@ func (c *attachResults) Execute(ctx context.Context, comm client.Communicator, l
 	if !filepath.IsAbs(c.FileLoc) {
 		reportFileLoc = GetWorkingDirectory(conf, c.FileLoc)
 	}
+	SetWorkdirBoundaryAttribute(ctx, conf, c.FileLoc)
 
 	reportFile, err := os.Open(reportFileLoc)
 	if err != nil {

--- a/agent/command/results_xunit.go
+++ b/agent/command/results_xunit.go
@@ -79,6 +79,10 @@ func (c *xunitResults) Execute(ctx context.Context,
 		return errors.Wrap(err, "applying expansions")
 	}
 
+	for _, file := range c.Files {
+		SetWorkdirBoundaryAttribute(ctx, conf, file)
+	}
+
 	errChan := make(chan error)
 	go func() {
 		err := c.parseAndUploadResults(ctx, conf, logger, comm)

--- a/agent/command/results_xunit.go
+++ b/agent/command/results_xunit.go
@@ -79,9 +79,7 @@ func (c *xunitResults) Execute(ctx context.Context,
 		return errors.Wrap(err, "applying expansions")
 	}
 
-	for _, file := range c.Files {
-		SetWorkdirBoundaryAttribute(ctx, conf, file)
-	}
+	SetWorkdirBoundaryAttribute(ctx, conf, c.Files...)
 
 	errChan := make(chan error)
 	go func() {

--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -217,6 +217,9 @@ func (c *s3get) Execute(ctx context.Context, comm client.Communicator, logger cl
 		attribute.String(s3GetAssumeRoleARN, c.assumedRoleARN),
 	)
 
+	SetWorkdirBoundaryAttribute(ctx, conf, c.LocalFile)
+	SetWorkdirBoundaryAttribute(ctx, conf, c.ExtractTo)
+
 	// create pail bucket
 	httpClient := utility.GetHTTPClient()
 	httpClient.Timeout = s3HTTPClientTimeout

--- a/agent/command/s3_get.go
+++ b/agent/command/s3_get.go
@@ -217,8 +217,7 @@ func (c *s3get) Execute(ctx context.Context, comm client.Communicator, logger cl
 		attribute.String(s3GetAssumeRoleARN, c.assumedRoleARN),
 	)
 
-	SetWorkdirBoundaryAttribute(ctx, conf, c.LocalFile)
-	SetWorkdirBoundaryAttribute(ctx, conf, c.ExtractTo)
+	SetWorkdirBoundaryAttribute(ctx, conf, c.LocalFile, c.ExtractTo)
 
 	// create pail bucket
 	httpClient := utility.GetHTTPClient()

--- a/agent/command/s3_get_test.go
+++ b/agent/command/s3_get_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
@@ -29,6 +30,8 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestS3GetValidateParams(t *testing.T) {
@@ -476,4 +479,59 @@ func TestGetWithRetryDoesNotRetryOnKeyNotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.True(t, pail.IsKeyNotFoundError(err))
 	assert.Equal(t, 1, mock.calls, "should not retry when key does not exist")
+}
+
+func TestS3GetSetsWorkdirBoundaryViolationAttribute(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, tp.Shutdown(ctx))
+	})
+
+	testCtx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	ctx, span := tp.Tracer("test").Start(testCtx, "s3.get")
+
+	dir := t.TempDir()
+	workdir := filepath.Join(dir, "workdir")
+	outsideFile := filepath.Join(dir, "outside-file.txt")
+	require.NoError(t, os.MkdirAll(workdir, 0755))
+
+	comm := client.NewMock("http://localhost.com")
+	tsk := task.Task{Id: "mock_id", Secret: "mock_secret"}
+	logger, err := comm.GetLoggerProducer(ctx, &tsk, nil)
+	require.NoError(t, err)
+
+	conf := &internal.TaskConfig{
+		WorkDir:    workdir,
+		Task:       tsk,
+		Expansions: util.Expansions{},
+	}
+
+	cmd := &s3get{
+		AwsKey:     "key",
+		AwsSecret:  "secret",
+		RemoteFile: "remote",
+		Bucket:     "test-bucket",
+		LocalFile:  outsideFile,
+	}
+
+	// Execute will fail at S3 bucket creation or check, but the workdir
+	// boundary violation attribute is set before that point.
+	_ = cmd.Execute(ctx, comm, logger, conf)
+	span.End()
+
+	ended := spanRecorder.Ended()
+	require.Len(t, ended, 1)
+
+	found := false
+	for _, attr := range ended[0].Attributes() {
+		if string(attr.Key) == workdirBoundaryViolationAttribute {
+			assert.True(t, attr.Value.AsBool())
+			found = true
+		}
+	}
+	assert.True(t, found, "workdir boundary violation attribute was not set on the span")
 }

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -398,6 +398,10 @@ func (s3pc *s3put) Execute(ctx context.Context, comm client.Communicator, logger
 		attribute.String(s3PutAssumeRoleARN, s3pc.assumedRoleARN),
 	)
 
+	SetWorkdirBoundaryAttribute(ctx, conf, s3pc.LocalFile)
+	SetWorkdirBoundaryAttribute(ctx, conf, s3pc.AssociatedLinksFile)
+	SetWorkdirBoundaryAttribute(ctx, conf, s3pc.LocalFilesIncludeFilterPrefix)
+
 	// create pail bucket
 	httpClient := utility.GetHTTPClient()
 	httpClient.Timeout = s3HTTPClientTimeout

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -348,6 +348,8 @@ func (s3pc *s3put) Execute(ctx context.Context, comm client.Communicator, logger
 		return nil
 	}
 
+	SetWorkdirBoundaryAttribute(ctx, conf, s3pc.LocalFile, s3pc.AssociatedLinksFile, s3pc.LocalFilesIncludeFilterPrefix)
+
 	if s3pc.AssociatedLinksFile != "" {
 		associatedLinks, err := readAssociatedLinksFile(s3pc.AssociatedLinksFile, conf)
 		if err != nil {
@@ -397,10 +399,6 @@ func (s3pc *s3put) Execute(ctx context.Context, comm client.Communicator, logger
 		attribute.String(s3PutRoleARN, s3pc.RoleARN),
 		attribute.String(s3PutAssumeRoleARN, s3pc.assumedRoleARN),
 	)
-
-	SetWorkdirBoundaryAttribute(ctx, conf, s3pc.LocalFile)
-	SetWorkdirBoundaryAttribute(ctx, conf, s3pc.AssociatedLinksFile)
-	SetWorkdirBoundaryAttribute(ctx, conf, s3pc.LocalFilesIncludeFilterPrefix)
 
 	// create pail bucket
 	httpClient := utility.GetHTTPClient()

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	s3Types "github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -28,6 +29,8 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestS3PutValidateParams(t *testing.T) {
@@ -1152,4 +1155,61 @@ func TestAttachFilesRecordsCredentialVarNames(t *testing.T) {
 		assert.Empty(t, file.AWSSecretVarName)
 		assert.Equal(t, "arn:aws:iam::000000000000:role/fake-role", file.AWSRoleARN)
 	})
+}
+
+func TestS3PutSetsWorkdirBoundaryViolationAttribute(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, tp.Shutdown(ctx))
+	})
+
+	ctx, span := tp.Tracer("test").Start(t.Context(), "s3.put")
+
+	dir := t.TempDir()
+	workdir := filepath.Join(dir, "workdir")
+	outsideFile := filepath.Join(dir, "outside-file.txt")
+	require.NoError(t, os.MkdirAll(workdir, 0755))
+	require.NoError(t, os.WriteFile(outsideFile, []byte("test data"), 0600))
+
+	comm := client.NewMock("http://localhost.com")
+	conf := &internal.TaskConfig{
+		Expansions:   util.Expansions{},
+		Task:         task.Task{Id: "mock_id", Secret: "mock_secret"},
+		Project:      model.Project{},
+		WorkDir:      workdir,
+		BuildVariant: model.BuildVariant{},
+		S3Usage:      &s3usage.S3Usage{},
+	}
+	logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+	require.NoError(t, err)
+
+	mock := &putCounterBucket{putsPerCall: 1}
+	s := &s3put{
+		AwsKey:      "key",
+		AwsSecret:   "secret",
+		Bucket:      "test-bucket",
+		LocalFile:   outsideFile,
+		RemoteFile:  "remote/upload.txt",
+		ContentType: "application/octet-stream",
+		Permissions: string(s3Types.ObjectCannedACLPublicRead),
+		bucket:      mock,
+	}
+
+	require.NoError(t, s.Execute(ctx, comm, logger, conf))
+	span.End()
+
+	ended := spanRecorder.Ended()
+	require.Len(t, ended, 1)
+
+	found := false
+	for _, attr := range ended[0].Attributes() {
+		if string(attr.Key) == workdirBoundaryViolationAttribute {
+			assert.True(t, attr.Value.AsBool())
+			found = true
+		}
+	}
+	assert.True(t, found, "workdir boundary violation attribute was not set on the span")
 }

--- a/agent/command/shell.go
+++ b/agent/command/shell.go
@@ -137,6 +137,8 @@ func (c *shellExec) Execute(ctx context.Context, _ client.Communicator, logger c
 		fmt.Sprintf("The working directory is an absolute path [%s], which isn't supported except when prefixed by '%s'.",
 			c.WorkingDir, conf.WorkDir))
 
+	SetWorkdirBoundaryAttribute(ctx, conf, c.WorkingDir)
+
 	c.WorkingDir, err = getWorkingDirectoryLegacy(conf, c.WorkingDir)
 	if err != nil {
 		return errors.Wrap(err, "getting working directory")

--- a/agent/command/shell_test.go
+++ b/agent/command/shell_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/mongodb/jasper"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/suite"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 type shellExecuteCommandSuite struct {
@@ -256,4 +258,40 @@ func (s *shellExecuteCommandSuite) TestFailingShellCommandErrors() {
 	err := cmd.Execute(s.ctx, s.comm, s.logger, s.conf)
 	s.Require().Error(err)
 	s.Contains(err.Error(), "shell script encountered problem: exit code 1")
+}
+
+func (s *shellExecuteCommandSuite) TestWorkdirBoundaryViolationSetsSpanAttribute() {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	s.T().Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		s.Require().NoError(tp.Shutdown(ctx))
+	})
+
+	ctx, span := tp.Tracer("test").Start(s.ctx, "test_shell_exec_workdir_boundary")
+
+	s.conf.WorkDir = "/data/mci/work"
+	cmd := &shellExec{
+		WorkingDir: "/etc",
+		Shell:      "bash",
+		Script:     "exit 0",
+	}
+	cmd.SetJasperManager(s.jasper)
+
+	// Execute errors because getWorkingDirectoryLegacy cannot resolve the
+	// joined path, but the boundary attribute is set before that point.
+	s.Error(cmd.Execute(ctx, s.comm, s.logger, s.conf))
+	span.End()
+
+	ended := spanRecorder.Ended()
+	s.Require().Len(ended, 1)
+	found := false
+	for _, attr := range ended[0].Attributes() {
+		if string(attr.Key) == workdirBoundaryViolationAttribute {
+			s.True(attr.Value.AsBool(), "workdir boundary violation attribute should be true")
+			found = true
+		}
+	}
+	s.True(found, "workdir boundary violation attribute was not set on the span")
 }

--- a/agent/command/shell_test.go
+++ b/agent/command/shell_test.go
@@ -271,9 +271,11 @@ func (s *shellExecuteCommandSuite) TestWorkdirBoundaryViolationSetsSpanAttribute
 
 	ctx, span := tp.Tracer("test").Start(s.ctx, "test_shell_exec_workdir_boundary")
 
-	s.conf.WorkDir = "/data/mci/work"
+	root := s.T().TempDir()
+	s.conf.WorkDir = filepath.Join(root, "work")
+	s.Require().NoError(os.MkdirAll(s.conf.WorkDir, 0755))
 	cmd := &shellExec{
-		WorkingDir: "/etc",
+		WorkingDir: filepath.Join(root, "outside"),
 		Shell:      "bash",
 		Script:     "exit 0",
 	}

--- a/agent/command/util.go
+++ b/agent/command/util.go
@@ -10,6 +10,7 @@ import (
 	"github.com/evergreen-ci/evergreen/agent/internal/client"
 	"github.com/pkg/errors"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -73,6 +74,50 @@ func GetWorkingDirectory(conf *internal.TaskConfig, path string) string {
 		return path
 	}
 	return filepath.Join(conf.WorkDir, path)
+}
+
+// workdirBoundaryViolationAttribute is the OTel span attribute name set when
+// a command's resolved path falls outside the task working directory.
+const workdirBoundaryViolationAttribute = "plugin.workdir_boundary_violation"
+
+// IsWorkdirBoundaryViolation returns true when the resolved path falls outside
+// conf.WorkDir. It resolves the path the same way GetWorkingDirectory does,
+// then uses filepath.Rel to determine containment. This correctly handles
+// sibling-prefix paths (e.g. /data/mci/work vs /data/mci/work-other) that a
+// naive strings.HasPrefix check would miss, as well as relative-traversal
+// paths (e.g. ../../etc) that resolve outside the workdir once joined.
+func IsWorkdirBoundaryViolation(conf *internal.TaskConfig, path string) bool {
+	if path == "" {
+		return false
+	}
+
+	resolved := path
+	if !filepath.IsAbs(path) {
+		resolved = filepath.Join(conf.WorkDir, path)
+	}
+
+	workdir := filepath.Clean(conf.WorkDir)
+	resolved = filepath.Clean(resolved)
+
+	rel, err := filepath.Rel(workdir, resolved)
+	if err != nil {
+		// The path is on a different volume or otherwise incomparable.
+		return true
+	}
+
+	return rel == ".." ||
+		strings.HasPrefix(rel, ".."+string(filepath.Separator)) ||
+		filepath.IsAbs(rel)
+}
+
+// SetWorkdirBoundaryAttribute checks if the resolved path falls outside the
+// task workdir and, if so, sets the workdirBoundaryViolationAttribute boolean
+// to true on the span from the context. This is informational only; it does
+// not block or error on violations.
+func SetWorkdirBoundaryAttribute(ctx context.Context, conf *internal.TaskConfig, path string) {
+	if IsWorkdirBoundaryViolation(conf, path) {
+		trace.SpanFromContext(ctx).SetAttributes(attribute.Bool(workdirBoundaryViolationAttribute, true))
+	}
 }
 
 // getWorkingDirectoryLegacy is a legacy function to get the working directory

--- a/agent/command/util.go
+++ b/agent/command/util.go
@@ -76,8 +76,8 @@ func GetWorkingDirectory(conf *internal.TaskConfig, path string) string {
 	return filepath.Join(conf.WorkDir, path)
 }
 
-// workdirBoundaryViolationAttribute is the OTel span attribute name set when
-// a command's resolved path falls outside the task working directory.
+// workdirBoundaryViolationAttribute records whether a command's resolved path
+// falls outside the task working directory.
 const workdirBoundaryViolationAttribute = "plugin.workdir_boundary_violation"
 
 // IsWorkdirBoundaryViolation returns true when the resolved path falls outside
@@ -110,14 +110,18 @@ func IsWorkdirBoundaryViolation(conf *internal.TaskConfig, path string) bool {
 		filepath.IsAbs(rel)
 }
 
-// SetWorkdirBoundaryAttribute checks if the resolved path falls outside the
-// task workdir and, if so, sets the workdirBoundaryViolationAttribute boolean
-// to true on the span from the context. This is informational only; it does
-// not block or error on violations.
-func SetWorkdirBoundaryAttribute(ctx context.Context, conf *internal.TaskConfig, path string) {
-	if IsWorkdirBoundaryViolation(conf, path) {
-		trace.SpanFromContext(ctx).SetAttributes(attribute.Bool(workdirBoundaryViolationAttribute, true))
+// SetWorkdirBoundaryAttribute records whether any resolved path falls outside
+// the task workdir on the span from the context. This is informational only;
+// it does not block or error on violations.
+func SetWorkdirBoundaryAttribute(ctx context.Context, conf *internal.TaskConfig, paths ...string) {
+	violation := false
+	for _, path := range paths {
+		if IsWorkdirBoundaryViolation(conf, path) {
+			violation = true
+			break
+		}
 	}
+	trace.SpanFromContext(ctx).SetAttributes(attribute.Bool(workdirBoundaryViolationAttribute, violation))
 }
 
 // getWorkingDirectoryLegacy is a legacy function to get the working directory

--- a/agent/command/util.go
+++ b/agent/command/util.go
@@ -80,12 +80,12 @@ func GetWorkingDirectory(conf *internal.TaskConfig, path string) string {
 // falls outside the task working directory.
 const workdirBoundaryViolationAttribute = "plugin.workdir_boundary_violation"
 
-// IsWorkdirBoundaryViolation returns true when the resolved path falls outside
-// conf.WorkDir. It resolves the path the same way GetWorkingDirectory does,
-// then uses filepath.Rel to determine containment. This correctly handles
-// sibling-prefix paths (e.g. /data/mci/work vs /data/mci/work-other) that a
-// naive strings.HasPrefix check would miss, as well as relative-traversal
-// paths (e.g. ../../etc) that resolve outside the workdir once joined.
+// IsWorkdirBoundaryViolation returns true when a configured path resolves
+// outside conf.WorkDir. It intentionally evaluates the configured path before
+// legacy command-specific rewriting so telemetry captures tasks that request
+// unsupported out-of-workdir paths, even if the command ultimately executes
+// from a rewritten path under the workdir. Relative paths are resolved as
+// GetWorkingDirectory resolves them, then filepath.Rel determines containment.
 func IsWorkdirBoundaryViolation(conf *internal.TaskConfig, path string) bool {
 	if path == "" {
 		return false

--- a/agent/command/util_test.go
+++ b/agent/command/util_test.go
@@ -1,14 +1,18 @@
 package command
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/evergreen-ci/evergreen/agent/internal"
 	"github.com/evergreen-ci/evergreen/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestCreateEnclosingDirectory(t *testing.T) {
@@ -82,4 +86,96 @@ func TestGetWorkingDirectoryLegacy(t *testing.T) {
 	out, err = getWorkingDirectoryLegacy(conf, "does-not-exist")
 	assert.Error(t, err)
 	assert.Equal(t, "", out)
+}
+
+func TestRelativePathUnderWorkdirIsNotViolation(t *testing.T) {
+	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
+	assert.False(t, IsWorkdirBoundaryViolation(conf, "src/foo"))
+}
+
+func TestAbsolutePathUnderWorkdirIsNotViolation(t *testing.T) {
+	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
+	assert.False(t, IsWorkdirBoundaryViolation(conf, "/data/mci/work/src/foo"))
+}
+
+func TestAbsolutePathOutsideWorkdirIsViolation(t *testing.T) {
+	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
+	assert.True(t, IsWorkdirBoundaryViolation(conf, "/etc/passwd"))
+}
+
+func TestEmptyPathIsNotViolation(t *testing.T) {
+	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
+	assert.False(t, IsWorkdirBoundaryViolation(conf, ""))
+}
+
+func TestPathEqualToWorkdirIsNotViolation(t *testing.T) {
+	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
+	assert.False(t, IsWorkdirBoundaryViolation(conf, "/data/mci/work"))
+}
+
+func TestSiblingPrefixPathIsViolation(t *testing.T) {
+	// /data/mci/work-other starts with /data/mci/work, so a naive
+	// strings.HasPrefix check would miss this. filepath.Rel correctly
+	// identifies it as outside the workdir.
+	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
+	assert.True(t, IsWorkdirBoundaryViolation(conf, "/data/mci/work-other"))
+}
+
+func TestRelativeTraversalOutsideWorkdirIsViolation(t *testing.T) {
+	// ../../etc/passwd joined to /data/mci/work resolves to /data/etc/passwd,
+	// which is outside the workdir.
+	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
+	assert.True(t, IsWorkdirBoundaryViolation(conf, "../../etc/passwd"))
+}
+
+func TestTrailingSlashNormalization(t *testing.T) {
+	// Workdir with trailing slash, path without — should not be a violation.
+	conf := &internal.TaskConfig{WorkDir: "/data/mci/work/"}
+	assert.False(t, IsWorkdirBoundaryViolation(conf, "/data/mci/work/foo"))
+
+	// Workdir without trailing slash, path with trailing slash — should not
+	// be a violation.
+	conf.WorkDir = "/data/mci/work"
+	assert.False(t, IsWorkdirBoundaryViolation(conf, "/data/mci/work/foo/"))
+
+	// Workdir with trailing slash, sibling-prefix path — should be a
+	// violation.
+	conf.WorkDir = "/data/mci/work/"
+	assert.True(t, IsWorkdirBoundaryViolation(conf, "/data/mci/work-other"))
+}
+
+func TestCrossVolumePathIsViolation(t *testing.T) {
+	// True cross-volume paths (different drive letters) only occur on Windows.
+	// On all platforms, filepath.Rel returns an error when the base is
+	// relative and the target is absolute, which exercises the same
+	// err != nil branch that a cross-volume path would on Windows.
+	conf := &internal.TaskConfig{WorkDir: "relative/workdir"}
+	assert.True(t, IsWorkdirBoundaryViolation(conf, "/etc/passwd"))
+}
+
+func TestSetWorkdirBoundaryAttributeSetsTrueOnViolation(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, tp.Shutdown(ctx))
+	})
+
+	ctx, span := tp.Tracer("test").Start(t.Context(), "test")
+	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
+	SetWorkdirBoundaryAttribute(ctx, conf, "/data/mci/work-other")
+	span.End()
+
+	ended := spanRecorder.Ended()
+	require.Len(t, ended, 1)
+
+	found := false
+	for _, attr := range ended[0].Attributes() {
+		if string(attr.Key) == workdirBoundaryViolationAttribute {
+			assert.True(t, attr.Value.AsBool(), "workdir boundary violation attribute should be true")
+			found = true
+		}
+	}
+	assert.True(t, found, "workdir boundary violation attribute was not set on the span")
 }

--- a/agent/command/util_test.go
+++ b/agent/command/util_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -89,18 +90,19 @@ func TestGetWorkingDirectoryLegacy(t *testing.T) {
 }
 
 func TestRelativePathUnderWorkdirIsNotViolation(t *testing.T) {
-	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
+	conf := &internal.TaskConfig{WorkDir: filepath.Join(t.TempDir(), "work")}
 	assert.False(t, IsWorkdirBoundaryViolation(conf, "src/foo"))
 }
 
 func TestAbsolutePathUnderWorkdirIsNotViolation(t *testing.T) {
-	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
-	assert.False(t, IsWorkdirBoundaryViolation(conf, "/data/mci/work/src/foo"))
+	conf := &internal.TaskConfig{WorkDir: filepath.Join(t.TempDir(), "work")}
+	assert.False(t, IsWorkdirBoundaryViolation(conf, filepath.Join(conf.WorkDir, "src", "foo")))
 }
 
 func TestAbsolutePathOutsideWorkdirIsViolation(t *testing.T) {
-	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
-	assert.True(t, IsWorkdirBoundaryViolation(conf, "/etc/passwd"))
+	root := t.TempDir()
+	conf := &internal.TaskConfig{WorkDir: filepath.Join(root, "work")}
+	assert.True(t, IsWorkdirBoundaryViolation(conf, filepath.Join(root, "outside")))
 }
 
 func TestEmptyPathIsNotViolation(t *testing.T) {
@@ -109,48 +111,56 @@ func TestEmptyPathIsNotViolation(t *testing.T) {
 }
 
 func TestPathEqualToWorkdirIsNotViolation(t *testing.T) {
-	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
-	assert.False(t, IsWorkdirBoundaryViolation(conf, "/data/mci/work"))
+	conf := &internal.TaskConfig{WorkDir: filepath.Join(t.TempDir(), "work")}
+	assert.False(t, IsWorkdirBoundaryViolation(conf, conf.WorkDir))
 }
 
 func TestSiblingPrefixPathIsViolation(t *testing.T) {
-	// /data/mci/work-other starts with /data/mci/work, so a naive
+	// work-other starts with work, so a naive
 	// strings.HasPrefix check would miss this. filepath.Rel correctly
 	// identifies it as outside the workdir.
-	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
-	assert.True(t, IsWorkdirBoundaryViolation(conf, "/data/mci/work-other"))
+	root := t.TempDir()
+	conf := &internal.TaskConfig{WorkDir: filepath.Join(root, "work")}
+	assert.True(t, IsWorkdirBoundaryViolation(conf, filepath.Join(root, "work-other")))
 }
 
 func TestRelativeTraversalOutsideWorkdirIsViolation(t *testing.T) {
 	// ../../etc/passwd joined to /data/mci/work resolves to /data/etc/passwd,
 	// which is outside the workdir.
-	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
+	conf := &internal.TaskConfig{WorkDir: filepath.Join(t.TempDir(), "data", "mci", "work")}
 	assert.True(t, IsWorkdirBoundaryViolation(conf, "../../etc/passwd"))
 }
 
 func TestTrailingSlashNormalization(t *testing.T) {
+	root := t.TempDir()
+	workdir := filepath.Join(root, "work")
+	inside := filepath.Join(workdir, "foo")
+	outside := filepath.Join(root, "work-other")
+
 	// Workdir with trailing slash, path without — should not be a violation.
-	conf := &internal.TaskConfig{WorkDir: "/data/mci/work/"}
-	assert.False(t, IsWorkdirBoundaryViolation(conf, "/data/mci/work/foo"))
+	conf := &internal.TaskConfig{WorkDir: workdir + string(filepath.Separator)}
+	assert.False(t, IsWorkdirBoundaryViolation(conf, inside))
 
 	// Workdir without trailing slash, path with trailing slash — should not
 	// be a violation.
-	conf.WorkDir = "/data/mci/work"
-	assert.False(t, IsWorkdirBoundaryViolation(conf, "/data/mci/work/foo/"))
+	conf.WorkDir = workdir
+	assert.False(t, IsWorkdirBoundaryViolation(conf, inside+string(filepath.Separator)))
 
 	// Workdir with trailing slash, sibling-prefix path — should be a
 	// violation.
-	conf.WorkDir = "/data/mci/work/"
-	assert.True(t, IsWorkdirBoundaryViolation(conf, "/data/mci/work-other"))
+	conf.WorkDir = workdir + string(filepath.Separator)
+	assert.True(t, IsWorkdirBoundaryViolation(conf, outside))
 }
 
 func TestCrossVolumePathIsViolation(t *testing.T) {
-	// True cross-volume paths (different drive letters) only occur on Windows.
-	// On all platforms, filepath.Rel returns an error when the base is
-	// relative and the target is absolute, which exercises the same
-	// err != nil branch that a cross-volume path would on Windows.
+	if runtime.GOOS == "windows" {
+		conf := &internal.TaskConfig{WorkDir: `C:\work`}
+		assert.True(t, IsWorkdirBoundaryViolation(conf, `D:\outside`))
+		return
+	}
+
 	conf := &internal.TaskConfig{WorkDir: "relative/workdir"}
-	assert.True(t, IsWorkdirBoundaryViolation(conf, "/etc/passwd"))
+	assert.True(t, IsWorkdirBoundaryViolation(conf, "/outside"))
 }
 
 func TestSetWorkdirBoundaryAttributeSetsTrueOnViolation(t *testing.T) {
@@ -163,8 +173,9 @@ func TestSetWorkdirBoundaryAttributeSetsTrueOnViolation(t *testing.T) {
 	})
 
 	ctx, span := tp.Tracer("test").Start(t.Context(), "test")
-	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
-	SetWorkdirBoundaryAttribute(ctx, conf, "/data/mci/work-other")
+	root := t.TempDir()
+	conf := &internal.TaskConfig{WorkDir: filepath.Join(root, "work")}
+	SetWorkdirBoundaryAttribute(ctx, conf, filepath.Join(root, "work-other"))
 	span.End()
 
 	ended := spanRecorder.Ended()
@@ -190,8 +201,8 @@ func TestSetWorkdirBoundaryAttributeSetsFalseWithoutViolation(t *testing.T) {
 	})
 
 	ctx, span := tp.Tracer("test").Start(t.Context(), "test")
-	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
-	SetWorkdirBoundaryAttribute(ctx, conf, "/data/mci/work/src/foo")
+	conf := &internal.TaskConfig{WorkDir: filepath.Join(t.TempDir(), "work")}
+	SetWorkdirBoundaryAttribute(ctx, conf, filepath.Join(conf.WorkDir, "src", "foo"))
 	span.End()
 
 	ended := spanRecorder.Ended()
@@ -217,8 +228,9 @@ func TestSetWorkdirBoundaryAttributePreservesViolationAcrossPaths(t *testing.T) 
 	})
 
 	ctx, span := tp.Tracer("test").Start(t.Context(), "test")
-	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
-	SetWorkdirBoundaryAttribute(ctx, conf, "/data/mci/work-other", "/data/mci/work/src/foo")
+	root := t.TempDir()
+	conf := &internal.TaskConfig{WorkDir: filepath.Join(root, "work")}
+	SetWorkdirBoundaryAttribute(ctx, conf, filepath.Join(root, "work-other"), filepath.Join(conf.WorkDir, "src", "foo"))
 	span.End()
 
 	ended := spanRecorder.Ended()

--- a/agent/command/util_test.go
+++ b/agent/command/util_test.go
@@ -179,3 +179,57 @@ func TestSetWorkdirBoundaryAttributeSetsTrueOnViolation(t *testing.T) {
 	}
 	assert.True(t, found, "workdir boundary violation attribute was not set on the span")
 }
+
+func TestSetWorkdirBoundaryAttributeSetsFalseWithoutViolation(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, tp.Shutdown(ctx))
+	})
+
+	ctx, span := tp.Tracer("test").Start(t.Context(), "test")
+	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
+	SetWorkdirBoundaryAttribute(ctx, conf, "/data/mci/work/src/foo")
+	span.End()
+
+	ended := spanRecorder.Ended()
+	require.Len(t, ended, 1)
+
+	found := false
+	for _, attr := range ended[0].Attributes() {
+		if string(attr.Key) == workdirBoundaryViolationAttribute {
+			assert.False(t, attr.Value.AsBool(), "workdir boundary violation attribute should be false")
+			found = true
+		}
+	}
+	assert.True(t, found, "workdir boundary violation attribute was not set on the span")
+}
+
+func TestSetWorkdirBoundaryAttributePreservesViolationAcrossPaths(t *testing.T) {
+	spanRecorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, tp.Shutdown(ctx))
+	})
+
+	ctx, span := tp.Tracer("test").Start(t.Context(), "test")
+	conf := &internal.TaskConfig{WorkDir: "/data/mci/work"}
+	SetWorkdirBoundaryAttribute(ctx, conf, "/data/mci/work-other", "/data/mci/work/src/foo")
+	span.End()
+
+	ended := spanRecorder.Ended()
+	require.Len(t, ended, 1)
+
+	found := false
+	for _, attr := range ended[0].Attributes() {
+		if string(attr.Key) == workdirBoundaryViolationAttribute {
+			assert.True(t, attr.Value.AsBool(), "workdir boundary violation attribute should remain true")
+			found = true
+		}
+	}
+	assert.True(t, found, "workdir boundary violation attribute was not set on the span")
+}

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-08-28b"
+	AgentVersion = "2026-08-31"
 )
 
 const (


### PR DESCRIPTION
PLATFORMS-30948: Add workdir-boundary telemetry to agent commands

PLATFORMS-30948

**Stack: PR 9 of 9 — depends on `pr08-reporting-graphql` (`https://github.com/evergreen-ci/evergreen/pull/10676`).**

This PR is safe to merge alone because it is observability-only and does not alter filesystem behavior.

### Description

Adds the boolean OpenTelemetry span attribute `plugin.workdir_boundary_violation` to filesystem-using agent commands. The attribute is `true` when any configured path resolves outside the task workdir and `false` when the command's checked paths remain inside it.

The instrumentation covers:

- command working directories for `shell.exec` and `subprocess.exec`;
- archive source, target, and extraction paths;
- S3 upload, download, extraction, associated-link, and multi-file prefix paths;
- artifact and test-result file paths or globs;
- performance-result files and `host.list` output paths.

For commands that accept multiple paths, the attribute uses OR semantics so one boundary crossing cannot be overwritten by a safe path. Empty optional paths do not count as violations. The check is lexical and uses native operating-system path semantics; it does not resolve symlinks.

This telemetry measures how often existing tasks depend on filesystem access outside their assigned workdir and identifies which command types produce those accesses. We need that baseline to assess compatibility risk, prioritize migrations, and make evidence-based decisions about stronger task filesystem isolation. This PR is observational only: it does not block, authorize, normalize, or rewrite paths.

### Documentation

No user-facing documentation changes are required in this slice. Stack ordering and cross-PR links are maintained separately.