### PR TITLE
DEVPROD-42572: Fix project PATCH route capturing incorrect `before` value

### DIFF
--- a/rest/route/project.go
+++ b/rest/route/project.go
@@ -293,7 +293,7 @@ func (h *projectIDPatchHandler) Run(ctx context.Context) gimlet.Responder {
 		return gimlet.MakeJSONErrorResponder(errors.Wrap(err, "validating project repotracker"))
 	}
 
-	before, err := dbModel.GetProjectSettings(ctx, h.newProjectRef)
+	before, err := dbModel.GetProjectSettings(ctx, h.originalProject)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "getting original project settings for project '%s'", h.newProjectRef.Identifier))
 	}

--- a/rest/route/project_test.go
+++ b/rest/route/project_test.go
@@ -50,7 +50,7 @@ func TestProjectPatchSuite(t *testing.T) {
 
 func (s *ProjectPatchByIDSuite) SetupTest() {
 	s.NoError(db.ClearCollections(serviceModel.RepoRefCollection, user.Collection, serviceModel.ProjectRefCollection, serviceModel.ProjectVarsCollection, fakeparameter.Collection, serviceModel.RepositoriesCollection, serviceModel.ProjectAliasCollection,
-		evergreen.ScopeCollection, evergreen.RoleCollection, evergreen.ConfigCollection))
+		evergreen.ScopeCollection, evergreen.RoleCollection, evergreen.ConfigCollection, event.EventCollection))
 	user := user.DBUser{
 		Id:          "langdon.alger",
 		SystemRoles: []string{"admin"},
@@ -511,6 +511,33 @@ func (s *ProjectPatchByIDSuite) TestRunEveryMainlineCommit() {
 	s.NoError(err)
 	s.NotNil(pRef.RunEveryMainlineCommit)
 	s.True(*pRef.RunEveryMainlineCommit)
+}
+
+func (s *ProjectPatchByIDSuite) TestEventLogCapturesOriginalProjectSettings() {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctx = gimlet.AttachUser(ctx, &user.DBUser{Id: "me"})
+
+	originalDisplayName := "Dimoxinil"
+
+	newDisplayName := "New Display Name"
+	jsonBody := []byte(fmt.Sprintf(`{"display_name": %q}`, newDisplayName))
+	req, _ := http.NewRequest(http.MethodPatch, "http://example.com/api/rest/v2/projects/dimoxinil", bytes.NewBuffer(jsonBody))
+	req = gimlet.SetURLVars(req, map[string]string{"project_id": "dimoxinil"})
+	err := s.rm.Parse(ctx, req)
+	s.NoError(err)
+
+	resp := s.rm.Run(ctx)
+	s.Require().Equal(http.StatusOK, resp.Status())
+
+	events, err := serviceModel.MostRecentProjectEvents(s.T().Context(), "dimoxinil", 1)
+	s.NoError(err)
+	s.Require().Len(events, 1)
+
+	eventData, ok := events[0].Data.(*serviceModel.ProjectChangeEvent)
+	s.Require().True(ok)
+	s.Equal(originalDisplayName, eventData.Before.ProjectRef.DisplayName, "before snapshot should have the original display name")
+	s.Equal(newDisplayName, eventData.After.ProjectRef.DisplayName, "after snapshot should have the new display name")
 }
 
 ////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
DEVPROD-42572

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

This was a pre-existing bug that may have been here for a while, but I didn't catch it when I was updating this part of the codebase 😔 Anyways, the `before` value should be set to the original project, not the new project.

Only affects project event logging.

### Testing

* Added a test that fails without this change