### PR TITLE
DEVPROD-42374 Add get-var and get-vars debugger command

### DIFF
--- a/agent/taskexec/local_executor.go
+++ b/agent/taskexec/local_executor.go
@@ -310,6 +310,16 @@ func (e *LocalExecutor) SetVariable(ctx context.Context, key, value string) {
 	e.logger.Infof(ctx, "Set variable %s=%s", key, value)
 }
 
+// GetVariable returns the value of an expansion by key and whether it exists.
+func (e *LocalExecutor) GetVariable(key string) (string, bool) {
+	return e.expansions.Get(key), e.expansions.Exists(key)
+}
+
+// GetVariables returns all current expansion variables.
+func (e *LocalExecutor) GetVariables() map[string]string {
+	return e.expansions.Map()
+}
+
 // StepNext executes the current step and advances to the next
 func (e *LocalExecutor) StepNext(ctx context.Context) error {
 	if !e.debugState.HasMoreSteps() {

--- a/agent/taskexec/local_executor.go
+++ b/agent/taskexec/local_executor.go
@@ -6,6 +6,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -310,14 +311,29 @@ func (e *LocalExecutor) SetVariable(ctx context.Context, key, value string) {
 	e.logger.Infof(ctx, "Set variable %s=%s", key, value)
 }
 
-// GetVariable returns the value of an expansion by key and whether it exists.
-func (e *LocalExecutor) GetVariable(key string) (string, bool) {
-	return e.expansions.Get(key), e.expansions.Exists(key)
+// GetVariable returns the value of an expansion by key, whether it exists,
+// and whether it should be redacted.
+func (e *LocalExecutor) GetVariable(key string) (value string, found bool, redacted bool) {
+	return e.expansions.Get(key), e.expansions.Exists(key), e.isRedacted(key)
 }
 
-// GetVariables returns all current expansion variables.
-func (e *LocalExecutor) GetVariables() map[string]string {
-	return e.expansions.Map()
+// GetVariables returns all current expansion variables and which keys are redacted.
+func (e *LocalExecutor) GetVariables() (vars map[string]string, redactedKeys map[string]bool) {
+	allVars := e.expansions.Map()
+	redacted := make(map[string]bool, len(e.taskConfig.Redacted))
+	for _, key := range e.taskConfig.Redacted {
+		if _, overridden := e.debugState.CustomVars[key]; !overridden {
+			redacted[key] = true
+		}
+	}
+	return allVars, redacted
+}
+
+func (e *LocalExecutor) isRedacted(key string) bool {
+	if _, overridden := e.debugState.CustomVars[key]; overridden {
+		return false
+	}
+	return slices.Contains(e.taskConfig.Redacted, key)
 }
 
 // StepNext executes the current step and advances to the next

--- a/agent/taskexec/local_executor_test.go
+++ b/agent/taskexec/local_executor_test.go
@@ -1012,3 +1012,27 @@ tasks:
 		assert.True(t, isNoOp, "s3.put inside a function should be detected as a noOp command")
 	})
 }
+
+func TestGetVariable(t *testing.T) {
+	t.Run("ReturnsSetVariable", func(t *testing.T) {
+		executor, err := NewLocalExecutor(t.Context(), LocalExecutorOptions{})
+		require.NoError(t, err)
+
+		executor.SetVariable(t.Context(), "my_key", "my_value")
+
+		value, found := executor.GetVariable("my_key")
+		assert.True(t, found)
+		assert.Equal(t, "my_value", value)
+	})
+	t.Run("ReturnsAllVariables", func(t *testing.T) {
+		executor, err := NewLocalExecutor(t.Context(), LocalExecutorOptions{})
+		require.NoError(t, err)
+
+		executor.SetVariable(t.Context(), "key1", "value1")
+		executor.SetVariable(t.Context(), "key2", "value2")
+
+		vars := executor.GetVariables()
+		assert.Equal(t, "value1", vars["key1"])
+		assert.Equal(t, "value2", vars["key2"])
+	})
+}

--- a/agent/taskexec/local_executor_test.go
+++ b/agent/taskexec/local_executor_test.go
@@ -1020,19 +1020,49 @@ func TestGetVariable(t *testing.T) {
 
 		executor.SetVariable(t.Context(), "my_key", "my_value")
 
-		value, found := executor.GetVariable("my_key")
+		value, found, redacted := executor.GetVariable("my_key")
 		assert.True(t, found)
+		assert.False(t, redacted)
 		assert.Equal(t, "my_value", value)
 	})
-	t.Run("ReturnsAllVariables", func(t *testing.T) {
+
+	t.Run("RedactedPrivateVariable", func(t *testing.T) {
+		executor, err := NewLocalExecutor(t.Context(), LocalExecutorOptions{})
+		require.NoError(t, err)
+
+		executor.expansions.Put("secret_token", "s3cr3t")
+		executor.taskConfig.Redacted = []string{"secret_token"}
+
+		_, found, redacted := executor.GetVariable("secret_token")
+		assert.True(t, found)
+		assert.True(t, redacted)
+	})
+}
+
+func TestGetVariables(t *testing.T) {
+	t.Run("ReturnsAllVariablesWithRedactionInfo", func(t *testing.T) {
 		executor, err := NewLocalExecutor(t.Context(), LocalExecutorOptions{})
 		require.NoError(t, err)
 
 		executor.SetVariable(t.Context(), "key1", "value1")
-		executor.SetVariable(t.Context(), "key2", "value2")
+		executor.expansions.Put("private_key", "secret")
+		executor.taskConfig.Redacted = []string{"private_key"}
 
-		vars := executor.GetVariables()
+		vars, redactedKeys := executor.GetVariables()
 		assert.Equal(t, "value1", vars["key1"])
-		assert.Equal(t, "value2", vars["key2"])
+		assert.Equal(t, "secret", vars["private_key"])
+		assert.False(t, redactedKeys["key1"])
+		assert.True(t, redactedKeys["private_key"])
+	})
+
+	t.Run("OverriddenPrivateVarNotRedacted", func(t *testing.T) {
+		executor, err := NewLocalExecutor(t.Context(), LocalExecutorOptions{})
+		require.NoError(t, err)
+
+		executor.taskConfig.Redacted = []string{"private_key"}
+		executor.SetVariable(t.Context(), "private_key", "overridden")
+
+		_, redactedKeys := executor.GetVariables()
+		assert.False(t, redactedKeys["private_key"])
 	})
 }

--- a/config.go
+++ b/config.go
@@ -35,11 +35,11 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-09-01"
+	ClientVersion = "2026-09-08"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-09-03c"
+	AgentVersion = "2026-09-08"
 )
 
 const (

--- a/docs/Hosts/Debug-Spawn-Hosts.md
+++ b/docs/Hosts/Debug-Spawn-Hosts.md
@@ -289,9 +289,15 @@ If a variable is not set, the output indicates this:
 MISSING_KEY: <not set>
 ```
 
+Private variables are redacted unless you've overridden them with `set-var`:
+
+```text
+secret_token=<redacted>
+```
+
 #### `evergreen debug get-vars`
 
-Display all expansion variables and their current values, sorted alphabetically.
+Display all expansion variables and their current values, sorted alphabetically. Private variables are shown as `<redacted>` unless overridden with `set-var`.
 
 ```bash
 evergreen debug get-vars
@@ -303,9 +309,7 @@ Example output:
 BUILD_TYPE=debug
 MY_FLAG=--verbose
 distro_id=ubuntu2204-large
-otel_collector_endpoint=DEBUG_MODE_NO_TRACE_COLLECTOR
-otel_parent_id=DEBUG_MODE_NO_TRACE_PARENT
-otel_trace_id=DEBUG_MODE_NO_TRACE_ID
+secret_token=<redacted>
 workdir=/data/mci
 ```
 

--- a/docs/Hosts/Debug-Spawn-Hosts.md
+++ b/docs/Hosts/Debug-Spawn-Hosts.md
@@ -110,6 +110,9 @@ evergreen debug next
 Need to test with different expansion values?
 
 ```bash
+# Check the current value of an expansion
+evergreen debug get-var BUILD_FLAGS
+
 # Set a custom expansion
 evergreen debug set-var VERBOSE=true
 evergreen debug set-var BUILD_FLAGS="--debug"
@@ -262,6 +265,49 @@ Set expansion: MY_FLAG=--verbose
 ```
 
 ### Inspection Commands
+
+#### `evergreen debug get-var <key> [<key>...]`
+
+Get the current value of one or more expansion variables.
+
+```bash
+evergreen debug get-var distro_id
+evergreen debug get-var MY_FLAG BUILD_TYPE
+```
+
+Example output:
+
+```text
+distro_id=ubuntu2204-large
+MY_FLAG=--verbose
+BUILD_TYPE=debug
+```
+
+If a variable is not set, the output indicates this:
+
+```text
+MISSING_KEY: <not set>
+```
+
+#### `evergreen debug get-vars`
+
+Display all expansion variables and their current values, sorted alphabetically.
+
+```bash
+evergreen debug get-vars
+```
+
+Example output:
+
+```text
+BUILD_TYPE=debug
+MY_FLAG=--verbose
+distro_id=ubuntu2204-large
+otel_collector_endpoint=DEBUG_MODE_NO_TRACE_COLLECTOR
+otel_parent_id=DEBUG_MODE_NO_TRACE_PARENT
+otel_trace_id=DEBUG_MODE_NO_TRACE_ID
+workdir=/data/mci
+```
 
 #### `evergreen debug list-steps`
 

--- a/operations/local_client.go
+++ b/operations/local_client.go
@@ -757,10 +757,12 @@ func getAndPrintVariable(url, key string) error {
 		return err
 	}
 
-	if result["found"].(bool) {
-		fmt.Printf("%s=%s\n", key, result["value"])
-	} else {
+	if !result["found"].(bool) {
 		fmt.Printf("%s: <not set>\n", key)
+	} else if result["redacted"].(bool) {
+		fmt.Printf("%s=<redacted>\n", key)
+	} else {
+		fmt.Printf("%s=%s\n", key, result["value"])
 	}
 	return nil
 }

--- a/operations/local_client.go
+++ b/operations/local_client.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"syscall"
 	"time"
@@ -173,6 +174,17 @@ func Debug() cli.Command {
 				Usage:     "Set a custom variable",
 				ArgsUsage: "<key>=<value>",
 				Action:    setVariableCmd,
+			},
+			{
+				Name:      "get-var",
+				Usage:     "Get expansion value(s) by name",
+				ArgsUsage: "<key> [<key>...]",
+				Action:    getVariableCmd,
+			},
+			{
+				Name:   "get-vars",
+				Usage:  "List all expansion variables",
+				Action: getVariablesCmd,
 			},
 			{
 				Name:      "jump",
@@ -705,6 +717,93 @@ func setVariableCmd(c *cli.Context) error {
 	}
 
 	fmt.Printf("Set variable: %s=%s\n", key, value)
+	return nil
+}
+
+// getVariableCmd gets one or more expansion values by name.
+func getVariableCmd(c *cli.Context) error {
+	if c.NArg() < 1 {
+		return errors.New("at least one variable name required")
+	}
+
+	url, err := getDaemonURL()
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < c.NArg(); i++ {
+		if err := getAndPrintVariable(url, c.Args().Get(i)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getAndPrintVariable(url, key string) error {
+	resp, err := http.Get(url + "/variable/get/" + key)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyData, _ := io.ReadAll(resp.Body)
+		return errors.Errorf("request failed with status %d: %s", resp.StatusCode, string(bodyData))
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+
+	if result["found"].(bool) {
+		fmt.Printf("%s=%s\n", key, result["value"])
+	} else {
+		fmt.Printf("%s: <not set>\n", key)
+	}
+	return nil
+}
+
+// getVariablesCmd lists all expansion variables.
+func getVariablesCmd(c *cli.Context) error {
+	url, err := getDaemonURL()
+	if err != nil {
+		return err
+	}
+
+	resp, err := http.Get(url + "/variable/all")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyData, _ := io.ReadAll(resp.Body)
+		return errors.Errorf("request failed with status %d: %s", resp.StatusCode, string(bodyData))
+	}
+
+	var result map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return err
+	}
+
+	variables := result["variables"].(map[string]any)
+	if len(variables) == 0 {
+		fmt.Println("No variables set.")
+		return nil
+	}
+
+	keys := make([]string, 0, len(variables))
+	for k := range variables {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		fmt.Printf("%s=%s\n", k, variables[k])
+	}
+
 	return nil
 }
 

--- a/operations/local_client_test.go
+++ b/operations/local_client_test.go
@@ -507,9 +507,10 @@ func TestGetVariableCmd(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			case "/variable/get/my_key":
 				require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
-					"key":   "my_key",
-					"value": "my_value",
-					"found": true,
+					"key":      "my_key",
+					"value":    "my_value",
+					"found":    true,
+					"redacted": false,
 				}))
 			}
 		}))
@@ -529,6 +530,42 @@ func TestGetVariableCmd(t *testing.T) {
 		app := cli.NewApp()
 		set := flag.NewFlagSet("test", 0)
 		require.NoError(t, set.Parse([]string{"my_key"}))
+		c := cli.NewContext(app, set, nil)
+
+		err = getVariableCmd(c)
+		assert.NoError(t, err)
+	})
+
+	t.Run("RedactedVariable", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/health":
+				w.WriteHeader(http.StatusOK)
+			case "/variable/get/secret_token":
+				require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+					"key":      "secret_token",
+					"value":    "<redacted>",
+					"found":    true,
+					"redacted": true,
+				}))
+			}
+		}))
+		defer server.Close()
+
+		tempDir := t.TempDir()
+		setHomeDir(t, tempDir)
+
+		daemonDir := filepath.Join(tempDir, ".evergreen-local")
+		require.NoError(t, os.MkdirAll(daemonDir, 0755))
+
+		var port int
+		_, err := fmt.Sscanf(server.URL, "http://127.0.0.1:%d", &port)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(daemonDir, "daemon.port"), []byte(fmt.Sprintf("%d", port)), 0644))
+
+		app := cli.NewApp()
+		set := flag.NewFlagSet("test", 0)
+		require.NoError(t, set.Parse([]string{"secret_token"}))
 		c := cli.NewContext(app, set, nil)
 
 		err = getVariableCmd(c)

--- a/operations/local_client_test.go
+++ b/operations/local_client_test.go
@@ -498,3 +498,77 @@ func TestValidateDebugLocal(t *testing.T) {
 		assert.Contains(t, err.Error(), "debug spawn hosts currently disabled")
 	})
 }
+
+func TestGetVariableCmd(t *testing.T) {
+	t.Run("SingleKeyFound", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/health":
+				w.WriteHeader(http.StatusOK)
+			case "/variable/get/my_key":
+				require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+					"key":   "my_key",
+					"value": "my_value",
+					"found": true,
+				}))
+			}
+		}))
+		defer server.Close()
+
+		tempDir := t.TempDir()
+		setHomeDir(t, tempDir)
+
+		daemonDir := filepath.Join(tempDir, ".evergreen-local")
+		require.NoError(t, os.MkdirAll(daemonDir, 0755))
+
+		var port int
+		_, err := fmt.Sscanf(server.URL, "http://127.0.0.1:%d", &port)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(daemonDir, "daemon.port"), []byte(fmt.Sprintf("%d", port)), 0644))
+
+		app := cli.NewApp()
+		set := flag.NewFlagSet("test", 0)
+		require.NoError(t, set.Parse([]string{"my_key"}))
+		c := cli.NewContext(app, set, nil)
+
+		err = getVariableCmd(c)
+		assert.NoError(t, err)
+	})
+}
+
+func TestGetVariablesCmd(t *testing.T) {
+	t.Run("SuccessfulFetch", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/health":
+				w.WriteHeader(http.StatusOK)
+			case "/variable/all":
+				require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+					"variables": map[string]string{
+						"alpha": "one",
+						"beta":  "two",
+					},
+				}))
+			}
+		}))
+		defer server.Close()
+
+		tempDir := t.TempDir()
+		setHomeDir(t, tempDir)
+
+		daemonDir := filepath.Join(tempDir, ".evergreen-local")
+		require.NoError(t, os.MkdirAll(daemonDir, 0755))
+
+		var port int
+		_, err := fmt.Sscanf(server.URL, "http://127.0.0.1:%d", &port)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(daemonDir, "daemon.port"), []byte(fmt.Sprintf("%d", port)), 0644))
+
+		app := cli.NewApp()
+		set := flag.NewFlagSet("test", 0)
+		c := cli.NewContext(app, set, nil)
+
+		err = getVariablesCmd(c)
+		assert.NoError(t, err)
+	})
+}

--- a/operations/local_daemon_rest.go
+++ b/operations/local_daemon_rest.go
@@ -47,6 +47,8 @@ func (d *localDaemonREST) Start(ctx context.Context) error {
 	router.HandleFunc("/step/run-until/{step}", d.handleRunUntil).Methods("POST")
 	router.HandleFunc("/step/jump/{step}", d.handleJumpTo).Methods("POST")
 	router.HandleFunc("/variable/set", d.handleSetVariable).Methods("POST")
+	router.HandleFunc("/variable/get/{key}", d.handleGetVariable).Methods("GET")
+	router.HandleFunc("/variable/all", d.handleGetVariables).Methods("GET")
 	router.HandleFunc("/status", d.handleStatus).Methods("GET")
 
 	if err := d.writeDaemonInfo(); err != nil {
@@ -425,6 +427,40 @@ func (d *localDaemonREST) handleSetVariable(w http.ResponseWriter, r *http.Reque
 
 	d.executor.SetVariable(r.Context(), req.Key, req.Value)
 	grip.Error(r.Context(), json.NewEncoder(w).Encode(map[string]bool{"success": true}))
+}
+
+// handleGetVariable returns the value of a single expansion variable.
+func (d *localDaemonREST) handleGetVariable(w http.ResponseWriter, r *http.Request) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	if d.executor == nil {
+		http.Error(w, "no configuration loaded", http.StatusBadRequest)
+		return
+	}
+
+	key := mux.Vars(r)["key"]
+	value, found := d.executor.GetVariable(key)
+	grip.Error(r.Context(), json.NewEncoder(w).Encode(map[string]any{
+		"key":   key,
+		"value": value,
+		"found": found,
+	}))
+}
+
+// handleGetVariables returns all expansion variables.
+func (d *localDaemonREST) handleGetVariables(w http.ResponseWriter, r *http.Request) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	if d.executor == nil {
+		http.Error(w, "no configuration loaded", http.StatusBadRequest)
+		return
+	}
+
+	grip.Error(r.Context(), json.NewEncoder(w).Encode(map[string]any{
+		"variables": d.executor.GetVariables(),
+	}))
 }
 
 // handleStepNext executes the next step with streaming output.

--- a/operations/local_daemon_rest.go
+++ b/operations/local_daemon_rest.go
@@ -440,11 +440,15 @@ func (d *localDaemonREST) handleGetVariable(w http.ResponseWriter, r *http.Reque
 	}
 
 	key := mux.Vars(r)["key"]
-	value, found := d.executor.GetVariable(key)
+	value, found, redacted := d.executor.GetVariable(key)
+	if redacted {
+		value = "<redacted>"
+	}
 	grip.Error(r.Context(), json.NewEncoder(w).Encode(map[string]any{
-		"key":   key,
-		"value": value,
-		"found": found,
+		"key":      key,
+		"value":    value,
+		"found":    found,
+		"redacted": redacted,
 	}))
 }
 
@@ -458,8 +462,12 @@ func (d *localDaemonREST) handleGetVariables(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
+	vars, redactedKeys := d.executor.GetVariables()
+	for key := range redactedKeys {
+		vars[key] = "<redacted>"
+	}
 	grip.Error(r.Context(), json.NewEncoder(w).Encode(map[string]any{
-		"variables": d.executor.GetVariables(),
+		"variables": vars,
 	}))
 }
 


### PR DESCRIPTION
DEVPROD-42374

### Description

The task debugger had `set-var` to override expansions but no way to read them back. The only workaround was modifying the task to print the value. This adds `get-var` to look up one or more expansion keys and `get-vars` to dump the full expansion environment, so users can inspect values directly during a debug session.

### Testing

Unit tests + manual staging verification.
### Documentation

Updated docs