### PR TITLE
DEVPROD-30684 Activate unscheduled execution tasks on display task restart

### DIFF
--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -2441,6 +2441,26 @@ func TestDisplayTaskRestart(t *testing.T) {
 		assert.Equal(evergreen.TaskUndispatched, dbTask.Status, dbTask.Id)
 		assert.True(dbTask.Activated, dbTask.Id)
 	}
+
+	// test that restarting a display task activates unscheduled execution tasks via resetTask
+	assert.NoError(resetTaskData())
+	assert.NoError(resetTask(ctx, "displayTask1", "caller"))
+	unscheduledTask, err := task.FindOneId(ctx, "task8")
+	assert.NoError(err)
+	require.NotNil(t, unscheduledTask)
+	assert.Equal(evergreen.TaskUndispatched, unscheduledTask.Status)
+	assert.True(unscheduledTask.Activated)
+	assert.Equal("caller", unscheduledTask.ActivatedBy)
+
+	// test that restarting a version activates unscheduled execution tasks
+	assert.NoError(resetTaskData())
+	assert.NoError(RestartVersion(ctx, "version", displayTasks, false, "test"))
+	unscheduledTask, err = task.FindOneId(ctx, "task8")
+	assert.NoError(err)
+	require.NotNil(t, unscheduledTask)
+	assert.Equal(evergreen.TaskUndispatched, unscheduledTask.Status)
+	assert.True(unscheduledTask.Activated)
+	assert.Equal("test", unscheduledTask.ActivatedBy)
 }
 
 func TestResetTaskOrDisplayTask(t *testing.T) {
@@ -2701,6 +2721,18 @@ func resetTaskData() error {
 	if err := task7.Insert(ctx); err != nil {
 		return err
 	}
+	task8 := &task.Task{
+		Id:            "task8",
+		DisplayName:   "task8",
+		BuildId:       build3.Id,
+		Version:       v.Id,
+		DisplayTaskId: utility.ToStringPtr("displayTask1"),
+		Status:        evergreen.TaskUndispatched,
+		Activated:     false,
+	}
+	if err := task8.Insert(ctx); err != nil {
+		return err
+	}
 	displayTask1 := &task.Task{
 		Id:             "displayTask1",
 		DisplayName:    "displayTask1",
@@ -2710,7 +2742,7 @@ func resetTaskData() error {
 		Version:        v.Id,
 		DisplayTaskId:  utility.ToStringPtr(""),
 		DisplayOnly:    true,
-		ExecutionTasks: []string{task5.Id, task6.Id},
+		ExecutionTasks: []string{task5.Id, task6.Id, task8.Id},
 		Status:         evergreen.TaskFailed,
 		Activated:      true,
 		DispatchTime:   time.Now(),

--- a/model/lifecycle_test.go
+++ b/model/lifecycle_test.go
@@ -2509,10 +2509,15 @@ func TestResetTaskOrDisplayTask(t *testing.T) {
 			require.NotNil(t, successfulExecTask)
 			assert.Equal(t, evergreen.TaskSucceeded, successfulExecTask.Status, "successful execution task should not be reset")
 
+			unscheduledExecTask, err := task.FindOneId(ctx, "task8")
+			assert.NoError(t, err)
+			require.NotNil(t, unscheduledExecTask)
+			assert.False(t, unscheduledExecTask.Activated, "unscheduled execution task should not be activated for failed-only restart")
+
 			dbUser, err := user.FindOneById(t.Context(), "caller")
 			assert.NoError(t, err)
 			require.NotNil(t, dbUser)
-			assert.Equal(t, len(dt.ExecutionTasks), dbUser.NumScheduledPatchTasks)
+			assert.Equal(t, 2, dbUser.NumScheduledPatchTasks, "scheduling limit should only count activated execution tasks")
 
 			assert.NoError(t, ResetTaskOrDisplayTask(ctx, settings, dt, "caller", evergreen.StepbackTaskActivator, true, nil))
 			dt, err = task.FindOneId(ctx, "displayTask1")

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -1740,6 +1740,36 @@ func ActivateTasks(ctx context.Context, tasks []Task, activationTime time.Time, 
 	return activatedTaskIDs, nil
 }
 
+// ActivateUnscheduledTasks activates tasks that are unscheduled (undispatched
+// and deactivated). This is used during display task restarts to activate
+// execution tasks that were never scheduled and therefore could not be handled
+// by ResetTasks.
+func ActivateUnscheduledTasks(ctx context.Context, taskIDs []string, caller string) error {
+	if len(taskIDs) == 0 {
+		return nil
+	}
+	_, err := UpdateAll(
+		ctx,
+		bson.M{
+			IdKey:        bson.M{"$in": taskIDs},
+			StatusKey:    evergreen.TaskUndispatched,
+			ActivatedKey: false,
+		},
+		[]bson.M{
+			{
+				"$set": bson.M{
+					ActivatedKey:     true,
+					ActivatedByKey:   caller,
+					ActivatedTimeKey: time.Now(),
+				},
+			},
+			{"$unset": bson.A{CanResetKey}},
+			addDisplayStatusCache,
+		},
+	)
+	return errors.Wrap(err, "activating unscheduled tasks")
+}
+
 // UpdateSchedulingLimit retrieves a user from the DB and updates their hourly scheduling limit info
 // if they are not a service user.
 func UpdateSchedulingLimit(ctx context.Context, username, requester, projectID, repoRefID string, numTasksModified int, activated bool) error {
@@ -3007,6 +3037,20 @@ func ArchiveMany(ctx context.Context, tasks []Task) error {
 				}
 				archivedTasks = append(archivedTasks, et.makeArchivedTask())
 				toUpdateExecTaskIds = append(toUpdateExecTaskIds, et.Id)
+			}
+
+			if !t.IsRestartFailedOnly() {
+				unscheduledExecTasks, err := FindAll(ctx, db.Query(bson.M{
+					IdKey:        bson.M{"$in": t.ExecutionTasks},
+					StatusKey:    evergreen.TaskUndispatched,
+					ActivatedKey: false,
+				}))
+				if err != nil {
+					return errors.Wrapf(err, "finding unscheduled execution tasks for display task '%s'", t.Id)
+				}
+				for _, et := range unscheduledExecTasks {
+					toUpdateExecTaskIds = append(toUpdateExecTaskIds, et.Id)
+				}
 			}
 		}
 	}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3257,7 +3257,7 @@ func (t *Task) SetResetWhenFinished(ctx context.Context, caller, repoRefID strin
 	if t.ResetWhenFinished {
 		return nil
 	}
-	if err := updateSchedulingLimitForResetWhenFinished(ctx, t, caller, repoRefID); err != nil {
+	if err := updateSchedulingLimitForResetWhenFinished(ctx, t, caller, repoRefID, true); err != nil {
 		return errors.Wrapf(err, "updating user '%s' patch task scheduling limit", caller)
 	}
 	t.ResetFailedWhenFinished = false
@@ -3318,7 +3318,7 @@ func (t *Task) SetResetFailedWhenFinished(ctx context.Context, caller, repoRefID
 	if t.ResetFailedWhenFinished {
 		return nil
 	}
-	if err := updateSchedulingLimitForResetWhenFinished(ctx, t, caller, repoRefID); err != nil {
+	if err := updateSchedulingLimitForResetWhenFinished(ctx, t, caller, repoRefID, false); err != nil {
 		return errors.Wrapf(err, "updating user '%s' patch task scheduling limit", caller)
 	}
 	t.ResetWhenFinished = false
@@ -3342,7 +3342,7 @@ func (t *Task) SetResetFailedWhenFinished(ctx context.Context, caller, repoRefID
 // updateSchedulingLimitForResetWhenFinished is the same as
 // UpdateSchedulingLimit but only applies if the task is being reset when
 // finished.
-func updateSchedulingLimitForResetWhenFinished(ctx context.Context, t *Task, caller, repoRefID string) error {
+func updateSchedulingLimitForResetWhenFinished(ctx context.Context, t *Task, caller, repoRefID string, countUnscheduled bool) error {
 	if !(t.Requester == evergreen.PatchVersionRequester || t.Requester == evergreen.GithubPRRequester) || evergreen.IsSystemActivator(caller) {
 		return nil
 	}
@@ -3362,7 +3362,21 @@ func updateSchedulingLimitForResetWhenFinished(ctx context.Context, t *Task, cal
 	if len(tasks) == 0 {
 		return nil
 	}
-	return errors.Wrap(CheckUsersPatchTaskLimit(ctx, t.Requester, caller, repoRefID, true, tasks...), "updating patch task limit for user")
+	if err := CheckUsersPatchTaskLimit(ctx, t.Requester, caller, repoRefID, true, tasks...); err != nil {
+		return errors.Wrap(err, "updating patch task limit for user")
+	}
+	if countUnscheduled {
+		numUnscheduled := 0
+		for _, et := range tasks {
+			if et.IsUnscheduled() {
+				numUnscheduled++
+			}
+		}
+		if numUnscheduled > 0 {
+			return UpdateSchedulingLimit(ctx, caller, t.Requester, tasks[0].Project, repoRefID, numUnscheduled, true)
+		}
+	}
+	return nil
 }
 
 // CheckUsersPatchTaskLimit takes in an input list of tasks that is set to get activated, and checks if they're

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3024,7 +3024,23 @@ func ArchiveMany(ctx context.Context, tasks []Task) error {
 			if err != nil {
 				return errors.Wrapf(err, "finding execution tasks for display task '%s'", t.Id)
 			}
-			execTaskIds = append(execTaskIds, t.ExecutionTasks...)
+			unscheduledExecTasks, err := FindAll(ctx, db.Query(bson.M{
+				IdKey:        bson.M{"$in": t.ExecutionTasks},
+				StatusKey:    evergreen.TaskUndispatched,
+				ActivatedKey: false,
+			}))
+			if err != nil {
+				return errors.Wrapf(err, "finding unscheduled execution tasks for display task '%s'", t.Id)
+			}
+			unscheduledExecTaskIDs := map[string]bool{}
+			for _, et := range unscheduledExecTasks {
+				unscheduledExecTaskIDs[et.Id] = true
+			}
+			for _, etID := range t.ExecutionTasks {
+				if !unscheduledExecTaskIDs[etID] {
+					execTaskIds = append(execTaskIds, etID)
+				}
+			}
 			for _, et := range execTasks {
 				if !utility.StringSliceContains(evergreen.TaskCompletedStatuses, et.Status) {
 					grip.Debug(ctx, message.Fields{
@@ -3037,20 +3053,6 @@ func ArchiveMany(ctx context.Context, tasks []Task) error {
 				}
 				archivedTasks = append(archivedTasks, et.makeArchivedTask())
 				toUpdateExecTaskIds = append(toUpdateExecTaskIds, et.Id)
-			}
-
-			if !t.IsRestartFailedOnly() {
-				unscheduledExecTasks, err := FindAll(ctx, db.Query(bson.M{
-					IdKey:        bson.M{"$in": t.ExecutionTasks},
-					StatusKey:    evergreen.TaskUndispatched,
-					ActivatedKey: false,
-				}))
-				if err != nil {
-					return errors.Wrapf(err, "finding unscheduled execution tasks for display task '%s'", t.Id)
-				}
-				for _, et := range unscheduledExecTasks {
-					toUpdateExecTaskIds = append(toUpdateExecTaskIds, et.Id)
-				}
 			}
 		}
 	}

--- a/model/task/task.go
+++ b/model/task/task.go
@@ -3024,11 +3024,11 @@ func ArchiveMany(ctx context.Context, tasks []Task) error {
 			if err != nil {
 				return errors.Wrapf(err, "finding execution tasks for display task '%s'", t.Id)
 			}
-			unscheduledExecTasks, err := FindAll(ctx, db.Query(bson.M{
+			unscheduledExecTasks, err := FindWithFields(ctx, bson.M{
 				IdKey:        bson.M{"$in": t.ExecutionTasks},
 				StatusKey:    evergreen.TaskUndispatched,
 				ActivatedKey: false,
-			}))
+			}, IdKey)
 			if err != nil {
 				return errors.Wrapf(err, "finding unscheduled execution tasks for display task '%s'", t.Id)
 			}

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2355,6 +2355,10 @@ func MarkTasksReset(ctx context.Context, taskIds []string, caller string) error 
 		return errors.Wrap(err, "resetting tasks in database")
 	}
 
+	if err = task.ActivateUnscheduledTasks(ctx, taskIds, caller); err != nil {
+		return errors.Wrap(err, "activating unscheduled tasks during reset")
+	}
+
 	catcher := grip.NewBasicCatcher()
 	catcher.Wrapf(UpdateUnblockedDependencies(ctx, tasks), "clearing unattainable dependencies for tasks")
 	for _, t := range tasks {

--- a/model/task_lifecycle.go
+++ b/model/task_lifecycle.go
@@ -2355,8 +2355,23 @@ func MarkTasksReset(ctx context.Context, taskIds []string, caller string) error 
 		return errors.Wrap(err, "resetting tasks in database")
 	}
 
+	numUnscheduled := 0
+	for _, t := range tasks {
+		if t.IsUnscheduled() {
+			numUnscheduled++
+		}
+	}
 	if err = task.ActivateUnscheduledTasks(ctx, taskIds, caller); err != nil {
 		return errors.Wrap(err, "activating unscheduled tasks during reset")
+	}
+	if numUnscheduled > 0 && len(tasks) > 0 {
+		repoRefID, err := getRepoRefIDForTasks(ctx, tasks)
+		if err != nil {
+			return errors.Wrap(err, "getting repo for unscheduled task scheduling limit")
+		}
+		if err := task.UpdateSchedulingLimit(ctx, caller, tasks[0].Requester, tasks[0].Project, repoRefID, numUnscheduled, true); err != nil {
+			return errors.Wrap(err, "updating scheduling limit for activated unscheduled tasks")
+		}
 	}
 
 	catcher := grip.NewBasicCatcher()


### PR DESCRIPTION
DEVPROD-30684

### Description

Restarting a display task silently skips any execution tasks that were unscheduled. The archive and reset filters both gate on completed statuses, so unscheduled tasks fell through both and were left behind permanently.

Now `MarkTasksReset` activates unscheduled execution tasks after resetting the completed ones, and `ArchiveMany` excludes them from the archive transaction so their execution number isn't bumped if they never ran on their most recent execution number.
### Testing
Reproduced bug in [staging](https://spruce-staging.corp.mongodb.com/task/evg_build_and_push_display_build_and_push_e6cc853794f3e113113def79140973cdeeb1d7f5_26_09_02_14_39_28/execution-tasks?execution=1&sorts=STATUS%3AASC) and then also verified the fix in [staging](https://spruce-staging.corp.mongodb.com/task/evg_build_and_push_display_build_and_push_2239e32d5fdf2aa5dd22ae267e2058485dff4a8f_26_09_01_15_24_04/execution-tasks?execution=1&sorts=STATUS%3AASC). In the latter link restarting the display task moved all execution tasks to will-run
