### PR TITLE
DEVPROD-38087 Validate and fail empty sign tokens

### DIFF
--- a/model/artifact/artifact_token.go
+++ b/model/artifact/artifact_token.go
@@ -37,6 +37,9 @@ func GenerateSignToken(appSecret []byte, taskID string, execution int, fileName 
 
 // ValidateSignToken checks that the token is valid and not expired.
 func ValidateSignToken(appSecret []byte, taskID string, execution int, fileName string, token string, expiryStr string) bool {
+	if len(appSecret) == 0 {
+		return false
+	}
 	expiry, err := strconv.ParseInt(expiryStr, 10, 64)
 	if err != nil {
 		return false

--- a/model/artifact/artifact_token_test.go
+++ b/model/artifact/artifact_token_test.go
@@ -30,4 +30,10 @@ func TestGenerateAndValidateSignToken(t *testing.T) {
 		expiredToken := computeMAC(key, taskID, execution, fileName, pastExpiry)
 		assert.False(t, ValidateSignToken(secret, taskID, execution, fileName, expiredToken, strconv.FormatInt(pastExpiry, 10)))
 	})
+
+	t.Run("EmptySecretRejectsForgedToken", func(t *testing.T) {
+		token, expiry := GenerateSignToken(nil, taskID, execution, fileName)
+		assert.False(t, ValidateSignToken(nil, taskID, execution, fileName, token, strconv.FormatInt(expiry, 10)))
+		assert.False(t, ValidateSignToken([]byte(""), taskID, execution, fileName, token, strconv.FormatInt(expiry, 10)))
+	})
 }

--- a/rest/route/artifact_sign_test.go
+++ b/rest/route/artifact_sign_test.go
@@ -105,6 +105,17 @@ func TestArtifactSignHandler(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
 	})
+	t.Run("EmptySecretFailsClosed", func(t *testing.T) {
+		settings := evergreen.GetEnvironment().Settings()
+		defer func() { settings.ArtifactSignSecret = testSecret }()
+		settings.ArtifactSignSecret = ""
+		forgedToken, forgedExpiry := artifact.GenerateSignToken(nil, "task1", 0, "signed_report")
+		req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/tasks/task1/artifact/sign?execution=0&name=signed_report&token=%s&exp=%d", forgedToken, forgedExpiry), nil)
+		req = gimlet.SetURLVars(req, map[string]string{"task_id": "task1"})
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
 	t.Run("SignedFileRedirects", func(t *testing.T) {
 		req, _ := http.NewRequest(http.MethodGet, fmt.Sprintf("/tasks/task1/artifact/sign?execution=0&name=signed_report&token=%s&exp=%d", validToken, validExpiry), nil)
 		req = gimlet.SetURLVars(req, map[string]string{"task_id": "task1"})


### PR DESCRIPTION
DEVPROD-38087


### Description

security recommendation 

### Testing

unit tests