### PR TITLE
DEVPROD-42890 allow tasks in allowed task groups on single task distros

### DIFF
--- a/rest/route/host_agent.go
+++ b/rest/route/host_agent.go
@@ -734,14 +734,20 @@ func validateSingleTaskDistro(singleTaskDistroAllowlist evergreen.ProjectTasksPa
 		}
 	}
 
-	// Check if the task is allowed on the distro.
+	// Check if the task (or task group) is allowed on the distro.
+	taskNames := []string{nextTask.DisplayName}
+	if nextTask.TaskGroup != "" {
+		taskNames = append(taskNames, nextTask.TaskGroup)
+	}
 	for _, allowedTask := range singleTaskDistroAllowlist.AllowedTasks {
-		matched, err := regexp.MatchString(allowedTask, nextTask.DisplayName)
-		if err != nil {
-			return false, errors.Wrapf(err, "could not process task regex '%s'", allowedTask)
-		}
-		if matched {
-			return true, nil
+		for _, taskName := range taskNames {
+			matched, err := regexp.MatchString(allowedTask, taskName)
+			if err != nil {
+				return false, errors.Wrapf(err, "could not process task regex '%s'", allowedTask)
+			}
+			if matched {
+				return true, nil
+			}
 		}
 	}
 

--- a/rest/route/host_agent_test.go
+++ b/rest/route/host_agent_test.go
@@ -2111,3 +2111,42 @@ func TestCheckHostHealth(t *testing.T) {
 		})
 	})
 }
+
+func TestValidateSingleTaskDistro(t *testing.T) {
+	allowlist := evergreen.ProjectTasksPair{
+		AllowedTasks: []string{"allowed_task", "allowed_group_TG"},
+		AllowedBVs:   []string{"allowed_bv"},
+	}
+
+	for testName, testCase := range map[string]struct {
+		nextTask *task.Task
+		expected bool
+	}{
+		"TaskInAllowedTaskGroupIsAllowed": {
+			nextTask: &task.Task{DisplayName: "member_task", TaskGroup: "allowed_group_TG", BuildVariant: "bv"},
+			expected: true,
+		},
+		"TaskInDisallowedTaskGroupIsNotAllowed": {
+			nextTask: &task.Task{DisplayName: "member_task", TaskGroup: "other_group_TG", BuildVariant: "bv"},
+			expected: false,
+		},
+		"TaskAllowedByItsOwnNameIsAllowed": {
+			nextTask: &task.Task{DisplayName: "allowed_task", BuildVariant: "bv"},
+			expected: true,
+		},
+		"TaskWithoutTaskGroupNotInAllowlistIsNotAllowed": {
+			nextTask: &task.Task{DisplayName: "other_task", BuildVariant: "bv"},
+			expected: false,
+		},
+		"TaskOnAllowedBuildVariantIsAllowed": {
+			nextTask: &task.Task{DisplayName: "other_task", BuildVariant: "allowed_bv"},
+			expected: true,
+		},
+	} {
+		t.Run(testName, func(t *testing.T) {
+			matched, err := validateSingleTaskDistro(allowlist, testCase.nextTask)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expected, matched)
+		})
+	}
+}


### PR DESCRIPTION
DEVPROD-42890 
<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Task groups aren't currently working for single-task distros; allow them so we can reduce how many tasks are allowed.

### Testing

Added a unit test.