### PR TITLE
DEVPROD-38075: Filter out builds/tasks from waterfall results

### DIFF
--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -91100,11 +91100,14 @@ func (ec *executionContext) unmarshalInputWaterfallOptions(ctx context.Context, 
 		asMap[k] = v
 	}
 
+	if _, present := asMap["includeAllBuildsAndTasks"]; !present {
+		asMap["includeAllBuildsAndTasks"] = true
+	}
 	if _, present := asMap["limit"]; !present {
 		asMap["limit"] = 5
 	}
 
-	fieldsInOrder := [...]string{"date", "limit", "minOrder", "maxOrder", "omitInactiveBuilds", "projectIdentifier", "requesters", "revision", "statuses", "tasks", "taskCaseSensitive", "variants", "variantCaseSensitive"}
+	fieldsInOrder := [...]string{"date", "includeAllBuildsAndTasks", "limit", "minOrder", "maxOrder", "omitInactiveBuilds", "projectIdentifier", "requesters", "revision", "statuses", "tasks", "taskCaseSensitive", "variants", "variantCaseSensitive"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -91118,6 +91121,13 @@ func (ec *executionContext) unmarshalInputWaterfallOptions(ctx context.Context, 
 				return it, err
 			}
 			it.Date = data
+		case "includeAllBuildsAndTasks":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("includeAllBuildsAndTasks"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.IncludeAllBuildsAndTasks = data
 		case "limit":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("limit"))
 			data, err := ec.unmarshalOInt2ᚖint(ctx, v)

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -761,8 +761,10 @@ type Waterfall struct {
 }
 
 type WaterfallOptions struct {
-	Date  *time.Time `json:"date,omitempty"`
-	Limit *int       `json:"limit,omitempty"`
+	Date *time.Time `json:"date,omitempty"`
+	// Return all builds and tasks for each matching version instead of applying the waterfall filters to them.
+	IncludeAllBuildsAndTasks *bool `json:"includeAllBuildsAndTasks,omitempty"`
+	Limit                    *int  `json:"limit,omitempty"`
 	// Return versions with an order greater than minOrder. Used for paginating backward.
 	MinOrder *int `json:"minOrder,omitempty"`
 	// Return versions with an order lower than maxOrder. Used for paginating forward.

--- a/graphql/schema/types/waterfall.graphql
+++ b/graphql/schema/types/waterfall.graphql
@@ -1,5 +1,7 @@
 input WaterfallOptions {
   date: Time
+  "Return all builds and tasks for each matching version instead of applying the waterfall filters to them."
+  includeAllBuildsAndTasks: Boolean = true
   limit: Int = 5
   "Return versions with an order greater than minOrder. Used for paginating backward."
   minOrder: Int

--- a/graphql/tests/query/waterfall/queries/task-status.graphql
+++ b/graphql/tests/query/waterfall/queries/task-status.graphql
@@ -1,5 +1,11 @@
 {
-  waterfall(options: { projectIdentifier: "spruce-identifier", statuses: ["system-failed"] }) {
+  waterfall(
+    options: {
+      projectIdentifier: "spruce-identifier"
+      statuses: ["system-failed"]
+      includeAllBuildsAndTasks: false
+    }
+  ) {
     versions {
       id
       activated

--- a/graphql/tests/query/waterfall/queries/task-status.graphql
+++ b/graphql/tests/query/waterfall/queries/task-status.graphql
@@ -4,6 +4,14 @@
       id
       activated
       requester
+      waterfallBuilds {
+        id
+        displayName
+        tasks {
+          id
+          displayName
+        }
+      }
     }
     pagination {
       activeVersionIds

--- a/graphql/tests/query/waterfall/queries/tasks.graphql
+++ b/graphql/tests/query/waterfall/queries/tasks.graphql
@@ -1,5 +1,11 @@
 {
-  waterfall(options: { projectIdentifier: "spruce-identifier", tasks: ["Task C"] }) {
+  waterfall(
+    options: {
+      projectIdentifier: "spruce-identifier"
+      tasks: ["Task C"]
+      includeAllBuildsAndTasks: false
+    }
+  ) {
     versions {
       id
       activated

--- a/graphql/tests/query/waterfall/queries/tasks.graphql
+++ b/graphql/tests/query/waterfall/queries/tasks.graphql
@@ -4,6 +4,14 @@
       id
       activated
       requester
+      waterfallBuilds {
+        id
+        displayName
+        tasks {
+          id
+          displayName
+        }
+      }
     }
     pagination {
       activeVersionIds

--- a/graphql/tests/query/waterfall/results.json
+++ b/graphql/tests/query/waterfall/results.json
@@ -672,11 +672,6 @@
                     "id": "evergreen_version1_build_b",
                     "activated": false,
                     "displayName": "01 Ubuntu 16.04"
-                  },
-                  {
-                    "id": "evergreen_version3_build",
-                    "activated": true,
-                    "displayName": "03 Linter"
                   }
                 ]
               }
@@ -738,17 +733,32 @@
               {
                 "id": "evergreen_version5",
                 "activated": true,
-                "requester": "gitter_request"
+                "requester": "gitter_request",
+                "waterfallBuilds": [
+                  {
+                    "id": "evergreen_version3_build",
+                    "displayName": "03 Linter",
+                    "tasks": [{ "id": "task_5", "displayName": "Task C" }]
+                  }
+                ]
               },
               {
                 "id": "evergreen_version4",
                 "activated": false,
-                "requester": "gitter_request"
+                "requester": "gitter_request",
+                "waterfallBuilds": null
               },
               {
                 "id": "evergreen_version3",
                 "activated": true,
-                "requester": "gitter_request"
+                "requester": "gitter_request",
+                "waterfallBuilds": [
+                  {
+                    "id": "evergreen_version3_build",
+                    "displayName": "03 Linter",
+                    "tasks": [{ "id": "task_5_v3", "displayName": "Task C" }]
+                  }
+                ]
               }
             ],
             "pagination": {
@@ -767,17 +777,32 @@
               {
                 "id": "evergreen_version5",
                 "activated": true,
-                "requester": "gitter_request"
+                "requester": "gitter_request",
+                "waterfallBuilds": [
+                  {
+                    "id": "evergreen_version3_build",
+                    "displayName": "03 Linter",
+                    "tasks": [{ "id": "task_5", "displayName": "Task C" }]
+                  }
+                ]
               },
               {
                 "id": "evergreen_version4",
                 "activated": false,
-                "requester": "gitter_request"
+                "requester": "gitter_request",
+                "waterfallBuilds": null
               },
               {
                 "id": "evergreen_version3",
                 "activated": true,
-                "requester": "gitter_request"
+                "requester": "gitter_request",
+                "waterfallBuilds": [
+                  {
+                    "id": "evergreen_version3_build",
+                    "displayName": "03 Linter",
+                    "tasks": [{ "id": "task_5_v3", "displayName": "Task C" }]
+                  }
+                ]
               }
             ],
             "pagination": {

--- a/graphql/tests/query/waterfall/results.json
+++ b/graphql/tests/query/waterfall/results.json
@@ -672,6 +672,11 @@
                     "id": "evergreen_version1_build_b",
                     "activated": false,
                     "displayName": "01 Ubuntu 16.04"
+                  },
+                  {
+                    "id": "evergreen_version3_build",
+                    "activated": true,
+                    "displayName": "03 Linter"
                   }
                 ]
               }

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1606,6 +1606,22 @@ func getWaterfallFromContext(ctx context.Context) (*Waterfall, bool) {
 	return nil, false
 }
 
+func getWaterfallFilterOptionsFromContext(ctx context.Context) model.WaterfallOptions {
+	for fc := graphql.GetFieldContext(ctx); fc != nil; fc = fc.Parent {
+		if options, ok := fc.Args["options"].(WaterfallOptions); ok && fc.Object == "Query" && fc.Field.Name == "waterfall" {
+			return model.WaterfallOptions{
+				OmitInactiveBuilds:   utility.FromBoolPtr(options.OmitInactiveBuilds),
+				Statuses:             utility.FilterSlice(options.Statuses, func(s string) bool { return s != "" }),
+				Tasks:                utility.FilterSlice(options.Tasks, func(s string) bool { return s != "" }),
+				TaskCaseSensitive:    utility.FromBoolTPtr(options.TaskCaseSensitive),
+				Variants:             utility.FilterSlice(options.Variants, func(s string) bool { return s != "" }),
+				VariantCaseSensitive: utility.FromBoolTPtr(options.TaskCaseSensitive),
+			}
+		}
+	}
+	return model.WaterfallOptions{}
+}
+
 // setTestQuarantineState updates the quarantine state for testName on the
 // given task.
 func setTestQuarantineState(ctx context.Context, taskID, testName string, isManuallyQuarantined bool) (*restModel.APITest, error) {

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1609,6 +1609,9 @@ func getWaterfallFromContext(ctx context.Context) (*Waterfall, bool) {
 func getWaterfallFilterOptionsFromContext(ctx context.Context) model.WaterfallOptions {
 	for fc := graphql.GetFieldContext(ctx); fc != nil; fc = fc.Parent {
 		if options, ok := fc.Args["options"].(WaterfallOptions); ok && fc.Object == "Query" && fc.Field.Name == "waterfall" {
+			if utility.FromBoolTPtr(options.IncludeAllBuildsAndTasks) {
+				return model.WaterfallOptions{}
+			}
 			return model.WaterfallOptions{
 				OmitInactiveBuilds:   utility.FromBoolPtr(options.OmitInactiveBuilds),
 				Statuses:             utility.FilterSlice(options.Statuses, func(s string) bool { return s != "" }),

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1606,9 +1606,11 @@ func getWaterfallFromContext(ctx context.Context) (*Waterfall, bool) {
 	return nil, false
 }
 
+// Grab options provided to parent waterfall resolver for use in nested resolvers
 func getWaterfallFilterOptionsFromContext(ctx context.Context) model.WaterfallOptions {
 	for fc := graphql.GetFieldContext(ctx); fc != nil; fc = fc.Parent {
 		if options, ok := fc.Args["options"].(WaterfallOptions); ok && fc.Object == "Query" && fc.Field.Name == "waterfall" {
+			// Ignore options if this flag is specified
 			if utility.FromBoolTPtr(options.IncludeAllBuildsAndTasks) {
 				return model.WaterfallOptions{}
 			}

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -776,7 +776,8 @@ func (r *versionLiteResolver) WaterfallBuilds(ctx context.Context, obj *model.Ve
 		}
 	}
 
-	builds, err := model.GetVersionBuilds(ctx, versionID, obj.BuildIds)
+	opts := getWaterfallFilterOptionsFromContext(ctx)
+	builds, err := model.GetVersionBuilds(ctx, *obj, opts)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting build variants for version '%s': %s", versionID, err.Error()))
 	}

--- a/model/waterfall.go
+++ b/model/waterfall.go
@@ -59,6 +59,31 @@ type WaterfallOptions struct {
 	VariantCaseSensitive bool     `bson:"-" json:"-"`
 }
 
+func addWaterfallTaskFilters(match bson.M, opts WaterfallOptions) {
+	if len(opts.Statuses) > 0 {
+		match[task.DisplayStatusCacheKey] = bson.M{"$in": opts.Statuses}
+	}
+	if len(opts.Tasks) > 0 {
+		taskNamesAsRegex := strings.Join(opts.Tasks, "|")
+		match[task.DisplayNameKey] = bson.M{"$regex": taskNamesAsRegex}
+		if !opts.TaskCaseSensitive {
+			match[task.DisplayNameKey].(bson.M)["$options"] = "i"
+		}
+	}
+	if len(opts.Variants) > 0 {
+		variantsAsRegex := strings.Join(opts.Variants, "|")
+		variantMatch := []bson.M{
+			{task.BuildVariantKey: bson.M{"$regex": variantsAsRegex}},
+			{task.BuildVariantDisplayNameKey: bson.M{"$regex": variantsAsRegex}},
+		}
+		if !opts.VariantCaseSensitive {
+			variantMatch[0][task.BuildVariantKey].(bson.M)["$options"] = "i"
+			variantMatch[1][task.BuildVariantDisplayNameKey].(bson.M)["$options"] = "i"
+		}
+		match["$and"] = []bson.M{{"$or": variantMatch}}
+	}
+}
+
 const (
 	minRevisionLength = 7
 )
@@ -138,34 +163,7 @@ func GetActiveVersionsByTaskFilters(ctx context.Context, projectId string, opts 
 	}
 	match[task.RevisionOrderNumberKey] = revisionFilter
 
-	if len(opts.Statuses) > 0 {
-		match[task.DisplayStatusCacheKey] = bson.M{"$in": opts.Statuses}
-	}
-
-	if len(opts.Tasks) > 0 {
-		taskNamesAsRegex := strings.Join(opts.Tasks, "|")
-		if opts.TaskCaseSensitive {
-			match[task.DisplayNameKey] = bson.M{"$regex": taskNamesAsRegex}
-		} else {
-			match[task.DisplayNameKey] = bson.M{"$regex": taskNamesAsRegex, "$options": "i"}
-		}
-
-	}
-
-	if len(opts.Variants) > 0 {
-		variantsAsRegex := strings.Join(opts.Variants, "|")
-		if opts.VariantCaseSensitive {
-			match["$or"] = []bson.M{
-				{task.BuildVariantKey: bson.M{"$regex": variantsAsRegex}},
-				{task.BuildVariantDisplayNameKey: bson.M{"$regex": variantsAsRegex}},
-			}
-		} else {
-			match["$or"] = []bson.M{
-				{task.BuildVariantKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
-				{task.BuildVariantDisplayNameKey: bson.M{"$regex": variantsAsRegex, "$options": "i"}},
-			}
-		}
-	}
+	addWaterfallTaskFilters(match, opts)
 
 	pipeline := []bson.M{{"$match": match}}
 
@@ -340,10 +338,10 @@ func GetAllWaterfallVersions(ctx context.Context, projectId string, minOrder int
 // GetVersionBuilds returns a list of builds with populated tasks for the given version.
 // Tasks are grouped by display task when applicable - execution tasks are shown under their
 // parent display task, while regular tasks (not part of a display task) are shown individually.
-func GetVersionBuilds(ctx context.Context, versionID string, buildIds []string) ([]*WaterfallBuild, error) {
+func GetVersionBuilds(ctx context.Context, version Version, opts WaterfallOptions) ([]*WaterfallBuild, error) {
 	ctx = utility.ContextWithAppendedAttributes(ctx, []attribute.KeyValue{attribute.String(evergreen.AggregationNameOtelAttribute, "GetVersionBuilds")})
 
-	if len(buildIds) == 0 {
+	if len(version.BuildIds) == 0 {
 		return []*WaterfallBuild{}, nil
 	}
 
@@ -352,8 +350,8 @@ func GetVersionBuilds(ctx context.Context, versionID string, buildIds []string) 
 	// 2. Regular tasks that are not part of a display task (DisplayTaskId is empty or doesn't exist)
 	// This excludes execution tasks that are part of a display task.
 	match := bson.M{
-		task.VersionKey:   versionID,
-		task.BuildIdKey:   bson.M{"$in": buildIds},
+		task.VersionKey:   version.Id,
+		task.BuildIdKey:   bson.M{"$in": version.BuildIds},
 		task.RequesterKey: bson.M{"$in": evergreen.SystemVersionRequesterTypes},
 		"$or": []bson.M{
 			{task.DisplayOnlyKey: true},
@@ -361,6 +359,8 @@ func GetVersionBuilds(ctx context.Context, versionID string, buildIds []string) 
 			{task.DisplayTaskIdKey: ""},
 		},
 	}
+
+	addWaterfallTaskFilters(match, opts)
 
 	pipeline := []bson.M{
 		{"$match": match},
@@ -405,7 +405,12 @@ func GetVersionBuilds(ctx context.Context, versionID string, buildIds []string) 
 			},
 		},
 		{"$unwind": "$build"},
-		{
+	}
+	if opts.OmitInactiveBuilds {
+		pipeline = append(pipeline, bson.M{"$match": bson.M{"build." + build.ActivatedKey: true}})
+	}
+	pipeline = append(pipeline,
+		bson.M{
 			"$project": bson.M{
 				"_id":           "$build." + build.IdKey,
 				"activated":     "$build." + build.ActivatedKey,
@@ -415,8 +420,8 @@ func GetVersionBuilds(ctx context.Context, versionID string, buildIds []string) 
 				"tasks":         1,
 			},
 		},
-		{"$sort": bson.M{"display_name": 1}},
-	}
+		bson.M{"$sort": bson.M{"display_name": 1}},
+	)
 
 	res := []*WaterfallBuild{}
 	env := evergreen.GetEnvironment()

--- a/model/waterfall_test.go
+++ b/model/waterfall_test.go
@@ -327,10 +327,11 @@ func TestGetVersionBuilds(t *testing.T) {
 		assert.NoError(t, v.Insert(t.Context()))
 
 		b := build.Build{
-			Id:          "b",
-			Activated:   true,
-			DisplayName: "Lint",
-			Version:     "v_1",
+			Id:           "b",
+			Activated:    false,
+			BuildVariant: "lint",
+			DisplayName:  "Lint",
+			Version:      "v_1",
 			Tasks: []build.TaskCache{
 				{Id: "t_80"},
 				{Id: "t_79"},
@@ -340,10 +341,11 @@ func TestGetVersionBuilds(t *testing.T) {
 		}
 		assert.NoError(t, b.Insert(t.Context()))
 		b = build.Build{
-			Id:          "a",
-			Activated:   true,
-			DisplayName: "Ubuntu 2204",
-			Version:     "v_1",
+			Id:           "a",
+			Activated:    true,
+			BuildVariant: "ubuntu",
+			DisplayName:  "Ubuntu 2204",
+			Version:      "v_1",
 			Tasks: []build.TaskCache{
 				{Id: "t_45"},
 				{Id: "t_12"},
@@ -352,28 +354,54 @@ func TestGetVersionBuilds(t *testing.T) {
 		}
 		assert.NoError(t, b.Insert(t.Context()))
 
-		tsk := task.Task{Id: "t_80", DisplayName: "Task 80", DisplayStatusCache: evergreen.TaskSucceeded, BuildId: "b", Version: "v_1", Requester: evergreen.RepotrackerVersionRequester}
+		tsk := task.Task{Id: "t_80", DisplayName: "Task 80", DisplayStatusCache: evergreen.TaskSucceeded, BuildId: "b", BuildVariant: "lint", BuildVariantDisplayName: "Lint", Version: "v_1", Requester: evergreen.RepotrackerVersionRequester}
 		assert.NoError(t, tsk.Insert(t.Context()))
-		tsk = task.Task{Id: "t_79", DisplayName: "Task 79", DisplayStatusCache: evergreen.TaskFailed, BuildId: "b", Version: "v_1", Requester: evergreen.RepotrackerVersionRequester}
+		tsk = task.Task{Id: "t_79", DisplayName: "Task 79", DisplayStatusCache: evergreen.TaskFailed, BuildId: "b", BuildVariant: "lint", BuildVariantDisplayName: "Lint", Version: "v_1", Requester: evergreen.RepotrackerVersionRequester}
 		assert.NoError(t, tsk.Insert(t.Context()))
-		tsk = task.Task{Id: "t_86", DisplayName: "Task 86", DisplayStatusCache: evergreen.TaskSucceeded, BuildId: "b", Version: "v_1", Requester: evergreen.RepotrackerVersionRequester}
+		tsk = task.Task{Id: "t_86", DisplayName: "Task 86", DisplayStatusCache: evergreen.TaskSucceeded, BuildId: "b", BuildVariant: "lint", BuildVariantDisplayName: "Lint", Version: "v_1", Requester: evergreen.RepotrackerVersionRequester}
 		assert.NoError(t, tsk.Insert(t.Context()))
-		tsk = task.Task{Id: "t_200", DisplayName: "Task 200", DisplayStatusCache: evergreen.TaskSucceeded, BuildId: "b", Version: "v_1", Requester: evergreen.RepotrackerVersionRequester}
+		tsk = task.Task{Id: "t_200", DisplayName: "Task 200", DisplayStatusCache: evergreen.TaskSucceeded, BuildId: "b", BuildVariant: "lint", BuildVariantDisplayName: "Lint", Version: "v_1", Requester: evergreen.RepotrackerVersionRequester}
 		assert.NoError(t, tsk.Insert(t.Context()))
-		tsk = task.Task{Id: "t_45", DisplayName: "Task 12", DisplayStatusCache: evergreen.TaskWillRun, BuildId: "a", Version: "v_1", Requester: evergreen.RepotrackerVersionRequester}
+		tsk = task.Task{Id: "t_45", DisplayName: "Task 12", DisplayStatusCache: evergreen.TaskWillRun, BuildId: "a", BuildVariant: "ubuntu", BuildVariantDisplayName: "Ubuntu 2204", Version: "v_1", Requester: evergreen.RepotrackerVersionRequester}
 		assert.NoError(t, tsk.Insert(t.Context()))
-		tsk = task.Task{Id: "t_12", DisplayName: "Task 12", DisplayStatusCache: evergreen.TaskWillRun, BuildId: "a", Version: "v_1", Requester: evergreen.RepotrackerVersionRequester}
+		tsk = task.Task{Id: "t_12", DisplayName: "Task 12", DisplayStatusCache: evergreen.TaskWillRun, BuildId: "a", BuildVariant: "ubuntu", BuildVariantDisplayName: "Ubuntu 2204", Version: "v_1", Requester: evergreen.RepotrackerVersionRequester}
 		assert.NoError(t, tsk.Insert(t.Context()))
-		tsk = task.Task{Id: "t_66", DisplayName: "Task 66", DisplayStatusCache: evergreen.TaskWillRun, BuildId: "a", Version: "v_1", Requester: evergreen.RepotrackerVersionRequester}
+		tsk = task.Task{Id: "t_66", DisplayName: "Task 66", DisplayStatusCache: evergreen.TaskWillRun, BuildId: "a", BuildVariant: "ubuntu", BuildVariantDisplayName: "Ubuntu 2204", Version: "v_1", Requester: evergreen.RepotrackerVersionRequester}
 		assert.NoError(t, tsk.Insert(t.Context()))
 
-		builds, err := GetVersionBuilds(t.Context(), v.Id, v.BuildIds)
+		builds, err := GetVersionBuilds(t.Context(), v, WaterfallOptions{})
 		assert.NoError(t, err)
 		assert.Len(t, builds, 2)
 
 		// Assert build variants are sorted alphabetically by display name.
 		assert.Equal(t, "Lint", builds[0].DisplayName)
 		assert.Equal(t, "Ubuntu 2204", builds[1].DisplayName)
+
+		builds, err = GetVersionBuilds(t.Context(), v, WaterfallOptions{
+			Tasks:                []string{"Task 79"},
+			TaskCaseSensitive:    true,
+			Statuses:             []string{evergreen.TaskFailed},
+			Variants:             []string{"Lint"},
+			VariantCaseSensitive: true,
+		})
+		assert.NoError(t, err)
+		require.Len(t, builds, 1)
+		require.Len(t, builds[0].Tasks, 1)
+		assert.Equal(t, "t_79", builds[0].Tasks[0].Id)
+
+		builds, err = GetVersionBuilds(t.Context(), v, WaterfallOptions{
+			Tasks:             []string{"task 12"},
+			TaskCaseSensitive: false,
+			Variants:          []string{"UBUNTU"},
+		})
+		assert.NoError(t, err)
+		require.Len(t, builds, 1)
+		assert.Len(t, builds[0].Tasks, 2)
+
+		builds, err = GetVersionBuilds(t.Context(), v, WaterfallOptions{OmitInactiveBuilds: true})
+		assert.NoError(t, err)
+		require.Len(t, builds, 1)
+		assert.Equal(t, "Ubuntu 2204", builds[0].DisplayName)
 	})
 
 	t.Run("IncludesDisplayTasksExcludesExecutionTasks", func(t *testing.T) {
@@ -457,7 +485,7 @@ func TestGetVersionBuilds(t *testing.T) {
 		}
 		assert.NoError(t, regularTask.Insert(t.Context()))
 
-		builds, err := GetVersionBuilds(t.Context(), v.Id, v.BuildIds)
+		builds, err := GetVersionBuilds(t.Context(), v, WaterfallOptions{})
 		assert.NoError(t, err)
 		require.Len(t, builds, 1)
 		assert.Equal(t, "Ubuntu", builds[0].DisplayName)


### PR DESCRIPTION
DEVPROD-38075

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

<!--add description, context, thought process, etc-->
When a user adds task/variant filters on the waterfall, we currently return all builds/tasks and filter the grid on the client. The original idea was that this would allow for snappier behavior upon clearing the filters, but in actuality these filters often match on a distinct set of versions, and so the cached unmatching tasks are never used at all.
- Utilize provided filters when attaching tasks/builds to the version
- Reuse filter queries between `GetActiveVersionsByTaskFilters` and `GetVersionBuilds` to ensure the same behavior
- This feature is opt-in and only applies when the `includeAllBuildsAndTasks` is set to false. This will allow testing and development on the UI once the backend is deployed to prod

### Testing

<!--add a description of how you tested it-->
- Existing GraphQL tests pass when missing `includeAllBuildsAndTasks` flag
- Add tests using flag
- Tested on staging with some local UI changes

<!--Remember to add or edit docs in the docs/ directory if relevant.-->
<!-- If you're editing docs only and are making structural changes (for example, adding links or new pages), create a patch for the Pine tasks to ensure our changes are compatible-->

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
