### PR TITLE
DEVPROD-42008 Fix evergreen command not found on spawn hosts

### DIFF
--- a/model/host/hostutil.go
+++ b/model/host/hostutil.go
@@ -1124,6 +1124,7 @@ func (h *Host) spawnHostSetupConfigDirCommands(conf []byte) string {
 		fmt.Sprintf("echo \"%s\" > %s", conf, h.spawnHostConfigFile()),
 		fmt.Sprintf("chmod +x %s", h.AgentMonitorBinary()),
 		fmt.Sprintf("cp %s %s", h.AgentMonitorBinary(), h.spawnHostConfigDir()),
+		fmt.Sprintf("(cp %s %s || true)", h.AgentBinary(), h.spawnHostConfigDir()),
 		fmt.Sprintf("(echo '\nexport PATH=\"${PATH}:%s\"\n' >> %s/.profile || true; echo '\nexport PATH=\"${PATH}:%s\"\n' >> %s/.bash_profile || true)", h.spawnHostConfigDir(), h.Distro.HomeDir(), h.spawnHostConfigDir(), h.Distro.HomeDir()),
 		fmt.Sprintf("(%s || true)", h.changeOwnerCommand(filepath.Join(h.Distro.HomeDir(), ".profile"), filepath.Join(h.Distro.HomeDir(), ".bash_profile"))),
 	}, " && ")

--- a/model/host/hostutil_test.go
+++ b/model/host/hostutil_test.go
@@ -1047,6 +1047,26 @@ func TestSpawnHostConfig(t *testing.T) {
 	assert.Equal(t, serviceUser.APIKey, config.APIKey)
 }
 
+func TestSpawnHostSetupConfigDirCommands(t *testing.T) {
+	h := &Host{
+		Distro: distro.Distro{
+			Arch: evergreen.ArchLinuxAmd64,
+			User: "user",
+		},
+	}
+	cmd := h.spawnHostSetupConfigDirCommands([]byte("config_content"))
+
+	t.Run("CopiesBothBinariesIntoConfigDir", func(t *testing.T) {
+		assert.Contains(t, cmd, "cp /home/user/evergreen_agent_monitor /home/user/cli_bin")
+		assert.Contains(t, cmd, "(cp /home/user/evergreen /home/user/cli_bin || true)")
+	})
+
+	t.Run("AddsConfigDirToPath", func(t *testing.T) {
+		assert.Contains(t, cmd, "export PATH")
+		assert.Contains(t, cmd, "/home/user/cli_bin")
+	})
+}
+
 func TestAddPublicKeyScript(t *testing.T) {
 	for tName, tCase := range map[string]func(t *testing.T, h *Host){
 		"CreatesExpectedScript": func(t *testing.T, h *Host) {


### PR DESCRIPTION
DEVPROD-42008

### Description

DEVPROD-24984 switched `spawnHostSetupConfigDirCommands` to copy evergreen_agent_monitor into ~/cli_bin instead of evergreen. Since ~/cli_bin is the only directory on PATH, bare evergreen commands stopped resolving, breaking the debug daemon startup script and any user workflow that calls evergreen without a path prefix.

The fix copies the compat evergreen binary into ~/cli_bin alongside the agent monitor, restoring the previous behavior. Adds a test to prevent the regression.
### Testing

Added a quick unit test to catch the regression in the future. Manually verified in staging.