### PR TITLE
DEVPROD-42319 Extract the PR checkout commands from the clone script

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -280,34 +280,7 @@ func (c *gitFetchProject) buildSourceCloneCommand(conf *internal.TaskConfig, opt
 
 	// If there's a PR checkout the ref containing the changes.
 	if usesGitHubParentPRCheckout(conf) {
-		var suffix, localBranchName, remoteBranchName, commitToTest string
-		if conf.GitHubParentPRCheckout != nil && conf.GitHubParentPRCheckout.ForSource {
-			suffix = "/head"
-			commitToTest = conf.GitHubParentPRCheckout.HeadHash
-			localBranchName = fmt.Sprintf("evg-pr-test-%s", utility.RandomString())
-			remoteBranchName = fmt.Sprintf("pull/%d", conf.GitHubParentPRCheckout.PRNumber)
-		} else if conf.Task.Requester == evergreen.GithubPRRequester {
-			// Github creates a ref called refs/pull/[pr number]/head
-			// that provides the entire tree of changes, including merges
-			suffix = "/head"
-			commitToTest = conf.GithubPatchData.HeadHash
-			localBranchName = fmt.Sprintf("evg-pr-test-%s", utility.RandomString())
-			remoteBranchName = fmt.Sprintf("pull/%d", conf.GithubPatchData.PRNumber)
-		} else if conf.Task.Requester == evergreen.GithubMergeRequester {
-			suffix = "" // redundant, included for clarity
-			commitToTest = conf.GithubMergeData.HeadSHA
-			localBranchName = fmt.Sprintf("evg-mg-test-%s", utility.RandomString())
-			// HeadRef looks like "refs/heads/gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056"
-			remoteBranchName = conf.GithubMergeData.HeadBranch
-		}
-		if commitToTest != "" {
-			gitCommands = append(gitCommands, []string{
-				fmt.Sprintf(`git fetch origin "%s%s:%s"`, remoteBranchName, suffix, localBranchName),
-				fmt.Sprintf(`git checkout "%s"`, localBranchName),
-				fmt.Sprintf("git reset --hard %s", commitToTest),
-			}...)
-		}
-
+		gitCommands = append(gitCommands, prCheckoutCommands(conf)...)
 	} else {
 		if opts.cloneDepth > 0 {
 			// If this git log fails, then we know the clone is too shallow so we unshallow before reset.
@@ -319,6 +292,55 @@ func (c *gitFetchProject) buildSourceCloneCommand(conf *internal.TaskConfig, opt
 	gitCommands = append(gitCommands, "git log --oneline -n 10")
 
 	return gitCommands, nil
+}
+
+// prCheckoutCommit returns the commit a PR or merge queue checkout leaves HEAD
+// at, or "" when the task does no PR checkout.
+func prCheckoutCommit(conf *internal.TaskConfig) string {
+	if conf.GitHubParentPRCheckout != nil && conf.GitHubParentPRCheckout.ForSource {
+		return conf.GitHubParentPRCheckout.HeadHash
+	}
+	switch conf.Task.Requester {
+	case evergreen.GithubPRRequester:
+		return conf.GithubPatchData.HeadHash
+	case evergreen.GithubMergeRequester:
+		return conf.GithubMergeData.HeadSHA
+	}
+	return ""
+}
+
+// prCheckoutCommands returns the commands that check out the ref containing a
+// PR's or merge queue group's changes. They run after a clone, which leaves HEAD
+// at the base revision.
+func prCheckoutCommands(conf *internal.TaskConfig) []string {
+	commitToTest := prCheckoutCommit(conf)
+	if commitToTest == "" {
+		return nil
+	}
+
+	var suffix, localBranchName, remoteBranchName string
+	if conf.GitHubParentPRCheckout != nil && conf.GitHubParentPRCheckout.ForSource {
+		suffix = "/head"
+		localBranchName = fmt.Sprintf("evg-pr-test-%s", utility.RandomString())
+		remoteBranchName = fmt.Sprintf("pull/%d", conf.GitHubParentPRCheckout.PRNumber)
+	} else if conf.Task.Requester == evergreen.GithubPRRequester {
+		// Github creates a ref called refs/pull/[pr number]/head
+		// that provides the entire tree of changes, including merges
+		suffix = "/head"
+		localBranchName = fmt.Sprintf("evg-pr-test-%s", utility.RandomString())
+		remoteBranchName = fmt.Sprintf("pull/%d", conf.GithubPatchData.PRNumber)
+	} else if conf.Task.Requester == evergreen.GithubMergeRequester {
+		suffix = "" // redundant, included for clarity
+		localBranchName = fmt.Sprintf("evg-mg-test-%s", utility.RandomString())
+		// HeadRef looks like "refs/heads/gh-readonly-queue/main/pr-515-9cd8a2532bcddf58369aa82eb66ba88e2323c056"
+		remoteBranchName = conf.GithubMergeData.HeadBranch
+	}
+
+	return []string{
+		fmt.Sprintf(`git fetch origin "%s%s:%s"`, remoteBranchName, suffix, localBranchName),
+		fmt.Sprintf(`git checkout "%s"`, localBranchName),
+		fmt.Sprintf("git reset --hard %s", commitToTest),
+	}
 }
 
 func (c *gitFetchProject) buildModuleCloneCommand(conf *internal.TaskConfig, opts cloneOpts, ref string, modulePatch *patch.ModulePatch) ([]string, error) {

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-08-27"
+	AgentVersion = "2026-08-28"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-42319

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
This is a no-op refactor that will make upcoming source cache changes easier because it needs the same commands
  on its restore path, and needs the commit a PR checkout lands on in order to compute its cache key.

### Testing

They are already asserted by existing tests that continue to pass


<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
