### PR TITLE
DEVPROD-42785: create env tmpfs base dir via sudo in provisionEnvTmpfs

### DIFF
--- a/agent/container/tmpfs_linux.go
+++ b/agent/container/tmpfs_linux.go
@@ -36,13 +36,9 @@ func provisionEnvTmpfs(dir string) error {
 	return nil
 }
 
-// ensureEnvDir creates dir (the per-task env dir) and its parents. The base
-// dir lives under /var/run, which is a root-owned tmpfs, so the agent cannot
-// create the base dir unprivileged and it disappears on every host reboot.
-// Unprivileged creation is attempted first because it succeeds in the steady
-// state (once the base dir exists and is owned by the agent); if that fails,
-// the base dir is created via sudo with mkdir and chown, like the mount step,
-// so per-task dirs can then be created unprivileged.
+// ensureEnvDir creates dir and its parents, falling back to sudo mkdir plus
+// chown (like the mount step) because the base dir under /var/run is on a
+// root-owned tmpfs and disappears on every reboot.
 func ensureEnvDir(dir string) error {
 	if err := os.MkdirAll(dir, 0700); err == nil {
 		return nil

--- a/agent/container/tmpfs_linux.go
+++ b/agent/container/tmpfs_linux.go
@@ -38,7 +38,9 @@ func provisionEnvTmpfs(dir string) error {
 
 // ensureEnvDir creates dir and its parents, falling back to sudo mkdir plus
 // chown (like the mount step) because the base dir under /var/run is on a
-// root-owned tmpfs and disappears on every reboot.
+// root-owned tmpfs and disappears on every reboot. The eventual end state is
+// image-level provisioning (e.g. a tmpfiles.d entry); the sudo path exists
+// only until then and is skipped whenever the base dir already exists.
 func ensureEnvDir(dir string) error {
 	if err := os.MkdirAll(dir, 0700); err == nil {
 		return nil

--- a/agent/container/tmpfs_linux.go
+++ b/agent/container/tmpfs_linux.go
@@ -38,9 +38,7 @@ func provisionEnvTmpfs(dir string) error {
 
 // ensureEnvDir creates dir and its parents, falling back to sudo mkdir plus
 // chown (like the mount step) because the base dir under /var/run is on a
-// root-owned tmpfs and disappears on every reboot. The eventual end state is
-// image-level provisioning (e.g. a tmpfiles.d entry); the sudo path exists
-// only until then and is skipped whenever the base dir already exists.
+// root-owned tmpfs and disappears on every reboot.
 func ensureEnvDir(dir string) error {
 	if err := os.MkdirAll(dir, 0700); err == nil {
 		return nil

--- a/agent/container/tmpfs_linux.go
+++ b/agent/container/tmpfs_linux.go
@@ -23,7 +23,7 @@ func provisionEnvTmpfs(dir string) error {
 			return errors.Wrapf(err, "clearing stale tmpfs mount at '%s'", dir)
 		}
 	}
-	if err := os.MkdirAll(dir, 0700); err != nil {
+	if err := ensureEnvDir(dir); err != nil {
 		return errors.Wrapf(err, "creating env tmpfs dir '%s'", dir)
 	}
 	uid := os.Getuid()
@@ -34,6 +34,29 @@ func provisionEnvTmpfs(dir string) error {
 		return errors.Wrapf(err, "mounting tmpfs at '%s'", dir)
 	}
 	return nil
+}
+
+// ensureEnvDir creates dir (the per-task env dir) and its parents. The base
+// dir lives under /var/run, which is a root-owned tmpfs, so the agent cannot
+// create the base dir unprivileged and it disappears on every host reboot.
+// Unprivileged creation is attempted first because it succeeds in the steady
+// state (once the base dir exists and is owned by the agent); if that fails,
+// the base dir is created via sudo with mkdir and chown, like the mount step,
+// so per-task dirs can then be created unprivileged.
+func ensureEnvDir(dir string) error {
+	if err := os.MkdirAll(dir, 0700); err == nil {
+		return nil
+	}
+	base := activeEnvFileBaseDir
+	uid := os.Getuid()
+	gid := os.Getgid()
+	if err := exec.Command("sudo", "mkdir", "-m", "0700", "-p", base).Run(); err != nil {
+		return errors.Wrapf(err, "creating env base dir '%s'", base)
+	}
+	if err := exec.Command("sudo", "chown", fmt.Sprintf("%d:%d", uid, gid), base).Run(); err != nil {
+		return errors.Wrapf(err, "chowning env base dir '%s'", base)
+	}
+	return errors.Wrapf(os.MkdirAll(dir, 0700), "creating per-task env dir under base dir '%s'", base)
 }
 
 // removeEnvTmpfs unmounts and removes the env tmpfs directory. If the

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-09-03c"
+	AgentVersion = "2026-09-08a"
 )
 
 const (


### PR DESCRIPTION
DEVPROD-42785

### Description

`provisionEnvTmpfs` (agent/container/tmpfs_linux.go) creates the per-task env dir with an unprivileged `os.MkdirAll`, but the base dir `/var/run/evergreen-env` lives under `/var/run` — a root-owned tmpfs. Consequences:

- The agent user cannot create the base dir unprivileged, so every container-enabled distro needed a bespoke setup-script line to pre-create and chown it.
- `/var/run` is tmpfs, so any host that reboots (e.g. spawn hosts) loses the base dir and the first task after reboot fails to provision the env tmpfs.

This change makes dir creation go through a new `ensureEnvDir` helper:

1. Unprivileged `os.MkdirAll` is attempted first — it succeeds in the steady state (base dir exists and is agent-owned), so no sudo exec per task.
2. On failure, the base dir is created via sudo (`mkdir -m 0700 -p` + `chown` to the agent uid/gid), mirroring the sudo mount/umount steps already in the same function, then the per-task dir is created unprivileged.

This removes the need for a bespoke distro setup-script line and makes the agent self-healing across reboots.

The agent already requires passwordless sudo on container-enabled distros (`sudo mount`/`sudo umount` in this same function; `sudo rm -rf`/`sudo umount -R` in agent/directory.go), so this adds no new capability requirement.

### Testing

- `GOOS=linux go build` and `GOOS=linux go vet` pass (file is `//go:build linux`).
- `make lint-agent-container` passes; gofmt clean.
- No new unit test: the sudo path requires root privileges and a real `/var/run`, so it is exercised by staging validation (Phase 0 workstream A).

### Documentation

No docs changes needed.

### Ops

Once this agent version rolls out, the `mkdir/chown /var/run/evergreen-env` lines in container-enabled distro setup scripts can be removed.

### End state

The long-term home for the base dir is image-level provisioning (e.g. a `tmpfiles.d` entry, or `RuntimeDirectory=` on the jasper unit) built via buildhost-configuration, which would remove the agent's sudo mkdir/chown path entirely. The agent-side fallback is forward-compatible with that: the unprivileged `mkdir` fast path succeeds whenever the base dir already exists, so the sudo path is skipped on hosts where the image provisions the dir. If container isolation graduates to Phase 1, migrate ownership into the image and delete the fallback.