### PR TITLE
DEVPROD-42333: Add configurable s3.put presign duration

### DIFF
--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -32,9 +32,7 @@ import (
 )
 
 const (
-	s3PutAttribute           = "evergreen.command.s3_put"
-	s3PresignMinimumDuration = time.Second
-	s3PresignMaximumDuration = 7 * 24 * time.Hour
+	s3PutAttribute = "evergreen.command.s3_put"
 )
 
 var (
@@ -309,11 +307,11 @@ func (s3pc *s3put) expandParams(conf *internal.TaskConfig) error {
 		if err != nil {
 			return errors.Wrap(err, "parsing presign duration")
 		}
-		if s3pc.presignDuration < s3PresignMinimumDuration || s3pc.presignDuration > s3PresignMaximumDuration {
-			return errors.Errorf("presign duration must be between %s and %s", s3PresignMinimumDuration, s3PresignMaximumDuration)
-		}
 		if s3pc.Visibility != artifact.Signed {
 			return errors.New("presign duration can only be used with signed visibility")
+		}
+		if err := artifact.ValidatePresignDuration(s3pc.presignDuration, s3pc.getRoleARN()); err != nil {
+			return err
 		}
 	}
 
@@ -394,6 +392,9 @@ func (s3pc *s3put) Execute(ctx context.Context, comm client.Communicator, logger
 			Expires:         expiration,
 			CanExpire:       true,
 		}
+	}
+	if err := artifact.ValidatePresignDuration(s3pc.presignDuration, s3pc.getRoleARN()); err != nil {
+		return err
 	}
 
 	// For key+secret uploads with no role ARN, resolve the AWS account ID via STS so cost tracking and lifecycle rule discovery can gate on it.

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -32,7 +32,9 @@ import (
 )
 
 const (
-	s3PutAttribute = "evergreen.command.s3_put"
+	s3PutAttribute           = "evergreen.command.s3_put"
+	s3PresignMinimumDuration = time.Second
+	s3PresignMaximumDuration = 7 * 24 * time.Hour
 )
 
 var (
@@ -110,6 +112,10 @@ type s3put struct {
 	// If unset, the file will be public.
 	Visibility string `mapstructure:"visibility" plugin:"expand"`
 
+	// PresignDuration controls how long presigned URLs remain valid. It only
+	// applies when Visibility is set to signed.
+	PresignDuration string `mapstructure:"presign_duration" plugin:"expand"`
+
 	// Optional, when set to true, causes this command to be skipped over without an error when
 	// the path specified in local_file does not exist. Defaults to false, which triggers errors
 	// for missing files.
@@ -147,6 +153,7 @@ type s3put struct {
 	preservePath       bool
 	skipExistingBool   bool
 	checksumSHA256Bool bool
+	presignDuration    time.Duration
 	isPatchable        bool
 	isPatchOnly        bool
 
@@ -294,6 +301,19 @@ func (s3pc *s3put) expandParams(conf *internal.TaskConfig) error {
 		s3pc.checksumSHA256Bool, err = strconv.ParseBool(s3pc.UploadChecksumSHA256)
 		if err != nil {
 			return errors.Wrap(err, "parsing checksum SHA256 parameter as a boolean")
+		}
+	}
+
+	if s3pc.PresignDuration != "" {
+		s3pc.presignDuration, err = time.ParseDuration(s3pc.PresignDuration)
+		if err != nil {
+			return errors.Wrap(err, "parsing presign duration")
+		}
+		if s3pc.presignDuration < s3PresignMinimumDuration || s3pc.presignDuration > s3PresignMaximumDuration {
+			return errors.Errorf("presign duration must be between %s and %s", s3PresignMinimumDuration, s3PresignMaximumDuration)
+		}
+		if s3pc.Visibility != artifact.Signed {
+			return errors.New("presign duration can only be used with signed visibility")
 		}
 	}
 
@@ -673,6 +693,7 @@ func (s3pc *s3put) attachFiles(ctx context.Context, comm client.Communicator, up
 			FileSize:         uploadInfo.FileSizeBytes,
 			PutRequests:      uploadInfo.PutRequests,
 			AssociatedLinks:  s3pc.associatedLinks,
+			PresignDuration:  s3pc.presignDuration,
 		})
 	}
 

--- a/agent/command/s3_put.go
+++ b/agent/command/s3_put.go
@@ -310,7 +310,7 @@ func (s3pc *s3put) expandParams(conf *internal.TaskConfig) error {
 		if s3pc.Visibility != artifact.Signed {
 			return errors.New("presign duration can only be used with signed visibility")
 		}
-		if err := artifact.ValidatePresignDuration(s3pc.presignDuration, s3pc.getRoleARN()); err != nil {
+		if err := s3pc.validatePresignDuration(); err != nil {
 			return err
 		}
 	}
@@ -393,7 +393,7 @@ func (s3pc *s3put) Execute(ctx context.Context, comm client.Communicator, logger
 			CanExpire:       true,
 		}
 	}
-	if err := artifact.ValidatePresignDuration(s3pc.presignDuration, s3pc.getRoleARN()); err != nil {
+	if err := s3pc.validatePresignDuration(); err != nil {
 		return err
 	}
 
@@ -756,6 +756,16 @@ func (s3pc *s3put) getRoleARN() string {
 		return s3pc.assumedRoleARN
 	}
 	return s3pc.RoleARN
+}
+
+func (s3pc *s3put) validatePresignDuration() error {
+	if s3pc.PresignDuration == "" {
+		return nil
+	}
+	if s3pc.getRoleARN() != "" {
+		return errors.New("presign duration cannot be used with role-backed credentials")
+	}
+	return artifact.ValidatePresignDuration(s3pc.presignDuration)
 }
 
 func readAssociatedLinksFile(fn string, conf *internal.TaskConfig) ([]artifact.AssociatedLink, error) {

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -430,14 +430,8 @@ func TestExpandS3PutPresignDuration(t *testing.T) {
 			visibility:   artifact.Signed,
 			expectsError: true,
 		},
-		"RoleDurationAtMaximumIsValid": {
-			duration:         "12h",
-			visibility:       artifact.Signed,
-			roleARN:          "arn:aws:iam::000000000000:role/test",
-			expectedDuration: 12 * time.Hour,
-		},
-		"RoleDurationAboveMaximumErrors": {
-			duration:     "13h",
+		"RoleDurationErrors": {
+			duration:     "1h",
 			visibility:   artifact.Signed,
 			roleARN:      "arn:aws:iam::000000000000:role/test",
 			expectsError: true,
@@ -459,6 +453,15 @@ func TestExpandS3PutPresignDuration(t *testing.T) {
 			assert.Equal(t, testCase.expectedDuration, cmd.presignDuration)
 		})
 	}
+}
+
+func TestValidateS3PutPresignDurationWithAssumedRoleErrors(t *testing.T) {
+	cmd := &s3put{
+		PresignDuration: "1h",
+		presignDuration: time.Hour,
+		assumedRoleARN:  "arn:aws:iam::000000000000:role/test",
+	}
+	require.Error(t, cmd.validatePresignDuration())
 }
 
 func TestSignedUrlVisibility(t *testing.T) {

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -390,6 +390,64 @@ func TestExpandS3PutParams(t *testing.T) {
 	})
 }
 
+func TestExpandS3PutPresignDuration(t *testing.T) {
+	conf := &internal.TaskConfig{
+		Expansions: *util.NewExpansions(map[string]string{"duration": "2h"}),
+	}
+
+	for name, testCase := range map[string]struct {
+		duration         string
+		visibility       string
+		expectedDuration time.Duration
+		expectsError     bool
+	}{
+		"UnsetUsesDefault": {
+			visibility: artifact.Signed,
+		},
+		"DurationIsParsed": {
+			duration:         "2h",
+			visibility:       artifact.Signed,
+			expectedDuration: 2 * time.Hour,
+		},
+		"DurationIsExpanded": {
+			duration:         "${duration}",
+			visibility:       artifact.Signed,
+			expectedDuration: 2 * time.Hour,
+		},
+		"InvalidDurationErrors": {
+			duration:     "two hours",
+			visibility:   artifact.Signed,
+			expectsError: true,
+		},
+		"DurationBelowMinimumErrors": {
+			duration:     "500ms",
+			visibility:   artifact.Signed,
+			expectsError: true,
+		},
+		"DurationAboveMaximumErrors": {
+			duration:     "169h",
+			visibility:   artifact.Signed,
+			expectsError: true,
+		},
+		"UnsignedVisibilityErrors": {
+			duration:     "1h",
+			visibility:   artifact.Public,
+			expectsError: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			cmd := &s3put{PresignDuration: testCase.duration, Visibility: testCase.visibility}
+			err := cmd.expandParams(conf)
+			if testCase.expectsError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedDuration, cmd.presignDuration)
+		})
+	}
+}
+
 func TestSignedUrlVisibility(t *testing.T) {
 	ctx := t.Context()
 
@@ -1154,6 +1212,13 @@ func TestAttachFilesRecordsCredentialVarNames(t *testing.T) {
 		assert.Empty(t, file.AWSKeyVarName)
 		assert.Empty(t, file.AWSSecretVarName)
 		assert.Equal(t, "arn:aws:iam::000000000000:role/fake-role", file.AWSRoleARN)
+	})
+
+	t.Run("PresignDurationIsAttached", func(t *testing.T) {
+		cmd := newCmd()
+		cmd.PresignDuration = "2h"
+		file := attach(t, cmd)
+		assert.Equal(t, 2*time.Hour, file.PresignDuration)
 	})
 }
 

--- a/agent/command/s3_put_test.go
+++ b/agent/command/s3_put_test.go
@@ -398,6 +398,7 @@ func TestExpandS3PutPresignDuration(t *testing.T) {
 	for name, testCase := range map[string]struct {
 		duration         string
 		visibility       string
+		roleARN          string
 		expectedDuration time.Duration
 		expectsError     bool
 	}{
@@ -429,6 +430,18 @@ func TestExpandS3PutPresignDuration(t *testing.T) {
 			visibility:   artifact.Signed,
 			expectsError: true,
 		},
+		"RoleDurationAtMaximumIsValid": {
+			duration:         "12h",
+			visibility:       artifact.Signed,
+			roleARN:          "arn:aws:iam::000000000000:role/test",
+			expectedDuration: 12 * time.Hour,
+		},
+		"RoleDurationAboveMaximumErrors": {
+			duration:     "13h",
+			visibility:   artifact.Signed,
+			roleARN:      "arn:aws:iam::000000000000:role/test",
+			expectsError: true,
+		},
 		"UnsignedVisibilityErrors": {
 			duration:     "1h",
 			visibility:   artifact.Public,
@@ -436,7 +449,7 @@ func TestExpandS3PutPresignDuration(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			cmd := &s3put{PresignDuration: testCase.duration, Visibility: testCase.visibility}
+			cmd := &s3put{PresignDuration: testCase.duration, Visibility: testCase.visibility, RoleARN: testCase.roleARN}
 			err := cmd.expandParams(conf)
 			if testCase.expectsError {
 				require.Error(t, err)

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-08-31"
+	AgentVersion = "2026-09-02"
 )
 
 const (

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1600,7 +1600,9 @@ Parameters:
   uploaded before that.
 - `presign_duration`: the duration that a URL generated for a `visibility: signed`
   artifact remains valid. Specify a duration from one second through seven days using
-  Go duration syntax, such as `30m`, `1h`, or `24h`. Defaults to 15 minutes when omitted.
+  Go duration syntax, such as `30m`, `1h`, or `24h`. When using `role_arn` or credentials
+  from `ec2.assume_role`, the maximum is 12 hours, although the role's configuration may
+  impose a lower limit. Defaults to 15 minutes when omitted.
 - `patchable`: defaults to true. If set to false, the command will
   no-op for patches (i.e. continue without performing the s3 put).
 - `patch_only`: defaults to false. If set to true, the command will

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1600,9 +1600,9 @@ Parameters:
   uploaded before that.
 - `presign_duration`: the duration that a URL generated for a `visibility: signed`
   artifact remains valid. Specify a duration from one second through seven days using
-  Go duration syntax, such as `30m`, `1h`, or `24h`. When using `role_arn` or credentials
-  from `ec2.assume_role`, the maximum is 12 hours, although the role's configuration may
-  impose a lower limit. Defaults to 15 minutes when omitted.
+  Go duration syntax, such as `30m`, `1h`, or `24h`. This option is only supported with
+  static AWS credentials; configurations using `role_arn` or credentials from
+  `ec2.assume_role` fail. Defaults to 15 minutes when omitted.
 - `patchable`: defaults to true. If set to false, the command will
   no-op for patches (i.e. continue without performing the s3 put).
 - `patch_only`: defaults to false. If set to true, the command will

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -1490,6 +1490,7 @@ distribution. Refer to [Task Artifacts Data Retention Policy](../Reference/Limit
     region: us-east-1
     permissions: private
     visibility: signed
+    presign_duration: 1h
     content_type: ${content_type|application/x-gzip}
     display_name: Binaries
 # Or:
@@ -1597,6 +1598,9 @@ Parameters:
   See [Rotating AWS credentials for signed artifacts](#rotating-aws-credentials-for-signed-artifacts)
   for how presigning picks up rotated credentials, and how to repair links for artifacts
   uploaded before that.
+- `presign_duration`: the duration that a URL generated for a `visibility: signed`
+  artifact remains valid. Specify a duration from one second through seven days using
+  Go duration syntax, such as `30m`, `1h`, or `24h`. Defaults to 15 minutes when omitted.
 - `patchable`: defaults to true. If set to false, the command will
   no-op for patches (i.e. continue without performing the s3 put).
 - `patch_only`: defaults to false. If set to true, the command will

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/evergreen-ci/birch v0.0.0-20250224221624-64f481f4b888
 	github.com/evergreen-ci/certdepot v0.0.0-20260326190252-5ab5e35f6cb7
 	github.com/evergreen-ci/gimlet v0.0.0-20260820213739-ce014252e539
-	github.com/evergreen-ci/pail v0.0.0-20260618132147-c9bcc0488a7f
+	github.com/evergreen-ci/pail v0.0.0-20260902154906-60ffdb29341d
 	github.com/evergreen-ci/poplar v0.0.0-20260330180450-c8cf511d1bd6
 	github.com/evergreen-ci/shrub v0.0.0-20251017154811-4d3ed1599154
 	github.com/evergreen-ci/utility v0.0.0-20260727185913-06cd8a26cd5e
@@ -243,5 +243,3 @@ require (
 )
 
 tool github.com/99designs/gqlgen
-
-replace github.com/evergreen-ci/pail => github.com/zackwintermdb/pail v0.0.0-20260831210140-94da12fd8ac6

--- a/go.mod
+++ b/go.mod
@@ -243,3 +243,5 @@ require (
 )
 
 tool github.com/99designs/gqlgen
+
+replace github.com/evergreen-ci/pail => github.com/zackwintermdb/pail v0.0.0-20260831210140-94da12fd8ac6

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,6 @@ github.com/evergreen-ci/lru v0.0.0-20260326190734-0d627bf39810 h1:Q+MNMS3rHQw6bG
 github.com/evergreen-ci/lru v0.0.0-20260326190734-0d627bf39810/go.mod h1:A+sGkHeCogvvRBXUrF/Ghu5Gec6lyLtb1MKZN/xfWmI=
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035 h1:oVU/ni/sRq+GAogUMLa7LBGtvVHMVLbisuytxBC5KaY=
 github.com/evergreen-ci/negroni v1.0.1-0.20211028183800-67b6d7c2c035/go.mod h1:pvK7NM0ZC+sfTLuIiJN4BgM1S9S5Oo79PJReAFFph18=
-github.com/evergreen-ci/pail v0.0.0-20260618132147-c9bcc0488a7f h1:7pjExNZ0z+ZRVNJpZH0vlTa6/iBxZXiAyN5coZ8f7Ok=
-github.com/evergreen-ci/pail v0.0.0-20260618132147-c9bcc0488a7f/go.mod h1:lj8oxBSqzEoapX1apBDy88B7wRjj27QQu9EXk2i3AOM=
 github.com/evergreen-ci/poplar v0.0.0-20260330180450-c8cf511d1bd6 h1:leuRlgINHoR0/takPgoHYrfHt5mAtXcLdKdfQ0KVnyQ=
 github.com/evergreen-ci/poplar v0.0.0-20260330180450-c8cf511d1bd6/go.mod h1:y7hhmPo+0k+kI8PTEyX9EziG2Um5727LFTu3Pln5gAQ=
 github.com/evergreen-ci/shrub v0.0.0-20251017154811-4d3ed1599154 h1:YO1VY9Qj68KjjRfd6TF8sHEss2kIfnpkUqZyxWAoEI8=
@@ -469,6 +467,8 @@ github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+github.com/zackwintermdb/pail v0.0.0-20260831210140-94da12fd8ac6 h1:wjitZoESBR6tlKU0CJB6KNu2MPwoG3aby4f2BCVqGhk=
+github.com/zackwintermdb/pail v0.0.0-20260831210140-94da12fd8ac6/go.mod h1:lj8oxBSqzEoapX1apBDy88B7wRjj27QQu9EXk2i3AOM=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
 github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 go.mongodb.org/mongo-driver v1.17.9 h1:IexDdCuuNJ3BHrELgBlyaH9p60JXAvdzWR128q+U5tU=

--- a/go.sum
+++ b/go.sum
@@ -467,8 +467,8 @@ github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M
 github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
-github.com/zackwintermdb/pail v0.0.0-20260831210140-94da12fd8ac6 h1:wjitZoESBR6tlKU0CJB6KNu2MPwoG3aby4f2BCVqGhk=
-github.com/zackwintermdb/pail v0.0.0-20260831210140-94da12fd8ac6/go.mod h1:lj8oxBSqzEoapX1apBDy88B7wRjj27QQu9EXk2i3AOM=
+github.com/evergreen-ci/pail v0.0.0-20260902154906-60ffdb29341d h1:3aioAuqGbes6BYYIehRmr6g8yADDqQzQB2XPa88zc8U=
+github.com/evergreen-ci/pail v0.0.0-20260902154906-60ffdb29341d/go.mod h1:lj8oxBSqzEoapX1apBDy88B7wRjj27QQu9EXk2i3AOM=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=
 github.com/zeebo/xxh3 v1.1.0/go.mod h1:IisAie1LELR4xhVinxWS5+zf1lA4p0MW4T+w+W07F5s=
 go.mongodb.org/mongo-driver v1.17.9 h1:IexDdCuuNJ3BHrELgBlyaH9p60JXAvdzWR128q+U5tU=

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -30,6 +31,19 @@ const (
 )
 
 var ValidVisibilities = []string{Public, Private, None, Signed, ""}
+
+const (
+	minimumPresignDuration     = time.Second
+	maximumPresignDuration     = 7 * 24 * time.Hour
+	maximumRolePresignDuration = 12 * time.Hour
+)
+
+var presignAWSConfigs = struct {
+	sync.Mutex
+	configs map[string]aws.Config
+}{
+	configs: map[string]aws.Config{},
+}
 
 // Entry stores groups of names and links (not content!) for
 // files uploaded to the api server by a running agent. These links could
@@ -201,6 +215,9 @@ func PresignFile(ctx context.Context, file File, resolver CredentialResolver) (s
 	if err := file.validate(); err != nil {
 		return "", errors.Wrap(err, "file validation failed")
 	}
+	if err := ValidatePresignDuration(file.PresignDuration, file.AWSRoleARN); err != nil {
+		return "", err
+	}
 
 	creds := credentialsForPresign(ctx, file, resolver)
 
@@ -209,36 +226,47 @@ func PresignFile(ctx context.Context, file File, resolver CredentialResolver) (s
 		externalID = &file.ExternalID
 	}
 
+	duration := file.PresignDuration
+	if duration == 0 {
+		duration = evergreen.PresignMinimumValidTime
+	}
+
 	requestParams := pail.PreSignRequestParams{
 		Bucket:                file.Bucket,
 		FileKey:               file.FileKey,
-		SignatureExpiryWindow: evergreen.PresignMinimumValidTime,
+		SignatureExpiryWindow: duration,
 		AWSKey:                creds.AWSKey,
 		AWSSecret:             creds.AWSSecret,
 		AWSRoleARN:            file.AWSRoleARN,
 		ExternalID:            externalID,
 	}
-	if file.PresignDuration != 0 {
-		requestParams.SignatureExpiryWindow = file.PresignDuration
-		return presignFileWithDuration(ctx, requestParams, file.PresignDuration)
-	}
-	return pail.PreSign(ctx, requestParams)
+	return presignFile(ctx, requestParams)
 }
 
-func presignFileWithDuration(ctx context.Context, params pail.PreSignRequestParams, duration time.Duration) (string, error) {
+// ValidatePresignDuration checks that a configured duration is supported by S3
+// and, when applicable, by AWS role sessions. A zero duration selects the default.
+func ValidatePresignDuration(duration time.Duration, roleARN string) error {
+	if duration == 0 {
+		return nil
+	}
+	if duration < minimumPresignDuration || duration > maximumPresignDuration {
+		return errors.Errorf("presign duration must be between %s and %s", minimumPresignDuration, maximumPresignDuration)
+	}
+	if roleARN != "" && duration > maximumRolePresignDuration {
+		return errors.Errorf("presign duration cannot exceed %s when using a role ARN", maximumRolePresignDuration)
+	}
+	return nil
+}
+
+func presignFile(ctx context.Context, params pail.PreSignRequestParams) (string, error) {
 	region := params.Region
 	if region == "" {
 		region = evergreen.DefaultEC2Region
 	}
 
-	cfg, err := awsconfig.LoadDefaultConfig(ctx,
-		awsconfig.WithRegion(region),
-		awsconfig.WithCredentialsCacheOptions(func(options *aws.CredentialsCacheOptions) {
-			options.ExpiryWindow = duration
-		}),
-	)
+	cfg, err := getPresignAWSConfig(ctx, region)
 	if err != nil {
-		return "", errors.Wrap(err, "loading AWS config")
+		return "", err
 	}
 
 	if params.AWSKey != "" {
@@ -252,10 +280,10 @@ func presignFileWithDuration(ctx context.Context, params pail.PreSignRequestPara
 		cfg.Credentials = pail.WithSeed(
 			stscreds.NewAssumeRoleProvider(stsClient, params.AWSRoleARN, func(options *stscreds.AssumeRoleOptions) {
 				options.ExternalID = params.ExternalID
-				options.Duration = max(duration, stscreds.DefaultDuration)
+				options.Duration = max(params.SignatureExpiryWindow, stscreds.DefaultDuration)
 			}),
 			cacheKey,
-			duration,
+			params.SignatureExpiryWindow,
 		)
 	}
 
@@ -263,12 +291,28 @@ func presignFileWithDuration(ctx context.Context, params pail.PreSignRequestPara
 	request, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(params.Bucket),
 		Key:    aws.String(params.FileKey),
-	}, s3.WithPresignExpires(duration))
+	}, s3.WithPresignExpires(params.SignatureExpiryWindow))
 	if err != nil {
 		return "", errors.Wrap(err, "presigning S3 object")
 	}
 
 	return request.URL, nil
+}
+
+func getPresignAWSConfig(ctx context.Context, region string) (aws.Config, error) {
+	presignAWSConfigs.Lock()
+	defer presignAWSConfigs.Unlock()
+
+	if cfg, ok := presignAWSConfigs.configs[region]; ok {
+		return cfg, nil
+	}
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+	if err != nil {
+		return aws.Config{}, errors.Wrap(err, "loading AWS config")
+	}
+	presignAWSConfigs.configs[region] = cfg
+	return cfg, nil
 }
 
 func GetAllArtifacts(ctx context.Context, tasks []TaskIDAndExecution) ([]File, error) {

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -6,12 +6,8 @@ import (
 	"net/url"
 	"path/filepath"
 	"strings"
-	"sync"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/pail"
 	"github.com/mongodb/grip"
@@ -34,13 +30,6 @@ const (
 	minimumPresignDuration = time.Second
 	maximumPresignDuration = 7 * 24 * time.Hour
 )
-
-var presignAWSConfigs = struct {
-	sync.Mutex
-	configs map[string]aws.Config
-}{
-	configs: map[string]aws.Config{},
-}
 
 // Entry stores groups of names and links (not content!) for
 // files uploaded to the api server by a running agent. These links could
@@ -232,14 +221,11 @@ func PresignFile(ctx context.Context, file File, resolver CredentialResolver) (s
 		Bucket:                file.Bucket,
 		FileKey:               file.FileKey,
 		SignatureExpiryWindow: evergreen.PresignMinimumValidTime,
+		PresignDuration:       file.PresignDuration,
 		AWSKey:                creds.AWSKey,
 		AWSSecret:             creds.AWSSecret,
 		AWSRoleARN:            file.AWSRoleARN,
 		ExternalID:            externalID,
-	}
-	if file.PresignDuration != 0 {
-		requestParams.SignatureExpiryWindow = file.PresignDuration
-		return presignFileWithDuration(ctx, requestParams)
 	}
 	return pail.PreSign(ctx, requestParams)
 }
@@ -250,49 +236,6 @@ func ValidatePresignDuration(duration time.Duration) error {
 		return errors.Errorf("presign duration must be between %s and %s", minimumPresignDuration, maximumPresignDuration)
 	}
 	return nil
-}
-
-func presignFileWithDuration(ctx context.Context, params pail.PreSignRequestParams) (string, error) {
-	region := params.Region
-	if region == "" {
-		region = evergreen.DefaultEC2Region
-	}
-
-	cfg, err := getPresignAWSConfig(ctx, region)
-	if err != nil {
-		return "", err
-	}
-
-	if params.AWSKey != "" {
-		cfg.Credentials = pail.CreateAWSStaticCredentials(params.AWSKey, params.AWSSecret, params.AWSSessionToken)
-	}
-
-	presignClient := s3.NewPresignClient(s3.NewFromConfig(cfg))
-	request, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String(params.Bucket),
-		Key:    aws.String(params.FileKey),
-	}, s3.WithPresignExpires(params.SignatureExpiryWindow))
-	if err != nil {
-		return "", errors.Wrap(err, "presigning S3 object")
-	}
-
-	return request.URL, nil
-}
-
-func getPresignAWSConfig(ctx context.Context, region string) (aws.Config, error) {
-	presignAWSConfigs.Lock()
-	defer presignAWSConfigs.Unlock()
-
-	if cfg, ok := presignAWSConfigs.configs[region]; ok {
-		return cfg, nil
-	}
-
-	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
-	if err != nil {
-		return aws.Config{}, errors.Wrap(err, "loading AWS config")
-	}
-	presignAWSConfigs.configs[region] = cfg
-	return cfg, nil
 }
 
 func GetAllArtifacts(ctx context.Context, tasks []TaskIDAndExecution) ([]File, error) {

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -8,6 +8,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/pail"
 	"github.com/mongodb/grip"
@@ -92,6 +97,8 @@ type File struct {
 	AssociatedLinks []AssociatedLink `json:"associated_links,omitempty" bson:"associated_links,omitempty"`
 	// DoNotEncodeLink indicates that the file link should not be escaped.
 	DoNotEncodeLink bool `json:"do_not_encode_link,omitempty" bson:"do_not_encode_link,omitempty"`
+	// PresignDuration is how long a presigned URL for this file remains valid.
+	PresignDuration time.Duration `json:"presign_duration,omitempty" bson:"presign_duration,omitempty"`
 }
 
 func (f *File) validate() error {
@@ -211,7 +218,57 @@ func PresignFile(ctx context.Context, file File, resolver CredentialResolver) (s
 		AWSRoleARN:            file.AWSRoleARN,
 		ExternalID:            externalID,
 	}
+	if file.PresignDuration != 0 {
+		requestParams.SignatureExpiryWindow = file.PresignDuration
+		return presignFileWithDuration(ctx, requestParams, file.PresignDuration)
+	}
 	return pail.PreSign(ctx, requestParams)
+}
+
+func presignFileWithDuration(ctx context.Context, params pail.PreSignRequestParams, duration time.Duration) (string, error) {
+	region := params.Region
+	if region == "" {
+		region = evergreen.DefaultEC2Region
+	}
+
+	cfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion(region),
+		awsconfig.WithCredentialsCacheOptions(func(options *aws.CredentialsCacheOptions) {
+			options.ExpiryWindow = duration
+		}),
+	)
+	if err != nil {
+		return "", errors.Wrap(err, "loading AWS config")
+	}
+
+	if params.AWSKey != "" {
+		cfg.Credentials = pail.CreateAWSStaticCredentials(params.AWSKey, params.AWSSecret, params.AWSSessionToken)
+	} else if params.AWSRoleARN != "" {
+		cacheKey := params.AWSRoleARN
+		if params.ExternalID != nil {
+			cacheKey += "|" + *params.ExternalID
+		}
+		stsClient := sts.NewFromConfig(cfg)
+		cfg.Credentials = pail.WithSeed(
+			stscreds.NewAssumeRoleProvider(stsClient, params.AWSRoleARN, func(options *stscreds.AssumeRoleOptions) {
+				options.ExternalID = params.ExternalID
+				options.Duration = max(duration, stscreds.DefaultDuration)
+			}),
+			cacheKey,
+			duration,
+		)
+	}
+
+	presignClient := s3.NewPresignClient(s3.NewFromConfig(cfg))
+	request, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(params.Bucket),
+		Key:    aws.String(params.FileKey),
+	}, s3.WithPresignExpires(duration))
+	if err != nil {
+		return "", errors.Wrap(err, "presigning S3 object")
+	}
+
+	return request.URL, nil
 }
 
 func GetAllArtifacts(ctx context.Context, tasks []TaskIDAndExecution) ([]File, error) {

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -11,9 +11,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/pail"
 	"github.com/mongodb/grip"
@@ -33,9 +31,8 @@ const (
 var ValidVisibilities = []string{Public, Private, None, Signed, ""}
 
 const (
-	minimumPresignDuration     = time.Second
-	maximumPresignDuration     = 7 * 24 * time.Hour
-	maximumRolePresignDuration = 12 * time.Hour
+	minimumPresignDuration = time.Second
+	maximumPresignDuration = 7 * 24 * time.Hour
 )
 
 var presignAWSConfigs = struct {
@@ -215,8 +212,13 @@ func PresignFile(ctx context.Context, file File, resolver CredentialResolver) (s
 	if err := file.validate(); err != nil {
 		return "", errors.Wrap(err, "file validation failed")
 	}
-	if err := ValidatePresignDuration(file.PresignDuration, file.AWSRoleARN); err != nil {
-		return "", err
+	if file.PresignDuration != 0 {
+		if file.AWSRoleARN != "" {
+			return "", errors.New("presign duration cannot be used with role-backed credentials")
+		}
+		if err := ValidatePresignDuration(file.PresignDuration); err != nil {
+			return "", err
+		}
 	}
 
 	creds := credentialsForPresign(ctx, file, resolver)
@@ -226,39 +228,31 @@ func PresignFile(ctx context.Context, file File, resolver CredentialResolver) (s
 		externalID = &file.ExternalID
 	}
 
-	duration := file.PresignDuration
-	if duration == 0 {
-		duration = evergreen.PresignMinimumValidTime
-	}
-
 	requestParams := pail.PreSignRequestParams{
 		Bucket:                file.Bucket,
 		FileKey:               file.FileKey,
-		SignatureExpiryWindow: duration,
+		SignatureExpiryWindow: evergreen.PresignMinimumValidTime,
 		AWSKey:                creds.AWSKey,
 		AWSSecret:             creds.AWSSecret,
 		AWSRoleARN:            file.AWSRoleARN,
 		ExternalID:            externalID,
 	}
-	return presignFile(ctx, requestParams)
+	if file.PresignDuration != 0 {
+		requestParams.SignatureExpiryWindow = file.PresignDuration
+		return presignFileWithDuration(ctx, requestParams)
+	}
+	return pail.PreSign(ctx, requestParams)
 }
 
-// ValidatePresignDuration checks that a configured duration is supported by S3
-// and, when applicable, by AWS role sessions. A zero duration selects the default.
-func ValidatePresignDuration(duration time.Duration, roleARN string) error {
-	if duration == 0 {
-		return nil
-	}
+// ValidatePresignDuration checks that a configured duration is supported by S3.
+func ValidatePresignDuration(duration time.Duration) error {
 	if duration < minimumPresignDuration || duration > maximumPresignDuration {
 		return errors.Errorf("presign duration must be between %s and %s", minimumPresignDuration, maximumPresignDuration)
-	}
-	if roleARN != "" && duration > maximumRolePresignDuration {
-		return errors.Errorf("presign duration cannot exceed %s when using a role ARN", maximumRolePresignDuration)
 	}
 	return nil
 }
 
-func presignFile(ctx context.Context, params pail.PreSignRequestParams) (string, error) {
+func presignFileWithDuration(ctx context.Context, params pail.PreSignRequestParams) (string, error) {
 	region := params.Region
 	if region == "" {
 		region = evergreen.DefaultEC2Region
@@ -271,20 +265,6 @@ func presignFile(ctx context.Context, params pail.PreSignRequestParams) (string,
 
 	if params.AWSKey != "" {
 		cfg.Credentials = pail.CreateAWSStaticCredentials(params.AWSKey, params.AWSSecret, params.AWSSessionToken)
-	} else if params.AWSRoleARN != "" {
-		cacheKey := params.AWSRoleARN
-		if params.ExternalID != nil {
-			cacheKey += "|" + *params.ExternalID
-		}
-		stsClient := sts.NewFromConfig(cfg)
-		cfg.Credentials = pail.WithSeed(
-			stscreds.NewAssumeRoleProvider(stsClient, params.AWSRoleARN, func(options *stscreds.AssumeRoleOptions) {
-				options.ExternalID = params.ExternalID
-				options.Duration = max(params.SignatureExpiryWindow, stscreds.DefaultDuration)
-			}),
-			cacheKey,
-			params.SignatureExpiryWindow,
-		)
 	}
 
 	presignClient := s3.NewPresignClient(s3.NewFromConfig(cfg))

--- a/model/artifact/artifact_file_test.go
+++ b/model/artifact/artifact_file_test.go
@@ -446,14 +446,13 @@ func TestPresignFileDuration(t *testing.T) {
 }
 
 func TestValidatePresignDuration(t *testing.T) {
-	const roleARN = "arn:aws:iam::000000000000:role/test"
-
 	for name, testCase := range map[string]struct {
 		duration     time.Duration
-		roleARN      string
 		expectsError bool
 	}{
-		"ZeroUsesDefault": {},
+		"ZeroErrors": {
+			expectsError: true,
+		},
 		"MinimumIsValid": {
 			duration: time.Second,
 		},
@@ -468,18 +467,9 @@ func TestValidatePresignDuration(t *testing.T) {
 			duration:     7*24*time.Hour + time.Second,
 			expectsError: true,
 		},
-		"RoleMaximumIsValid": {
-			duration: 12 * time.Hour,
-			roleARN:  roleARN,
-		},
-		"AboveRoleMaximumErrors": {
-			duration:     12*time.Hour + time.Second,
-			roleARN:      roleARN,
-			expectsError: true,
-		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			err := ValidatePresignDuration(testCase.duration, testCase.roleARN)
+			err := ValidatePresignDuration(testCase.duration)
 			if testCase.expectsError {
 				assert.Error(t, err)
 			} else {
@@ -487,4 +477,16 @@ func TestValidatePresignDuration(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPresignFileRoleDurationErrors(t *testing.T) {
+	_, err := PresignFile(t.Context(), File{
+		Name:            "Binaries",
+		Bucket:          "bucket",
+		FileKey:         "key",
+		Visibility:      Signed,
+		AWSRoleARN:      "arn:aws:iam::000000000000:role/test",
+		PresignDuration: time.Hour,
+	}, nil)
+	require.Error(t, err)
 }

--- a/model/artifact/artifact_file_test.go
+++ b/model/artifact/artifact_file_test.go
@@ -2,7 +2,9 @@ package artifact
 
 import (
 	"context"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/evergreen-ci/evergreen/db"
 	_ "github.com/evergreen-ci/evergreen/testutil"
@@ -32,14 +34,15 @@ func (s *TestArtifactFileSuite) SetupTest() {
 			BuildId:         "build1",
 			Files: []File{
 				{
-					Name:           "cat_pix",
-					Link:           "http://placekitten.com/800/600",
-					Visibility:     "signed",
-					IgnoreForFetch: false,
-					AWSKey:         "key",
-					AWSSecret:      "secret",
-					Bucket:         "bucket",
-					FileKey:        "filekey",
+					Name:            "cat_pix",
+					Link:            "http://placekitten.com/800/600",
+					Visibility:      "signed",
+					IgnoreForFetch:  false,
+					AWSKey:          "key",
+					AWSSecret:       "secret",
+					Bucket:          "bucket",
+					FileKey:         "filekey",
+					PresignDuration: 2 * time.Hour,
 				},
 				{
 					Name:           "fast_download",
@@ -109,6 +112,7 @@ func (s *TestArtifactFileSuite) TestArtifactFieldsArePresent() {
 	s.Len(entryFromDb.Files, 2)
 	s.Equal("cat_pix", entryFromDb.Files[0].Name)
 	s.Equal("http://placekitten.com/800/600", entryFromDb.Files[0].Link)
+	s.Equal(2*time.Hour, entryFromDb.Files[0].PresignDuration)
 	s.Equal("fast_download", entryFromDb.Files[1].Name)
 	s.Equal("https://fastdl.mongodb.org", entryFromDb.Files[1].Link)
 	s.Equal(1, entryFromDb.Execution)
@@ -405,4 +409,38 @@ func TestPresignFileDoesNotWriteToDB(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, after, 1)
 	assert.Equal(t, "AKIAFAKESTOREDKEY", after[0].Files[0].AWSKey)
+}
+
+func TestPresignFileDuration(t *testing.T) {
+	resolver := func(context.Context, File) (*Credentials, error) {
+		return &Credentials{AWSKey: "AKIAFAKEKEY", AWSSecret: "fake-secret"}, nil
+	}
+
+	for name, testCase := range map[string]struct {
+		duration        time.Duration
+		expectedSeconds string
+	}{
+		"UnsetUsesDefault": {
+			expectedSeconds: "900",
+		},
+		"ConfiguredDurationIsUsed": {
+			duration:        2 * time.Hour,
+			expectedSeconds: "7200",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			presignedURL, err := PresignFile(t.Context(), File{
+				Name:            "Binaries",
+				Bucket:          "bucket",
+				FileKey:         "key",
+				Visibility:      Signed,
+				PresignDuration: testCase.duration,
+			}, resolver)
+			require.NoError(t, err)
+
+			parsed, err := url.Parse(presignedURL)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedSeconds, parsed.Query().Get("X-Amz-Expires"))
+		})
+	}
 }

--- a/model/artifact/artifact_file_test.go
+++ b/model/artifact/artifact_file_test.go
@@ -444,3 +444,47 @@ func TestPresignFileDuration(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatePresignDuration(t *testing.T) {
+	const roleARN = "arn:aws:iam::000000000000:role/test"
+
+	for name, testCase := range map[string]struct {
+		duration     time.Duration
+		roleARN      string
+		expectsError bool
+	}{
+		"ZeroUsesDefault": {},
+		"MinimumIsValid": {
+			duration: time.Second,
+		},
+		"StaticCredentialMaximumIsValid": {
+			duration: 7 * 24 * time.Hour,
+		},
+		"BelowMinimumErrors": {
+			duration:     time.Millisecond,
+			expectsError: true,
+		},
+		"AboveS3MaximumErrors": {
+			duration:     7*24*time.Hour + time.Second,
+			expectsError: true,
+		},
+		"RoleMaximumIsValid": {
+			duration: 12 * time.Hour,
+			roleARN:  roleARN,
+		},
+		"AboveRoleMaximumErrors": {
+			duration:     12*time.Hour + time.Second,
+			roleARN:      roleARN,
+			expectsError: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := ValidatePresignDuration(testCase.duration, testCase.roleARN)
+			if testCase.expectsError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
DEVPROD-XXXX

### Description

Add an optional `presign_duration` parameter to `s3.put` commands with `visibility: signed`.

The duration accepts Go duration syntax and is validated against S3's supported range of one second through seven days. It is supported only with static AWS credentials; commands using `role_arn` or credentials from `ec2.assume_role` fail before uploading. Evergreen stores an explicitly configured duration with the artifact and applies it whenever the lazy artifact endpoint generates a presigned S3 URL.

Depends on [evergreen-ci/pail#155](https://github.com/evergreen-ci/pail/pull/155), which adds the presign-duration option to pail so Evergreen does not duplicate AWS configuration or caching.

#### Backward compatibility

This is an additive, optional parameter. Existing `s3.put` configurations that omit `presign_duration`, including role-backed configurations, retain the current signing flow and 15-minute URL lifetime. Existing artifact records do not contain the new field, deserialize it as zero, and therefore also retain the 15-minute behavior without a database migration. The persisted JSON/BSON field uses `omitempty`, so it is written only when a command explicitly configures a duration.

### Testing

- `make test-model-artifact`
- `make test-agent-command RUN_TEST='Test(ExpandS3PutPresignDuration|ValidateS3PutPresignDurationWithAssumedRoleErrors|AttachFilesRecordsCredentialVarNames)'`
- `make lint-model-artifact`
- `make lint-agent-command`
- `make lint-evergreen`
- `BRANCH_NAME=main bash scripts/verify-agent-version-update.sh`
- `go test . -run '^TestPreSignDuration$'` in pail

The full `make test-agent-command` suite was also run. All `s3.put` tests passed; unrelated environment-dependent tests failed because no third-party settings override was supplied and `/usr/bin/python` is unavailable on the test host.

### Documentation

Documented `presign_duration`, its accepted syntax and bounds, its static-credential requirement, its default, and an example in `docs/Project-Configuration/Project-Commands.md`.
