### PR TITLE
 DEVPROD-38175 Reject user-created run-child-patch subscriptions and verify parent-child relationship before finalizing

### DIFF
--- a/rest/data/subscription.go
+++ b/rest/data/subscription.go
@@ -83,6 +83,15 @@ func SaveSubscriptions(ctx context.Context, owner string, subscriptions []restMo
 			}
 		}
 
+		// The run-child-patch subscriber is only ever created internally, from a
+		// verified parent/child trigger relationship.
+		if dbSubscription.Subscriber.Type == event.RunChildPatchSubscriberType {
+			return gimlet.ErrorResponse{
+				StatusCode: http.StatusBadRequest,
+				Message:    fmt.Sprintf("subscriber type '%s' is reserved for internal use", event.RunChildPatchSubscriberType),
+			}
+		}
+
 		if !trigger.ValidateTrigger(dbSubscription.ResourceType, dbSubscription.Trigger) {
 			return gimlet.ErrorResponse{
 				StatusCode: http.StatusBadRequest,

--- a/rest/data/subscription_test.go
+++ b/rest/data/subscription_test.go
@@ -465,6 +465,39 @@ func TestSaveSubscriptionsRejectsOtherOwnersSubscription(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot modify a subscription owned by another user or project")
 }
 
+func TestSaveSubscriptionsRejectsRunChildPatchSubscriber(t *testing.T) {
+	require.NoError(t, db.ClearCollections(event.SubscriptionsCollection))
+
+	subscription := restModel.APISubscription{
+		ResourceType: utility.ToStringPtr(event.ResourceTypePatch),
+		Trigger:      utility.ToStringPtr(event.TriggerOutcome),
+		Owner:        utility.ToStringPtr("regular-user"),
+		OwnerType:    utility.ToStringPtr(string(event.OwnerTypePerson)),
+		Selectors: []restModel.APISelector{
+			{
+				Type: utility.ToStringPtr(event.SelectorObject),
+				Data: utility.ToStringPtr(event.ObjectPatch),
+			},
+		},
+		Subscriber: restModel.APISubscriber{
+			Type: utility.ToStringPtr(event.RunChildPatchSubscriberType),
+			Target: map[string]any{
+				"parent_status":  "*",
+				"child_patch_id": "5aab4514f27e4f9984646d97",
+				"requester":      evergreen.TriggerRequester,
+			},
+		},
+	}
+
+	err := SaveSubscriptions(t.Context(), "regular-user", []restModel.APISubscription{subscription}, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reserved for internal use")
+
+	subs, err := event.FindSubscriptionsByOwner(t.Context(), "regular-user", event.OwnerTypePerson)
+	assert.NoError(t, err)
+	assert.Empty(t, subs)
+}
+
 func TestSaveProjectSubscriptionAuthorization(t *testing.T) {
 	env := testutil.NewEnvironment(t.Context(), t)
 	rm := env.RoleManager()

--- a/trigger/patch.go
+++ b/trigger/patch.go
@@ -126,7 +126,7 @@ func (t *patchTriggers) patchOutcome(ctx context.Context, sub *event.Subscriptio
 			if suppressable {
 				return nil, nil
 			}
-			err = finalizeChildPatch(ctx, sub)
+			err = finalizeChildPatch(ctx, sub, t.patch.Id.Hex())
 
 			if err != nil {
 				return nil, errors.Wrap(err, "finalizing child patch")
@@ -167,7 +167,9 @@ func (t *patchTriggers) patchFailure(ctx context.Context, sub *event.Subscriptio
 	return t.generate(ctx, sub)
 }
 
-func finalizeChildPatch(ctx context.Context, sub *event.Subscription) error {
+// finalizeChildPatch finalizes the subscription's target patch. parentPatchID is the patch
+// that the event fired for; only a child of that patch may be finalized here.
+func finalizeChildPatch(ctx context.Context, sub *event.Subscription, parentPatchID string) error {
 	target, ok := sub.Subscriber.Target.(*event.ChildPatchSubscriber)
 	if !ok {
 		return errors.Errorf("target '%s' had unexpected type %T", sub.Subscriber.Target, sub.Subscriber.Target)
@@ -178,6 +180,9 @@ func finalizeChildPatch(ctx context.Context, sub *event.Subscription) error {
 	}
 	if childPatch == nil {
 		return errors.Errorf("child patch '%s' not found", target.ChildPatchId)
+	}
+	if !childPatch.IsChild() || childPatch.Triggers.ParentPatch != parentPatchID {
+		return errors.Errorf("patch '%s' is not a child of patch '%s'", childPatch.Id.Hex(), parentPatchID)
 	}
 	// Return if patch is already finalized
 	if childPatch.Version != "" {

--- a/trigger/patch_test.go
+++ b/trigger/patch_test.go
@@ -80,6 +80,9 @@ func (s *patchSuite) SetupTest() {
 		Status:     evergreen.VersionCreated,
 		StartTime:  startTime,
 		FinishTime: startTime.Add(10 * time.Minute),
+		Triggers: patch.TriggerInfo{
+			ParentPatch: patchID.Hex(),
+		},
 		GithubPatchData: thirdparty.GithubPatch{
 			BaseOwner: "evergreen-ci",
 			BaseRepo:  "evergreen",
@@ -294,6 +297,54 @@ func (s *patchSuite) TestRunChildrenOnPatchOutcome() {
 	s.Contains(err.Error(), "finalizing child patch")
 	s.Nil(n)
 
+}
+
+func (s *patchSuite) TestRunChildrenOnPatchOutcomeWithUnrelatedTargetShouldError() {
+	for testName, targetPatch := range map[string]patch.Patch{
+		// An external PR patch that was never finalized, so it has no version.
+		"UnfinalizedPatchWithNoParent": {
+			Id:      mgobson.NewObjectId(),
+			Project: "test",
+			Author:  "someone",
+			Status:  evergreen.VersionCreated,
+		},
+		"ChildOfADifferentParent": {
+			Id:      mgobson.NewObjectId(),
+			Project: "test",
+			Author:  "someone",
+			Status:  evergreen.VersionCreated,
+			Triggers: patch.TriggerInfo{
+				ParentPatch: mgobson.NewObjectId().Hex(),
+			},
+		},
+	} {
+		s.Run(testName, func() {
+			s.NoError(targetPatch.Insert(s.ctx))
+
+			// A parent status of "*" matches any outcome of the event's patch.
+			sub := event.NewSubscriptionByID(event.ResourceTypePatch, event.TriggerOutcome, s.event.ResourceId, event.Subscriber{
+				Type: event.RunChildPatchSubscriberType,
+				Target: &event.ChildPatchSubscriber{
+					ParentStatus: "*",
+					ChildPatchId: targetPatch.Id.Hex(),
+					Requester:    evergreen.TriggerRequester,
+				},
+			})
+			s.NoError(sub.Upsert(s.ctx))
+
+			s.data.Status = evergreen.VersionSucceeded
+			n, err := s.t.patchOutcome(s.ctx, &sub)
+			s.Require().Error(err)
+			s.Contains(err.Error(), "is not a child of")
+			s.Nil(n)
+
+			// The target patch must not have been finalized.
+			dbPatch, err := patch.FindOneId(s.ctx, targetPatch.Id.Hex())
+			s.NoError(err)
+			s.Require().NotNil(dbPatch)
+			s.Empty(dbPatch.Version)
+		})
+	}
 }
 
 func (s *patchSuite) TestPatchFamilyOutcomeWithAbortedPatch() {


### PR DESCRIPTION
DEVPROD-38175

### Description

A user could POST a subscription with a run-child-patch subscriber pointing at any patch ID, and finalizeChildPatch in trigger/patch.go would finalize (and run) that patch on their behalf, with no check that it was actually a child of the patch whose event fired. 

SaveSubscriptions in rest/data/subscription.go now rejects RunChildPatchSubscriberType outright since that subscriber is only ever created internally, and finalizeChildPatch now takes the firing patch's ID and errors unless the target is a real child of it.

### Testing

Added tests 