### PR TITLE
DEVPROD-41718 support per-module clone_depth in git.get_project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,12 @@ Whenever modifying the `operations/` package (CLI commands), increment `ClientVe
 The format is the calendar date (`YYYY-MM-DD`); append a letter suffix (e.g. `2026-05-20a`) if there
 are multiple changes on the same day.
 
+### Agent Changes
+
+Whenever modifying the `agent/` package, increment `AgentVersion` in `config.go` to trigger agent
+rollover. The format is the calendar date (`YYYY-MM-DD`); append a letter suffix (e.g. `2026-05-20a`)
+if there are multiple changes on the same day.
+
 ### CI Self-Tests
 
 The Evergreen codebase has automated tests defined in `self-tests.yml`, which itself runs in Evergreen. For most tasks in

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -822,16 +822,14 @@ func (c *gitFetchProject) retryFetch(ctx context.Context, logger client.LoggerPr
 // moduleCloneDepth returns the depth to clone a module at, and the reason the
 // module's configured depth does not apply, if it does not. A module's clone
 // depth comes from the project config rather than the command, so it is
-// independent of the depth used for the source repo.
-func moduleCloneDepth(conf *internal.TaskConfig, module *model.Module, repo string) (depth int, skipReason string) {
+// independent of the depth used for the source repo. Wiki modules need no
+// special case here because their clone never takes a depth.
+func moduleCloneDepth(conf *internal.TaskConfig, module *model.Module) (depth int, skipReason string) {
 	if module.CloneDepth == 0 {
 		return 0, ""
 	}
 	if conf.Distro != nil && conf.Distro.DisableShallowClone {
 		return 0, "clone depth is disabled for this distro"
-	}
-	if model.IsWikiRepo(repo) {
-		return 0, "wiki modules are always cloned in full"
 	}
 	return module.CloneDepth, ""
 }
@@ -877,7 +875,7 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 		dir:    moduleBase,
 	}
 
-	cloneDepth, skipDepthReason := moduleCloneDepth(conf, module, repo)
+	cloneDepth, skipDepthReason := moduleCloneDepth(conf, module)
 	if skipDepthReason != "" {
 		logger.Task().Infof(ctx, "Ignoring the clone depth configured for module '%s': %s.", module.Name, skipDepthReason)
 	}

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -386,6 +386,12 @@ func (c *gitFetchProject) buildModuleCloneCommand(conf *internal.TaskConfig, opt
 			fmt.Sprintf("git reset --hard %s", checkout.HeadHash),
 		}...)
 	} else {
+		if opts.cloneDepth > 0 {
+			// A shallow clone only contains the default branch's recent history, so
+			// the module's ref may be missing. If so, deepen the clone to the full
+			// history of every branch before checking it out.
+			gitCommands = append(gitCommands, fmt.Sprintf(`git log HEAD..'%s' || git fetch --unshallow origin '+refs/heads/*:refs/remotes/origin/*'`, ref))
+		}
 		gitCommands = append(gitCommands, fmt.Sprintf("git checkout '%s'", ref))
 	}
 
@@ -813,6 +819,23 @@ func (c *gitFetchProject) retryFetch(ctx context.Context, logger client.LoggerPr
 		})
 }
 
+// moduleCloneDepth returns the depth to clone a module at, and the reason the
+// module's configured depth does not apply, if it does not. A module's clone
+// depth comes from the project config rather than the command, so it is
+// independent of the depth used for the source repo.
+func moduleCloneDepth(conf *internal.TaskConfig, module *model.Module, repo string) (depth int, skipReason string) {
+	if module.CloneDepth == 0 {
+		return 0, ""
+	}
+	if conf.Distro != nil && conf.Distro.DisableShallowClone {
+		return 0, "clone depth is disabled for this distro"
+	}
+	if model.IsWikiRepo(repo) {
+		return 0, "wiki modules are always cloned in full"
+	}
+	return module.CloneDepth, ""
+}
+
 func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 	comm client.Communicator,
 	conf *internal.TaskConfig,
@@ -853,6 +876,12 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 		branch: "",
 		dir:    moduleBase,
 	}
+
+	cloneDepth, skipDepthReason := moduleCloneDepth(conf, module, repo)
+	if skipDepthReason != "" {
+		logger.Task().Infof(ctx, "Ignoring the clone depth configured for module '%s': %s.", module.Name, skipDepthReason)
+	}
+	opts.cloneDepth = cloneDepth
 
 	// If the module repo is using the deprecated ssh cloning method, extract the owner
 	// and repo from the string and save it to clone options so that the an https cloning link

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -819,21 +819,6 @@ func (c *gitFetchProject) retryFetch(ctx context.Context, logger client.LoggerPr
 		})
 }
 
-// moduleCloneDepth returns the depth to clone a module at, and the reason the
-// module's configured depth does not apply, if it does not. A module's clone
-// depth comes from the project config rather than the command, so it is
-// independent of the depth used for the source repo. Wiki modules need no
-// special case here because their clone never takes a depth.
-func moduleCloneDepth(conf *internal.TaskConfig, module *model.Module) (depth int, skipReason string) {
-	if module.CloneDepth == 0 {
-		return 0, ""
-	}
-	if conf.Distro != nil && conf.Distro.DisableShallowClone {
-		return 0, "clone depth is disabled for this distro"
-	}
-	return module.CloneDepth, ""
-}
-
 func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 	comm client.Communicator,
 	conf *internal.TaskConfig,
@@ -875,11 +860,14 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 		dir:    moduleBase,
 	}
 
-	cloneDepth, skipDepthReason := moduleCloneDepth(conf, module)
-	if skipDepthReason != "" {
-		logger.Task().Infof(ctx, "Ignoring the clone depth configured for module '%s': %s.", module.Name, skipDepthReason)
+	// The module's clone depth comes from the project config rather than the
+	// command, so it is independent of the depth used for the source repo.
+	shallowCloneEnabled := conf.Distro == nil || !conf.Distro.DisableShallowClone
+	if !shallowCloneEnabled && module.CloneDepth != 0 {
+		logger.Task().Infof(ctx, "Clone depth is disabled for this distro; ignoring the clone depth configured for module '%s'.", module.Name)
+	} else {
+		opts.cloneDepth = module.CloneDepth
 	}
-	opts.cloneDepth = cloneDepth
 
 	// If the module repo is using the deprecated ssh cloning method, extract the owner
 	// and repo from the string and save it to clone options so that the an https cloning link

--- a/agent/command/git.go
+++ b/agent/command/git.go
@@ -860,10 +860,8 @@ func (c *gitFetchProject) fetchModuleSource(ctx context.Context,
 		dir:    moduleBase,
 	}
 
-	// The module's clone depth comes from the project config rather than the
-	// command, so it is independent of the depth used for the source repo.
-	shallowCloneEnabled := conf.Distro == nil || !conf.Distro.DisableShallowClone
-	if !shallowCloneEnabled && module.CloneDepth != 0 {
+	shallowCloneDisabled := conf.Distro != nil && conf.Distro.DisableShallowClone
+	if module.CloneDepth > 0 && shallowCloneDisabled {
 		logger.Task().Infof(ctx, "Clone depth is disabled for this distro; ignoring the clone depth configured for module '%s'.", module.Name)
 	} else {
 		opts.cloneDepth = module.CloneDepth

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/evergreen-ci/evergreen/agent/internal/redactor"
 	agenttestutil "github.com/evergreen-ci/evergreen/agent/internal/testutil"
 	agentutil "github.com/evergreen-ci/evergreen/agent/util"
-	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
@@ -1339,50 +1338,4 @@ func TestBuildModuleCloneCommandCloneDepth(t *testing.T) {
 		assert.NotContains(t, joined, "--depth")
 		assert.NotContains(t, joined, "--unshallow")
 	})
-}
-
-func TestModuleCloneDepth(t *testing.T) {
-	for _, tc := range []struct {
-		name          string
-		conf          *internal.TaskConfig
-		module        model.Module
-		expectedDepth int
-		expectSkipped bool
-	}{
-		{
-			name:          "ConfiguredDepthIsUsed",
-			conf:          &internal.TaskConfig{},
-			module:        model.Module{Name: "module1", CloneDepth: 10},
-			expectedDepth: 10,
-		},
-		{
-			name:          "UnsetDepthClonesInFull",
-			conf:          &internal.TaskConfig{},
-			module:        model.Module{Name: "module1"},
-			expectedDepth: 0,
-		},
-		{
-			name:          "NegativeDepthIsPassedThroughForValidation",
-			conf:          &internal.TaskConfig{},
-			module:        model.Module{Name: "module1", CloneDepth: -1},
-			expectedDepth: -1,
-		},
-		{
-			name:          "DistroWithShallowCloneDisabledSkipsDepth",
-			conf:          &internal.TaskConfig{Distro: &apimodels.DistroView{DisableShallowClone: true}},
-			module:        model.Module{Name: "module1", CloneDepth: 10},
-			expectedDepth: 0,
-			expectSkipped: true,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			depth, skipReason := moduleCloneDepth(tc.conf, &tc.module)
-			assert.Equal(t, tc.expectedDepth, depth)
-			if tc.expectSkipped {
-				assert.NotEmpty(t, skipReason)
-			} else {
-				assert.Empty(t, skipReason)
-			}
-		})
-	}
 }

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/evergreen-ci/evergreen/agent/internal/redactor"
 	agenttestutil "github.com/evergreen-ci/evergreen/agent/internal/testutil"
 	agentutil "github.com/evergreen-ci/evergreen/agent/util"
+	"github.com/evergreen-ci/evergreen/apimodels"
 	"github.com/evergreen-ci/evergreen/db"
 	"github.com/evergreen-ci/evergreen/model"
 	"github.com/evergreen-ci/evergreen/model/build"
@@ -1290,4 +1291,111 @@ func TestParentRepoForGitHubAppToken(t *testing.T) {
 	assert.Equal(t, "mongo", parentRepoForGitHubAppToken("mongo.wiki"))
 	assert.Equal(t, "mongo", parentRepoForGitHubAppToken("mongo.wiki.git"))
 	assert.Equal(t, "other", parentRepoForGitHubAppToken("other"))
+}
+
+func TestBuildModuleCloneCommandCloneDepth(t *testing.T) {
+	c := &gitFetchProject{Directory: "dir", Token: projectGitHubToken}
+	conf := &internal.TaskConfig{}
+	baseOpts := cloneOpts{
+		token: projectGitHubToken,
+		owner: "evergreen-ci",
+		repo:  "sample",
+		dir:   "module",
+	}
+
+	t.Run("PositiveDepthShallowClonesAndDeepensForMissingRef", func(t *testing.T) {
+		opts := baseOpts
+		opts.cloneDepth = 5
+		cmds, err := c.buildModuleCloneCommand(conf, opts, "main", nil)
+		require.NoError(t, err)
+		joined := strings.Join(cmds, "\n")
+		assert.Contains(t, joined, "--depth 5")
+		assert.Contains(t, joined, "git log HEAD..'main' || git fetch --unshallow")
+		assert.Contains(t, joined, "git checkout 'main'")
+	})
+
+	t.Run("UnsetDepthClonesInFull", func(t *testing.T) {
+		cmds, err := c.buildModuleCloneCommand(conf, baseOpts, "main", nil)
+		require.NoError(t, err)
+		joined := strings.Join(cmds, "\n")
+		assert.NotContains(t, joined, "--depth")
+		assert.NotContains(t, joined, "--unshallow")
+	})
+
+	t.Run("NegativeDepthShouldError", func(t *testing.T) {
+		opts := baseOpts
+		opts.cloneDepth = -1
+		_, err := c.buildModuleCloneCommand(conf, opts, "main", nil)
+		assert.ErrorContains(t, err, "clone depth cannot be negative")
+	})
+
+	t.Run("WikiModuleIgnoresDepth", func(t *testing.T) {
+		opts := baseOpts
+		opts.repo = "parent.wiki"
+		opts.cloneDepth = 5
+		cmds, err := c.buildModuleCloneCommand(conf, opts, "", nil)
+		require.NoError(t, err)
+		joined := strings.Join(cmds, "\n")
+		assert.NotContains(t, joined, "--depth")
+		assert.NotContains(t, joined, "--unshallow")
+	})
+}
+
+func TestModuleCloneDepth(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		conf          *internal.TaskConfig
+		module        model.Module
+		repo          string
+		expectedDepth int
+		expectSkipped bool
+	}{
+		{
+			name:          "ConfiguredDepthIsUsed",
+			conf:          &internal.TaskConfig{},
+			module:        model.Module{Name: "module1", CloneDepth: 10},
+			repo:          "sample",
+			expectedDepth: 10,
+		},
+		{
+			name:          "UnsetDepthClonesInFull",
+			conf:          &internal.TaskConfig{},
+			module:        model.Module{Name: "module1"},
+			repo:          "sample",
+			expectedDepth: 0,
+		},
+		{
+			name:          "NegativeDepthIsPassedThroughForValidation",
+			conf:          &internal.TaskConfig{},
+			module:        model.Module{Name: "module1", CloneDepth: -1},
+			repo:          "sample",
+			expectedDepth: -1,
+		},
+		{
+			name:          "DistroWithShallowCloneDisabledSkipsDepth",
+			conf:          &internal.TaskConfig{Distro: &apimodels.DistroView{DisableShallowClone: true}},
+			module:        model.Module{Name: "module1", CloneDepth: 10},
+			repo:          "sample",
+			expectedDepth: 0,
+			expectSkipped: true,
+		},
+		{
+			name:          "WikiModuleSkipsDepth",
+			conf:          &internal.TaskConfig{},
+			module:        model.Module{Name: "module1", CloneDepth: 10},
+			repo:          "parent.wiki",
+			expectedDepth: 0,
+			expectSkipped: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			depth, skipReason := moduleCloneDepth(tc.conf, &tc.module, tc.repo)
+			assert.Equal(t, tc.expectedDepth, depth)
+			if tc.expectSkipped {
+				assert.NotEmpty(t, skipReason)
+			} else {
+				assert.Empty(t, skipReason)
+			}
+		})
+	}
 }

--- a/agent/command/git_test.go
+++ b/agent/command/git_test.go
@@ -1346,7 +1346,6 @@ func TestModuleCloneDepth(t *testing.T) {
 		name          string
 		conf          *internal.TaskConfig
 		module        model.Module
-		repo          string
 		expectedDepth int
 		expectSkipped bool
 	}{
@@ -1354,42 +1353,30 @@ func TestModuleCloneDepth(t *testing.T) {
 			name:          "ConfiguredDepthIsUsed",
 			conf:          &internal.TaskConfig{},
 			module:        model.Module{Name: "module1", CloneDepth: 10},
-			repo:          "sample",
 			expectedDepth: 10,
 		},
 		{
 			name:          "UnsetDepthClonesInFull",
 			conf:          &internal.TaskConfig{},
 			module:        model.Module{Name: "module1"},
-			repo:          "sample",
 			expectedDepth: 0,
 		},
 		{
 			name:          "NegativeDepthIsPassedThroughForValidation",
 			conf:          &internal.TaskConfig{},
 			module:        model.Module{Name: "module1", CloneDepth: -1},
-			repo:          "sample",
 			expectedDepth: -1,
 		},
 		{
 			name:          "DistroWithShallowCloneDisabledSkipsDepth",
 			conf:          &internal.TaskConfig{Distro: &apimodels.DistroView{DisableShallowClone: true}},
 			module:        model.Module{Name: "module1", CloneDepth: 10},
-			repo:          "sample",
-			expectedDepth: 0,
-			expectSkipped: true,
-		},
-		{
-			name:          "WikiModuleSkipsDepth",
-			conf:          &internal.TaskConfig{},
-			module:        model.Module{Name: "module1", CloneDepth: 10},
-			repo:          "parent.wiki",
 			expectedDepth: 0,
 			expectSkipped: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			depth, skipReason := moduleCloneDepth(tc.conf, &tc.module, tc.repo)
+			depth, skipReason := moduleCloneDepth(tc.conf, &tc.module)
 			assert.Equal(t, tc.expectedDepth, depth)
 			if tc.expectSkipped {
 				assert.NotEmpty(t, skipReason)

--- a/config.go
+++ b/config.go
@@ -39,7 +39,7 @@ var (
 
 	// Agent version to control agent rollover. The format is the calendar date
 	// (YYYY-MM-DD).
-	AgentVersion = "2026-09-10b"
+	AgentVersion = "2026-09-11"
 )
 
 const (

--- a/docs/Project-Configuration/Project-Commands.md
+++ b/docs/Project-Configuration/Project-Commands.md
@@ -994,6 +994,9 @@ The parameters for each module are:
   parameter if both specified (for commits)
 - `branch`: must be the name of branch, commit hashes _are not
   accepted_.
+- `clone_depth`: clone the module with `git clone --depth <clone_depth>`. This is
+  set per module in the [modules](Project-Configuration-Files#modules) section,
+  not on the command, and the command's `clone_depth` does not apply to modules.
 
 ### Module Hash Hierarchy
 

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -519,10 +519,9 @@ Fields:
   dynamically retrieved for each Github PR, CLI patch, and periodic build submission
 - `clone_depth`: clone this module with `git clone --depth <clone_depth>`. It is
   independent of [git.get_project](Project-Commands#gitgetproject)'s own
-  `clone_depth`, which only applies to the source repo. If the module's revision
-  is not in the shallow clone, Evergreen deepens the clone before checking it
-  out, so a depth that is too small costs time but never fails the checkout.
-  Ignored for wiki modules and on distros where shallow clone is disabled.
+  `clone_depth`, which only applies to the source repo. Ignored for wiki modules,
+  distros where shallow clone is disabled, or when the module's revision is not
+  in the shallow clone.
 
 #### Wiki modules
 

--- a/docs/Project-Configuration/Project-Configuration-Files.md
+++ b/docs/Project-Configuration/Project-Configuration-Files.md
@@ -517,6 +517,12 @@ Fields:
   time of the Evergreen version creation)
 - `auto_update`: if true, the latest revision for the module will be
   dynamically retrieved for each Github PR, CLI patch, and periodic build submission
+- `clone_depth`: clone this module with `git clone --depth <clone_depth>`. It is
+  independent of [git.get_project](Project-Commands#gitgetproject)'s own
+  `clone_depth`, which only applies to the source repo. If the module's revision
+  is not in the shallow clone, Evergreen deepens the clone before checking it
+  out, so a depth that is too small costs time but never fails the checkout.
+  Ignored for wiki modules and on distros where shallow clone is disabled.
 
 #### Wiki modules
 

--- a/model/project.go
+++ b/model/project.go
@@ -562,9 +562,7 @@ type Module struct {
 	Prefix     string `yaml:"prefix,omitempty" bson:"prefix"  plugin:"expand"`
 	Ref        string `yaml:"ref,omitempty" bson:"ref"  plugin:"expand"`
 	AutoUpdate bool   `yaml:"auto_update,omitempty" bson:"auto_update"`
-	// CloneDepth shallow clones the module with git clone --depth. It only
-	// applies to git.get_project's module clones and is independent of the
-	// command's own clone_depth, which only affects the source repo.
+	// CloneDepth shallow clones the module with git clone --depth.
 	CloneDepth int `yaml:"clone_depth,omitempty" bson:"clone_depth,omitempty"`
 }
 

--- a/model/project.go
+++ b/model/project.go
@@ -562,6 +562,10 @@ type Module struct {
 	Prefix     string `yaml:"prefix,omitempty" bson:"prefix"  plugin:"expand"`
 	Ref        string `yaml:"ref,omitempty" bson:"ref"  plugin:"expand"`
 	AutoUpdate bool   `yaml:"auto_update,omitempty" bson:"auto_update"`
+	// CloneDepth shallow clones the module with git clone --depth. It only
+	// applies to git.get_project's module clones and is independent of the
+	// command's own clone_depth, which only affects the source repo.
+	CloneDepth int `yaml:"clone_depth,omitempty" bson:"clone_depth,omitempty"`
 }
 
 // GetOwnerAndRepo returns the owner and repo for a module

--- a/model/project_parser_test.go
+++ b/model/project_parser_test.go
@@ -4699,3 +4699,26 @@ tasks:
 		require.NoError(b, err)
 	}
 }
+
+func TestParseModuleCloneDepth(t *testing.T) {
+	yml := `
+modules:
+- name: "shallow"
+  repo: "dsi"
+  owner: "10gen"
+  branch: "main"
+  clone_depth: 1
+- name: "full"
+  repo: "mongo"
+  owner: "10gen"
+  branch: "main"
+tasks:
+- name: t1
+`
+	pp, decodeErr, err := createIntermediateProject([]byte(yml), false, nil)
+	require.NoError(t, err)
+	require.NoError(t, decodeErr)
+	require.Len(t, pp.Modules, 2)
+	assert.Equal(t, 1, pp.Modules[0].CloneDepth)
+	assert.Zero(t, pp.Modules[1].CloneDepth)
+}

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -140,6 +140,7 @@ var projectErrorValidators = []projectValidator{
 	validateHostCreates,
 	validateDuplicateBVTasks,
 	validateGenerateTasks,
+	validateModuleCloneDepths,
 }
 
 // Functions used to validate the syntax of project configs representing properties found on the project page.
@@ -1170,6 +1171,21 @@ func checkTaskNames(task *model.ProjectTask) ValidationErrors {
 	return errs
 }
 
+// validateModuleCloneDepths checks that no module sets a clone depth that git
+// cannot clone with, which would fail the task at git.get_project.
+func validateModuleCloneDepths(project *model.Project) ValidationErrors {
+	errs := ValidationErrors{}
+	for _, module := range project.Modules {
+		if module.CloneDepth < 0 {
+			errs = append(errs, ValidationError{
+				Level:   Error,
+				Message: fmt.Sprintf("module '%s' cannot have a negative clone depth", module.Name),
+			})
+		}
+	}
+	return errs
+}
+
 // checkModules checks to make sure that the module's name, branch, and repo are correct.
 func checkModules(project *model.Project) ValidationErrors {
 	errs := ValidationErrors{}
@@ -1225,13 +1241,6 @@ func checkModules(project *model.Project) ValidationErrors {
 			errs = append(errs, ValidationError{
 				Level:   Warning,
 				Message: fmt.Sprintf("module '%s' should have a set repo", module.Name),
-			})
-		}
-
-		if module.CloneDepth < 0 {
-			errs = append(errs, ValidationError{
-				Level:   Error,
-				Message: fmt.Sprintf("module '%s' cannot have a negative clone depth", module.Name),
 			})
 		}
 

--- a/validator/project_validator.go
+++ b/validator/project_validator.go
@@ -1228,6 +1228,13 @@ func checkModules(project *model.Project) ValidationErrors {
 			})
 		}
 
+		if module.CloneDepth < 0 {
+			errs = append(errs, ValidationError{
+				Level:   Error,
+				Message: fmt.Sprintf("module '%s' cannot have a negative clone depth", module.Name),
+			})
+		}
+
 	}
 
 	return errs

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2126,6 +2126,40 @@ func TestCheckModules(t *testing.T) {
 	})
 }
 
+func TestCheckModulesCloneDepth(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		cloneDepth  int
+		expectError bool
+	}{
+		{name: "UnsetDepthShouldNotError"},
+		{name: "PositiveDepthShouldNotError", cloneDepth: 100},
+		{name: "NegativeDepthShouldError", cloneDepth: -1, expectError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			project := &model.Project{
+				Modules: model.ModuleList{
+					model.Module{
+						Name:       "module-0",
+						Branch:     "main",
+						Owner:      "evergreen-ci",
+						Repo:       "evergreen",
+						CloneDepth: tc.cloneDepth,
+					},
+				},
+			}
+			errs := checkModules(project)
+			if tc.expectError {
+				require.Len(t, errs, 1)
+				assert.Equal(t, Error, errs[0].Level)
+				assert.Contains(t, errs[0].Message, "negative clone depth")
+			} else {
+				assert.Empty(t, errs)
+			}
+		})
+	}
+}
+
 func TestValidateBVNames(t *testing.T) {
 	Convey("When validating a project's build variants' names", t, func() {
 		Convey("if any variant has a duplicate entry, an error should be returned", func() {

--- a/validator/project_validator_test.go
+++ b/validator/project_validator_test.go
@@ -2126,7 +2126,7 @@ func TestCheckModules(t *testing.T) {
 	})
 }
 
-func TestCheckModulesCloneDepth(t *testing.T) {
+func TestValidateModuleCloneDepths(t *testing.T) {
 	for _, tc := range []struct {
 		name        string
 		cloneDepth  int
@@ -2148,7 +2148,7 @@ func TestCheckModulesCloneDepth(t *testing.T) {
 					},
 				},
 			}
-			errs := checkModules(project)
+			errs := validateModuleCloneDepths(project)
 			if tc.expectError {
 				require.Len(t, errs, 1)
 				assert.Equal(t, Error, errs[0].Level)


### PR DESCRIPTION
DEVPROD-41718
<!-- Tip: To have Jira automatically create a ticket, prefix the pull request title with DEVPROD-XXXX verbatim. Ticket will be created when the PR is marked as ready for review (not when a draft is opened). -->

### Description

Add support for per-module clone_depth, and validation on the values.

### Testing

Added some unit tests.

### Documentation

Added to the module documentation.

<!--
Before putting up for review, briefly consider (or mention in the PR description):

* Usability
    * Does it fulfill the user's need?
    * Is it reasonably easy for users to understand/use?
* Correctness
    * Does the code do what it's expected to do?
    * Is there enough automated test coverage?
* Performance
    * Does it do anything that's slow or resource-intensive?
    * Especially consider common cases like doing many DB operations in a nested loop, expensive DB queries without
      indexes, deep recursive calls, etc.
* Code health
    * Does it follow Evergreen's conventions/style?
    * Is it readable, easy to understand, and maintainable?
    * Remember to clean up any leftover TODOs or temporary debugging code/comments!
* Security - Does this change have any security implications?
* Backward compatibility
    * Does it break existing behavior or APIs?
    * Do we need to send out comms to users?
* Ops - Is there any ops work that needs to be done alongside this change?
* Monitoring - Does this change need to be monitored post-deploy?
* Data warehouse models
    * If you're adding a field to the Test, Task, Build, Version, Host, Host Events, Project, or Patch structs, consider creating a DPIPE ticket to expose this in the data warehouse. Please also add @abby.vlosky, @amy.metlesitz, and @kelly.mcmeekin as watchers to the ticket.
    * If you implement a change to the semantic meaning or structure of any existing field or object (i.e. change the definition of a field, allowable inputs, data types, etc.), please post a quick summary of the change to #ask-data and cc @pta-devprod-analysts so they can assess impact on downstream models.

-->
