### PR TITLE
DEVPROD-41619 Copy module config overrides when cloning patches with --diff-patchId

### DIFF
--- a/config.go
+++ b/config.go
@@ -35,7 +35,7 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-08-28"
+	ClientVersion = "2026-09-01"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).

--- a/operations/patch.go
+++ b/operations/patch.go
@@ -552,6 +552,13 @@ func PatchFile() cli.Command {
 				}
 				diffData.fullPatch = rp.Patch.Diff
 				diffData.base = rp.Patch.Githash
+				for _, lmi := range rp.LocalModuleIncludes {
+					params.LocalModuleIncludes = append(params.LocalModuleIncludes, patch.LocalModuleInclude{
+						Module:      lmi.Module,
+						FileName:    lmi.FileName,
+						FileContent: lmi.FileContent,
+					})
+				}
 			}
 
 			if err = params.validateSubmission(ctx, &diffData); err != nil {

--- a/rest/data/patch.go
+++ b/rest/data/patch.go
@@ -267,6 +267,14 @@ func GetRawPatches(ctx context.Context, patchID string) (*restModel.APIRawPatch,
 		rawPatch.Patch.Githash = patchDoc.Githash
 	}
 
+	for _, lmi := range patchDoc.LocalModuleIncludes {
+		rawPatch.LocalModuleIncludes = append(rawPatch.LocalModuleIncludes, restModel.APILocalModuleInclude{
+			Module:      lmi.Module,
+			FileName:    lmi.FileName,
+			FileContent: lmi.FileContent,
+		})
+	}
+
 	return &rawPatch, nil
 }
 

--- a/rest/data/patch_test.go
+++ b/rest/data/patch_test.go
@@ -554,6 +554,13 @@ func TestGetRawPatches(t *testing.T) {
 		Patches: []patch.ModulePatch{
 			{ModuleName: "different", Githash: "home fries"},
 		},
+		LocalModuleIncludes: []patch.LocalModuleInclude{
+			{
+				Module:      "myModule",
+				FileName:    "config.yml",
+				FileContent: []byte("some yaml content"),
+			},
+		},
 	}
 	assert.NoError(t, p.Insert(t.Context()))
 	raw, err := GetRawPatches(t.Context(), p.Id.Hex())
@@ -564,4 +571,9 @@ func TestGetRawPatches(t *testing.T) {
 	require.Len(t, raw.RawModules, 1)
 	assert.Equal(t, raw.RawModules[0].Name, p.Patches[0].ModuleName)
 	assert.Equal(t, raw.RawModules[0].Githash, p.Patches[0].Githash)
+
+	require.Len(t, raw.LocalModuleIncludes, 1)
+	assert.Equal(t, "myModule", raw.LocalModuleIncludes[0].Module)
+	assert.Equal(t, "config.yml", raw.LocalModuleIncludes[0].FileName)
+	assert.Equal(t, []byte("some yaml content"), raw.LocalModuleIncludes[0].FileContent)
 }

--- a/rest/model/patch.go
+++ b/rest/model/patch.go
@@ -136,6 +136,8 @@ type APIRawPatch struct {
 	Patch APIRawModule `json:"patch"`
 	// The list of module diffs
 	RawModules []APIRawModule `json:"raw_modules"`
+	// LocalModuleIncludes contains module config file overrides from the source patch.
+	LocalModuleIncludes []APILocalModuleInclude `json:"local_module_includes,omitempty"`
 }
 
 // APIRawModule contains a module diff.
@@ -149,8 +151,9 @@ type APIRawModule struct {
 }
 
 type APILocalModuleInclude struct {
-	Module   string `json:"module"`
-	FileName string `json:"filename"`
+	Module      string `json:"module"`
+	FileName    string `json:"filename"`
+	FileContent []byte `json:"file_content,omitempty"`
 }
 
 // ToService converts a service layer parameter using the data from APIParameter

--- a/rest/route/patch_test.go
+++ b/rest/route/patch_test.go
@@ -840,6 +840,13 @@ func TestPatchRawModulesHandler(t *testing.T) {
 				},
 			},
 		},
+		LocalModuleIncludes: []patch.LocalModuleInclude{
+			{
+				Module:      "module1",
+				FileName:    "evergreen.yml",
+				FileContent: []byte("module config override"),
+			},
+		},
 	}
 	assert.NoError(t, patchToInsert.Insert(t.Context()))
 
@@ -863,6 +870,11 @@ func TestPatchRawModulesHandler(t *testing.T) {
 
 	assert.Equal(t, "module2", modules[1].Name)
 	assert.Equal(t, "module2 diff", modules[1].Diff)
+
+	require.Len(t, rawModulesResponse.LocalModuleIncludes, 1)
+	assert.Equal(t, "module1", rawModulesResponse.LocalModuleIncludes[0].Module)
+	assert.Equal(t, "evergreen.yml", rawModulesResponse.LocalModuleIncludes[0].FileName)
+	assert.Equal(t, []byte("module config override"), rawModulesResponse.LocalModuleIncludes[0].FileContent)
 }
 
 func TestPatchRawHandler(t *testing.T) {


### PR DESCRIPTION
DEVPROD-41619

### Description

Patches created with `patch-file --diff-patchId` were missing the source patch's module config changes, causing cloned patches to silently use mainline config instead. 

This adds the module config overrides to the raw patch API response and passes them through to the new patch during creation.
### Testing

Added unit tests. [Verified](https://spruce-staging.corp.mongodb.com/patch/6a99ce2b2c598e00075d88dc/configure/tasks) correct behavior in staging (achieved by running 
```
/Users/malikhadjri/GolandProjects/evergreen/clients/darwin_arm64/evergreen -c ~/evergreen-staging.yml patch-file --diff-patchId 6a99cdd785b97800075c3f4e --variants module-include-test-variant --tasks unit_tests --project sandbox
``` 
which is cloned off of [this](https://spruce-staging.corp.mongodb.com/patch/6a99cdd785b97800075c3f4e/configure/tasks) patch with the original module changes).