### PR TITLE
DEVPROD-42118: Fix merge queue recovery jobs

### DIFF
--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -587,6 +587,24 @@ func FindMergeQueuePatchesByProject(ctx context.Context, projectID string) ([]Pa
 	return Find(ctx, db.Query(query))
 }
 
+// FindAllMergeQueuePatchesByProject reports whether a patch exists for the merge patch with this
+// project, org, repo, and head SHA.
+func FindAllMergeQueuePatchesByProject(ctx context.Context, projectID, org, repo, headSHA string) (bool, error) {
+	query := bson.M{
+		AliasKey:   evergreen.CommitQueueAlias,
+		ProjectKey: projectID,
+		bsonutil.GetDottedKeyName(GithubMergeDataKey, githubMergeGroupOrgKey):     org,
+		bsonutil.GetDottedKeyName(GithubMergeDataKey, githubMergeGroupRepoKey):    repo,
+		bsonutil.GetDottedKeyName(GithubMergeDataKey, githubMergeGroupHeadSHAKey): headSHA,
+	}
+
+	patches, err := Find(ctx, db.Query(query).WithFields(IdKey).Limit(1))
+	if err != nil {
+		return false, errors.Wrap(err, "finding merge queue patches by head SHA")
+	}
+	return len(patches) > 0, nil
+}
+
 // FindFinalizedMergeQueuePatchesMissingCompletionMetrics returns finalized merge queue patches that did not receive
 // a GitHub removal webhook and have not yet had completion metrics emitted.
 func FindFinalizedMergeQueuePatchesMissingCompletionMetrics(ctx context.Context, projectID string) ([]Patch, error) {

--- a/model/patch/db.go
+++ b/model/patch/db.go
@@ -587,15 +587,18 @@ func FindMergeQueuePatchesByProject(ctx context.Context, projectID string) ([]Pa
 	return Find(ctx, db.Query(query))
 }
 
-// FindAllMergeQueuePatchesByProject reports whether a patch exists for the merge patch with this
+// HasDuplicateMergeQueuePatch reports whether a patch exists for the merge patch with this
 // project, org, repo, and head SHA.
-func FindAllMergeQueuePatchesByProject(ctx context.Context, projectID, org, repo, headSHA string) (bool, error) {
+func HasDuplicateMergeQueuePatch(ctx context.Context, projectID, org, repo, headSHA string) (bool, error) {
 	query := bson.M{
 		AliasKey:   evergreen.CommitQueueAlias,
 		ProjectKey: projectID,
 		bsonutil.GetDottedKeyName(GithubMergeDataKey, githubMergeGroupOrgKey):     org,
 		bsonutil.GetDottedKeyName(GithubMergeDataKey, githubMergeGroupRepoKey):    repo,
 		bsonutil.GetDottedKeyName(GithubMergeDataKey, githubMergeGroupHeadSHAKey): headSHA,
+		CreateTimeKey: bson.M{
+			"$gte": time.Now().Add(-24 * time.Hour),
+		},
 	}
 
 	patches, err := Find(ctx, db.Query(query).WithFields(IdKey).Limit(1))

--- a/model/patch/db_test.go
+++ b/model/patch/db_test.go
@@ -919,11 +919,11 @@ func TestHasMergeQueuePatchForHeadSHASeesFinishedPatches(t *testing.T) {
 	}
 	require.NoError(t, db.Insert(t.Context(), Collection, p))
 
-	hasPatch, err := FindAllMergeQueuePatchesByProject(t.Context(), "my-project", "10gen", "mongo", "head-sha")
+	hasPatch, err := HasDuplicateMergeQueuePatch(t.Context(), "my-project", "10gen", "mongo", "head-sha")
 	require.NoError(t, err)
 	assert.True(t, hasPatch)
 
-	hasPatch, err = FindAllMergeQueuePatchesByProject(t.Context(), "my-project", "10gen", "mongo", "other-head-sha")
+	hasPatch, err = HasDuplicateMergeQueuePatch(t.Context(), "my-project", "10gen", "mongo", "other-head-sha")
 	require.NoError(t, err)
 	assert.False(t, hasPatch)
 }

--- a/model/patch/db_test.go
+++ b/model/patch/db_test.go
@@ -904,3 +904,26 @@ func TestFindFinalizedMergeQueuePatchesMissingCompletionMetricsExcludesNonEligib
 	assert.Contains(t, patchIDs, eligible.Id)
 	assert.Contains(t, patchIDs, failedEmit.Id)
 }
+
+func TestHasMergeQueuePatchForHeadSHASeesFinishedPatches(t *testing.T) {
+	t.Cleanup(func() { require.NoError(t, db.ClearCollections(Collection)) })
+	require.NoError(t, db.ClearCollections(Collection))
+
+	p := Patch{
+		Id:              bson.NewObjectId(),
+		Project:         "my-project",
+		Alias:           evergreen.CommitQueueAlias,
+		Status:          evergreen.VersionSucceeded,
+		CreateTime:      time.Now(),
+		GithubMergeData: thirdparty.GithubMergeGroup{Org: "10gen", Repo: "mongo", HeadSHA: "head-sha"},
+	}
+	require.NoError(t, db.Insert(t.Context(), Collection, p))
+
+	hasPatch, err := FindAllMergeQueuePatchesByProject(t.Context(), "my-project", "10gen", "mongo", "head-sha")
+	require.NoError(t, err)
+	assert.True(t, hasPatch)
+
+	hasPatch, err = FindAllMergeQueuePatchesByProject(t.Context(), "my-project", "10gen", "mongo", "other-head-sha")
+	require.NoError(t, err)
+	assert.False(t, hasPatch)
+}

--- a/thirdparty/github.go
+++ b/thirdparty/github.go
@@ -2087,6 +2087,9 @@ type mergeQueueFrontEntryResponse struct {
 			MergeQueue struct {
 				Entries struct {
 					Nodes []struct {
+						BaseCommit struct {
+							Oid string `json:"oid"`
+						} `json:"baseCommit"`
 						HeadCommit struct {
 							Oid string `json:"oid"`
 						} `json:"headCommit"`
@@ -2128,7 +2131,7 @@ func GetMergeQueueFrontEntry(ctx context.Context, owner, repo, baseBranch string
 			repository(owner: $owner, name: $repo) {
 				mergeQueue(branch: $branch) {
 					entries(first: 1) {
-						nodes { headCommit { oid } pullRequest { number } }
+						nodes { baseCommit { oid } headCommit { oid } pullRequest { number } }
 					}
 				}
 			}
@@ -2174,6 +2177,6 @@ func GetMergeQueueFrontEntry(ctx context.Context, owner, repo, baseBranch string
 
 	node := nodes[0]
 	// Merge group refs follow this naming scheme according to GitHub docs.
-	headRef = fmt.Sprintf("refs/heads/gh-readonly-queue/%s/pr-%d-%s", baseBranch, node.PullRequest.Number, node.HeadCommit.Oid)
+	headRef = fmt.Sprintf("refs/heads/gh-readonly-queue/%s/pr-%d-%s", baseBranch, node.PullRequest.Number, node.BaseCommit.Oid)
 	return headRef, node.HeadCommit.Oid, true, nil
 }

--- a/units/merge_queue_patch_recovery.go
+++ b/units/merge_queue_patch_recovery.go
@@ -107,14 +107,12 @@ func (j *mergeQueuePatchRecoveryJob) recoverProject(ctx context.Context, project
 		return nil
 	}
 
-	existingPatches, err := patch.FindMergeQueuePatchesByProject(ctx, projectRef.Id)
+	hasPatch, err := patch.FindAllMergeQueuePatchesByProject(ctx, projectRef.Id, projectRef.Owner, projectRef.Repo, frontSHA)
 	if err != nil {
-		return errors.Wrap(err, "finding active merge queue patches")
+		return errors.Wrap(err, "checking for an existing merge queue patch")
 	}
-	for _, p := range existingPatches {
-		if p.GithubMergeData.HeadSHA == frontSHA {
-			return nil
-		}
+	if hasPatch {
+		return nil
 	}
 
 	if err := j.recoverMergeGroup(ctx, projectRef, frontRef, frontSHA); err != nil {

--- a/units/merge_queue_patch_recovery.go
+++ b/units/merge_queue_patch_recovery.go
@@ -107,7 +107,7 @@ func (j *mergeQueuePatchRecoveryJob) recoverProject(ctx context.Context, project
 		return nil
 	}
 
-	hasPatch, err := patch.FindAllMergeQueuePatchesByProject(ctx, projectRef.Id, projectRef.Owner, projectRef.Repo, frontSHA)
+	hasPatch, err := patch.HasDuplicateMergeQueuePatch(ctx, projectRef.Id, projectRef.Owner, projectRef.Repo, frontSHA)
 	if err != nil {
 		return errors.Wrap(err, "checking for an existing merge queue patch")
 	}


### PR DESCRIPTION
DEVPROD-42118

### Description

fixed 2 merge queue recovery bugs: 
1. cant find existing patches
2. use correct sha

### Testing

unit tests 
staging
1. made a merge queue commit
2. manually deleted patch that was created 
3. verified that recovery job created the [patch](https://spruce.corp.mongodb.com/version/6a97aafbbcf4c00007ba3c64/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) 
4. merged correctly after that finished 