### PR TITLE
DEVPROD-38057: Unlink REST models for `GithubPatchData`, `IncludedLocalModules`, and `ChildPatchAlias`

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -140,8 +140,6 @@ models:
     model: github.com/evergreen-ci/evergreen/rest/model.APICedarConfig
   ChildPatch:
     model: github.com/evergreen-ci/evergreen/rest/model.ChildPatch
-  ChildPatchAlias:
-    model: github.com/evergreen-ci/evergreen/rest/model.APIChildPatchAlias
   ClientBinary:
     model: github.com/evergreen-ci/evergreen/rest/model.APIClientBinary
   ClientConfig:
@@ -306,7 +304,7 @@ models:
   GitHubDynamicTokenPermissionGroup:
     model: github.com/evergreen-ci/evergreen/rest/model.APIGitHubDynamicTokenPermissionGroup
   GithubPatch:
-    model: github.com/evergreen-ci/evergreen/rest/model.APIGithubPatch
+    model: github.com/evergreen-ci/evergreen/thirdparty.GithubPatch
   GithubProjectConflicts:
     model: github.com/evergreen-ci/evergreen/model.GithubProjectConflicts
   GithubPRSubscriber:
@@ -573,7 +571,7 @@ models:
     model: github.com/evergreen-ci/evergreen/model/patch.Patch
     fields:
       includedLocalModules:
-        resolver: true
+        fieldName: "LocalModuleIncludes"
       parameters:
         resolver: true
   Patches:
@@ -583,7 +581,7 @@ models:
       patches:
         resolver: true
   IncludedLocalModule:
-    model: github.com/evergreen-ci/evergreen/rest/model.APILocalModuleInclude
+    model: github.com/evergreen-ci/evergreen/model/patch.LocalModuleInclude
   PatchTriggerAlias:
     model: github.com/evergreen-ci/evergreen/rest/model.APIPatchTriggerDefinition
   PatchTriggerAliasInput:
@@ -1028,8 +1026,6 @@ models:
   VariantQuarantineStatus:
     model: github.com/evergreen-ci/evergreen/rest/model.APIVariantQuarantineStatus
   VariantTask:
-    model: github.com/evergreen-ci/evergreen/rest/model.VariantTask
-  VariantTaskInput:
     model: github.com/evergreen-ci/evergreen/rest/model.VariantTask
   Version:
     model: github.com/evergreen-ci/evergreen/rest/model.APIVersion

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -1194,9 +1194,9 @@ type ComplexityRoot struct {
 		GithubPatchData       func(childComplexity int) int
 		Hidden                func(childComplexity int) int
 		ID                    func(childComplexity int) int
-		IncludedLocalModules  func(childComplexity int) int
 		IngestTime            func(childComplexity int) int
 		InvalidatedByUpstream func(childComplexity int) int
+		LocalModuleIncludes   func(childComplexity int) int
 		ModuleCodeChanges     func(childComplexity int) int
 		Parameters            func(childComplexity int) int
 		PatchNumber           func(childComplexity int) int
@@ -2626,14 +2626,10 @@ type MutationResolver interface {
 type PatchResolver interface {
 	ID(ctx context.Context, obj *patch.Patch) (string, error)
 
-	ChildPatchAliases(ctx context.Context, obj *patch.Patch) ([]*model.APIChildPatchAlias, error)
+	ChildPatchAliases(ctx context.Context, obj *patch.Patch) ([]*ChildPatchAlias, error)
 	ChildPatches(ctx context.Context, obj *patch.Patch) ([]*patch.Patch, error)
 
 	GeneratedTaskCounts(ctx context.Context, obj *patch.Patch) ([]*GeneratedTaskCountResults, error)
-
-	GithubPatchData(ctx context.Context, obj *patch.Patch) (*model.APIGithubPatch, error)
-
-	IncludedLocalModules(ctx context.Context, obj *patch.Patch) ([]*model.APILocalModuleInclude, error)
 
 	InvalidatedByUpstream(ctx context.Context, obj *patch.Patch) (bool, error)
 	ModuleCodeChanges(ctx context.Context, obj *patch.Patch) ([]*model.APIModulePatch, error)
@@ -7580,12 +7576,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Patch.ID(childComplexity), true
-	case "Patch.includedLocalModules":
-		if e.complexity.Patch.IncludedLocalModules == nil {
-			break
-		}
-
-		return e.complexity.Patch.IncludedLocalModules(childComplexity), true
 	case "Patch.ingestTime":
 		if e.complexity.Patch.IngestTime == nil {
 			break
@@ -7598,6 +7588,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Patch.InvalidatedByUpstream(childComplexity), true
+	case "Patch.includedLocalModules":
+		if e.complexity.Patch.LocalModuleIncludes == nil {
+			break
+		}
+
+		return e.complexity.Patch.LocalModuleIncludes(childComplexity), true
 	case "Patch.moduleCodeChanges":
 		if e.complexity.Patch.ModuleCodeChanges == nil {
 			break
@@ -23904,7 +23900,7 @@ func (ec *executionContext) fieldContext_CedarConfig_dbName(_ context.Context, f
 	return fc, nil
 }
 
-func (ec *executionContext) _ChildPatchAlias_alias(ctx context.Context, field graphql.CollectedField, obj *model.APIChildPatchAlias) (ret graphql.Marshaler) {
+func (ec *executionContext) _ChildPatchAlias_alias(ctx context.Context, field graphql.CollectedField, obj *ChildPatchAlias) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -23914,7 +23910,7 @@ func (ec *executionContext) _ChildPatchAlias_alias(ctx context.Context, field gr
 			return obj.Alias, nil
 		},
 		nil,
-		ec.marshalNString2ᚖstring,
+		ec.marshalNString2string,
 		true,
 		true,
 	)
@@ -23933,7 +23929,7 @@ func (ec *executionContext) fieldContext_ChildPatchAlias_alias(_ context.Context
 	return fc, nil
 }
 
-func (ec *executionContext) _ChildPatchAlias_patchId(ctx context.Context, field graphql.CollectedField, obj *model.APIChildPatchAlias) (ret graphql.Marshaler) {
+func (ec *executionContext) _ChildPatchAlias_patchId(ctx context.Context, field graphql.CollectedField, obj *ChildPatchAlias) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -23943,7 +23939,7 @@ func (ec *executionContext) _ChildPatchAlias_patchId(ctx context.Context, field 
 			return obj.PatchID, nil
 		},
 		nil,
-		ec.marshalNString2ᚖstring,
+		ec.marshalNString2string,
 		true,
 		true,
 	)
@@ -28934,7 +28930,7 @@ func (ec *executionContext) fieldContext_GithubPRSubscriber_repo(_ context.Conte
 	return fc, nil
 }
 
-func (ec *executionContext) _GithubPatch_author(ctx context.Context, field graphql.CollectedField, obj *model.APIGithubPatch) (ret graphql.Marshaler) {
+func (ec *executionContext) _GithubPatch_author(ctx context.Context, field graphql.CollectedField, obj *thirdparty.GithubPatch) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -28944,7 +28940,7 @@ func (ec *executionContext) _GithubPatch_author(ctx context.Context, field graph
 			return obj.Author, nil
 		},
 		nil,
-		ec.marshalOString2ᚖstring,
+		ec.marshalOString2string,
 		true,
 		false,
 	)
@@ -28963,7 +28959,7 @@ func (ec *executionContext) fieldContext_GithubPatch_author(_ context.Context, f
 	return fc, nil
 }
 
-func (ec *executionContext) _GithubPatch_baseOwner(ctx context.Context, field graphql.CollectedField, obj *model.APIGithubPatch) (ret graphql.Marshaler) {
+func (ec *executionContext) _GithubPatch_baseOwner(ctx context.Context, field graphql.CollectedField, obj *thirdparty.GithubPatch) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -28973,7 +28969,7 @@ func (ec *executionContext) _GithubPatch_baseOwner(ctx context.Context, field gr
 			return obj.BaseOwner, nil
 		},
 		nil,
-		ec.marshalOString2ᚖstring,
+		ec.marshalOString2string,
 		true,
 		false,
 	)
@@ -28992,7 +28988,7 @@ func (ec *executionContext) fieldContext_GithubPatch_baseOwner(_ context.Context
 	return fc, nil
 }
 
-func (ec *executionContext) _GithubPatch_baseRepo(ctx context.Context, field graphql.CollectedField, obj *model.APIGithubPatch) (ret graphql.Marshaler) {
+func (ec *executionContext) _GithubPatch_baseRepo(ctx context.Context, field graphql.CollectedField, obj *thirdparty.GithubPatch) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -29002,7 +28998,7 @@ func (ec *executionContext) _GithubPatch_baseRepo(ctx context.Context, field gra
 			return obj.BaseRepo, nil
 		},
 		nil,
-		ec.marshalOString2ᚖstring,
+		ec.marshalOString2string,
 		true,
 		false,
 	)
@@ -29021,7 +29017,7 @@ func (ec *executionContext) fieldContext_GithubPatch_baseRepo(_ context.Context,
 	return fc, nil
 }
 
-func (ec *executionContext) _GithubPatch_headBranch(ctx context.Context, field graphql.CollectedField, obj *model.APIGithubPatch) (ret graphql.Marshaler) {
+func (ec *executionContext) _GithubPatch_headBranch(ctx context.Context, field graphql.CollectedField, obj *thirdparty.GithubPatch) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -29031,7 +29027,7 @@ func (ec *executionContext) _GithubPatch_headBranch(ctx context.Context, field g
 			return obj.HeadBranch, nil
 		},
 		nil,
-		ec.marshalOString2ᚖstring,
+		ec.marshalOString2string,
 		true,
 		false,
 	)
@@ -29050,7 +29046,7 @@ func (ec *executionContext) fieldContext_GithubPatch_headBranch(_ context.Contex
 	return fc, nil
 }
 
-func (ec *executionContext) _GithubPatch_headHash(ctx context.Context, field graphql.CollectedField, obj *model.APIGithubPatch) (ret graphql.Marshaler) {
+func (ec *executionContext) _GithubPatch_headHash(ctx context.Context, field graphql.CollectedField, obj *thirdparty.GithubPatch) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -29060,7 +29056,7 @@ func (ec *executionContext) _GithubPatch_headHash(ctx context.Context, field gra
 			return obj.HeadHash, nil
 		},
 		nil,
-		ec.marshalOString2ᚖstring,
+		ec.marshalOString2string,
 		true,
 		false,
 	)
@@ -29079,7 +29075,7 @@ func (ec *executionContext) fieldContext_GithubPatch_headHash(_ context.Context,
 	return fc, nil
 }
 
-func (ec *executionContext) _GithubPatch_headOwner(ctx context.Context, field graphql.CollectedField, obj *model.APIGithubPatch) (ret graphql.Marshaler) {
+func (ec *executionContext) _GithubPatch_headOwner(ctx context.Context, field graphql.CollectedField, obj *thirdparty.GithubPatch) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -29089,7 +29085,7 @@ func (ec *executionContext) _GithubPatch_headOwner(ctx context.Context, field gr
 			return obj.HeadOwner, nil
 		},
 		nil,
-		ec.marshalOString2ᚖstring,
+		ec.marshalOString2string,
 		true,
 		false,
 	)
@@ -29108,7 +29104,7 @@ func (ec *executionContext) fieldContext_GithubPatch_headOwner(_ context.Context
 	return fc, nil
 }
 
-func (ec *executionContext) _GithubPatch_headRepo(ctx context.Context, field graphql.CollectedField, obj *model.APIGithubPatch) (ret graphql.Marshaler) {
+func (ec *executionContext) _GithubPatch_headRepo(ctx context.Context, field graphql.CollectedField, obj *thirdparty.GithubPatch) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -29118,7 +29114,7 @@ func (ec *executionContext) _GithubPatch_headRepo(ctx context.Context, field gra
 			return obj.HeadRepo, nil
 		},
 		nil,
-		ec.marshalOString2ᚖstring,
+		ec.marshalOString2string,
 		true,
 		false,
 	)
@@ -29137,7 +29133,7 @@ func (ec *executionContext) fieldContext_GithubPatch_headRepo(_ context.Context,
 	return fc, nil
 }
 
-func (ec *executionContext) _GithubPatch_prNumber(ctx context.Context, field graphql.CollectedField, obj *model.APIGithubPatch) (ret graphql.Marshaler) {
+func (ec *executionContext) _GithubPatch_prNumber(ctx context.Context, field graphql.CollectedField, obj *thirdparty.GithubPatch) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -34228,7 +34224,7 @@ func (ec *executionContext) fieldContext_ImageToolchainsPayload_totalCount(_ con
 	return fc, nil
 }
 
-func (ec *executionContext) _IncludedLocalModule_module(ctx context.Context, field graphql.CollectedField, obj *model.APILocalModuleInclude) (ret graphql.Marshaler) {
+func (ec *executionContext) _IncludedLocalModule_module(ctx context.Context, field graphql.CollectedField, obj *patch.LocalModuleInclude) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -34257,7 +34253,7 @@ func (ec *executionContext) fieldContext_IncludedLocalModule_module(_ context.Co
 	return fc, nil
 }
 
-func (ec *executionContext) _IncludedLocalModule_fileName(ctx context.Context, field graphql.CollectedField, obj *model.APILocalModuleInclude) (ret graphql.Marshaler) {
+func (ec *executionContext) _IncludedLocalModule_fileName(ctx context.Context, field graphql.CollectedField, obj *patch.LocalModuleInclude) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -44447,7 +44443,7 @@ func (ec *executionContext) _Patch_childPatchAliases(ctx context.Context, field 
 			return ec.resolvers.Patch().ChildPatchAliases(ctx, obj)
 		},
 		nil,
-		ec.marshalNChildPatchAlias2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIChildPatchAliasᚄ,
+		ec.marshalNChildPatchAlias2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐChildPatchAliasᚄ,
 		true,
 		true,
 	)
@@ -44690,10 +44686,10 @@ func (ec *executionContext) _Patch_githubPatchData(ctx context.Context, field gr
 		field,
 		ec.fieldContext_Patch_githubPatchData,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Patch().GithubPatchData(ctx, obj)
+			return obj.GithubPatchData, nil
 		},
 		nil,
-		ec.marshalOGithubPatch2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIGithubPatch,
+		ec.marshalOGithubPatch2githubᚗcomᚋevergreenᚑciᚋevergreenᚋthirdpartyᚐGithubPatch,
 		true,
 		false,
 	)
@@ -44703,8 +44699,8 @@ func (ec *executionContext) fieldContext_Patch_githubPatchData(_ context.Context
 	fc = &graphql.FieldContext{
 		Object:     "Patch",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "author":
@@ -44766,10 +44762,10 @@ func (ec *executionContext) _Patch_includedLocalModules(ctx context.Context, fie
 		field,
 		ec.fieldContext_Patch_includedLocalModules,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Patch().IncludedLocalModules(ctx, obj)
+			return obj.LocalModuleIncludes, nil
 		},
 		nil,
-		ec.marshalNIncludedLocalModule2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPILocalModuleIncludeᚄ,
+		ec.marshalNIncludedLocalModule2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋpatchᚐLocalModuleIncludeᚄ,
 		true,
 		true,
 	)
@@ -44779,8 +44775,8 @@ func (ec *executionContext) fieldContext_Patch_includedLocalModules(_ context.Co
 	fc = &graphql.FieldContext{
 		Object:     "Patch",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "module":
@@ -94264,7 +94260,7 @@ func (ec *executionContext) _CedarConfig(ctx context.Context, sel ast.SelectionS
 
 var childPatchAliasImplementors = []string{"ChildPatchAlias"}
 
-func (ec *executionContext) _ChildPatchAlias(ctx context.Context, sel ast.SelectionSet, obj *model.APIChildPatchAlias) graphql.Marshaler {
+func (ec *executionContext) _ChildPatchAlias(ctx context.Context, sel ast.SelectionSet, obj *ChildPatchAlias) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, childPatchAliasImplementors)
 
 	out := graphql.NewFieldSet(fields)
@@ -96568,7 +96564,7 @@ func (ec *executionContext) _GithubPRSubscriber(ctx context.Context, sel ast.Sel
 
 var githubPatchImplementors = []string{"GithubPatch"}
 
-func (ec *executionContext) _GithubPatch(ctx context.Context, sel ast.SelectionSet, obj *model.APIGithubPatch) graphql.Marshaler {
+func (ec *executionContext) _GithubPatch(ctx context.Context, sel ast.SelectionSet, obj *thirdparty.GithubPatch) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, githubPatchImplementors)
 
 	out := graphql.NewFieldSet(fields)
@@ -98606,7 +98602,7 @@ func (ec *executionContext) _ImageToolchainsPayload(ctx context.Context, sel ast
 
 var includedLocalModuleImplementors = []string{"IncludedLocalModule"}
 
-func (ec *executionContext) _IncludedLocalModule(ctx context.Context, sel ast.SelectionSet, obj *model.APILocalModuleInclude) graphql.Marshaler {
+func (ec *executionContext) _IncludedLocalModule(ctx context.Context, sel ast.SelectionSet, obj *patch.LocalModuleInclude) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, includedLocalModuleImplementors)
 
 	out := graphql.NewFieldSet(fields)
@@ -100989,79 +100985,17 @@ func (ec *executionContext) _Patch(ctx context.Context, sel ast.SelectionSet, ob
 				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "githubPatchData":
-			field := field
-
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Patch_githubPatchData(ctx, field, obj)
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			out.Values[i] = ec._Patch_githubPatchData(ctx, field, obj)
 		case "hidden":
 			out.Values[i] = ec._Patch_hidden(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "includedLocalModules":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Patch_includedLocalModules(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
+			out.Values[i] = ec._Patch_includedLocalModules(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
 			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "ingestTime":
 			out.Values[i] = ec._Patch_ingestTime(ctx, field, obj)
 		case "invalidatedByUpstream":
@@ -114662,7 +114596,7 @@ func (ec *executionContext) marshalNBuildVariantTuple2ᚖgithubᚗcomᚋevergree
 	return ec._BuildVariantTuple(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNChildPatchAlias2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIChildPatchAliasᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.APIChildPatchAlias) graphql.Marshaler {
+func (ec *executionContext) marshalNChildPatchAlias2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐChildPatchAliasᚄ(ctx context.Context, sel ast.SelectionSet, v []*ChildPatchAlias) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -114686,7 +114620,7 @@ func (ec *executionContext) marshalNChildPatchAlias2ᚕᚖgithubᚗcomᚋevergre
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNChildPatchAlias2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIChildPatchAlias(ctx, sel, v[i])
+			ret[i] = ec.marshalNChildPatchAlias2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐChildPatchAlias(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -114706,7 +114640,7 @@ func (ec *executionContext) marshalNChildPatchAlias2ᚕᚖgithubᚗcomᚋevergre
 	return ret
 }
 
-func (ec *executionContext) marshalNChildPatchAlias2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIChildPatchAlias(ctx context.Context, sel ast.SelectionSet, v *model.APIChildPatchAlias) graphql.Marshaler {
+func (ec *executionContext) marshalNChildPatchAlias2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐChildPatchAlias(ctx context.Context, sel ast.SelectionSet, v *ChildPatchAlias) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
@@ -116597,7 +116531,11 @@ func (ec *executionContext) marshalNImageToolchainsPayload2ᚖgithubᚗcomᚋeve
 	return ec._ImageToolchainsPayload(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNIncludedLocalModule2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPILocalModuleIncludeᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.APILocalModuleInclude) graphql.Marshaler {
+func (ec *executionContext) marshalNIncludedLocalModule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋpatchᚐLocalModuleInclude(ctx context.Context, sel ast.SelectionSet, v patch.LocalModuleInclude) graphql.Marshaler {
+	return ec._IncludedLocalModule(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNIncludedLocalModule2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋpatchᚐLocalModuleIncludeᚄ(ctx context.Context, sel ast.SelectionSet, v []patch.LocalModuleInclude) graphql.Marshaler {
 	ret := make(graphql.Array, len(v))
 	var wg sync.WaitGroup
 	isLen1 := len(v) == 1
@@ -116621,7 +116559,7 @@ func (ec *executionContext) marshalNIncludedLocalModule2ᚕᚖgithubᚗcomᚋeve
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNIncludedLocalModule2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPILocalModuleInclude(ctx, sel, v[i])
+			ret[i] = ec.marshalNIncludedLocalModule2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋpatchᚐLocalModuleInclude(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -116639,16 +116577,6 @@ func (ec *executionContext) marshalNIncludedLocalModule2ᚕᚖgithubᚗcomᚋeve
 	}
 
 	return ret
-}
-
-func (ec *executionContext) marshalNIncludedLocalModule2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPILocalModuleInclude(ctx context.Context, sel ast.SelectionSet, v *model.APILocalModuleInclude) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._IncludedLocalModule(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNInstanceTag2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋhostᚐTag(ctx context.Context, sel ast.SelectionSet, v host.Tag) graphql.Marshaler {
@@ -121720,11 +121648,8 @@ func (ec *executionContext) marshalOGithubPRSubscriber2ᚖgithubᚗcomᚋevergre
 	return ec._GithubPRSubscriber(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalOGithubPatch2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIGithubPatch(ctx context.Context, sel ast.SelectionSet, v *model.APIGithubPatch) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._GithubPatch(ctx, sel, v)
+func (ec *executionContext) marshalOGithubPatch2githubᚗcomᚋevergreenᚑciᚋevergreenᚋthirdpartyᚐGithubPatch(ctx context.Context, sel ast.SelectionSet, v thirdparty.GithubPatch) graphql.Marshaler {
+	return ec._GithubPatch(ctx, sel, &v)
 }
 
 func (ec *executionContext) marshalOGithubUser2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIGithubUser(ctx context.Context, sel ast.SelectionSet, v *model.APIGithubUser) graphql.Marshaler {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -63,6 +63,11 @@ type BuildVariantOptions struct {
 	Variants                   []string `json:"variants,omitempty"`
 }
 
+type ChildPatchAlias struct {
+	Alias   string `json:"alias"`
+	PatchID string `json:"patchId"`
+}
+
 // CreateDistroInput is the input to the createDistro mutation.
 type CreateDistroInput struct {
 	NewDistroID      string `json:"newDistroId"`

--- a/graphql/patch_resolver.go
+++ b/graphql/patch_resolver.go
@@ -24,16 +24,13 @@ func (r *patchResolver) ID(ctx context.Context, obj *patch.Patch) (string, error
 }
 
 // ChildPatchAliases is the resolver for the childPatchAliases field.
-func (r *patchResolver) ChildPatchAliases(ctx context.Context, obj *patch.Patch) ([]*restModel.APIChildPatchAlias, error) {
-	if len(obj.Triggers.ChildPatches) == 0 || len(obj.Triggers.Aliases) == 0 {
-		return []*restModel.APIChildPatchAlias{}, nil
-	}
-	result := make([]*restModel.APIChildPatchAlias, 0, len(obj.Triggers.ChildPatches))
+func (r *patchResolver) ChildPatchAliases(ctx context.Context, obj *patch.Patch) ([]*ChildPatchAlias, error) {
+	result := make([]*ChildPatchAlias, 0, len(obj.Triggers.ChildPatches))
 	for i, childPatchID := range obj.Triggers.ChildPatches {
 		if i < len(obj.Triggers.Aliases) {
-			result = append(result, &restModel.APIChildPatchAlias{
-				Alias:   utility.ToStringPtr(obj.Triggers.Aliases[i]),
-				PatchID: utility.ToStringPtr(childPatchID),
+			result = append(result, &ChildPatchAlias{
+				Alias:   obj.Triggers.Aliases[i],
+				PatchID: childPatchID,
 			})
 		}
 	}
@@ -106,25 +103,6 @@ func (r *patchResolver) GeneratedTaskCounts(ctx context.Context, obj *patch.Patc
 		}
 	}
 	return res, nil
-}
-
-// GithubPatchData is the resolver for the githubPatchData field.
-func (r *patchResolver) GithubPatchData(ctx context.Context, obj *patch.Patch) (*restModel.APIGithubPatch, error) {
-	apiGithubPatch := &restModel.APIGithubPatch{}
-	apiGithubPatch.BuildFromService(obj.GithubPatchData)
-	return apiGithubPatch, nil
-}
-
-// IncludedLocalModules is the resolver for the includedLocalModules field.
-func (r *patchResolver) IncludedLocalModules(ctx context.Context, obj *patch.Patch) ([]*restModel.APILocalModuleInclude, error) {
-	result := make([]*restModel.APILocalModuleInclude, 0, len(obj.LocalModuleIncludes))
-	for _, module := range obj.LocalModuleIncludes {
-		result = append(result, &restModel.APILocalModuleInclude{
-			Module:   module.Module,
-			FileName: module.FileName,
-		})
-	}
-	return result, nil
 }
 
 // InvalidatedByUpstream is the resolver for the invalidatedByUpstream field.


### PR DESCRIPTION
DEVPROD-38057

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

I tried to unlink more models, but they were too complicated or introduced conflicts with other objects (such as the `Project` object). I unlinked the ones that were easy to do.