### PR TITLE
DEVPROD-42318: Add source cache bucket and project allowlist to admin settings

### DIFF
--- a/agent/internal/task_config.go
+++ b/agent/internal/task_config.go
@@ -78,6 +78,9 @@ type TaskConfig struct {
 	// ArtifactAWSAccountsWithoutLifecycleRules contains the AWS account IDs of the accounts that we
 	// calculate s3 costs for but cannot read lifecycle rules from.
 	ArtifactAWSAccountsWithoutLifecycleRules []string
+	// SourceCacheBucket is the git.get_project source cache bucket, resolved
+	// server-side.
+	SourceCacheBucket evergreen.BucketConfig
 	// awsAccountIDByKey caches resolved AWS account IDs keyed by AWS access key ID,
 	// so repeated s3.put commands using the same key avoid redundant STS calls.
 	awsAccountIDByKey map[string]string
@@ -301,6 +304,7 @@ func NewTaskConfig(opts TaskConfigOptions) (*TaskConfig, error) {
 	if opts.ExpansionsAndVars != nil {
 		taskConfig.DevprodOwnedAWSAccountIDs = opts.ExpansionsAndVars.DevprodOwnedAWSAccountIDs
 		taskConfig.ArtifactAWSAccountsWithoutLifecycleRules = opts.ExpansionsAndVars.ArtifactAWSAccountsWithoutLifecycleRules
+		taskConfig.SourceCacheBucket = opts.ExpansionsAndVars.SourceCacheBucket
 	}
 
 	if opts.ExpansionsAndVars != nil && opts.ExpansionsAndVars.Expansions != nil {

--- a/apimodels/agent_models.go
+++ b/apimodels/agent_models.go
@@ -396,6 +396,9 @@ type ExpansionsAndVars struct {
 	// ArtifactAWSAccountsWithoutLifecycleRules contains the AWS account IDs of the accounts that we
 	// calculate s3 costs for but cannot read lifecycle rules from.
 	ArtifactAWSAccountsWithoutLifecycleRules []string `json:"artifact_aws_accounts_without_lifecycle_rules,omitempty"`
+	// SourceCacheBucket is the git.get_project source cache bucket resolved for
+	// the task's project. It is zero when the project is not opted in.
+	SourceCacheBucket evergreen.BucketConfig `json:"source_cache_bucket,omitempty"`
 }
 
 // CheckRunOutput represents the output for a CheckRun.

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-08-27"
+	AgentVersion = "2026-08-28"
 )
 
 const (

--- a/config_bucket.go
+++ b/config_bucket.go
@@ -49,6 +49,10 @@ type BucketsConfig struct {
 	RetryFailedLogMoveMaxJobsPerRun int `bson:"retry_failed_log_move_max_jobs_per_run" json:"retry_failed_log_move_max_jobs_per_run" yaml:"retry_failed_log_move_max_jobs_per_run"`
 	// TestResultsBucket is the bucket information for test results.
 	TestResultsBucket BucketConfig `bson:"test_results_bucket" json:"test_results_bucket" yaml:"test_results_bucket"`
+	// SourceCacheBucket is the bucket information for the git.get_project source cache.
+	SourceCacheBucket BucketConfig `bson:"source_cache_bucket" json:"source_cache_bucket" yaml:"source_cache_bucket"`
+	// SourceCacheProjects is the list of project IDs whose tasks may use the source cache.
+	SourceCacheProjects []string `bson:"source_cache_projects" json:"source_cache_projects" yaml:"source_cache_projects"`
 	// Credentials for accessing the LogBucket.
 	Credentials S3Credentials `bson:"credentials" json:"credentials" yaml:"credentials"`
 }
@@ -61,6 +65,8 @@ var (
 	BucketsConfigRetryFailedLogMoveLookbackDaysKey  = bsonutil.MustHaveTag(BucketsConfig{}, "RetryFailedLogMoveLookbackDays")
 	BucketsConfigRetryFailedLogMoveMaxJobsPerRunKey = bsonutil.MustHaveTag(BucketsConfig{}, "RetryFailedLogMoveMaxJobsPerRun")
 	BucketsConfigTestResultsBucketKey               = bsonutil.MustHaveTag(BucketsConfig{}, "TestResultsBucket")
+	BucketsConfigSourceCacheBucketKey               = bsonutil.MustHaveTag(BucketsConfig{}, "SourceCacheBucket")
+	BucketsConfigSourceCacheProjectsKey             = bsonutil.MustHaveTag(BucketsConfig{}, "SourceCacheProjects")
 	BucketsConfigCredentialsKey                     = bsonutil.MustHaveTag(BucketsConfig{}, "Credentials")
 )
 
@@ -118,6 +124,8 @@ func (c *BucketsConfig) Set(ctx context.Context) error {
 				BucketsConfigRetryFailedLogMoveLookbackDaysKey:  c.RetryFailedLogMoveLookbackDays,
 				BucketsConfigRetryFailedLogMoveMaxJobsPerRunKey: c.RetryFailedLogMoveMaxJobsPerRun,
 				BucketsConfigTestResultsBucketKey:               c.TestResultsBucket,
+				BucketsConfigSourceCacheBucketKey:               c.SourceCacheBucket,
+				BucketsConfigSourceCacheProjectsKey:             c.SourceCacheProjects,
 				BucketsConfigCredentialsKey:                     c.Credentials,
 			},
 		}),
@@ -130,6 +138,7 @@ func (c *BucketsConfig) ValidateAndDefault() error {
 	catcher.Add(c.LogBucket.validate())
 	catcher.Add(c.LogBucketLongRetention.validate())
 	catcher.Add(c.LogBucketFailedTasks.validate())
+	catcher.Add(c.SourceCacheBucket.validate())
 	if c.RetryFailedLogMoveLookbackDays < 0 {
 		catcher.Add(errors.New("retry_failed_log_move_lookback_days cannot be negative"))
 	}
@@ -146,6 +155,15 @@ func (c *BucketsConfig) GetLogBucket(projectID string) BucketConfig {
 		return c.LogBucketLongRetention
 	}
 	return c.LogBucket
+}
+
+// GetSourceCacheBucket returns the source cache bucket for the project, or a
+// zero BucketConfig when the project isn't opted in or no bucket is configured.
+func (c *BucketsConfig) GetSourceCacheBucket(projectID string) BucketConfig {
+	if !slices.Contains(c.SourceCacheProjects, projectID) {
+		return BucketConfig{}
+	}
+	return c.SourceCacheBucket
 }
 
 // LogBucketExpirationDays returns the configured expiration days for the given

--- a/config_bucket_test.go
+++ b/config_bucket_test.go
@@ -53,3 +53,28 @@ func TestBucketsConfigLogBucketExpirationDays(t *testing.T) {
 		assert.False(t, ok)
 	})
 }
+
+func TestBucketsConfigGetSourceCacheBucket(t *testing.T) {
+	bucket := BucketConfig{Name: "source-cache", RoleARN: "arn:aws:iam::123:role/source-cache"}
+
+	t.Run("ProjectInListShouldReturnBucket", func(t *testing.T) {
+		cfg := &BucketsConfig{SourceCacheBucket: bucket, SourceCacheProjects: []string{"proj-a", "proj-b"}}
+		assert.Equal(t, bucket, cfg.GetSourceCacheBucket("proj-b"))
+	})
+
+	// Absence from the list is the only "off" state the feature has.
+	t.Run("ProjectNotNamedAnywhereShouldReturnZeroBucket", func(t *testing.T) {
+		cfg := &BucketsConfig{SourceCacheBucket: bucket, SourceCacheProjects: []string{"proj-a"}}
+		assert.Zero(t, cfg.GetSourceCacheBucket("proj-unnamed"))
+	})
+
+	t.Run("EmptyProjectListShouldReturnZeroBucketForEveryProject", func(t *testing.T) {
+		cfg := &BucketsConfig{SourceCacheBucket: bucket}
+		assert.Zero(t, cfg.GetSourceCacheBucket("proj-a"))
+	})
+
+	t.Run("ListedProjectWithNoBucketConfiguredShouldReturnZeroBucket", func(t *testing.T) {
+		cfg := &BucketsConfig{SourceCacheProjects: []string{"proj-a"}}
+		assert.Zero(t, cfg.GetSourceCacheBucket("proj-a"))
+	})
+}

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -344,6 +344,8 @@ type ComplexityRoot struct {
 		RetryFailedLogMoveLookbackDays   func(childComplexity int) int
 		RetryFailedLogMoveLookbackMonths func(childComplexity int) int
 		RetryFailedLogMoveMaxJobsPerRun  func(childComplexity int) int
+		SourceCacheBucket                func(childComplexity int) int
+		SourceCacheProjects              func(childComplexity int) int
 		TestResultsBucket                func(childComplexity int) int
 	}
 
@@ -3972,6 +3974,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.BucketsConfig.RetryFailedLogMoveMaxJobsPerRun(childComplexity), true
+	case "BucketsConfig.sourceCacheBucket":
+		if e.complexity.BucketsConfig.SourceCacheBucket == nil {
+			break
+		}
+
+		return e.complexity.BucketsConfig.SourceCacheBucket(childComplexity), true
+	case "BucketsConfig.sourceCacheProjects":
+		if e.complexity.BucketsConfig.SourceCacheProjects == nil {
+			break
+		}
+
+		return e.complexity.BucketsConfig.SourceCacheProjects(childComplexity), true
 	case "BucketsConfig.testResultsBucket":
 		if e.complexity.BucketsConfig.TestResultsBucket == nil {
 			break
@@ -18692,6 +18706,10 @@ func (ec *executionContext) fieldContext_AdminSettings_buckets(_ context.Context
 				return ec.fieldContext_BucketsConfig_retryFailedLogMoveMaxJobsPerRun(ctx, field)
 			case "testResultsBucket":
 				return ec.fieldContext_BucketsConfig_testResultsBucket(ctx, field)
+			case "sourceCacheBucket":
+				return ec.fieldContext_BucketsConfig_sourceCacheBucket(ctx, field)
+			case "sourceCacheProjects":
+				return ec.fieldContext_BucketsConfig_sourceCacheProjects(ctx, field)
 			case "internalBuckets":
 				return ec.fieldContext_BucketsConfig_internalBuckets(ctx, field)
 			case "credentials":
@@ -23362,6 +23380,84 @@ func (ec *executionContext) fieldContext_BucketsConfig_testResultsBucket(_ conte
 				return ec.fieldContext_BucketConfig_lifecycleSyncError(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type BucketConfig", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _BucketsConfig_sourceCacheBucket(ctx context.Context, field graphql.CollectedField, obj *model.APIBucketsConfig) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_BucketsConfig_sourceCacheBucket,
+		func(ctx context.Context) (any, error) {
+			return obj.SourceCacheBucket, nil
+		},
+		nil,
+		ec.marshalOBucketConfig2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIBucketConfig,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_BucketsConfig_sourceCacheBucket(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "BucketsConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "name":
+				return ec.fieldContext_BucketConfig_name(ctx, field)
+			case "testResultsPrefix":
+				return ec.fieldContext_BucketConfig_testResultsPrefix(ctx, field)
+			case "roleARN":
+				return ec.fieldContext_BucketConfig_roleARN(ctx, field)
+			case "type":
+				return ec.fieldContext_BucketConfig_type(ctx, field)
+			case "expirationDays":
+				return ec.fieldContext_BucketConfig_expirationDays(ctx, field)
+			case "transitionToIADays":
+				return ec.fieldContext_BucketConfig_transitionToIADays(ctx, field)
+			case "transitionToGlacierDays":
+				return ec.fieldContext_BucketConfig_transitionToGlacierDays(ctx, field)
+			case "lifecycleLastSyncedAt":
+				return ec.fieldContext_BucketConfig_lifecycleLastSyncedAt(ctx, field)
+			case "lifecycleSyncError":
+				return ec.fieldContext_BucketConfig_lifecycleSyncError(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type BucketConfig", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _BucketsConfig_sourceCacheProjects(ctx context.Context, field graphql.CollectedField, obj *model.APIBucketsConfig) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		ec.fieldContext_BucketsConfig_sourceCacheProjects,
+		func(ctx context.Context) (any, error) {
+			return obj.SourceCacheProjects, nil
+		},
+		nil,
+		ec.marshalOString2ᚕstringᚄ,
+		true,
+		false,
+	)
+}
+
+func (ec *executionContext) fieldContext_BucketsConfig_sourceCacheProjects(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "BucketsConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -81664,7 +81760,7 @@ func (ec *executionContext) unmarshalInputBucketsConfigInput(ctx context.Context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"logBucket", "logBucketLongRetention", "logBucketFailedTasks", "longRetentionProjects", "retryFailedLogMoveLookbackDays", "retryFailedLogMoveLookbackMonths", "retryFailedLogMoveMaxJobsPerRun", "testResultsBucket", "internalBuckets", "credentials"}
+	fieldsInOrder := [...]string{"logBucket", "logBucketLongRetention", "logBucketFailedTasks", "longRetentionProjects", "retryFailedLogMoveLookbackDays", "retryFailedLogMoveLookbackMonths", "retryFailedLogMoveMaxJobsPerRun", "testResultsBucket", "sourceCacheBucket", "sourceCacheProjects", "internalBuckets", "credentials"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -81727,6 +81823,20 @@ func (ec *executionContext) unmarshalInputBucketsConfigInput(ctx context.Context
 				return it, err
 			}
 			it.TestResultsBucket = data
+		case "sourceCacheBucket":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sourceCacheBucket"))
+			data, err := ec.unmarshalOBucketConfigInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIBucketConfig(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SourceCacheBucket = data
+		case "sourceCacheProjects":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("sourceCacheProjects"))
+			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.SourceCacheProjects = data
 		case "internalBuckets":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("internalBuckets"))
 			data, err := ec.unmarshalOString2ᚕstringᚄ(ctx, v)
@@ -93137,6 +93247,10 @@ func (ec *executionContext) _BucketsConfig(ctx context.Context, sel ast.Selectio
 			out.Values[i] = ec._BucketsConfig_retryFailedLogMoveMaxJobsPerRun(ctx, field, obj)
 		case "testResultsBucket":
 			out.Values[i] = ec._BucketsConfig_testResultsBucket(ctx, field, obj)
+		case "sourceCacheBucket":
+			out.Values[i] = ec._BucketsConfig_sourceCacheBucket(ctx, field, obj)
+		case "sourceCacheProjects":
+			out.Values[i] = ec._BucketsConfig_sourceCacheProjects(ctx, field, obj)
 		case "internalBuckets":
 			out.Values[i] = ec._BucketsConfig_internalBuckets(ctx, field, obj)
 		case "credentials":

--- a/graphql/schema/types/adminSettings/other.graphql
+++ b/graphql/schema/types/adminSettings/other.graphql
@@ -27,6 +27,8 @@ input BucketsConfigInput {
   retryFailedLogMoveLookbackMonths: Int
   retryFailedLogMoveMaxJobsPerRun: Int
   testResultsBucket: BucketConfigInput
+  sourceCacheBucket: BucketConfigInput
+  sourceCacheProjects: [String!]
   internalBuckets: [String!]
   credentials: S3CredentialsInput @redactSecrets
 }
@@ -41,6 +43,8 @@ type BucketsConfig {
   retryFailedLogMoveLookbackMonths: Int
   retryFailedLogMoveMaxJobsPerRun: Int
   testResultsBucket: BucketConfig
+  sourceCacheBucket: BucketConfig
+  sourceCacheProjects: [String!]
   internalBuckets: [String!]
   credentials: S3Credentials @requireAdmin
 }

--- a/rest/model/admin.go
+++ b/rest/model/admin.go
@@ -789,6 +789,8 @@ type APIBucketsConfig struct {
 	RetryFailedLogMoveLookbackMonths *int             `json:"retry_failed_log_move_lookback_months,omitempty"`
 	RetryFailedLogMoveMaxJobsPerRun  *int             `json:"retry_failed_log_move_max_jobs_per_run,omitempty"`
 	TestResultsBucket                APIBucketConfig  `json:"test_results_bucket"`
+	SourceCacheBucket                APIBucketConfig  `json:"source_cache_bucket"`
+	SourceCacheProjects              []string         `json:"source_cache_projects"`
 	InternalBuckets                  []string         `json:"internal_buckets"`
 	Credentials                      APIS3Credentials `json:"credentials"`
 }
@@ -865,6 +867,8 @@ func (a *APIBucketsConfig) BuildFromService(h any) error {
 		a.LogBucketLongRetention.buildFromService(v.LogBucketLongRetention)
 		a.LogBucketFailedTasks.buildFromService(v.LogBucketFailedTasks)
 		a.TestResultsBucket.buildFromService(v.TestResultsBucket)
+		a.SourceCacheBucket.buildFromService(v.SourceCacheBucket)
+		a.SourceCacheProjects = v.SourceCacheProjects
 
 		a.LongRetentionProjects = v.LongRetentionProjects
 		a.RetryFailedLogMoveLookbackDays = utility.ToIntPtr(v.RetryFailedLogMoveLookbackDays)
@@ -906,6 +910,8 @@ func (a *APIBucketsConfig) ToService() (any, error) {
 		RetryFailedLogMoveLookbackDays:  utility.FromIntPtr(lookbackDays),
 		RetryFailedLogMoveMaxJobsPerRun: utility.FromIntPtr(a.RetryFailedLogMoveMaxJobsPerRun),
 		TestResultsBucket:               a.TestResultsBucket.ToService(),
+		SourceCacheBucket:               a.SourceCacheBucket.ToService(),
+		SourceCacheProjects:             a.SourceCacheProjects,
 		Credentials:                     creds,
 	}, nil
 }

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -448,6 +448,17 @@ func (h *getExpansionsAndVarsHandler) Run(ctx context.Context) gimlet.Responder 
 		res.Parameters[param.Key] = param.Value
 	}
 
+	res.SourceCacheBucket = h.settings.Buckets.GetSourceCacheBucket(t.Project)
+	if res.SourceCacheBucket.Name == "" {
+		grip.Debug(ctx, message.Fields{
+			"message":     "no source cache bucket for task",
+			"task":        t.Id,
+			"project":     t.Project,
+			"opted_in":    slices.Contains(h.settings.Buckets.SourceCacheProjects, t.Project),
+			"bucket_name": h.settings.Buckets.SourceCacheBucket.Name,
+		})
+	}
+
 	var costCfg evergreen.CostConfig
 	if err := costCfg.Get(ctx); err != nil {
 		grip.Error(ctx, errors.Wrap(err, "loading cost config for expansions_and_vars"))

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -83,6 +83,26 @@ func TestAgentGetExpansionsAndVars(t *testing.T) {
 			assert.Equal(t, map[string]bool{"b": true}, data.PrivateVars)
 			assert.Equal(t, []string{"pass", "secret"}, data.RedactKeys)
 		},
+		"RunReturnsSourceCacheBucketForAllowlistedProject": func(ctx context.Context, t *testing.T, rh *getExpansionsAndVarsHandler) {
+			rh.settings.Buckets.SourceCacheBucket = evergreen.BucketConfig{Name: "source-cache"}
+			rh.settings.Buckets.SourceCacheProjects = []string{"p1"}
+			rh.taskID = "t1"
+			resp := rh.Run(ctx)
+			require.NotZero(t, resp)
+			data, ok := resp.Data().(apimodels.ExpansionsAndVars)
+			require.True(t, ok)
+			assert.Equal(t, "source-cache", data.SourceCacheBucket.Name)
+		},
+		"RunReturnsNoSourceCacheBucketForProjectNotAllowlisted": func(ctx context.Context, t *testing.T, rh *getExpansionsAndVarsHandler) {
+			rh.settings.Buckets.SourceCacheBucket = evergreen.BucketConfig{Name: "source-cache"}
+			rh.settings.Buckets.SourceCacheProjects = nil
+			rh.taskID = "t1"
+			resp := rh.Run(ctx)
+			require.NotZero(t, resp)
+			data, ok := resp.Data().(apimodels.ExpansionsAndVars)
+			require.True(t, ok)
+			assert.Zero(t, data.SourceCacheBucket)
+		},
 		"RunSucceedsWithHostDistroExpansions": func(ctx context.Context, t *testing.T, rh *getExpansionsAndVarsHandler) {
 			rh.taskID = "t1"
 			rh.hostID = "host_id"


### PR DESCRIPTION
DEVPROD-42318


### Description
 Adds `SourceCacheBucket` and a `SourceCacheProjects` allowlist to `BucketsConfig` in `config_bucket.go`, resolved server-side by `GetSourceCacheBucket`.
 
This will be used by an  upcoming `git.get_project` source cache that is opted into per project via admin settings.

### Testing

This is part of of a bigger change and it was tested manually by setting a bucket and project allow list, creating patches on staging and making sure it works as expected. 