### PR TITLE
DEVPROD-42865: Mount compat client path into task isolation containers

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -108,6 +108,11 @@ type Options struct {
 	// alive after a task failure so on-call can docker exec into it for
 	// post-mortem inspection. Zero disables retention.
 	ContainerRetainOnFailureSecs int
+	// CompatClientPath is the legacy home evergreen client path (typically
+	// ~/evergreen) that existing tasks still invoke. When set, it is mounted
+	// read-only into isolation containers so those tasks can run the client
+	// there.
+	CompatClientPath string
 }
 
 // AddLoggableInfo is a helper to add relevant information about the agent

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -108,8 +108,8 @@ type Options struct {
 	// alive after a task failure so on-call can docker exec into it for
 	// post-mortem inspection. Zero disables retention.
 	ContainerRetainOnFailureSecs int
-	// CompatClientPath is the legacy home evergreen client path for
-	// isolation container mounts.
+	// CompatClientPath is the absolute path to the legacy ~/evergreen binary,
+	// mounted read-only into isolation containers.
 	CompatClientPath string
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -108,10 +108,8 @@ type Options struct {
 	// alive after a task failure so on-call can docker exec into it for
 	// post-mortem inspection. Zero disables retention.
 	ContainerRetainOnFailureSecs int
-	// CompatClientPath is the legacy home evergreen client path (typically
-	// ~/evergreen) that existing tasks still invoke. When set, it is mounted
-	// read-only into isolation containers so those tasks can run the client
-	// there.
+	// CompatClientPath is the legacy home evergreen client path, mounted
+	// read-only into isolation containers.
 	CompatClientPath string
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -108,8 +108,8 @@ type Options struct {
 	// alive after a task failure so on-call can docker exec into it for
 	// post-mortem inspection. Zero disables retention.
 	ContainerRetainOnFailureSecs int
-	// CompatClientPath is the legacy home evergreen client path, mounted
-	// read-only into isolation containers.
+	// CompatClientPath is the legacy home evergreen client path for
+	// isolation container mounts.
 	CompatClientPath string
 }
 

--- a/agent/container.go
+++ b/agent/container.go
@@ -266,9 +266,12 @@ const (
 
 // containerToolchainDirs are the host toolchain directories bind-mounted
 // read-only into the container. Toolchains are installed at AMI provisioning
-// rather than baked into the image. Only these paths are mounted; the whole
-// of /opt is not, because a read-only mount still lets a task read (and
-// exfiltrate) anything beneath it.
+// rather than baked into the image, and the source of truth for this list
+// is the toolchain roles in buildhost-post-config; new toolchain roles must be
+// reflected here. This list must stay explicit and must never include all of
+// /opt or the home directory, because a read-only mount still lets a task read
+// (and exfiltrate) anything beneath it. /opt/evergreen must never be added, as
+// it holds jasper credentials.
 var containerToolchainDirs = []string{
 	"/opt/mongodbtoolchain",
 	"/opt/golang",
@@ -276,6 +279,9 @@ var containerToolchainDirs = []string{
 	"/opt/ruby",
 	"/opt/node",
 	"/opt/python",
+	// Installed by the toolchain-devtools role in buildhost-post-config on
+	// amazon2023 distros; absent elsewhere, in which case the mount is skipped.
+	"/opt/devtools",
 }
 
 // toolchainMounts returns read-only mounts for the toolchain directories and

--- a/agent/container.go
+++ b/agent/container.go
@@ -190,7 +190,7 @@ func (a *Agent) ensureContainer(ctx context.Context, conf *internal.TaskConfig, 
 		}
 	}
 
-	extraMounts := toolchainMounts(ctx, conf.Task.Id, log)
+	extraMounts := toolchainMounts(ctx, conf.Task.Id, a.opts.CompatClientPath, log)
 
 	factory := a.containerFactory
 	if factory == nil {
@@ -266,9 +266,10 @@ const (
 
 // containerToolchainDirs are the host toolchain directories bind-mounted
 // read-only into the container. Toolchains are installed at AMI provisioning
-// rather than baked into the image. Only these paths are mounted; the whole
-// of /opt is not, because a read-only mount still lets a task read (and
-// exfiltrate) anything beneath it.
+// rather than baked into the image. Only these paths (plus the compat client
+// path passed in by the monitor) are mounted; the whole of /opt is not,
+// because a read-only mount still lets a task read (and exfiltrate) anything
+// beneath it.
 var containerToolchainDirs = []string{
 	"/opt/mongodbtoolchain",
 	"/opt/golang",
@@ -278,16 +279,25 @@ var containerToolchainDirs = []string{
 	"/opt/python",
 }
 
-// toolchainMounts returns read-only mounts for the toolchain directories that
-// exist on the host. Nonexistent sources are skipped because Docker rejects
-// bind mounts whose source is missing, which would fail container creation.
-func toolchainMounts(ctx context.Context, taskID string, log grip.Journaler) []agentcontainer.Mount {
+// toolchainMounts returns read-only mounts for the toolchain directories and
+// the compat client path that exist on the host. Nonexistent sources are
+// skipped because Docker rejects bind mounts whose source is missing, which
+// would fail container creation.
+func toolchainMounts(ctx context.Context, taskID, compatClientPath string, log grip.Journaler) []agentcontainer.Mount {
 	var mounts []agentcontainer.Mount
-	for _, dir := range containerToolchainDirs {
-		if _, err := os.Stat(dir); err != nil {
-			continue
+	mounted := map[string]bool{}
+	addMount := func(source string) {
+		if _, err := os.Stat(source); err != nil || mounted[source] {
+			return
 		}
-		mounts = append(mounts, agentcontainer.Mount{Source: dir, Target: dir, ReadOnly: true})
+		mounted[source] = true
+		mounts = append(mounts, agentcontainer.Mount{Source: source, Target: source, ReadOnly: true})
+	}
+	for _, dir := range containerToolchainDirs {
+		addMount(dir)
+	}
+	if compatClientPath != "" {
+		addMount(compatClientPath)
 	}
 	if len(mounts) == 0 && log != nil {
 		log.Warningf(ctx, "No host toolchain directories found; container for task '%s' will only see image-provided toolchains.", taskID)

--- a/agent/container.go
+++ b/agent/container.go
@@ -267,7 +267,8 @@ const (
 // containerToolchainDirs are the host toolchain directories bind-mounted
 // read-only into the container. This allowlist mirrors the toolchain roles in
 // buildhost-post-config; keep it explicit rather than mounting all of /opt or
-// the home directory, and never add /opt/evergreen (jasper credentials).
+// the home directory, because a read-only mount still lets a task read (and
+// exfiltrate) anything beneath it. Never add /opt/evergreen (jasper credentials).
 var containerToolchainDirs = []string{
 	"/opt/mongodbtoolchain",
 	"/opt/golang",

--- a/agent/container.go
+++ b/agent/container.go
@@ -266,10 +266,9 @@ const (
 
 // containerToolchainDirs are the host toolchain directories bind-mounted
 // read-only into the container. Toolchains are installed at AMI provisioning
-// rather than baked into the image. Only these paths (plus the compat client
-// path passed in by the monitor) are mounted; the whole of /opt is not,
-// because a read-only mount still lets a task read (and exfiltrate) anything
-// beneath it.
+// rather than baked into the image. Only these paths are mounted; the whole
+// of /opt is not, because a read-only mount still lets a task read (and
+// exfiltrate) anything beneath it.
 var containerToolchainDirs = []string{
 	"/opt/mongodbtoolchain",
 	"/opt/golang",
@@ -280,9 +279,8 @@ var containerToolchainDirs = []string{
 }
 
 // toolchainMounts returns read-only mounts for the toolchain directories and
-// the compat client path that exist on the host. Nonexistent sources are
-// skipped because Docker rejects bind mounts whose source is missing, which
-// would fail container creation.
+// the compat client path, skipping sources that do not exist on the host
+// because Docker rejects bind mounts with missing sources.
 func toolchainMounts(ctx context.Context, taskID, compatClientPath string, log grip.Journaler) []agentcontainer.Mount {
 	var mounts []agentcontainer.Mount
 	mounted := map[string]bool{}

--- a/agent/container.go
+++ b/agent/container.go
@@ -265,13 +265,9 @@ const (
 )
 
 // containerToolchainDirs are the host toolchain directories bind-mounted
-// read-only into the container. Toolchains are installed at AMI provisioning
-// rather than baked into the image, and the source of truth for this list
-// is the toolchain roles in buildhost-post-config; new toolchain roles must be
-// reflected here. This list must stay explicit and must never include all of
-// /opt or the home directory, because a read-only mount still lets a task read
-// (and exfiltrate) anything beneath it. /opt/evergreen must never be added, as
-// it holds jasper credentials.
+// read-only into the container. This allowlist mirrors the toolchain roles in
+// buildhost-post-config; keep it explicit rather than mounting all of /opt or
+// the home directory, and never add /opt/evergreen (jasper credentials).
 var containerToolchainDirs = []string{
 	"/opt/mongodbtoolchain",
 	"/opt/golang",
@@ -279,14 +275,13 @@ var containerToolchainDirs = []string{
 	"/opt/ruby",
 	"/opt/node",
 	"/opt/python",
-	// Installed by the toolchain-devtools role in buildhost-post-config on
-	// amazon2023 distros; absent elsewhere, in which case the mount is skipped.
+	// Installed by the toolchain-devtools role on amazon2023 distros.
 	"/opt/devtools",
 }
 
 // toolchainMounts returns read-only mounts for the toolchain directories and
-// the compat client path, skipping sources that do not exist on the host
-// because Docker rejects bind mounts with missing sources.
+// the compat client path, skipping sources that do not exist because Docker
+// rejects bind mounts with missing sources.
 func toolchainMounts(ctx context.Context, taskID, compatClientPath string, log grip.Journaler) []agentcontainer.Mount {
 	var mounts []agentcontainer.Mount
 	mounted := map[string]bool{}

--- a/agent/container_test.go
+++ b/agent/container_test.go
@@ -618,12 +618,78 @@ func TestToolchainMountsOnlyIncludesExistingDirsReadOnly(t *testing.T) {
 	t.Cleanup(func() { containerToolchainDirs = original })
 	containerToolchainDirs = []string{existing, missing}
 
-	mounts := toolchainMounts(t.Context(), "task-1", nil)
+	mounts := toolchainMounts(t.Context(), "task-1", "", nil)
 
 	require.Len(t, mounts, 1, "a nonexistent source would make Docker reject container creation")
 	assert.Equal(t, existing, mounts[0].Source)
 	assert.Equal(t, existing, mounts[0].Target)
 	assert.True(t, mounts[0].ReadOnly, "toolchain mounts must be read-only")
+}
+
+func TestToolchainMountsIncludesExistingCompatClientPath(t *testing.T) {
+	compatPath := filepath.Join(t.TempDir(), "evergreen")
+	require.NoError(t, os.WriteFile(compatPath, []byte("client"), 0755))
+
+	mounts := toolchainMounts(t.Context(), "task-1", compatPath, nil)
+
+	require.Len(t, mounts, 1)
+	assert.Equal(t, compatPath, mounts[0].Source)
+	assert.Equal(t, compatPath, mounts[0].Target, "the compat client must appear at the same path inside the container so legacy tasks can invoke it")
+	assert.True(t, mounts[0].ReadOnly, "compat client mount must be read-only")
+}
+
+func TestToolchainMountsSkipsMissingCompatClientPath(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "absent", "evergreen")
+
+	assert.Empty(t, toolchainMounts(t.Context(), "task-1", missing, nil),
+		"a nonexistent source would make Docker reject container creation")
+}
+
+func TestToolchainMountsSkipsEmptyCompatClientPath(t *testing.T) {
+	assert.Empty(t, toolchainMounts(t.Context(), "task-1", "", nil))
+}
+
+func TestToolchainMountsDoesNotDuplicateCompatClientPathMatchingToolchainDir(t *testing.T) {
+	compatPath := t.TempDir()
+
+	original := containerToolchainDirs
+	t.Cleanup(func() { containerToolchainDirs = original })
+	containerToolchainDirs = []string{compatPath}
+
+	mounts := toolchainMounts(t.Context(), "task-1", compatPath, nil)
+
+	require.Len(t, mounts, 1, "the same source should not be mounted twice")
+}
+
+func TestEnsureContainerPassesCompatClientMount(t *testing.T) {
+	ctx := t.Context()
+	compatPath := filepath.Join(t.TempDir(), "evergreen")
+	require.NoError(t, os.WriteFile(compatPath, []byte("client"), 0755))
+
+	a := agentForContainerTest()
+	a.opts.CompatClientPath = compatPath
+	var gotConfig agentcontainer.Config
+	a.containerFactory = func(_ context.Context, cfg agentcontainer.Config) (ContainerHandle, error) {
+		gotConfig = cfg
+		return &fakeContainer{id: "newid", name: "evergreen-task-new", envFileHostDir: "/tmp/env-new"}, nil
+	}
+	conf := &internal.TaskConfig{
+		Distro: makeDistroWithIsolation("ubuntu:22.04"),
+		Task:   task.Task{Id: "task-1"},
+	}
+
+	err := a.ensureContainer(ctx, conf, nil)
+	require.NoError(t, err)
+
+	var found bool
+	for _, mount := range gotConfig.ExtraMounts {
+		if mount.Source == compatPath {
+			found = true
+			assert.Equal(t, compatPath, mount.Target)
+			assert.True(t, mount.ReadOnly)
+		}
+	}
+	assert.True(t, found, "compat client path should be mounted into the isolation container")
 }
 
 func TestSecureContainerDirs(t *testing.T) {

--- a/agent/container_test.go
+++ b/agent/container_test.go
@@ -610,6 +610,16 @@ func TestContainerToolchainDirsDoesNotMountAllOfOpt(t *testing.T) {
 		"mounting all of /opt exposes anything provisioning writes there to every containerized task")
 }
 
+func TestContainerToolchainDirsIncludesDevTools(t *testing.T) {
+	assert.Contains(t, containerToolchainDirs, "/opt/devtools",
+		"installed by the toolchain-devtools role in buildhost-post-config on amazon2023 distros")
+}
+
+func TestContainerToolchainDirsNeverIncludesEvergreenDir(t *testing.T) {
+	assert.NotContains(t, containerToolchainDirs, "/opt/evergreen",
+		"it holds jasper credentials")
+}
+
 func TestToolchainMountsOnlyIncludesExistingDirsReadOnly(t *testing.T) {
 	existing := t.TempDir()
 	missing := filepath.Join(t.TempDir(), "absent")
@@ -630,6 +640,10 @@ func TestToolchainMountsIncludesExistingCompatClientPath(t *testing.T) {
 	compatPath := filepath.Join(t.TempDir(), "evergreen")
 	require.NoError(t, os.WriteFile(compatPath, []byte("client"), 0755))
 
+	original := containerToolchainDirs
+	t.Cleanup(func() { containerToolchainDirs = original })
+	containerToolchainDirs = nil
+
 	mounts := toolchainMounts(t.Context(), "task-1", compatPath, nil)
 
 	require.Len(t, mounts, 1)
@@ -641,11 +655,19 @@ func TestToolchainMountsIncludesExistingCompatClientPath(t *testing.T) {
 func TestToolchainMountsSkipsMissingCompatClientPath(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "absent", "evergreen")
 
+	original := containerToolchainDirs
+	t.Cleanup(func() { containerToolchainDirs = original })
+	containerToolchainDirs = nil
+
 	assert.Empty(t, toolchainMounts(t.Context(), "task-1", missing, nil),
 		"a nonexistent source would make Docker reject container creation")
 }
 
 func TestToolchainMountsSkipsEmptyCompatClientPath(t *testing.T) {
+	original := containerToolchainDirs
+	t.Cleanup(func() { containerToolchainDirs = original })
+	containerToolchainDirs = nil
+
 	assert.Empty(t, toolchainMounts(t.Context(), "task-1", "", nil))
 }
 

--- a/agent/container_test.go
+++ b/agent/container_test.go
@@ -634,7 +634,7 @@ func TestToolchainMountsIncludesExistingCompatClientPath(t *testing.T) {
 
 	require.Len(t, mounts, 1)
 	assert.Equal(t, compatPath, mounts[0].Source)
-	assert.Equal(t, compatPath, mounts[0].Target, "the compat client must appear at the same path inside the container so legacy tasks can invoke it")
+	assert.Equal(t, compatPath, mounts[0].Target, "compat client must appear at the same path in the container")
 	assert.True(t, mounts[0].ReadOnly, "compat client mount must be read-only")
 }
 

--- a/config.go
+++ b/config.go
@@ -35,11 +35,11 @@ var (
 
 	// ClientVersion is the commandline version string used to control updating
 	// the CLI. The format is the calendar date (YYYY-MM-DD).
-	ClientVersion = "2026-09-09"
+	ClientVersion = "2026-09-10"
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-09-10a"
+	AgentVersion = "2026-09-10b"
 )
 
 const (

--- a/operations/agent.go
+++ b/operations/agent.go
@@ -31,6 +31,7 @@ const (
 	agentHostSecretFlagName              = "host_secret"
 	singleTaskDistroFlagName             = "single_task_distro"
 	containerRetainOnFailureSecsFlagName = "container_retain_on_failure_secs"
+	compatClientPathFlagName             = "compat_client_path"
 )
 
 func Agent() cli.Command {
@@ -115,6 +116,10 @@ func Agent() cli.Command {
 				Usage: "seconds to retain the isolation container after a task failure for on-call inspection (0 = destroy immediately, default = 300)",
 				Value: 300,
 			},
+			cli.StringFlag{
+				Name:  compatClientPathFlagName,
+				Usage: "internal only: legacy home client path to mount read-only into isolation containers; set by the agent monitor",
+			},
 		},
 		Before: mergeBeforeFuncs(
 			func(c *cli.Context) error {
@@ -159,6 +164,7 @@ func Agent() cli.Command {
 				SendTaskLogsToGlobalSender:   c.Bool(sendTaskLogsToGlobalSenderFlagName),
 				SingleTaskDistro:             c.Bool(singleTaskDistroFlagName),
 				ContainerRetainOnFailureSecs: c.Int(containerRetainOnFailureSecsFlagName),
+				CompatClientPath:             c.String(compatClientPathFlagName),
 			}
 
 			// Once the agent has retrieved the host ID and secret, unset those

--- a/operations/agent.go
+++ b/operations/agent.go
@@ -118,7 +118,7 @@ func Agent() cli.Command {
 			},
 			cli.StringFlag{
 				Name:  compatClientPathFlagName,
-				Usage: "internal only: legacy home client path to mount read-only into isolation containers; set by the agent monitor",
+				Usage: "internal only: legacy home client path to mount into isolation containers; set by the agent monitor",
 			},
 		},
 		Before: mergeBeforeFuncs(

--- a/operations/agent_monitor.go
+++ b/operations/agent_monitor.go
@@ -432,9 +432,8 @@ func (m *monitor) allowAgentNice(ctx context.Context) error {
 		m.clientPath}).Run(ctx)
 }
 
-// agentCmdArgs builds the argv for the agent process the monitor spawns. The
-// compat client path is forwarded so the agent can mount it read-only into
-// task isolation containers.
+// agentCmdArgs builds the argv for the agent process the monitor spawns,
+// forwarding the compat client path for container mounting.
 func (m *monitor) agentCmdArgs() []string {
 	args := append([]string{m.clientPath, "agent"}, m.agentArgs...)
 	if m.compatClientPath != "" {

--- a/operations/agent_monitor.go
+++ b/operations/agent_monitor.go
@@ -432,9 +432,20 @@ func (m *monitor) allowAgentNice(ctx context.Context) error {
 		m.clientPath}).Run(ctx)
 }
 
+// agentCmdArgs builds the argv for the agent process the monitor spawns. The
+// compat client path is forwarded so the agent can mount it read-only into
+// task isolation containers.
+func (m *monitor) agentCmdArgs() []string {
+	args := append([]string{m.clientPath, "agent"}, m.agentArgs...)
+	if m.compatClientPath != "" {
+		args = append(args, fmt.Sprintf("--compat_client_path=%s", m.compatClientPath))
+	}
+	return args
+}
+
 // createAgentProcess attempts to start an agent subprocess.
 func (m *monitor) createAgentProcess(ctx context.Context, retry utility.RetryOptions) (jasper.Process, error) {
-	agentCmdArgs := append([]string{m.clientPath, "agent"}, m.agentArgs...)
+	agentCmdArgs := m.agentCmdArgs()
 
 	// Copy the monitor's environment to the agent.
 	env := make(map[string]string)

--- a/operations/agent_monitor.go
+++ b/operations/agent_monitor.go
@@ -432,8 +432,7 @@ func (m *monitor) allowAgentNice(ctx context.Context) error {
 		m.clientPath}).Run(ctx)
 }
 
-// agentCmdArgs builds the argv for the agent process the monitor spawns,
-// forwarding the compat client path for container mounting.
+// agentCmdArgs builds the agent argv, forwarding the compat client path.
 func (m *monitor) agentCmdArgs() []string {
 	args := append([]string{m.clientPath, "agent"}, m.agentArgs...)
 	if m.compatClientPath != "" {

--- a/operations/agent_monitor_test.go
+++ b/operations/agent_monitor_test.go
@@ -142,3 +142,27 @@ func TestAgentMonitorWithJasper(t *testing.T) {
 		})
 	}
 }
+
+func TestAgentCmdArgsForwardsCompatClientPath(t *testing.T) {
+	m := &monitor{
+		clientPath:       "/path/to/client",
+		compatClientPath: "/home/user/evergreen",
+		agentArgs:        []string{"--api_server=http://localhost", "--host_id=h1"},
+	}
+
+	args := m.agentCmdArgs()
+
+	assert.Equal(t, []string{
+		"/path/to/client",
+		"agent",
+		"--api_server=http://localhost",
+		"--host_id=h1",
+		"--compat_client_path=/home/user/evergreen",
+	}, args, "the monitor must pass the compat client path down to the agent so it can mount it into isolation containers")
+}
+
+func TestAgentCmdArgsOmitsUnsetCompatClientPath(t *testing.T) {
+	m := &monitor{clientPath: "/path/to/client"}
+
+	assert.Equal(t, []string{"/path/to/client", "agent"}, m.agentCmdArgs())
+}

--- a/operations/agent_monitor_test.go
+++ b/operations/agent_monitor_test.go
@@ -158,7 +158,7 @@ func TestAgentCmdArgsForwardsCompatClientPath(t *testing.T) {
 		"--api_server=http://localhost",
 		"--host_id=h1",
 		"--compat_client_path=/home/user/evergreen",
-	}, args, "the monitor must pass the compat client path down to the agent so it can mount it into isolation containers")
+	}, args)
 }
 
 func TestAgentCmdArgsOmitsUnsetCompatClientPath(t *testing.T) {


### PR DESCRIPTION
DEVPROD-42865

### Description

Adds the evergreen CLI compat client path (the legacy `~/evergreen` binary) to the agent's container mount allowlist, using the same semantics as the toolchain mounts, and threads the path from the monitor down to the agent.

The mount allowlist (`containerToolchainDirs` / the mount construction in `ensureContainer`) lives in the agent and executes at task start on the host; nothing in buildhost-configuration runs at that point — it only builds images and AMIs, so it cannot mount anything into a per-task container.

Changes:
1. **Agent**: accepts the compat client path as an option (`--compat_client_path`), and `toolchainMounts` adds it to the mount allowlist with toolchain-mount semantics — read-only, same path in and out, skipped if the source does not exist on the host (or the option is unset). A duplicate of an already-mounted source is not mounted twice.
2. **Monitor** (`operations/agent_monitor.go`): the monitor already holds `--compat_client_path`; it now forwards the path to the agent process it spawns via a new `agentCmdArgs` helper.

Until this lands, every resmoke/jstest task fails at timeout determination in a container, which excludes the largest mongo workload family from any canary ramp.

### Testing

- New unit tests (TDD, watched failing first):
  - `TestToolchainMountsIncludesExistingCompatClientPath` / `SkipsMissingCompatClientPath` / `SkipsEmptyCompatClientPath` / `DoesNotDuplicateCompatClientPathMatchingToolchainDir` (agent/container_test.go)
  - `TestEnsureContainerPassesCompatClientMount` — compat path reaches the container factory config
  - `TestAgentCmdArgsForwardsCompatClientPath` / `TestAgentCmdArgsOmitsUnsetCompatClientPath` (operations/agent_monitor_test.go)
- `make test-agent RUN_TEST='TestToolchainMounts|TestEnsureContainer|TestContainerToolchainDirs'` green; `make test-operations RUN_TEST='TestAgentCmdArgs|TestAgentMonitorWithJasper'` green.
- `make lint-agent` and `make lint-operations` pass.

### Documentation

No docs changes needed; `--compat_client_path` on the agent command is internal-only, mirroring the monitor's flag.
