### PR TITLE
DEVPROD-38023 Log server-side error when creating installation token fails

### DIFF
--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -2162,6 +2162,12 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 		Permissions: permissions,
 	}, true)
 	if err != nil {
+		grip.Error(ctx, message.WrapError(err, message.Fields{
+			"message": "creating installation token",
+			"task":    t.Id,
+			"owner":   h.owner,
+			"repo":    h.repo,
+		}))
 		// This intentionally returns a 4xx error to prevent the agent from
 		// retrying because CreateInstallationToken already retries internally,
 		// including (potentially) transient "Bad Request" responses from GitHub.

--- a/rest/route/agent.go
+++ b/rest/route/agent.go
@@ -2163,10 +2163,12 @@ func (h *createGitHubDynamicAccessToken) Run(ctx context.Context) gimlet.Respond
 	}, true)
 	if err != nil {
 		grip.Error(ctx, message.WrapError(err, message.Fields{
-			"message": "creating installation token",
-			"task":    t.Id,
-			"owner":   h.owner,
-			"repo":    h.repo,
+			"message":    "creating installation token",
+			"task_id":    t.Id,
+			"owner":      h.owner,
+			"repo":       h.repo,
+			"project_id": t.Project,
+			"app_id":     githubAppAuth.AppID,
 		}))
 		// This intentionally returns a 4xx error to prevent the agent from
 		// retrying because CreateInstallationToken already retries internally,


### PR DESCRIPTION
DEVPROD-38023

### Description

The change from #10724 for this ticket targeted transient 400s from GitHub's API, but the 400 the agent sees actually comes from gimlet defaulting any error to HTTP 400, and GitHub itself never returned a 400 on this path. The agent's `RetryRequest` discards the response body, so the actual error is lost. This adds a server-side log so the root cause is captured in Splunk before I work on a further fix.