### PR TITLE
DEVPROD-43062: Reuse assumed STS credentials when presigning artifact files

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -379,6 +379,9 @@ const (
 	// should be valid for.
 	PresignMinimumValidTime = 15 * time.Minute
 
+	// PresignCredentialsLifetime is the minimum remaining validity for reusing assumed-role credentials when presigning instead of reassuming the role.
+	PresignCredentialsLifetime = 5 * time.Minute
+
 	// HighExecTimeoutThreshold is the exec timeout duration above which a task
 	// has an unusually long timeout and warrants alerting.
 	HighExecTimeoutThreshold = 72 * time.Hour

--- a/model/artifact/artifact_file.go
+++ b/model/artifact/artifact_file.go
@@ -217,10 +217,11 @@ func PresignFile(ctx context.Context, file File, resolver CredentialResolver) (s
 		externalID = &file.ExternalID
 	}
 
+	// The expiry window also serves as pail's minimum remaining lifetime for reusing assumed-role credentials, so it must be well below the 15m STS credential duration for the cache to be effective.
 	requestParams := pail.PreSignRequestParams{
 		Bucket:                file.Bucket,
 		FileKey:               file.FileKey,
-		SignatureExpiryWindow: evergreen.PresignMinimumValidTime,
+		SignatureExpiryWindow: evergreen.PresignCredentialsLifetime,
 		PresignDuration:       file.PresignDuration,
 		AWSKey:                creds.AWSKey,
 		AWSSecret:             creds.AWSSecret,


### PR DESCRIPTION
DEVPROD-43062

<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

GET /rest/v2/builds/{build_id}/tasks was timing out in minutes whenever a page included a role-backed signed artifact task such as save_waterfall_artifacts_binaries. Prod traces showed requests  hung 11-27 minutes with no DB work, pointing at the artifact presign step.

The presign credentials cache was dead because PresignFile set pail's minimumLifetime reuse threshold to 15 minutes, exactly the STS credential duration, so the cache never reused an assumed role and every file's presign ran its own serialized STS AssumeRole. 

Setting that threshold to 5 minutes via PresignCredentialsLifetime lets each ~15-minute STS credential cover ~10 minutes of presigns across files, cutting AssumeRole calls to roughly one per role per 10 minutes and removing the fan-out that caused the timeouts, with presigned-URL expiry (PresignDuration) unchanged.
  
  
### Testing
edited existing 