### PR TITLE
DEVPROD-42291: Include child patch costs in version cost resolver

### DIFF
--- a/graphql/loaders/version.go
+++ b/graphql/loaders/version.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/mongodb/grip"
 	"github.com/mongodb/grip/message"
@@ -15,7 +14,7 @@ import (
 type versionReader struct{}
 
 func (v *versionReader) getVersions(ctx context.Context, versionIDs []string) (map[string]*model.Version, error) {
-	query := db.Query(bson.M{model.VersionIdKey: bson.M{"$in": versionIDs}}).Project(bson.M{model.VersionBuildVariantsKey: 0})
+	query := model.VersionByIds(versionIDs).Project(bson.M{model.VersionBuildVariantsKey: 0})
 	versions, err := model.VersionFind(ctx, query)
 	if err != nil {
 		grip.Error(ctx, message.WrapError(err, message.Fields{

--- a/graphql/tests/version/cost/data.json
+++ b/graphql/tests/version/cost/data.json
@@ -1,0 +1,49 @@
+{
+  "versions": [
+    {
+      "_id": "aabbccddeeff001122334455",
+      "identifier": "evergreen",
+      "r": "patch_request",
+      "status": "succeeded",
+      "cost": {
+        "adjusted_ec2_cost": 5.0,
+        "adjusted_ebs_throughput_cost": 1.0
+      }
+    },
+    {
+      "_id": "child-version-1",
+      "identifier": "child-project-1",
+      "r": "patch_request",
+      "status": "succeeded",
+      "cost": {
+        "adjusted_ec2_cost": 3.0
+      }
+    },
+    {
+      "_id": "child-version-2",
+      "identifier": "child-project-2",
+      "r": "patch_request",
+      "cost": {
+        "adjusted_ec2_cost": 1.0,
+        "adjusted_ebs_throughput_cost": 0.5
+      }
+    }
+  ],
+  "patches": [
+    {
+      "_id": {
+        "$oid": "aabbccddeeff001122334455"
+      },
+      "version": "aabbccddeeff001122334455",
+      "triggers": {
+        "child_patches": ["child-version-1", "child-version-2"]
+      }
+    }
+  ],
+  "project_ref": [
+    {
+      "_id": "evergreen",
+      "identifier": "evergreen"
+    }
+  ]
+}

--- a/graphql/tests/version/cost/queries/cost.graphql
+++ b/graphql/tests/version/cost/queries/cost.graphql
@@ -1,0 +1,10 @@
+{
+  version(versionId: "aabbccddeeff001122334455") {
+    cost {
+      total
+      childPatchesTotalCost
+      adjustedEC2Cost
+      adjustedEBSThroughputCost
+    }
+  }
+}

--- a/graphql/tests/version/cost/results.json
+++ b/graphql/tests/version/cost/results.json
@@ -1,0 +1,19 @@
+{
+  "tests": [
+    {
+      "query_file": "cost.graphql",
+      "result": {
+        "data": {
+          "version": {
+            "cost": {
+              "total": 10.5,
+              "childPatchesTotalCost": 4.5,
+              "adjustedEC2Cost": 5,
+              "adjustedEBSThroughputCost": 1
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -134,13 +134,34 @@ func (r *versionResolver) ChildVersions(ctx context.Context, obj *restModel.APIV
 }
 
 // Cost is the field resolver for Version.cost. It applies RoundCost to all adjusted fields
-// so the GraphQL API returns clean values without floating-point noise.
+// so the GraphQL API returns clean values without floating-point noise. For patch versions
+// with child patches, it also includes the child patches' costs in the total.
 func (r *versionResolver) Cost(ctx context.Context, obj *restModel.APIVersion) (*cost.Cost, error) {
 	if obj.Cost == nil {
 		return nil, nil
 	}
+
+	// If the version is a patch requester, we need to include costs of its child patches.
+	childPatchesCost := float64(0)
+	if obj.IsPatchRequester() {
+		versionID := utility.FromStringPtr(obj.Id)
+		foundPatch, err := loaders.GetPatch(ctx, versionID)
+		if err != nil {
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching patch '%s' for cost: %s", versionID, err.Error()), err)
+		}
+		if foundPatch != nil && len(foundPatch.Triggers.ChildPatches) > 0 {
+			childVersions, err := model.VersionFind(ctx, model.VersionByIds(foundPatch.Triggers.ChildPatches).WithFields(model.VersionCostKey))
+			if err != nil {
+				return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding child versions for cost: %s", err.Error()), err)
+			}
+			childPatchesCost, _ = cost.SumPerChildVersionAdjustedTotals(len(childVersions), func(i int) (actual, predicted *cost.Cost) {
+				return &childVersions[i].Cost, nil
+			})
+		}
+	}
 	rounded := obj.Cost.RoundedBase()
-	rounded.Total = cost.RoundCost(obj.Cost.AdjustedTotal())
+	rounded.ChildPatchesTotalCost = cost.RoundCost(childPatchesCost)
+	rounded.Total = cost.RoundCost(obj.Cost.AdjustedTotal() + childPatchesCost)
 	return &rounded, nil
 }
 

--- a/model/version_db.go
+++ b/model/version_db.go
@@ -68,6 +68,11 @@ func VersionById(id string) db.Q {
 	return db.Query(bson.M{VersionIdKey: id})
 }
 
+// VersionByIds returns a db.Q object which will filter on {_id : {$in : <ids>}}.
+func VersionByIds(ids []string) db.Q {
+	return db.Query(bson.M{VersionIdKey: bson.M{"$in": ids}})
+}
+
 // All is a query for all versions.
 var VersionAll = db.Query(bson.D{})
 


### PR DESCRIPTION
DEVPROD-42291

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

This PR includes child patch cost data in `version.cost`. This is helpful as we won't have to do conditional workarounds [like this](https://github.com/evergreen-ci/ui/blob/2519a52ec6a463378ae26d57bdf13b665089cc4b/apps/spruce/src/pages/version/Metadata/ExecutionSection/index.tsx#L21), and because it will simplify transitioning off of REST for GraphQL.

### Testing

* Added GraphQL test