### PR TITLE
DEVPROD-38023 Retry on bad requests for github.generate_token

### DIFF
--- a/model/githubapp/github_app_auth.go
+++ b/model/githubapp/github_app_auth.go
@@ -127,7 +127,7 @@ func (g *GithubAppAuth) CreateCachedInstallationToken(ctx context.Context, owner
 		}
 	}
 
-	installToken, err := g.createInstallationTokenForID(ctx, installationID, opts)
+	installToken, err := g.createInstallationTokenForID(ctx, installationID, opts, retryConfig{})
 	if err != nil {
 		return "", errors.Wrap(err, "creating installation token")
 	}
@@ -145,14 +145,16 @@ func (g *GithubAppAuth) CreateGitHubSenderInstallationToken(ctx context.Context,
 
 // CreateInstallationToken creates an installation token for the given
 // owner/repo. This is never cached, and should only be used in scenarios where
-// the token can be revoked at any time.
-func (g *GithubAppAuth) CreateInstallationToken(ctx context.Context, owner, repo string, opts *github.InstallationTokenOptions) (string, *github.InstallationPermissions, error) {
+// the token can be revoked at any time. When retry400 is true, bad request responses
+// are retried up to GitHubMaxRetries times, since those responses have been shown to be
+// transient in the past.
+func (g *GithubAppAuth) CreateInstallationToken(ctx context.Context, owner, repo string, opts *github.InstallationTokenOptions, retry400 bool) (string, *github.InstallationPermissions, error) {
 	installationID, err := getInstallationID(ctx, g, owner, repo)
 	if err != nil {
 		return "", nil, errors.Wrapf(err, "getting installation id for '%s/%s'", owner, repo)
 	}
 
-	installToken, err := g.createInstallationTokenForID(ctx, installationID, opts)
+	installToken, err := g.createInstallationTokenForID(ctx, installationID, opts, retryConfig{retry400: retry400})
 	if err != nil {
 		return "", nil, errors.Wrapf(err, "creating installation token for '%s/%s'", owner, repo)
 	}
@@ -169,14 +171,14 @@ type installationToken struct {
 
 // createInstallationTokenForID returns an installation token from GitHub given an installation ID.
 // This function cannot be moved to thirdparty because it is needed to set up the environment.
-func (g *GithubAppAuth) createInstallationTokenForID(ctx context.Context, installationID int64, opts *github.InstallationTokenOptions) (*installationToken, error) {
+func (g *GithubAppAuth) createInstallationTokenForID(ctx context.Context, installationID int64, opts *github.InstallationTokenOptions, conf retryConfig) (*installationToken, error) {
 	const caller = "CreateInstallationToken"
 	ctx, span := tracer.Start(ctx, caller, trace.WithAttributes(
 		attribute.String(githubAppEndpointAttribute, caller),
 	))
 	defer span.End()
 
-	client, err := getGitHubClientForAuth(g)
+	client, err := getGitHubClientForAuth(g, conf)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting GitHub client for token creation")
 	}

--- a/model/githubapp/github_app_installation.go
+++ b/model/githubapp/github_app_installation.go
@@ -97,6 +97,11 @@ func (h *GitHubAppInstallation) Upsert(ctx context.Context) error {
 	return err
 }
 
+// retryConfig customizes retry behavior for GitHub app API calls.
+type retryConfig struct {
+	retry400 bool
+}
+
 // GitHubClient adds a Close method to the GitHub client that
 // puts the underlying HTTP client back into the pool.
 type GitHubClient struct {
@@ -116,14 +121,14 @@ func (g *GitHubClient) Close() {
 // getGitHubClientForAuth returns a GitHub client with the GitHub app's private key.
 // This function cannot be moved to thirdparty because it is needed to set up the environment.
 // Couple this with a defered call with Close() to clean up the client.
-func getGitHubClientForAuth(authFields *GithubAppAuth) (*GitHubClient, error) {
+func getGitHubClientForAuth(authFields *GithubAppAuth, conf retryConfig) (*GitHubClient, error) {
 	key, err := jwt.ParseRSAPrivateKeyFromPEM(authFields.PrivateKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "parsing private key")
 	}
 
 	itr := ghinstallation.NewAppsTransportFromPrivateKey(otelhttp.NewTransport(utility.DefaultTransport()), authFields.AppID, key)
-	httpClient := utility.GetCustomHTTPRetryableClientWithTransport(itr, githubClientShouldRetry(), utility.RetryHTTPDelay(utility.RetryOptions{
+	httpClient := utility.GetCustomHTTPRetryableClientWithTransport(itr, githubClientShouldRetry(conf), utility.RetryHTTPDelay(utility.RetryOptions{
 		MinDelay:    GitHubRetryMinDelay,
 		MaxDelay:    GitHubRetryMaxDelay,
 		MaxAttempts: GitHubMaxRetries + 1,
@@ -134,7 +139,7 @@ func getGitHubClientForAuth(authFields *GithubAppAuth) (*GitHubClient, error) {
 	return &wrappedClient, nil
 }
 
-func githubClientShouldRetry() utility.HTTPRetryFunction {
+func githubClientShouldRetry(conf retryConfig) utility.HTTPRetryFunction {
 	defaultRetryableStatuses := utility.NewDefaultHTTPRetryConf().Statuses
 	// The GitHub API returns 403 Forbidden when a secondary rate limit is
 	// exceeded. This should ideally be covered already by checking for
@@ -207,6 +212,14 @@ func githubClientShouldRetry() utility.HTTPRetryFunction {
 			return true
 		}
 
+		if conf.retry400 && resp.StatusCode == http.StatusBadRequest && index < GitHubMaxRetries {
+			grip.Warning(req.Context(), makeLogMsg(map[string]any{
+				"message":     "retrying GitHub app endpoint after bad request",
+				"status_code": resp.StatusCode,
+			}))
+			return true
+		}
+
 		grip.ErrorWhen(req.Context(), resp.StatusCode >= http.StatusBadRequest, makeLogMsg(map[string]any{
 			"message":     "GitHub app endpoint returned response but is not retryable",
 			"status_code": resp.StatusCode,
@@ -219,7 +232,7 @@ func githubClientShouldRetry() utility.HTTPRetryFunction {
 // getInstallationIDFromGitHub returns an installation ID from GitHub given an owner and a repo.
 // This function cannot be moved to thirdparty because it is needed to set up the environment.
 func getInstallationIDFromGitHub(ctx context.Context, authFields *GithubAppAuth, owner, repo string) (int64, error) {
-	client, err := getGitHubClientForAuth(authFields)
+	client, err := getGitHubClientForAuth(authFields, retryConfig{})
 	if err != nil {
 		return 0, errors.Wrap(err, "getting GitHub client to get the installation ID")
 	}

--- a/model/githubapp/github_app_test.go
+++ b/model/githubapp/github_app_test.go
@@ -2,6 +2,8 @@ package githubapp
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -270,4 +272,34 @@ func TestCreateCacheID(t *testing.T) {
 			assert.Equal(t, tc.expected, result)
 		})
 	}
+}
+
+func TestGithubClientShouldRetry(t *testing.T) {
+	makeRequest := func() *http.Request {
+		return httptest.NewRequest(http.MethodPost, "https://api.github.com/app/installations/1/access_tokens", nil)
+	}
+
+	t.Run("BadRequestWithoutOptInDoesNotRetry", func(t *testing.T) {
+		retryFn := githubClientShouldRetry(retryConfig{})
+		resp := &http.Response{StatusCode: http.StatusBadRequest}
+		assert.False(t, retryFn(0, makeRequest(), resp, nil))
+	})
+
+	t.Run("BadRequestWithOptInRetries", func(t *testing.T) {
+		retryFn := githubClientShouldRetry(retryConfig{retry400: true})
+		resp := &http.Response{StatusCode: http.StatusBadRequest}
+		assert.True(t, retryFn(0, makeRequest(), resp, nil))
+	})
+
+	t.Run("ServerErrorRetriesWithoutOptIn", func(t *testing.T) {
+		retryFn := githubClientShouldRetry(retryConfig{})
+		resp := &http.Response{StatusCode: http.StatusInternalServerError}
+		assert.True(t, retryFn(0, makeRequest(), resp, nil))
+	})
+
+	t.Run("SuccessfulResponseDoesNotRetry", func(t *testing.T) {
+		retryFn := githubClientShouldRetry(retryConfig{retry400: true})
+		resp := &http.Response{StatusCode: http.StatusOK}
+		assert.False(t, retryFn(0, makeRequest(), resp, nil))
+	})
 }

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -2160,10 +2160,11 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 	// tasks could be using.
 	token, permissions, err := githubAppAuth.CreateInstallationToken(ctx, h.owner, h.repo, &github.InstallationTokenOptions{
 		Permissions: permissions,
-	})
+	}, true)
 	if err != nil {
 		// This intentionally returns a 4xx error to prevent the agent from
-		// retrying because CreateInstallationToken already retries internally.
+		// retrying because CreateInstallationToken already retries internally,
+		// including (potentially) transient "Bad Request" responses from GitHub.
 		// It's assumed that if the token can't be created after retries, it's
 		// not a transient issue.
 		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "creating installation token for '%s/%s'", h.owner, h.repo))

--- a/thirdparty/github_test.go
+++ b/thirdparty/github_test.go
@@ -227,7 +227,7 @@ func getInstallationTokenNoCache(ctx context.Context, owner, repo string, opts *
 		return "", errors.Wrap(err, "getting config")
 	}
 
-	token, _, err := githubapp.CreateGitHubAppAuth(settings).CreateInstallationToken(ctx, owner, repo, opts)
+	token, _, err := githubapp.CreateGitHubAppAuth(settings).CreateInstallationToken(ctx, owner, repo, opts, false)
 	if err != nil {
 		return "", errors.Wrap(err, "creating installation token")
 	}

--- a/units/provisioning_setup_host.go
+++ b/units/provisioning_setup_host.go
@@ -889,7 +889,7 @@ func GetGithubTokensForTask(ctx context.Context, taskId string) (string, []strin
 	if projectOwner != "" && projectRepo != "" && err == nil && settings != nil {
 		// Ignore any errors because if the repo is not private, cloning the repo will still work.
 		// Either way, we should still spin up the host even if we can't fetch the data.
-		githubAppToken, _, err = githubapp.CreateGitHubAppAuth(settings).CreateInstallationToken(ctx, projectOwner, projectRepo, opts)
+		githubAppToken, _, err = githubapp.CreateGitHubAppAuth(settings).CreateInstallationToken(ctx, projectOwner, projectRepo, opts, false)
 		catcher.Add(err)
 
 	}
@@ -901,7 +901,7 @@ func GetGithubTokensForTask(ctx context.Context, taskId string) (string, []strin
 			catcher.Add(err)
 		}
 		if module.Owner != "" && repo != "" && settings != nil {
-			token, _, err := githubapp.CreateGitHubAppAuth(settings).CreateInstallationToken(ctx, module.Owner, repo, opts)
+			token, _, err := githubapp.CreateGitHubAppAuth(settings).CreateInstallationToken(ctx, module.Owner, repo, opts, false)
 			catcher.Add(err)
 			moduleTokens = append(moduleTokens, fmt.Sprintf("%s:%s", moduleName, token))
 		}


### PR DESCRIPTION
DEVPROD-38023

### Description

BFs have been associated with transient 400 Bad Request responses from GitHub's installation token endpoint during `github.generate_token`. Today a 400 is never retried on this path (retry logic only covers 5xx and 403).

This adds an opt-in to the GitHub app retry logic so 400s get the same retry budget as other transient errors, but only when the caller adds it. I used a `retryConfig` approach to match the pattern in the thirdparty package (they cannot be shared due to cyclical dependencies), and even though it is just one bool in there I thought it may be useful for easy tweaking / adding in the future.
### Testing

Added a unit test. Hardcoded the command to return 400 on the first invocation and [verified in staging](https://spruce-staging.corp.mongodb.com/task/evg_ubuntu2204_test_model_host_c5e33e275798262847005a248c84fd156de4e596_26_08_28_19_57_10/logs?execution=0).
