### PR TITLE
DEVPROD-42674: Change manifest failures to 5xxs from 4xxs

### DIFF
--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -1608,13 +1608,13 @@ func (h *manifestLoadHandler) Run(ctx context.Context) gimlet.Responder {
 	}
 	currentManifest, err := manifest.FindFromVersion(ctx, v.Id, v.Identifier, v.Revision, v.Requester)
 	if err != nil {
-		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "retrieving manifest with version id '%s'", t.Version))
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "retrieving manifest with version id '%s'", t.Version))
 	}
 
 	env := evergreen.GetEnvironment()
 	project, _, err := model.FindAndTranslateProjectForVersion(ctx, env.Settings(), v, false)
 	if err != nil {
-		return gimlet.MakeJSONErrorResponder(errors.Wrapf(err, "loading project from version"))
+		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "loading project from version"))
 	}
 	if project == nil {
 		return gimlet.MakeJSONErrorResponder(gimlet.ErrorResponse{

--- a/rest/route/agent_test.go
+++ b/rest/route/agent_test.go
@@ -2167,3 +2167,37 @@ func TestGetParserProject(t *testing.T) {
 		})
 	}
 }
+
+func TestManifestLoadParserProjectStorageErrorShouldBeInternalServerError(t *testing.T) {
+	ctx := t.Context()
+
+	env := &mock.Environment{}
+	require.NoError(t, env.Configure(ctx))
+
+	collections := []string{manifest.Collection, model.ProjectRefCollection, model.VersionCollection}
+	require.NoError(t, db.ClearCollections(collections...))
+	t.Cleanup(func() {
+		assert.NoError(t, db.ClearCollections(collections...))
+	})
+
+	const (
+		projectID = "project"
+		versionID = "version"
+	)
+	require.NoError(t, (&model.ProjectRef{Id: projectID}).Insert(ctx))
+	require.NoError(t, (&model.Version{
+		Id:                   versionID,
+		Identifier:           projectID,
+		ProjectStorageMethod: evergreen.ParserProjectStorageMethod("invalid"),
+	}).Insert(ctx))
+
+	tsk := &task.Task{Project: projectID, Version: versionID}
+	ctx = context.WithValue(ctx, model.ApiTaskKey, tsk)
+	h := &manifestLoadHandler{settings: env.Settings()}
+
+	resp := h.Run(ctx)
+	require.Equal(t, http.StatusInternalServerError, resp.Status())
+	errResp, ok := resp.Data().(gimlet.ErrorResponse)
+	require.True(t, ok)
+	assert.Contains(t, errResp.Message, "loading project from version")
+}


### PR DESCRIPTION
DEVPROD-42674

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
We were returning a client error when we failed from `FindFromVersion` or `FindAndTranslateProjectForVersion`. Because we returned a client error there was [no retries](https://github.com/evergreen-ci/utility/blob/06cd8a26cd5e/http.go#L419-L425) so if there was any hiccups, we'd hard fail the request. You can see an example [here](https://ui.honeycomb.io/mongodb-4b/environments/production/result/mN5rhUrbkG2/trace/sm9J9UnMc8e?fields[]=s_name&fields[]=s_serviceName&span=f12e3037777e7eb0).

<!--add description, context, thought process, etc-->

### Testing
* Added tests