### PR TITLE
DEVPROD-43039: Avoid calling dataloaders at top-level queries

### DIFF
--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -14,7 +14,6 @@ import (
 	"github.com/evergreen-ci/evergreen"
 	"github.com/evergreen-ci/evergreen/api"
 	"github.com/evergreen-ci/evergreen/cloud"
-	"github.com/evergreen-ci/evergreen/graphql/loaders"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/annotations"
 	"github.com/evergreen-ci/evergreen/model/build"
@@ -393,11 +392,10 @@ func (r *mutationResolver) UpdateHostStatus(ctx context.Context, hostIds []strin
 // SetPatchVisibility is the resolver for the setPatchVisibility field.
 func (r *mutationResolver) SetPatchVisibility(ctx context.Context, patchIds []string, hidden bool) ([]*patch.Patch, error) {
 	user := mustHaveUser(ctx)
-	loaders.PreloadPatches(ctx, patchIds)
 
 	patchPtrs := []*patch.Patch{}
 	for _, pId := range patchIds {
-		p, err := loaders.GetPatch(ctx, pId)
+		p, err := patch.FindOneId(ctx, pId)
 		if err != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting patch '%s': %s", pId, err.Error()))
 		}
@@ -1488,10 +1486,9 @@ func (r *mutationResolver) RestartVersions(ctx context.Context, versionID string
 		versionIDs = append(versionIDs, utility.FromStringPtr(version.VersionId))
 	}
 
-	loaders.PreloadVersions(ctx, versionIDs)
 	versions := []*model.Version{}
 	for _, vId := range versionIDs {
-		v, versionErr := loaders.GetVersion(ctx, vId)
+		v, versionErr := model.VersionFindOneId(ctx, vId)
 		if versionErr != nil {
 			return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", vId, versionErr.Error()))
 		}

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -430,7 +430,7 @@ func (r *mutationResolver) SchedulePatch(ctx context.Context, patchID string, co
 	if err != nil {
 		return nil, mapHTTPStatusToGqlError(ctx, statusCode, werrors.Errorf("scheduling patch '%s': %s", patchID, err.Error()))
 	}
-	scheduledPatch, err := loaders.GetPatch(ctx, patchID)
+	scheduledPatch, err := patch.FindOneId(ctx, patchID)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("getting scheduled patch '%s': %s", patchID, err.Error()))
 	}

--- a/graphql/mutation_resolver.go
+++ b/graphql/mutation_resolver.go
@@ -422,7 +422,7 @@ func (r *mutationResolver) SchedulePatch(ctx context.Context, patchID string, co
 	patchUpdateReq := buildFromGqlInput(configure)
 	usr := mustHaveUser(ctx)
 	patchUpdateReq.Caller = usr.Id
-	version, err := loaders.GetVersion(ctx, patchID)
+	version, err := model.VersionFindOneId(ctx, patchID)
 	if err != nil && !adb.ResultsNotFound(err) {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching patch '%s': %s", patchID, err.Error()))
 	}

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -1229,7 +1229,7 @@ func (r *queryResolver) HasVersion(ctx context.Context, patchID string) (bool, e
 
 // Version is the resolver for the version field.
 func (r *queryResolver) Version(ctx context.Context, versionID string) (*model.Version, error) {
-	v, err := loaders.GetVersion(ctx, versionID)
+	v, err := model.VersionFindOneId(ctx, versionID)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("fetching version '%s': %s", versionID, err.Error()))
 	}

--- a/graphql/query_resolver.go
+++ b/graphql/query_resolver.go
@@ -400,7 +400,7 @@ func (r *queryResolver) TaskQueueDistros(ctx context.Context) ([]*TaskQueueDistr
 
 // Patch is the resolver for the patch field.
 func (r *queryResolver) Patch(ctx context.Context, patchID string) (*patch.Patch, error) {
-	p, err := loaders.GetPatch(ctx, patchID)
+	p, err := patch.FindOneId(ctx, patchID)
 	if err != nil {
 		return nil, InternalServerError.Send(ctx, fmt.Sprintf("finding patch '%s': %s", patchID, err.Error()), err)
 	}
@@ -1216,7 +1216,7 @@ func (r *queryResolver) HasVersion(ctx context.Context, patchID string) (bool, e
 	}
 
 	if patch.IsValidId(patchID) {
-		p, err := loaders.GetPatch(ctx, patchID)
+		p, err := patch.FindOneId(ctx, patchID)
 		if err != nil {
 			return false, InternalServerError.Send(ctx, fmt.Sprintf("fetching patch '%s': %s", patchID, err.Error()), err)
 		}

--- a/graphql/util.go
+++ b/graphql/util.go
@@ -296,7 +296,7 @@ func generateBuildVariants(ctx context.Context, versionId string, buildVariantOp
 
 // modifyVersionHandler handles the boilerplate code for performing a modify version action, i.e. schedule, unschedule, restart and set priority
 func modifyVersionHandler(ctx context.Context, versionID string, modification model.VersionModification) error {
-	v, err := loaders.GetVersion(ctx, versionID)
+	v, err := model.VersionFindOneId(ctx, versionID)
 	if err != nil {
 		return ResourceNotFound.Send(ctx, fmt.Sprintf("finding version '%s': %s", versionID, err.Error()))
 	}


### PR DESCRIPTION
DEVPROD-43039

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

I swapped this call to `loaders.GetVersion` but it's not operating correctly, possibly due to some kind of cache. Switched it back to `model.VersionFindOneId` for now and I think I will make a ticket detailing the issue.

### Testing

* Tested making a patch on staging
