### PR TITLE
DEVPROD-42783: Skip host-wide pkill on container-isolated distros without a container

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1636,7 +1636,7 @@ func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupC
 		} else if tc.taskConfig.Distro.ContainerIsolation != nil {
 			// Task processes live in containers, which may not exist yet; the
 			// host-wide pkill is unsafe here.
-			logger.Infof(ctx, "Skipping process cleanup for task '%s': distro has container isolation enabled but no container is running.", tc.task.ID)
+			logger.Warningf(ctx, "Skipping process cleanup for task '%s': distro has container isolation enabled but no container is running.", tc.task.ID)
 		} else {
 			logger.Infof(ctx, "Cleaning up processes for task: '%s'.", tc.task.ID)
 			if err := agentutil.KillSpawnedProcs(ctx, tc.task.ID, tc.taskConfig.WorkDir, tc.taskConfig.Distro.ExecUser, logger); err != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1633,6 +1633,12 @@ func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupC
 					logger.Infof(ctx, "Completed in-container process cleanup for task '%s'.", tc.task.ID)
 				}
 			}
+		} else if tc.taskConfig.Distro.ContainerIsolation != nil {
+			// Never run the host-wide pkill on a container-isolated
+			// distro: task processes live in container namespaces, and
+			// the container may not exist yet (task start, or failed
+			// container creation), so there is nothing safe to kill here.
+			logger.Infof(ctx, "Skipping process cleanup for task '%s': distro has container isolation enabled but no container is running.", tc.task.ID)
 		} else {
 			logger.Infof(ctx, "Cleaning up processes for task: '%s'.", tc.task.ID)
 			if err := agentutil.KillSpawnedProcs(ctx, tc.task.ID, tc.taskConfig.WorkDir, tc.taskConfig.Distro.ExecUser, logger); err != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1634,10 +1634,8 @@ func (a *Agent) killProcs(ctx context.Context, tc *taskContext, ignoreTaskGroupC
 				}
 			}
 		} else if tc.taskConfig.Distro.ContainerIsolation != nil {
-			// Never run the host-wide pkill on a container-isolated
-			// distro: task processes live in container namespaces, and
-			// the container may not exist yet (task start, or failed
-			// container creation), so there is nothing safe to kill here.
+			// Task processes live in containers, which may not exist yet; the
+			// host-wide pkill is unsafe here.
 			logger.Infof(ctx, "Skipping process cleanup for task '%s': distro has container isolation enabled but no container is running.", tc.task.ID)
 		} else {
 			logger.Infof(ctx, "Cleaning up processes for task: '%s'.", tc.task.ID)

--- a/agent/container_test.go
+++ b/agent/container_test.go
@@ -122,10 +122,8 @@ func TestKillProcsContainerRouting(t *testing.T) {
 	})
 }
 
-// TestKillProcsIsolationDistroWithoutContainerSkipsHostKill verifies that on a
-// container-isolated distro the host-wide pkill never runs, even when no
-// container exists yet (task start, or failed container creation in fail-open
-// mode).
+// TestKillProcsIsolationDistroWithoutContainerSkipsHostKill verifies the
+// host-wide pkill never runs on an isolated distro without a container.
 func TestKillProcsIsolationDistroWithoutContainerSkipsHostKill(t *testing.T) {
 	ctx := t.Context()
 	a := agentForKillTest()

--- a/agent/container_test.go
+++ b/agent/container_test.go
@@ -122,6 +122,42 @@ func TestKillProcsContainerRouting(t *testing.T) {
 	})
 }
 
+// TestKillProcsIsolationDistroWithoutContainerSkipsHostKill verifies that on a
+// container-isolated distro the host-wide pkill never runs, even when no
+// container exists yet (task start, or failed container creation in fail-open
+// mode).
+func TestKillProcsIsolationDistroWithoutContainerSkipsHostKill(t *testing.T) {
+	ctx := t.Context()
+	a := agentForKillTest()
+	sender := send.MakeInternalLogger()
+
+	tc := &taskContext{
+		task:   client.TaskData{ID: "test-task-1"},
+		logger: client.NewSingleChannelLogHarness("test", sender),
+		taskConfig: &internal.TaskConfig{
+			WorkDir: t.TempDir(),
+			Distro: &apimodels.DistroView{
+				ContainerIsolation: &apimodels.ContainerIsolationSettings{Image: "ubuntu:22.04"},
+			},
+		},
+	}
+
+	require.NoError(t, a.killProcs(ctx, tc, true, "test"))
+	var messages []string
+	for {
+		msg, ok := sender.GetMessageSafe()
+		if !ok {
+			break
+		}
+		messages = append(messages, msg.Message.String())
+	}
+	joined := strings.Join(messages, "\n")
+	assert.Contains(t, joined, "Skipping process cleanup",
+		"the host-wide pkill must be skipped on an isolated distro with no container")
+	assert.NotContains(t, joined, "Cleaned up processes",
+		"the host-side kill must not run on an isolated distro with no container")
+}
+
 func makeSnapshotTC(expansions map[string]string, redacted []string, secrets map[string]string) *taskContext {
 	exp := util.Expansions{}
 	maps.Copy(exp, expansions)

--- a/agent/container_test.go
+++ b/agent/container_test.go
@@ -135,6 +135,7 @@ func TestKillProcsIsolationDistroWithoutContainerSkipsHostKill(t *testing.T) {
 		taskConfig: &internal.TaskConfig{
 			WorkDir: t.TempDir(),
 			Distro: &apimodels.DistroView{
+				ExecUser:           "evg-task-user",
 				ContainerIsolation: &apimodels.ContainerIsolationSettings{Image: "ubuntu:22.04"},
 			},
 		},

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-09-09b"
+	AgentVersion = "2026-09-09c"
 )
 
 const (

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-09-03c"
+	AgentVersion = "2026-09-08a"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-42783

### Description

On container-enabled distros, `killProcs` fell through to the host-side user-wide pkill (`KillSpawnedProcs`) whenever `ContainerID` was empty. On an isolated distro, all task processes live in container namespaces, so the host-wide pkill is both useless and dangerous: it can kill unrelated host processes belonging to the agent user.

This window is hit whenever no container exists yet:

- task start, before container creation
- container creation failure in fail-open mode (`RequireIsolation=false`, the default) — every such failure currently risks a dead host instead of a host-mode fallback
- the Phase 1 rollback story (kill switch / distro reconfiguration) is unsafe for the same reason

The fix gates the host-side kill on the distro's container isolation setting (`DistroView.ContainerIsolation`) rather than on whether a container ID is set, and skips the host-side kill when isolation is enabled but no container is running. In-container kill and Docker artifact cleanup behavior are unchanged: on a fail-open isolation distro with no container, Docker artifact cleanup still runs so host-mode fallback remains viable, and it stays skipped while an isolation container is active.

### Testing

- New test `TestKillProcsIsolationDistroWithoutContainerSkipsHostKill` asserts the skip is logged and the host-side kill never runs for an isolated distro with no container.
- Existing `TestKillProcsContainerRouting`, `TestKillProcsContainerIsolationSkipsDockerCleanup`, and `TestKillProcsFailOpenIsolationRunsDockerCleanup` pass unchanged.
- `go test ./agent/` passes in full; `make lint-agent` is clean.

### Documentation

Not needed: no user-facing configuration or behavior change beyond the safety fix; the skip is logged in the task log.