### PR TITLE
DEVPROD-42404 Rename colliding route.Variant and route.variant types

### DIFF
--- a/rest/route/patch.go
+++ b/rest/route/patch.go
@@ -622,6 +622,10 @@ type patchTasks struct {
 	Variants []patchVariant `json:"variants"`
 }
 
+// patchVariant is named for the route it serves rather than just "variant"
+// because it appears in the generated OpenAPI spec alongside versionVariant.
+// Names that differ only by case collide when clients are generated from the
+// spec, silently dropping endpoints. See DEVPROD-42404.
 type patchVariant struct {
 	Id    string   `json:"id"`
 	Tasks []string `json:"tasks"`

--- a/rest/route/patch.go
+++ b/rest/route/patch.go
@@ -619,10 +619,10 @@ type patchTasks struct {
 	// Required, these are the variants and tasks that the patch should run.
 	// For an already-scheduled patch, any new tasks in this array will be
 	// created and any existing tasks not in this array will be unscheduled.
-	Variants []variant `json:"variants"`
+	Variants []patchVariant `json:"variants"`
 }
 
-type variant struct {
+type patchVariant struct {
 	Id    string   `json:"id"`
 	Tasks []string `json:"tasks"`
 }

--- a/rest/route/patch_test.go
+++ b/rest/route/patch_test.go
@@ -1108,7 +1108,7 @@ buildvariants:
 	description := "some text"
 	body := patchTasks{
 		Description: description,
-		Variants:    []variant{{Id: "ubuntu", Tasks: []string{"compile", "passing_test"}}},
+		Variants:    []patchVariant{{Id: "ubuntu", Tasks: []string{"compile", "passing_test"}}},
 	}
 	jsonBody, err := json.Marshal(&body)
 	assert.NoError(t, err)
@@ -1144,7 +1144,7 @@ buildvariants:
 	// valid request, reconfiguring a finalized patch
 	handler = makeSchedulePatchHandler(env).(*schedulePatchHandler)
 	body = patchTasks{
-		Variants: []variant{{Id: "ubuntu", Tasks: []string{"failing_test"}}},
+		Variants: []patchVariant{{Id: "ubuntu", Tasks: []string{"failing_test"}}},
 	}
 	jsonBody, err = json.Marshal(&body)
 	assert.NoError(t, err)
@@ -1202,7 +1202,7 @@ buildvariants:
 
 	handler = makeSchedulePatchHandler(env).(*schedulePatchHandler)
 	body = patchTasks{
-		Variants: []variant{{Id: "ubuntu", Tasks: []string{"*"}}},
+		Variants: []patchVariant{{Id: "ubuntu", Tasks: []string{"*"}}},
 	}
 	jsonBody, err = json.Marshal(&body)
 	assert.NoError(t, err)
@@ -1236,7 +1236,7 @@ buildvariants:
 	require.NoError(t, pp.Insert(t.Context()))
 	handler = makeSchedulePatchHandler(env).(*schedulePatchHandler)
 	body = patchTasks{
-		Variants: []variant{{Id: "ubuntu_task_group", Tasks: []string{"task_group_task_2"}}},
+		Variants: []patchVariant{{Id: "ubuntu_task_group", Tasks: []string{"task_group_task_2"}}},
 	}
 	jsonBody, err = json.Marshal(&body)
 	assert.NoError(t, err)
@@ -1520,7 +1520,7 @@ tasks:
 	description := "some text"
 	body := patchTasks{
 		Description: description,
-		Variants:    []variant{{Id: "generate-tasks-for-version", Tasks: []string{"version_gen"}}},
+		Variants:    []patchVariant{{Id: "generate-tasks-for-version", Tasks: []string{"version_gen"}}},
 	}
 	jsonBody, err := json.Marshal(&body)
 	assert.NoError(t, err)
@@ -1550,7 +1550,7 @@ tasks:
 	// this task has two dependencies which should also be activated
 	handler = makeSchedulePatchHandler(env).(*schedulePatchHandler)
 	body = patchTasks{
-		Variants: []variant{
+		Variants: []patchVariant{
 			{Id: "testBV4", Tasks: []string{"dependencyTask"}},
 		},
 	}
@@ -1576,7 +1576,7 @@ tasks:
 	// Check that scheduling a task group works.
 	handler = makeSchedulePatchHandler(env).(*schedulePatchHandler)
 	body = patchTasks{
-		Variants: []variant{
+		Variants: []patchVariant{
 			{Id: "testBV1", Tasks: []string{"some_task_group"}},
 		},
 	}

--- a/rest/route/version.go
+++ b/rest/route/version.go
@@ -361,6 +361,10 @@ type versionActivateTasksHandler struct {
 	versionId string
 }
 
+// versionVariant is named for the route it serves rather than just "variant"
+// because it appears in the generated OpenAPI spec alongside patchVariant.
+// Names that differ only by case collide when clients are generated from the
+// spec, silently dropping endpoints. See DEVPROD-42404.
 type versionVariant struct {
 	Name  string   `json:"name"`
 	Tasks []string `json:"tasks"`

--- a/rest/route/version.go
+++ b/rest/route/version.go
@@ -356,12 +356,12 @@ func (h *versionRestartHandler) Run(ctx context.Context) gimlet.Responder {
 // POST /rest/v2/versions/{version_id}/activate_tasks
 
 type versionActivateTasksHandler struct {
-	Variants []Variant `json:"variants" validate:"required"`
+	Variants []versionVariant `json:"variants" validate:"required"`
 
 	versionId string
 }
 
-type Variant struct {
+type versionVariant struct {
 	Name  string   `json:"name"`
 	Tasks []string `json:"tasks"`
 }

--- a/rest/route/version_test.go
+++ b/rest/route/version_test.go
@@ -338,7 +338,7 @@ func (s *VersionSuite) TestActivateVersionTasks() {
 
 	handler := &versionActivateTasksHandler{
 		versionId: versionId,
-		Variants: []Variant{
+		Variants: []versionVariant{
 			{
 				Name:  s.bv[0],
 				Tasks: []string{"test_task_1", "test_task_2"},
@@ -375,7 +375,7 @@ func (s *VersionSuite) TestActivateVersionTasksInvalidVariant() {
 
 	handler := &versionActivateTasksHandler{
 		versionId: versionId,
-		Variants: []Variant{
+		Variants: []versionVariant{
 			{
 				Name:  s.bv[0],
 				Tasks: []string{"test_task_1", "test_task_2"},


### PR DESCRIPTION
DEVPROD-42404

  ### Description

`route.Variant` and `route.variant` differ only by case, so client generators collapse them, which causes us to drop the patch configure route; would be nice to have this work correctly before sending a migration email for evergreen.py. 

### Testing

Added a unit test to catch if these ever collide again, since someone might try to "fix" this.