### PR TITLE
DEVPROD-31861: remove temporary debug logs

### DIFF
--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -322,18 +322,6 @@ func TryResetTask(ctx context.Context, settings *evergreen.Settings, taskId, use
 		if !t.IsFinished() {
 			if detail != nil {
 				if t.DisplayOnly {
-					// TODO (DEVPROD-31861): remove this log once confirmed that
-					// the display task does not race to reset anymore.
-					grip.Info(ctx, message.Fields{
-						"message":                     "reached max executions for display task, marking the display task and all unfinished execution tasks as finished",
-						"display_task_id":             t.Id,
-						"display_task_execution":      t.Execution,
-						"display_task_status":         t.Status,
-						"display_task_max_executions": maxExecution,
-						"num_execution_tasks":         len(t.ExecutionTasks),
-						"origin":                      origin,
-						"ticket":                      "DEVPROD-31861",
-					})
 					for _, etId := range t.ExecutionTasks {
 						execTask, err = task.FindOneId(ctx, etId)
 						if err != nil {
@@ -343,20 +331,6 @@ func TryResetTask(ctx context.Context, settings *evergreen.Settings, taskId, use
 						// some individual execution tasks may already be
 						// finished. Only MarkEnd on unfinished execution tasks.
 						if !evergreen.IsFinishedTaskStatus(execTask.Status) {
-							// TODO (DEVPROD-31861): remove this log once
-							// confirmed that the display task does not race to
-							// reset anymore.
-							grip.Info(ctx, message.Fields{
-								"message":                     "reached max executions for display task, marking unfinished execution task as finished",
-								"display_task_id":             t.Id,
-								"display_task_execution":      t.Execution,
-								"display_task_max_executions": maxExecution,
-								"execution_task_id":           execTask.Id,
-								"execution_task_execution":    execTask.Execution,
-								"execution_task_status":       execTask.Status,
-								"origin":                      origin,
-								"ticket":                      "DEVPROD-31861",
-							})
 							if err = MarkEnd(ctx, settings, execTask, origin, time.Now(), detail); err != nil {
 								return errors.Wrap(err, "marking execution task as ended")
 							}


### PR DESCRIPTION
DEVPROD-31861

### Description

Confirmed that after deploying #10700, these temporary logs don't log, which means that the display task race bug no longer occurs.

I also manually confirmed by checking a few execution tasks that have non-sequential executions. For example in [this display task](https://spruce.corp.mongodb.com/task/mongodb_mongo_master_rhel8_debug_aubsan_all_feature_flags_generated_by_burn_in_tags_display_burn_in_tests_patch_51e79031c07c8a89a4b04c13eeb828ae2e2b7d62_6a95ac70d86a9d0007965c9f_26_08_31_16_32_06/execution-tasks?execution=1&sorts=STATUS%3AASC), all the tasks succeeded on execution 1 except for one which is repeatedly system-failing. When the display task was reset for system failure, only the one system-failing task restarted and the rest remained on execution 1 with successful statuses (prior to #10700 and #10691, the bug would mark already-finished tasks finished again and change them from success to system-failed).