### PR TITLE
DEVPROD-42363: Give CLI patches their own source cache namespace

### DIFF
--- a/rest/route/source_cache.go
+++ b/rest/route/source_cache.go
@@ -17,6 +17,8 @@ import (
 	"github.com/evergreen-ci/evergreen/model/task"
 	"github.com/evergreen-ci/gimlet"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // POST /rest/v2/task/{task_id}/source_cache/credentials
@@ -53,6 +55,9 @@ func (h *sourceCacheCredentials) Parse(ctx context.Context, r *http.Request) err
 }
 
 func (h *sourceCacheCredentials) Run(ctx context.Context) gimlet.Responder {
+	ctx, span := tracer.Start(ctx, "source-cache-credentials")
+	defer span.End()
+
 	t, err := task.FindOneId(ctx, h.taskID)
 	if err != nil {
 		return gimlet.MakeJSONInternalErrorResponder(errors.Wrapf(err, "finding task '%s'", h.taskID))
@@ -152,24 +157,20 @@ func validateSourceCacheRepoComponents(owner, repo string) error {
 	return nil
 }
 
+// sourceCacheNamespaceAttribute names the source cache namespace a task resolves to.
+const sourceCacheNamespaceAttribute = "evergreen.command.git_get_project.source_cache.namespace"
+
 // sourceCacheNamespaceForTask returns the namespace the task's own artifact lives in.
-func sourceCacheNamespaceForTask(ctx context.Context, t *task.Task) (string, error) {
+func sourceCacheNamespaceForTask(t *task.Task) string {
 	if t.Requester == evergreen.GithubPRRequester || t.Requester == evergreen.GithubMergeRequester {
-		return evergreen.SourceCachePRNamespace, nil
+		return evergreen.SourceCachePRNamespace
 	}
 	if !evergreen.IsPatchRequester(t.Requester) {
-		return evergreen.SourceCacheBaseNamespace, nil
+		return evergreen.SourceCacheBaseNamespace
 	}
-
-	// A parent PR checkout leaves the working tree at unreviewed PR code.
-	p, err := patch.FindOneId(ctx, t.Version)
-	if err != nil {
-		return "", errors.Wrapf(err, "finding patch '%s'", t.Version)
-	}
-	if p != nil && p.GitHubParentPRCheckout != nil && p.GitHubParentPRCheckout.ForSource {
-		return evergreen.SourceCachePRNamespace, nil
-	}
-	return evergreen.SourceCacheBaseNamespace, nil
+	// A CLI patch can run at a commit mainline has not built yet, so it must not
+	// write to the base namespace a mainline build will write to.
+	return evergreen.SourceCacheCLINamespace
 }
 
 // sourceCachePlan holds the exact origin keys a session may touch.
@@ -187,10 +188,8 @@ type sourceCacheCandidate struct {
 // buildSourceCachePlan resolves the ordered restore keys and the save key from the
 // task, the patch, and the clone shape the agent resolved.
 func buildSourceCachePlan(ctx context.Context, t *task.Task, pRef *model.ProjectRef, req apimodels.SourceCacheCredentialsRequest) (*sourceCachePlan, error) {
-	namespace, err := sourceCacheNamespaceForTask(ctx, t)
-	if err != nil {
-		return nil, errors.Wrap(err, "resolving the namespace")
-	}
+	namespace := sourceCacheNamespaceForTask(t)
+	trace.SpanFromContext(ctx).SetAttributes(attribute.String(sourceCacheNamespaceAttribute, namespace))
 	prRevision, err := sourceCachePRRevision(ctx, t)
 	if err != nil {
 		return nil, errors.Wrap(err, "resolving the PR head")

--- a/rest/route/source_cache.go
+++ b/rest/route/source_cache.go
@@ -21,6 +21,9 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// sourceCacheNamespaceAttribute names the source cache namespace a task resolves to.
+const sourceCacheNamespaceAttribute = "evergreen.command.git_get_project.source_cache.namespace"
+
 // POST /rest/v2/task/{task_id}/source_cache/credentials
 //
 // Returns source cache credentials scoped server-side to the task's own repo
@@ -156,9 +159,6 @@ func validateSourceCacheRepoComponents(owner, repo string) error {
 	}
 	return nil
 }
-
-// sourceCacheNamespaceAttribute names the source cache namespace a task resolves to.
-const sourceCacheNamespaceAttribute = "evergreen.command.git_get_project.source_cache.namespace"
 
 // sourceCacheNamespaceForTask returns the namespace the task's own artifact lives in.
 func sourceCacheNamespaceForTask(t *task.Task) string {

--- a/rest/route/source_cache_test.go
+++ b/rest/route/source_cache_test.go
@@ -163,7 +163,7 @@ func TestSourceCacheCredentialsRun(t *testing.T) {
 func TestSourceCacheNamespaceForTask(t *testing.T) {
 	for tName, tCase := range map[string]struct {
 		requester     string
-		parentPR      *patch.GitHubParentPRCheckout
+		insertPatch   bool
 		wantNamespace string
 	}{
 		"MainlineCommitGetsTheBaseNamespace": {
@@ -178,37 +178,27 @@ func TestSourceCacheNamespaceForTask(t *testing.T) {
 			requester:     evergreen.GithubMergeRequester,
 			wantNamespace: evergreen.SourceCachePRNamespace,
 		},
-		"PlainPatchGetsTheBaseNamespace": {
+		"CLIPatchGetsTheCLINamespace": {
 			requester:     evergreen.PatchVersionRequester,
-			wantNamespace: evergreen.SourceCacheBaseNamespace,
+			insertPatch:   true,
+			wantNamespace: evergreen.SourceCacheCLINamespace,
 		},
-		"PatchWithAParentPRSourceCheckoutGetsThePRNamespace": {
+		"PatchWithNoPatchDocumentGetsTheCLINamespace": {
 			requester:     evergreen.PatchVersionRequester,
-			parentPR:      &patch.GitHubParentPRCheckout{ForSource: true, PRNumber: 9001, HeadHash: "abc123"},
-			wantNamespace: evergreen.SourceCachePRNamespace,
-		},
-		"PatchWithAParentPRModuleCheckoutGetsTheBaseNamespace": {
-			requester:     evergreen.PatchVersionRequester,
-			parentPR:      &patch.GitHubParentPRCheckout{ForModule: "some-module", PRNumber: 9001, HeadHash: "abc123"},
-			wantNamespace: evergreen.SourceCacheBaseNamespace,
+			wantNamespace: evergreen.SourceCacheCLINamespace,
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			require.NoError(t, db.ClearCollections(patch.Collection))
 
 			const versionID = "5bedc62ee4055d31f0340b1d"
-			if tCase.parentPR != nil {
-				patchDoc := patch.Patch{
-					Id:                     mgobson.ObjectIdHex(versionID),
-					GitHubParentPRCheckout: tCase.parentPR,
-				}
+			if tCase.insertPatch {
+				patchDoc := patch.Patch{Id: mgobson.ObjectIdHex(versionID)}
 				require.NoError(t, patchDoc.Insert(t.Context()))
 			}
 
 			tsk := &task.Task{Id: sourceCacheTaskID, Requester: tCase.requester, Version: versionID}
-			namespace, err := sourceCacheNamespaceForTask(t.Context(), tsk)
-			require.NoError(t, err)
-			assert.Equal(t, tCase.wantNamespace, namespace)
+			assert.Equal(t, tCase.wantNamespace, sourceCacheNamespaceForTask(tsk))
 		})
 	}
 }
@@ -284,9 +274,10 @@ func sourceCachePlanKeyParts(key string) (namespace, revision string) {
 
 func TestSourceCachePlan(t *testing.T) {
 	for tName, tCase := range map[string]struct {
-		requester string
-		head      string
-		want      [][2]string
+		requester   string
+		head        string
+		insertPatch bool
+		want        [][2]string
 	}{
 		"MainlineRestoresTheBaseArtifact": {
 			requester: evergreen.RepotrackerVersionRequester,
@@ -297,10 +288,19 @@ func TestSourceCachePlan(t *testing.T) {
 			head:      "55ca6286e3e4f4fba5d0448333fa99fc5a404a73",
 			want:      [][2]string{{"pr", "55ca6286e3e4f4fba5d0448333fa99fc5a404a73"}, {"base", "abc123"}},
 		},
+		"CLIPatchRestoresTheCLIArtifactThenTheBaseArtifact": {
+			requester:   evergreen.PatchVersionRequester,
+			insertPatch: true,
+			want:        [][2]string{{"cli", "abc123"}, {"base", "abc123"}},
+		},
 	} {
 		t.Run(tName, func(t *testing.T) {
 			require.NoError(t, db.ClearCollections(task.Collection, model.ProjectRefCollection, patch.Collection))
 			const versionID = "5bedc62ee4055d31f0340b1d"
+			if tCase.insertPatch {
+				patchDoc := patch.Patch{Id: mgobson.ObjectIdHex(versionID)}
+				require.NoError(t, patchDoc.Insert(t.Context()))
+			}
 			if tCase.head != "" {
 				patchDoc := patch.Patch{
 					Id:              mgobson.ObjectIdHex(versionID),

--- a/source_cache.go
+++ b/source_cache.go
@@ -19,6 +19,10 @@ const (
 	// credentials handed to a PR task can deny writes to the base namespace.
 	SourceCachePRNamespace = "pr"
 
+	// SourceCacheCLINamespace holds artifacts produced by CLI patches, so a patch
+	// cannot pre-populate the base namespace before mainline builds a commit.
+	SourceCacheCLINamespace = "cli"
+
 	// SourceCacheExternalID is the fixed external ID for source cache role assumptions.
 	SourceCacheExternalID = "source-cache:"
 


### PR DESCRIPTION
DEVPROD-42363

### Description
CLI patches currently write to the same source cache namespace as mainline commits, so since writes are first-writer-wins, a patch can pre-populate the cache entry for a commit mainline hasn't built yet and poison what mainline later restores. This gives CLI patches their own `cli` namespace, mirroring what PR and merge queue patches already have, so they can still read from `base` but can never write to it.

### Testing

Added tests 

