### PR TITLE
DEVPROD-38054: Change GraphQL `Version` model from `model.APIVersion` -> `model.Version`

### DIFF
--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -1038,6 +1038,8 @@ models:
         resolver: true
       status:
         resolver: true
+      order:
+        fieldName: "RevisionOrderNumber"
   VersionLite:
     model: github.com/evergreen-ci/evergreen/model.Version
     fields:

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -1040,6 +1040,8 @@ models:
         resolver: true
       order:
         fieldName: "RevisionOrderNumber"
+      parameters:
+        resolver: true
   VersionLite:
     model: github.com/evergreen-ci/evergreen/model.Version
     fields:

--- a/gqlgen.yml
+++ b/gqlgen.yml
@@ -1032,7 +1032,7 @@ models:
   VariantTaskInput:
     model: github.com/evergreen-ci/evergreen/rest/model.VariantTask
   Version:
-    model: github.com/evergreen-ci/evergreen/rest/model.APIVersion
+    model: github.com/evergreen-ci/evergreen/model.Version
     fields:
       cost:
         resolver: true

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -2358,7 +2358,6 @@ type ComplexityRoot struct {
 		IsPatch                      func(childComplexity int) int
 		Manifest                     func(childComplexity int) int
 		Message                      func(childComplexity int) int
-		Order                        func(childComplexity int) int
 		Parameters                   func(childComplexity int) int
 		Patch                        func(childComplexity int) int
 		PredictedCost                func(childComplexity int) int
@@ -2368,6 +2367,7 @@ type ComplexityRoot struct {
 		Repo                         func(childComplexity int) int
 		Requester                    func(childComplexity int) int
 		Revision                     func(childComplexity int) int
+		RevisionOrderNumber          func(childComplexity int) int
 		StartTime                    func(childComplexity int) int
 		Status                       func(childComplexity int) int
 		TaskCount                    func(childComplexity int, options *TaskCountOptions) int
@@ -2868,7 +2868,6 @@ type VersionResolver interface {
 	IsPatch(ctx context.Context, obj *model1.Version) (bool, error)
 	Manifest(ctx context.Context, obj *model1.Version) (*Manifest, error)
 
-	Order(ctx context.Context, obj *model1.Version) (int, error)
 	Parameters(ctx context.Context, obj *model1.Version) ([]*model.APIParameter, error)
 	Patch(ctx context.Context, obj *model1.Version) (*patch.Patch, error)
 
@@ -12787,12 +12786,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Version.Message(childComplexity), true
-	case "Version.order":
-		if e.complexity.Version.Order == nil {
-			break
-		}
-
-		return e.complexity.Version.Order(childComplexity), true
 	case "Version.parameters":
 		if e.complexity.Version.Parameters == nil {
 			break
@@ -12847,6 +12840,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.Version.Revision(childComplexity), true
+	case "Version.order":
+		if e.complexity.Version.RevisionOrderNumber == nil {
+			break
+		}
+
+		return e.complexity.Version.RevisionOrderNumber(childComplexity), true
 	case "Version.startTime":
 		if e.complexity.Version.StartTime == nil {
 			break
@@ -75850,7 +75849,7 @@ func (ec *executionContext) _Version_order(ctx context.Context, field graphql.Co
 		field,
 		ec.fieldContext_Version_order,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Version().Order(ctx, obj)
+			return obj.RevisionOrderNumber, nil
 		},
 		nil,
 		ec.marshalNInt2int,
@@ -75863,8 +75862,8 @@ func (ec *executionContext) fieldContext_Version_order(_ context.Context, field 
 	fc = &graphql.FieldContext{
 		Object:     "Version",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
 		},
@@ -112185,41 +112184,10 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "order":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Version_order(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
+			out.Values[i] = ec._Version_order(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
 			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "parameters":
 			field := field
 

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -75235,9 +75235,9 @@ func (ec *executionContext) _Version_buildVariants(ctx context.Context, field gr
 			return ec.resolvers.Version().BuildVariants(ctx, obj, fc.Args["options"].(BuildVariantOptions))
 		},
 		nil,
-		ec.marshalOGroupedBuildVariant2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedBuildVariantᚄ,
+		ec.marshalNGroupedBuildVariant2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedBuildVariantᚄ,
 		true,
-		false,
+		true,
 	)
 }
 
@@ -75284,9 +75284,9 @@ func (ec *executionContext) _Version_buildVariantStats(ctx context.Context, fiel
 			return ec.resolvers.Version().BuildVariantStats(ctx, obj, fc.Args["options"].(BuildVariantOptions))
 		},
 		nil,
-		ec.marshalOGroupedTaskStatusCount2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐGroupedTaskStatusCountᚄ,
+		ec.marshalNGroupedTaskStatusCount2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐGroupedTaskStatusCountᚄ,
 		true,
-		false,
+		true,
 	)
 }
 
@@ -75332,9 +75332,9 @@ func (ec *executionContext) _Version_childVersions(ctx context.Context, field gr
 			return ec.resolvers.Version().ChildVersions(ctx, obj)
 		},
 		nil,
-		ec.marshalOVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersionᚄ,
+		ec.marshalNVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersionᚄ,
 		true,
-		false,
+		true,
 	)
 }
 
@@ -75686,9 +75686,9 @@ func (ec *executionContext) _Version_gitTags(ctx context.Context, field graphql.
 			return obj.GitTags, nil
 		},
 		nil,
-		ec.marshalOGitTag2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGitTagᚄ,
+		ec.marshalNGitTag2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGitTagᚄ,
 		true,
-		false,
+		true,
 	)
 }
 
@@ -111876,13 +111876,16 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 		case "buildVariants":
 			field := field
 
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
 				res = ec._Version_buildVariants(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -111909,13 +111912,16 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 		case "buildVariantStats":
 			field := field
 
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
 				res = ec._Version_buildVariantStats(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -111942,13 +111948,16 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 		case "childVersions":
 			field := field
 
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
 				res = ec._Version_childVersions(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -112093,6 +112102,9 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "gitTags":
 			out.Values[i] = ec._Version_gitTags(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
 		case "ignored":
 			out.Values[i] = ec._Version_ignored(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -115714,6 +115726,50 @@ func (ec *executionContext) marshalNGitTag2githubᚗcomᚋevergreenᚑciᚋeverg
 	return ec._GitTag(ctx, sel, &v)
 }
 
+func (ec *executionContext) marshalNGitTag2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGitTagᚄ(ctx context.Context, sel ast.SelectionSet, v []model1.GitTag) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNGitTag2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGitTag(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalNGithubProjectConflicts2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGithubProjectConflicts(ctx context.Context, sel ast.SelectionSet, v model1.GithubProjectConflicts) graphql.Marshaler {
 	return ec._GithubProjectConflicts(ctx, sel, &v)
 }
@@ -115726,6 +115782,50 @@ func (ec *executionContext) marshalNGithubProjectConflicts2ᚖgithubᚗcomᚋeve
 		return graphql.Null
 	}
 	return ec._GithubProjectConflicts(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNGroupedBuildVariant2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedBuildVariantᚄ(ctx context.Context, sel ast.SelectionSet, v []*GroupedBuildVariant) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNGroupedBuildVariant2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedBuildVariant(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalNGroupedBuildVariant2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedBuildVariant(ctx context.Context, sel ast.SelectionSet, v *GroupedBuildVariant) graphql.Marshaler {
@@ -115844,6 +115944,50 @@ func (ec *executionContext) marshalNGroupedProjects2ᚖgithubᚗcomᚋevergreen�
 		return graphql.Null
 	}
 	return ec._GroupedProjects(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNGroupedTaskStatusCount2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐGroupedTaskStatusCountᚄ(ctx context.Context, sel ast.SelectionSet, v []*task.GroupedTaskStatusCount) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNGroupedTaskStatusCount2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐGroupedTaskStatusCount(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalNGroupedTaskStatusCount2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐGroupedTaskStatusCount(ctx context.Context, sel ast.SelectionSet, v *task.GroupedTaskStatusCount) graphql.Marshaler {
@@ -119995,6 +120139,50 @@ func (ec *executionContext) marshalNVersion2githubᚗcomᚋevergreenᚑciᚋever
 	return ec._Version(ctx, sel, &v)
 }
 
+func (ec *executionContext) marshalNVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersionᚄ(ctx context.Context, sel ast.SelectionSet, v []*model1.Version) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersion(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalNVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersion(ctx context.Context, sel ast.SelectionSet, v *model1.Version) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -121650,100 +121838,6 @@ func (ec *executionContext) unmarshalOGraphiteConfigInput2ᚖgithubᚗcomᚋever
 	}
 	res, err := ec.unmarshalInputGraphiteConfigInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOGroupedBuildVariant2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedBuildVariantᚄ(ctx context.Context, sel ast.SelectionSet, v []*GroupedBuildVariant) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNGroupedBuildVariant2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedBuildVariant(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
-}
-
-func (ec *executionContext) marshalOGroupedTaskStatusCount2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐGroupedTaskStatusCountᚄ(ctx context.Context, sel ast.SelectionSet, v []*task.GroupedTaskStatusCount) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNGroupedTaskStatusCount2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐGroupedTaskStatusCount(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
 }
 
 func (ec *executionContext) marshalOHost2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋhostᚐHost(ctx context.Context, sel ast.SelectionSet, v *host.Host) graphql.Marshaler {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -2618,7 +2618,7 @@ type MutationResolver interface {
 	UpdatePublicKey(ctx context.Context, targetKeyName string, updateInfo PublicKeyInput) ([]*model.APIPubKey, error)
 	UpdateUserSettings(ctx context.Context, userSettings *model.APIUserSettings) (bool, error)
 	RefreshGitHubStatuses(ctx context.Context, opts RefreshGitHubStatusesInput) (*RefreshGitHubStatusesPayload, error)
-	RestartVersions(ctx context.Context, versionID string, abort bool, versionsToRestart []*model1.VersionToRestart) ([]*model.APIVersion, error)
+	RestartVersions(ctx context.Context, versionID string, abort bool, versionsToRestart []*model1.VersionToRestart) ([]*model1.Version, error)
 	ScheduleUndispatchedBaseTasks(ctx context.Context, versionID string) ([]*model.APITask, error)
 	SetVersionPriority(ctx context.Context, versionID string, priority int) (*string, error)
 	UnscheduleVersionTasks(ctx context.Context, versionID string, abort bool) (*string, error)
@@ -2724,7 +2724,7 @@ type QueryResolver interface {
 	Waterfall(ctx context.Context, options WaterfallOptions) (*Waterfall, error)
 	TaskHistory(ctx context.Context, options TaskHistoryOpts) (*TaskHistory, error)
 	HasVersion(ctx context.Context, patchID string) (bool, error)
-	Version(ctx context.Context, versionID string) (*model.APIVersion, error)
+	Version(ctx context.Context, versionID string) (*model1.Version, error)
 	Image(ctx context.Context, imageID string) (*model.APIImage, error)
 	Images(ctx context.Context) ([]string, error)
 }
@@ -2821,7 +2821,7 @@ type TaskResolver interface {
 
 	TotalTestCount(ctx context.Context, obj *model.APITask) (int, error)
 	Version(ctx context.Context, obj *model.APITask) (*model1.Version, error)
-	VersionMetadata(ctx context.Context, obj *model.APITask) (*model.APIVersion, error)
+	VersionMetadata(ctx context.Context, obj *model.APITask) (*model1.Version, error)
 }
 type TaskConfigResolver interface {
 	AllowedRequesters(ctx context.Context, obj *model1.BuildVariantTaskUnit) ([]string, error)
@@ -2854,37 +2854,37 @@ type UserResolver interface {
 	TokenAccessTokenExpiresAt(ctx context.Context, obj *user.DBUser) (*time.Time, error)
 }
 type VersionResolver interface {
-	BaseVersion(ctx context.Context, obj *model.APIVersion) (*model.APIVersion, error)
+	BaseVersion(ctx context.Context, obj *model1.Version) (*model1.Version, error)
 
-	BuildVariants(ctx context.Context, obj *model.APIVersion, options BuildVariantOptions) ([]*GroupedBuildVariant, error)
-	BuildVariantStats(ctx context.Context, obj *model.APIVersion, options BuildVariantOptions) ([]*task.GroupedTaskStatusCount, error)
-	ChildVersions(ctx context.Context, obj *model.APIVersion) ([]*model.APIVersion, error)
-	Cost(ctx context.Context, obj *model.APIVersion) (*cost.Cost, error)
+	BuildVariants(ctx context.Context, obj *model1.Version, options BuildVariantOptions) ([]*GroupedBuildVariant, error)
+	BuildVariantStats(ctx context.Context, obj *model1.Version, options BuildVariantOptions) ([]*task.GroupedTaskStatusCount, error)
+	ChildVersions(ctx context.Context, obj *model1.Version) ([]*model1.Version, error)
+	Cost(ctx context.Context, obj *model1.Version) (*cost.Cost, error)
 
-	ExternalLinksForMetadata(ctx context.Context, obj *model.APIVersion) ([]*ExternalLinkForMetadata, error)
+	ExternalLinksForMetadata(ctx context.Context, obj *model1.Version) ([]*ExternalLinkForMetadata, error)
 
-	GeneratedTaskCounts(ctx context.Context, obj *model.APIVersion) ([]*GeneratedTaskCountResults, error)
-	GitTags(ctx context.Context, obj *model.APIVersion) ([]*model1.GitTag, error)
+	GeneratedTaskCounts(ctx context.Context, obj *model1.Version) ([]*GeneratedTaskCountResults, error)
 
-	IsPatch(ctx context.Context, obj *model.APIVersion) (bool, error)
-	Manifest(ctx context.Context, obj *model.APIVersion) (*Manifest, error)
+	IsPatch(ctx context.Context, obj *model1.Version) (bool, error)
+	Manifest(ctx context.Context, obj *model1.Version) (*Manifest, error)
 
-	Patch(ctx context.Context, obj *model.APIVersion) (*patch.Patch, error)
+	Order(ctx context.Context, obj *model1.Version) (int, error)
+	Parameters(ctx context.Context, obj *model1.Version) ([]*model.APIParameter, error)
+	Patch(ctx context.Context, obj *model1.Version) (*patch.Patch, error)
 
-	PreviousVersion(ctx context.Context, obj *model.APIVersion) (*model.APIVersion, error)
-	ProjectMetadata(ctx context.Context, obj *model.APIVersion) (*model.APIProjectRef, error)
-	QuarantinedTestsSkippedCount(ctx context.Context, obj *model.APIVersion) (int, error)
+	PreviousVersion(ctx context.Context, obj *model1.Version) (*model1.Version, error)
+	ProjectMetadata(ctx context.Context, obj *model1.Version) (*model.APIProjectRef, error)
+	QuarantinedTestsSkippedCount(ctx context.Context, obj *model1.Version) (int, error)
 
-	Status(ctx context.Context, obj *model.APIVersion) (string, error)
-	TaskCount(ctx context.Context, obj *model.APIVersion, options *TaskCountOptions) (*int, error)
-	TaskQuarantinedTestsSample(ctx context.Context, obj *model.APIVersion, taskIds []string, limit *int) ([]*testresult.TaskTestResultsQuarantinedSample, error)
-	Tasks(ctx context.Context, obj *model.APIVersion, options TaskFilterOptions) (*VersionTasks, error)
-	TaskStatuses(ctx context.Context, obj *model.APIVersion) ([]string, error)
-	TaskStatusStats(ctx context.Context, obj *model.APIVersion, options BuildVariantOptions) (*task.TaskStats, error)
-	UpstreamProject(ctx context.Context, obj *model.APIVersion) (*UpstreamProject, error)
-	User(ctx context.Context, obj *model.APIVersion) (*user.DBUser, error)
-	VersionTiming(ctx context.Context, obj *model.APIVersion) (*VersionTiming, error)
-	Warnings(ctx context.Context, obj *model.APIVersion) ([]string, error)
+	Status(ctx context.Context, obj *model1.Version) (string, error)
+	TaskCount(ctx context.Context, obj *model1.Version, options *TaskCountOptions) (*int, error)
+	TaskQuarantinedTestsSample(ctx context.Context, obj *model1.Version, taskIds []string, limit *int) ([]*testresult.TaskTestResultsQuarantinedSample, error)
+	Tasks(ctx context.Context, obj *model1.Version, options TaskFilterOptions) (*VersionTasks, error)
+	TaskStatuses(ctx context.Context, obj *model1.Version) ([]string, error)
+	TaskStatusStats(ctx context.Context, obj *model1.Version, options BuildVariantOptions) (*task.TaskStats, error)
+	UpstreamProject(ctx context.Context, obj *model1.Version) (*UpstreamProject, error)
+	User(ctx context.Context, obj *model1.Version) (*user.DBUser, error)
+	VersionTiming(ctx context.Context, obj *model1.Version) (*VersionTiming, error)
 }
 type VersionLiteResolver interface {
 	BaseVersion(ctx context.Context, obj *model1.Version) (*model1.Version, error)
@@ -35618,7 +35618,7 @@ func (ec *executionContext) _MainlineCommitVersion_rolledUpVersions(ctx context.
 			return obj.RolledUpVersions, nil
 		},
 		nil,
-		ec.marshalOVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersionᚄ,
+		ec.marshalOVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersionᚄ,
 		true,
 		false,
 	)
@@ -35733,7 +35733,7 @@ func (ec *executionContext) _MainlineCommitVersion_version(ctx context.Context, 
 			return obj.Version, nil
 		},
 		nil,
-		ec.marshalOVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion,
+		ec.marshalOVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersion,
 		true,
 		false,
 	)
@@ -42174,7 +42174,7 @@ func (ec *executionContext) _Mutation_restartVersions(ctx context.Context, field
 			return ec.resolvers.Mutation().RestartVersions(ctx, fc.Args["versionId"].(string), fc.Args["abort"].(bool), fc.Args["versionsToRestart"].([]*model1.VersionToRestart))
 		},
 		nil,
-		ec.marshalOVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersionᚄ,
+		ec.marshalOVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersionᚄ,
 		true,
 		false,
 	)
@@ -54325,7 +54325,7 @@ func (ec *executionContext) _Query_version(ctx context.Context, field graphql.Co
 			return ec.resolvers.Query().Version(ctx, fc.Args["versionId"].(string))
 		},
 		nil,
-		ec.marshalNVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion,
+		ec.marshalNVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersion,
 		true,
 		true,
 	)
@@ -66826,7 +66826,7 @@ func (ec *executionContext) _Task_versionMetadata(ctx context.Context, field gra
 			return ec.resolvers.Task().VersionMetadata(ctx, obj)
 		},
 		nil,
-		ec.marshalNVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion,
+		ec.marshalNVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersion,
 		true,
 		true,
 	)
@@ -73720,7 +73720,7 @@ func (ec *executionContext) _UpstreamProject_version(ctx context.Context, field 
 			return obj.Version, nil
 		},
 		nil,
-		ec.marshalOVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion,
+		ec.marshalOVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersion,
 		true,
 		false,
 	)
@@ -74964,7 +74964,7 @@ func (ec *executionContext) fieldContext_VariantTask_tasks(_ context.Context, fi
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_id(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_id(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -74974,7 +74974,7 @@ func (ec *executionContext) _Version_id(ctx context.Context, field graphql.Colle
 			return obj.Id, nil
 		},
 		nil,
-		ec.marshalNString2ᚖstring,
+		ec.marshalNString2string,
 		true,
 		true,
 	)
@@ -74993,7 +74993,7 @@ func (ec *executionContext) fieldContext_Version_id(_ context.Context, field gra
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_activated(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_activated(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75022,7 +75022,7 @@ func (ec *executionContext) fieldContext_Version_activated(_ context.Context, fi
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_author(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_author(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75032,7 +75032,7 @@ func (ec *executionContext) _Version_author(ctx context.Context, field graphql.C
 			return obj.Author, nil
 		},
 		nil,
-		ec.marshalNString2ᚖstring,
+		ec.marshalNString2string,
 		true,
 		true,
 	)
@@ -75051,7 +75051,7 @@ func (ec *executionContext) fieldContext_Version_author(_ context.Context, field
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_authorEmail(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_authorEmail(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75061,7 +75061,7 @@ func (ec *executionContext) _Version_authorEmail(ctx context.Context, field grap
 			return obj.AuthorEmail, nil
 		},
 		nil,
-		ec.marshalNString2ᚖstring,
+		ec.marshalNString2string,
 		true,
 		true,
 	)
@@ -75080,7 +75080,7 @@ func (ec *executionContext) fieldContext_Version_authorEmail(_ context.Context, 
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_baseVersion(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_baseVersion(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75090,7 +75090,7 @@ func (ec *executionContext) _Version_baseVersion(ctx context.Context, field grap
 			return ec.resolvers.Version().BaseVersion(ctx, obj)
 		},
 		nil,
-		ec.marshalOVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion,
+		ec.marshalOVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersion,
 		true,
 		false,
 	)
@@ -75195,7 +75195,7 @@ func (ec *executionContext) fieldContext_Version_baseVersion(_ context.Context, 
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_branch(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_branch(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75205,7 +75205,7 @@ func (ec *executionContext) _Version_branch(ctx context.Context, field graphql.C
 			return obj.Branch, nil
 		},
 		nil,
-		ec.marshalNString2ᚖstring,
+		ec.marshalNString2string,
 		true,
 		true,
 	)
@@ -75224,7 +75224,7 @@ func (ec *executionContext) fieldContext_Version_branch(_ context.Context, field
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_buildVariants(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_buildVariants(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75273,7 +75273,7 @@ func (ec *executionContext) fieldContext_Version_buildVariants(ctx context.Conte
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_buildVariantStats(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_buildVariantStats(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75322,7 +75322,7 @@ func (ec *executionContext) fieldContext_Version_buildVariantStats(ctx context.C
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_childVersions(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_childVersions(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75332,7 +75332,7 @@ func (ec *executionContext) _Version_childVersions(ctx context.Context, field gr
 			return ec.resolvers.Version().ChildVersions(ctx, obj)
 		},
 		nil,
-		ec.marshalOVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersionᚄ,
+		ec.marshalOVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersionᚄ,
 		true,
 		false,
 	)
@@ -75437,7 +75437,7 @@ func (ec *executionContext) fieldContext_Version_childVersions(_ context.Context
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_cost(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_cost(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75486,7 +75486,7 @@ func (ec *executionContext) fieldContext_Version_cost(_ context.Context, field g
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_createTime(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_createTime(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75496,7 +75496,7 @@ func (ec *executionContext) _Version_createTime(ctx context.Context, field graph
 			return obj.CreateTime, nil
 		},
 		nil,
-		ec.marshalNTime2ᚖtimeᚐTime,
+		ec.marshalNTime2timeᚐTime,
 		true,
 		true,
 	)
@@ -75515,7 +75515,7 @@ func (ec *executionContext) fieldContext_Version_createTime(_ context.Context, f
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_ingestTime(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_ingestTime(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75525,7 +75525,7 @@ func (ec *executionContext) _Version_ingestTime(ctx context.Context, field graph
 			return obj.IngestTime, nil
 		},
 		nil,
-		ec.marshalOTime2ᚖtimeᚐTime,
+		ec.marshalOTime2timeᚐTime,
 		true,
 		false,
 	)
@@ -75544,7 +75544,7 @@ func (ec *executionContext) fieldContext_Version_ingestTime(_ context.Context, f
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_errors(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_errors(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75554,7 +75554,7 @@ func (ec *executionContext) _Version_errors(ctx context.Context, field graphql.C
 			return obj.Errors, nil
 		},
 		nil,
-		ec.marshalNString2ᚕᚖstringᚄ,
+		ec.marshalNString2ᚕstringᚄ,
 		true,
 		true,
 	)
@@ -75573,7 +75573,7 @@ func (ec *executionContext) fieldContext_Version_errors(_ context.Context, field
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_externalLinksForMetadata(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_externalLinksForMetadata(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75608,7 +75608,7 @@ func (ec *executionContext) fieldContext_Version_externalLinksForMetadata(_ cont
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_finishTime(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_finishTime(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75618,7 +75618,7 @@ func (ec *executionContext) _Version_finishTime(ctx context.Context, field graph
 			return obj.FinishTime, nil
 		},
 		nil,
-		ec.marshalOTime2ᚖtimeᚐTime,
+		ec.marshalOTime2timeᚐTime,
 		true,
 		false,
 	)
@@ -75637,7 +75637,7 @@ func (ec *executionContext) fieldContext_Version_finishTime(_ context.Context, f
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_generatedTaskCounts(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_generatedTaskCounts(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75676,17 +75676,17 @@ func (ec *executionContext) fieldContext_Version_generatedTaskCounts(_ context.C
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_gitTags(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_gitTags(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		ec.fieldContext_Version_gitTags,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Version().GitTags(ctx, obj)
+			return obj.GitTags, nil
 		},
 		nil,
-		ec.marshalOGitTag2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGitTagᚄ,
+		ec.marshalOGitTag2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGitTagᚄ,
 		true,
 		false,
 	)
@@ -75696,8 +75696,8 @@ func (ec *executionContext) fieldContext_Version_gitTags(_ context.Context, fiel
 	fc = &graphql.FieldContext{
 		Object:     "Version",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "tag":
@@ -75711,7 +75711,7 @@ func (ec *executionContext) fieldContext_Version_gitTags(_ context.Context, fiel
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_ignored(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_ignored(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75721,7 +75721,7 @@ func (ec *executionContext) _Version_ignored(ctx context.Context, field graphql.
 			return obj.Ignored, nil
 		},
 		nil,
-		ec.marshalNBoolean2ᚖbool,
+		ec.marshalNBoolean2bool,
 		true,
 		true,
 	)
@@ -75740,7 +75740,7 @@ func (ec *executionContext) fieldContext_Version_ignored(_ context.Context, fiel
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_isPatch(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_isPatch(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75769,7 +75769,7 @@ func (ec *executionContext) fieldContext_Version_isPatch(_ context.Context, fiel
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_manifest(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_manifest(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75814,7 +75814,7 @@ func (ec *executionContext) fieldContext_Version_manifest(_ context.Context, fie
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_message(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_message(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75824,7 +75824,7 @@ func (ec *executionContext) _Version_message(ctx context.Context, field graphql.
 			return obj.Message, nil
 		},
 		nil,
-		ec.marshalNString2ᚖstring,
+		ec.marshalNString2string,
 		true,
 		true,
 	)
@@ -75843,14 +75843,14 @@ func (ec *executionContext) fieldContext_Version_message(_ context.Context, fiel
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_order(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_order(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		ec.fieldContext_Version_order,
 		func(ctx context.Context) (any, error) {
-			return obj.Order, nil
+			return ec.resolvers.Version().Order(ctx, obj)
 		},
 		nil,
 		ec.marshalNInt2int,
@@ -75863,8 +75863,8 @@ func (ec *executionContext) fieldContext_Version_order(_ context.Context, field 
 	fc = &graphql.FieldContext{
 		Object:     "Version",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
 		},
@@ -75872,17 +75872,17 @@ func (ec *executionContext) fieldContext_Version_order(_ context.Context, field 
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_parameters(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_parameters(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		ec.fieldContext_Version_parameters,
 		func(ctx context.Context) (any, error) {
-			return obj.Parameters, nil
+			return ec.resolvers.Version().Parameters(ctx, obj)
 		},
 		nil,
-		ec.marshalNParameter2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIParameterᚄ,
+		ec.marshalNParameter2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIParameterᚄ,
 		true,
 		true,
 	)
@@ -75892,8 +75892,8 @@ func (ec *executionContext) fieldContext_Version_parameters(_ context.Context, f
 	fc = &graphql.FieldContext{
 		Object:     "Version",
 		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
+		IsMethod:   true,
+		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
 			case "key":
@@ -75907,7 +75907,7 @@ func (ec *executionContext) fieldContext_Version_parameters(_ context.Context, f
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_patch(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_patch(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -75992,7 +75992,7 @@ func (ec *executionContext) fieldContext_Version_patch(_ context.Context, field 
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_predictedCost(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_predictedCost(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -76002,7 +76002,7 @@ func (ec *executionContext) _Version_predictedCost(ctx context.Context, field gr
 			return obj.PredictedCost, nil
 		},
 		nil,
-		ec.marshalOCost2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋcostᚐCost,
+		ec.marshalOCost2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋcostᚐCost,
 		true,
 		false,
 	)
@@ -76041,7 +76041,7 @@ func (ec *executionContext) fieldContext_Version_predictedCost(_ context.Context
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_previousVersion(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_previousVersion(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -76051,7 +76051,7 @@ func (ec *executionContext) _Version_previousVersion(ctx context.Context, field 
 			return ec.resolvers.Version().PreviousVersion(ctx, obj)
 		},
 		nil,
-		ec.marshalOVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion,
+		ec.marshalOVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersion,
 		true,
 		false,
 	)
@@ -76156,7 +76156,7 @@ func (ec *executionContext) fieldContext_Version_previousVersion(_ context.Conte
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_projectMetadata(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_projectMetadata(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -76297,7 +76297,7 @@ func (ec *executionContext) fieldContext_Version_projectMetadata(_ context.Conte
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_quarantinedTestsSkippedCount(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_quarantinedTestsSkippedCount(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -76326,7 +76326,7 @@ func (ec *executionContext) fieldContext_Version_quarantinedTestsSkippedCount(_ 
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_repo(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_repo(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -76336,7 +76336,7 @@ func (ec *executionContext) _Version_repo(ctx context.Context, field graphql.Col
 			return obj.Repo, nil
 		},
 		nil,
-		ec.marshalNString2ᚖstring,
+		ec.marshalNString2string,
 		true,
 		true,
 	)
@@ -76355,7 +76355,7 @@ func (ec *executionContext) fieldContext_Version_repo(_ context.Context, field g
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_requester(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_requester(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -76365,7 +76365,7 @@ func (ec *executionContext) _Version_requester(ctx context.Context, field graphq
 			return obj.Requester, nil
 		},
 		nil,
-		ec.marshalNString2ᚖstring,
+		ec.marshalNString2string,
 		true,
 		true,
 	)
@@ -76384,7 +76384,7 @@ func (ec *executionContext) fieldContext_Version_requester(_ context.Context, fi
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_revision(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_revision(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -76394,7 +76394,7 @@ func (ec *executionContext) _Version_revision(ctx context.Context, field graphql
 			return obj.Revision, nil
 		},
 		nil,
-		ec.marshalNString2ᚖstring,
+		ec.marshalNString2string,
 		true,
 		true,
 	)
@@ -76413,7 +76413,7 @@ func (ec *executionContext) fieldContext_Version_revision(_ context.Context, fie
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_startTime(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_startTime(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -76423,7 +76423,7 @@ func (ec *executionContext) _Version_startTime(ctx context.Context, field graphq
 			return obj.StartTime, nil
 		},
 		nil,
-		ec.marshalOTime2ᚖtimeᚐTime,
+		ec.marshalOTime2timeᚐTime,
 		true,
 		false,
 	)
@@ -76442,7 +76442,7 @@ func (ec *executionContext) fieldContext_Version_startTime(_ context.Context, fi
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_status(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_status(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -76471,7 +76471,7 @@ func (ec *executionContext) fieldContext_Version_status(_ context.Context, field
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_taskCount(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_taskCount(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -76512,7 +76512,7 @@ func (ec *executionContext) fieldContext_Version_taskCount(ctx context.Context, 
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_taskQuarantinedTestsSample(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_taskQuarantinedTestsSample(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -76563,7 +76563,7 @@ func (ec *executionContext) fieldContext_Version_taskQuarantinedTestsSample(ctx 
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_tasks(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_tasks(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -76610,7 +76610,7 @@ func (ec *executionContext) fieldContext_Version_tasks(ctx context.Context, fiel
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_taskStatuses(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_taskStatuses(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -76639,7 +76639,7 @@ func (ec *executionContext) fieldContext_Version_taskStatuses(_ context.Context,
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_taskStatusStats(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_taskStatusStats(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -76686,7 +76686,7 @@ func (ec *executionContext) fieldContext_Version_taskStatusStats(ctx context.Con
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_upstreamProject(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_upstreamProject(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -76735,7 +76735,7 @@ func (ec *executionContext) fieldContext_Version_upstreamProject(_ context.Conte
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_user(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_user(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -76788,7 +76788,7 @@ func (ec *executionContext) fieldContext_Version_user(_ context.Context, field g
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_versionTiming(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_versionTiming(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
@@ -76823,14 +76823,14 @@ func (ec *executionContext) fieldContext_Version_versionTiming(_ context.Context
 	return fc, nil
 }
 
-func (ec *executionContext) _Version_warnings(ctx context.Context, field graphql.CollectedField, obj *model.APIVersion) (ret graphql.Marshaler) {
+func (ec *executionContext) _Version_warnings(ctx context.Context, field graphql.CollectedField, obj *model1.Version) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
 		ec.OperationContext,
 		field,
 		ec.fieldContext_Version_warnings,
 		func(ctx context.Context) (any, error) {
-			return ec.resolvers.Version().Warnings(ctx, obj)
+			return obj.Warnings, nil
 		},
 		nil,
 		ec.marshalNString2ᚕstringᚄ,
@@ -76843,8 +76843,8 @@ func (ec *executionContext) fieldContext_Version_warnings(_ context.Context, fie
 	fc = &graphql.FieldContext{
 		Object:     "Version",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
 		},
@@ -111809,7 +111809,7 @@ func (ec *executionContext) _VariantTask(ctx context.Context, sel ast.SelectionS
 
 var versionImplementors = []string{"Version"}
 
-func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, obj *model.APIVersion) graphql.Marshaler {
+func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, obj *model1.Version) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, versionImplementors)
 
 	out := graphql.NewFieldSet(fields)
@@ -112092,38 +112092,7 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "gitTags":
-			field := field
-
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Version_gitTags(ctx, field, obj)
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			out.Values[i] = ec._Version_gitTags(ctx, field, obj)
 		case "ignored":
 			out.Values[i] = ec._Version_ignored(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -112204,15 +112173,77 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "order":
-			out.Values[i] = ec._Version_order(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Version_order(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
 			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "parameters":
-			out.Values[i] = ec._Version_parameters(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Version_parameters(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
 			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "patch":
 			field := field
 
@@ -112677,41 +112708,10 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "warnings":
-			field := field
-
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Version_warnings(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
-				return res
+			out.Values[i] = ec._Version_warnings(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
 			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -115714,16 +115714,6 @@ func (ec *executionContext) marshalNGitTag2githubᚗcomᚋevergreenᚑciᚋeverg
 	return ec._GitTag(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNGitTag2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGitTag(ctx context.Context, sel ast.SelectionSet, v *model1.GitTag) graphql.Marshaler {
-	if v == nil {
-		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
-			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
-		}
-		return graphql.Null
-	}
-	return ec._GitTag(ctx, sel, v)
-}
-
 func (ec *executionContext) marshalNGithubProjectConflicts2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGithubProjectConflicts(ctx context.Context, sel ast.SelectionSet, v model1.GithubProjectConflicts) graphql.Marshaler {
 	return ec._GithubProjectConflicts(ctx, sel, &v)
 }
@@ -117500,54 +117490,6 @@ func (ec *executionContext) marshalNPackage2ᚖgithubᚗcomᚋevergreenᚑciᚋe
 func (ec *executionContext) unmarshalNPackageOpts2githubᚗcomᚋevergreenᚑciᚋevergreenᚋthirdpartyᚐPackageFilterOptions(ctx context.Context, v any) (thirdparty.PackageFilterOptions, error) {
 	res, err := ec.unmarshalInputPackageOpts(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalNParameter2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIParameter(ctx context.Context, sel ast.SelectionSet, v model.APIParameter) graphql.Marshaler {
-	return ec._Parameter(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNParameter2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIParameterᚄ(ctx context.Context, sel ast.SelectionSet, v []model.APIParameter) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNParameter2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIParameter(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
 }
 
 func (ec *executionContext) marshalNParameter2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIParameterᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.APIParameter) graphql.Marshaler {
@@ -120049,11 +119991,11 @@ func (ec *executionContext) unmarshalNVariantTasks2ᚖgithubᚗcomᚋevergreen�
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNVersion2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion(ctx context.Context, sel ast.SelectionSet, v model.APIVersion) graphql.Marshaler {
+func (ec *executionContext) marshalNVersion2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersion(ctx context.Context, sel ast.SelectionSet, v model1.Version) graphql.Marshaler {
 	return ec._Version(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion(ctx context.Context, sel ast.SelectionSet, v *model.APIVersion) graphql.Marshaler {
+func (ec *executionContext) marshalNVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersion(ctx context.Context, sel ast.SelectionSet, v *model1.Version) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
@@ -121624,53 +121566,6 @@ func (ec *executionContext) marshalOGitTag2ᚕgithubᚗcomᚋevergreenᚑciᚋev
 				defer wg.Done()
 			}
 			ret[i] = ec.marshalNGitTag2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGitTag(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
-}
-
-func (ec *executionContext) marshalOGitTag2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGitTagᚄ(ctx context.Context, sel ast.SelectionSet, v []*model1.GitTag) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNGitTag2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGitTag(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -124477,7 +124372,7 @@ func (ec *executionContext) unmarshalOUserSettingsInput2ᚖgithubᚗcomᚋevergr
 	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalOVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersionᚄ(ctx context.Context, sel ast.SelectionSet, v []*model.APIVersion) graphql.Marshaler {
+func (ec *executionContext) marshalOVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersionᚄ(ctx context.Context, sel ast.SelectionSet, v []*model1.Version) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
@@ -124504,7 +124399,7 @@ func (ec *executionContext) marshalOVersion2ᚕᚖgithubᚗcomᚋevergreenᚑci�
 			if !isLen1 {
 				defer wg.Done()
 			}
-			ret[i] = ec.marshalNVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion(ctx, sel, v[i])
+			ret[i] = ec.marshalNVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersion(ctx, sel, v[i])
 		}
 		if isLen1 {
 			f(i)
@@ -124524,7 +124419,7 @@ func (ec *executionContext) marshalOVersion2ᚕᚖgithubᚗcomᚋevergreenᚑci�
 	return ret
 }
 
-func (ec *executionContext) marshalOVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPIVersion(ctx context.Context, sel ast.SelectionSet, v *model.APIVersion) graphql.Marshaler {
+func (ec *executionContext) marshalOVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersion(ctx context.Context, sel ast.SelectionSet, v *model1.Version) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -75234,9 +75234,9 @@ func (ec *executionContext) _Version_buildVariants(ctx context.Context, field gr
 			return ec.resolvers.Version().BuildVariants(ctx, obj, fc.Args["options"].(BuildVariantOptions))
 		},
 		nil,
-		ec.marshalNGroupedBuildVariant2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedBuildVariantᚄ,
+		ec.marshalOGroupedBuildVariant2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedBuildVariantᚄ,
 		true,
-		true,
+		false,
 	)
 }
 
@@ -75283,9 +75283,9 @@ func (ec *executionContext) _Version_buildVariantStats(ctx context.Context, fiel
 			return ec.resolvers.Version().BuildVariantStats(ctx, obj, fc.Args["options"].(BuildVariantOptions))
 		},
 		nil,
-		ec.marshalNGroupedTaskStatusCount2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐGroupedTaskStatusCountᚄ,
+		ec.marshalOGroupedTaskStatusCount2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐGroupedTaskStatusCountᚄ,
 		true,
-		true,
+		false,
 	)
 }
 
@@ -75331,9 +75331,9 @@ func (ec *executionContext) _Version_childVersions(ctx context.Context, field gr
 			return ec.resolvers.Version().ChildVersions(ctx, obj)
 		},
 		nil,
-		ec.marshalNVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersionᚄ,
+		ec.marshalOVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersionᚄ,
 		true,
-		true,
+		false,
 	)
 }
 
@@ -75685,9 +75685,9 @@ func (ec *executionContext) _Version_gitTags(ctx context.Context, field graphql.
 			return obj.GitTags, nil
 		},
 		nil,
-		ec.marshalNGitTag2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGitTagᚄ,
+		ec.marshalOGitTag2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGitTagᚄ,
 		true,
-		true,
+		false,
 	)
 }
 
@@ -76522,9 +76522,9 @@ func (ec *executionContext) _Version_taskQuarantinedTestsSample(ctx context.Cont
 			return ec.resolvers.Version().TaskQuarantinedTestsSample(ctx, obj, fc.Args["taskIds"].([]string), fc.Args["limit"].(*int))
 		},
 		nil,
-		ec.marshalOTaskQuarantinedTestsSample2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtestresultᚐTaskTestResultsQuarantinedSampleᚄ,
+		ec.marshalNTaskQuarantinedTestsSample2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtestresultᚐTaskTestResultsQuarantinedSampleᚄ,
 		true,
-		false,
+		true,
 	)
 }
 
@@ -111875,16 +111875,13 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 		case "buildVariants":
 			field := field
 
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
 				res = ec._Version_buildVariants(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
 				return res
 			}
 
@@ -111911,16 +111908,13 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 		case "buildVariantStats":
 			field := field
 
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
 				res = ec._Version_buildVariantStats(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
 				return res
 			}
 
@@ -111947,16 +111941,13 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 		case "childVersions":
 			field := field
 
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
 				res = ec._Version_childVersions(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
 				return res
 			}
 
@@ -112101,9 +112092,6 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		case "gitTags":
 			out.Values[i] = ec._Version_gitTags(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
-			}
 		case "ignored":
 			out.Values[i] = ec._Version_ignored(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -112450,13 +112438,16 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 		case "taskQuarantinedTestsSample":
 			field := field
 
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
 				res = ec._Version_taskQuarantinedTestsSample(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
 				return res
 			}
 
@@ -115694,50 +115685,6 @@ func (ec *executionContext) marshalNGitTag2githubᚗcomᚋevergreenᚑciᚋeverg
 	return ec._GitTag(ctx, sel, &v)
 }
 
-func (ec *executionContext) marshalNGitTag2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGitTagᚄ(ctx context.Context, sel ast.SelectionSet, v []model1.GitTag) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNGitTag2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGitTag(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
-}
-
 func (ec *executionContext) marshalNGithubProjectConflicts2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐGithubProjectConflicts(ctx context.Context, sel ast.SelectionSet, v model1.GithubProjectConflicts) graphql.Marshaler {
 	return ec._GithubProjectConflicts(ctx, sel, &v)
 }
@@ -115750,50 +115697,6 @@ func (ec *executionContext) marshalNGithubProjectConflicts2ᚖgithubᚗcomᚋeve
 		return graphql.Null
 	}
 	return ec._GithubProjectConflicts(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalNGroupedBuildVariant2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedBuildVariantᚄ(ctx context.Context, sel ast.SelectionSet, v []*GroupedBuildVariant) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNGroupedBuildVariant2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedBuildVariant(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
 }
 
 func (ec *executionContext) marshalNGroupedBuildVariant2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedBuildVariant(ctx context.Context, sel ast.SelectionSet, v *GroupedBuildVariant) graphql.Marshaler {
@@ -115912,50 +115815,6 @@ func (ec *executionContext) marshalNGroupedProjects2ᚖgithubᚗcomᚋevergreen�
 		return graphql.Null
 	}
 	return ec._GroupedProjects(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalNGroupedTaskStatusCount2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐGroupedTaskStatusCountᚄ(ctx context.Context, sel ast.SelectionSet, v []*task.GroupedTaskStatusCount) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNGroupedTaskStatusCount2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐGroupedTaskStatusCount(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
 }
 
 func (ec *executionContext) marshalNGroupedTaskStatusCount2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐGroupedTaskStatusCount(ctx context.Context, sel ast.SelectionSet, v *task.GroupedTaskStatusCount) graphql.Marshaler {
@@ -119418,6 +119277,50 @@ func (ec *executionContext) marshalNTaskQuarantineEntry2ᚕgithubᚗcomᚋevergr
 	return ret
 }
 
+func (ec *executionContext) marshalNTaskQuarantinedTestsSample2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtestresultᚐTaskTestResultsQuarantinedSampleᚄ(ctx context.Context, sel ast.SelectionSet, v []*testresult.TaskTestResultsQuarantinedSample) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTaskQuarantinedTestsSample2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtestresultᚐTaskTestResultsQuarantinedSample(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalNTaskQuarantinedTestsSample2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtestresultᚐTaskTestResultsQuarantinedSample(ctx context.Context, sel ast.SelectionSet, v *testresult.TaskTestResultsQuarantinedSample) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -120105,50 +120008,6 @@ func (ec *executionContext) unmarshalNVariantTasks2ᚖgithubᚗcomᚋevergreen�
 
 func (ec *executionContext) marshalNVersion2githubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersion(ctx context.Context, sel ast.SelectionSet, v model1.Version) graphql.Marshaler {
 	return ec._Version(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNVersion2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersionᚄ(ctx context.Context, sel ast.SelectionSet, v []*model1.Version) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersion(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
 }
 
 func (ec *executionContext) marshalNVersion2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚐVersion(ctx context.Context, sel ast.SelectionSet, v *model1.Version) graphql.Marshaler {
@@ -121806,6 +121665,100 @@ func (ec *executionContext) unmarshalOGraphiteConfigInput2ᚖgithubᚗcomᚋever
 	}
 	res, err := ec.unmarshalInputGraphiteConfigInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOGroupedBuildVariant2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedBuildVariantᚄ(ctx context.Context, sel ast.SelectionSet, v []*GroupedBuildVariant) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNGroupedBuildVariant2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋgraphqlᚐGroupedBuildVariant(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalOGroupedTaskStatusCount2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐGroupedTaskStatusCountᚄ(ctx context.Context, sel ast.SelectionSet, v []*task.GroupedTaskStatusCount) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNGroupedTaskStatusCount2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtaskᚐGroupedTaskStatusCount(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalOHost2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋhostᚐHost(ctx context.Context, sel ast.SelectionSet, v *host.Host) graphql.Marshaler {
@@ -123996,53 +123949,6 @@ func (ec *executionContext) marshalOTaskOwnershipSettings2githubᚗcomᚋevergre
 func (ec *executionContext) unmarshalOTaskOwnershipSettingsInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITaskOwnershipSettings(ctx context.Context, v any) (model.APITaskOwnershipSettings, error) {
 	res, err := ec.unmarshalInputTaskOwnershipSettingsInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOTaskQuarantinedTestsSample2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtestresultᚐTaskTestResultsQuarantinedSampleᚄ(ctx context.Context, sel ast.SelectionSet, v []*testresult.TaskTestResultsQuarantinedSample) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNTaskQuarantinedTestsSample2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtestresultᚐTaskTestResultsQuarantinedSample(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
 }
 
 func (ec *executionContext) marshalOTaskSpecifier2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITaskSpecifierᚄ(ctx context.Context, sel ast.SelectionSet, v []model.APITaskSpecifier) graphql.Marshaler {

--- a/graphql/generated.go
+++ b/graphql/generated.go
@@ -76522,9 +76522,9 @@ func (ec *executionContext) _Version_taskQuarantinedTestsSample(ctx context.Cont
 			return ec.resolvers.Version().TaskQuarantinedTestsSample(ctx, obj, fc.Args["taskIds"].([]string), fc.Args["limit"].(*int))
 		},
 		nil,
-		ec.marshalNTaskQuarantinedTestsSample2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtestresultᚐTaskTestResultsQuarantinedSampleᚄ,
+		ec.marshalOTaskQuarantinedTestsSample2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtestresultᚐTaskTestResultsQuarantinedSampleᚄ,
 		true,
-		true,
+		false,
 	)
 }
 
@@ -112438,16 +112438,13 @@ func (ec *executionContext) _Version(ctx context.Context, sel ast.SelectionSet, 
 		case "taskQuarantinedTestsSample":
 			field := field
 
-			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
 				defer func() {
 					if r := recover(); r != nil {
 						ec.Error(ctx, ec.Recover(ctx, r))
 					}
 				}()
 				res = ec._Version_taskQuarantinedTestsSample(ctx, field, obj)
-				if res == graphql.Null {
-					atomic.AddUint32(&fs.Invalids, 1)
-				}
 				return res
 			}
 
@@ -119277,50 +119274,6 @@ func (ec *executionContext) marshalNTaskQuarantineEntry2ᚕgithubᚗcomᚋevergr
 	return ret
 }
 
-func (ec *executionContext) marshalNTaskQuarantinedTestsSample2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtestresultᚐTaskTestResultsQuarantinedSampleᚄ(ctx context.Context, sel ast.SelectionSet, v []*testresult.TaskTestResultsQuarantinedSample) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		fc := &graphql.FieldContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithFieldContext(ctx, fc)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNTaskQuarantinedTestsSample2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtestresultᚐTaskTestResultsQuarantinedSample(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-
-	for _, e := range ret {
-		if e == graphql.Null {
-			return graphql.Null
-		}
-	}
-
-	return ret
-}
-
 func (ec *executionContext) marshalNTaskQuarantinedTestsSample2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtestresultᚐTaskTestResultsQuarantinedSample(ctx context.Context, sel ast.SelectionSet, v *testresult.TaskTestResultsQuarantinedSample) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -123949,6 +123902,53 @@ func (ec *executionContext) marshalOTaskOwnershipSettings2githubᚗcomᚋevergre
 func (ec *executionContext) unmarshalOTaskOwnershipSettingsInput2githubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITaskOwnershipSettings(ctx context.Context, v any) (model.APITaskOwnershipSettings, error) {
 	res, err := ec.unmarshalInputTaskOwnershipSettingsInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOTaskQuarantinedTestsSample2ᚕᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtestresultᚐTaskTestResultsQuarantinedSampleᚄ(ctx context.Context, sel ast.SelectionSet, v []*testresult.TaskTestResultsQuarantinedSample) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNTaskQuarantinedTestsSample2ᚖgithubᚗcomᚋevergreenᚑciᚋevergreenᚋmodelᚋtestresultᚐTaskTestResultsQuarantinedSample(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalOTaskSpecifier2ᚕgithubᚗcomᚋevergreenᚑciᚋevergreenᚋrestᚋmodelᚐAPITaskSpecifierᚄ(ctx context.Context, sel ast.SelectionSet, v []model.APITaskSpecifier) graphql.Marshaler {

--- a/graphql/models_gen.go
+++ b/graphql/models_gen.go
@@ -275,8 +275,8 @@ type JiraNotificationsProjectEntryInput struct {
 }
 
 type MainlineCommitVersion struct {
-	RolledUpVersions []*model.APIVersion `json:"rolledUpVersions,omitempty"`
-	Version          *model.APIVersion   `json:"version,omitempty"`
+	RolledUpVersions []*model1.Version `json:"rolledUpVersions,omitempty"`
+	Version          *model1.Version   `json:"version,omitempty"`
 }
 
 // MainlineCommits is returned by the mainline commits query.
@@ -714,15 +714,15 @@ type UpdateVolumeInput struct {
 }
 
 type UpstreamProject struct {
-	Owner       string            `json:"owner"`
-	Project     string            `json:"project"`
-	Repo        string            `json:"repo"`
-	ResourceID  string            `json:"resourceID"`
-	Revision    string            `json:"revision"`
-	Task        *model.APITask    `json:"task,omitempty"`
-	TriggerID   string            `json:"triggerID"`
-	TriggerType string            `json:"triggerType"`
-	Version     *model.APIVersion `json:"version,omitempty"`
+	Owner       string          `json:"owner"`
+	Project     string          `json:"project"`
+	Repo        string          `json:"repo"`
+	ResourceID  string          `json:"resourceID"`
+	Revision    string          `json:"revision"`
+	Task        *model.APITask  `json:"task,omitempty"`
+	TriggerID   string          `json:"triggerID"`
+	TriggerType string          `json:"triggerType"`
+	Version     *model1.Version `json:"version,omitempty"`
 }
 
 // UserConfig is returned by the userConfig query.

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -1469,7 +1469,7 @@ func (r *mutationResolver) RefreshGitHubStatuses(ctx context.Context, opts Refre
 }
 
 // RestartVersions is the resolver for the restartVersions field.
-func (r *mutationResolver) RestartVersions(ctx context.Context, versionID string, abort bool, versionsToRestart []*model.VersionToRestart) ([]*restModel.APIVersion, error) {
+func (r *mutationResolver) RestartVersions(ctx context.Context, versionID string, abort bool, versionsToRestart []*model.VersionToRestart) ([]*model.Version, error) {
 	if len(versionsToRestart) == 0 {
 		return nil, InputValidationError.Send(ctx, "No versions provided. You must provide at least one version to restart.")
 	}
@@ -1482,21 +1482,23 @@ func (r *mutationResolver) RestartVersions(ctx context.Context, versionID string
 	if err != nil {
 		return nil, err
 	}
-	versions := []*restModel.APIVersion{}
+
+	versionIDs := []string{}
 	for _, version := range versionsToRestart {
-		if version.VersionId != nil {
-			currVersionID := utility.FromStringPtr(version.VersionId)
-			v, versionErr := model.VersionFindOneIdWithBuildVariants(ctx, currVersionID)
-			if versionErr != nil {
-				return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", currVersionID, versionErr.Error()))
-			}
-			if v == nil {
-				return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("version '%s' not found", currVersionID))
-			}
-			apiVersion := restModel.APIVersion{}
-			apiVersion.BuildFromService(ctx, *v)
-			versions = append(versions, &apiVersion)
+		versionIDs = append(versionIDs, utility.FromStringPtr(version.VersionId))
+	}
+
+	loaders.PreloadVersions(ctx, versionIDs)
+	versions := []*model.Version{}
+	for _, vId := range versionIDs {
+		v, versionErr := loaders.GetVersion(ctx, vId)
+		if versionErr != nil {
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", vId, versionErr.Error()))
 		}
+		if v == nil {
+			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("version '%s' not found", vId))
+		}
+		versions = append(versions, v)
 	}
 	return versions, nil
 }

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -422,7 +422,7 @@ func (r *mutationResolver) SchedulePatch(ctx context.Context, patchID string, co
 	patchUpdateReq := buildFromGqlInput(configure)
 	usr := mustHaveUser(ctx)
 	patchUpdateReq.Caller = usr.Id
-	version, err := model.VersionFindOneId(ctx, patchID)
+	version, err := loaders.GetVersion(ctx, patchID)
 	if err != nil && !adb.ResultsNotFound(err) {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching patch '%s': %s", patchID, err.Error()))
 	}

--- a/graphql/patch_resolver.go
+++ b/graphql/patch_resolver.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/99designs/gqlgen/graphql"
 	"github.com/evergreen-ci/evergreen"
@@ -149,41 +148,11 @@ func (r *patchResolver) ModuleCodeChanges(ctx context.Context, obj *patch.Patch)
 
 // Parameters is the resolver for the parameters field.
 func (r *patchResolver) Parameters(ctx context.Context, obj *patch.Patch) ([]*restModel.APIParameter, error) {
-	config, err := evergreen.GetConfig(ctx)
+	redactedParameters, err := redactParameters(ctx, obj.Project, obj.Parameters)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting Evergreen configuration: %s", err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("redacting parameters for patch '%s': %s", obj.Id.Hex(), err.Error()), err)
 	}
-
-	projectId := obj.Project
-	projVars, err := model.FindMergedProjectVars(ctx, projectId)
-	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting project vars for project '%s': %s", projectId, err.Error()))
-	}
-
-	redactKeys := config.LoggerConfig.RedactKeys
-	var res []*restModel.APIParameter
-	for _, param := range obj.Parameters {
-		redactedParam := &restModel.APIParameter{
-			Key:   utility.ToStringPtr(param.Key),
-			Value: utility.ToStringPtr(param.Value),
-		}
-		for _, pattern := range redactKeys {
-			if strings.Contains(strings.ToLower(param.Key), pattern) {
-				redactedParam.Value = utility.ToStringPtr(evergreen.RedactedValue)
-				break
-			}
-		}
-		if projVars != nil {
-			for varKey, varValue := range projVars.Vars {
-				if strings.Contains(param.Value, varValue) && projVars.PrivateVars[varKey] {
-					redactedParam.Value = utility.ToStringPtr(evergreen.RedactedValue)
-					break
-				}
-			}
-		}
-		res = append(res, redactedParam)
-	}
-	return res, nil
+	return redactedParameters, nil
 }
 
 // PatchTriggerAliases is the resolver for the patchTriggerAliases field.

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -872,18 +872,16 @@ func (r *queryResolver) MainlineCommits(ctx context.Context, options MainlineCom
 		// Loop through the current versions to check for matching versions.
 		for _, v := range versions {
 			mainlineCommitVersion := MainlineCommitVersion{}
-			apiVersion := restModel.APIVersion{}
-			apiVersion.BuildFromService(ctx, v)
 			versionsCheckedCount++
 
 			if !utility.FromBoolPtr(v.Activated) {
-				collapseCommit(ctx, mainlineCommits, &mainlineCommitVersion, apiVersion)
+				collapseCommit(ctx, mainlineCommits, &mainlineCommitVersion, v)
 			} else if hasFilters && !versionsMatchingTasksMap[v.Id] {
-				collapseCommit(ctx, mainlineCommits, &mainlineCommitVersion, apiVersion)
+				collapseCommit(ctx, mainlineCommits, &mainlineCommitVersion, v)
 			} else {
 				matchingVersionCount++
 				mainlineCommits.NextPageOrderNumber = utility.ToIntPtr(v.RevisionOrderNumber)
-				mainlineCommitVersion.Version = &apiVersion
+				mainlineCommitVersion.Version = &v
 			}
 
 			// Only add a mainlineCommit if a new one was added and it's not a modified existing RolledUpVersion.
@@ -1230,17 +1228,15 @@ func (r *queryResolver) HasVersion(ctx context.Context, patchID string) (bool, e
 }
 
 // Version is the resolver for the version field.
-func (r *queryResolver) Version(ctx context.Context, versionID string) (*restModel.APIVersion, error) {
-	v, err := model.VersionFindOneIdWithBuildVariants(ctx, versionID)
+func (r *queryResolver) Version(ctx context.Context, versionID string) (*model.Version, error) {
+	v, err := loaders.GetVersion(ctx, versionID)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionID, err.Error()))
 	}
 	if v == nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("version '%s' not found", versionID))
 	}
-	apiVersion := restModel.APIVersion{}
-	apiVersion.BuildFromService(ctx, *v)
-	return &apiVersion, nil
+	return v, nil
 }
 
 // Image is the resolver for the image field returning information about an image including kernel, version, ami, name, and last deployed time.

--- a/graphql/query_test.go
+++ b/graphql/query_test.go
@@ -142,7 +142,7 @@ func TestMainlineCommits(t *testing.T) {
 
 	lastCommit := res.Versions[len(res.Versions)-1].Version
 	assert.NotNil(t, lastCommit)
-	require.Equal(t, utility.FromIntPtr(res.NextPageOrderNumber), lastCommit.Order)
+	require.Equal(t, utility.FromIntPtr(res.NextPageOrderNumber), lastCommit.RevisionOrderNumber)
 
 	mainlineCommitOptions.ShouldCollapse = utility.FalsePtr()
 	// Should return all mainline commits without folding up unmatching ones when there are filters and shouldCollapse is false
@@ -164,7 +164,7 @@ func TestMainlineCommits(t *testing.T) {
 
 	lastCommit = res.Versions[len(res.Versions)-1].Version
 	assert.NotNil(t, lastCommit)
-	require.Equal(t, utility.FromIntPtr(res.NextPageOrderNumber), lastCommit.Order)
+	require.Equal(t, utility.FromIntPtr(res.NextPageOrderNumber), lastCommit.RevisionOrderNumber)
 
 	// Should only return mainline commits that match the passed in requester
 	mainlineCommitOptions.Requesters = []string{evergreen.RepotrackerVersionRequester}
@@ -178,7 +178,7 @@ func TestMainlineCommits(t *testing.T) {
 
 	for _, v := range res.Versions {
 		if v.Version != nil {
-			assert.Equal(t, evergreen.RepotrackerVersionRequester, utility.FromStringPtr(v.Version.Requester))
+			assert.Equal(t, evergreen.RepotrackerVersionRequester, v.Version.Requester)
 		}
 	}
 }

--- a/graphql/schema/types/version.graphql
+++ b/graphql/schema/types/version.graphql
@@ -87,7 +87,10 @@ type Version {
   """
   Returns up to limit (default 50) TSS-quarantined tests per task; quarantinedTestsSkippedCount is authoritative because stored samples may be truncated.
   """
-  taskQuarantinedTestsSample(taskIds: [String!]!, limit: Int): [TaskQuarantinedTestsSample!]
+  taskQuarantinedTestsSample(
+    taskIds: [String!]!
+    limit: Int
+  ): [TaskQuarantinedTestsSample!]
   tasks(options: TaskFilterOptions!): VersionTasks!
   taskStatuses: [String!]!
   taskStatusStats(options: BuildVariantOptions!): TaskStats

--- a/graphql/schema/types/version.graphql
+++ b/graphql/schema/types/version.graphql
@@ -56,9 +56,9 @@ type Version {
   authorEmail: String!
   baseVersion: Version
   branch: String!
-  buildVariants(options: BuildVariantOptions!): [GroupedBuildVariant!]
-  buildVariantStats(options: BuildVariantOptions!): [GroupedTaskStatusCount!]
-  childVersions: [Version!]
+  buildVariants(options: BuildVariantOptions!): [GroupedBuildVariant!]!
+  buildVariantStats(options: BuildVariantOptions!): [GroupedTaskStatusCount!]!
+  childVersions: [Version!]!
   cost: Cost
   createTime: Time!
   ingestTime: Time
@@ -66,7 +66,7 @@ type Version {
   externalLinksForMetadata: [ExternalLinkForMetadata!]!
   finishTime: Time
   generatedTaskCounts: [GeneratedTaskCountResults!]!
-  gitTags: [GitTag!]
+  gitTags: [GitTag!]!
   ignored: Boolean!
   isPatch: Boolean!
   manifest: Manifest
@@ -93,7 +93,7 @@ type Version {
   ): [TaskQuarantinedTestsSample!]
   tasks(options: TaskFilterOptions!): VersionTasks!
   taskStatuses: [String!]!
-  taskStatusStats(options: BuildVariantOptions!): TaskStats
+  taskStatusStats(options: BuildVariantOptions!): TaskStats # TODO: Must make this match the taskStatusStats field on VersionLite
   upstreamProject: UpstreamProject
   user: User!
   versionTiming: VersionTiming

--- a/graphql/schema/types/version.graphql
+++ b/graphql/schema/types/version.graphql
@@ -56,9 +56,9 @@ type Version {
   authorEmail: String!
   baseVersion: Version
   branch: String!
-  buildVariants(options: BuildVariantOptions!): [GroupedBuildVariant!]!
-  buildVariantStats(options: BuildVariantOptions!): [GroupedTaskStatusCount!]!
-  childVersions: [Version!]!
+  buildVariants(options: BuildVariantOptions!): [GroupedBuildVariant!]
+  buildVariantStats(options: BuildVariantOptions!): [GroupedTaskStatusCount!]
+  childVersions: [Version!]
   cost: Cost
   createTime: Time!
   ingestTime: Time
@@ -66,7 +66,7 @@ type Version {
   externalLinksForMetadata: [ExternalLinkForMetadata!]!
   finishTime: Time
   generatedTaskCounts: [GeneratedTaskCountResults!]!
-  gitTags: [GitTag!]!
+  gitTags: [GitTag!]
   ignored: Boolean!
   isPatch: Boolean!
   manifest: Manifest
@@ -90,7 +90,7 @@ type Version {
   taskQuarantinedTestsSample(
     taskIds: [String!]!
     limit: Int
-  ): [TaskQuarantinedTestsSample!]
+  ): [TaskQuarantinedTestsSample!]!
   tasks(options: TaskFilterOptions!): VersionTasks!
   taskStatuses: [String!]!
   taskStatusStats(options: BuildVariantOptions!): TaskStats # TODO: Must make this match the taskStatusStats field on VersionLite

--- a/graphql/schema/types/version.graphql
+++ b/graphql/schema/types/version.graphql
@@ -90,7 +90,7 @@ type Version {
   taskQuarantinedTestsSample(
     taskIds: [String!]!
     limit: Int
-  ): [TaskQuarantinedTestsSample!]!
+  ): [TaskQuarantinedTestsSample!]
   tasks(options: TaskFilterOptions!): VersionTasks!
   taskStatuses: [String!]!
   taskStatusStats(options: BuildVariantOptions!): TaskStats # TODO: Must make this match the taskStatusStats field on VersionLite

--- a/graphql/task_resolver.go
+++ b/graphql/task_resolver.go
@@ -963,7 +963,7 @@ func (r *taskResolver) Version(ctx context.Context, obj *restModel.APITask) (*mo
 }
 
 // VersionMetadata is the resolver for the versionMetadata field.
-func (r *taskResolver) VersionMetadata(ctx context.Context, obj *restModel.APITask) (*restModel.APIVersion, error) {
+func (r *taskResolver) VersionMetadata(ctx context.Context, obj *restModel.APITask) (*model.Version, error) {
 	versionID := utility.FromStringPtr(obj.Version)
 	v, err := loaders.GetVersion(ctx, versionID)
 	if err != nil {
@@ -972,9 +972,7 @@ func (r *taskResolver) VersionMetadata(ctx context.Context, obj *restModel.APITa
 	if v == nil {
 		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("version '%s' not found", versionID))
 	}
-	apiVersion := &restModel.APIVersion{}
-	apiVersion.BuildFromService(ctx, *v)
-	return apiVersion, nil
+	return v, nil
 }
 
 // AllowedRequesters is the resolver for the allowedRequesters field.

--- a/graphql/tests/version/parameters/data.json
+++ b/graphql/tests/version/parameters/data.json
@@ -1,0 +1,34 @@
+{
+  "versions": [
+    {
+      "_id": "5e4ff3abe3c3317e352062e4",
+      "identifier": "spruce",
+      "parameters": [
+        {
+          "key": "iter_count",
+          "value": "5"
+        },
+        {
+          "key": "my_parameter",
+          "value": "this_is_it"
+        },
+        {
+          "key": "secret_parameter",
+          "value": "abc"
+        }
+      ]
+    }
+  ],
+  "project_ref": [
+    {
+      "_id": "spruce",
+      "identifier": "spruce"
+    }
+  ],
+  "admin": [
+    {
+      "_id": "logger_config",
+      "redact_keys": ["secret", "password"]
+    }
+  ]
+}

--- a/graphql/tests/version/parameters/queries/redact_parameters.graphql
+++ b/graphql/tests/version/parameters/queries/redact_parameters.graphql
@@ -1,0 +1,8 @@
+{
+  version(versionId: "5e4ff3abe3c3317e352062e4") {
+    parameters {
+      key
+      value
+    }
+  }
+}

--- a/graphql/tests/version/parameters/results.json
+++ b/graphql/tests/version/parameters/results.json
@@ -1,0 +1,27 @@
+{
+  "tests": [
+    {
+      "query_file": "redact_parameters.graphql",
+      "result": {
+        "data": {
+          "version": {
+            "parameters": [
+              {
+                "key": "iter_count",
+                "value": "5"
+              },
+              {
+                "key": "my_parameter",
+                "value": "this_is_it"
+              },
+              {
+                "key": "secret_parameter",
+                "value": "{REDACTED}"
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1633,3 +1633,40 @@ func buildQuarantineMutationResponse(ctx context.Context, t *task.Task, testName
 	}
 	return apiTest, nil
 }
+
+func redactParameters(ctx context.Context, projectId string, parameters []patch.Parameter) ([]*restModel.APIParameter, error) {
+	config, err := evergreen.GetConfig(ctx)
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting Evergreen configuration: %s", err.Error()))
+	}
+
+	projVars, err := model.FindMergedProjectVars(ctx, projectId)
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting project vars for project '%s': %s", projectId, err.Error()))
+	}
+
+	redactKeys := config.LoggerConfig.RedactKeys
+	res := make([]*restModel.APIParameter, 0, len(parameters))
+	for _, param := range parameters {
+		redactedParam := &restModel.APIParameter{
+			Key:   utility.ToStringPtr(param.Key),
+			Value: utility.ToStringPtr(param.Value),
+		}
+		for _, pattern := range redactKeys {
+			if strings.Contains(strings.ToLower(param.Key), pattern) {
+				redactedParam.Value = utility.ToStringPtr(evergreen.RedactedValue)
+				break
+			}
+		}
+		if projVars != nil {
+			for varKey, varValue := range projVars.Vars {
+				if strings.Contains(param.Value, varValue) && projVars.PrivateVars[varKey] {
+					redactedParam.Value = utility.ToStringPtr(evergreen.RedactedValue)
+					break
+				}
+			}
+		}
+		res = append(res, redactedParam)
+	}
+	return res, nil
+}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -1161,16 +1161,16 @@ func concurrentlyBuildVersionsMatchingTasksMap(ctx context.Context, versions []m
 	return hasMatchingTasksMap, nil
 }
 
-func collapseCommit(ctx context.Context, mainlineCommits MainlineCommits, mainlineCommitVersion *MainlineCommitVersion, apiVersion restModel.APIVersion) {
+func collapseCommit(ctx context.Context, mainlineCommits MainlineCommits, mainlineCommitVersion *MainlineCommitVersion, version model.Version) {
 	if len(mainlineCommits.Versions) > 0 {
 		lastMainlineCommit := mainlineCommits.Versions[len(mainlineCommits.Versions)-1]
 		if lastMainlineCommit.RolledUpVersions != nil {
-			lastMainlineCommit.RolledUpVersions = append(lastMainlineCommit.RolledUpVersions, &apiVersion)
+			lastMainlineCommit.RolledUpVersions = append(lastMainlineCommit.RolledUpVersions, &version)
 		} else {
-			mainlineCommitVersion.RolledUpVersions = []*restModel.APIVersion{&apiVersion}
+			mainlineCommitVersion.RolledUpVersions = []*model.Version{&version}
 		}
 	} else {
-		mainlineCommitVersion.RolledUpVersions = []*restModel.APIVersion{&apiVersion}
+		mainlineCommitVersion.RolledUpVersions = []*model.Version{&version}
 	}
 }
 

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -296,7 +296,7 @@ func generateBuildVariants(ctx context.Context, versionId string, buildVariantOp
 
 // modifyVersionHandler handles the boilerplate code for performing a modify version action, i.e. schedule, unschedule, restart and set priority
 func modifyVersionHandler(ctx context.Context, versionID string, modification model.VersionModification) error {
-	v, err := model.VersionFindOneId(ctx, versionID)
+	v, err := loaders.GetVersion(ctx, versionID)
 	if err != nil {
 		return ResourceNotFound.Send(ctx, fmt.Sprintf("finding version '%s': %s", versionID, err.Error()))
 	}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -500,20 +500,6 @@ func applyVolumeOptions(ctx context.Context, volume host.Volume, volumeOptions r
 	return nil
 }
 
-func setVersionActivationStatus(ctx context.Context, version *model.Version) error {
-	defaultSort := []task.TasksSortOrder{
-		{Key: task.DisplayNameKey, Order: 1},
-	}
-	opts := task.GetTasksByVersionOptions{
-		Sorts: defaultSort,
-	}
-	tasks, _, err := task.GetTasksByVersion(ctx, version.Id, opts)
-	if err != nil {
-		return errors.Wrapf(err, "getting tasks for version '%s'", version.Id)
-	}
-	return errors.Wrapf(version.SetActivated(ctx, task.AnyActiveTasks(tasks)), "updating version activated status for '%s'", version.Id)
-}
-
 func isPopulated(buildVariantOptions *BuildVariantOptions) bool {
 	if buildVariantOptions == nil {
 		return false

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -26,24 +26,20 @@ import (
 )
 
 // BaseVersion is the resolver for the baseVersion field.
-func (r *versionResolver) BaseVersion(ctx context.Context, obj *restModel.APIVersion) (*restModel.APIVersion, error) {
-	versionID := utility.FromStringPtr(obj.Id)
-	baseVersion, err := model.FindBaseVersionForVersion(ctx, versionID)
+func (r *versionResolver) BaseVersion(ctx context.Context, obj *model.Version) (*model.Version, error) {
+	baseVersion, err := model.FindBaseVersionForVersion(ctx, obj.Id)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding base version for version '%s': %s", versionID, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding base version for version '%s': %s", obj.Id, err.Error()))
 	}
 	if baseVersion == nil {
 		return nil, nil
 	}
-
-	apiVersion := restModel.APIVersion{}
-	apiVersion.BuildFromService(ctx, *baseVersion)
-	return &apiVersion, nil
+	return baseVersion, nil
 }
 
 // BuildVariants is the resolver for the buildVariants field.
-func (r *versionResolver) BuildVariants(ctx context.Context, obj *restModel.APIVersion, options BuildVariantOptions) ([]*GroupedBuildVariant, error) {
-	versionID := utility.FromStringPtr(obj.Id)
+func (r *versionResolver) BuildVariants(ctx context.Context, obj *model.Version, options BuildVariantOptions) ([]*GroupedBuildVariant, error) {
+	versionID := obj.Id
 	// If activated is nil in the db we should resolve it and cache it for subsequent queries. There is a very low likely hood of this field being hit
 	if obj.Activated == nil {
 		version, err := model.VersionFindOneIdWithBuildVariants(ctx, versionID)
@@ -56,10 +52,10 @@ func (r *versionResolver) BuildVariants(ctx context.Context, obj *restModel.APIV
 		obj.Activated = version.Activated
 	}
 
-	if obj.IsPatchRequester() && !utility.FromBoolPtr(obj.Activated) {
+	if evergreen.IsPatchRequester(obj.Requester) && !utility.FromBoolPtr(obj.Activated) {
 		return nil, nil
 	}
-	groupedBuildVariants, err := generateBuildVariants(ctx, versionID, options, utility.FromStringPtr(obj.Requester), r.sc.GetURL())
+	groupedBuildVariants, err := generateBuildVariants(ctx, versionID, options, obj.Requester, r.sc.GetURL())
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("generating build variants for version '%s': %s", versionID, err.Error()))
 	}
@@ -67,7 +63,7 @@ func (r *versionResolver) BuildVariants(ctx context.Context, obj *restModel.APIV
 }
 
 // BuildVariantStats is the resolver for the buildVariantStats field.
-func (r *versionResolver) BuildVariantStats(ctx context.Context, obj *restModel.APIVersion, options BuildVariantOptions) ([]*task.GroupedTaskStatusCount, error) {
+func (r *versionResolver) BuildVariantStats(ctx context.Context, obj *model.Version, options BuildVariantOptions) ([]*task.GroupedTaskStatusCount, error) {
 	includeNeverActivatedTasks := options.IncludeNeverActivatedTasks
 	if includeNeverActivatedTasks == nil {
 		includeNeverActivatedTasks = utility.ToBoolPtr(false)
@@ -76,22 +72,21 @@ func (r *versionResolver) BuildVariantStats(ctx context.Context, obj *restModel.
 		TaskNames:                  options.Tasks,
 		Variants:                   options.Variants,
 		Statuses:                   options.Statuses,
-		IncludeNeverActivatedTasks: *includeNeverActivatedTasks || !obj.IsPatchRequester(),
+		IncludeNeverActivatedTasks: *includeNeverActivatedTasks || !evergreen.IsPatchRequester(obj.Requester),
 	}
-	versionID := utility.FromStringPtr(obj.Id)
-	stats, err := task.GetGroupedTaskStatsByVersion(ctx, versionID, opts)
+	stats, err := task.GetGroupedTaskStatsByVersion(ctx, obj.Id, opts)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting task stats for version '%s': %s", versionID, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting task stats for version '%s': %s", obj.Id, err.Error()))
 	}
 	return stats, nil
 }
 
 // ChildVersions is the resolver for the childVersions field.
-func (r *versionResolver) ChildVersions(ctx context.Context, obj *restModel.APIVersion) ([]*restModel.APIVersion, error) {
-	if !evergreen.IsPatchRequester(utility.FromStringPtr(obj.Requester)) {
+func (r *versionResolver) ChildVersions(ctx context.Context, obj *model.Version) ([]*model.Version, error) {
+	if !evergreen.IsPatchRequester(obj.Requester) {
 		return nil, nil
 	}
-	patchID := utility.FromStringPtr(obj.Id)
+	patchID := obj.Id
 	if err := data.ValidatePatchID(patchID); err != nil {
 		return nil, werrors.WithStack(err)
 	}
@@ -106,7 +101,7 @@ func (r *versionResolver) ChildVersions(ctx context.Context, obj *restModel.APIV
 	if len(childPatchIds) > 0 {
 		loaders.PreloadPatches(ctx, childPatchIds)
 		loaders.PreloadVersions(ctx, childPatchIds)
-		childVersions := []*restModel.APIVersion{}
+		childVersions := []*model.Version{}
 		for _, cp := range childPatchIds {
 			// this calls the graphql Version query resolver
 			cv, err := r.Query().Version(ctx, cp)
@@ -137,15 +132,11 @@ func (r *versionResolver) ChildVersions(ctx context.Context, obj *restModel.APIV
 // Cost is the field resolver for Version.cost. It applies RoundCost to all adjusted fields
 // so the GraphQL API returns clean values without floating-point noise. For patch versions
 // with child patches, it also includes the child patches' costs in the total.
-func (r *versionResolver) Cost(ctx context.Context, obj *restModel.APIVersion) (*cost.Cost, error) {
-	if obj.Cost == nil {
-		return nil, nil
-	}
-
+func (r *versionResolver) Cost(ctx context.Context, obj *model.Version) (*cost.Cost, error) {
 	// If the version is a patch requester, we need to include costs of its child patches.
 	childPatchesCost := float64(0)
-	if obj.IsPatchRequester() {
-		versionID := utility.FromStringPtr(obj.Id)
+	if evergreen.IsPatchRequester(obj.Requester) {
+		versionID := obj.Id
 		foundPatch, err := loaders.GetPatch(ctx, versionID)
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching patch '%s' for cost: %s", versionID, err.Error()), err)
@@ -167,8 +158,8 @@ func (r *versionResolver) Cost(ctx context.Context, obj *restModel.APIVersion) (
 }
 
 // ExternalLinksForMetadata is the resolver for the externalLinksForMetadata field.
-func (r *versionResolver) ExternalLinksForMetadata(ctx context.Context, obj *restModel.APIVersion) ([]*ExternalLinkForMetadata, error) {
-	projectID := utility.FromStringPtr(obj.Project)
+func (r *versionResolver) ExternalLinksForMetadata(ctx context.Context, obj *model.Version) ([]*ExternalLinkForMetadata, error) {
+	projectID := obj.Branch
 	pRef, err := data.FindProjectById(ctx, projectID, false, false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching project '%s': %s", projectID, err.Error()))
@@ -179,11 +170,11 @@ func (r *versionResolver) ExternalLinksForMetadata(ctx context.Context, obj *res
 	var externalLinks []*ExternalLinkForMetadata
 
 	for _, link := range pRef.ExternalLinks {
-		if utility.StringSliceContains(link.Requesters, utility.FromStringPtr(obj.Requester)) {
+		if utility.StringSliceContains(link.Requesters, obj.Requester) {
 			// Replace {version_id} with the actual version ID.
-			formattedURL := strings.Replace(link.URLTemplate, "{version_id}", utility.FromStringPtr(obj.Id), -1)
+			formattedURL := strings.Replace(link.URLTemplate, "{version_id}", obj.Id, -1)
 			// Replace {revision} with the actual revision.
-			formattedURL = strings.Replace(formattedURL, "{revision}", utility.FromStringPtr(obj.Revision), -1)
+			formattedURL = strings.Replace(formattedURL, "{revision}", obj.Revision, -1)
 			externalLinks = append(externalLinks, &ExternalLinkForMetadata{
 				URL:         formattedURL,
 				DisplayName: link.DisplayName,
@@ -194,8 +185,8 @@ func (r *versionResolver) ExternalLinksForMetadata(ctx context.Context, obj *res
 }
 
 // GeneratedTaskCounts is the resolver for the generatedTaskCounts field.
-func (r *versionResolver) GeneratedTaskCounts(ctx context.Context, obj *restModel.APIVersion) ([]*GeneratedTaskCountResults, error) {
-	versionID := utility.FromStringPtr(obj.Id)
+func (r *versionResolver) GeneratedTaskCounts(ctx context.Context, obj *model.Version) ([]*GeneratedTaskCountResults, error) {
+	versionID := obj.Id
 	v, err := model.VersionFindOneId(ctx, versionID)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionID, err.Error()))
@@ -221,29 +212,16 @@ func (r *versionResolver) GeneratedTaskCounts(ctx context.Context, obj *restMode
 	return res, nil
 }
 
-// GitTags is the resolver for the gitTags field.
-func (r *versionResolver) GitTags(ctx context.Context, obj *restModel.APIVersion) ([]*model.GitTag, error) {
-	gitTags := make([]*model.GitTag, 0, len(obj.GitTags))
-	for _, gt := range obj.GitTags {
-		gitTags = append(gitTags, &model.GitTag{
-			Tag:    utility.FromStringPtr(gt.Tag),
-			Pusher: utility.FromStringPtr(gt.Pusher),
-		})
-	}
-	return gitTags, nil
-}
-
 // IsPatch is the resolver for the isPatch field.
-func (r *versionResolver) IsPatch(ctx context.Context, obj *restModel.APIVersion) (bool, error) {
-	return evergreen.IsPatchRequester(utility.FromStringPtr(obj.Requester)), nil
+func (r *versionResolver) IsPatch(ctx context.Context, obj *model.Version) (bool, error) {
+	return evergreen.IsPatchRequester(obj.Requester), nil
 }
 
 // Manifest is the resolver for the manifest field.
-func (r *versionResolver) Manifest(ctx context.Context, obj *restModel.APIVersion) (*Manifest, error) {
-	versionID := utility.FromStringPtr(obj.Id)
-	m, err := manifest.FindFromVersion(ctx, versionID, utility.FromStringPtr(obj.Project), utility.FromStringPtr(obj.Revision), utility.FromStringPtr(obj.Requester))
+func (r *versionResolver) Manifest(ctx context.Context, obj *model.Version) (*Manifest, error) {
+	m, err := manifest.FindFromVersion(ctx, obj.Id, obj.Branch, obj.Revision, obj.Requester)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting manifest for version '%s': %s", versionID, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting manifest for version '%s': %s", obj.Id, err.Error()))
 	}
 	if m == nil {
 		return nil, nil
@@ -265,57 +243,62 @@ func (r *versionResolver) Manifest(ctx context.Context, obj *restModel.APIVersio
 	return &versionManifest, nil
 }
 
+// Order is the resolver for the order field.
+func (r *versionResolver) Order(ctx context.Context, obj *model.Version) (int, error) {
+	panic(fmt.Errorf("not implemented: Order - order"))
+}
+
+// Parameters is the resolver for the parameters field.
+func (r *versionResolver) Parameters(ctx context.Context, obj *model.Version) ([]*restModel.APIParameter, error) {
+	panic(fmt.Errorf("not implemented: Parameters - parameters"))
+}
+
 // Patch is the resolver for the patch field.
-func (r *versionResolver) Patch(ctx context.Context, obj *restModel.APIVersion) (*patch.Patch, error) {
-	if !evergreen.IsPatchRequester(utility.FromStringPtr(obj.Requester)) {
+func (r *versionResolver) Patch(ctx context.Context, obj *model.Version) (*patch.Patch, error) {
+	if !evergreen.IsPatchRequester(obj.Requester) {
 		return nil, nil
 	}
-	patchID := utility.FromStringPtr(obj.Id)
-	p, err := loaders.GetPatch(ctx, patchID)
+	p, err := loaders.GetPatch(ctx, obj.Id)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding patch '%s': %s", patchID, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding patch '%s': %s", obj.Id, err.Error()))
 	}
 	return p, nil
 }
 
 // PreviousVersion is the resolver for the previousVersion field.
-func (r *versionResolver) PreviousVersion(ctx context.Context, obj *restModel.APIVersion) (*restModel.APIVersion, error) {
-	if !obj.IsPatchRequester() {
-		previousVersion, err := model.VersionFindOne(ctx, model.VersionByProjectIdAndOrder(utility.FromStringPtr(obj.Project), obj.Order-1))
+func (r *versionResolver) PreviousVersion(ctx context.Context, obj *model.Version) (*model.Version, error) {
+	if !evergreen.IsPatchRequester(obj.Requester) {
+		previousVersion, err := model.VersionFindOne(ctx, model.VersionByProjectIdAndOrder(obj.Branch, obj.RevisionOrderNumber-1))
 		if err != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding previous version for version '%s': %s", utility.FromStringPtr(obj.Id), err.Error()))
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding previous version for version '%s': %s", obj.Id, err.Error()))
 		}
 		if previousVersion == nil {
 			return nil, nil
 		}
-		apiVersion := restModel.APIVersion{}
-		apiVersion.BuildFromService(ctx, *previousVersion)
-		return &apiVersion, nil
+		return previousVersion, nil
 	}
-
 	return nil, nil
 }
 
 // ProjectMetadata is the resolver for the projectMetadata field.
-func (r *versionResolver) ProjectMetadata(ctx context.Context, obj *restModel.APIVersion) (*restModel.APIProjectRef, error) {
-	apiProjectRef, err := getAPIProjectRef(ctx, obj.Project)
+func (r *versionResolver) ProjectMetadata(ctx context.Context, obj *model.Version) (*restModel.APIProjectRef, error) {
+	apiProjectRef, err := getAPIProjectRef(ctx, &obj.Branch)
 	return apiProjectRef, err
 }
 
 // QuarantinedTestsSkippedCount is the resolver for the quarantinedTestsSkippedCount field.
-func (r *versionResolver) QuarantinedTestsSkippedCount(ctx context.Context, obj *restModel.APIVersion) (int, error) {
-	versionID := utility.FromStringPtr(obj.Id)
-	count, err := task.GetQuarantinedTestsSkippedCountByVersion(ctx, versionID)
+func (r *versionResolver) QuarantinedTestsSkippedCount(ctx context.Context, obj *model.Version) (int, error) {
+	count, err := task.GetQuarantinedTestsSkippedCountByVersion(ctx, obj.Id)
 	if err != nil {
-		return 0, InternalServerError.Send(ctx, fmt.Sprintf("getting TSS-skipped test count for version '%s': %s", versionID, err.Error()))
+		return 0, InternalServerError.Send(ctx, fmt.Sprintf("getting TSS-skipped test count for version '%s': %s", obj.Id, err.Error()))
 	}
 
 	return count, nil
 }
 
 // Status is the resolver for the status field.
-func (r *versionResolver) Status(ctx context.Context, obj *restModel.APIVersion) (string, error) {
-	versionID := utility.FromStringPtr(obj.Id)
+func (r *versionResolver) Status(ctx context.Context, obj *model.Version) (string, error) {
+	versionID := obj.Id
 	v, err := model.VersionFindOneId(ctx, versionID)
 	if err != nil {
 		return "", InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionID, err.Error()))
@@ -327,24 +310,23 @@ func (r *versionResolver) Status(ctx context.Context, obj *restModel.APIVersion)
 }
 
 // TaskCount is the resolver for the taskCount field.
-func (r *versionResolver) TaskCount(ctx context.Context, obj *restModel.APIVersion, options *TaskCountOptions) (*int, error) {
-	versionID := utility.FromStringPtr(obj.Id)
+func (r *versionResolver) TaskCount(ctx context.Context, obj *model.Version, options *TaskCountOptions) (*int, error) {
 	// if includeNeverActivatedTasks is nil, we default to using the value of the requester
-	includeNeverActivatedTasks := utility.ToBoolPtr(!obj.IsPatchRequester())
+	includeNeverActivatedTasks := utility.ToBoolPtr(!evergreen.IsPatchRequester(obj.Requester))
 	if options != nil && options.IncludeNeverActivatedTasks != nil {
 		includeNeverActivatedTasks = options.IncludeNeverActivatedTasks
 	}
-	taskCount, err := task.Count(ctx, db.Query(task.DisplayTasksByVersion(versionID, utility.FromBoolPtr(includeNeverActivatedTasks))))
+	taskCount, err := task.Count(ctx, db.Query(task.DisplayTasksByVersion(obj.Id, utility.FromBoolPtr(includeNeverActivatedTasks))))
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting task count for version '%s': %s", versionID, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting task count for version '%s': %s", obj.Id, err.Error()))
 	}
 	return &taskCount, nil
 }
 
 // TaskQuarantinedTestsSample is the resolver for the taskQuarantinedTestsSample field.
-func (r *versionResolver) TaskQuarantinedTestsSample(ctx context.Context, obj *restModel.APIVersion, taskIds []string, limit *int) ([]*testresult.TaskTestResultsQuarantinedSample, error) {
-	versionID := utility.FromStringPtr(obj.Id)
-	if err := checkProjectAccess(ctx, utility.FromStringPtr(obj.Project), ProjectPermissionTasks, AccessLevelView); err != nil {
+func (r *versionResolver) TaskQuarantinedTestsSample(ctx context.Context, obj *model.Version, taskIds []string, limit *int) ([]*testresult.TaskTestResultsQuarantinedSample, error) {
+	versionID := obj.Id
+	if err := checkProjectAccess(ctx, obj.Branch, ProjectPermissionTasks, AccessLevelView); err != nil {
 		return nil, err
 	}
 	if len(taskIds) == 0 {
@@ -456,8 +438,8 @@ func (r *versionResolver) TaskQuarantinedTestsSample(ctx context.Context, obj *r
 }
 
 // Tasks is the resolver for the tasks field.
-func (r *versionResolver) Tasks(ctx context.Context, obj *restModel.APIVersion, options TaskFilterOptions) (*VersionTasks, error) {
-	versionID := utility.FromStringPtr(obj.Id)
+func (r *versionResolver) Tasks(ctx context.Context, obj *model.Version, options TaskFilterOptions) (*VersionTasks, error) {
+	versionID := obj.Id
 	includeNeverActivatedTasks := options.IncludeNeverActivatedTasks
 	if includeNeverActivatedTasks == nil {
 		includeNeverActivatedTasks = utility.ToBoolPtr(false)
@@ -506,7 +488,7 @@ func (r *versionResolver) Tasks(ctx context.Context, obj *restModel.APIVersion, 
 		}
 	}
 	baseVersionID := ""
-	baseVersion, err := model.FindBaseVersionForVersion(ctx, utility.FromStringPtr(obj.Id))
+	baseVersion, err := model.FindBaseVersionForVersion(ctx, versionID)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding base version for version '%s': %s", versionID, err.Error()))
 	}
@@ -522,7 +504,7 @@ func (r *versionResolver) Tasks(ctx context.Context, obj *restModel.APIVersion, 
 		Limit:        limitParam,
 		Sorts:        taskSorts,
 		// If the version is a patch, we want to exclude inactive tasks by default.
-		IncludeNeverActivatedTasks: *includeNeverActivatedTasks || !evergreen.IsPatchRequester(utility.FromStringPtr(obj.Requester)),
+		IncludeNeverActivatedTasks: *includeNeverActivatedTasks || !evergreen.IsPatchRequester(obj.Requester),
 		BaseVersionID:              baseVersionID,
 	}
 	tasks, count, err := task.GetTasksByVersion(ctx, versionID, opts)
@@ -547,17 +529,16 @@ func (r *versionResolver) Tasks(ctx context.Context, obj *restModel.APIVersion, 
 }
 
 // TaskStatuses is the resolver for the taskStatuses field.
-func (r *versionResolver) TaskStatuses(ctx context.Context, obj *restModel.APIVersion) ([]string, error) {
-	versionID := utility.FromStringPtr(obj.Id)
-	statuses, err := task.GetTaskStatusesByVersion(ctx, versionID)
+func (r *versionResolver) TaskStatuses(ctx context.Context, obj *model.Version) ([]string, error) {
+	statuses, err := task.GetTaskStatusesByVersion(ctx, obj.Id)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting task statuses for version '%s': %s", versionID, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting task statuses for version '%s': %s", obj.Id, err.Error()))
 	}
 	return statuses, nil
 }
 
 // TaskStatusStats is the resolver for the taskStatusStats field.
-func (r *versionResolver) TaskStatusStats(ctx context.Context, obj *restModel.APIVersion, options BuildVariantOptions) (*task.TaskStats, error) {
+func (r *versionResolver) TaskStatusStats(ctx context.Context, obj *model.Version, options BuildVariantOptions) (*task.TaskStats, error) {
 	includeNeverActivatedTasks := options.IncludeNeverActivatedTasks
 	if includeNeverActivatedTasks == nil {
 		includeNeverActivatedTasks = utility.ToBoolPtr(false)
@@ -568,24 +549,23 @@ func (r *versionResolver) TaskStatusStats(ctx context.Context, obj *restModel.AP
 		Variants:              options.Variants,
 		Statuses:              getValidTaskStatusesFilter(options.Statuses),
 		// If the version is a patch, we don't want to include its never activated tasks.
-		IncludeNeverActivatedTasks: *includeNeverActivatedTasks || !obj.IsPatchRequester(),
+		IncludeNeverActivatedTasks: *includeNeverActivatedTasks || !evergreen.IsPatchRequester(obj.Requester),
 	}
 
-	versionID := utility.FromStringPtr(obj.Id)
-	stats, err := task.GetFilteredTaskStatsByVersion(ctx, versionID, opts)
+	stats, err := task.GetFilteredTaskStatsByVersion(ctx, obj.Id, opts)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting task status stats for version '%s': %s", versionID, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting task status stats for version '%s': %s", obj.Id, err.Error()))
 	}
 	return stats, nil
 }
 
 // UpstreamProject is the resolver for the upstreamProject field.
-func (r *versionResolver) UpstreamProject(ctx context.Context, obj *restModel.APIVersion) (*UpstreamProject, error) {
-	if utility.FromStringPtr(obj.Requester) != evergreen.TriggerRequester {
+func (r *versionResolver) UpstreamProject(ctx context.Context, obj *model.Version) (*UpstreamProject, error) {
+	if obj.Requester != evergreen.TriggerRequester {
 		return nil, nil
 	}
 
-	versionID := utility.FromStringPtr(obj.Id)
+	versionID := obj.Id
 	v, err := model.VersionFindOneId(ctx, versionID)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionID, err.Error()))
@@ -635,13 +615,10 @@ func (r *versionResolver) UpstreamProject(ctx context.Context, obj *restModel.AP
 			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("upstream version '%s' not found", upstreamBuild.Version))
 		}
 
-		apiVersion := restModel.APIVersion{}
-		apiVersion.BuildFromService(ctx, *upstreamVersion)
-
 		projectID = upstreamVersion.Identifier
 		upstreamProject = &UpstreamProject{
 			Revision: upstreamBuild.Revision,
-			Version:  &apiVersion,
+			Version:  upstreamVersion,
 		}
 	} else if v.TriggerType == model.ProjectTriggerLevelPush {
 		projectID = v.TriggerID
@@ -666,13 +643,13 @@ func (r *versionResolver) UpstreamProject(ctx context.Context, obj *restModel.AP
 }
 
 // User is the resolver for the user field.
-func (r *versionResolver) User(ctx context.Context, obj *restModel.APIVersion) (*user.DBUser, error) {
-	return getVersionAuthorDBUser(ctx, utility.FromStringPtr(obj.AuthorID), utility.FromStringPtr(obj.Author), utility.FromStringPtr(obj.AuthorEmail))
+func (r *versionResolver) User(ctx context.Context, obj *model.Version) (*user.DBUser, error) {
+	return getVersionAuthorDBUser(ctx, obj.AuthorID, obj.Author, obj.AuthorEmail)
 }
 
 // VersionTiming is the resolver for the versionTiming field.
-func (r *versionResolver) VersionTiming(ctx context.Context, obj *restModel.APIVersion) (*VersionTiming, error) {
-	versionID := utility.FromStringPtr(obj.Id)
+func (r *versionResolver) VersionTiming(ctx context.Context, obj *model.Version) (*VersionTiming, error) {
+	versionID := obj.Id
 	v, err := model.VersionFindOneId(ctx, versionID)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionID, err.Error()))
@@ -701,19 +678,6 @@ func (r *versionResolver) VersionTiming(ctx context.Context, obj *restModel.APIV
 		TimeTaken: &apiTimeTaken,
 		Makespan:  &apiMakespan,
 	}, nil
-}
-
-// Warnings is the resolver for the warnings field.
-func (r *versionResolver) Warnings(ctx context.Context, obj *restModel.APIVersion) ([]string, error) {
-	versionID := utility.FromStringPtr(obj.Id)
-	v, err := model.VersionFindOneId(ctx, versionID)
-	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionID, err.Error()))
-	}
-	if v == nil {
-		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("version '%s' not found", versionID))
-	}
-	return v.Warnings, nil
 }
 
 // BaseVersion is the resolver for the baseVersion field.

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -158,7 +158,7 @@ func (r *versionResolver) Cost(ctx context.Context, obj *model.Version) (*cost.C
 
 // ExternalLinksForMetadata is the resolver for the externalLinksForMetadata field.
 func (r *versionResolver) ExternalLinksForMetadata(ctx context.Context, obj *model.Version) ([]*ExternalLinkForMetadata, error) {
-	projectID := obj.Branch
+	projectID := obj.Identifier
 	pRef, err := data.FindProjectById(ctx, projectID, false, false)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching project '%s': %s", projectID, err.Error()))
@@ -218,7 +218,7 @@ func (r *versionResolver) IsPatch(ctx context.Context, obj *model.Version) (bool
 
 // Manifest is the resolver for the manifest field.
 func (r *versionResolver) Manifest(ctx context.Context, obj *model.Version) (*Manifest, error) {
-	m, err := manifest.FindFromVersion(ctx, obj.Id, obj.Branch, obj.Revision, obj.Requester)
+	m, err := manifest.FindFromVersion(ctx, obj.Id, obj.Identifier, obj.Revision, obj.Requester)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting manifest for version '%s': %s", obj.Id, err.Error()))
 	}
@@ -267,7 +267,7 @@ func (r *versionResolver) Patch(ctx context.Context, obj *model.Version) (*patch
 // PreviousVersion is the resolver for the previousVersion field.
 func (r *versionResolver) PreviousVersion(ctx context.Context, obj *model.Version) (*model.Version, error) {
 	if !evergreen.IsPatchRequester(obj.Requester) {
-		previousVersion, err := model.VersionFindOne(ctx, model.VersionByProjectIdAndOrder(obj.Branch, obj.RevisionOrderNumber-1))
+		previousVersion, err := model.VersionFindOne(ctx, model.VersionByProjectIdAndOrder(obj.Identifier, obj.RevisionOrderNumber-1))
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding previous version for version '%s': %s", obj.Id, err.Error()))
 		}
@@ -281,7 +281,7 @@ func (r *versionResolver) PreviousVersion(ctx context.Context, obj *model.Versio
 
 // ProjectMetadata is the resolver for the projectMetadata field.
 func (r *versionResolver) ProjectMetadata(ctx context.Context, obj *model.Version) (*restModel.APIProjectRef, error) {
-	apiProjectRef, err := getAPIProjectRef(ctx, &obj.Branch)
+	apiProjectRef, err := getAPIProjectRef(ctx, &obj.Identifier)
 	return apiProjectRef, err
 }
 
@@ -325,7 +325,7 @@ func (r *versionResolver) TaskCount(ctx context.Context, obj *model.Version, opt
 // TaskQuarantinedTestsSample is the resolver for the taskQuarantinedTestsSample field.
 func (r *versionResolver) TaskQuarantinedTestsSample(ctx context.Context, obj *model.Version, taskIds []string, limit *int) ([]*testresult.TaskTestResultsQuarantinedSample, error) {
 	versionID := obj.Id
-	if err := checkProjectAccess(ctx, obj.Branch, ProjectPermissionTasks, AccessLevelView); err != nil {
+	if err := checkProjectAccess(ctx, obj.Identifier, ProjectPermissionTasks, AccessLevelView); err != nil {
 		return nil, err
 	}
 	if len(taskIds) == 0 {

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -103,8 +103,7 @@ func (r *versionResolver) ChildVersions(ctx context.Context, obj *model.Version)
 		loaders.PreloadVersions(ctx, childPatchIds)
 		childVersions := []*model.Version{}
 		for _, cp := range childPatchIds {
-			// this calls the graphql Version query resolver
-			cv, err := r.Query().Version(ctx, cp)
+			cv, err := loaders.GetVersion(ctx, cp)
 			if err != nil {
 				// before erroring due to the version being nil or not found,
 				// fetch the child patch to see if it's activated

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -242,11 +242,6 @@ func (r *versionResolver) Manifest(ctx context.Context, obj *model.Version) (*Ma
 	return &versionManifest, nil
 }
 
-// Order is the resolver for the order field.
-func (r *versionResolver) Order(ctx context.Context, obj *model.Version) (int, error) {
-	panic(fmt.Errorf("not implemented: Order - order"))
-}
-
 // Parameters is the resolver for the parameters field.
 func (r *versionResolver) Parameters(ctx context.Context, obj *model.Version) ([]*restModel.APIParameter, error) {
 	panic(fmt.Errorf("not implemented: Parameters - parameters"))

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -244,7 +244,11 @@ func (r *versionResolver) Manifest(ctx context.Context, obj *model.Version) (*Ma
 
 // Parameters is the resolver for the parameters field.
 func (r *versionResolver) Parameters(ctx context.Context, obj *model.Version) ([]*restModel.APIParameter, error) {
-	panic(fmt.Errorf("not implemented: Parameters - parameters"))
+	redactedParameters, err := redactParameters(ctx, obj.Identifier, obj.Parameters)
+	if err != nil {
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("redacting parameters for version '%s': %s", obj.Id, err.Error()), err)
+	}
+	return redactedParameters, nil
 }
 
 // Patch is the resolver for the patch field.

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -40,9 +40,9 @@ func (r *versionResolver) BaseVersion(ctx context.Context, obj *model.Version) (
 // BuildVariants is the resolver for the buildVariants field.
 func (r *versionResolver) BuildVariants(ctx context.Context, obj *model.Version, options BuildVariantOptions) ([]*GroupedBuildVariant, error) {
 	versionID := obj.Id
-	// If activated is nil in the db we should resolve it and cache it for subsequent queries. There is a very low likely hood of this field being hit
+	// If activated is nil in the db, we should resolve it and cache it for subsequent queries. There is a very low likelihood of this field being hit.
 	if obj.Activated == nil {
-		version, err := model.VersionFindOneIdWithBuildVariants(ctx, versionID)
+		version, err := loaders.GetVersion(ctx, versionID)
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding version '%s': %s", versionID, err.Error()))
 		}
@@ -186,7 +186,7 @@ func (r *versionResolver) ExternalLinksForMetadata(ctx context.Context, obj *mod
 // GeneratedTaskCounts is the resolver for the generatedTaskCounts field.
 func (r *versionResolver) GeneratedTaskCounts(ctx context.Context, obj *model.Version) ([]*GeneratedTaskCountResults, error) {
 	versionID := obj.Id
-	v, err := model.VersionFindOneId(ctx, versionID)
+	v, err := loaders.GetVersion(ctx, versionID)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionID, err.Error()))
 	}
@@ -297,7 +297,7 @@ func (r *versionResolver) QuarantinedTestsSkippedCount(ctx context.Context, obj 
 // Status is the resolver for the status field.
 func (r *versionResolver) Status(ctx context.Context, obj *model.Version) (string, error) {
 	versionID := obj.Id
-	v, err := model.VersionFindOneId(ctx, versionID)
+	v, err := loaders.GetVersion(ctx, versionID)
 	if err != nil {
 		return "", InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionID, err.Error()))
 	}
@@ -564,7 +564,7 @@ func (r *versionResolver) UpstreamProject(ctx context.Context, obj *model.Versio
 	}
 
 	versionID := obj.Id
-	v, err := model.VersionFindOneId(ctx, versionID)
+	v, err := loaders.GetVersion(ctx, versionID)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionID, err.Error()))
 	}
@@ -605,7 +605,7 @@ func (r *versionResolver) UpstreamProject(ctx context.Context, obj *model.Versio
 			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("upstream build '%s' not found", v.TriggerID))
 		}
 
-		upstreamVersion, err := model.VersionFindOneIdWithBuildVariants(ctx, upstreamBuild.Version)
+		upstreamVersion, err := loaders.GetVersion(ctx, upstreamBuild.Version)
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching upstream version '%s': %s", upstreamBuild.Version, err.Error()))
 		}
@@ -648,7 +648,7 @@ func (r *versionResolver) User(ctx context.Context, obj *model.Version) (*user.D
 // VersionTiming is the resolver for the versionTiming field.
 func (r *versionResolver) VersionTiming(ctx context.Context, obj *model.Version) (*VersionTiming, error) {
 	versionID := obj.Id
-	v, err := model.VersionFindOneId(ctx, versionID)
+	v, err := loaders.GetVersion(ctx, versionID)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionID, err.Error()))
 	}

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -103,7 +103,7 @@ func (r *versionResolver) ChildVersions(ctx context.Context, obj *model.Version)
 		loaders.PreloadVersions(ctx, childPatchIds)
 		childVersions := []*model.Version{}
 		for _, cp := range childPatchIds {
-			cv, err := r.Query().Version(ctx, cp)
+			cv, err := loaders.GetVersion(ctx, cp)
 			if err != nil {
 				// before erroring due to the version being nil or not found,
 				// fetch the child patch to see if it's activated

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -39,25 +39,12 @@ func (r *versionResolver) BaseVersion(ctx context.Context, obj *model.Version) (
 
 // BuildVariants is the resolver for the buildVariants field.
 func (r *versionResolver) BuildVariants(ctx context.Context, obj *model.Version, options BuildVariantOptions) ([]*GroupedBuildVariant, error) {
-	versionID := obj.Id
-	// If activated is nil in the db, we should resolve it and cache it for subsequent queries. There is a very low likelihood of this field being hit.
-	if obj.Activated == nil {
-		version, err := loaders.GetVersion(ctx, versionID)
-		if err != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding version '%s': %s", versionID, err.Error()))
-		}
-		if err = setVersionActivationStatus(ctx, version); err != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("setting version activation status for version '%s': %s", versionID, err.Error()))
-		}
-		obj.Activated = version.Activated
-	}
-
 	if evergreen.IsPatchRequester(obj.Requester) && !utility.FromBoolPtr(obj.Activated) {
 		return nil, nil
 	}
-	groupedBuildVariants, err := generateBuildVariants(ctx, versionID, options, obj.Requester, r.sc.GetURL())
+	groupedBuildVariants, err := generateBuildVariants(ctx, obj.Id, options, obj.Requester, r.sc.GetURL())
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("generating build variants for version '%s': %s", versionID, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("generating build variants for version '%s': %s", obj.Id, err.Error()))
 	}
 	return groupedBuildVariants, nil
 }
@@ -185,22 +172,13 @@ func (r *versionResolver) ExternalLinksForMetadata(ctx context.Context, obj *mod
 
 // GeneratedTaskCounts is the resolver for the generatedTaskCounts field.
 func (r *versionResolver) GeneratedTaskCounts(ctx context.Context, obj *model.Version) ([]*GeneratedTaskCountResults, error) {
-	versionID := obj.Id
-	v, err := loaders.GetVersion(ctx, versionID)
-	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionID, err.Error()))
-	}
-	if v == nil {
-		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("version '%s' not found", versionID))
-	}
-
 	var res []*GeneratedTaskCountResults
 	versionGeneratorTasks, err := task.Find(ctx, bson.M{
-		task.VersionKey:      versionID,
+		task.VersionKey:      obj.Id,
 		task.GenerateTaskKey: true,
 	})
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding generator tasks from version '%s': %s", versionID, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding generator tasks from version '%s': %s", obj.Id, err.Error()))
 	}
 	for _, generatorTask := range versionGeneratorTasks {
 		res = append(res, &GeneratedTaskCountResults{
@@ -296,15 +274,7 @@ func (r *versionResolver) QuarantinedTestsSkippedCount(ctx context.Context, obj 
 
 // Status is the resolver for the status field.
 func (r *versionResolver) Status(ctx context.Context, obj *model.Version) (string, error) {
-	versionID := obj.Id
-	v, err := loaders.GetVersion(ctx, versionID)
-	if err != nil {
-		return "", InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionID, err.Error()))
-	}
-	if v == nil {
-		return "", ResourceNotFound.Send(ctx, fmt.Sprintf("version '%s' not found", versionID))
-	}
-	return getDisplayStatus(ctx, v)
+	return getDisplayStatus(ctx, obj)
 }
 
 // TaskCount is the resolver for the taskCount field.
@@ -563,27 +533,19 @@ func (r *versionResolver) UpstreamProject(ctx context.Context, obj *model.Versio
 		return nil, nil
 	}
 
-	versionID := obj.Id
-	v, err := loaders.GetVersion(ctx, versionID)
-	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionID, err.Error()))
-	}
-	if v == nil {
-		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("version '%s' not found", versionID))
-	}
-	if v.TriggerID == "" || v.TriggerType == "" {
+	if obj.TriggerID == "" || obj.TriggerType == "" {
 		return nil, nil
 	}
 
 	var projectID string
 	var upstreamProject *UpstreamProject
-	if v.TriggerType == model.ProjectTriggerLevelTask {
-		upstreamTask, err := task.FindOneId(ctx, v.TriggerID)
+	if obj.TriggerType == model.ProjectTriggerLevelTask {
+		upstreamTask, err := task.FindOneId(ctx, obj.TriggerID)
 		if err != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching upstream task '%s': %s", v.TriggerID, err.Error()))
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching upstream task '%s': %s", obj.TriggerID, err.Error()))
 		}
 		if upstreamTask == nil {
-			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("upstream task '%s' not found", v.TriggerID))
+			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("upstream task '%s' not found", obj.TriggerID))
 		}
 
 		apiTask := restModel.APITask{}
@@ -596,13 +558,13 @@ func (r *versionResolver) UpstreamProject(ctx context.Context, obj *model.Versio
 			Revision: upstreamTask.Revision,
 			Task:     &apiTask,
 		}
-	} else if v.TriggerType == model.ProjectTriggerLevelBuild {
-		upstreamBuild, err := build.FindOneId(ctx, v.TriggerID)
+	} else if obj.TriggerType == model.ProjectTriggerLevelBuild {
+		upstreamBuild, err := build.FindOneId(ctx, obj.TriggerID)
 		if err != nil {
-			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching upstream build '%s': %s", v.TriggerID, err.Error()))
+			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching upstream build '%s': %s", obj.TriggerID, err.Error()))
 		}
 		if upstreamBuild == nil {
-			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("upstream build '%s' not found", v.TriggerID))
+			return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("upstream build '%s' not found", obj.TriggerID))
 		}
 
 		upstreamVersion, err := loaders.GetVersion(ctx, upstreamBuild.Version)
@@ -618,10 +580,10 @@ func (r *versionResolver) UpstreamProject(ctx context.Context, obj *model.Versio
 			Revision: upstreamBuild.Revision,
 			Version:  upstreamVersion,
 		}
-	} else if v.TriggerType == model.ProjectTriggerLevelPush {
-		projectID = v.TriggerID
+	} else if obj.TriggerType == model.ProjectTriggerLevelPush {
+		projectID = obj.TriggerID
 		upstreamProject = &UpstreamProject{
-			Revision: v.TriggerSHA,
+			Revision: obj.TriggerSHA,
 		}
 	}
 	upstreamProjectRef, err := model.FindBranchProjectRefSecondary(ctx, projectID)
@@ -635,8 +597,8 @@ func (r *versionResolver) UpstreamProject(ctx context.Context, obj *model.Versio
 	upstreamProject.Owner = upstreamProjectRef.Owner
 	upstreamProject.Repo = upstreamProjectRef.Repo
 	upstreamProject.Project = upstreamProjectRef.Identifier
-	upstreamProject.TriggerID = v.TriggerID
-	upstreamProject.TriggerType = v.TriggerType
+	upstreamProject.TriggerID = obj.TriggerID
+	upstreamProject.TriggerType = obj.TriggerType
 	return upstreamProject, nil
 }
 
@@ -647,17 +609,9 @@ func (r *versionResolver) User(ctx context.Context, obj *model.Version) (*user.D
 
 // VersionTiming is the resolver for the versionTiming field.
 func (r *versionResolver) VersionTiming(ctx context.Context, obj *model.Version) (*VersionTiming, error) {
-	versionID := obj.Id
-	v, err := loaders.GetVersion(ctx, versionID)
+	timeTaken, makespan, err := obj.GetTimeSpent(ctx)
 	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionID, err.Error()))
-	}
-	if v == nil {
-		return nil, ResourceNotFound.Send(ctx, fmt.Sprintf("version '%s' not found", versionID))
-	}
-	timeTaken, makespan, err := v.GetTimeSpent(ctx)
-	if err != nil {
-		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting timing for version '%s': %s", versionID, err.Error()))
+		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting timing for version '%s': %s", obj.Id, err.Error()))
 	}
 	// return nil if rounded timeTaken/makespan == 0s
 	t := timeTaken.Round(time.Second)

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -103,7 +103,7 @@ func (r *versionResolver) ChildVersions(ctx context.Context, obj *model.Version)
 		loaders.PreloadVersions(ctx, childPatchIds)
 		childVersions := []*model.Version{}
 		for _, cp := range childPatchIds {
-			cv, err := loaders.GetVersion(ctx, cp)
+			cv, err := r.Query().Version(ctx, cp)
 			if err != nil {
 				// before erroring due to the version being nil or not found,
 				// fetch the child patch to see if it's activated

--- a/graphql/version_resolver.go
+++ b/graphql/version_resolver.go
@@ -309,12 +309,12 @@ func (r *versionResolver) Status(ctx context.Context, obj *model.Version) (strin
 
 // TaskCount is the resolver for the taskCount field.
 func (r *versionResolver) TaskCount(ctx context.Context, obj *model.Version, options *TaskCountOptions) (*int, error) {
-	// if includeNeverActivatedTasks is nil, we default to using the value of the requester
-	includeNeverActivatedTasks := utility.ToBoolPtr(!evergreen.IsPatchRequester(obj.Requester))
+	// If includeNeverActivatedTasks is nil, default to using the value of the requester.
+	includeNeverActivatedTasks := !evergreen.IsPatchRequester(obj.Requester)
 	if options != nil && options.IncludeNeverActivatedTasks != nil {
-		includeNeverActivatedTasks = options.IncludeNeverActivatedTasks
+		includeNeverActivatedTasks = *options.IncludeNeverActivatedTasks
 	}
-	taskCount, err := task.Count(ctx, db.Query(task.DisplayTasksByVersion(obj.Id, utility.FromBoolPtr(includeNeverActivatedTasks))))
+	taskCount, err := task.Count(ctx, db.Query(task.DisplayTasksByVersion(obj.Id, includeNeverActivatedTasks)))
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting task count for version '%s': %s", obj.Id, err.Error()))
 	}


### PR DESCRIPTION
DEVPROD-38054

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description
Changes `GraphQL` Version object to map to non-REST model. This changes function signature of several resolvers so they needed to be updated.

Also I redacted parameters for versions because I think that it was an oversight we missed when redacting parameters for patches

### Testing
* Checked functionality on staging (view versions, view waterfall, restart versions)
* I didn't edit any of the files reported by the CodeQL failure