### PR TITLE
DEVPROD-42320: Restore and save git.get_project source through the source cache

### DIFF
--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -552,12 +552,18 @@ func (c *gitFetchProject) saveSourceCache(ctx context.Context, comm client.Commu
 }
 
 // buildPostRestoreCommand returns the script run over a restored tree. It
-// verifies HEAD against the expected revision and optionally checks out a PR.
+// verifies HEAD against the expected revision, reconciles the checked out
+// branch, and optionally checks out a PR.
 func (c *gitFetchProject) buildPostRestoreCommand(conf *internal.TaskConfig, opts cloneOpts, revision string, runPRCheckout bool) []string {
 	cmds := c.scriptInProjectDir(fmt.Sprintf(`test "$(git rev-parse HEAD)" = "%s"`, revision))
 	cmds = append(cmds, setOriginURLCommands(opts)...)
 	if runPRCheckout {
 		cmds = append(cmds, prCheckoutCommands(conf)...)
+	} else if opts.branch != "" {
+		// The cache key pins the revision but not the branch, so a producer
+		// that cloned a different branch at the same commit would leave that
+		// branch name behind for `git branch` to report.
+		cmds = append(cmds, fmt.Sprintf(`git checkout -B '%s' %s`, opts.branch, revision))
 	}
 	return append(cmds, "git log --oneline -n 10")
 }

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -493,12 +493,12 @@ func (c *gitFetchProject) fetchOrRestoreSource(ctx context.Context, comm client.
 		runPRCheckout := revision != sc.revision
 		// buildPostRestoreCommand verifies HEAD against revision, so a restored
 		// tree at the wrong commit fails here and falls back to a clone below.
-		if err := c.runGitScript(ctx, logger, conf, c.buildPostRestoreCommand(conf, opts, revision, runPRCheckout)); err != nil {
+		if err := c.runCommands(ctx, logger, conf, c.buildPostRestoreCommand(conf, opts, revision, runPRCheckout)); err != nil {
 			fallbackReason = errors.Wrap(err, "preparing restored source tree").Error()
 			break
 		}
 		logger.Task().Infof(ctx, "Restored source from the cache for revision '%s'.", revision)
-		trace.SpanFromContext(ctx).SetAttributes(attribute.String(sourceCacheAttribute("restored_revision"), revision))
+		trace.SpanFromContext(ctx).SetAttributes(attribute.String(sourceCacheRestoredRevisionAttribute, revision))
 		sc.setSpanOutcome(ctx, sourceCacheHit, "")
 		return nil
 	}
@@ -531,21 +531,22 @@ func (c *gitFetchProject) fetchOrRestoreSource(ctx context.Context, comm client.
 // cloneSource clones the project from GitHub.
 func (c *gitFetchProject) cloneSource(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig, opts cloneOpts) error {
 	start := time.Now()
-	if err := c.fetchSource(ctx, logger, comm, conf, opts); err != nil {
-		return errors.Wrap(err, "running fetch command")
-	}
-	setSourceCacheSpanDuration(ctx, "clone_duration", time.Since(start))
-	return nil
+	// Deferred so a failed clone is timed too, since those are the runs most
+	// worth comparing against a cache hit.
+	defer func() {
+		setSourceCacheSpanDuration(ctx, sourceCacheCloneDurationAttribute, time.Since(start))
+	}()
+	return errors.Wrap(c.fetchSource(ctx, logger, comm, conf, opts), "running fetch command")
 }
 
 // saveSourceCache scrubs the cloned tree of anything task-specific, uploads it,
 // and puts the task's own authenticated origin URL back for the rest of the run.
 func (c *gitFetchProject) saveSourceCache(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig, sc *sourceCache, opts cloneOpts) (bool, error) {
-	if err := c.runGitScript(ctx, logger, conf, c.buildPreSaveCommand(opts)); err != nil {
+	if err := c.runCommands(ctx, logger, conf, c.buildPreSaveCommand(opts)); err != nil {
 		return false, errors.Wrap(err, "scrubbing source tree before saving")
 	}
 	produced, saveErr := sc.save(ctx, comm, logger)
-	if err := c.runGitScript(ctx, logger, conf, c.buildPostSaveCommand(opts)); err != nil {
+	if err := c.runCommands(ctx, logger, conf, c.buildPostSaveCommand(opts)); err != nil {
 		return produced, errors.Wrap(err, "restoring origin URL after saving")
 	}
 	return produced, saveErr
@@ -603,7 +604,7 @@ func setOriginURLCommands(opts cloneOpts) []string {
 	}
 }
 
-func (c *gitFetchProject) runGitScript(ctx context.Context, logger client.LoggerProducer, conf *internal.TaskConfig, cmds []string) error {
+func (c *gitFetchProject) runCommands(ctx context.Context, logger client.LoggerProducer, conf *internal.TaskConfig, cmds []string) error {
 	script := strings.Join(cmds, "\n")
 	logger.Task().Debugf(ctx, "Commands are: %s", script)
 	return c.JasperManager().CreateCommand(ctx).Add([]string{"bash", "-c", script}).Directory(conf.WorkDir).

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -558,6 +558,9 @@ func (c *gitFetchProject) saveSourceCache(ctx context.Context, comm client.Commu
 func (c *gitFetchProject) buildPostRestoreCommand(conf *internal.TaskConfig, opts cloneOpts, revision string, runPRCheckout bool) []string {
 	cmds := c.scriptInProjectDir(fmt.Sprintf(`test "$(git rev-parse HEAD)" = "%s"`, revision))
 	cmds = append(cmds, setOriginURLCommands(opts)...)
+	// The archive was scrubbed of the producer's credentials, so a restored
+	// tree needs this task's own put into the submodule remotes.
+	cmds = append(cmds, restoreGitConfigCredentialsCommands(opts.token)...)
 	if runPRCheckout {
 		cmds = append(cmds, prCheckoutCommands(conf)...)
 	} else if opts.branch != "" {
@@ -574,13 +577,40 @@ func (c *gitFetchProject) buildPostRestoreCommand(conf *internal.TaskConfig, opt
 // own credential, so both are scrubbed.
 func (c *gitFetchProject) buildPreSaveCommand(opts cloneOpts) []string {
 	tokenless := cloneOpts{owner: opts.owner, repo: opts.repo}
-	return append(c.scriptInProjectDir("rm -rf .git/hooks"), setOriginURLCommands(tokenless)...)
+	cmds := append(c.scriptInProjectDir("rm -rf .git/hooks"), setOriginURLCommands(tokenless)...)
+	return append(cmds, scrubGitConfigCredentialsCommand)
 }
 
-// buildPostSaveCommand puts the task's own authenticated origin URL back after
-// the scrubbed tree has been archived.
+// scrubGitConfigCredentialsCommand strips the userinfo from every remote URL
+// recorded under .git. Submodule URLs are resolved with the parent's credential
+// and written to .git/config and .git/modules/*/config, so setting origin alone
+// would leave the producer's token in the archive.
+const scrubGitConfigCredentialsCommand = `find .git -type f -name config | while read -r cfg; do sed -E 's#://[^/@]*@#://#g' "$cfg" > "$cfg.scrubbed" && mv "$cfg.scrubbed" "$cfg"; done`
+
+// restoreGitConfigCredentialsCommands is the inverse of
+// scrubGitConfigCredentialsCommand for submodules: it puts the task's own
+// credential back into the scrubbed GitHub URLs so submodule fetches keep
+// working. URLs that already carry userinfo, such as the origin the caller set
+// separately, do not match and are left alone.
+func restoreGitConfigCredentialsCommands(token string) []string {
+	if token == "" {
+		return nil
+	}
+	rewrite := fmt.Sprintf(`s#://github\.com/#://x-access-token:%s@github.com/#g`, token)
+	return []string{
+		"set +o xtrace",
+		fmt.Sprintf("echo %s", strconv.Quote("restoring submodule credentials in .git configs")),
+		fmt.Sprintf(`find .git -type f -name config | while read -r cfg; do sed -E '%s' "$cfg" > "$cfg.restored" && mv "$cfg.restored" "$cfg"; done`, rewrite),
+		"set -o xtrace",
+	}
+}
+
+// buildPostSaveCommand puts the task's own credentials back after the scrubbed
+// tree has been archived, for origin and for any submodule remotes the scrub
+// stripped.
 func (c *gitFetchProject) buildPostSaveCommand(opts cloneOpts) []string {
-	return append(c.scriptInProjectDir(), setOriginURLCommands(opts)...)
+	cmds := append(c.scriptInProjectDir(), setOriginURLCommands(opts)...)
+	return append(cmds, restoreGitConfigCredentialsCommands(opts.token)...)
 }
 
 // scriptInProjectDir starts a git script in the project directory, with cmds

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -473,6 +473,20 @@ func (c *gitFetchProject) fetchOrRestoreSource(ctx context.Context, comm client.
 		return err
 	}
 
+	// A cache hit on the merge SHA never contacts GitHub, so nothing else would notice a deleted ref.
+	deleted, err := mergeQueueRefDeleted(ctx, comm, conf, c.Token, opts)
+	if err != nil {
+		// The clone's own check is still a backstop for an inconclusive answer.
+		logger.Task().Warningf(ctx, "Checking whether the merge queue ref still exists: %s", err)
+	} else if deleted {
+		c.refNotFound = true
+		if markErr := comm.MarkMergeQueueGitRefNotFound(ctx, conf.TaskData()); markErr != nil {
+			logger.Task().Warningf(ctx, "Failed to mark git ref not found: %s", markErr)
+		}
+		setSourceCacheSpanSkipped(ctx, "the merge queue ref was deleted")
+		return errors.New(mergeQueueRefGoneMessage)
+	}
+
 	fallbackReason := ""
 	for _, revision := range sc.restoreRevisions() {
 		_, remoteKey, err := sc.cacheKeysForRevision(revision)
@@ -668,23 +682,14 @@ func (c *gitFetchProject) fetchSource(ctx context.Context, logger client.LoggerP
 		opts.token = token
 
 		// On the second attempt, check if the merge queue ref was deleted before retrying.
-		if attempt == 2 && conf.Task.Requester == evergreen.GithubMergeRequester && conf.GithubMergeData.HeadBranch != "" {
-			ref := "heads/" + conf.GithubMergeData.HeadBranch
-			// A user-supplied clone token can't authenticate an app-scoped API call.
-			appToken := token
-			var tokenErr error
-			if c.Token != "" {
-				appToken, tokenErr = comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), opts.owner, opts.repo, false)
+		if attempt == 2 {
+			deleted, checkErr := mergeQueueRefDeleted(ctx, comm, conf, c.Token, opts)
+			if checkErr != nil {
+				return checkErr
 			}
-			if tokenErr == nil && appToken != "" {
-				exists, checkErr := thirdparty.MergeQueueRefExists(ctx, opts.owner, opts.repo, ref, appToken)
-				if checkErr != nil {
-					return errors.Wrap(checkErr, "checking if merge queue ref exists")
-				}
-				if !exists {
-					c.refNotFound = true
-					return errors.New("the GitHub merge SHA is not available most likely because the merge completed or was aborted")
-				}
+			if deleted {
+				c.refNotFound = true
+				return errors.New(mergeQueueRefGoneMessage)
 			}
 		}
 
@@ -723,6 +728,39 @@ func (c *gitFetchProject) fetchSource(ctx context.Context, logger client.LoggerP
 		return nil
 	})
 	return token, err
+}
+
+// mergeQueueRefGoneMessage is the error a merge queue task fails with once its head ref is confirmed deleted.
+const mergeQueueRefGoneMessage = "the GitHub merge SHA is not available most likely because the merge completed or was aborted"
+
+// mergeQueueRefExists is a variable so tests can check the fail-fast path without reaching GitHub.
+var mergeQueueRefExists = thirdparty.MergeQueueRefExists
+
+// mergeQueueRefDeleted reports whether this merge queue task's head ref is gone from GitHub, meaning the
+// queue item merged or was kicked out. It reports false whenever there is no definite answer to be had.
+func mergeQueueRefDeleted(ctx context.Context, comm client.Communicator, conf *internal.TaskConfig, userToken string, opts cloneOpts) (bool, error) {
+	if conf.Task.Requester != evergreen.GithubMergeRequester || conf.GithubMergeData.HeadBranch == "" {
+		return false, nil
+	}
+
+	// A user-supplied clone token can't authenticate an app-scoped API call.
+	appToken := opts.token
+	if userToken != "" {
+		var err error
+		appToken, err = comm.CreateInstallationTokenForClone(ctx, conf.TaskData(), opts.owner, opts.repo, false)
+		if err != nil {
+			return false, nil
+		}
+	}
+	if appToken == "" {
+		return false, nil
+	}
+
+	exists, err := mergeQueueRefExists(ctx, opts.owner, opts.repo, "heads/"+conf.GithubMergeData.HeadBranch, appToken)
+	if err != nil {
+		return false, errors.Wrap(err, "checking if merge queue ref exists")
+	}
+	return !exists, nil
 }
 
 func refreshCloneToken(ctx context.Context, comm client.Communicator, conf *internal.TaskConfig, owner, repo string) (string, error) {
@@ -769,7 +807,7 @@ func (c *gitFetchProject) retryFetch(ctx context.Context, logger client.LoggerPr
 					if markErr := comm.MarkMergeQueueGitRefNotFound(ctx, conf.TaskData()); markErr != nil {
 						logger.Task().Warningf(ctx, "Failed to mark git ref not found: %s", markErr)
 					}
-					return false, errors.Wrap(err, "the GitHub merge SHA is not available most likely because the merge completed or was aborted")
+					return false, errors.Wrap(err, mergeQueueRefGoneMessage)
 				}
 				return true, errors.Wrapf(err, "attempt %d", attemptNum)
 			}

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -459,6 +460,150 @@ func (c *gitFetchProject) Execute(ctx context.Context, comm client.Communicator,
 	return err
 }
 
+// fetchOrRestoreSource restores the project directory from the source cache when
+// the project is opted in, and otherwise clones it from GitHub. Any source cache
+// failure falls back to the clone, so the cache can only save time, never change
+// what is tested.
+func (c *gitFetchProject) fetchOrRestoreSource(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig, opts cloneOpts) error {
+	sc, skipReason := newSourceCache(conf, c, opts, runtime.GOOS)
+	if sc == nil {
+		logger.Task().Infof(ctx, "Not using the source cache: %s.", skipReason)
+		setSourceCacheSpanSkipped(ctx, skipReason)
+		return c.cloneSource(ctx, comm, logger, conf, opts)
+	}
+
+	fallbackReason := ""
+	for _, revision := range sc.restoreRevisions() {
+		_, remoteKey, err := sc.cacheKeysForRevision(revision)
+		if err != nil {
+			fallbackReason = errors.Wrap(err, "computing the source cache key").Error()
+			break
+		}
+		logger.Task().Infof(ctx, "Looking up source cache '%s/%s'.", sc.cfg.Name, remoteKey)
+		restored, err := sc.restore(ctx, comm, logger, remoteKey)
+		if err != nil {
+			fallbackReason = err.Error()
+			break
+		}
+		if !restored {
+			continue
+		}
+		// A base revision artifact is at the commit the PR is built on, so the
+		// PR still has to be checked out over it.
+		runPRCheckout := revision != sc.revision
+		// buildPostRestoreCommand verifies HEAD against revision, so a restored
+		// tree at the wrong commit fails here and falls back to a clone below.
+		if err := c.runGitScript(ctx, logger, conf, c.buildPostRestoreCommand(conf, opts, revision, runPRCheckout)); err != nil {
+			fallbackReason = errors.Wrap(err, "preparing restored source tree").Error()
+			break
+		}
+		logger.Task().Infof(ctx, "Restored source from the cache for revision '%s'.", revision)
+		trace.SpanFromContext(ctx).SetAttributes(attribute.String(sourceCacheAttribute("restored_revision"), revision))
+		sc.setSpanOutcome(ctx, sourceCacheHit, "")
+		return nil
+	}
+	if fallbackReason != "" {
+		logger.Task().Warningf(ctx, "Falling back to a GitHub clone: %s", fallbackReason)
+	}
+
+	if err := c.cloneSource(ctx, comm, logger, conf, opts); err != nil {
+		return err
+	}
+
+	outcome := sourceCacheMissProduced
+	produced, err := c.saveSourceCache(ctx, comm, logger, conf, sc, opts)
+	if err != nil {
+		logger.Task().Warningf(ctx, "Saving source to the cache: %s", err)
+		outcome = sourceCacheFallback
+		if fallbackReason == "" {
+			fallbackReason = err.Error()
+		}
+	} else if !produced {
+		outcome = sourceCacheMissLostRace
+	}
+	if fallbackReason != "" {
+		outcome = sourceCacheFallback
+	}
+	sc.setSpanOutcome(ctx, outcome, fallbackReason)
+	return nil
+}
+
+// cloneSource clones the project from GitHub.
+func (c *gitFetchProject) cloneSource(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig, opts cloneOpts) error {
+	start := time.Now()
+	if err := c.fetchSource(ctx, logger, comm, conf, opts); err != nil {
+		return errors.Wrap(err, "running fetch command")
+	}
+	setSourceCacheSpanDuration(ctx, "clone_duration", time.Since(start))
+	return nil
+}
+
+// saveSourceCache scrubs the cloned tree of anything task-specific, uploads it,
+// and puts the task's own authenticated origin URL back for the rest of the run.
+func (c *gitFetchProject) saveSourceCache(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig, sc *sourceCache, opts cloneOpts) (bool, error) {
+	if err := c.runGitScript(ctx, logger, conf, c.buildPreSaveCommand(opts)); err != nil {
+		return false, errors.Wrap(err, "scrubbing source tree before saving")
+	}
+	produced, saveErr := sc.save(ctx, comm, logger)
+	if err := c.runGitScript(ctx, logger, conf, c.buildPostSaveCommand(opts)); err != nil {
+		return produced, errors.Wrap(err, "restoring origin URL after saving")
+	}
+	return produced, saveErr
+}
+
+// buildPostRestoreCommand returns the script run over a restored tree. It
+// verifies HEAD against the expected revision and optionally checks out a PR.
+func (c *gitFetchProject) buildPostRestoreCommand(conf *internal.TaskConfig, opts cloneOpts, revision string, runPRCheckout bool) []string {
+	cmds := c.scriptInProjectDir(fmt.Sprintf(`test "$(git rev-parse HEAD)" = "%s"`, revision))
+	cmds = append(cmds, setOriginURLCommands(opts)...)
+	if runPRCheckout {
+		cmds = append(cmds, prCheckoutCommands(conf)...)
+	}
+	return append(cmds, "git log --oneline -n 10")
+}
+
+// buildPreSaveCommand returns the script run before archiving the cloned tree.
+// Hooks in a restored .git execute on checkout, and origin holds the producer's
+// own credential, so both are scrubbed.
+func (c *gitFetchProject) buildPreSaveCommand(opts cloneOpts) []string {
+	tokenless := cloneOpts{owner: opts.owner, repo: opts.repo}
+	return append(c.scriptInProjectDir("rm -rf .git/hooks"), setOriginURLCommands(tokenless)...)
+}
+
+// buildPostSaveCommand puts the task's own authenticated origin URL back after
+// the scrubbed tree has been archived.
+func (c *gitFetchProject) buildPostSaveCommand(opts cloneOpts) []string {
+	return append(c.scriptInProjectDir(), setOriginURLCommands(opts)...)
+}
+
+// scriptInProjectDir starts a git script in the project directory, with cmds
+// appended after the shell options every one of these scripts sets.
+func (c *gitFetchProject) scriptInProjectDir(cmds ...string) []string {
+	return append([]string{
+		"set -o xtrace",
+		"set -o errexit",
+		fmt.Sprintf("cd %s", c.Directory),
+	}, cmds...)
+}
+
+// setOriginURLCommands points origin at the given URL with xtrace off, since the
+// URL embeds a token when one is set.
+func setOriginURLCommands(opts cloneOpts) []string {
+	return []string{
+		"set +o xtrace",
+		fmt.Sprintf("echo %s", strconv.Quote("git remote set-url origin <redacted>")),
+		fmt.Sprintf("git remote set-url origin %s", thirdparty.FormGitURLForApp(opts.owner, opts.repo, opts.token)),
+		"set -o xtrace",
+	}
+}
+
+func (c *gitFetchProject) runGitScript(ctx context.Context, logger client.LoggerProducer, conf *internal.TaskConfig, cmds []string) error {
+	script := strings.Join(cmds, "\n")
+	logger.Task().Debugf(ctx, "Commands are: %s", script)
+	return c.JasperManager().CreateCommand(ctx).Add([]string{"bash", "-c", script}).Directory(conf.WorkDir).
+		SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorSender(level.Error, logger.Execution().GetSender()).Run(ctx)
+}
+
 func (c *gitFetchProject) fetchSource(ctx context.Context, logger client.LoggerProducer, comm client.Communicator, conf *internal.TaskConfig, opts cloneOpts) error {
 	attempt := 0
 	token := opts.token
@@ -775,9 +920,9 @@ func (c *gitFetchProject) fetch(ctx context.Context,
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// Clone the project.
-	if err := c.fetchSource(ctx, logger, comm, conf, opts); err != nil {
-		return errors.Wrap(err, "running fetch command")
+	// Clone the project, or restore it from the source cache.
+	if err := c.fetchOrRestoreSource(ctx, comm, logger, conf, opts); err != nil {
+		return err
 	}
 
 	// Retrieve the patch for the version if one exists.

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -469,7 +469,8 @@ func (c *gitFetchProject) fetchOrRestoreSource(ctx context.Context, comm client.
 	if sc == nil {
 		logger.Task().Infof(ctx, "Not using the source cache: %s.", skipReason)
 		setSourceCacheSpanSkipped(ctx, skipReason)
-		return c.cloneSource(ctx, comm, logger, conf, opts)
+		_, err := c.cloneSource(ctx, comm, logger, conf, opts)
+		return err
 	}
 
 	fallbackReason := ""
@@ -506,9 +507,13 @@ func (c *gitFetchProject) fetchOrRestoreSource(ctx context.Context, comm client.
 		logger.Task().Warningf(ctx, "Falling back to a GitHub clone: %s", fallbackReason)
 	}
 
-	if err := c.cloneSource(ctx, comm, logger, conf, opts); err != nil {
+	token, err := c.cloneSource(ctx, comm, logger, conf, opts)
+	if err != nil {
 		return err
 	}
+	// The clone may have refreshed the token, and the post-save script puts this
+	// URL back into .git for the rest of the task to use.
+	opts.token = token
 
 	outcome := sourceCacheMissProduced
 	produced, err := c.saveSourceCache(ctx, comm, logger, conf, sc, opts)
@@ -528,15 +533,17 @@ func (c *gitFetchProject) fetchOrRestoreSource(ctx context.Context, comm client.
 	return nil
 }
 
-// cloneSource clones the project from GitHub.
-func (c *gitFetchProject) cloneSource(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig, opts cloneOpts) error {
+// cloneSource clones the project from GitHub, returning the token the clone
+// ended up using.
+func (c *gitFetchProject) cloneSource(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, conf *internal.TaskConfig, opts cloneOpts) (string, error) {
 	start := time.Now()
 	// Deferred so a failed clone is timed too, since those are the runs most
 	// worth comparing against a cache hit.
 	defer func() {
 		setSourceCacheSpanDuration(ctx, sourceCacheCloneDurationAttribute, time.Since(start))
 	}()
-	return errors.Wrap(c.fetchSource(ctx, logger, comm, conf, opts), "running fetch command")
+	token, err := c.fetchSource(ctx, logger, comm, conf, opts)
+	return token, errors.Wrap(err, "running fetch command")
 }
 
 // saveSourceCache scrubs the cloned tree of anything task-specific, uploads it,
@@ -641,10 +648,13 @@ func (c *gitFetchProject) runCommands(ctx context.Context, logger client.LoggerP
 		SetOutputSender(level.Info, logger.Task().GetSender()).SetErrorSender(level.Error, logger.Execution().GetSender()).Run(ctx)
 }
 
-func (c *gitFetchProject) fetchSource(ctx context.Context, logger client.LoggerProducer, comm client.Communicator, conf *internal.TaskConfig, opts cloneOpts) error {
+// fetchSource clones the project, returning the token it ended up using. A
+// retry can refresh the token, and callers that rewrite the origin URL
+// afterwards need the current one rather than the one they passed in.
+func (c *gitFetchProject) fetchSource(ctx context.Context, logger client.LoggerProducer, comm client.Communicator, conf *internal.TaskConfig, opts cloneOpts) (string, error) {
 	attempt := 0
 	token := opts.token
-	return c.retryFetch(ctx, logger, comm, conf, true, opts, func(opts cloneOpts) error {
+	err := c.retryFetch(ctx, logger, comm, conf, true, opts, func(opts cloneOpts) error {
 		attempt++
 		// Don't refresh c.Token because it is user supplied.
 		if attempt == gitFetchProjectRetries && c.Token == "" {
@@ -712,6 +722,7 @@ func (c *gitFetchProject) fetchSource(ctx context.Context, logger client.LoggerP
 
 		return nil
 	})
+	return token, err
 }
 
 func refreshCloneToken(ctx context.Context, comm client.Communicator, conf *internal.TaskConfig, owner, repo string) (string, error) {

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -574,8 +574,8 @@ func (c *gitFetchProject) saveSourceCache(ctx context.Context, comm client.Commu
 }
 
 // buildPostRestoreCommand returns the script run over a restored tree. It
-// verifies HEAD against the expected revision, reconciles the checked out
-// branch, and optionally checks out a PR.
+// verifies HEAD against the expected revision, restores this task's
+// credentials, and optionally checks out a PR.
 func (c *gitFetchProject) buildPostRestoreCommand(conf *internal.TaskConfig, opts cloneOpts, revision string, runPRCheckout bool) []string {
 	cmds := c.scriptInProjectDir(fmt.Sprintf(`test "$(git rev-parse HEAD)" = "%s"`, revision))
 	cmds = append(cmds, setOriginURLCommands(opts)...)
@@ -584,11 +584,6 @@ func (c *gitFetchProject) buildPostRestoreCommand(conf *internal.TaskConfig, opt
 	cmds = append(cmds, restoreGitConfigCredentialsCommands(opts.token)...)
 	if runPRCheckout {
 		cmds = append(cmds, prCheckoutCommands(conf)...)
-	} else if opts.branch != "" {
-		// The cache key pins the revision but not the branch, so a producer
-		// that cloned a different branch at the same commit would leave that
-		// branch name behind for `git branch` to report.
-		cmds = append(cmds, fmt.Sprintf(`git checkout -B '%s' %s`, opts.branch, revision))
 	}
 	return append(cmds, "git log --oneline -n 10")
 }

--- a/agent/command/git_source_cache.go
+++ b/agent/command/git_source_cache.go
@@ -151,7 +151,7 @@ func (sc *sourceCache) cacheKeysForRevision(revision string) (string, string, er
 	if err != nil {
 		return "", "", err
 	}
-	return key, path.Join(sourceCachePrefix, namespace, sc.owner, sc.repo, revision, key+cacheArchiveSuffix), nil
+	return key, path.Join(sourceCachePrefix, sc.owner, sc.repo, namespace, revision, key+cacheArchiveSuffix), nil
 }
 
 func (sc *sourceCache) projectDir() string {

--- a/agent/command/git_source_cache.go
+++ b/agent/command/git_source_cache.go
@@ -72,6 +72,7 @@ type sourceCache struct {
 	workDir           string
 	dir               string
 	owner, repo       string
+	branch            string
 	baseRevision      string
 	prRevision        string
 	revision          string
@@ -110,6 +111,7 @@ func newSourceCache(conf *internal.TaskConfig, c *gitFetchProject, opts cloneOpt
 		dir:               c.Directory,
 		owner:             opts.owner,
 		repo:              opts.repo,
+		branch:            opts.branch,
 		baseRevision:      conf.Task.Revision,
 		cloneDepth:        opts.cloneDepth,
 		recurseSubmodules: opts.recurseSubmodules,
@@ -146,7 +148,12 @@ func (sc *sourceCache) namespaceForRevision(revision string) string {
 // keyFor returns the content key and S3 object key for a revision.
 func (sc *sourceCache) cacheKeysForRevision(revision string) (string, string, error) {
 	namespace := sc.namespaceForRevision(revision)
-	expansions := []string{namespace, sc.owner, sc.repo, revision, strconv.Itoa(sc.cloneDepth), strconv.FormatBool(sc.recurseSubmodules)}
+	// A PR artifact is already pinned to the PR head, so the branch would only fragment its keys.
+	branch := sc.branch
+	if namespace == sourceCachePRNamespace {
+		branch = ""
+	}
+	expansions := []string{namespace, sc.owner, sc.repo, branch, revision, strconv.Itoa(sc.cloneDepth), strconv.FormatBool(sc.recurseSubmodules)}
 	key, err := computeCacheKey(nil, expansions, true)
 	if err != nil {
 		return "", "", err

--- a/agent/command/git_source_cache.go
+++ b/agent/command/git_source_cache.go
@@ -31,6 +31,29 @@ const sourceCachePRNamespace = "pr"
 // sourceCacheRegion is the region the source cache bucket lives in.
 const sourceCacheRegion = evergreen.DefaultEC2Region
 
+var (
+	sourceCacheOutcomeAttribute           = sourceCacheAttribute("outcome")
+	sourceCacheReasonAttribute            = sourceCacheAttribute("reason")
+	sourceCacheKeyAttribute               = sourceCacheAttribute("cache_key")
+	sourceCacheOwnerAttribute             = sourceCacheAttribute("owner")
+	sourceCacheRepoAttribute              = sourceCacheAttribute("repo")
+	sourceCacheRevisionAttribute          = sourceCacheAttribute("revision")
+	sourceCacheRestoredRevisionAttribute  = sourceCacheAttribute("restored_revision")
+	sourceCacheCloneDepthAttribute        = sourceCacheAttribute("clone_depth")
+	sourceCacheRecurseSubmodulesAttribute = sourceCacheAttribute("recurse_submodules")
+	sourceCacheArtifactBytesAttribute     = sourceCacheAttribute("artifact_bytes")
+
+	sourceCacheCloneDurationAttribute    = sourceCacheAttribute("clone_duration_ms")
+	sourceCacheDownloadDurationAttribute = sourceCacheAttribute("download_duration_ms")
+	sourceCacheExtractDurationAttribute  = sourceCacheAttribute("extract_duration_ms")
+	sourceCacheArchiveDurationAttribute  = sourceCacheAttribute("archive_duration_ms")
+	sourceCacheUploadDurationAttribute   = sourceCacheAttribute("upload_duration_ms")
+)
+
+func sourceCacheAttribute(name string) string {
+	return fmt.Sprintf("%s.source_cache.%s", gitGetProjectAttribute, name)
+}
+
 // Source cache outcomes reported on the command's span.
 const (
 	sourceCacheHit          = "hit"
@@ -198,7 +221,7 @@ func (sc *sourceCache) restore(ctx context.Context, comm client.Communicator, lo
 	if miss {
 		return false, nil
 	}
-	setSourceCacheSpanDuration(ctx, "download_duration", time.Since(start))
+	setSourceCacheSpanDuration(ctx, sourceCacheDownloadDurationAttribute, time.Since(start))
 
 	info, err := os.Stat(localPath)
 	if err != nil {
@@ -207,7 +230,7 @@ func (sc *sourceCache) restore(ctx context.Context, comm client.Communicator, lo
 	if info.Size() == 0 {
 		return false, nil
 	}
-	trace.SpanFromContext(ctx).SetAttributes(attribute.Int64(sourceCacheAttribute("artifact_bytes"), info.Size()))
+	trace.SpanFromContext(ctx).SetAttributes(attribute.Int64(sourceCacheArtifactBytesAttribute, info.Size()))
 
 	f, err := os.Open(localPath)
 	if err != nil {
@@ -230,7 +253,7 @@ func (sc *sourceCache) restore(ctx context.Context, comm client.Communicator, lo
 	if err := extractTarball(ctx, f, sc.projectDir(), []string{}, true); err != nil {
 		return false, errors.Wrap(err, "extracting source cache archive")
 	}
-	setSourceCacheSpanDuration(ctx, "extract_duration", time.Since(start))
+	setSourceCacheSpanDuration(ctx, sourceCacheExtractDurationAttribute, time.Since(start))
 	return true, nil
 }
 
@@ -248,9 +271,9 @@ func (sc *sourceCache) save(ctx context.Context, comm client.Communicator, logge
 	if err := makeCacheArchive(ctx, sc.projectDir(), []string{sc.projectDir()}, localPath, logger.Task(), true); err != nil {
 		return false, errors.Wrap(err, "creating source cache archive")
 	}
-	setSourceCacheSpanDuration(ctx, "archive_duration", time.Since(start))
+	setSourceCacheSpanDuration(ctx, sourceCacheArchiveDurationAttribute, time.Since(start))
 	if info, err := os.Stat(localPath); err == nil {
-		trace.SpanFromContext(ctx).SetAttributes(attribute.Int64(sourceCacheAttribute("artifact_bytes"), info.Size()))
+		trace.SpanFromContext(ctx).SetAttributes(attribute.Int64(sourceCacheArtifactBytesAttribute, info.Size()))
 	}
 
 	httpClient := utility.GetHTTPClient()
@@ -283,29 +306,29 @@ func (sc *sourceCache) save(ctx context.Context, comm client.Communicator, logge
 	if err != nil {
 		return false, errors.Wrapf(err, "uploading cache object '%s'", sc.remoteKey)
 	}
-	setSourceCacheSpanDuration(ctx, "upload_duration", time.Since(start))
+	setSourceCacheSpanDuration(ctx, sourceCacheUploadDurationAttribute, time.Since(start))
 	return !alreadyExists, nil
 }
 
-func setSourceCacheSpanDuration(ctx context.Context, name string, d time.Duration) {
+func setSourceCacheSpanDuration(ctx context.Context, attr string, d time.Duration) {
 	ms := float64(d) / float64(time.Millisecond)
-	trace.SpanFromContext(ctx).SetAttributes(attribute.Float64(sourceCacheAttribute(name+"_ms"), ms))
+	trace.SpanFromContext(ctx).SetAttributes(attribute.Float64(attr, ms))
 }
 
 // setSpanOutcome records the outcome of the source cache path, with the reason
 // for the outcomes that have one.
 func (sc *sourceCache) setSpanOutcome(ctx context.Context, outcome, reason string) {
 	attrs := []attribute.KeyValue{
-		attribute.String(sourceCacheAttribute("outcome"), outcome),
-		attribute.String(sourceCacheAttribute("cache_key"), sc.key),
-		attribute.String(sourceCacheAttribute("owner"), sc.owner),
-		attribute.String(sourceCacheAttribute("repo"), sc.repo),
-		attribute.String(sourceCacheAttribute("revision"), sc.revision),
-		attribute.Int(sourceCacheAttribute("clone_depth"), sc.cloneDepth),
-		attribute.Bool(sourceCacheAttribute("recurse_submodules"), sc.recurseSubmodules),
+		attribute.String(sourceCacheOutcomeAttribute, outcome),
+		attribute.String(sourceCacheKeyAttribute, sc.key),
+		attribute.String(sourceCacheOwnerAttribute, sc.owner),
+		attribute.String(sourceCacheRepoAttribute, sc.repo),
+		attribute.String(sourceCacheRevisionAttribute, sc.revision),
+		attribute.Int(sourceCacheCloneDepthAttribute, sc.cloneDepth),
+		attribute.Bool(sourceCacheRecurseSubmodulesAttribute, sc.recurseSubmodules),
 	}
 	if reason != "" {
-		attrs = append(attrs, attribute.String(sourceCacheAttribute("reason"), reason))
+		attrs = append(attrs, attribute.String(sourceCacheReasonAttribute, reason))
 	}
 	trace.SpanFromContext(ctx).SetAttributes(attrs...)
 }
@@ -314,11 +337,7 @@ func (sc *sourceCache) setSpanOutcome(ctx context.Context, outcome, reason strin
 // source cache, so disabled runs stay queryable alongside the rest.
 func setSourceCacheSpanSkipped(ctx context.Context, reason string) {
 	trace.SpanFromContext(ctx).SetAttributes(
-		attribute.String(sourceCacheAttribute("outcome"), sourceCacheSkipped),
-		attribute.String(sourceCacheAttribute("reason"), reason),
+		attribute.String(sourceCacheOutcomeAttribute, sourceCacheSkipped),
+		attribute.String(sourceCacheReasonAttribute, reason),
 	)
-}
-
-func sourceCacheAttribute(name string) string {
-	return fmt.Sprintf("%s.source_cache.%s", gitGetProjectAttribute, name)
 }

--- a/agent/command/git_source_cache.go
+++ b/agent/command/git_source_cache.go
@@ -1,0 +1,324 @@
+package command
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/aws/smithy-go"
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/evergreen/agent/internal/client"
+	"github.com/evergreen-ci/pail"
+	"github.com/evergreen-ci/utility"
+	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// sourceCachePrefix is the top-level S3 key prefix for source cache artifacts.
+const sourceCachePrefix = "source_cache/v1"
+
+// sourceCachePRNamespace isolates artifacts produced by PR or merge queue tasks
+// from base-revision artifacts to enforce trust boundaries.
+const sourceCachePRNamespace = "pr"
+
+// sourceCacheRegion is the region the source cache bucket lives in.
+const sourceCacheRegion = evergreen.DefaultEC2Region
+
+// Source cache outcomes reported on the command's span.
+const (
+	sourceCacheHit          = "hit"
+	sourceCacheMissProduced = "miss_produced"
+	sourceCacheMissLostRace = "miss_lost_race"
+	sourceCacheSkipped      = "skipped"
+	sourceCacheFallback     = "fallback"
+)
+
+// sourceCache round-trips a task's cloned project directory through S3 on behalf
+// of git.get_project. It keys on (owner, repo, revision, clone shape) so every
+// version built on a commit shares one artifact.
+type sourceCache struct {
+	cfg               evergreen.BucketConfig
+	taskData          client.TaskData
+	workDir           string
+	dir               string
+	owner, repo       string
+	baseRevision      string
+	prRevision        string
+	revision          string
+	cloneDepth        int
+	recurseSubmodules bool
+
+	key       string
+	remoteKey string
+}
+
+// newSourceCache returns the source cache for this run, or a nil cache and the
+// reason it is off, given the agent's GOOS. It never returns an error the
+// command should fail on.
+func newSourceCache(conf *internal.TaskConfig, c *gitFetchProject, opts cloneOpts, goos string) (*sourceCache, string) {
+	if goos != "linux" {
+		// Producers and consumers must share a platform because the key holds
+		// no platform component and working-tree materialization differs.
+		return nil, "the source cache is only enabled on Linux agents"
+	}
+	if conf.SourceCacheBucket.Name == "" {
+		return nil, "no source cache bucket is configured for this project"
+	}
+	if c.Filter != "" || len(c.SparseCheckoutPaths) > 0 {
+		// A restored partial clone keeps a promisor remote whose lazy fetches
+		// would run later with an expired token.
+		return nil, "the source cache is skipped for partial and sparse clones"
+	}
+	if conf.Task.Revision == "" {
+		return nil, "the task has no revision to key the source cache on"
+	}
+
+	sc := &sourceCache{
+		cfg:               conf.SourceCacheBucket,
+		taskData:          conf.TaskData(),
+		workDir:           conf.WorkDir,
+		dir:               c.Directory,
+		owner:             opts.owner,
+		repo:              opts.repo,
+		baseRevision:      conf.Task.Revision,
+		cloneDepth:        opts.cloneDepth,
+		recurseSubmodules: opts.recurseSubmodules,
+	}
+	if pr := prCheckoutCommit(conf); pr != conf.Task.Revision {
+		sc.prRevision = pr
+	}
+	sc.revision = sc.restoreRevisions()[0]
+
+	key, remoteKey, err := sc.cacheKeysForRevision(sc.revision)
+	if err != nil {
+		return nil, fmt.Sprintf("computing the source cache key: %s", err)
+	}
+	sc.key = key
+	sc.remoteKey = remoteKey
+	return sc, ""
+}
+
+// restoreRevisions returns candidate lookup revisions, most specific first.
+func (sc *sourceCache) restoreRevisions() []string {
+	if sc.prRevision != "" {
+		return []string{sc.prRevision, sc.baseRevision}
+	}
+	return []string{sc.baseRevision}
+}
+
+func (sc *sourceCache) namespaceForRevision(revision string) string {
+	if revision == sc.prRevision {
+		return sourceCachePRNamespace
+	}
+	return ""
+}
+
+// keyFor returns the content key and S3 object key for a revision.
+func (sc *sourceCache) cacheKeysForRevision(revision string) (string, string, error) {
+	namespace := sc.namespaceForRevision(revision)
+	expansions := []string{namespace, sc.owner, sc.repo, revision, strconv.Itoa(sc.cloneDepth), strconv.FormatBool(sc.recurseSubmodules)}
+	key, err := computeCacheKey(nil, expansions, true)
+	if err != nil {
+		return "", "", err
+	}
+	return key, path.Join(sourceCachePrefix, namespace, sc.owner, sc.repo, revision, key+cacheArchiveSuffix), nil
+}
+
+func (sc *sourceCache) projectDir() string {
+	return filepath.Join(sc.workDir, sc.dir)
+}
+
+func (sc *sourceCache) createBucket(ctx context.Context, comm client.Communicator, httpClient *http.Client, ifNotExists bool) (pail.Bucket, error) {
+	opts := pail.S3Options{
+		Region:      sourceCacheRegion,
+		Name:        sc.cfg.Name,
+		IfNotExists: ifNotExists,
+	}
+	if sc.cfg.RoleARN != "" {
+		opts.Credentials = newCachedEvergreenCredentials(comm, sc.taskData, nil, sc.cfg.RoleARN, nil)
+	}
+	bucket, err := pail.NewS3MultiPartBucketWithHTTPClient(ctx, httpClient, opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "connecting to S3")
+	}
+	return bucket, errors.Wrap(bucket.Check(ctx), "checking bucket")
+}
+
+// restore downloads and extracts the cached source tree at remoteKey.
+func (sc *sourceCache) restore(ctx context.Context, comm client.Communicator, logger client.LoggerProducer, remoteKey string) (bool, error) {
+	httpClient := utility.GetHTTPClient()
+	httpClient.Timeout = s3HTTPClientTimeout
+	defer utility.PutHTTPClient(httpClient)
+
+	bucket, err := sc.createBucket(ctx, comm, httpClient, false)
+	if err != nil {
+		return false, err
+	}
+
+	localPath, err := createTempCacheArchive(sc.workDir)
+	if err != nil {
+		return false, errors.Wrap(err, "creating local cache file")
+	}
+	defer func() {
+		logger.Task().Error(ctx, errors.Wrapf(os.Remove(localPath), "removing local cache archive '%s'", localPath))
+	}()
+
+	start := time.Now()
+	miss := false
+	downloadDesc := fmt.Sprintf("download cache object '%s'", remoteKey)
+	err = retryS3Op(ctx, logger.Task(), downloadDesc, func() (bool, error) {
+		downloadErr := bucket.Download(ctx, remoteKey, localPath)
+		if downloadErr == nil {
+			return false, nil
+		}
+		switch classifyCacheDownloadErr(downloadErr) {
+		case cacheDownloadMaybeMiss:
+			logger.Task().Warningf(ctx, "git source cache: got access-denied downloading '%s/%s', treating as a miss.", sc.cfg.Name, remoteKey)
+			miss = true
+			return false, nil
+		case cacheDownloadMiss:
+			miss = true
+			return false, nil
+		case cacheDownloadFatal:
+			return false, downloadErr
+		default:
+			return true, downloadErr
+		}
+	})
+	if err != nil {
+		return false, errors.Wrapf(err, "downloading cache object '%s'", remoteKey)
+	}
+	if miss {
+		return false, nil
+	}
+	setSourceCacheSpanDuration(ctx, "download_duration", time.Since(start))
+
+	info, err := os.Stat(localPath)
+	if err != nil {
+		return false, errors.Wrapf(err, "stating downloaded source cache file '%s'", localPath)
+	}
+	if info.Size() == 0 {
+		return false, nil
+	}
+	trace.SpanFromContext(ctx).SetAttributes(attribute.Int64(sourceCacheAttribute("artifact_bytes"), info.Size()))
+
+	f, err := os.Open(localPath)
+	if err != nil {
+		return false, errors.Wrapf(err, "opening source cache archive '%s'", localPath)
+	}
+	defer f.Close()
+
+	// The clone path starts by removing the project directory, so the restore
+	// path does too rather than extracting over whatever is there.
+	if err := os.RemoveAll(sc.projectDir()); err != nil {
+		return false, errors.Wrapf(err, "removing project directory '%s'", sc.dir)
+	}
+	// The archive holds no entry for the project directory itself, so recreate
+	// it with the mode the clone path leaves behind.
+	if err := os.MkdirAll(sc.projectDir(), 0755); err != nil {
+		return false, errors.Wrapf(err, "creating project directory '%s'", sc.dir)
+	}
+
+	start = time.Now()
+	if err := extractTarball(ctx, f, sc.projectDir(), []string{}, true); err != nil {
+		return false, errors.Wrap(err, "extracting source cache archive")
+	}
+	setSourceCacheSpanDuration(ctx, "extract_duration", time.Since(start))
+	return true, nil
+}
+
+// save archives and uploads the project directory.
+func (sc *sourceCache) save(ctx context.Context, comm client.Communicator, logger client.LoggerProducer) (bool, error) {
+	localPath, err := createTempCacheArchive(sc.workDir)
+	if err != nil {
+		return false, errors.Wrap(err, "creating local cache file")
+	}
+	defer func() {
+		logger.Task().Error(ctx, errors.Wrapf(os.Remove(localPath), "removing local cache archive '%s'", localPath))
+	}()
+
+	start := time.Now()
+	if err := makeCacheArchive(ctx, sc.projectDir(), []string{sc.projectDir()}, localPath, logger.Task(), true); err != nil {
+		return false, errors.Wrap(err, "creating source cache archive")
+	}
+	setSourceCacheSpanDuration(ctx, "archive_duration", time.Since(start))
+	if info, err := os.Stat(localPath); err == nil {
+		trace.SpanFromContext(ctx).SetAttributes(attribute.Int64(sourceCacheAttribute("artifact_bytes"), info.Size()))
+	}
+
+	httpClient := utility.GetHTTPClient()
+	httpClient.Timeout = s3HTTPClientTimeout
+	defer utility.PutHTTPClient(httpClient)
+
+	bucket, err := sc.createBucket(ctx, comm, httpClient, true)
+	if err != nil {
+		return false, err
+	}
+
+	start = time.Now()
+	alreadyExists := false
+	uploadDesc := fmt.Sprintf("upload cache object '%s'", sc.remoteKey)
+	err = retryS3Op(ctx, logger.Task(), uploadDesc, func() (bool, error) {
+		uploadErr := bucket.Upload(ctx, sc.remoteKey, localPath)
+		if uploadErr == nil {
+			return false, nil
+		}
+		var apiErr smithy.APIError
+		if errors.As(uploadErr, &apiErr) && apiErr.ErrorCode() == "PreconditionFailed" {
+			alreadyExists = true
+			return false, nil
+		}
+		if isS3ClientError(uploadErr) {
+			return false, uploadErr
+		}
+		return true, uploadErr
+	})
+	if err != nil {
+		return false, errors.Wrapf(err, "uploading cache object '%s'", sc.remoteKey)
+	}
+	setSourceCacheSpanDuration(ctx, "upload_duration", time.Since(start))
+	return !alreadyExists, nil
+}
+
+func setSourceCacheSpanDuration(ctx context.Context, name string, d time.Duration) {
+	ms := float64(d) / float64(time.Millisecond)
+	trace.SpanFromContext(ctx).SetAttributes(attribute.Float64(sourceCacheAttribute(name+"_ms"), ms))
+}
+
+// setSpanOutcome records the outcome of the source cache path, with the reason
+// for the outcomes that have one.
+func (sc *sourceCache) setSpanOutcome(ctx context.Context, outcome, reason string) {
+	attrs := []attribute.KeyValue{
+		attribute.String(sourceCacheAttribute("outcome"), outcome),
+		attribute.String(sourceCacheAttribute("cache_key"), sc.key),
+		attribute.String(sourceCacheAttribute("owner"), sc.owner),
+		attribute.String(sourceCacheAttribute("repo"), sc.repo),
+		attribute.String(sourceCacheAttribute("revision"), sc.revision),
+		attribute.Int(sourceCacheAttribute("clone_depth"), sc.cloneDepth),
+		attribute.Bool(sourceCacheAttribute("recurse_submodules"), sc.recurseSubmodules),
+	}
+	if reason != "" {
+		attrs = append(attrs, attribute.String(sourceCacheAttribute("reason"), reason))
+	}
+	trace.SpanFromContext(ctx).SetAttributes(attrs...)
+}
+
+// setSpanSkipped records a skip and its reason for a run that never built a
+// source cache, so disabled runs stay queryable alongside the rest.
+func setSourceCacheSpanSkipped(ctx context.Context, reason string) {
+	trace.SpanFromContext(ctx).SetAttributes(
+		attribute.String(sourceCacheAttribute("outcome"), sourceCacheSkipped),
+		attribute.String(sourceCacheAttribute("reason"), reason),
+	)
+}
+
+func sourceCacheAttribute(name string) string {
+	return fmt.Sprintf("%s.source_cache.%s", gitGetProjectAttribute, name)
+}

--- a/agent/command/git_source_cache_test.go
+++ b/agent/command/git_source_cache_test.go
@@ -1,0 +1,318 @@
+package command
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/evergreen-ci/evergreen"
+	"github.com/evergreen-ci/evergreen/agent/internal"
+	"github.com/evergreen-ci/evergreen/agent/internal/client"
+	"github.com/evergreen-ci/evergreen/model/patch"
+	"github.com/evergreen-ci/evergreen/model/task"
+	"github.com/mongodb/grip"
+	"github.com/mongodb/jasper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func sourceCacheTestConfig() *internal.TaskConfig {
+	return &internal.TaskConfig{
+		Task:              task.Task{Id: "t1", Revision: "abc123"},
+		SourceCacheBucket: evergreen.BucketConfig{Name: "source-cache"},
+		WorkDir:           "/data/mci",
+	}
+}
+
+func sourceCacheTestOpts() cloneOpts {
+	return cloneOpts{owner: "some-org", repo: "some-repo", dir: "src", cloneDepth: 1000}
+}
+
+func TestNewSourceCacheSkipsWhenNotOptedInOrSparse(t *testing.T) {
+	t.Run("NoBucketConfiguredSkips", func(t *testing.T) {
+		conf := sourceCacheTestConfig()
+		conf.SourceCacheBucket = evergreen.BucketConfig{}
+		sc, reason := newSourceCache(conf, &gitFetchProject{Directory: "src"}, sourceCacheTestOpts(), "linux")
+		assert.Nil(t, sc)
+		assert.Contains(t, reason, "no source cache bucket")
+	})
+	t.Run("SparseCheckoutSkips", func(t *testing.T) {
+		c := &gitFetchProject{Directory: "src", Filter: "blob:none", SparseCheckoutPaths: []string{"/etc"}}
+		sc, reason := newSourceCache(sourceCacheTestConfig(), c, sourceCacheTestOpts(), "linux")
+		assert.Nil(t, sc)
+		assert.Contains(t, reason, "sparse")
+	})
+	t.Run("NonLinuxAgentSkips", func(t *testing.T) {
+		sc, reason := newSourceCache(sourceCacheTestConfig(), &gitFetchProject{Directory: "src"}, sourceCacheTestOpts(), "windows")
+		assert.Nil(t, sc)
+		assert.Contains(t, reason, "Linux")
+	})
+	t.Run("OptedInProjectIsNotSkipped", func(t *testing.T) {
+		sc, reason := newSourceCache(sourceCacheTestConfig(), &gitFetchProject{Directory: "src"}, sourceCacheTestOpts(), "linux")
+		require.NotNil(t, sc)
+		assert.Empty(t, reason)
+	})
+}
+
+func TestSourceCacheKeyVariesByRevisionAndCloneShape(t *testing.T) {
+	c := &gitFetchProject{Directory: "src"}
+
+	base, _ := newSourceCache(sourceCacheTestConfig(), c, sourceCacheTestOpts(), "linux")
+	require.NotNil(t, base)
+	same, _ := newSourceCache(sourceCacheTestConfig(), c, sourceCacheTestOpts(), "linux")
+	require.NotNil(t, same)
+	assert.Equal(t, base.key, same.key)
+	assert.Equal(t, "source_cache/v1/some-org/some-repo/abc123/"+base.key+".tgz", base.remoteKey)
+
+	otherRevisionConf := sourceCacheTestConfig()
+	otherRevisionConf.Task.Revision = "def456"
+	otherRevision, _ := newSourceCache(otherRevisionConf, c, sourceCacheTestOpts(), "linux")
+	require.NotNil(t, otherRevision)
+	assert.NotEqual(t, base.key, otherRevision.key)
+
+	shallowOpts := sourceCacheTestOpts()
+	shallowOpts.cloneDepth = 1
+	shallow, _ := newSourceCache(sourceCacheTestConfig(), c, shallowOpts, "linux")
+	require.NotNil(t, shallow)
+	assert.NotEqual(t, base.key, shallow.key)
+
+	// The project directory is deliberately not in the key: the artifact is
+	// rooted inside it, so a tree cloned into one directory restores into
+	// another. TestSourceCacheArchiveRestoresIntoADifferentDirectory covers the
+	// layout half of that contract.
+	otherDir, _ := newSourceCache(sourceCacheTestConfig(), &gitFetchProject{Directory: "other"}, sourceCacheTestOpts(), "linux")
+	require.NotNil(t, otherDir)
+	assert.Equal(t, base.remoteKey, otherDir.remoteKey)
+	assert.Equal(t, filepath.Join("/data/mci", "other"), otherDir.projectDir())
+}
+
+func TestSourceCacheKeysPRCheckoutsInTheirOwnNamespace(t *testing.T) {
+	c := &gitFetchProject{Directory: "src"}
+	const prHead = "55ca6286e3e4f4fba5d0448333fa99fc5a404a73"
+
+	for _, tc := range []struct {
+		name    string
+		mutate  func(*internal.TaskConfig)
+		wantRev string
+	}{
+		{
+			name:    "MainlineTaskKeysOnItsOwnRevision",
+			mutate:  func(*internal.TaskConfig) {},
+			wantRev: "abc123",
+		},
+		{
+			name: "PullRequestKeysOnThePRHead",
+			mutate: func(conf *internal.TaskConfig) {
+				conf.Task.Requester = evergreen.GithubPRRequester
+				conf.GithubPatchData.PRNumber = 9001
+				conf.GithubPatchData.HeadHash = prHead
+			},
+			wantRev: prHead,
+		},
+		{
+			name: "MergeQueueKeysOnTheQueueHead",
+			mutate: func(conf *internal.TaskConfig) {
+				conf.Task.Requester = evergreen.GithubMergeRequester
+				conf.GithubMergeData.HeadSHA = prHead
+				conf.GithubMergeData.HeadBranch = "gh-readonly-queue/main/pr-9001"
+			},
+			wantRev: prHead,
+		},
+		{
+			name: "ParentPRCheckoutKeysOnTheParentPRHead",
+			mutate: func(conf *internal.TaskConfig) {
+				conf.GitHubParentPRCheckout = &patch.GitHubParentPRCheckout{ForSource: true, PRNumber: 9001, HeadHash: prHead}
+			},
+			wantRev: prHead,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := sourceCacheTestConfig()
+			tc.mutate(conf)
+			sc, reason := newSourceCache(conf, c, sourceCacheTestOpts(), "linux")
+			require.NotNil(t, sc, reason)
+
+			assert.Equal(t, tc.wantRev, sc.revision, "a task must save under whatever its own clone leaves HEAD at")
+			isPR := tc.wantRev != "abc123"
+			if isPR {
+				// The PR artifact is tried first, then the base revision one a
+				// mainline build produces.
+				assert.Equal(t, []string{prHead, "abc123"}, sc.restoreRevisions())
+				assert.Equal(t, "source_cache/v1/pr/some-org/some-repo/"+prHead+"/"+sc.key+".tgz", sc.remoteKey)
+			} else {
+				assert.Equal(t, []string{"abc123"}, sc.restoreRevisions())
+				assert.Equal(t, "source_cache/v1/some-org/some-repo/abc123/"+sc.key+".tgz", sc.remoteKey)
+			}
+
+			// The namespace is the security boundary: whatever a PR task saves,
+			// its base revision key must stay byte-identical to the key a
+			// mainline task on that same commit computes.
+			mainline, _ := newSourceCache(sourceCacheTestConfig(), c, sourceCacheTestOpts(), "linux")
+			require.NotNil(t, mainline)
+			_, baseKey, err := sc.cacheKeysForRevision("abc123")
+			require.NoError(t, err)
+			assert.Equal(t, mainline.remoteKey, baseKey)
+			if isPR {
+				assert.NotEqual(t, mainline.remoteKey, sc.remoteKey)
+			}
+		})
+	}
+}
+
+func TestBuildPostRestoreCommand(t *testing.T) {
+	c := &gitFetchProject{Directory: "src"}
+	const prHead = "55ca6286e3e4f4fba5d0448333fa99fc5a404a73"
+
+	prConf := func() *internal.TaskConfig {
+		conf := sourceCacheTestConfig()
+		conf.Task.Requester = evergreen.GithubPRRequester
+		conf.GithubPatchData.PRNumber = 9001
+		conf.GithubPatchData.HeadHash = prHead
+		return conf
+	}
+
+	t.Run("SkipsPRCheckoutOnAPRNamespacedHit", func(t *testing.T) {
+		conf := prConf()
+		joined := strings.Join(c.buildPostRestoreCommand(conf, cloneOpts{owner: "some-org", repo: "some-repo"}, prHead, false), "\n")
+		assert.Contains(t, joined, `test "$(git rev-parse HEAD)" = "`+prHead+`"`)
+		assert.NotContains(t, joined, "git fetch origin")
+	})
+
+	t.Run("VerifiesHeadBeforeTrustingTree", func(t *testing.T) {
+		conf := sourceCacheTestConfig()
+		joined := strings.Join(c.buildPostRestoreCommand(conf, cloneOpts{owner: "some-org", repo: "some-repo", token: projectGitHubToken}, conf.Task.Revision, false), "\n")
+		assert.Contains(t, joined, `test "$(git rev-parse HEAD)" = "abc123"`)
+	})
+
+	// A restored tree keeps the producer's scrubbed, tokenless origin, so the
+	// restore must put the task's own credential back. Otherwise a hit would
+	// leave a remote that can't fetch from a private repo, where a clone can.
+	t.Run("RestoresAuthenticatedOriginSoHitMatchesClone", func(t *testing.T) {
+		conf := sourceCacheTestConfig()
+		joined := strings.Join(c.buildPostRestoreCommand(conf, cloneOpts{owner: "some-org", repo: "some-repo", token: projectGitHubToken}, conf.Task.Revision, false), "\n")
+		assert.Contains(t, joined, "git remote set-url origin https://x-access-token:"+projectGitHubToken+"@github.com/some-org/some-repo.git")
+	})
+
+	t.Run("FetchesPRRefWithAuthenticatedOrigin", func(t *testing.T) {
+		conf := prConf()
+		joined := strings.Join(c.buildPostRestoreCommand(conf, cloneOpts{owner: "some-org", repo: "some-repo", token: projectGitHubToken}, conf.Task.Revision, true), "\n")
+		assert.Contains(t, joined, "git remote set-url origin https://x-access-token:"+projectGitHubToken+"@github.com/some-org/some-repo.git")
+		assert.Contains(t, joined, `git fetch origin "pull/9001/head:evg-pr-test-`)
+		assert.Contains(t, joined, "git reset --hard "+prHead)
+	})
+}
+
+func TestBuildPreSaveCommandScrubsHooksAndToken(t *testing.T) {
+	c := &gitFetchProject{Directory: "src"}
+	joined := strings.Join(c.buildPreSaveCommand(cloneOpts{owner: "some-org", repo: "some-repo", token: projectGitHubToken}), "\n")
+	assert.Contains(t, joined, "rm -rf .git/hooks")
+	assert.Contains(t, joined, "git remote set-url origin https://github.com/some-org/some-repo.git")
+	assert.NotContains(t, joined, projectGitHubToken)
+}
+
+// TestPostRestoreCommandFailsOnWrongRevision verifies a restored tree at the wrong revision is rejected.
+func TestPostRestoreCommandFailsOnWrongRevision(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not installed")
+	}
+	ctx := t.Context()
+
+	workDir := t.TempDir()
+	repoDir := filepath.Join(workDir, "src")
+	for _, args := range [][]string{
+		{"init", "--initial-branch=main", repoDir},
+		{"-C", repoDir, "commit", "--allow-empty", "-m", "initial", "--author=t <t@t>"},
+		// A restored tree always came from a clone, so it always has an origin
+		// for the post-restore script to point back at the task's own URL.
+		{"-C", repoDir, "remote", "add", "origin", "https://github.com/some-org/some-repo.git"},
+	} {
+		cmd := exec.CommandContext(ctx, "git", args...)
+		cmd.Env = append(cmd.Environ(), "GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t", "GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t")
+		require.NoError(t, cmd.Run())
+	}
+
+	jpm, err := jasper.NewSynchronizedManager(false)
+	require.NoError(t, err)
+	c := &gitFetchProject{Directory: "src"}
+	c.SetJasperManager(jpm)
+	comm := client.NewMock("http://localhost.com")
+	conf := sourceCacheTestConfig()
+	conf.WorkDir = workDir
+	logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+	require.NoError(t, err)
+
+	opts := cloneOpts{owner: "some-org", repo: "some-repo"}
+
+	// The revision the task asked for isn't the one in the restored tree.
+	assert.Error(t, c.runGitScript(ctx, logger, conf, c.buildPostRestoreCommand(conf, opts, conf.Task.Revision, false)))
+
+	headBytes, err := exec.CommandContext(ctx, "git", "-C", repoDir, "rev-parse", "HEAD").Output()
+	require.NoError(t, err)
+	conf.Task.Revision = strings.TrimSpace(string(headBytes))
+	assert.NoError(t, c.runGitScript(ctx, logger, conf, c.buildPostRestoreCommand(conf, opts, conf.Task.Revision, false)))
+}
+
+func TestSourceCacheSpanDurationsAreNumericMilliseconds(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	ctx, span := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder)).Tracer("test").Start(t.Context(), "git.get_project")
+	setSourceCacheSpanDuration(ctx, "clone_duration", 1500*time.Millisecond)
+	setSourceCacheSpanDuration(ctx, "download_duration", 250*time.Microsecond)
+	span.End()
+
+	want := map[string]float64{
+		"evergreen.command.git_get_project.source_cache.clone_duration_ms":    1500,
+		"evergreen.command.git_get_project.source_cache.download_duration_ms": 0.25,
+	}
+	ended := recorder.Ended()
+	require.Len(t, ended, 1)
+	for _, attr := range ended[0].Attributes() {
+		expected, ok := want[string(attr.Key)]
+		require.True(t, ok, "unexpected attribute '%s'", attr.Key)
+		assert.Equal(t, attribute.FLOAT64, attr.Value.Type())
+		assert.InDelta(t, expected, attr.Value.AsFloat64(), 0.001)
+		delete(want, string(attr.Key))
+	}
+	assert.Empty(t, want)
+}
+
+func TestSourceCacheArchiveRestoresIntoADifferentDirectory(t *testing.T) {
+	ctx := t.Context()
+	logger := grip.NewJournaler("test")
+
+	producerWorkDir := t.TempDir()
+	producer := &sourceCache{workDir: producerWorkDir, dir: "src"}
+	require.NoError(t, os.MkdirAll(filepath.Join(producer.projectDir(), "subdir"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(producer.projectDir(), "top.txt"), []byte("top"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(producer.projectDir(), "subdir", "nested.txt"), []byte("nested"), 0644))
+
+	archive := filepath.Join(t.TempDir(), "source"+cacheArchiveSuffix)
+	require.NoError(t, makeCacheArchive(ctx, producer.projectDir(), []string{producer.projectDir()}, archive, logger, true))
+
+	consumerWorkDir := t.TempDir()
+	consumer := &sourceCache{workDir: consumerWorkDir, dir: "other"}
+	require.NoError(t, os.MkdirAll(consumer.projectDir(), 0755))
+	f, err := os.Open(archive)
+	require.NoError(t, err)
+	t.Cleanup(func() { assert.NoError(t, f.Close()) })
+	require.NoError(t, extractTarball(ctx, f, consumer.projectDir(), []string{}, true))
+
+	top, err := os.ReadFile(filepath.Join(consumer.projectDir(), "top.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "top", string(top))
+	nested, err := os.ReadFile(filepath.Join(consumer.projectDir(), "subdir", "nested.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "nested", string(nested))
+
+	// The producer's directory name must not survive anywhere in the restored
+	// tree, which is what a workDir-rooted archive would leave behind.
+	_, err = os.Stat(filepath.Join(consumer.projectDir(), "src"))
+	assert.True(t, os.IsNotExist(err))
+	_, err = os.Stat(filepath.Join(consumerWorkDir, "src"))
+	assert.True(t, os.IsNotExist(err))
+}

--- a/agent/command/git_source_cache_test.go
+++ b/agent/command/git_source_cache_test.go
@@ -272,17 +272,17 @@ func TestPostRestoreCommandFailsOnWrongRevision(t *testing.T) {
 	opts := cloneOpts{owner: "some-org", repo: "some-repo"}
 
 	// The revision the task asked for isn't the one in the restored tree.
-	assert.Error(t, c.runGitScript(ctx, logger, conf, c.buildPostRestoreCommand(conf, opts, conf.Task.Revision, false)))
+	assert.Error(t, c.runCommands(ctx, logger, conf, c.buildPostRestoreCommand(conf, opts, conf.Task.Revision, false)))
 
 	headBytes, err := exec.CommandContext(ctx, "git", "-C", repoDir, "rev-parse", "HEAD").Output()
 	require.NoError(t, err)
 	conf.Task.Revision = strings.TrimSpace(string(headBytes))
-	assert.NoError(t, c.runGitScript(ctx, logger, conf, c.buildPostRestoreCommand(conf, opts, conf.Task.Revision, false)))
+	assert.NoError(t, c.runCommands(ctx, logger, conf, c.buildPostRestoreCommand(conf, opts, conf.Task.Revision, false)))
 
 	// The tree was produced on main, but this task asked for a branch that
 	// points at the same commit, so the restored tree has to report that one.
 	branchOpts := cloneOpts{owner: "some-org", repo: "some-repo", branch: "release-v1"}
-	require.NoError(t, c.runGitScript(ctx, logger, conf, c.buildPostRestoreCommand(conf, branchOpts, conf.Task.Revision, false)))
+	require.NoError(t, c.runCommands(ctx, logger, conf, c.buildPostRestoreCommand(conf, branchOpts, conf.Task.Revision, false)))
 	branchBytes, err := exec.CommandContext(ctx, "git", "-C", repoDir, "rev-parse", "--abbrev-ref", "HEAD").Output()
 	require.NoError(t, err)
 	assert.Equal(t, "release-v1", strings.TrimSpace(string(branchBytes)))
@@ -294,8 +294,8 @@ func TestPostRestoreCommandFailsOnWrongRevision(t *testing.T) {
 func TestSourceCacheSpanDurationsAreNumericMilliseconds(t *testing.T) {
 	recorder := tracetest.NewSpanRecorder()
 	ctx, span := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder)).Tracer("test").Start(t.Context(), "git.get_project")
-	setSourceCacheSpanDuration(ctx, "clone_duration", 1500*time.Millisecond)
-	setSourceCacheSpanDuration(ctx, "download_duration", 250*time.Microsecond)
+	setSourceCacheSpanDuration(ctx, sourceCacheCloneDurationAttribute, 1500*time.Millisecond)
+	setSourceCacheSpanDuration(ctx, sourceCacheDownloadDurationAttribute, 250*time.Microsecond)
 	span.End()
 
 	want := map[string]float64{

--- a/agent/command/git_source_cache_test.go
+++ b/agent/command/git_source_cache_test.go
@@ -349,3 +349,101 @@ func TestSourceCacheArchiveRestoresIntoADifferentDirectory(t *testing.T) {
 	_, err = os.Stat(filepath.Join(consumerWorkDir, "src"))
 	assert.True(t, os.IsNotExist(err))
 }
+
+// TestPreSaveCommandScrubsSubmoduleTokens runs the pre-save script over a real
+// repo, since the submodule scrub is a shell pipeline whose behavior a string
+// assertion would not catch.
+func TestPreSaveCommandScrubsSubmoduleTokens(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not installed")
+	}
+	ctx := t.Context()
+
+	workDir := t.TempDir()
+	repoDir := filepath.Join(workDir, "src")
+	for _, args := range [][]string{
+		{"init", "--initial-branch=main", repoDir},
+		{"-C", repoDir, "remote", "add", "origin", "https://x-access-token:" + projectGitHubToken + "@github.com/some-org/some-repo.git"},
+	} {
+		require.NoError(t, exec.CommandContext(ctx, "git", args...).Run())
+	}
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, ".git", "modules", "sub"), 0755))
+	tokenURL := "https://x-access-token:" + projectGitHubToken + "@github.com/some-org/some-sub.git"
+	// Git resolves a relative submodule URL with the parent's credential and
+	// records it in both the parent config and the submodule's own config.
+	parentConfig := filepath.Join(repoDir, ".git", "config")
+	existing, err := os.ReadFile(parentConfig)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(parentConfig,
+		append(existing, []byte("[submodule \"sub\"]\n\turl = "+tokenURL+"\n")...), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, ".git", "modules", "sub", "config"),
+		[]byte("[remote \"origin\"]\n\turl = "+tokenURL+"\n"), 0644))
+
+	c := &gitFetchProject{Directory: "src"}
+	script := strings.Join(c.buildPreSaveCommand(cloneOpts{owner: "some-org", repo: "some-repo", token: projectGitHubToken}), "\n")
+	cmd := exec.CommandContext(ctx, "bash", "-c", script)
+	cmd.Dir = workDir
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, string(out))
+
+	for _, config := range []string{
+		filepath.Join(repoDir, ".git", "config"),
+		filepath.Join(repoDir, ".git", "modules", "sub", "config"),
+	} {
+		contents, err := os.ReadFile(config)
+		require.NoError(t, err)
+		assert.NotContains(t, string(contents), projectGitHubToken, "token left in '%s'", config)
+		assert.Contains(t, string(contents), "https://github.com/some-org/some-sub.git")
+	}
+}
+
+// TestPostSaveCommandRestoresSubmoduleTokens runs the scrub and then the
+// restore over a real repo, since together they have to leave the submodule
+// remotes usable again for the rest of the producer's task.
+func TestPostSaveCommandRestoresSubmoduleTokens(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not installed")
+	}
+	ctx := t.Context()
+
+	workDir := t.TempDir()
+	repoDir := filepath.Join(workDir, "src")
+	opts := cloneOpts{owner: "some-org", repo: "some-repo", token: projectGitHubToken}
+	tokenURL := "https://x-access-token:" + projectGitHubToken + "@github.com/some-org/some-sub.git"
+	for _, args := range [][]string{
+		{"init", "--initial-branch=main", repoDir},
+		{"-C", repoDir, "remote", "add", "origin", "https://x-access-token:" + projectGitHubToken + "@github.com/some-org/some-repo.git"},
+	} {
+		require.NoError(t, exec.CommandContext(ctx, "git", args...).Run())
+	}
+	require.NoError(t, os.MkdirAll(filepath.Join(repoDir, ".git", "modules", "sub"), 0755))
+	parentConfig := filepath.Join(repoDir, ".git", "config")
+	existing, err := os.ReadFile(parentConfig)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(parentConfig,
+		append(existing, []byte("[submodule \"sub\"]\n\turl = "+tokenURL+"\n")...), 0644))
+	moduleConfig := filepath.Join(repoDir, ".git", "modules", "sub", "config")
+	require.NoError(t, os.WriteFile(moduleConfig,
+		[]byte("[remote \"origin\"]\n\turl = "+tokenURL+"\n"), 0644))
+
+	c := &gitFetchProject{Directory: "src"}
+	runScript := func(cmds []string) {
+		cmd := exec.CommandContext(ctx, "bash", "-c", strings.Join(cmds, "\n"))
+		cmd.Dir = workDir
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, string(out))
+	}
+	runScript(c.buildPreSaveCommand(opts))
+	runScript(c.buildPostSaveCommand(opts))
+
+	for _, config := range []string{parentConfig, moduleConfig} {
+		contents, err := os.ReadFile(config)
+		require.NoError(t, err)
+		assert.Contains(t, string(contents), tokenURL, "submodule credential not restored in '%s'", config)
+	}
+	// The origin is set explicitly rather than by the rewrite, so it must not
+	// have picked up a second credential.
+	origin, err := os.ReadFile(parentConfig)
+	require.NoError(t, err)
+	assert.NotContains(t, string(origin), "x-access-token:"+projectGitHubToken+"@x-access-token:")
+}

--- a/agent/command/git_source_cache_test.go
+++ b/agent/command/git_source_cache_test.go
@@ -144,7 +144,7 @@ func TestSourceCacheKeysPRCheckoutsInTheirOwnNamespace(t *testing.T) {
 				// The PR artifact is tried first, then the base revision one a
 				// mainline build produces.
 				assert.Equal(t, []string{prHead, "abc123"}, sc.restoreRevisions())
-				assert.Equal(t, "source_cache/v1/pr/some-org/some-repo/"+prHead+"/"+sc.key+".tgz", sc.remoteKey)
+				assert.Equal(t, "source_cache/v1/some-org/some-repo/pr/"+prHead+"/"+sc.key+".tgz", sc.remoteKey)
 			} else {
 				assert.Equal(t, []string{"abc123"}, sc.restoreRevisions())
 				assert.Equal(t, "source_cache/v1/some-org/some-repo/abc123/"+sc.key+".tgz", sc.remoteKey)

--- a/agent/command/git_source_cache_test.go
+++ b/agent/command/git_source_cache_test.go
@@ -85,6 +85,19 @@ func TestSourceCacheKeyVariesByRevisionAndCloneShape(t *testing.T) {
 	require.NotNil(t, shallow)
 	assert.NotEqual(t, base.key, shallow.key)
 
+	// Two project refs on one repo at the same commit must not share an artifact.
+	branchOpts := sourceCacheTestOpts()
+	branchOpts.branch = "release-v1"
+	branch, _ := newSourceCache(sourceCacheTestConfig(), c, branchOpts, "linux")
+	require.NotNil(t, branch)
+	assert.NotEqual(t, base.key, branch.key)
+
+	otherBranchOpts := sourceCacheTestOpts()
+	otherBranchOpts.branch = "release-v2"
+	otherBranch, _ := newSourceCache(sourceCacheTestConfig(), c, otherBranchOpts, "linux")
+	require.NotNil(t, otherBranch)
+	assert.NotEqual(t, branch.key, otherBranch.key)
+
 	// The project directory is deliberately not in the key: the artifact is
 	// rooted inside it, so a tree cloned into one directory restores into
 	// another. TestSourceCacheArchiveRestoresIntoADifferentDirectory covers the
@@ -93,6 +106,35 @@ func TestSourceCacheKeyVariesByRevisionAndCloneShape(t *testing.T) {
 	require.NotNil(t, otherDir)
 	assert.Equal(t, base.remoteKey, otherDir.remoteKey)
 	assert.Equal(t, filepath.Join("/data/mci", "other"), otherDir.projectDir())
+}
+
+// A PR artifact is pinned to the PR head, so the branch would fragment it for no gain.
+func TestSourceCachePRKeysIgnoreTheBranch(t *testing.T) {
+	c := &gitFetchProject{Directory: "src"}
+	const prHead = "55ca6286e3e4f4fba5d0448333fa99fc5a404a73"
+
+	prConf := func() *internal.TaskConfig {
+		conf := sourceCacheTestConfig()
+		conf.Task.Requester = evergreen.GithubPRRequester
+		conf.GithubPatchData.PRNumber = 9001
+		conf.GithubPatchData.HeadHash = prHead
+		return conf
+	}
+
+	branchOpts := sourceCacheTestOpts()
+	branchOpts.branch = "release-v1"
+	withBranch, _ := newSourceCache(prConf(), c, branchOpts, "linux")
+	require.NotNil(t, withBranch)
+	withoutBranch, _ := newSourceCache(prConf(), c, sourceCacheTestOpts(), "linux")
+	require.NotNil(t, withoutBranch)
+	assert.Equal(t, withoutBranch.remoteKey, withBranch.remoteKey)
+
+	// The base revision the PR falls back to is keyed on the branch.
+	baseKey, _, err := withBranch.cacheKeysForRevision("abc123")
+	require.NoError(t, err)
+	otherBaseKey, _, err := withoutBranch.cacheKeysForRevision("abc123")
+	require.NoError(t, err)
+	assert.NotEqual(t, otherBaseKey, baseKey)
 }
 
 func TestSourceCacheKeysPRCheckoutsInTheirOwnNamespace(t *testing.T) {
@@ -202,26 +244,14 @@ func TestBuildPostRestoreCommand(t *testing.T) {
 		assert.Contains(t, joined, "git remote set-url origin https://x-access-token:"+projectGitHubToken+"@github.com/some-org/some-repo.git")
 	})
 
-	// The cache key pins the revision but not the branch, so a hit produced by
-	// a different branch at the same commit would otherwise report that
-	// branch's name.
-	t.Run("ReconcilesBranchOnANonPRHit", func(t *testing.T) {
+	// Renaming the branch here would mislabel a PR hit, whose tree is at the PR head.
+	t.Run("LeavesTheRestoredBranchAlone", func(t *testing.T) {
 		conf := sourceCacheTestConfig()
 		joined := strings.Join(c.buildPostRestoreCommand(conf, cloneOpts{owner: "some-org", repo: "some-repo", branch: "release-v1"}, conf.Task.Revision, false), "\n")
-		assert.Contains(t, joined, `git checkout -B 'release-v1' abc123`)
-	})
-
-	t.Run("SkipsBranchReconciliationWhenPRCheckoutRuns", func(t *testing.T) {
-		conf := prConf()
-		joined := strings.Join(c.buildPostRestoreCommand(conf, cloneOpts{owner: "some-org", repo: "some-repo", branch: "release-v1"}, conf.Task.Revision, true), "\n")
 		assert.NotContains(t, joined, "git checkout -B")
-		assert.Contains(t, joined, `git fetch origin "pull/9001/head:evg-pr-test-`)
-	})
 
-	t.Run("OmitsBranchReconciliationWithoutABranch", func(t *testing.T) {
-		conf := sourceCacheTestConfig()
-		joined := strings.Join(c.buildPostRestoreCommand(conf, cloneOpts{owner: "some-org", repo: "some-repo"}, conf.Task.Revision, false), "\n")
-		assert.NotContains(t, joined, "git checkout -B")
+		prJoined := strings.Join(c.buildPostRestoreCommand(prConf(), cloneOpts{owner: "some-org", repo: "some-repo", branch: "release-v1"}, prHead, false), "\n")
+		assert.NotContains(t, prJoined, "git checkout -B")
 	})
 
 	t.Run("FetchesPRRefWithAuthenticatedOrigin", func(t *testing.T) {
@@ -282,16 +312,12 @@ func TestPostRestoreCommandFailsOnWrongRevision(t *testing.T) {
 	conf.Task.Revision = strings.TrimSpace(string(headBytes))
 	assert.NoError(t, c.runCommands(ctx, logger, conf, c.buildPostRestoreCommand(conf, opts, conf.Task.Revision, false)))
 
-	// The tree was produced on main, but this task asked for a branch that
-	// points at the same commit, so the restored tree has to report that one.
+	// The branch the producer left behind is kept as is, since the key pins it.
 	branchOpts := cloneOpts{owner: "some-org", repo: "some-repo", branch: "release-v1"}
 	require.NoError(t, c.runCommands(ctx, logger, conf, c.buildPostRestoreCommand(conf, branchOpts, conf.Task.Revision, false)))
 	branchBytes, err := exec.CommandContext(ctx, "git", "-C", repoDir, "rev-parse", "--abbrev-ref", "HEAD").Output()
 	require.NoError(t, err)
-	assert.Equal(t, "release-v1", strings.TrimSpace(string(branchBytes)))
-	headAfter, err := exec.CommandContext(ctx, "git", "-C", repoDir, "rev-parse", "HEAD").Output()
-	require.NoError(t, err)
-	assert.Equal(t, conf.Task.Revision, strings.TrimSpace(string(headAfter)))
+	assert.Equal(t, "main", strings.TrimSpace(string(branchBytes)))
 }
 
 func TestSourceCacheSpanDurationsAreNumericMilliseconds(t *testing.T) {

--- a/agent/command/git_source_cache_test.go
+++ b/agent/command/git_source_cache_test.go
@@ -199,6 +199,28 @@ func TestBuildPostRestoreCommand(t *testing.T) {
 		assert.Contains(t, joined, "git remote set-url origin https://x-access-token:"+projectGitHubToken+"@github.com/some-org/some-repo.git")
 	})
 
+	// The cache key pins the revision but not the branch, so a hit produced by
+	// a different branch at the same commit would otherwise report that
+	// branch's name.
+	t.Run("ReconcilesBranchOnANonPRHit", func(t *testing.T) {
+		conf := sourceCacheTestConfig()
+		joined := strings.Join(c.buildPostRestoreCommand(conf, cloneOpts{owner: "some-org", repo: "some-repo", branch: "release-v1"}, conf.Task.Revision, false), "\n")
+		assert.Contains(t, joined, `git checkout -B 'release-v1' abc123`)
+	})
+
+	t.Run("SkipsBranchReconciliationWhenPRCheckoutRuns", func(t *testing.T) {
+		conf := prConf()
+		joined := strings.Join(c.buildPostRestoreCommand(conf, cloneOpts{owner: "some-org", repo: "some-repo", branch: "release-v1"}, conf.Task.Revision, true), "\n")
+		assert.NotContains(t, joined, "git checkout -B")
+		assert.Contains(t, joined, `git fetch origin "pull/9001/head:evg-pr-test-`)
+	})
+
+	t.Run("OmitsBranchReconciliationWithoutABranch", func(t *testing.T) {
+		conf := sourceCacheTestConfig()
+		joined := strings.Join(c.buildPostRestoreCommand(conf, cloneOpts{owner: "some-org", repo: "some-repo"}, conf.Task.Revision, false), "\n")
+		assert.NotContains(t, joined, "git checkout -B")
+	})
+
 	t.Run("FetchesPRRefWithAuthenticatedOrigin", func(t *testing.T) {
 		conf := prConf()
 		joined := strings.Join(c.buildPostRestoreCommand(conf, cloneOpts{owner: "some-org", repo: "some-repo", token: projectGitHubToken}, conf.Task.Revision, true), "\n")
@@ -256,6 +278,17 @@ func TestPostRestoreCommandFailsOnWrongRevision(t *testing.T) {
 	require.NoError(t, err)
 	conf.Task.Revision = strings.TrimSpace(string(headBytes))
 	assert.NoError(t, c.runGitScript(ctx, logger, conf, c.buildPostRestoreCommand(conf, opts, conf.Task.Revision, false)))
+
+	// The tree was produced on main, but this task asked for a branch that
+	// points at the same commit, so the restored tree has to report that one.
+	branchOpts := cloneOpts{owner: "some-org", repo: "some-repo", branch: "release-v1"}
+	require.NoError(t, c.runGitScript(ctx, logger, conf, c.buildPostRestoreCommand(conf, branchOpts, conf.Task.Revision, false)))
+	branchBytes, err := exec.CommandContext(ctx, "git", "-C", repoDir, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	require.NoError(t, err)
+	assert.Equal(t, "release-v1", strings.TrimSpace(string(branchBytes)))
+	headAfter, err := exec.CommandContext(ctx, "git", "-C", repoDir, "rev-parse", "HEAD").Output()
+	require.NoError(t, err)
+	assert.Equal(t, conf.Task.Revision, strings.TrimSpace(string(headAfter)))
 }
 
 func TestSourceCacheSpanDurationsAreNumericMilliseconds(t *testing.T) {

--- a/agent/command/git_source_cache_test.go
+++ b/agent/command/git_source_cache_test.go
@@ -1,9 +1,11 @@
 package command
 
 import (
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +17,7 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/jasper"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
@@ -446,4 +449,120 @@ func TestPostSaveCommandRestoresSubmoduleTokens(t *testing.T) {
 	origin, err := os.ReadFile(parentConfig)
 	require.NoError(t, err)
 	assert.NotContains(t, string(origin), "x-access-token:"+projectGitHubToken+"@x-access-token:")
+}
+
+// mergeQueueTestConfig returns a merge queue task config keyed on its cached queue head.
+func mergeQueueTestConfig() *internal.TaskConfig {
+	conf := sourceCacheTestConfig()
+	conf.Task.Requester = evergreen.GithubMergeRequester
+	conf.GithubMergeData.HeadSHA = "55ca6286e3e4f4fba5d0448333fa99fc5a404a73"
+	conf.GithubMergeData.HeadBranch = "gh-readonly-queue/main/pr-9001"
+	return conf
+}
+
+// stubMergeQueueRefExists swaps the GitHub lookup for the duration of a test.
+func stubMergeQueueRefExists(t *testing.T, exists bool, err error) *int {
+	calls := 0
+	original := mergeQueueRefExists
+	mergeQueueRefExists = func(ctx context.Context, owner, repo, ref, token string) (bool, error) {
+		calls++
+		return exists, err
+	}
+	t.Cleanup(func() { mergeQueueRefExists = original })
+	return &calls
+}
+
+func TestMergeQueueRefDeletedOnlyChecksMergeQueueTasks(t *testing.T) {
+	opts := sourceCacheTestOpts()
+	opts.token = "a-token"
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(*internal.TaskConfig, *cloneOpts)
+	}{
+		{
+			name:   "MainlineTaskIsNotChecked",
+			mutate: func(conf *internal.TaskConfig, _ *cloneOpts) { *conf = *sourceCacheTestConfig() },
+		},
+		{
+			name: "PullRequestTaskIsNotChecked",
+			mutate: func(conf *internal.TaskConfig, _ *cloneOpts) {
+				*conf = *sourceCacheTestConfig()
+				conf.Task.Requester = evergreen.GithubPRRequester
+			},
+		},
+		{
+			name:   "MergeQueueTaskWithoutAHeadBranchIsNotChecked",
+			mutate: func(conf *internal.TaskConfig, _ *cloneOpts) { conf.GithubMergeData.HeadBranch = "" },
+		},
+		{
+			name:   "MergeQueueTaskWithoutATokenIsNotChecked",
+			mutate: func(_ *internal.TaskConfig, opts *cloneOpts) { opts.token = "" },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := stubMergeQueueRefExists(t, false, nil)
+			conf, tcOpts := mergeQueueTestConfig(), opts
+			tc.mutate(conf, &tcOpts)
+
+			deleted, err := mergeQueueRefDeleted(t.Context(), client.NewMock("http://localhost.com"), conf, "", tcOpts)
+			assert.NoError(t, err)
+			// A task that is never checked has no definite answer, so it must not fail fast.
+			assert.False(t, deleted)
+			assert.Zero(t, *calls)
+		})
+	}
+}
+
+func TestMergeQueueRefDeletedReportsGitHubsAnswer(t *testing.T) {
+	opts := sourceCacheTestOpts()
+	opts.token = "a-token"
+	comm := client.NewMock("http://localhost.com")
+
+	t.Run("DeletedRefIsReported", func(t *testing.T) {
+		calls := stubMergeQueueRefExists(t, false, nil)
+		deleted, err := mergeQueueRefDeleted(t.Context(), comm, mergeQueueTestConfig(), "", opts)
+		assert.NoError(t, err)
+		assert.True(t, deleted)
+		assert.Equal(t, 1, *calls)
+	})
+
+	t.Run("ExistingRefIsNotReported", func(t *testing.T) {
+		stubMergeQueueRefExists(t, true, nil)
+		deleted, err := mergeQueueRefDeleted(t.Context(), comm, mergeQueueTestConfig(), "", opts)
+		assert.NoError(t, err)
+		assert.False(t, deleted)
+	})
+
+	t.Run("LookupErrorIsReturnedWithoutADeletedVerdict", func(t *testing.T) {
+		stubMergeQueueRefExists(t, false, errors.New("GitHub is down"))
+		deleted, err := mergeQueueRefDeleted(t.Context(), comm, mergeQueueTestConfig(), "", opts)
+		assert.ErrorContains(t, err, "GitHub is down")
+		assert.False(t, deleted)
+	})
+}
+
+func TestFetchOrRestoreSourceFailsFastWhenTheMergeQueueRefIsDeleted(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		// The check lives behind the source cache, which only runs on Linux.
+		t.Skip("the source cache is only enabled on Linux agents")
+	}
+	ctx := t.Context()
+	opts := sourceCacheTestOpts()
+	opts.token = "a-token"
+
+	calls := stubMergeQueueRefExists(t, false, nil)
+	comm := client.NewMock("http://localhost.com")
+	conf := mergeQueueTestConfig()
+	logger, err := comm.GetLoggerProducer(ctx, &conf.Task, nil)
+	require.NoError(t, err)
+	c := &gitFetchProject{Directory: "src"}
+
+	// No Jasper manager is set, so reaching a restore or a clone panics rather than quietly passing.
+	err = c.fetchOrRestoreSource(ctx, comm, logger, conf, opts)
+
+	require.ErrorContains(t, err, mergeQueueRefGoneMessage)
+	assert.Equal(t, 1, *calls)
+	assert.True(t, c.refNotFound)
+	assert.True(t, comm.MarkedMergeQueueGitRefNotFound)
 }

--- a/agent/internal/client/mock.go
+++ b/agent/internal/client/mock.go
@@ -45,6 +45,7 @@ type Mock struct {
 	NextTaskShouldFail                   bool
 	GetPatchFileShouldFail               bool
 	TaskShouldRetryOnFail                bool
+	MarkedMergeQueueGitRefNotFound       bool
 	loggingShouldFail                    bool
 	NextTaskResponse                     *apimodels.NextTaskResponse
 	NextTaskIsNil                        bool
@@ -609,6 +610,7 @@ func (c *Mock) MarkFailedTaskToRestart(ctx context.Context, td TaskData) error {
 }
 
 func (c *Mock) MarkMergeQueueGitRefNotFound(ctx context.Context, td TaskData) error {
+	c.MarkedMergeQueueGitRefNotFound = true
 	return nil
 }
 

--- a/agent/otel.go
+++ b/agent/otel.go
@@ -428,29 +428,29 @@ func addNetworkMetrics(ctx context.Context, meter metric.Meter) error {
 		observer.ObserveInt64(transmit, int64(stats.BytesSent))
 		observer.ObserveInt64(receive, int64(stats.BytesRecv))
 
-		if !lastTime.IsZero() {
-			dt := now.Sub(lastTime).Seconds()
-			if dt > 0 {
-				txBps := float64(stats.BytesSent-lastTransmit) / dt
-				rxBps := float64(stats.BytesRecv-lastReceive) / dt
-				if txBps < 0 {
-					txBps = 0
-				}
-				if rxBps < 0 {
-					rxBps = 0
-				}
-				observer.ObserveFloat64(transmitBps, txBps)
-				observer.ObserveFloat64(receiveBps, rxBps)
-				if txBps > maxTransmit {
-					maxTransmit = txBps
-				}
-				if rxBps > maxReceive {
-					maxReceive = rxBps
-				}
-				observer.ObserveFloat64(maxTransmitBps, maxTransmit)
-				observer.ObserveFloat64(maxReceiveBps, maxReceive)
+		// Windows has a coarse clock, so two collections can land on the same tick. Report a
+		// zero rate in that case rather than dropping the gauges from the collection entirely.
+		var txBps, rxBps float64
+		if dt := now.Sub(lastTime).Seconds(); dt > 0 {
+			txBps = float64(stats.BytesSent-lastTransmit) / dt
+			rxBps = float64(stats.BytesRecv-lastReceive) / dt
+			if txBps < 0 {
+				txBps = 0
+			}
+			if rxBps < 0 {
+				rxBps = 0
 			}
 		}
+		observer.ObserveFloat64(transmitBps, txBps)
+		observer.ObserveFloat64(receiveBps, rxBps)
+		if txBps > maxTransmit {
+			maxTransmit = txBps
+		}
+		if rxBps > maxReceive {
+			maxReceive = rxBps
+		}
+		observer.ObserveFloat64(maxTransmitBps, maxTransmit)
+		observer.ObserveFloat64(maxReceiveBps, maxReceive)
 		lastTransmit = stats.BytesSent
 		lastReceive = stats.BytesRecv
 		lastTime = now

--- a/agent/otel_test.go
+++ b/agent/otel_test.go
@@ -69,27 +69,6 @@ func TestMetrics(t *testing.T) {
 			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[1].Data.(metricdata.Sum[int64]).DataPoints)
 			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[1].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
 		}
-		testCases["NetworkMetrics"] = func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
-			assert.NoError(t, addNetworkMetrics(t.Context(), meter))
-			var metrics metricdata.ResourceMetrics
-			assert.NoError(t, reader.Collect(ctx, &metrics))
-			require.NotEmpty(t, metrics.ScopeMetrics)
-			require.Len(t, metrics.ScopeMetrics[0].Metrics, 6)
-			assert.Equal(t, fmt.Sprintf("%s.transmit", networkIOInstrumentPrefix), metrics.ScopeMetrics[0].Metrics[0].Name)
-			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
-			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
-		}
-		testCases["SocketMetrics"] = func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
-			assert.NoError(t, addSocketMetrics(t.Context(), meter))
-			var metrics metricdata.ResourceMetrics
-			assert.NoError(t, reader.Collect(ctx, &metrics))
-			require.NotEmpty(t, metrics.ScopeMetrics)
-			require.Len(t, metrics.ScopeMetrics[0].Metrics, 11)
-			assert.Equal(t, fmt.Sprintf("%s.established", socketCountPrefix), metrics.ScopeMetrics[0].Metrics[0].Name)
-			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
-			// Socket count may be zero if no connections, so we just check the metric exists
-			assert.GreaterOrEqual(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value, int64(0))
-		}
 	} else {
 		testCases["ProcessMetrics"] = func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
 			assert.NoError(t, addProcessMetrics(meter))
@@ -101,27 +80,29 @@ func TestMetrics(t *testing.T) {
 			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
 			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
 		}
-		testCases["NetworkMetrics"] = func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
-			assert.NoError(t, addNetworkMetrics(t.Context(), meter))
-			var metrics metricdata.ResourceMetrics
-			assert.NoError(t, reader.Collect(ctx, &metrics))
-			require.NotEmpty(t, metrics.ScopeMetrics)
-			require.Len(t, metrics.ScopeMetrics[0].Metrics, 2)
-			assert.Equal(t, fmt.Sprintf("%s.transmit", networkIOInstrumentPrefix), metrics.ScopeMetrics[0].Metrics[0].Name)
-			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
-			assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
-		}
-		testCases["SocketMetrics"] = func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
-			assert.NoError(t, addSocketMetrics(t.Context(), meter))
-			var metrics metricdata.ResourceMetrics
-			assert.NoError(t, reader.Collect(ctx, &metrics))
-			require.NotEmpty(t, metrics.ScopeMetrics)
-			require.Len(t, metrics.ScopeMetrics[0].Metrics, 11)
-			assert.Equal(t, fmt.Sprintf("%s.established", socketCountPrefix), metrics.ScopeMetrics[0].Metrics[0].Name)
-			require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
-			// Socket count may be zero if no connections, so we just check the metric exists
-			assert.GreaterOrEqual(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value, int64(0))
-		}
+	}
+
+	testCases["NetworkMetrics"] = func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
+		assert.NoError(t, addNetworkMetrics(t.Context(), meter))
+		var metrics metricdata.ResourceMetrics
+		assert.NoError(t, reader.Collect(ctx, &metrics))
+		require.NotEmpty(t, metrics.ScopeMetrics)
+		require.Len(t, metrics.ScopeMetrics[0].Metrics, 6)
+		assert.Equal(t, fmt.Sprintf("%s.transmit", networkIOInstrumentPrefix), metrics.ScopeMetrics[0].Metrics[0].Name)
+		require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
+		assert.NotZero(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
+	}
+
+	testCases["SocketMetrics"] = func(t *testing.T, meter metric.Meter, reader sdk.Reader) {
+		assert.NoError(t, addSocketMetrics(t.Context(), meter))
+		var metrics metricdata.ResourceMetrics
+		assert.NoError(t, reader.Collect(ctx, &metrics))
+		require.NotEmpty(t, metrics.ScopeMetrics)
+		require.Len(t, metrics.ScopeMetrics[0].Metrics, 11)
+		assert.Equal(t, fmt.Sprintf("%s.established", socketCountPrefix), metrics.ScopeMetrics[0].Metrics[0].Name)
+		require.NotEmpty(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints)
+		// Socket count may be zero if there are no connections, so just check the metric exists.
+		assert.GreaterOrEqual(t, metrics.ScopeMetrics[0].Metrics[0].Data.(metricdata.Sum[int64]).DataPoints[0].Value, int64(0))
 	}
 
 	for testName, testCase := range testCases {

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-08-28"
+	AgentVersion = "2026-08-28b"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-42320

### Description

This adds a source cache that is opt in on a per project option. When opted in, `git.get_project` caches the cloned project directory to S3 and restores it on later tasks. 

The key is (namespace, owner, repo, revision, clone shape), not the version ID, so they can be shared between versions, restarts, etc (although ones created by PRs won't be used by mainline commits). 
    
Failures fall back to the normal clone. 

### Decisions/Tradeoffs 

- This is for Linux only. This keeps V1 simpler and covers the majority of the pain points. 
- Rather than always caching the full clone, I made clone depth part of the key so that projects that have for example 50 with clone depth 1 and 2 with full clones don't have to always get a full clone from s3, especially if their repo is very large. 
- I left the version ID out of the key. While this comes with blast radius concerns, it will also give us a lot more re-use in a way that users can't get from optimizing their yamls. I will also have a follow up PR to further reduce the blast radius concern. 
- PR and merge queue patches can save to the cache under the pr namespace but it won't be used by mainline commits (PR patches can use one created by a mainline commit). While they technically could be used, I chose not to to have that trust boundary. 

### Testing

In addition to the unit tests I tested this manually in staging: 

-  Ran a staging patch and confirmed one task cloned and uploaded while the rest restored from
    the cache: https://spruce-staging.corp.mongodb.com/version/6a906cde6c51b900074979f6/tasks
- Ran a staging patch splitting tasks across clone depth 1, 1000, and full clone, and
    confirmed exactly three uploads with the remaining tasks reusing them:
    https://spruce-staging.corp.mongodb.com/version/6a908ec5eac0190007f1f5b1/tasks. 
- Restarted an already-run staging patch and confirmed 100% hits across all three clone
    depths, with no misses and no fallbacks, on the same keys the original run produced:
    https://spruce-staging.corp.mongodb.com/version/6a90c4257e075e00078de91a/tasks
 - Ran a staging patch with four tasks cloning the same commit into different directory names
    (`evergreen`, `src`, `mongo`, `nested/project`) on a key nothing had written before, and
    confirmed one producer, three hits, and a single distinct cache key across all four:
    https://spruce-staging.corp.mongodb.com/version/6a90fb2e9712aa0007e49d59/tasks and
    https://ui.honeycomb.io/mongodb-4b/environments/staging/datasets/evergreen-agent/result/DgpBAhHjc47
 - Ran a PR-triggered staging version
    (https://spruce-staging.corp.mongodb.com/version/6a9085ee69b2b5000725dc98/tasks) and a
    merge-queue run
    (https://spruce-staging.corp.mongodb.com/version/6a908c93cb9f0700076d7d42/tasks) and
    confirmed each did one clone and served the rest from the cache.



### Up Next

My next PR will make it self healing. It will let a task that downloads a source cache artifact and finds the tarball undecodable overwrite that object with a good one to reduce the blast radius of a corrupt cache. 